### PR TITLE
remove workspace isolation footguns

### DIFF
--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -71,7 +71,7 @@ async def query_ws_events(
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
-    events, has_more = await memory_service.query_events(
+    events, has_more = await memory_service.query_workspace_events(
         workspace_id, agent_name=agent_name, session_id=session_id,
         event_type=event_type, after=after, before=before, limit=limit,
     )
@@ -89,7 +89,7 @@ async def search_ws_events(
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
-    events = await memory_service.search_events(workspace_id, q, limit=limit)
+    events = await memory_service.search_workspace_events(workspace_id, q, limit=limit)
     return HistoryEventListResponse(
         events=[HistoryEventResponse(**e) for e in events],
         has_more=False,
@@ -102,7 +102,7 @@ async def get_ws_event(
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
-    event = await memory_service.get_event(event_id, workspace_id)
+    event = await memory_service.get_workspace_event(event_id, workspace_id)
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     return HistoryEventResponse(**event)
@@ -115,7 +115,7 @@ async def delete_ws_agent(
 ):
     """Delete all events for an agent in this workspace."""
     await _check_member(workspace_id, current_user["id"])
-    await memory_service.delete_agent_events(agent_name, workspace_id=workspace_id)
+    await memory_service.delete_workspace_agent_events(agent_name, workspace_id)
 
 
 @ws_router.get("/agent-names")
@@ -144,7 +144,7 @@ async def delete_personal_agent(
     current_user: dict = Depends(get_current_user),
 ):
     """Delete all personal events for an agent."""
-    await memory_service.delete_agent_events(agent_name, user_id=current_user["id"])
+    await memory_service.delete_personal_agent_events(agent_name, current_user["id"])
 
 
 @personal_router.post("/events", response_model=HistoryEventResponse, status_code=201)
@@ -182,8 +182,8 @@ async def query_personal_events(
     limit: int = Query(50, ge=1, le=200),
     current_user: dict = Depends(get_current_user),
 ):
-    events, has_more = await memory_service.query_events(
-        None, user_id=current_user["id"],
+    events, has_more = await memory_service.query_personal_events(
+        current_user["id"],
         agent_name=agent_name, session_id=session_id,
         event_type=event_type, after=after, before=before, limit=limit,
     )
@@ -199,8 +199,8 @@ async def search_personal_events(
     limit: int = Query(50, ge=1, le=200),
     current_user: dict = Depends(get_current_user),
 ):
-    events = await memory_service.search_events(
-        None, q, user_id=current_user["id"], limit=limit,
+    events = await memory_service.search_personal_events(
+        current_user["id"], q, limit=limit,
     )
     return HistoryEventListResponse(
         events=[HistoryEventResponse(**e) for e in events],
@@ -213,7 +213,7 @@ async def get_personal_event(
     event_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
-    event = await memory_service.get_event(event_id)
-    if not event or (event.get("workspace_id") is not None) or (event.get("created_by") != current_user["id"]):
+    event = await memory_service.get_personal_event(event_id, current_user["id"])
+    if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     return HistoryEventResponse(**event)

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -111,47 +111,38 @@ async def push_events_batch(
     return results
 
 
-async def get_event(event_id: UUID, workspace_id: UUID | None = None) -> dict | None:
+async def get_workspace_event(event_id: UUID, workspace_id: UUID) -> dict | None:
     pool = get_pool()
-    if workspace_id is not None:
-        row = await pool.fetchrow(
-            "SELECT * FROM history_events WHERE id = $1 AND workspace_id = $2",
-            event_id, workspace_id,
-        )
-    else:
-        row = await pool.fetchrow(
-            "SELECT * FROM history_events WHERE id = $1",
-            event_id,
-        )
+    row = await pool.fetchrow(
+        "SELECT * FROM history_events WHERE id = $1 AND workspace_id = $2",
+        event_id, workspace_id,
+    )
     return dict(row) if row else None
 
 
-async def query_events(
-    workspace_id: UUID | None,
-    user_id: UUID | None = None,
-    agent_name: str | None = None,
-    session_id: str | None = None,
-    event_type: str | None = None,
-    after: str | None = None,
-    before: str | None = None,
-    limit: int = 50,
-) -> tuple[list[dict], bool]:
-    """Query events with filters. Returns (events, has_more)."""
+async def get_personal_event(event_id: UUID, user_id: UUID) -> dict | None:
     pool = get_pool()
-    limit = min(limit, 200)
+    row = await pool.fetchrow(
+        "SELECT * FROM history_events "
+        "WHERE id = $1 AND workspace_id IS NULL AND created_by = $2",
+        event_id, user_id,
+    )
+    return dict(row) if row else None
 
-    conditions: list[str] = []
-    args: list = []
-    idx = 1
 
-    if workspace_id is not None:
-        conditions.append(f"workspace_id = ${idx}")
-        args.append(workspace_id)
-        idx += 1
-    elif user_id is not None:
-        conditions.append(f"workspace_id IS NULL AND created_by = ${idx}")
-        args.append(user_id)
-        idx += 1
+def _build_event_filters(
+    base_condition: str,
+    base_args: list,
+    agent_name: str | None,
+    session_id: str | None,
+    event_type: str | None,
+    after: str | None,
+    before: str | None,
+) -> tuple[str, list, int]:
+    """Append optional filters to a base scope condition. Returns (where, args, next_idx)."""
+    conditions = [base_condition]
+    args = list(base_args)
+    idx = len(args) + 1
 
     if agent_name:
         conditions.append(f"agent_name = ${idx}")
@@ -174,17 +165,21 @@ async def query_events(
         args.append(before)
         idx += 1
 
-    where = " AND ".join(conditions) if conditions else "TRUE"
-    args.append(limit + 1)
+    return " AND ".join(conditions), args, idx
 
+
+async def _query_events(
+    where: str, args: list, limit_idx: int, limit: int,
+) -> tuple[list[dict], bool]:
+    pool = get_pool()
+    args = [*args, limit + 1]
     rows = await pool.fetch(
         f"SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
         f"tool_name, content, metadata, attachments, created_at "
         f"FROM history_events WHERE {where} "
-        f"ORDER BY created_at ASC LIMIT ${idx}",
+        f"ORDER BY created_at ASC LIMIT ${limit_idx}",
         *args,
     )
-
     events = [dict(r) for r in rows]
     has_more = len(events) > limit
     if has_more:
@@ -192,65 +187,112 @@ async def query_events(
     return events, has_more
 
 
-async def search_events(
-    workspace_id: UUID | None, query: str, user_id: UUID | None = None, limit: int = 50,
+async def query_workspace_events(
+    workspace_id: UUID,
+    agent_name: str | None = None,
+    session_id: str | None = None,
+    event_type: str | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    limit: int = 50,
+) -> tuple[list[dict], bool]:
+    """Query events in a workspace. Returns (events, has_more)."""
+    limit = min(limit, 200)
+    where, args, next_idx = _build_event_filters(
+        "workspace_id = $1", [workspace_id],
+        agent_name, session_id, event_type, after, before,
+    )
+    return await _query_events(where, args, next_idx, limit)
+
+
+async def query_personal_events(
+    user_id: UUID,
+    agent_name: str | None = None,
+    session_id: str | None = None,
+    event_type: str | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    limit: int = 50,
+) -> tuple[list[dict], bool]:
+    """Query personal (non-workspace) events for a user. Returns (events, has_more)."""
+    limit = min(limit, 200)
+    where, args, next_idx = _build_event_filters(
+        "workspace_id IS NULL AND created_by = $1", [user_id],
+        agent_name, session_id, event_type, after, before,
+    )
+    return await _query_events(where, args, next_idx, limit)
+
+
+async def search_workspace_events(
+    workspace_id: UUID, query: str, limit: int = 50,
 ) -> list[dict]:
-    """Full-text search on events."""
+    """Full-text search on workspace events."""
     pool = get_pool()
     limit = min(limit, 200)
-
-    if workspace_id is not None:
-        rows = await pool.fetch(
-            "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
-            "tool_name, content, metadata, attachments, created_at, "
-            "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
-            "FROM history_events "
-            "WHERE workspace_id = $1 AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
-            "ORDER BY rank DESC LIMIT $3",
-            workspace_id, query, limit,
-        )
-    else:
-        rows = await pool.fetch(
-            "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
-            "tool_name, content, metadata, attachments, created_at, "
-            "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
-            "FROM history_events "
-            "WHERE workspace_id IS NULL AND created_by = $1 "
-            "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
-            "ORDER BY rank DESC LIMIT $3",
-            user_id, query, limit,
-        )
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "tool_name, content, metadata, attachments, created_at, "
+        "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
+        "FROM history_events "
+        "WHERE workspace_id = $1 AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
+        "ORDER BY rank DESC LIMIT $3",
+        workspace_id, query, limit,
+    )
     return [dict(r) for r in rows]
 
 
-async def search_events_vector(
-    workspace_id: UUID | None, query_embedding: np.ndarray,
-    user_id: UUID | None = None, limit: int = 20,
+async def search_personal_events(
+    user_id: UUID, query: str, limit: int = 50,
 ) -> list[dict]:
-    """Semantic vector search using pgvector cosine distance."""
+    """Full-text search on personal events."""
     pool = get_pool()
     limit = min(limit, 200)
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "tool_name, content, metadata, attachments, created_at, "
+        "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
+        "FROM history_events "
+        "WHERE workspace_id IS NULL AND created_by = $1 "
+        "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
+        "ORDER BY rank DESC LIMIT $3",
+        user_id, query, limit,
+    )
+    return [dict(r) for r in rows]
 
-    if workspace_id is not None:
-        rows = await pool.fetch(
-            "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
-            "tool_name, content, metadata, attachments, created_at, "
-            "1 - (embedding <=> $2) AS similarity "
-            "FROM history_events "
-            "WHERE workspace_id = $1 AND embedding IS NOT NULL "
-            "ORDER BY embedding <=> $2 LIMIT $3",
-            workspace_id, query_embedding, limit,
-        )
-    else:
-        rows = await pool.fetch(
-            "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
-            "tool_name, content, metadata, attachments, created_at, "
-            "1 - (embedding <=> $2) AS similarity "
-            "FROM history_events "
-            "WHERE workspace_id IS NULL AND created_by = $1 AND embedding IS NOT NULL "
-            "ORDER BY embedding <=> $2 LIMIT $3",
-            user_id, query_embedding, limit,
-        )
+
+async def search_workspace_events_vector(
+    workspace_id: UUID, query_embedding: np.ndarray, limit: int = 20,
+) -> list[dict]:
+    """Semantic vector search on workspace events."""
+    pool = get_pool()
+    limit = min(limit, 200)
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "tool_name, content, metadata, attachments, created_at, "
+        "1 - (embedding <=> $2) AS similarity "
+        "FROM history_events "
+        "WHERE workspace_id = $1 AND embedding IS NOT NULL "
+        "ORDER BY embedding <=> $2 LIMIT $3",
+        workspace_id, query_embedding, limit,
+    )
+    return [dict(r) for r in rows]
+
+
+async def search_personal_events_vector(
+    user_id: UUID, query_embedding: np.ndarray, limit: int = 20,
+) -> list[dict]:
+    """Semantic vector search on personal events."""
+    pool = get_pool()
+    limit = min(limit, 200)
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "tool_name, content, metadata, attachments, created_at, "
+        "1 - (embedding <=> $2) AS similarity "
+        "FROM history_events "
+        "WHERE workspace_id IS NULL AND created_by = $1 AND embedding IS NOT NULL "
+        "ORDER BY embedding <=> $2 LIMIT $3",
+        user_id, query_embedding, limit,
+    )
     return [dict(r) for r in rows]
 
 
@@ -314,25 +356,23 @@ async def query_all_user_events(
     return events, has_more
 
 
-async def delete_agent_events(
-    agent_name: str,
-    workspace_id: UUID | None = None,
-    user_id: UUID | None = None,
-) -> int:
-    """Delete all events for a given agent. Returns count deleted."""
+async def delete_workspace_agent_events(agent_name: str, workspace_id: UUID) -> int:
+    """Delete all workspace events for a given agent. Returns count deleted."""
     pool = get_pool()
-    if workspace_id is not None:
-        result = await pool.execute(
-            "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id = $2",
-            agent_name, workspace_id,
-        )
-    elif user_id is not None:
-        result = await pool.execute(
-            "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id IS NULL AND created_by = $2",
-            agent_name, user_id,
-        )
-    else:
-        return 0
+    result = await pool.execute(
+        "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id = $2",
+        agent_name, workspace_id,
+    )
+    return int(result.split()[-1]) if result else 0
+
+
+async def delete_personal_agent_events(agent_name: str, user_id: UUID) -> int:
+    """Delete all personal events for a given agent. Returns count deleted."""
+    pool = get_pool()
+    result = await pool.execute(
+        "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id IS NULL AND created_by = $2",
+        agent_name, user_id,
+    )
     return int(result.split()[-1]) if result else 0
 
 


### PR DESCRIPTION
## Summary
- `memory_service` accepted optional `workspace_id`/`user_id` and silently fell through to unsafe defaults. `query_events(None, None, ...)` ran `WHERE TRUE` across every tenant; `get_event(id)` did an unscoped read patched at the router with a post-fetch `created_by` check.
- Split each dual-purpose function into a workspace/personal pair with required, positional scope. Callers can't forget it, and the "None means all rows" footgun is gone.
- Router updated; the personal `get` endpoint's post-fetch auth check is deleted — the service enforces scope now.

## Changes
- `get_event` → `get_workspace_event(event_id, workspace_id)` / `get_personal_event(event_id, user_id)`
- `query_events` → `query_workspace_events(workspace_id, ...)` / `query_personal_events(user_id, ...)`
- `search_events` → `search_workspace_events` / `search_personal_events`
- `search_events_vector` → `search_workspace_events_vector` / `search_personal_events_vector`
- `delete_agent_events` → `delete_workspace_agent_events(agent_name, workspace_id)` / `delete_personal_agent_events(agent_name, user_id)`

HTTP routes unchanged — CLI and plugin clients are unaffected.

## Test plan
- [ ] `pytest backend/tests` passes
- [ ] Workspace memory endpoints: list, search, get-by-id, delete-agent still work
- [ ] Personal memory endpoints: list, search, get-by-id, delete-agent still work
- [ ] Attempting to fetch a personal event by ID as a different user returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)