### PR TITLE
Auto-provision default workspace on first login

### DIFF
--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -36,10 +36,13 @@ async def register_user(
 
     # Auto-provision a default workspace for new humans. Agent/persona users
     # get their workspaces via the persona flow, so skip them here.
+    # workspaces.name is VARCHAR(128); trim the display so the suffix always fits.
     if user_type == "human":
         from . import workspace_service
+        suffix = "'s Workspace"
+        ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"
         await workspace_service.create_workspace(
-            name=f"{user['display_name']}'s Workspace",
+            name=ws_name,
             description="",
             creator_id=user["id"],
             is_public=False,

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -32,7 +32,19 @@ async def register_user(
         if "unique" in str(e).lower() and "name" in str(e).lower():
             raise ValueError(f"Username '{name}' is already taken")
         raise
-    return dict(row), api_key
+    user = dict(row)
+
+    # Auto-provision a default workspace for new humans. Agent/persona users
+    # get their workspaces via the persona flow, so skip them here.
+    if user_type == "human":
+        from . import workspace_service
+        await workspace_service.create_workspace(
+            name=f"{user['display_name']}'s Workspace",
+            description="",
+            creator_id=user["id"],
+            is_public=False,
+        )
+    return user, api_key
 
 
 async def get_user_by_id(user_id: UUID) -> dict | None:

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -55,8 +55,20 @@ async def test_list_my_workspaces(client: AsyncClient):
 
     resp = await client.get("/api/v1/workspaces/mine", headers=h)
     assert resp.status_code == 200
+    # Registration auto-provisions a default workspace, so WS1/WS2 come alongside it.
     names = {w["name"] for w in resp.json()["workspaces"]}
-    assert names == {"WS1", "WS2"}
+    assert {"WS1", "WS2"}.issubset(names)
+
+
+@pytest.mark.asyncio
+async def test_registration_auto_provisions_default_workspace(client: AsyncClient):
+    key, body = await _register(client)
+    resp = await client.get("/api/v1/workspaces/mine", headers=_auth(key))
+    assert resp.status_code == 200
+    workspaces = resp.json()["workspaces"]
+    assert len(workspaces) == 1
+    assert workspaces[0]["name"] == f"{body['display_name']}'s Workspace"
+    assert workspaces[0]["member_count"] == 1
 
 
 # --- Invite flow ---


### PR DESCRIPTION
## Summary
- New users land in an empty UI after signup; they have to manually create a workspace before doing anything useful. Give them one up front.
- `register_user` (the `POST /api/v1/users/register` path) now auto-creates `"<display>'s Workspace"` for `type="human"` registrations. Agent/persona users still get workspaces via the persona flow.
- Workspace name is trimmed to `128 - len("'s Workspace")` before formatting so a max-length display_name never overflows `workspaces.name VARCHAR(128)` and leaves a half-provisioned account.

## Notes
- Rebased onto current main (which removed the Auth0 integration), so the earlier Auth0 JIT hook + `test_auth0.py` changes are gone — only the email/password path remains.

## Test plan
- [x] `test_registration_auto_provisions_default_workspace` — `/users/register` leaves the new user with exactly one workspace as owner
- [x] Updated `test_list_my_workspaces` to tolerate the auto-provisioned workspace
- [ ] Manual: register a fresh account, confirm a workspace appears without any extra clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)