### PR TITLE
feat: typed KG relations + graph-expanded memory retrieval

### DIFF
--- a/backend/migrations/versions/0003_page_relations.py
+++ b/backend/migrations/versions/0003_page_relations.py
@@ -1,0 +1,40 @@
+"""Add page_relations table for typed knowledge graph edges.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-09
+"""
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+CREATE TABLE IF NOT EXISTS page_relations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_page_id UUID NOT NULL REFERENCES notebook_pages(id) ON DELETE CASCADE,
+    relation_type VARCHAR(64) NOT NULL,
+    target_page_id UUID NOT NULL REFERENCES notebook_pages(id) ON DELETE CASCADE,
+    confidence REAL NOT NULL DEFAULT 0.8,
+    valid_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+    valid_until TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(source_page_id, relation_type, target_page_id)
+)
+""")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_page_relations_source "
+        "ON page_relations(source_page_id) WHERE valid_until IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_page_relations_target "
+        "ON page_relations(target_page_id) WHERE valid_until IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS page_relations")

--- a/backend/services/injection_service.py
+++ b/backend/services/injection_service.py
@@ -4,7 +4,8 @@ Scores candidates on:
   injection_score = relevance x recency x staleness x confidence
 
 Candidate sources: always-inject notes, keyword-matched notes/patterns,
-vector-similar events, FTS-matched events.
+1-hop graph neighbours via typed page_relations, vector-similar events,
+FTS-matched events.
 """
 
 import json
@@ -300,6 +301,40 @@ async def compute_injection(
                 ),
                 confidence=confidence,
                 source_type="pattern" if note_type == "pattern" else "note",
+            ))
+
+    # --- Graph expansion: 1-hop neighbours of matched pages via typed relations ---
+    matched_page_ids = [
+        UUID(c.key.split(":", 1)[1])
+        for c in candidates
+        if c.key.startswith("page:")
+    ]
+    if matched_page_ids:
+        neighbour_pages = await notebook_service.get_page_neighbors(matched_page_ids, notebook_id)
+        for nb in neighbour_pages:
+            nb_key = f"page:{nb['id']}"
+            if any(c.key == nb_key for c in candidates):
+                continue
+            nb_meta = nb.get("metadata", {})
+            nb_inject_count = nb_meta.get("inject_count", 0)
+            nb_last_inj_str = nb_meta.get("last_injected_at")
+            nb_last_inj = datetime.fromisoformat(nb_last_inj_str) if nb_last_inj_str else None
+            nb_content = f"## {nb['name']}\n{nb['content_markdown']}"
+
+            # Relevance is discounted because this is an indirect (graph-traversal) match.
+            # The relation confidence from the KG is used directly as the candidate confidence.
+            candidates.append(InjectionCandidate(
+                key=nb_key,
+                content=nb_content,
+                section_header=nb["name"],
+                relevance=0.55,
+                recency=recency_score(nb_inject_count, nb_last_inj, now, recency_intervals),
+                staleness=_compute_staleness(
+                    nb_key, session_state, prompt_num, now,
+                    avg_gap, fast_threshold, decay_fast, decay_slow,
+                ),
+                confidence=float(nb.get("confidence", 0.7)),
+                source_type="note",
             ))
 
     # --- Vector-similar history events ---

--- a/backend/services/notebook_service.py
+++ b/backend/services/notebook_service.py
@@ -439,31 +439,125 @@ async def get_outlinks(page_id: UUID) -> list[dict]:
 
 
 async def get_page_graph(notebook_id: UUID) -> dict:
-    """Get the full link graph for a notebook: {nodes, edges}."""
+    """Get the full link graph for a notebook: {nodes, edges}.
+
+    Edges include both implicit wiki links (page_links) and explicit typed
+    relations (page_relations, currently valid only).
+    """
     pool = get_pool()
-    # Get all pages as nodes
     pages = await pool.fetch(
         "SELECT id, name FROM notebook_pages WHERE notebook_id = $1", notebook_id,
     )
     nodes = [{"id": str(p["id"]), "name": p["name"]} for p in pages]
 
