### PR TITLE
[codex] Align local frontend port in start.sh

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,7 +281,7 @@ The backend serves the skill manifest at `GET /skill/octopus/SKILL.md` for plugi
 ./start.sh
 ```
 
-Runs Postgres via docker compose, then uvicorn on `:3456` and `next dev` on `:3000`.
+Runs Postgres via docker compose, then uvicorn on `:3456` and `next dev` on `:3457`.
 
 ### Self-hosted (docker compose)
 

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
 PIDS=()
+# Keep local dev ports aligned with backend defaults and docker compose.
+BACKEND_PORT=3456
+FRONTEND_PORT=3457
 
 cleanup() {
     echo ""
@@ -36,21 +39,21 @@ echo "Starting Octopus services..."
 echo "================================"
 
 # --- Backend (FastAPI) ---
-echo "[backend]  Starting on port 3456..."
+echo "[backend]  Starting on port ${BACKEND_PORT}..."
 cd "$PROJECT_ROOT"
-uvicorn backend.main:app --host 0.0.0.0 --port 3456 &
+uvicorn backend.main:app --host 0.0.0.0 --port "$BACKEND_PORT" &
 PIDS+=($!)
 
 # --- Frontend (Next.js) ---
-echo "[frontend] Starting on port 3000..."
+echo "[frontend] Starting on port ${FRONTEND_PORT}..."
 cd "$PROJECT_ROOT/frontend"
-PORT=3000 npm run dev &
+PORT="$FRONTEND_PORT" npm run dev &
 PIDS+=($!)
 
 echo "================================"
 echo "All services started. Press Ctrl+C to stop."
-echo "  Backend  -> http://localhost:3456"
-echo "  Frontend -> http://localhost:3000"
+echo "  Backend  -> http://localhost:${BACKEND_PORT}"
+echo "  Frontend -> http://localhost:${FRONTEND_PORT}"
 echo "================================"
 
 # Wait for all background processes


### PR DESCRIPTION
## What changed
- updated `start.sh` to use shared local port variables
- changed the frontend dev server port from `3000` to `3457`
- updated the startup log output to print the aligned backend/frontend URLs

## Why
`start.sh` was the outlier in local development. The backend defaults, Docker setup, and contributor docs all expect the frontend on `3457`, but `./start.sh` launched Next.js on `3000`.

## Root cause
The script had hard-coded frontend port values that had drifted from the rest of the repo's local-development defaults.

## Impact
Running `./start.sh` now matches the documented local URLs and the backend's default `PUBLIC_URL` / `CORS_ORIGINS` expectations.

## Validation
- `bash -n start.sh`