### PR TITLE
chore: drop unused anthropic dep

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,6 @@ httpx>=0.27.0
 bcrypt>=4.0.0
 pycrdt>=0.9.0
 pgvector>=0.3.0
-anthropic>=0.40.0
 slowapi>=0.1.9
 alembic>=1.14.0
 sqlalchemy[asyncio]>=2.0.0


### PR DESCRIPTION
## Summary

PR #25 moved all LLM inference out of the backend (curation + universal search now live in plugin skills). The \`anthropic\` package has zero importers.

Verified:

\`\`\`bash
$ grep -rE '^import anthropic|from anthropic|AsyncAnthropic' .
# no matches
\`\`\`

Stacks on #25. Retargetable to main once #25 lands.

## Test plan

- [ ] \`pip install -r backend/requirements.txt\` succeeds
- [ ] Backend starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)