-    # Get all links between pages in this notebook
     page_ids = [p["id"] for p in pages]
     if not page_ids:
         return {"nodes": nodes, "edges": []}
 
-    edges_rows = await pool.fetch(
+    wiki_rows = await pool.fetch(
         "SELECT source_page_id, target_page_id, link_text FROM page_links "
         "WHERE source_page_id = ANY($1) AND target_page_id = ANY($1)",
         page_ids,
     )
     edges = [
-        {"source": str(e["source_page_id"]), "target": str(e["target_page_id"]),
-         "label": e["link_text"]}
-        for e in edges_rows
+        {
+            "source": str(e["source_page_id"]),
+            "target": str(e["target_page_id"]),
+            "label": e["link_text"],
+            "edge_type": "wiki",
+        }
+        for e in wiki_rows
     ]
 
+    relation_rows = await pool.fetch(
+        "SELECT source_page_id, target_page_id, relation_type, confidence "
+        "FROM page_relations "
+        "WHERE source_page_id = ANY($1) AND target_page_id = ANY($1) "
+        "AND valid_until IS NULL",
+        page_ids,
+    )
+    for r in relation_rows:
+        edges.append({
+            "source": str(r["source_page_id"]),
+            "target": str(r["target_page_id"]),
+            "label": r["relation_type"],
+            "edge_type": "relation",
+            "confidence": r["confidence"],
+        })
+
     return {"nodes": nodes, "edges": edges}
+
+
+# --- Typed knowledge-graph relations ---
+
+
+async def upsert_relation(
+    source_page_id: UUID,
+    relation_type: str,
+    target_page_id: UUID,
+    confidence: float = 0.8,
+) -> None:
+    """Insert or refresh a typed relation between two pages.
+
+    If a row already exists for (source, relation_type, target) it is updated
+    with the new confidence and its valid_until is cleared (re-activated).
+    """
+    pool = get_pool()
+    await pool.execute(
+        "INSERT INTO page_relations "
+        "(source_page_id, relation_type, target_page_id, confidence, valid_from, valid_until) "
+        "VALUES ($1, $2, $3, $4, now(), NULL) "
+        "ON CONFLICT (source_page_id, relation_type, target_page_id) DO UPDATE "
+        "SET confidence = $4, valid_from = now(), valid_until = NULL",
+        source_page_id, relation_type, target_page_id, confidence,
+    )
+
+
+async def invalidate_conflicting_relations(
+    source_page_id: UUID,
+    relation_type: str,
+    superseding_target_id: UUID,
+) -> None:
+    """Expire all current relations of a given type from source, except the new one.
+
+    Use this when a new fact supersedes prior ones of the same kind, e.g. a new
+    "prefers" relation replacing an old one.
+    """
+    pool = get_pool()
+    await pool.execute(
+        "UPDATE page_relations SET valid_until = now() "
+        "WHERE source_page_id = $1 AND relation_type = $2 "
+        "AND target_page_id != $3 AND valid_until IS NULL",
+        source_page_id, relation_type, superseding_target_id,
+    )
+
+
+async def get_page_neighbors(
+    page_ids: list[UUID],
+    notebook_id: UUID,
+) -> list[dict]:
+    """Return 1-hop neighbours via currently-valid page_relations.
+
+    Each result dict contains the neighbouring page's full fields plus
+    the relation metadata (relation_type, confidence, direction).
+    """
+    if not page_ids:
+        return []
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT np.id, np.notebook_id, np.name, np.content_markdown, np.metadata, "
+        "pr.relation_type, pr.confidence, "
+        "CASE WHEN pr.source_page_id = ANY($1) THEN 'outgoing' ELSE 'incoming' END AS direction "
+        "FROM page_relations pr "
+        "JOIN notebook_pages np ON np.id = "
+        "  CASE WHEN pr.source_page_id = ANY($1) THEN pr.target_page_id "
+        "       ELSE pr.source_page_id END "
+        "WHERE (pr.source_page_id = ANY($1) OR pr.target_page_id = ANY($1)) "
+        "AND pr.valid_until IS NULL "
+        "AND np.notebook_id = $2",
+        page_ids, notebook_id,
+    )
+    return [dict(r) for r in rows]
 
 
 # --- Page embeddings ---

