### PR TITLE
docs: instruct agents to share GitHub + Assert review links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,4 +12,7 @@ If you are about to ask the user to do something for you, think about whether yo
 
 Previous Claude coding sessions are stored as `.jsonl` files in your ~/.claude file. Read these to understand prior decisions, debugging sessions, and context that isn't in git history.
 
+When you create or update a PR, share both the GitHub link and the Assert review link with the user at the end of your session:
 
+- GitHub: `https://github.com/Assert-Labs/assert/pull/<number>`
+- Assert: `https://app.assert.dev/review/github/Assert-Labs/assert/<number>`


### PR DESCRIPTION
## Summary
- Adds a line to `CLAUDE.md` instructing agents to share both the GitHub PR URL and the Assert review URL at the end of any session where they open or update a PR.

## Test plan
- [ ] Next time an agent opens a PR, confirm it surfaces both links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)