### PR TITLE
Auto-curate wiki on SessionEnd via headless claude

### DIFF
--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -44,6 +44,13 @@
       "type": "string",
       "default": "true",
       "sensitive": false
+    },
+    "auto_curate": {
+      "title": "Auto-curate Wiki",
+      "description": "Run /octopus:sleep headless at session end to re-index history into wiki pages (true/false, default true)",
+      "type": "string",
+      "default": "true",
+      "sensitive": false
     }
   },
   "skills": "./skills/",

--- a/plugins/claude-plugin/hooks/hooks.json
+++ b/plugins/claude-plugin/hooks/hooks.json
@@ -43,6 +43,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_session_end.py",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -57,6 +57,7 @@ def get_config() -> dict:
             "workspace_id": cli.get("default_workspace", ""),
             "history_store_id": cli.get("default_store", ""),
             "inject_context": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_inject_context", "true"),
+            "auto_curate": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_auto_curate", "true"),
         }
 
     return {
@@ -66,6 +67,7 @@ def get_config() -> dict:
         "workspace_id": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_workspace_id", ""),
         "history_store_id": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_history_store_id", ""),
         "inject_context": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_inject_context", "true"),
+        "auto_curate": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_auto_curate", "true"),
     }
 
 

--- a/plugins/claude-plugin/scripts/on_session_end.py
+++ b/plugins/claude-plugin/scripts/on_session_end.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""SessionEnd hook: spawn a headless `claude -p /octopus:sleep` to re-index the wiki.
+
+Runs detached so it doesn't block session teardown. Gated by the `auto_curate`
+config flag, a cooldown, and a recursion guard (OCTOPUS_SKIP_AUTO_CURATE=1) so
+the spawned sleep session doesn't re-trigger itself.
+"""
+
+import os
+import sys
+import time
+import shutil
+import subprocess
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import get_config, is_configured, load_state, save_state
+
+COOLDOWN_SECONDS = 30 * 60  # skip if we curated in the last 30 min
+
+
+def main():
+    # Recursion guard: the headless `claude -p` we spawn will itself fire SessionEnd.
+    if os.environ.get("OCTOPUS_SKIP_AUTO_CURATE") == "1":
+        return
+
+    if not is_configured():
+        return
+
+    cfg = get_config()
+    if str(cfg.get("auto_curate", "true")).lower() != "true":
+        return
+
+    if not cfg["workspace_id"] or not cfg["history_store_id"]:
+        return
+
+    state = load_state()
+    if not state.get("streaming_enabled", True):
+        return
+
+    now = time.time()
+    last = state.get("last_curate_at", 0) or 0
+    if now - last < COOLDOWN_SECONDS:
+        return
+
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return
+
+    env = os.environ.copy()
+    env["OCTOPUS_SKIP_AUTO_CURATE"] = "1"
+
+    # Detach: new session, stdio to /dev/null, no wait. Fire-and-forget.
+    try:
+        subprocess.Popen(
+            [claude_bin, "-p", "/octopus:sleep"],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception:
+        return
+
+    state["last_curate_at"] = now
+    save_state(state)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `SessionEnd` hook spawns `claude -p /octopus:sleep` detached so the user's own coding agent re-indexes the wiki after every session (bring-your-own memory management).
- New `auto_curate` plugin userConfig (default `true`) — users opt out rather than opt in
- 30-min cooldown + `OCTOPUS_SKIP_AUTO_CURATE=1` recursion guard so the spawned sleep session doesn't re-trigger itself.

## Files
- `plugins/claude-plugin/hooks/hooks.json` — register `SessionEnd`
- `plugins/claude-plugin/.claude-plugin/plugin.json` — add `auto_curate` userConfig
- `plugins/claude-plugin/scripts/config.py` — surface `auto_curate` env var in `get_config()`
- `plugins/claude-plugin/scripts/on_session_end.py` — new detached-spawn script

## Test plan
- [ ] Fresh install: verify `auto_curate` defaults to `true` in plugin config UI
- [ ] End a session with events; confirm a background `claude -p /octopus:sleep` starts and wiki pages get created/updated
- [ ] End a second session <30 min later; confirm cooldown skips the re-curate
- [ ] Inspect the spawned sleep session's own SessionEnd; confirm `OCTOPUS_SKIP_AUTO_CURATE=1` prevents recursion
- [ ] Set `auto_curate=false`; confirm no spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)