--- a/backend/services/sleep_service.py
+++ b/backend/services/sleep_service.py
@@ -475,7 +475,18 @@ Analyze the new content and produce a JSON response with these actions:
      "add_links": [str]           # Page titles to add as [[wiki links]] to the category
    }}]
 
-6. "health": {{"loops_detected": bool, "stuck": bool, "recommend_restart": bool, "message": "optional"}}
+6. "extract_relations": [{{
+     "source_title": str,         # Title of the source page (must already exist)
+     "relation_type": str,        # Short verb phrase: "uses", "prefers", "works_on", "knows", "related_to", "replaced_by", etc.
+     "target_title": str,         # Title of the target page (must already exist)
+     "confidence": float,         # 0-1 confidence in this relation
+     "supersedes": bool           # If true, expire all prior relations of the same type from source
+   }}]
+   - Only emit relations between pages that you know exist (current or just created).
+   - Use "supersedes": true when new information replaces old (e.g. user now prefers Vue over React).
+   - Keep relation_type short and consistent across sessions (reuse the same verbs).
+
+7. "health": {{"loops_detected": bool, "stuck": bool, "recommend_restart": bool, "message": "optional"}}
 
 ## Guidelines
 - **Categorize everything.** Every note should belong to a category. If a category page doesn't exist, create one.
@@ -758,6 +769,41 @@ async def _execute_actions(agent_id: UUID, notebook_id: UUID, config: dict, resu
             )
             for pid_str in source_ids:
                 await notebook_service.delete_page(UUID(pid_str), notebook_id)
+
+    # Extract typed relations
+    for rel in result.get("extract_relations", []):
+        source_title = rel.get("source_title", "").strip()
+        target_title = rel.get("target_title", "").strip()
+        relation_type = rel.get("relation_type", "").strip()
+        if not (source_title and target_title and relation_type):
+            continue
+        confidence = float(rel.get("confidence", 0.8))
+        supersedes = bool(rel.get("supersedes", False))
+
+        source_row = await pool.fetchrow(
+            "SELECT id FROM notebook_pages WHERE notebook_id = $1 AND name = $2",
+            notebook_id, source_title,
+        )
+        target_row = await pool.fetchrow(
+            "SELECT id FROM notebook_pages WHERE notebook_id = $1 AND name = $2",
+            notebook_id, target_title,
+        )
+        if not source_row or not target_row:
+            continue
+
+        source_id = source_row["id"]
+        target_id = target_row["id"]
+        try:
+            await notebook_service.upsert_relation(source_id, relation_type, target_id, confidence)
+            if supersedes:
+                await notebook_service.invalidate_conflicting_relations(
+                    source_id, relation_type, target_id,
+                )
+        except Exception:
+            logger.debug(
+                "Failed to upsert relation %s -[%s]-> %s",
+                source_title, relation_type, target_title, exc_info=True,
+            )
 
     # Delete notes
     for page_id_str in result.get("delete_notes", []):


### PR DESCRIPTION
## Summary

Adds a typed knowledge graph layer on top of the notebook wiki-link graph, and uses 1-hop graph expansion to surface richer context during memory injection.

- **Migration `0003`** — `page_relations` table with `source_page_id`, `relation_type`, `target_page_id`, `confidence`, `valid_from`, `valid_until` for temporal validity
- **`notebook_service`** — `upsert_relation`, `invalidate_conflicting_relations`, `get_page_neighbors` (1-hop traversal), updated `get_page_graph` to return both wiki-link and typed relation edges
- **`sleep_service`** — curation LLM can now emit `extract_relations` actions; executor resolves page titles, upserts relations, and expires superseded ones
- **`injection_service`** — graph expansion step adds 1-hop neighbours of FTS-matched pages as discounted candidates, providing richer contextual injection

## Test plan
- [ ] Run `alembic upgrade head` — migration applies cleanly
- [ ] Sleep agent extracts and stores relations from notebook pages
- [ ] `GET /workspaces/{id}/notebooks/{id}/graph` returns both link and typed relation edges
- [ ] Memory injection includes graph-neighbour pages with discounted scores

Made with [Cursor](https://cursor.com)