### PR TITLE
chore: rename boozle to octopus

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,14 @@
 {
-  "name": "boozle-plugins",
+  "name": "octopus-plugins",
   "owner": {
     "name": "Fergana Labs",
     "email": "support@ferganalabs.com"
   },
   "plugins": [
     {
-      "name": "boozle",
+      "name": "octopus",
       "source": "./plugins/claude-plugin",
-      "description": "Connect Claude Code to Boozle — stream activity to history, inject agent persona/memory, collaborate in workspaces.",
+      "description": "Connect Claude Code to Octopus — stream activity to history, inject agent persona/memory, collaborate in workspaces.",
       "version": "0.1.0",
       "author": {
         "name": "Fergana Labs"

--- a/cli/scraper.py
+++ b/cli/scraper.py
@@ -24,7 +24,7 @@ from .bookmark_parser import Bookmark
 
 logger = logging.getLogger(__name__)
 
-_USER_AGENT = "Mozilla/5.0 (compatible; Octopus/1.0; +https://getboozle.com)"
+_USER_AGENT = "Mozilla/5.0 (compatible; Octopus/1.0; +https://getoctopus.com)"
 
 _YOUTUBE_PATTERNS = [
     re.compile(r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([a-zA-Z0-9_-]{11})"),


### PR DESCRIPTION
## Summary
- Rename marketplace plugin identifier `boozle` → `octopus` (and `boozle-plugins` → `octopus-plugins`) in `.claude-plugin/marketplace.json`
- Update scraper User-Agent URL from `getboozle.com` → `getoctopus.com` in `cli/scraper.py`

Note: the openclaw plugin's `package-lock.json` also had `@boozle/` references, but that plugin was removed in 46cb47f so no change is needed there.

## Heads-up
- Renaming the plugin changes its public identifier — anyone who installed it as `boozle` will need to reinstall as `octopus`.
- `getoctopus.com` is a literal swap of the old domain. If the real marketing URL is different, update `cli/scraper.py:27`.

## Test plan
- [ ] Confirm `getoctopus.com` is the intended URL (or pick the right one)
- [ ] Reinstall the plugin under the new name in a Claude Code marketplace test
- [ ] `grep -ri boozle .` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)