### PR TITLE
Readme revamp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Boozle Contributors
+Copyright (c) 2026 Fergana Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ Found a bug? [Open an issue](https://github.com/Fergana-Labs/octopus/issues).
 
 | Name | Role | Contact |
 |------|------|---------|
-| [@triobaba](https://github.com/triobaba) | Creator & lead maintainer | GitHub issues or [security@getoctopus.com](mailto:security@getoctopus.com) for vulnerabilities |
+| [@henry-dowling](https://github.com/henry-dowling) | Lead maintainer | GitHub issues or [security@getoctopus.com](mailto:security@getoctopus.com) for vulnerabilities |
+| [@samzliu](https://github.com/samzliu) | Creator | GitHub issues |
+| [@triobaba](https://github.com/triobaba) | Creator | GitHub issues |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Found a bug? [Open an issue](https://github.com/Fergana-Labs/octopus/issues).
 
 | Name | Role | Contact |
 |------|------|---------|
-| [@henry-dowling](https://github.com/henry-dowling) | Lead maintainer | GitHub issues or [security@getoctopus.com](mailto:security@getoctopus.com) for vulnerabilities |
+| [@henry-dowling](https://github.com/henry-dowling) | Creator & Lead maintainer | GitHub issues or [security@getoctopus.com](mailto:security@getoctopus.com) for vulnerabilities |
 | [@samzliu](https://github.com/samzliu) | Creator | GitHub issues |
 | [@triobaba](https://github.com/triobaba) | Creator | GitHub issues |
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,50 @@
-# Octopus
+<p align="center">
+  <img src="docs/assets/logo.svg" alt="Octopus" width="320" />
+</p>
 
-A centralized, collaborative memory for teams of AI agents.
+<h3 align="center">Collaborative memory for teams of AI agents</h3>
 
-Every Claude Code session, every research paper, every webpage, every conversation — it all goes into one shared knowledge base that any agent on your team can access and learn from. A sleep agent curates it into a searchable wiki with categories, backlinks, and semantic search.
+<p align="center">
+  Every session, paper, webpage, and conversation goes into one shared knowledge base.<br/>
+  A sleep agent curates it into a searchable wiki — so your whole team learns from every agent.
+</p>
 
-## Quickstart
+<p align="center">
+  <a href="https://github.com/Fergana-Labs/octopus/actions/workflows/test.yml"><img src="https://github.com/Fergana-Labs/octopus/actions/workflows/test.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
+  <a href="https://getoctopus.com"><img src="https://img.shields.io/badge/Website-getoctopus.com-F97316" alt="Website" /></a>
+</p>
+
+<!-- TODO: Add product screenshot or GIF here -->
+
+---
+
+## Table of Contents
+
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Integrations](#integrations)
+- [Self-Hosted](#self-hosted)
+- [Documentation](#documentation)
+- [FAQ](#faq)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Features
+
+**Automatic knowledge capture** — The Claude Code plugin streams every tool call, edit, and session into Octopus. No manual effort. Your agents build the knowledge base just by working.
+
+**Sleep agent curation** — A background agent reads new data every 30 minutes and organizes it into a categorized wiki with folders, summaries, and [[backlinks]]. Knowledge stays structured without human maintenance.
+
+**Wiki notebooks** — Rich collaborative pages with [[wiki links]], page graph visualization, backlink tracking, and semantic search powered by pgvector embeddings.
+
+**Universal search** — An agentic search loop that queries across files, history, notebooks, tables, and chats in a single request. Ask a question, get answers from everything.
+
+**Real-time collaboration** — Agents and humans chat side-by-side in workspace channels. Share findings, coordinate work, and keep everyone in sync.
+
+**Shareable pages** — Create HTML documents (reports, dashboards, slide decks) that anyone with a link can view. Turn research into deliverables.
+
+## Quick Start
 
 ### 1. Create an account + persona
 
@@ -42,60 +82,30 @@ Your agent sessions now auto-stream to Octopus. Try these prompts:
 > "Check my Octopus knowledge base — what do we know about authentication patterns?"
 
 **Create a shareable report:**
-> "Create a Octopus page summarizing our key findings on database performance"
+> "Create an Octopus page summarizing our key findings on database performance"
 
 ### 5. The sleep agent curates
 
 Every 30 minutes, a sleep agent reads newly ingested data and organizes it into a categorized wiki with [[backlinks]], folders, and summaries. Configure it on the Personas page.
 
-## How it works
+## Integrations
 
-```
-Claude Code plugin     → Activity streams to Octopus history
-  auto-captures every    → Sleep agent curates into wiki
-  tool call, edit,       → Anyone can search across everything
-  and session
-```
+### Claude Code Plugin
 
-Everything lives in a **workspace** — a permissioned container where multiple agents and humans collaborate.
-
-## What the plugin does
-
-The Octopus Claude Code plugin hooks into your session lifecycle:
+The plugin hooks into your session lifecycle:
 
 | Hook | What it does |
 |------|-------------|
 | **SessionStart** | Loads persona context, injects relevant memory into prompt |
-| **PostToolUse** | Streams every tool call to Octopus history (async, doesn't slow you down) |
+| **PostToolUse** | Streams every tool call to Octopus history (async, non-blocking) |
 | **UserPromptSubmit** | Records prompts for context tracking |
 | **Stop** | Pushes session summary with key findings |
 
 **Skills available in Claude Code:**
-- `/octopus:connect` — connect to a workspace
-- `/octopus:disconnect` — pause activity streaming
-- `/octopus:status` — show connection status
-- `/octopus:sync` — force-refresh local context cache
-- `/octopus:persona` — view or set agent persona
-- `/octopus:config` — view or change config
+`/octopus:connect` · `/octopus:disconnect` · `/octopus:status` · `/octopus:sync` · `/octopus:persona` · `/octopus:config`
 
-## Architecture
+### MCP Server
 
-**Consume** — data flows in
-- **Files** — PDFs, images, documents
-- **History** — agent event logs (every tool call, message, session)
-- **Tables** — structured data with typed columns
-
-**Curate** — auto-organized knowledge
-- **Notebooks** — wiki pages with [[backlinks]], page graph, semantic search
-- **Personas** — sleep agent + notebook, scoped to a workspace
-
-**Collaborate** — team communication
-- **Chats** — real-time messaging, agents alongside humans
-- **Pages** — shareable HTML (reports, dashboards, slide decks)
-
-## Other integrations
-
-### MCP Server (for agents without the plugin)
 ```bash
 # Hosted
 claude mcp add --transport http octopus https://getoctopus.com/mcp \
@@ -107,23 +117,22 @@ claude mcp add -e OCTOPUS_API_KEY=KEY -e OCTOPUS_URL=https://getoctopus.com \
 ```
 
 ### OpenClaw Plugin
+
 ```bash
 openclaw plugin add @octopus/openclaw-octopus
 ```
 
 ### CLI
+
 ```bash
 pip install octopus
-octopus import-bookmarks <file.html>   # Import bookmarks
-octopus history push <content>          # Push an event
-octopus --help                          # Full command list
+octopus import-bookmarks <file.html>   # Import bookmarks with scraping
+octopus search <query>                 # Universal cross-resource search
+octopus history push <content>         # Push an event
+octopus --help                         # Full command list
 ```
 
-## Hosted
-
-[getoctopus.com](https://getoctopus.com) — free to start.
-
-## Self-hosted
+## Self-Hosted
 
 ```bash
 git clone https://github.com/Fergana-Labs/octopus.git
@@ -141,15 +150,30 @@ Includes Caddy for automatic HTTPS. Requires PostgreSQL with pgvector. Optional:
 
 | Document | What it covers |
 |----------|---------------|
-| [Architecture](ARCHITECTURE.md) | System diagram, data model, backend/frontend structure, deployment |
-| [Use Cases](USE_CASES.md) | 7 end-to-end scenarios — team KB, research, multi-agent, self-hosted |
+| [Architecture](ARCHITECTURE.md) | System diagram, data model, backend/frontend structure |
+| [Use Cases](USE_CASES.md) | End-to-end scenarios — team KB, research, multi-agent |
 | [Contributing](CONTRIBUTING.md) | Local dev setup, running tests, submitting PRs |
 | [Design System](DESIGN.md) | Colors, typography, spacing, agent/human visual language |
 | [Testing](TESTING.md) | Test frameworks, suites, conventions |
 | [Security](SECURITY.md) | Vulnerability reporting policy |
 | [Changelog](CHANGELOG.md) | Release history |
 
-In-app docs are available at `/docs` when running the frontend.
+## FAQ
+
+**What LLMs does Octopus use?**
+The sleep agent and universal search use Anthropic Claude. Embeddings use OpenAI `text-embedding-3-small`. You bring your own API keys.
+
+**Can I use this without Claude Code?**
+Yes. The MCP server exposes 30+ tools that work with any MCP-compatible client. The CLI works standalone. The OpenClaw plugin connects to OpenClaw agents.
+
+**Is my data private?**
+On the hosted version, workspaces are permissioned — only invited members can access data. For full control, self-host with Docker Compose and keep everything on your infrastructure.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+
+Found a bug? [Open an issue](https://github.com/Fergana-Labs/octopus/issues).
 
 ## Maintainers
 
@@ -157,8 +181,6 @@ In-app docs are available at `/docs` when running the frontend.
 |------|------|---------|
 | [@triobaba](https://github.com/triobaba) | Creator & lead maintainer | GitHub issues or [security@getoctopus.com](mailto:security@getoctopus.com) for vulnerabilities |
 
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
-
 ## License
 
-MIT
+[MIT](LICENSE) — Copyright (c) 2026 Fergana Labs

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" fill="none">
+  <!-- Octopus icon -->
+  <g transform="translate(10, 8)">
+    <!-- Head -->
+    <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316"/>
+    <!-- Eyes -->
+    <circle cx="25" cy="22" r="4" fill="#fff"/>
+    <circle cx="39" cy="22" r="4" fill="#fff"/>
+    <circle cx="26" cy="22" r="2" fill="#0F172A"/>
+    <circle cx="40" cy="22" r="2" fill="#0F172A"/>
+    <!-- Tentacles -->
+    <path d="M12 38 Q8 52 4 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+    <path d="M20 40 Q18 54 14 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+    <path d="M32 42 Q32 56 32 64" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+    <path d="M44 40 Q46 54 50 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+    <path d="M52 38 Q56 52 60 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  </g>
+  <!-- Wordmark -->
+  <text x="82" y="52" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="42" font-weight="800" fill="#0F172A" letter-spacing="-1.5">Octopus</text>
+</svg>


### PR DESCRIPTION
## Summary

  - Restructure README with centered logo, badge row (CI, license, website), tagline, table of contents, features section, FAQ, and proper doc links
  - Add SVG logo with brand orange octopus icon + wordmark
  - Reframe internal architecture (Consume/Curate/Collaborate) as 6 user-facing features
  - Add inline FAQ (LLMs used, Claude Code requirement, data privacy)
  - Edit maintainers table
  - Update LICENSE copyright from "Boozle Contributors" to "Fergana Labs"