### PR TITLE
chore: drop dead /mcp/* Caddy handler

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -16,10 +16,6 @@ app.example.com {
         reverse_proxy backend:3456
     }
 
-    handle /mcp/* {
-        reverse_proxy backend:3456
-    }
-
     handle /health {
         reverse_proxy backend:3456
     }


### PR DESCRIPTION
## Summary

PR #25 deleted the MCP server. No backend code serves \`/mcp/*\` anymore, so the reverse_proxy block in the Caddyfile pointed at a dead endpoint.

Verified:

\`\`\`bash
$ grep -rE 'mcp|MCP|/mcp' backend/
# no matches
\`\`\`

Stacks on #25. Retargetable to main once #25 lands.

## Scope note

This PR leaves \`/ws/*\` alone. That handler is removed in #26 (kill-yjs), where the WebSocket path itself goes away. Keeping these as separate PRs so each can land independently.

## Test plan

- [ ] \`caddy validate --config Caddyfile\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)