### PR TITLE
docs(architecture): show plugin skills shell out to CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,14 +8,19 @@ Octopus is a collaborative memory platform for AI agent teams. Three layers: a N
 ┌──────────────────────────────────────────────────────────────────────┐
 │                          Clients                                     │
 │                                                                      │
-│  ┌─────────────┐  ┌──────────────┐  ┌────────────────────┐          │
-│  │ Next.js UI  │  │ CLI / HTTP   │  │ Claude plugin      │          │
-│  │ (browser)   │  │ clients      │  │ (skill + hooks)    │          │
-│  └──────┬──────┘  └──────┬───────┘  └─────────┬──────────┘          │
-│         │ REST           │ REST              │ REST                 │
-└─────────┼────────────────┼───────────────────┼──────────────────────┘
-          │                │                   │
-          ▼                ▼                   ▼
+│   ┌─────────────┐              ┌──────────────────────────┐          │
+│   │ Next.js UI  │              │ Claude plugin            │          │
+│   │ (browser)   │              │   hooks  ──▶ REST        │          │
+│   │             │              │   skills ──▶ octopus CLI │          │
+│   └──────┬──────┘              └─────────┬──────────┬─────┘          │
+│          │ REST                          │ shell    │ REST           │
+│          │                       ┌───────┴────────┐ │                │
+│          │                       │  octopus CLI   │ │                │
+│          │                       └───────┬────────┘ │                │
+│          │                               │ REST     │                │
+└──────────┼───────────────────────────────┼──────────┼────────────────┘
+           │                               │          │
+           ▼                               ▼          ▼
 ┌──────────────────────────────────────────────────────────────────────┐
 │                      FastAPI Backend (:3456)                          │
 │                                                                      │
@@ -256,15 +261,15 @@ frontend/src/
 
 ### CLI (`cli/`)
 
-A Python CLI for scripted access: auth, history push, and notebook sync.
+A Python CLI intended to be driven by coding agents running alongside Octopus (e.g. Claude Code via the plugin below). Exposes auth, workspaces, notebooks, history push / query / search, tables, and files over REST. Humans can run it too, but the primary consumer is the agent.
 
 ### Claude plugin (`plugins/claude-plugin/`)
 
-A skill bundle loaded by Claude Code. Includes:
+A plugin loaded by Claude Code. Two integration paths into the backend:
 
-- `skills/` — curation, universal search, and other agentic skills that call back into the Octopus REST API.
-- `hooks/` — Claude Code hooks that auto-push history events to a workspace.
-- `scripts/` — helpers invoked by skills.
+- `hooks/hooks.json` registers Claude Code lifecycle hooks (SessionStart, UserPromptSubmit, PostToolUse, Stop, SessionEnd). The handlers in `scripts/` push events and inject context via the lightweight `octopus_client.py` HTTP client — direct REST, no CLI in the loop.
+- `skills/` ships slash-command skills (`/octopus:connect`, `/search`, `/sleep`, …). These are `SKILL.md` prompt templates that shell out to the `octopus` CLI; they do not call REST directly.
+- `CLAUDE.md` teaches the agent the CLI exists and documents the relevant commands so the agent uses it unprompted.
 
 The backend serves the skill manifest at `GET /skill/octopus/SKILL.md` for plugin bootstrap.
 


### PR DESCRIPTION
## Summary

- The Clients diagram in `ARCHITECTURE.md` showed CLI, HTTP clients, and the Claude plugin as three parallel REST clients. In practice the plugin has two channels — hooks talk REST directly via `scripts/octopus_client.py`, but skills (`/octopus:search`, `/sleep`, …) shell out to the `octopus` CLI. The diagram now layers the CLI under the plugin and labels each path.
- Rewrites the Client surface prose to match: notes the CLI is primarily an agent interface (not human), corrects `hooks/` vs `scripts/` (handlers live in `scripts/`; `hooks/hooks.json` only registers them), and calls out that `CLAUDE.md` is what teaches the agent the CLI exists.

## Test plan

- [ ] Render `ARCHITECTURE.md` on GitHub and confirm the ASCII diagram aligns in the monospace block
- [ ] Skim the Client surface section for accuracy against the actual `plugins/claude-plugin/` layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)