### PR TITLE
Project-level config scope for hooks (overrides user-level)

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -1,11 +1,26 @@
-"""Auth credential and config storage for the octopus CLI."""
+"""Auth credential and config storage for the octopus CLI.
+
+Config lives in two scopes:
+- user:    ~/.octopus/config.json  (applies everywhere)
+- project: <repo>/.octopus/config.json  (overrides user-level when present)
+
+Project lookup walks up from cwd. Project values override user values.
+Auth (api_key, username) is always stored at user scope — it's per-machine,
+not per-repo.
+"""
 
 import json
 import os
 from pathlib import Path
+from typing import Literal
 
-CONFIG_DIR = Path.home() / ".octopus"
-CONFIG_FILE = CONFIG_DIR / "config.json"
+USER_CONFIG_DIR = Path.home() / ".octopus"
+USER_CONFIG_FILE = USER_CONFIG_DIR / "config.json"
+
+PROJECT_DIRNAME = ".octopus"
+PROJECT_FILENAME = "config.json"
+
+Scope = Literal["user", "project"]
 
 DEFAULT_CONFIG = {
     "base_url": "http://localhost:3456",
@@ -18,16 +33,38 @@ DEFAULT_CONFIG = {
     "notify_rooms": [],
 }
 
+# Keys that are always user-scoped regardless of requested scope.
+AUTH_KEYS = {"api_key", "username"}
+
+
+def find_project_config(start: Path | None = None) -> Path | None:
+    """Walk up from cwd looking for .octopus/config.json. Return path or None."""
+    cur = (start or Path.cwd()).resolve()
+    for parent in [cur, *cur.parents]:
+        candidate = parent / PROJECT_DIRNAME / PROJECT_FILENAME
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
 
 def load_config() -> dict:
-    """Load config, with env var overrides."""
+    """Load config. Project-level overrides user-level. Env vars override both."""
     cfg = dict(DEFAULT_CONFIG)
-    if CONFIG_FILE.exists():
-        try:
-            cfg.update(json.loads(CONFIG_FILE.read_text()))
-        except (json.JSONDecodeError, OSError):
-            pass
-    # Env var overrides
+
+    if USER_CONFIG_FILE.exists():
+        cfg.update(_read_json(USER_CONFIG_FILE))
+
+    project_path = find_project_config()
+    if project_path:
+        cfg.update(_read_json(project_path))
+
     if url := os.environ.get("OCTOPUS_URL"):
         cfg["base_url"] = url
     if key := os.environ.get("OCTOPUS_API_KEY"):
@@ -35,7 +72,27 @@ def load_config() -> dict:
     return cfg
 
 
+def _path_for_scope(scope: Scope) -> Path:
+    if scope == "user":
+        return USER_CONFIG_FILE
+    existing = find_project_config()
+    if existing:
+        return existing
+    return Path.cwd() / PROJECT_DIRNAME / PROJECT_FILENAME
+
+
+def _write_to(path: Path, updates: dict) -> None:
+    existing = _read_json(path) if path.exists() else {}
+    for key, val in updates.items():
+        if val is not None:
+            existing[key] = val
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(existing, indent=2) + "\n")
+
+
 def save_config(
+    *,
+    scope: Scope = "user",
     base_url: str | None = None,
     api_key: str | None = None,
     username: str | None = None,
@@ -45,53 +102,58 @@ def save_config(
     output_format: str | None = None,
     notify_rooms: list[str] | None = None,
 ) -> None:
-    """Save config, merging with existing values."""
-    cfg = load_config()
-    if base_url is not None:
-        cfg["base_url"] = base_url
-    if api_key is not None:
-        cfg["api_key"] = api_key
-    if username is not None:
-        cfg["username"] = username
-    if default_workspace is not None:
-        cfg["default_workspace"] = default_workspace
-    if default_chat is not None:
-        cfg["default_chat"] = default_chat
-    if default_store is not None:
-        cfg["default_store"] = default_store
-    if output_format is not None:
-        cfg["output_format"] = output_format
-    if notify_rooms is not None:
-        cfg["notify_rooms"] = notify_rooms
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    CONFIG_FILE.write_text(json.dumps(cfg, indent=2) + "\n")
+    """Save config to the chosen scope.
+
+    Auth keys (api_key, username) are always written to the user scope even if
+    scope='project' — auth is per-machine, not per-repo.
+    """
+    all_updates = {
+        "base_url": base_url,
+        "api_key": api_key,
+        "username": username,
+        "default_workspace": default_workspace,
+        "default_chat": default_chat,
+        "default_store": default_store,
+        "output_format": output_format,
+        "notify_rooms": notify_rooms,
+    }
+
+    auth_updates = {k: v for k, v in all_updates.items() if k in AUTH_KEYS}
+    other_updates = {k: v for k, v in all_updates.items() if k not in AUTH_KEYS}
+
+    if any(v is not None for v in auth_updates.values()):
+        _write_to(USER_CONFIG_FILE, auth_updates)
+
+    if any(v is not None for v in other_updates.values()):
+        _write_to(_path_for_scope(scope), other_updates)
 
 
-def clear_config() -> None:
-    """Remove stored config."""
-    if CONFIG_FILE.exists():
-        CONFIG_FILE.unlink()
+def clear_config(scope: Scope = "user") -> None:
+    """Remove stored config for the given scope."""
+    if scope == "user":
+        if USER_CONFIG_FILE.exists():
+            USER_CONFIG_FILE.unlink()
+        return
+    project_path = find_project_config()
+    if project_path and project_path.exists():
+        project_path.unlink()
 
 
 def get_notify_rooms() -> list[str]:
-    """Get list of rooms subscribed for notifications."""
-    cfg = load_config()
-    return cfg.get("notify_rooms", [])
+    return load_config().get("notify_rooms", [])
 
 
 def add_notify_room(room_id: str) -> None:
-    """Subscribe to notifications for a room."""
-    cfg = load_config()
-    rooms = cfg.get("notify_rooms", [])
-    if room_id not in rooms:
-        rooms.append(room_id)
-        save_config(notify_rooms=rooms)
+    rooms = get_notify_rooms()
+    if room_id in rooms:
+        return
+    rooms.append(room_id)
+    save_config(notify_rooms=rooms)
 
 
 def remove_notify_room(room_id: str) -> None:
-    """Unsubscribe from notifications for a room."""
-    cfg = load_config()
-    rooms = cfg.get("notify_rooms", [])
-    if room_id in rooms:
-        rooms.remove(room_id)
-        save_config(notify_rooms=rooms)
+    rooms = get_notify_rooms()
+    if room_id not in rooms:
+        return
+    rooms.remove(room_id)
+    save_config(notify_rooms=rooms)

--- a/cli/main.py
+++ b/cli/main.py
@@ -857,12 +857,20 @@ def setup():
     """Interactive first-time setup. Sets base URL, authenticates, and configures defaults."""
     console.print("\n[bold]Octopus setup[/bold]  (press Enter to accept defaults)\n")
 
+    # --- Step 0: Scope ---
+    console.print("[bold]Config scope[/bold]")
+    console.print("  [bold]project[/bold]  save to [cyan].octopus/config.json[/cyan] in this repo (overrides user config)")
+    console.print("  [bold]user[/bold]     save to [cyan]~/.octopus/config.json[/cyan] (applies everywhere)")
+    console.print("  [dim]Auth (api_key) always goes to user scope — it's per-machine.[/dim]")
+    scope_input = typer.prompt("Scope", default="project").strip().lower()
+    scope = "project" if scope_input.startswith("p") else "user"
+
     # --- Step 1: API endpoint ---
     cfg = load_config()
     current_url = cfg.get("base_url", "http://localhost:3456")
     default_url = "https://getoctopus.com" if "localhost" in current_url else current_url
     base_url = typer.prompt("API endpoint", default=default_url).rstrip("/")
-    save_config(base_url=base_url)
+    save_config(base_url=base_url, scope=scope)
 
     # --- Step 2: Auth ---
     has_key = bool(cfg.get("api_key"))
@@ -928,13 +936,13 @@ def setup():
             is_uuid = bool(re.match(r"^[0-9a-f-]{32,36}$", ws_action, re.I))
             if is_uuid:
                 workspace_id = ws_action
-                save_config(default_workspace=workspace_id)
+                save_config(default_workspace=workspace_id, scope=scope)
                 console.print(f"  [green]✓[/green] Default workspace set to [bold]{workspace_id[:8]}…[/bold]")
             else:
                 try:
                     ws_data = c.create_workspace(ws_action)
                     workspace_id = str(ws_data["id"])
-                    save_config(default_workspace=workspace_id)
+                    save_config(default_workspace=workspace_id, scope=scope)
                     console.print(f"  [green]✓[/green] Created workspace [bold]{ws_data['name']}[/bold]  invite: {ws_data['invite_code']}")
                 except OctopusError as e:
                     console.print(f"[red]Could not create workspace: {e.detail}[/red]")
@@ -960,12 +968,12 @@ def setup():
 
             is_uuid = bool(re.match(r"^[0-9a-f-]{32,36}$", store_action, re.I))
             if is_uuid:
-                save_config(default_store=store_action)
+                save_config(default_store=store_action, scope=scope)
                 console.print(f"  [green]✓[/green] Default store set to [bold]{store_action[:8]}…[/bold]")
             else:
                 try:
                     store_data = c.create_history(workspace_id, store_action)
-                    save_config(default_store=str(store_data["id"]))
+                    save_config(default_store=str(store_data["id"]), scope=scope)
                     console.print(f"  [green]✓[/green] Created history store [bold]{store_data['name']}[/bold]")
                 except OctopusError as e:
                     console.print(f"[red]Could not create history store: {e.detail}[/red]")
@@ -982,22 +990,42 @@ def setup():
 # ===========================================================================
 
 @app.command("config")
-def config_cmd(key: Optional[str] = typer.Argument(None), value: Optional[str] = typer.Argument(None)):
-    """Show or set config. Keys: base_url, default_workspace, default_store, output_format."""
+def config_cmd(
+    key: Optional[str] = typer.Argument(None),
+    value: Optional[str] = typer.Argument(None),
+    project: bool = typer.Option(False, "--project", help="Write to project-level config (.octopus/config.json in the repo)."),
+):
+    """Show or set config. Keys: base_url, default_workspace, default_store, output_format.
+
+    By default writes to ~/.octopus/config.json. Pass --project to write to
+    .octopus/config.json in the current project (created if missing). Project
+    config overrides user config when both exist.
+    """
+    from .config import find_project_config, USER_CONFIG_FILE
+
     if key and value:
-        cfg = load_config()
-        cfg[key] = value
-        save_config(**{k: v for k, v in cfg.items() if k in [
-            "base_url", "api_key", "username", "default_workspace", "default_chat",
-            "default_store", "output_format", "public_url",
-        ]})
-        console.print(f"[green]{key} = {value}[/green]")
-    else:
-        cfg = load_config()
-        display = dict(cfg)
-        if display.get("api_key"):
-            display["api_key"] = display["api_key"][:10] + "..."
-        console.print(json.dumps(display, indent=2, default=str))
+        scope = "project" if project else "user"
+        allowed = {
+            "base_url", "default_workspace", "default_chat",
+            "default_store", "output_format",
+        }
+        if key not in allowed and key not in {"api_key", "username"}:
+            console.print(f"[red]Unknown config key: {key}[/red]")
+            raise typer.Exit(1)
+        save_config(**{key: value, "scope": scope})
+        target = "project" if project else "user"
+        console.print(f"[green]{key} = {value}[/green]  [dim](scope: {target})[/dim]")
+        return
+
+    cfg = load_config()
+    display = dict(cfg)
+    if display.get("api_key"):
+        display["api_key"] = display["api_key"][:10] + "..."
+
+    project_path = find_project_config()
+    console.print(f"[dim]user:    {USER_CONFIG_FILE}[/dim]")
+    console.print(f"[dim]project: {project_path or '(none — project config not set)'}[/dim]\n")
+    console.print(json.dumps(display, indent=2, default=str))
 
 
 # ===========================================================================

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -30,15 +30,37 @@ def get_stdin_data() -> dict:
         return {}
 
 
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def _find_project_config() -> Path | None:
+    """Walk up from cwd looking for .octopus/config.json."""
+    try:
+        cur = Path.cwd().resolve()
+    except Exception:
+        return None
+    for parent in [cur, *cur.parents]:
+        candidate = parent / ".octopus" / "config.json"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _load_cli_config() -> dict:
-    """Load CLI config from ~/.octopus/config.json as fallback."""
-    cli_config = Path.home() / ".octopus" / "config.json"
-    if cli_config.exists():
-        try:
-            return json.loads(cli_config.read_text())
-        except Exception:
-            pass
-    return {}
+    """Load CLI config. Project-level (.octopus/config.json walking up from cwd)
+    overrides user-level (~/.octopus/config.json)."""
+    merged: dict = {}
+    user_path = Path.home() / ".octopus" / "config.json"
+    if user_path.exists():
+        merged.update(_read_json(user_path))
+    project_path = _find_project_config()
+    if project_path:
+        merged.update(_read_json(project_path))
+    return merged
 
 
 def get_config() -> dict:

--- a/plugins/claude-plugin/skills/connect/SKILL.md
+++ b/plugins/claude-plugin/skills/connect/SKILL.md
@@ -18,29 +18,37 @@ The `octopus` CLI must be installed (`pip install -e .` from the octopus repo, o
    - If that fails, try `pip install octopus` (from PyPI)
    - Verify with `which octopus` again. If still not found, tell the user to install manually and stop.
 
-2. **Check current config**: Run `octopus config` to see if credentials are already set. Also check plugin state at `~/.claude/plugins/data/octopus/state.json`.
+2. **Check current config**: Run `octopus config` to see if credentials are already set, which scope they're in, and whether a project config already exists. Also check plugin state at `~/.claude/plugins/data/octopus/state.json`.
 
-3. **Register or authenticate**: If no API key is configured:
+3. **Pick a config scope**: Ask the user where to save workspace/store defaults:
+   - **project** (default): saves to `.octopus/config.json` in the current repo. Hooks only fire with these settings when Claude runs inside this repo. Good for per-project workspaces and keeping other repos untouched.
+   - **user**: saves to `~/.octopus/config.json`. Hooks fire with these settings in every Claude session on this machine.
+   - Project config overrides user config when both exist.
+   - Auth (`api_key`) is always stored at user scope regardless of choice — it's per-machine.
+   - Remember the chosen scope — pass `--project` to `octopus config` calls below if the user picked project scope.
+   - If project scope: remind the user to add `.octopus/` to their `.gitignore` if they don't want the config committed.
+
+4. **Register or authenticate**: If no API key is configured:
    - Ask if they have an existing Octopus account or need to create one
    - To register: `octopus register <agent_name> --description "description" --json`
-   - This stores the API key in `~/.octopus/config.json` automatically
+   - This stores the API key in `~/.octopus/config.json` automatically (user scope)
    - To use an existing key: `octopus auth <api_endpoint> --api-key <key>`
 
-4. **Verify connection**: `octopus whoami`
+5. **Verify connection**: `octopus whoami`
 
-5. **Pick a workspace**:
+6. **Pick a workspace**:
    - List workspaces: `octopus workspaces list --mine --json`
    - If none, create one: `octopus workspaces create "workspace-name" --json`
-   - Set as default: `octopus config default_workspace <workspace_id>`
+   - Set as default (add `--project` if project scope was chosen): `octopus config default_workspace <workspace_id> [--project]`
 
-6. **Create history store**:
+7. **Create history store**:
    - List existing: `octopus history list --ws <workspace_id> --json`
    - Create if needed: `octopus history create "<agent_name>-activity" --ws <workspace_id> --json`
-   - Set as default: `octopus config default_store <store_id>`
+   - Set as default (add `--project` if project scope was chosen): `octopus config default_store <store_id> [--project]`
 
-7. **Update plugin config**: Tell the user to update their Octopus plugin settings with the workspace_id and history_store_id values.
+8. **Update plugin config**: Tell the user to update their Octopus plugin settings with the workspace_id and history_store_id values.
 
-8. **Test connectivity**: Push a test event:
+9. **Test connectivity**: Push a test event:
    `octopus history push --ws <workspace_id> --store <store_id> --agent <agent_name> --type session_start --content "Octopus plugin connected successfully."`
 
-9. **Confirm**: Report success and summarize the configuration.
+10. **Confirm**: Report success and summarize the configuration, including which scope (project or user) the workspace/store settings were saved to.


### PR DESCRIPTION
## Summary
- Adds a user-vs-project choice to `octopus setup` and `/octopus:connect` so hook behavior can be scoped to a single repo.
- Project config lives at `.octopus/config.json`, discovered by walking up from cwd; overrides `~/.octopus/config.json` when both exist.
- Auth (`api_key`, `username`) is always written to user scope — it's per-machine, not per-repo.

## Why
Hooks in `plugins/claude-plugin/hooks/hooks.json` fire in every Claude Code session on the machine (including the auto-curation spawn in `on_session_end.py`). Until now there was no way to scope which `workspace_id` / `history_store_id` they target. This adds a per-repo override without breaking the existing "set-and-forget" user-level behavior.

## Changes
- `cli/config.py` — layer user + project; `save_config(..., scope=...)` routes writes; auth keys always pinned to user scope.
- `cli/main.py` — setup wizard adds Step 0 (scope prompt, default `project`); `octopus config <k> <v>` gets a `--project` flag; `octopus config` (no args) shows which scope files are active.
- `plugins/claude-plugin/scripts/config.py` — same layering in the hook loader so hooks pick up the right workspace/store based on cwd.
- `plugins/claude-plugin/skills/connect/SKILL.md` — onboarding asks scope and threads `--project` through subsequent `octopus config` calls.

## Test plan
- [ ] `octopus setup` in a fresh repo, pick `project` — verify `.octopus/config.json` is created with `default_workspace`/`default_store` and `~/.octopus/config.json` only holds auth.
- [ ] `octopus setup` in another repo, pick `user` — verify values land in `~/.octopus/config.json`.
- [ ] `octopus config` shows both paths and the merged view.
- [ ] `octopus config default_workspace <id> --project` writes to the repo's `.octopus/config.json`.
- [ ] Run a Claude session inside a repo with project config — confirm hooks push events to the project workspace.
- [ ] Run a Claude session outside that repo — confirm hooks fall back to user-level config.
- [ ] `/octopus:connect` walks through the scope question and completes onboarding end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)