### PR TITLE
fix(ci): ruff + black cleanup to unblock backend-lint

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -42,6 +42,7 @@ _last_seen_written = _LastSeenCache(_LAST_SEEN_CACHE_SIZE)
 # API key helpers
 # ---------------------------------------------------------------------------
 
+
 def generate_api_key() -> str:
     return "mc_" + secrets.token_urlsafe(32)
 
@@ -62,15 +63,14 @@ def verify_password(password: str, password_hash: str) -> bool:
 # FastAPI dependencies
 # ---------------------------------------------------------------------------
 
+
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> dict:
     token: str = credentials.credentials
 
     if not token.startswith("mc_"):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
     key_hash = hash_api_key(token)
     pool = get_pool()
@@ -81,25 +81,19 @@ async def get_current_user(
         key_hash,
     )
     if not row:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
     user = dict(row)
 
     uid = str(user["id"])
     now = time.monotonic()
     if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:
         _last_seen_written.set(uid, now)
-        await pool.execute(
-            "UPDATE users SET last_seen = now() WHERE id = $1", user["id"]
-        )
+        await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", user["id"])
     return user
 
 
 async def get_current_user_optional(
-    credentials: HTTPAuthorizationCredentials | None = Depends(
-        HTTPBearer(auto_error=False)
-    ),
+    credentials: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),
 ) -> dict | None:
     if credentials is None:
         return None

--- a/backend/database.py
+++ b/backend/database.py
@@ -13,12 +13,8 @@ pool: asyncpg.Pool | None = None
 
 async def _init_connection(conn: asyncpg.Connection) -> None:
     await register_vector(conn)
-    await conn.set_type_codec(
-        "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
-    )
-    await conn.set_type_codec(
-        "json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
-    )
+    await conn.set_type_codec("jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog")
+    await conn.set_type_codec("json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog")
 
 
 async def init_db() -> None:
@@ -41,8 +37,8 @@ async def init_db() -> None:
     def _run_alembic():
         # alembic.ini lives next to pyproject.toml at the repo root
         ini_path = os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
-        from alembic.config import Config
         from alembic import command as alembic_cmd
+        from alembic.config import Config
 
         cfg = Config(ini_path)
         alembic_cmd.upgrade(cfg, "head")

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,13 @@ from .config import settings
 from .database import close_db, init_db
 from .middleware import limiter
 from .routers import (
-    aggregate, files, memory, notebooks, skill, tables, users,
+    aggregate,
+    files,
+    memory,
+    notebooks,
+    skill,
+    tables,
+    users,
     workspaces,
 )
 
@@ -43,7 +49,8 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
-app.add_middleware(CORSMiddleware,
+app.add_middleware(
+    CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],

--- a/backend/migrations/versions/0001_initial_schema.py
+++ b/backend/migrations/versions/0001_initial_schema.py
@@ -4,6 +4,7 @@ Revision ID: 0001
 Revises:
 Create Date: 2026-04-14
 """
+
 from alembic import op
 
 revision = "0001"
@@ -397,30 +398,64 @@ CREATE TABLE IF NOT EXISTS embedding_projections (
 
     # Standard indexes
     op.execute("CREATE INDEX IF NOT EXISTS idx_users_api_key_hash ON users(api_key_hash)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_users_owner ON users(owner_id) WHERE owner_id IS NOT NULL")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_users_owner ON users(owner_id) WHERE owner_id IS NOT NULL"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_workspaces_invite_code ON workspaces(invite_code)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_workspace_members_user ON workspace_members(user_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_chats_workspace ON chats(workspace_id) WHERE workspace_id IS NOT NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_created ON chat_messages(chat_id, created_at)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_chat_messages_fts ON chat_messages USING GIN(to_tsvector('english', content))")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_chat_watches_persona ON chat_watches(persona_id) WHERE enabled = true")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workspace_members_user ON workspace_members(user_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chats_workspace ON chats(workspace_id) WHERE workspace_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_created ON chat_messages(chat_id, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chat_messages_fts ON chat_messages USING GIN(to_tsvector('english', content))"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chat_watches_persona ON chat_watches(persona_id) WHERE enabled = true"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_notebooks_workspace ON notebooks(workspace_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_notebook_pages_notebook ON notebook_pages(notebook_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notebook_pages_notebook ON notebook_pages(notebook_id)"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_notebook_pages_folder ON notebook_pages(folder_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_notebook_folders_notebook ON notebook_folders(notebook_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_history_events_workspace ON history_events(workspace_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_history_events_agent_session ON history_events(agent_name, session_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_history_events_fts ON history_events USING GIN(to_tsvector('english', content))")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_history_events_metadata ON history_events USING GIN(metadata)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_notebook_pages_fts ON notebook_pages USING GIN(to_tsvector('english', content_markdown))")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notebook_folders_notebook ON notebook_folders(notebook_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_workspace ON history_events(workspace_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_agent_session ON history_events(agent_name, session_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_fts ON history_events USING GIN(to_tsvector('english', content))"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_metadata ON history_events USING GIN(metadata)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notebook_pages_fts ON notebook_pages USING GIN(to_tsvector('english', content_markdown))"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_page_links_target ON page_links(target_page_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_injection_sessions_persona ON injection_sessions(persona_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_injection_sessions_persona ON injection_sessions(persona_id)"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_decks_workspace ON decks(workspace_id)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_deck_shares_deck ON deck_shares(deck_id)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_deck_shares_token ON deck_shares(token)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_deck_share_views_share ON deck_share_views(share_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_deck_share_views_session ON deck_share_views(session_token)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_deck_share_page_views_view ON deck_share_page_views(view_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_deck_share_views_share ON deck_share_views(share_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_deck_share_views_session ON deck_share_views(session_token)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_deck_share_page_views_view ON deck_share_page_views(view_id)"
+    )
     op.execute("CREATE INDEX IF NOT EXISTS idx_tables_workspace ON tables(workspace_id)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_table_rows_table ON table_rows(table_id, row_order)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_table_rows_data ON table_rows USING GIN(data)")
@@ -428,25 +463,59 @@ CREATE TABLE IF NOT EXISTS embedding_projections (
     op.execute("CREATE INDEX IF NOT EXISTS idx_documents_workspace ON documents(workspace_id)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_documents_status ON documents(workspace_id, status)")
     op.execute("CREATE INDEX IF NOT EXISTS idx_object_shares_user ON object_shares(user_id)")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_webhooks_workspace ON webhooks(workspace_id) WHERE is_active = true")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_pending ON webhook_deliveries(status, next_retry_at) WHERE status = 'pending'")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_webhooks_workspace ON webhooks(workspace_id) WHERE is_active = true"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_pending ON webhook_deliveries(status, next_retry_at) WHERE status = 'pending'"
+    )
 
     # Partial / HNSW indexes
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_unique_pair ON chats(dm_user_a, dm_user_b) WHERE is_dm = true")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_notebook_pages_root_unique ON notebook_pages(notebook_id, name) WHERE folder_id IS NULL")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_notebook_pages_folder_unique ON notebook_pages(notebook_id, folder_id, name) WHERE folder_id IS NOT NULL")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_notebook_unique ON notebooks(created_by, name) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_notebooks_personal ON notebooks(created_by) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_chats_personal ON chats(creator_id) WHERE workspace_id IS NULL AND is_dm = false")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_deck_unique ON decks(created_by, name) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_decks_personal ON decks(created_by) WHERE workspace_id IS NULL")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_table_unique ON tables(created_by, name) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_tables_personal ON tables(created_by) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_files_personal ON files(uploaded_by) WHERE workspace_id IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_injection_sessions_pending ON injection_sessions(persona_id) WHERE completed_at IS NOT NULL AND scored_at IS NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_table_rows_embedding ON table_rows USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_notebook_pages_embedding ON notebook_pages USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL")
-    op.execute("CREATE INDEX IF NOT EXISTS idx_history_events_embedding ON history_events USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL")
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_unique_pair ON chats(dm_user_a, dm_user_b) WHERE is_dm = true"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_notebook_pages_root_unique ON notebook_pages(notebook_id, name) WHERE folder_id IS NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_notebook_pages_folder_unique ON notebook_pages(notebook_id, folder_id, name) WHERE folder_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_notebook_unique ON notebooks(created_by, name) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notebooks_personal ON notebooks(created_by) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chats_personal ON chats(creator_id) WHERE workspace_id IS NULL AND is_dm = false"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_deck_unique ON decks(created_by, name) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decks_personal ON decks(created_by) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_table_unique ON tables(created_by, name) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tables_personal ON tables(created_by) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_files_personal ON files(uploaded_by) WHERE workspace_id IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_injection_sessions_pending ON injection_sessions(persona_id) WHERE completed_at IS NOT NULL AND scored_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_table_rows_embedding ON table_rows USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notebook_pages_embedding ON notebook_pages USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_embedding ON history_events USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL"
+    )
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/0006_drop_auth0_sub.py
+++ b/backend/migrations/versions/0006_drop_auth0_sub.py
@@ -5,6 +5,7 @@ Auth0 integration is removed; login is password + API key only.
 Revision ID: 0006
 Revises: 0001
 """
+
 from alembic import op
 
 revision = "0006"

--- a/backend/migrations/versions/0007_remove_personas.py
+++ b/backend/migrations/versions/0007_remove_personas.py
@@ -10,6 +10,7 @@ were deprecated in PR25. This migration removes their remaining schema footprint
 Revision ID: 0007
 Revises: 0006
 """
+
 from alembic import op
 
 revision = "0007"
@@ -38,6 +39,5 @@ def downgrade() -> None:
     op.execute("ALTER TABLE users ADD COLUMN history_id UUID")
     op.execute("ALTER TABLE users ADD COLUMN notebook_id UUID")
     op.execute(
-        "ALTER TABLE users ADD COLUMN owner_id UUID "
-        "REFERENCES users(id) ON DELETE CASCADE"
+        "ALTER TABLE users ADD COLUMN owner_id UUID " "REFERENCES users(id) ON DELETE CASCADE"
     )

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-
 # --- Users ---
 
 
@@ -181,7 +180,8 @@ class ColumnDefinition(BaseModel):
     id: str = Field("", max_length=64)
     name: str = Field(..., min_length=1, max_length=128)
     type: str = Field(
-        ..., pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
+        ...,
+        pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
     )
     order: int = Field(0, ge=0)
     required: bool = False
@@ -220,7 +220,8 @@ class TableListResponse(BaseModel):
 class ColumnAddRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=128)
     type: str = Field(
-        ..., pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
+        ...,
+        pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
     )
     required: bool = False
     default: str | int | float | bool | list | None = None
@@ -230,7 +231,8 @@ class ColumnAddRequest(BaseModel):
 class ColumnUpdateRequest(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=128)
     type: str | None = Field(
-        None, pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
+        None,
+        pattern=r"^(text|number|boolean|date|datetime|url|email|select|multiselect|json)$",
     )
     required: bool | None = None
     default: str | int | float | bool | list | None = None
@@ -296,7 +298,9 @@ class HistoryEventCreateRequest(BaseModel):
     tool_name: str | None = Field(None, max_length=128)
     metadata: dict = Field(default_factory=dict)
     attachments: list[Attachment] | None = None
-    created_at: datetime | None = Field(None, description="ISO timestamp; defaults to now if omitted")
+    created_at: datetime | None = Field(
+        None, description="ISO timestamp; defaults to now if omitted"
+    )
 
 
 class HistoryEventBatchRequest(BaseModel):

--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -51,7 +51,9 @@ async def activity_timeline(
 ):
     """Agent activity bucketed by time for the dashboard timeline."""
     return await analytics_service.get_activity_timeline(
-        current_user["id"], days=days, bucket=bucket,
+        current_user["id"],
+        days=days,
+        bucket=bucket,
     )
 
 
@@ -62,7 +64,8 @@ async def knowledge_density(
 ):
     """Topic clusters for the knowledge density heatmap."""
     return await analytics_service.get_knowledge_density(
-        current_user["id"], max_clusters=max_clusters,
+        current_user["id"],
+        max_clusters=max_clusters,
     )
 
 
@@ -74,5 +77,7 @@ async def embedding_projection(
 ):
     """2D UMAP projection of embeddings for the space explorer."""
     return await analytics_service.get_embedding_projection(
-        current_user["id"], max_points=max_points, source=source,
+        current_user["id"],
+        max_points=max_points,
+        source=source,
     )

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -5,9 +5,9 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 
 from ..auth import get_current_user
+from ..database import get_pool
 from ..models import FileListResponse, FileResponse
 from ..services import storage_service, workspace_service
-from ..database import get_pool
 
 ws_router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/files", tags=["files"])
 personal_router = APIRouter(prefix="/api/v1/files", tags=["personal_files"])
@@ -55,7 +55,10 @@ async def upload_ws_file(
     filename = file.filename or "upload"
 
     storage_key = await storage_service.upload_file(
-        str(workspace_id), filename, content, content_type,
+        str(workspace_id),
+        filename,
+        content,
+        content_type,
     )
 
     pool = get_pool()
@@ -63,7 +66,12 @@ async def upload_ws_file(
         "INSERT INTO files (workspace_id, name, content_type, size_bytes, storage_key, uploaded_by) "
         "VALUES ($1, $2, $3, $4, $5, $6) "
         "RETURNING id, workspace_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at",
-        workspace_id, filename, content_type, len(content), storage_key, current_user["id"],
+        workspace_id,
+        filename,
+        content_type,
+        len(content),
+        storage_key,
+        current_user["id"],
     )
     return await _file_to_response(dict(row))
 
@@ -86,7 +94,8 @@ async def list_ws_files(
 
 @ws_router.get("/{file_id}", response_model=FileResponse)
 async def get_ws_file(
-    workspace_id: UUID, file_id: UUID,
+    workspace_id: UUID,
+    file_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -94,7 +103,8 @@ async def get_ws_file(
     row = await pool.fetchrow(
         "SELECT id, workspace_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at "
         "FROM files WHERE id = $1 AND workspace_id = $2",
-        file_id, workspace_id,
+        file_id,
+        workspace_id,
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
@@ -103,14 +113,16 @@ async def get_ws_file(
 
 @ws_router.delete("/{file_id}", status_code=204)
 async def delete_ws_file(
-    workspace_id: UUID, file_id: UUID,
+    workspace_id: UUID,
+    file_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT storage_key FROM files WHERE id = $1 AND workspace_id = $2",
-        file_id, workspace_id,
+        file_id,
+        workspace_id,
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
@@ -118,7 +130,9 @@ async def delete_ws_file(
         await storage_service.delete_file(row["storage_key"])
     except Exception:
         pass  # Best-effort S3 cleanup
-    await pool.execute("DELETE FROM files WHERE id = $1 AND workspace_id = $2", file_id, workspace_id)
+    await pool.execute(
+        "DELETE FROM files WHERE id = $1 AND workspace_id = $2", file_id, workspace_id
+    )
 
 
 # ===== Personal file endpoints =====
@@ -140,7 +154,10 @@ async def upload_personal_file(
     filename = file.filename or "upload"
 
     storage_key = await storage_service.upload_file(
-        None, filename, content, content_type,
+        None,
+        filename,
+        content,
+        content_type,
     )
 
     pool = get_pool()
@@ -148,7 +165,11 @@ async def upload_personal_file(
         "INSERT INTO files (name, content_type, size_bytes, storage_key, uploaded_by) "
         "VALUES ($1, $2, $3, $4, $5) "
         "RETURNING id, workspace_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at",
-        filename, content_type, len(content), storage_key, current_user["id"],
+        filename,
+        content_type,
+        len(content),
+        storage_key,
+        current_user["id"],
     )
     return await _file_to_response(dict(row))
 
@@ -176,7 +197,8 @@ async def get_personal_file(
     row = await pool.fetchrow(
         "SELECT id, workspace_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at "
         "FROM files WHERE id = $1 AND workspace_id IS NULL AND uploaded_by = $2",
-        file_id, current_user["id"],
+        file_id,
+        current_user["id"],
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
@@ -191,7 +213,8 @@ async def delete_personal_file(
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT storage_key FROM files WHERE id = $1 AND workspace_id IS NULL AND uploaded_by = $2",
-        file_id, current_user["id"],
+        file_id,
+        current_user["id"],
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -34,16 +34,22 @@ async def _check_member(workspace_id: UUID, user_id: UUID) -> None:
 
 @ws_router.post("/events", response_model=HistoryEventResponse, status_code=201)
 async def push_ws_event(
-    workspace_id: UUID, req: HistoryEventCreateRequest,
+    workspace_id: UUID,
+    req: HistoryEventCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     attachments = [a.model_dump(mode="json") for a in req.attachments] if req.attachments else None
     event = await memory_service.push_event(
-        workspace_id, agent_name=req.agent_name, event_type=req.event_type,
-        content=req.content, created_by=current_user["id"],
-        session_id=req.session_id, tool_name=req.tool_name,
-        metadata=req.metadata, attachments=attachments,
+        workspace_id,
+        agent_name=req.agent_name,
+        event_type=req.event_type,
+        content=req.content,
+        created_by=current_user["id"],
+        session_id=req.session_id,
+        tool_name=req.tool_name,
+        metadata=req.metadata,
+        attachments=attachments,
         created_at=req.created_at,
     )
     return HistoryEventResponse(**event)
@@ -51,7 +57,8 @@ async def push_ws_event(
 
 @ws_router.post("/events/batch", response_model=list[HistoryEventResponse], status_code=201)
 async def push_ws_events_batch(
-    workspace_id: UUID, req: HistoryEventBatchRequest,
+    workspace_id: UUID,
+    req: HistoryEventBatchRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -73,8 +80,13 @@ async def query_ws_events(
 ):
     await _check_member(workspace_id, current_user["id"])
     events, has_more = await memory_service.query_workspace_events(
-        workspace_id, agent_name=agent_name, session_id=session_id,
-        event_type=event_type, after=after, before=before, limit=limit,
+        workspace_id,
+        agent_name=agent_name,
+        session_id=session_id,
+        event_type=event_type,
+        after=after,
+        before=before,
+        limit=limit,
     )
     return HistoryEventListResponse(
         events=[HistoryEventResponse(**e) for e in events],
@@ -99,7 +111,8 @@ async def search_ws_events(
 
 @ws_router.get("/events/{event_id}", response_model=HistoryEventResponse)
 async def get_ws_event(
-    workspace_id: UUID, event_id: UUID,
+    workspace_id: UUID,
+    event_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -111,7 +124,8 @@ async def get_ws_event(
 
 @ws_router.delete("/agents/{agent_name}", status_code=204)
 async def delete_ws_agent(
-    workspace_id: UUID, agent_name: str,
+    workspace_id: UUID,
+    agent_name: str,
     current_user: dict = Depends(get_current_user),
 ):
     """Delete all events for an agent in this workspace."""
@@ -127,6 +141,7 @@ async def list_ws_agent_names(
     """List distinct agent names in this workspace."""
     await _check_member(workspace_id, current_user["id"])
     from ..database import get_pool
+
     pool = get_pool()
     rows = await pool.fetch(
         "SELECT DISTINCT agent_name FROM history_events "
@@ -155,10 +170,15 @@ async def push_personal_event(
 ):
     attachments = [a.model_dump(mode="json") for a in req.attachments] if req.attachments else None
     event = await memory_service.push_event(
-        None, agent_name=req.agent_name, event_type=req.event_type,
-        content=req.content, created_by=current_user["id"],
-        session_id=req.session_id, tool_name=req.tool_name,
-        metadata=req.metadata, attachments=attachments,
+        None,
+        agent_name=req.agent_name,
+        event_type=req.event_type,
+        content=req.content,
+        created_by=current_user["id"],
+        session_id=req.session_id,
+        tool_name=req.tool_name,
+        metadata=req.metadata,
+        attachments=attachments,
         created_at=req.created_at,
     )
     return HistoryEventResponse(**event)
@@ -186,8 +206,12 @@ async def query_personal_events(
 ):
     events, has_more = await memory_service.query_personal_events(
         current_user["id"],
-        agent_name=agent_name, session_id=session_id,
-        event_type=event_type, after=after, before=before, limit=limit,
+        agent_name=agent_name,
+        session_id=session_id,
+        event_type=event_type,
+        after=after,
+        before=before,
+        limit=limit,
     )
     return HistoryEventListResponse(
         events=[HistoryEventResponse(**e) for e in events],
@@ -202,7 +226,9 @@ async def search_personal_events(
     current_user: dict = Depends(get_current_user),
 ):
     events = await memory_service.search_personal_events(
-        current_user["id"], q, limit=limit,
+        current_user["id"],
+        q,
+        limit=limit,
     )
     return HistoryEventListResponse(
         events=[HistoryEventResponse(**e) for e in events],

--- a/backend/routers/notebooks.py
+++ b/backend/routers/notebooks.py
@@ -55,13 +55,17 @@ async def _check_notebook_owner(notebook_id: UUID, user_id: UUID) -> dict:
 
 @ws_router.post("", response_model=NotebookResponse, status_code=201)
 async def create_ws_notebook(
-    workspace_id: UUID, req: NotebookCreateRequest,
+    workspace_id: UUID,
+    req: NotebookCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
     try:
         nb = await notebook_service.create_notebook(
-            workspace_id, req.name, req.description, current_user["id"],
+            workspace_id,
+            req.name,
+            req.description,
+            current_user["id"],
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -72,7 +76,8 @@ async def create_ws_notebook(
 
 @ws_router.get("", response_model=NotebookListResponse)
 async def list_ws_notebooks(
-    workspace_id: UUID, current_user: dict = Depends(get_current_user),
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
     nbs = await notebook_service.list_notebooks(workspace_id)
@@ -81,7 +86,8 @@ async def list_ws_notebooks(
 
 @ws_router.get("/{notebook_id}", response_model=NotebookResponse)
 async def get_ws_notebook(
-    workspace_id: UUID, notebook_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -91,7 +97,8 @@ async def get_ws_notebook(
 
 @ws_router.delete("/{notebook_id}", status_code=204)
 async def delete_ws_notebook(
-    workspace_id: UUID, notebook_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -101,7 +108,8 @@ async def delete_ws_notebook(
 
 @ws_router.get("/{notebook_id}/pages", response_model=PageTreeResponse)
 async def list_ws_pages(
-    workspace_id: UUID, notebook_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -112,15 +120,20 @@ async def list_ws_pages(
 
 @ws_router.post("/{notebook_id}/pages", response_model=PageResponse, status_code=201)
 async def create_ws_page(
-    workspace_id: UUID, notebook_id: UUID, req: PageCreateRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    req: PageCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_ws_notebook(workspace_id, notebook_id)
     try:
         page = await notebook_service.create_page(
-            notebook_id, req.name, current_user["id"],
-            folder_id=req.folder_id, content=req.content,
+            notebook_id,
+            req.name,
+            current_user["id"],
+            folder_id=req.folder_id,
+            content=req.content,
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -131,14 +144,17 @@ async def create_ws_page(
 
 @ws_router.get("/{notebook_id}/pages/semantic-search")
 async def semantic_search_ws_pages(
-    workspace_id: UUID, notebook_id: UUID,
-    q: str, limit: int = 20,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    q: str,
+    limit: int = 20,
     current_user: dict = Depends(get_current_user),
 ):
     """Semantic search on notebook pages using embeddings."""
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_ws_notebook(workspace_id, notebook_id)
     from ..services import embeddings as embedding_service
+
     if not embedding_service.is_configured():
         raise HTTPException(status_code=503, detail="Embedding service not configured")
     query_embedding = await embedding_service.embed_text(q)
@@ -150,7 +166,9 @@ async def semantic_search_ws_pages(
 
 @ws_router.get("/{notebook_id}/pages/{page_id}", response_model=PageResponse)
 async def get_ws_page(
-    workspace_id: UUID, notebook_id: UUID, page_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -163,15 +181,22 @@ async def get_ws_page(
 
 @ws_router.patch("/{notebook_id}/pages/{page_id}", response_model=PageResponse)
 async def update_ws_page(
-    workspace_id: UUID, notebook_id: UUID, page_id: UUID, req: PageUpdateRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
+    req: PageUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_ws_notebook(workspace_id, notebook_id)
     page = await notebook_service.update_page(
-        page_id, notebook_id, current_user["id"],
-        name=req.name, folder_id=req.folder_id,
-        content=req.content, move_to_root=req.move_to_root,
+        page_id,
+        notebook_id,
+        current_user["id"],
+        name=req.name,
+        folder_id=req.folder_id,
+        content=req.content,
+        move_to_root=req.move_to_root,
     )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -180,7 +205,9 @@ async def update_ws_page(
 
 @ws_router.delete("/{notebook_id}/pages/{page_id}", status_code=204)
 async def delete_ws_page(
-    workspace_id: UUID, notebook_id: UUID, page_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -195,7 +222,9 @@ async def delete_ws_page(
 
 @ws_router.get("/{notebook_id}/pages/{page_id}/backlinks")
 async def get_ws_backlinks(
-    workspace_id: UUID, notebook_id: UUID, page_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     """Get pages that link to this page via [[wiki links]]."""
@@ -207,7 +236,9 @@ async def get_ws_backlinks(
 
 @ws_router.get("/{notebook_id}/pages/{page_id}/outlinks")
 async def get_ws_outlinks(
-    workspace_id: UUID, notebook_id: UUID, page_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     """Get pages that this page links to via [[wiki links]]."""
@@ -219,7 +250,8 @@ async def get_ws_outlinks(
 
 @ws_router.get("/{notebook_id}/graph")
 async def get_ws_page_graph(
-    workspace_id: UUID, notebook_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     """Get the full wiki link graph for a notebook (nodes + edges)."""
@@ -228,17 +260,20 @@ async def get_ws_page_graph(
     return await notebook_service.get_page_graph(notebook_id)
 
 
-
 @ws_router.post("/{notebook_id}/folders", response_model=FolderResponse, status_code=201)
 async def create_ws_folder(
-    workspace_id: UUID, notebook_id: UUID, req: FolderCreateRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    req: FolderCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_ws_notebook(workspace_id, notebook_id)
     try:
         folder = await notebook_service.create_folder(
-            notebook_id, req.name, current_user["id"],
+            notebook_id,
+            req.name,
+            current_user["id"],
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -249,7 +284,10 @@ async def create_ws_folder(
 
 @ws_router.patch("/{notebook_id}/folders/{folder_id}", response_model=FolderResponse)
 async def rename_ws_folder(
-    workspace_id: UUID, notebook_id: UUID, folder_id: UUID, req: FolderUpdateRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    folder_id: UUID,
+    req: FolderUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -262,7 +300,9 @@ async def rename_ws_folder(
 
 @ws_router.delete("/{notebook_id}/folders/{folder_id}", status_code=204)
 async def delete_ws_folder(
-    workspace_id: UUID, notebook_id: UUID, folder_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    folder_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -277,7 +317,8 @@ async def delete_ws_folder(
 
 @ws_router.get("/{notebook_id}/permissions", response_model=PermissionResponse)
 async def get_permissions(
-    workspace_id: UUID, notebook_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_ws_access(workspace_id, current_user["id"])
@@ -288,7 +329,9 @@ async def get_permissions(
 
 @ws_router.patch("/{notebook_id}/permissions")
 async def set_visibility(
-    workspace_id: UUID, notebook_id: UUID, req: SetVisibilityRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    req: SetVisibilityRequest,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -301,7 +344,9 @@ async def set_visibility(
 
 @ws_router.post("/{notebook_id}/permissions/share", response_model=ShareResponse)
 async def add_share(
-    workspace_id: UUID, notebook_id: UUID, req: ShareRequest,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    req: ShareRequest,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -309,21 +354,30 @@ async def add_share(
         raise HTTPException(status_code=403, detail="Only owner/admin can share")
     await _check_ws_notebook(workspace_id, notebook_id)
     share = await permission_service.add_share(
-        "notebook", notebook_id, req.user_id, req.permission, current_user["id"],
+        "notebook",
+        notebook_id,
+        req.user_id,
+        req.permission,
+        current_user["id"],
     )
     from ..database import get_pool
+
     pool = get_pool()
     user = await pool.fetchrow("SELECT name FROM users WHERE id = $1", req.user_id)
     return ShareResponse(
-        user_id=share["user_id"], user_name=user["name"] if user else "",
-        permission=share["permission"], granted_by=share["granted_by"],
+        user_id=share["user_id"],
+        user_name=user["name"] if user else "",
+        permission=share["permission"],
+        granted_by=share["granted_by"],
         created_at=share["created_at"],
     )
 
 
 @ws_router.delete("/{notebook_id}/permissions/share/{user_id}", status_code=204)
 async def remove_share(
-    workspace_id: UUID, notebook_id: UUID, user_id: UUID,
+    workspace_id: UUID,
+    notebook_id: UUID,
+    user_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -338,11 +392,15 @@ async def remove_share(
 
 @personal_router.post("", response_model=NotebookResponse, status_code=201)
 async def create_personal_notebook(
-    req: NotebookCreateRequest, current_user: dict = Depends(get_current_user),
+    req: NotebookCreateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     try:
         nb = await notebook_service.create_notebook(
-            None, req.name, req.description, current_user["id"],
+            None,
+            req.name,
+            req.description,
+            current_user["id"],
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -359,7 +417,8 @@ async def list_personal_notebooks(current_user: dict = Depends(get_current_user)
 
 @personal_router.get("/{notebook_id}", response_model=NotebookResponse)
 async def get_personal_notebook(
-    notebook_id: UUID, current_user: dict = Depends(get_current_user),
+    notebook_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     nb = await _check_notebook_owner(notebook_id, current_user["id"])
     return NotebookResponse(**nb)
@@ -367,7 +426,8 @@ async def get_personal_notebook(
 
 @personal_router.delete("/{notebook_id}", status_code=204)
 async def delete_personal_notebook(
-    notebook_id: UUID, current_user: dict = Depends(get_current_user),
+    notebook_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     await notebook_service.delete_notebook(notebook_id)
@@ -375,7 +435,8 @@ async def delete_personal_notebook(
 
 @personal_router.get("/{notebook_id}/pages", response_model=PageTreeResponse)
 async def list_personal_pages(
-    notebook_id: UUID, current_user: dict = Depends(get_current_user),
+    notebook_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     tree = await notebook_service.list_page_tree(notebook_id)
@@ -384,14 +445,18 @@ async def list_personal_pages(
 
 @personal_router.post("/{notebook_id}/pages", response_model=PageResponse, status_code=201)
 async def create_personal_page(
-    notebook_id: UUID, req: PageCreateRequest,
+    notebook_id: UUID,
+    req: PageCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     try:
         page = await notebook_service.create_page(
-            notebook_id, req.name, current_user["id"],
-            folder_id=req.folder_id, content=req.content,
+            notebook_id,
+            req.name,
+            current_user["id"],
+            folder_id=req.folder_id,
+            content=req.content,
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -402,11 +467,14 @@ async def create_personal_page(
 
 @personal_router.get("/{notebook_id}/pages/semantic-search")
 async def semantic_search_personal_pages(
-    notebook_id: UUID, q: str, limit: int = 20,
+    notebook_id: UUID,
+    q: str,
+    limit: int = 20,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     from ..services import embeddings as embedding_service
+
     if not embedding_service.is_configured():
         raise HTTPException(status_code=503, detail="Embedding service not configured")
     query_embedding = await embedding_service.embed_text(q)
@@ -418,7 +486,8 @@ async def semantic_search_personal_pages(
 
 @personal_router.get("/{notebook_id}/pages/{page_id}", response_model=PageResponse)
 async def get_personal_page(
-    notebook_id: UUID, page_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
@@ -430,14 +499,20 @@ async def get_personal_page(
 
 @personal_router.patch("/{notebook_id}/pages/{page_id}", response_model=PageResponse)
 async def update_personal_page(
-    notebook_id: UUID, page_id: UUID, req: PageUpdateRequest,
+    notebook_id: UUID,
+    page_id: UUID,
+    req: PageUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     page = await notebook_service.update_page(
-        page_id, notebook_id, current_user["id"],
-        name=req.name, folder_id=req.folder_id,
-        content=req.content, move_to_root=req.move_to_root,
+        page_id,
+        notebook_id,
+        current_user["id"],
+        name=req.name,
+        folder_id=req.folder_id,
+        content=req.content,
+        move_to_root=req.move_to_root,
     )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -446,7 +521,8 @@ async def update_personal_page(
 
 @personal_router.delete("/{notebook_id}/pages/{page_id}", status_code=204)
 async def delete_personal_page(
-    notebook_id: UUID, page_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
@@ -460,7 +536,8 @@ async def delete_personal_page(
 
 @personal_router.get("/{notebook_id}/pages/{page_id}/backlinks")
 async def get_personal_backlinks(
-    notebook_id: UUID, page_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
@@ -470,7 +547,8 @@ async def get_personal_backlinks(
 
 @personal_router.get("/{notebook_id}/pages/{page_id}/outlinks")
 async def get_personal_outlinks(
-    notebook_id: UUID, page_id: UUID,
+    notebook_id: UUID,
+    page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
@@ -487,16 +565,18 @@ async def get_personal_page_graph(
     return await notebook_service.get_page_graph(notebook_id)
 
 
-
 @personal_router.post("/{notebook_id}/folders", response_model=FolderResponse, status_code=201)
 async def create_personal_folder(
-    notebook_id: UUID, req: FolderCreateRequest,
+    notebook_id: UUID,
+    req: FolderCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     try:
         folder = await notebook_service.create_folder(
-            notebook_id, req.name, current_user["id"],
+            notebook_id,
+            req.name,
+            current_user["id"],
         )
     except Exception as e:
         if "unique" in str(e).lower():
@@ -507,7 +587,9 @@ async def create_personal_folder(
 
 @personal_router.patch("/{notebook_id}/folders/{folder_id}", response_model=FolderResponse)
 async def rename_personal_folder(
-    notebook_id: UUID, folder_id: UUID, req: FolderUpdateRequest,
+    notebook_id: UUID,
+    folder_id: UUID,
+    req: FolderUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
@@ -519,12 +601,11 @@ async def rename_personal_folder(
 
 @personal_router.delete("/{notebook_id}/folders/{folder_id}", status_code=204)
 async def delete_personal_folder(
-    notebook_id: UUID, folder_id: UUID,
+    notebook_id: UUID,
+    folder_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_notebook_owner(notebook_id, current_user["id"])
     deleted = await notebook_service.delete_folder(folder_id, notebook_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Folder not found")
-
-

--- a/backend/routers/tables.py
+++ b/backend/routers/tables.py
@@ -28,7 +28,7 @@ from ..models import (
     TableResponse,
     TableUpdateRequest,
 )
-from ..services import table_service, permission_service, workspace_service
+from ..services import permission_service, table_service, workspace_service
 
 ws_router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/tables", tags=["tables"])
 personal_router = APIRouter(prefix="/api/v1/tables", tags=["personal_tables"])
@@ -75,20 +75,26 @@ def _parse_row_ids(body: dict) -> list[UUID]:
 
 @ws_router.post("", response_model=TableResponse, status_code=201)
 async def create_ws_table(
-    workspace_id: UUID, req: TableCreateRequest,
+    workspace_id: UUID,
+    req: TableCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     columns = [c.model_dump() for c in req.columns]
     table = await table_service.create_table(
-        workspace_id, req.name, req.description, columns, current_user["id"],
+        workspace_id,
+        req.name,
+        req.description,
+        columns,
+        current_user["id"],
     )
     return TableResponse(**table)
 
 
 @ws_router.get("", response_model=TableListResponse)
 async def list_ws_tables(
-    workspace_id: UUID, current_user: dict = Depends(get_current_user),
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     tables = await table_service.list_tables(workspace_id)
@@ -97,7 +103,8 @@ async def list_ws_tables(
 
 @ws_router.get("/{table_id}", response_model=TableResponse)
 async def get_ws_table(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -107,13 +114,18 @@ async def get_ws_table(
 
 @ws_router.patch("/{table_id}", response_model=TableResponse)
 async def update_ws_table(
-    workspace_id: UUID, table_id: UUID, req: TableUpdateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: TableUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     await _check_ws_table(workspace_id, table_id)
     table = await table_service.update_table(
-        table_id, current_user["id"], name=req.name, description=req.description,
+        table_id,
+        current_user["id"],
+        name=req.name,
+        description=req.description,
     )
     if not table:
         raise HTTPException(status_code=404, detail="Table not found")
@@ -122,7 +134,8 @@ async def update_ws_table(
 
 @ws_router.delete("/{table_id}", status_code=204)
 async def delete_ws_table(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -139,7 +152,9 @@ async def delete_ws_table(
 
 @ws_router.post("/{table_id}/columns", response_model=TableResponse, status_code=201)
 async def add_ws_column(
-    workspace_id: UUID, table_id: UUID, req: ColumnAddRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: ColumnAddRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -152,13 +167,19 @@ async def add_ws_column(
 
 @ws_router.patch("/{table_id}/columns/{column_id}", response_model=TableResponse)
 async def update_ws_column(
-    workspace_id: UUID, table_id: UUID, column_id: str, req: ColumnUpdateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    column_id: str,
+    req: ColumnUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
     await _check_ws_table(workspace_id, table_id)
     table = await table_service.update_column(
-        table_id, column_id, req.model_dump(exclude_none=True), current_user["id"],
+        table_id,
+        column_id,
+        req.model_dump(exclude_none=True),
+        current_user["id"],
     )
     if not table:
         raise HTTPException(status_code=404, detail="Table or column not found")
@@ -167,7 +188,9 @@ async def update_ws_column(
 
 @ws_router.delete("/{table_id}/columns/{column_id}", response_model=TableResponse)
 async def delete_ws_column(
-    workspace_id: UUID, table_id: UUID, column_id: str,
+    workspace_id: UUID,
+    table_id: UUID,
+    column_id: str,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -180,7 +203,9 @@ async def delete_ws_column(
 
 @ws_router.put("/{table_id}/columns/reorder", response_model=TableResponse)
 async def reorder_ws_columns(
-    workspace_id: UUID, table_id: UUID, req: ColumnReorderRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: ColumnReorderRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -196,7 +221,8 @@ async def reorder_ws_columns(
 
 @ws_router.get("/{table_id}/rows", response_model=RowListResponse)
 async def list_ws_rows(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     sort_by: str | None = Query(None),
     sort_order: str = Query("asc", pattern=r"^(asc|desc)$"),
     limit: int = Query(100, ge=1, le=1000),
@@ -208,8 +234,12 @@ async def list_ws_rows(
     await _check_ws_table(workspace_id, table_id)
     parsed_filters = json.loads(filters) if filters else None
     rows, total = await table_service.list_rows(
-        table_id, filters=parsed_filters, sort_by=sort_by,
-        sort_order=sort_order, limit=limit, offset=offset,
+        table_id,
+        filters=parsed_filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
     )
     return RowListResponse(
         rows=[RowResponse(**r) for r in rows],
@@ -220,7 +250,9 @@ async def list_ws_rows(
 
 @ws_router.post("/{table_id}/rows", response_model=RowResponse, status_code=201)
 async def create_ws_row(
-    workspace_id: UUID, table_id: UUID, req: RowCreateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: RowCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -231,7 +263,9 @@ async def create_ws_row(
 
 @ws_router.post("/{table_id}/rows/batch", status_code=201)
 async def create_ws_rows_batch(
-    workspace_id: UUID, table_id: UUID, req: RowBatchCreateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: RowBatchCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -243,14 +277,17 @@ async def create_ws_rows_batch(
 
 @ws_router.get("/{table_id}/rows/semantic-search")
 async def semantic_search_ws_rows(
-    workspace_id: UUID, table_id: UUID,
-    q: str, limit: int = 20,
+    workspace_id: UUID,
+    table_id: UUID,
+    q: str,
+    limit: int = 20,
     current_user: dict = Depends(get_current_user),
 ):
     """Semantic search on table rows using embeddings."""
     await _check_member(workspace_id, current_user["id"])
     await _check_ws_table(workspace_id, table_id)
     from ..services import embeddings as embedding_service
+
     if not embedding_service.is_configured():
         raise HTTPException(status_code=503, detail="Embedding service not configured")
     query_embedding = await embedding_service.embed_text(q)
@@ -262,7 +299,10 @@ async def semantic_search_ws_rows(
 
 @ws_router.patch("/{table_id}/rows/{row_id}", response_model=RowResponse)
 async def update_ws_row(
-    workspace_id: UUID, table_id: UUID, row_id: UUID, req: RowUpdateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    row_id: UUID,
+    req: RowUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -275,7 +315,9 @@ async def update_ws_row(
 
 @ws_router.delete("/{table_id}/rows/{row_id}", status_code=204)
 async def delete_ws_row(
-    workspace_id: UUID, table_id: UUID, row_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
+    row_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -287,7 +329,9 @@ async def delete_ws_row(
 
 @ws_router.post("/{table_id}/rows/delete", status_code=200)
 async def delete_ws_rows_batch(
-    workspace_id: UUID, table_id: UUID, body: dict,
+    workspace_id: UUID,
+    table_id: UUID,
+    body: dict,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -299,7 +343,9 @@ async def delete_ws_rows_batch(
 
 @ws_router.post("/{table_id}/rows/update", status_code=200)
 async def update_ws_rows_batch(
-    workspace_id: UUID, table_id: UUID, req: RowBatchUpdateRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: RowBatchUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -311,7 +357,8 @@ async def update_ws_rows_batch(
 
 @ws_router.get("/{table_id}/rows/count")
 async def count_ws_rows(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     filters: str | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
@@ -324,7 +371,9 @@ async def count_ws_rows(
 
 @ws_router.put("/{table_id}/embedding")
 async def set_ws_embedding_config(
-    workspace_id: UUID, table_id: UUID, config: dict,
+    workspace_id: UUID,
+    table_id: UUID,
+    config: dict,
     current_user: dict = Depends(get_current_user),
 ):
     """Configure which columns to embed for semantic search.
@@ -341,7 +390,8 @@ async def set_ws_embedding_config(
 
 @ws_router.post("/{table_id}/embedding/backfill")
 async def backfill_ws_embeddings(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     """Re-embed all rows in the table based on current embedding config."""
@@ -352,7 +402,8 @@ async def backfill_ws_embeddings(
 
 @ws_router.get("/{table_id}/export/csv")
 async def export_ws_csv(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     filters: str | None = Query(None),
     sort_by: str | None = Query(None),
     sort_order: str = Query("asc"),
@@ -363,7 +414,10 @@ async def export_ws_csv(
     table = await _check_ws_table(workspace_id, table_id)
     parsed_filters = json.loads(filters) if filters else None
     rows = await table_service.export_rows_all(
-        table_id, filters=parsed_filters, sort_by=sort_by, sort_order=sort_order,
+        table_id,
+        filters=parsed_filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     cols = sorted(table["columns"], key=lambda c: c.get("order", 0))
 
@@ -393,7 +447,8 @@ async def export_ws_csv(
 
 @ws_router.get("/{table_id}/rows/search")
 async def search_ws_rows(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     q: str = Query(..., min_length=1),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
@@ -411,7 +466,8 @@ async def search_ws_rows(
 
 @ws_router.get("/{table_id}/rows/summary")
 async def summarize_ws_rows(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     filters: str | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
@@ -423,7 +479,9 @@ async def summarize_ws_rows(
 
 @ws_router.post("/{table_id}/rows/{row_id}/duplicate", response_model=RowResponse, status_code=201)
 async def duplicate_ws_row(
-    workspace_id: UUID, table_id: UUID, row_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
+    row_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -439,7 +497,9 @@ async def duplicate_ws_row(
 
 @ws_router.post("/{table_id}/views", status_code=201)
 async def save_ws_view(
-    workspace_id: UUID, table_id: UUID, body: dict,
+    workspace_id: UUID,
+    table_id: UUID,
+    body: dict,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -452,7 +512,9 @@ async def save_ws_view(
 
 @ws_router.delete("/{table_id}/views/{view_id}")
 async def delete_ws_view(
-    workspace_id: UUID, table_id: UUID, view_id: str,
+    workspace_id: UUID,
+    table_id: UUID,
+    view_id: str,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -468,7 +530,8 @@ async def delete_ws_view(
 
 @ws_router.get("/{table_id}/permissions", response_model=PermissionResponse)
 async def get_permissions(
-    workspace_id: UUID, table_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_member(workspace_id, current_user["id"])
@@ -479,7 +542,9 @@ async def get_permissions(
 
 @ws_router.patch("/{table_id}/permissions")
 async def set_visibility(
-    workspace_id: UUID, table_id: UUID, req: SetVisibilityRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: SetVisibilityRequest,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -492,7 +557,9 @@ async def set_visibility(
 
 @ws_router.post("/{table_id}/permissions/share", response_model=ShareResponse)
 async def add_share(
-    workspace_id: UUID, table_id: UUID, req: ShareRequest,
+    workspace_id: UUID,
+    table_id: UUID,
+    req: ShareRequest,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -500,21 +567,30 @@ async def add_share(
         raise HTTPException(status_code=403, detail="Only owner/admin can share")
     await _check_ws_table(workspace_id, table_id)
     share = await permission_service.add_share(
-        "table", table_id, req.user_id, req.permission, current_user["id"],
+        "table",
+        table_id,
+        req.user_id,
+        req.permission,
+        current_user["id"],
     )
     from ..database import get_pool
+
     pool = get_pool()
     user = await pool.fetchrow("SELECT name FROM users WHERE id = $1", req.user_id)
     return ShareResponse(
-        user_id=share["user_id"], user_name=user["name"] if user else "",
-        permission=share["permission"], granted_by=share["granted_by"],
+        user_id=share["user_id"],
+        user_name=user["name"] if user else "",
+        permission=share["permission"],
+        granted_by=share["granted_by"],
         created_at=share["created_at"],
     )
 
 
 @ws_router.delete("/{table_id}/permissions/share/{user_id}", status_code=204)
 async def remove_share(
-    workspace_id: UUID, table_id: UUID, user_id: UUID,
+    workspace_id: UUID,
+    table_id: UUID,
+    user_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
@@ -529,11 +605,16 @@ async def remove_share(
 
 @personal_router.post("", response_model=TableResponse, status_code=201)
 async def create_personal_table(
-    req: TableCreateRequest, current_user: dict = Depends(get_current_user),
+    req: TableCreateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     columns = [c.model_dump() for c in req.columns]
     table = await table_service.create_table(
-        None, req.name, req.description, columns, current_user["id"],
+        None,
+        req.name,
+        req.description,
+        columns,
+        current_user["id"],
     )
     return TableResponse(**table)
 
@@ -552,11 +633,16 @@ async def get_personal_table(table_id: UUID, current_user: dict = Depends(get_cu
 
 @personal_router.patch("/{table_id}", response_model=TableResponse)
 async def update_personal_table(
-    table_id: UUID, req: TableUpdateRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: TableUpdateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.update_table(
-        table_id, current_user["id"], name=req.name, description=req.description,
+        table_id,
+        current_user["id"],
+        name=req.name,
+        description=req.description,
     )
     if not table:
         raise HTTPException(status_code=404, detail="Table not found")
@@ -574,7 +660,9 @@ async def delete_personal_table(table_id: UUID, current_user: dict = Depends(get
 
 @personal_router.post("/{table_id}/columns", response_model=TableResponse, status_code=201)
 async def add_personal_column(
-    table_id: UUID, req: ColumnAddRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: ColumnAddRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.add_column(table_id, req.model_dump(), current_user["id"])
@@ -585,12 +673,17 @@ async def add_personal_column(
 
 @personal_router.patch("/{table_id}/columns/{column_id}", response_model=TableResponse)
 async def update_personal_column(
-    table_id: UUID, column_id: str, req: ColumnUpdateRequest,
+    table_id: UUID,
+    column_id: str,
+    req: ColumnUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.update_column(
-        table_id, column_id, req.model_dump(exclude_none=True), current_user["id"],
+        table_id,
+        column_id,
+        req.model_dump(exclude_none=True),
+        current_user["id"],
     )
     if not table:
         raise HTTPException(status_code=404, detail="Table or column not found")
@@ -599,7 +692,9 @@ async def update_personal_column(
 
 @personal_router.delete("/{table_id}/columns/{column_id}", response_model=TableResponse)
 async def delete_personal_column(
-    table_id: UUID, column_id: str, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    column_id: str,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.delete_column(table_id, column_id, current_user["id"])
@@ -610,7 +705,9 @@ async def delete_personal_column(
 
 @personal_router.put("/{table_id}/columns/reorder", response_model=TableResponse)
 async def reorder_personal_columns(
-    table_id: UUID, req: ColumnReorderRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: ColumnReorderRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.reorder_columns(table_id, req.column_ids, current_user["id"])
@@ -635,8 +732,12 @@ async def list_personal_rows(
     await _check_table_owner(table_id, current_user["id"])
     parsed_filters = json.loads(filters) if filters else None
     rows, total = await table_service.list_rows(
-        table_id, filters=parsed_filters, sort_by=sort_by,
-        sort_order=sort_order, limit=limit, offset=offset,
+        table_id,
+        filters=parsed_filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
     )
     return RowListResponse(
         rows=[RowResponse(**r) for r in rows],
@@ -647,7 +748,9 @@ async def list_personal_rows(
 
 @personal_router.post("/{table_id}/rows", response_model=RowResponse, status_code=201)
 async def create_personal_row(
-    table_id: UUID, req: RowCreateRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: RowCreateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     row = await table_service.create_row(table_id, req.data, current_user["id"])
@@ -656,7 +759,9 @@ async def create_personal_row(
 
 @personal_router.post("/{table_id}/rows/batch", status_code=201)
 async def create_personal_rows_batch(
-    table_id: UUID, req: RowBatchCreateRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: RowBatchCreateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     rows_data = [r.data for r in req.rows]
@@ -666,7 +771,9 @@ async def create_personal_rows_batch(
 
 @personal_router.patch("/{table_id}/rows/{row_id}", response_model=RowResponse)
 async def update_personal_row(
-    table_id: UUID, row_id: UUID, req: RowUpdateRequest,
+    table_id: UUID,
+    row_id: UUID,
+    req: RowUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
@@ -678,7 +785,9 @@ async def update_personal_row(
 
 @personal_router.delete("/{table_id}/rows/{row_id}", status_code=204)
 async def delete_personal_row(
-    table_id: UUID, row_id: UUID, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    row_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     deleted = await table_service.delete_row(row_id, table_id=table_id)
@@ -688,7 +797,9 @@ async def delete_personal_row(
 
 @personal_router.post("/{table_id}/rows/delete", status_code=200)
 async def delete_personal_rows_batch(
-    table_id: UUID, body: dict, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    body: dict,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     row_ids = _parse_row_ids(body)
@@ -698,7 +809,9 @@ async def delete_personal_rows_batch(
 
 @personal_router.post("/{table_id}/rows/update", status_code=200)
 async def update_personal_rows_batch(
-    table_id: UUID, req: RowBatchUpdateRequest, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    req: RowBatchUpdateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     updates = [{"row_id": r.row_id, "data": r.data} for r in req.rows]
@@ -730,7 +843,10 @@ async def export_personal_csv(
     table = await _check_table_owner(table_id, current_user["id"])
     parsed_filters = json.loads(filters) if filters else None
     rows = await table_service.export_rows_all(
-        table_id, filters=parsed_filters, sort_by=sort_by, sort_order=sort_order,
+        table_id,
+        filters=parsed_filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     cols = sorted(table["columns"], key=lambda c: c.get("order", 0))
 
@@ -786,9 +902,12 @@ async def summarize_personal_rows(
     return await table_service.summarize_rows(table_id, filters=parsed_filters)
 
 
-@personal_router.post("/{table_id}/rows/{row_id}/duplicate", response_model=RowResponse, status_code=201)
+@personal_router.post(
+    "/{table_id}/rows/{row_id}/duplicate", response_model=RowResponse, status_code=201
+)
 async def duplicate_personal_row(
-    table_id: UUID, row_id: UUID,
+    table_id: UUID,
+    row_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
@@ -803,7 +922,9 @@ async def duplicate_personal_row(
 
 @personal_router.post("/{table_id}/views", status_code=201)
 async def save_personal_view(
-    table_id: UUID, body: dict, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    body: dict,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.save_view(table_id, body, current_user["id"])
@@ -814,7 +935,9 @@ async def save_personal_view(
 
 @personal_router.delete("/{table_id}/views/{view_id}")
 async def delete_personal_view(
-    table_id: UUID, view_id: str, current_user: dict = Depends(get_current_user),
+    table_id: UUID,
+    view_id: str,
+    current_user: dict = Depends(get_current_user),
 ):
     await _check_table_owner(table_id, current_user["id"])
     table = await table_service.delete_view(table_id, view_id, current_user["id"])

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -43,9 +43,7 @@ async def login(request: Request, req: LoginRequest):
             name=req.name, password=req.password
         )
     except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e)
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
     return UserRegisterResponse(
         id=user["id"],
         name=user["name"],
@@ -60,9 +58,7 @@ async def get_me(current_user: dict = Depends(get_current_user)):
 
 
 @router.patch("/me", response_model=UserProfile)
-async def update_me(
-    req: UserUpdateRequest, current_user: dict = Depends(get_current_user)
-):
+async def update_me(req: UserUpdateRequest, current_user: dict = Depends(get_current_user)):
     updated = await user_service.update_user(
         user_id=current_user["id"],
         display_name=req.display_name,
@@ -79,6 +75,7 @@ async def search_users(
 ):
     """Search for users by name or display name."""
     from ..database import get_pool
+
     pool = get_pool()
     rows = await pool.fetch(
         "SELECT id, name, display_name FROM users "

--- a/backend/routers/workspaces.py
+++ b/backend/routers/workspaces.py
@@ -17,7 +17,9 @@ from ..services import workspace_service
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
 
-async def _serialize_workspace_for_viewer(workspace: dict, viewer_id: UUID | None) -> WorkspaceResponse:
+async def _serialize_workspace_for_viewer(
+    workspace: dict, viewer_id: UUID | None
+) -> WorkspaceResponse:
     is_member = bool(viewer_id and await workspace_service.is_member(workspace["id"], viewer_id))
     is_public = bool(workspace.get("is_public"))
     if not is_public and not is_member:
@@ -31,11 +33,14 @@ async def _serialize_workspace_for_viewer(workspace: dict, viewer_id: UUID | Non
 
 @router.post("", response_model=WorkspaceResponse, status_code=201)
 async def create_workspace(
-    req: WorkspaceCreateRequest, current_user: dict = Depends(get_current_user),
+    req: WorkspaceCreateRequest,
+    current_user: dict = Depends(get_current_user),
 ):
     ws = await workspace_service.create_workspace(
-        name=req.name, description=req.description,
-        creator_id=current_user["id"], is_public=req.is_public,
+        name=req.name,
+        description=req.description,
+        creator_id=current_user["id"],
+        is_public=req.is_public,
     )
     return WorkspaceResponse(**ws)
 
@@ -44,10 +49,7 @@ async def create_workspace(
 async def list_workspaces(current_user: dict | None = Depends(get_current_user_optional)):
     workspaces = await workspace_service.list_public_workspaces()
     viewer_id = current_user["id"] if current_user else None
-    serialized = [
-        await _serialize_workspace_for_viewer(w, viewer_id)
-        for w in workspaces
-    ]
+    serialized = [await _serialize_workspace_for_viewer(w, viewer_id) for w in workspaces]
     return WorkspaceListResponse(workspaces=serialized)
 
 
@@ -59,7 +61,8 @@ async def list_my_workspaces(current_user: dict = Depends(get_current_user)):
 
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)
 async def get_workspace(
-    workspace_id: UUID, current_user: dict | None = Depends(get_current_user_optional),
+    workspace_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
     ws = await workspace_service.get_workspace(workspace_id)
     if not ws:
@@ -70,14 +73,17 @@ async def get_workspace(
 
 @router.patch("/{workspace_id}", response_model=WorkspaceResponse)
 async def update_workspace(
-    workspace_id: UUID, req: WorkspaceUpdateRequest,
+    workspace_id: UUID,
+    req: WorkspaceUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
     if role not in ("owner", "admin"):
         raise HTTPException(status_code=403, detail="Only owner/admin can update workspace")
     ws = await workspace_service.update_workspace(
-        workspace_id, name=req.name, description=req.description,
+        workspace_id,
+        name=req.name,
+        description=req.description,
     )
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -86,7 +92,8 @@ async def update_workspace(
 
 @router.delete("/{workspace_id}", status_code=204)
 async def delete_workspace(
-    workspace_id: UUID, current_user: dict = Depends(get_current_user),
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     deleted = await workspace_service.delete_workspace(workspace_id, current_user["id"])
     if not deleted:
@@ -95,7 +102,8 @@ async def delete_workspace(
 
 @router.post("/join/{invite_code}", response_model=WorkspaceResponse)
 async def join_workspace(
-    invite_code: str, current_user: dict = Depends(get_current_user),
+    invite_code: str,
+    current_user: dict = Depends(get_current_user),
 ):
     ws = await workspace_service.join_by_invite(invite_code, current_user["id"])
     if not ws:
@@ -105,7 +113,8 @@ async def join_workspace(
 
 @router.post("/{workspace_id}/leave", status_code=204)
 async def leave_workspace(
-    workspace_id: UUID, current_user: dict = Depends(get_current_user),
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     left = await workspace_service.leave_workspace(workspace_id, current_user["id"])
     if not left:
@@ -114,7 +123,8 @@ async def leave_workspace(
 
 @router.get("/{workspace_id}/members", response_model=list[WorkspaceMember])
 async def get_members(
-    workspace_id: UUID, current_user: dict = Depends(get_current_user),
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
 ):
     if not await workspace_service.is_member(workspace_id, current_user["id"]):
         raise HTTPException(status_code=403, detail="Not a workspace member")
@@ -136,6 +146,7 @@ async def add_member(
     if not username:
         raise HTTPException(status_code=400, detail="username is required")
     from ..database import get_pool
+
     pool = get_pool()
     user = await pool.fetchrow("SELECT id FROM users WHERE name = $1", username)
     if not user:
@@ -148,7 +159,8 @@ async def add_member(
 
 @router.post("/{workspace_id}/kick/{user_id}", status_code=204)
 async def kick_member(
-    workspace_id: UUID, user_id: UUID,
+    workspace_id: UUID,
+    user_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
     kicked = await workspace_service.kick_member(workspace_id, user_id, current_user["id"])

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -1,7 +1,8 @@
 """Analytics service: aggregated views for dashboard visualizations."""
 
 import logging
-from datetime import datetime, timedelta, timezone
+import re
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import numpy as np
@@ -50,7 +51,7 @@ async def get_activity_timeline(
     if bucket not in ("hour", "day", "week"):
         bucket = "day"
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff = datetime.now(UTC) - timedelta(days=days)
 
     rows = await pool.fetch(
         _ACCESSIBLE_EVENTS_CTE + """
@@ -65,7 +66,9 @@ async def get_activity_timeline(
         GROUP BY bucket_date, me.agent_name, me.event_type
         ORDER BY bucket_date
         """,
-        user_id, bucket, cutoff,
+        user_id,
+        bucket,
+        cutoff,
     )
 
     # Build response shape
@@ -88,9 +91,7 @@ async def get_activity_timeline(
             b["agents"][agent] = {"total": 0, "by_type": {}}
 
         b["agents"][agent]["total"] += cnt
-        b["agents"][agent]["by_type"][etype] = (
-            b["agents"][agent]["by_type"].get(etype, 0) + cnt
-        )
+        b["agents"][agent]["by_type"][etype] = b["agents"][agent]["by_type"].get(etype, 0) + cnt
 
     return {
         "agents": sorted(agents_set),
@@ -102,23 +103,104 @@ _density_cache: dict[str, tuple[float, dict]] = {}
 _DENSITY_TTL = 300  # 5 minutes
 
 # Common words that survive Postgres stemming but aren't meaningful topics
-_STOP_STEMS = frozenset({
-    "use", "also", "one", "two", "new", "get", "set", "may", "need",
-    "make", "like", "work", "want", "know", "see", "run", "add",
-    "way", "tri", "call", "chang", "type", "name", "valu", "file",
-    "data", "page", "tabl", "creat", "updat", "delet", "list",
-    "function", "return", "true", "false", "null", "string", "number",
-    "error", "code", "time", "note", "item", "can", "would", "could",
-    "via", "first", "within", "includ", "each", "allow", "provid",
-    "ensur", "base", "current", "follow", "implement", "specif",
-    "exist", "requir", "support", "differ", "key", "singl", "multi",
-    "per", "high", "low", "medium", "fast", "slow", "cost", "date",
-    "releas", "window", "context", "speed", "qualiti", "mtok",
-    "generat", "check", "result", "build", "process", "issu",
-    "perform", "test", "start", "stop", "open", "close", "sourc",
-})
-
-import re
+_STOP_STEMS = frozenset(
+    {
+        "use",
+        "also",
+        "one",
+        "two",
+        "new",
+        "get",
+        "set",
+        "may",
+        "need",
+        "make",
+        "like",
+        "work",
+        "want",
+        "know",
+        "see",
+        "run",
+        "add",
+        "way",
+        "tri",
+        "call",
+        "chang",
+        "type",
+        "name",
+        "valu",
+        "file",
+        "data",
+        "page",
+        "tabl",
+        "creat",
+        "updat",
+        "delet",
+        "list",
+        "function",
+        "return",
+        "true",
+        "false",
+        "null",
+        "string",
+        "number",
+        "error",
+        "code",
+        "time",
+        "note",
+        "item",
+        "can",
+        "would",
+        "could",
+        "via",
+        "first",
+        "within",
+        "includ",
+        "each",
+        "allow",
+        "provid",
+        "ensur",
+        "base",
+        "current",
+        "follow",
+        "implement",
+        "specif",
+        "exist",
+        "requir",
+        "support",
+        "differ",
+        "key",
+        "singl",
+        "multi",
+        "per",
+        "high",
+        "low",
+        "medium",
+        "fast",
+        "slow",
+        "cost",
+        "date",
+        "releas",
+        "window",
+        "context",
+        "speed",
+        "qualiti",
+        "mtok",
+        "generat",
+        "check",
+        "result",
+        "build",
+        "process",
+        "issu",
+        "perform",
+        "test",
+        "start",
+        "stop",
+        "open",
+        "close",
+        "sourc",
+    }
+)
 
 # Matches auto-generated column names like col1, col2, column_3, etc.
 _COLUMN_NAME_RE = re.compile(r"^col\d+$|^column\d+$|^field\d+$|^row\d+$|^val\d+$")
@@ -134,7 +216,7 @@ async def get_knowledge_density(
 
     # Check in-memory cache
     cache_key = f"{user_id}:{max_clusters}"
-    now = datetime.now(timezone.utc).timestamp()
+    now = datetime.now(UTC).timestamp()
     if cache_key in _density_cache:
         cached_at, cached_result = _density_cache[cache_key]
         if now - cached_at < _DENSITY_TTL:
@@ -173,7 +255,8 @@ async def get_knowledge_density(
             LIMIT 1
         ) orig
         """,
-        user_id, max_clusters * 5,
+        user_id,
+        max_clusters * 5,
     )
     page_terms = [(r["stem"], r["original_word"], r["ndoc"]) for r in rows]
 
@@ -192,7 +275,8 @@ async def get_knowledge_density(
         ORDER BY ndoc DESC
         LIMIT $2
         """,
-        user_id, max_clusters * 5,
+        user_id,
+        max_clusters * 5,
     )
     table_terms = [(r["stem"], r["ndoc"]) for r in tbl_rows]
 
@@ -209,22 +293,28 @@ async def get_knowledge_density(
         return False
 
     # Count total documents for TF-IDF denominator
-    total_pages = await pool.fetchval(
-        _ACCESSIBLE_NOTEBOOKS_CTE + """
+    total_pages = (
+        await pool.fetchval(
+            _ACCESSIBLE_NOTEBOOKS_CTE + """
         SELECT COUNT(*) FROM notebook_pages np
         WHERE np.notebook_id IN (SELECT notebook_id FROM accessible_notebooks)
           AND np.content_markdown IS NOT NULL AND np.content_markdown != ''
         """,
-        user_id,
-    ) or 1
-    total_tbl_rows = await pool.fetchval(
-        _ACCESSIBLE_TABLES_CTE + """
+            user_id,
+        )
+        or 1
+    )
+    total_tbl_rows = (
+        await pool.fetchval(
+            _ACCESSIBLE_TABLES_CTE + """
         SELECT COUNT(*) FROM table_rows tr
         WHERE tr.table_id IN (SELECT table_id FROM accessible_tables)
           AND tr.data IS NOT NULL
         """,
-        user_id,
-    ) or 1
+            user_id,
+        )
+        or 1
+    )
     total_docs = total_pages + total_tbl_rows
 
     import math
@@ -264,7 +354,9 @@ async def get_knowledge_density(
 
     # Rank by TF-IDF (surfaces distinctive terms), take top N
     top_terms = sorted(
-        term_counts.items(), key=lambda x: x[1]["tfidf"], reverse=True,
+        term_counts.items(),
+        key=lambda x: x[1]["tfidf"],
+        reverse=True,
     )[:max_clusters]
 
     if not top_terms:
@@ -290,7 +382,8 @@ async def get_knowledge_density(
           LIMIT 3
         ) np
         """,
-        user_id, words,
+        user_id,
+        words,
     )
     for r in enrich_rows:
         enrichment[r["word"]].append(r)
@@ -311,17 +404,19 @@ async def get_knowledge_density(
                 if oldest_at is None or ts < oldest_at:
                     oldest_at = ts
 
-        clusters.append({
-            "label": counts.get("label", word.capitalize()),
-            "count": counts["raw_total"],
-            "sources": {
-                "notebook_pages": counts["notebook_pages"],
-                "table_rows": counts["table_rows"],
-            },
-            "newest_at": newest_at.isoformat() if newest_at else None,
-            "oldest_at": oldest_at.isoformat() if oldest_at else None,
-            "sample_titles": sample_titles,
-        })
+        clusters.append(
+            {
+                "label": counts.get("label", word.capitalize()),
+                "count": counts["raw_total"],
+                "sources": {
+                    "notebook_pages": counts["notebook_pages"],
+                    "table_rows": counts["table_rows"],
+                },
+                "newest_at": newest_at.isoformat() if newest_at else None,
+                "oldest_at": oldest_at.isoformat() if oldest_at else None,
+                "sample_titles": sample_titles,
+            }
+        )
 
     result = {"clusters": clusters}
     _density_cache[cache_key] = (now, result)
@@ -343,7 +438,8 @@ async def get_embedding_projection(
     cache = await pool.fetchrow(
         "SELECT points, embedding_count, computed_at FROM embedding_projections "
         "WHERE user_id = $1 AND source_type = $2",
-        user_id, source_key,
+        user_id,
+        source_key,
     )
 
     # Count current embeddings
@@ -382,7 +478,7 @@ async def get_embedding_projection(
         total_count += row or 0
 
     # Check if cache is still valid
-    one_hour_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+    one_hour_ago = datetime.now(UTC) - timedelta(hours=1)
     if cache and cache["computed_at"] > one_hour_ago:
         count_diff = abs(total_count - cache["embedding_count"])
         if count_diff / max(cache["embedding_count"], 1) < 0.1:
@@ -409,16 +505,19 @@ async def get_embedding_projection(
             ORDER BY np.updated_at DESC
             LIMIT $2
             """,
-            user_id, per_source_limit,
+            user_id,
+            per_source_limit,
         )
         for r in rows:
-            all_items.append({
-                "id": str(r["id"]),
-                "label": r["label"],
-                "source": "notebook_pages",
-                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
-                "embedding": np.array(r["embedding"]),
-            })
+            all_items.append(
+                {
+                    "id": str(r["id"]),
+                    "label": r["label"],
+                    "source": "notebook_pages",
+                    "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                    "embedding": np.array(r["embedding"]),
+                }
+            )
 
     if source is None or source == "table_rows":
         rows = await pool.fetch(
@@ -431,16 +530,19 @@ async def get_embedding_projection(
             ORDER BY tr.created_at DESC
             LIMIT $2
             """,
-            user_id, per_source_limit,
+            user_id,
+            per_source_limit,
         )
         for r in rows:
-            all_items.append({
-                "id": str(r["id"]),
-                "label": r["table_name"],
-                "source": "table_rows",
-                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
-                "embedding": np.array(r["embedding"]),
-            })
+            all_items.append(
+                {
+                    "id": str(r["id"]),
+                    "label": r["table_name"],
+                    "source": "table_rows",
+                    "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                    "embedding": np.array(r["embedding"]),
+                }
+            )
 
     if source is None or source == "history_events":
         rows = await pool.fetch(
@@ -452,19 +554,26 @@ async def get_embedding_projection(
             ORDER BY me.created_at DESC
             LIMIT $2
             """,
-            user_id, per_source_limit,
+            user_id,
+            per_source_limit,
         )
         for r in rows:
-            all_items.append({
-                "id": str(r["id"]),
-                "label": f"{r['agent_name'] or 'agent'}: {r['event_type'] or 'event'}",
-                "source": "history_events",
-                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
-                "embedding": np.array(r["embedding"]),
-            })
+            all_items.append(
+                {
+                    "id": str(r["id"]),
+                    "label": f"{r['agent_name'] or 'agent'}: {r['event_type'] or 'event'}",
+                    "source": "history_events",
+                    "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                    "embedding": np.array(r["embedding"]),
+                }
+            )
 
     if not all_items:
-        return {"points": [], "stats": {"total_embeddings": total_count, "projected": 0}, "cached": False}
+        return {
+            "points": [],
+            "stats": {"total_embeddings": total_count, "projected": 0},
+            "cached": False,
+        }
 
     # 3D PCA projection
     embeddings_matrix = np.stack([item["embedding"] for item in all_items])
@@ -485,15 +594,17 @@ async def get_embedding_projection(
     # Build points
     points = []
     for i, item in enumerate(all_items):
-        points.append({
-            "id": item["id"],
-            "x": round(float(coords[i, 0]), 4),
-            "y": round(float(coords[i, 1]), 4),
-            "z": round(float(coords[i, 2]), 4),
-            "source": item["source"],
-            "label": item["label"],
-            "created_at": item["created_at"],
-        })
+        points.append(
+            {
+                "id": item["id"],
+                "x": round(float(coords[i, 0]), 4),
+                "y": round(float(coords[i, 1]), 4),
+                "z": round(float(coords[i, 2]), 4),
+                "source": item["source"],
+                "label": item["label"],
+                "created_at": item["created_at"],
+            }
+        )
 
     # Update cache
     await pool.execute(
@@ -501,7 +612,10 @@ async def get_embedding_projection(
         "VALUES ($1, $2, $3, $4, NOW()) "
         "ON CONFLICT (user_id, source_type) "
         "DO UPDATE SET points = $3, embedding_count = $4, computed_at = NOW()",
-        user_id, source_key, points, total_count,
+        user_id,
+        source_key,
+        points,
+        total_count,
     )
 
     return {

--- a/backend/services/embeddings/auto.py
+++ b/backend/services/embeddings/auto.py
@@ -26,25 +26,31 @@ def get_embedder() -> BaseEmbedder:
 
     if provider == "openai":
         from .openai_compat import OpenAICompatEmbedder
+
         _embedder = OpenAICompatEmbedder()
 
     elif provider == "huggingface":
         from .huggingface import HuggingFaceEmbedder
+
         _embedder = HuggingFaceEmbedder()
 
     elif provider == "local":
         from .local import LocalEmbedder
+
         _embedder = LocalEmbedder()
 
     elif provider == "auto":
         if os.getenv("OPENAI_API_KEY") or os.getenv("EMBEDDING_API_KEY"):
             from .openai_compat import OpenAICompatEmbedder
+
             _embedder = OpenAICompatEmbedder()
         elif os.getenv("HF_TOKEN"):
             from .huggingface import HuggingFaceEmbedder
+
             _embedder = HuggingFaceEmbedder()
         else:
             from .local import LocalEmbedder
+
             _embedder = LocalEmbedder()
 
     else:

--- a/backend/services/embeddings/local.py
+++ b/backend/services/embeddings/local.py
@@ -30,6 +30,7 @@ class LocalEmbedder(BaseEmbedder):
     def is_configured(self) -> bool:
         try:
             import sentence_transformers  # noqa: F401
+
             return True
         except ImportError:
             return False

--- a/backend/services/embeddings/openai_compat.py
+++ b/backend/services/embeddings/openai_compat.py
@@ -25,11 +25,7 @@ class OpenAICompatEmbedder(BaseEmbedder):
         model: str | None = None,
         dims: int | None = None,
     ):
-        self.api_key = (
-            api_key
-            or os.getenv("EMBEDDING_API_KEY")
-            or os.getenv("OPENAI_API_KEY", "")
-        )
+        self.api_key = api_key or os.getenv("EMBEDDING_API_KEY") or os.getenv("OPENAI_API_KEY", "")
         self.api_url = api_url or os.getenv(
             "EMBEDDING_API_URL", "https://api.openai.com/v1/embeddings"
         )

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -6,7 +6,7 @@ Grouped by agent_name → session_id for display.
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 import numpy as np
@@ -28,7 +28,8 @@ async def _embed_event(event_id: UUID, content: str) -> None:
             pool = get_pool()
             await pool.execute(
                 "UPDATE history_events SET embedding = $1 WHERE id = $2",
-                vec, event_id,
+                vec,
+                event_id,
             )
     except Exception:
         logger.debug("Failed to embed event %s", event_id, exc_info=True)
@@ -44,7 +45,8 @@ async def _embed_events_batch(event_ids: list[UUID], contents: list[str]) -> Non
                 for eid, vec in zip(event_ids, vecs):
                     await conn.execute(
                         "UPDATE history_events SET embedding = $1 WHERE id = $2",
-                        vec, eid,
+                        vec,
+                        eid,
                     )
     except Exception:
         logger.debug("Failed to batch-embed events", exc_info=True)
@@ -69,9 +71,9 @@ async def push_event(
     pool = get_pool()
     meta = metadata or {}
     if created_at is None:
-        ts = datetime.now(timezone.utc)
+        ts = datetime.now(UTC)
     elif created_at.tzinfo is None:
-        ts = created_at.replace(tzinfo=timezone.utc)
+        ts = created_at.replace(tzinfo=UTC)
     else:
         ts = created_at
     row = await pool.fetchrow(
@@ -80,8 +82,16 @@ async def push_event(
         "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10) "
         "RETURNING id, workspace_id, created_by, agent_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at",
-        workspace_id, created_by, agent_name, event_type, content,
-        session_id, tool_name, meta, attachments, ts,
+        workspace_id,
+        created_by,
+        agent_name,
+        event_type,
+        content,
+        session_id,
+        tool_name,
+        meta,
+        attachments,
+        ts,
     )
     event = dict(row)
     if embedding_service.is_configured():
@@ -90,7 +100,9 @@ async def push_event(
 
 
 async def push_events_batch(
-    workspace_id: UUID | None, created_by: UUID, events: list[dict],
+    workspace_id: UUID | None,
+    created_by: UUID,
+    events: list[dict],
 ) -> list[dict]:
     """Batch push events. Returns list of created events."""
     pool = get_pool()
@@ -101,9 +113,9 @@ async def push_events_batch(
                 meta = evt.get("metadata", {})
                 raw_ts = evt.get("created_at")
                 if raw_ts is None:
-                    ts = datetime.now(timezone.utc)
+                    ts = datetime.now(UTC)
                 elif raw_ts.tzinfo is None:
-                    ts = raw_ts.replace(tzinfo=timezone.utc)
+                    ts = raw_ts.replace(tzinfo=UTC)
                 else:
                     ts = raw_ts
                 row = await conn.fetchrow(
@@ -113,10 +125,16 @@ async def push_events_batch(
                     "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10) "
                     "RETURNING id, workspace_id, created_by, agent_name, event_type, "
                     "session_id, tool_name, content, metadata, attachments, created_at",
-                    workspace_id, created_by,
-                    evt["agent_name"], evt["event_type"], evt["content"],
-                    evt.get("session_id"), evt.get("tool_name"), meta,
-                    evt.get("attachments"), ts,
+                    workspace_id,
+                    created_by,
+                    evt["agent_name"],
+                    evt["event_type"],
+                    evt["content"],
+                    evt.get("session_id"),
+                    evt.get("tool_name"),
+                    meta,
+                    evt.get("attachments"),
+                    ts,
                 )
                 results.append(dict(row))
     if embedding_service.is_configured() and results:
@@ -130,7 +148,8 @@ async def get_workspace_event(event_id: UUID, workspace_id: UUID) -> dict | None
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT * FROM history_events WHERE id = $1 AND workspace_id = $2",
-        event_id, workspace_id,
+        event_id,
+        workspace_id,
     )
     return dict(row) if row else None
 
@@ -140,7 +159,8 @@ async def get_personal_event(event_id: UUID, user_id: UUID) -> dict | None:
     row = await pool.fetchrow(
         "SELECT * FROM history_events "
         "WHERE id = $1 AND workspace_id IS NULL AND created_by = $2",
-        event_id, user_id,
+        event_id,
+        user_id,
     )
     return dict(row) if row else None
 
@@ -184,7 +204,10 @@ def _build_event_filters(
 
 
 async def _query_events(
-    where: str, args: list, limit_idx: int, limit: int,
+    where: str,
+    args: list,
+    limit_idx: int,
+    limit: int,
 ) -> tuple[list[dict], bool]:
     pool = get_pool()
     args = [*args, limit + 1]
@@ -214,8 +237,13 @@ async def query_workspace_events(
     """Query events in a workspace. Returns (events, has_more)."""
     limit = min(limit, 200)
     where, args, next_idx = _build_event_filters(
-        "workspace_id = $1", [workspace_id],
-        agent_name, session_id, event_type, after, before,
+        "workspace_id = $1",
+        [workspace_id],
+        agent_name,
+        session_id,
+        event_type,
+        after,
+        before,
     )
     return await _query_events(where, args, next_idx, limit)
 
@@ -232,14 +260,21 @@ async def query_personal_events(
     """Query personal (non-workspace) events for a user. Returns (events, has_more)."""
     limit = min(limit, 200)
     where, args, next_idx = _build_event_filters(
-        "workspace_id IS NULL AND created_by = $1", [user_id],
-        agent_name, session_id, event_type, after, before,
+        "workspace_id IS NULL AND created_by = $1",
+        [user_id],
+        agent_name,
+        session_id,
+        event_type,
+        after,
+        before,
     )
     return await _query_events(where, args, next_idx, limit)
 
 
 async def search_workspace_events(
-    workspace_id: UUID, query: str, limit: int = 50,
+    workspace_id: UUID,
+    query: str,
+    limit: int = 50,
 ) -> list[dict]:
     """Full-text search on workspace events."""
     pool = get_pool()
@@ -251,13 +286,17 @@ async def search_workspace_events(
         "FROM history_events "
         "WHERE workspace_id = $1 AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
         "ORDER BY rank DESC LIMIT $3",
-        workspace_id, query, limit,
+        workspace_id,
+        query,
+        limit,
     )
     return [dict(r) for r in rows]
 
 
 async def search_personal_events(
-    user_id: UUID, query: str, limit: int = 50,
+    user_id: UUID,
+    query: str,
+    limit: int = 50,
 ) -> list[dict]:
     """Full-text search on personal events."""
     pool = get_pool()
@@ -270,13 +309,17 @@ async def search_personal_events(
         "WHERE workspace_id IS NULL AND created_by = $1 "
         "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
         "ORDER BY rank DESC LIMIT $3",
-        user_id, query, limit,
+        user_id,
+        query,
+        limit,
     )
     return [dict(r) for r in rows]
 
 
 async def search_workspace_events_vector(
-    workspace_id: UUID, query_embedding: np.ndarray, limit: int = 20,
+    workspace_id: UUID,
+    query_embedding: np.ndarray,
+    limit: int = 20,
 ) -> list[dict]:
     """Semantic vector search on workspace events."""
     pool = get_pool()
@@ -288,13 +331,17 @@ async def search_workspace_events_vector(
         "FROM history_events "
         "WHERE workspace_id = $1 AND embedding IS NOT NULL "
         "ORDER BY embedding <=> $2 LIMIT $3",
-        workspace_id, query_embedding, limit,
+        workspace_id,
+        query_embedding,
+        limit,
     )
     return [dict(r) for r in rows]
 
 
 async def search_personal_events_vector(
-    user_id: UUID, query_embedding: np.ndarray, limit: int = 20,
+    user_id: UUID,
+    query_embedding: np.ndarray,
+    limit: int = 20,
 ) -> list[dict]:
     """Semantic vector search on personal events."""
     pool = get_pool()
@@ -306,7 +353,9 @@ async def search_personal_events_vector(
         "FROM history_events "
         "WHERE workspace_id IS NULL AND created_by = $1 AND embedding IS NOT NULL "
         "ORDER BY embedding <=> $2 LIMIT $3",
-        user_id, query_embedding, limit,
+        user_id,
+        query_embedding,
+        limit,
     )
     return [dict(r) for r in rows]
 
@@ -376,7 +425,8 @@ async def delete_workspace_agent_events(agent_name: str, workspace_id: UUID) -> 
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id = $2",
-        agent_name, workspace_id,
+        agent_name,
+        workspace_id,
     )
     return int(result.split()[-1]) if result else 0
 
@@ -386,7 +436,8 @@ async def delete_personal_agent_events(agent_name: str, user_id: UUID) -> int:
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id IS NULL AND created_by = $2",
-        agent_name, user_id,
+        agent_name,
+        user_id,
     )
     return int(result.split()[-1]) if result else 0
 
@@ -394,7 +445,10 @@ async def delete_personal_agent_events(agent_name: str, user_id: UUID) -> int:
 async def get_workspace_event_count(workspace_id: UUID) -> int:
     """Count events in a workspace."""
     pool = get_pool()
-    return await pool.fetchval(
-        "SELECT COUNT(*) FROM history_events WHERE workspace_id = $1",
-        workspace_id,
-    ) or 0
+    return (
+        await pool.fetchval(
+            "SELECT COUNT(*) FROM history_events WHERE workspace_id = $1",
+            workspace_id,
+        )
+        or 0
+    )

--- a/backend/services/notebook_service.py
+++ b/backend/services/notebook_service.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import hashlib
-import json
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -22,14 +21,20 @@ def _content_hash(content: str) -> str:
 
 
 async def create_notebook(
-    workspace_id: UUID | None, name: str, description: str, created_by: UUID,
+    workspace_id: UUID | None,
+    name: str,
+    description: str,
+    created_by: UUID,
 ) -> dict:
     pool = get_pool()
     row = await pool.fetchrow(
         "INSERT INTO notebooks (workspace_id, name, description, created_by) "
         "VALUES ($1, $2, $3, $4) "
         "RETURNING id, workspace_id, name, description, created_by, created_at, updated_at",
-        workspace_id, name, description, created_by,
+        workspace_id,
+        name,
+        description,
+        created_by,
     )
     return dict(row)
 
@@ -95,7 +100,9 @@ async def create_folder(notebook_id: UUID, name: str, created_by: UUID) -> dict:
         "INSERT INTO notebook_folders (notebook_id, name, created_by) "
         "VALUES ($1, $2, $3) "
         "RETURNING id, notebook_id, name, created_by, created_at, updated_at",
-        notebook_id, name, created_by,
+        notebook_id,
+        name,
+        created_by,
     )
     return dict(row)
 
@@ -106,7 +113,9 @@ async def rename_folder(folder_id: UUID, notebook_id: UUID, name: str) -> dict |
         "UPDATE notebook_folders SET name = $1, updated_at = now() "
         "WHERE id = $2 AND notebook_id = $3 "
         "RETURNING id, notebook_id, name, created_by, created_at, updated_at",
-        name, folder_id, notebook_id,
+        name,
+        folder_id,
+        notebook_id,
     )
     return dict(row) if row else None
 
@@ -115,7 +124,8 @@ async def delete_folder(folder_id: UUID, notebook_id: UUID) -> bool:
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM notebook_folders WHERE id = $1 AND notebook_id = $2",
-        folder_id, notebook_id,
+        folder_id,
+        notebook_id,
     )
     return result == "DELETE 1"
 
@@ -124,8 +134,11 @@ async def delete_folder(folder_id: UUID, notebook_id: UUID) -> bool:
 
 
 async def create_page(
-    notebook_id: UUID, name: str, created_by: UUID,
-    folder_id: UUID | None = None, content: str = "",
+    notebook_id: UUID,
+    name: str,
+    created_by: UUID,
+    folder_id: UUID | None = None,
+    content: str = "",
     metadata: dict | None = None,
 ) -> dict:
     pool = get_pool()
@@ -137,7 +150,13 @@ async def create_page(
         "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $7) "
         "RETURNING id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
         "created_by, updated_by, created_at, updated_at",
-        notebook_id, folder_id, name, content, ch, meta, created_by,
+        notebook_id,
+        folder_id,
+        name,
+        content,
+        ch,
+        meta,
+        created_by,
     )
     page = dict(row)
     # Fire-and-forget: embed page + extract wiki links
@@ -155,7 +174,8 @@ async def get_page(page_id: UUID, notebook_id: UUID) -> dict | None:
         "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
         "created_by, updated_by, created_at, updated_at "
         "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
-        page_id, notebook_id,
+        page_id,
+        notebook_id,
     )
     return dict(row) if row else None
 
@@ -185,9 +205,13 @@ class ConcurrentEditError(Exception):
 
 
 async def update_page(
-    page_id: UUID, notebook_id: UUID, updated_by: UUID,
-    name: str | None = None, folder_id: UUID | None = None,
-    content: str | None = None, move_to_root: bool = False,
+    page_id: UUID,
+    notebook_id: UUID,
+    updated_by: UUID,
+    name: str | None = None,
+    folder_id: UUID | None = None,
+    content: str | None = None,
+    move_to_root: bool = False,
     metadata: dict | None = None,
     on_conflict: Callable[[dict], Awaitable[str]] | None = None,
 ) -> dict | None:
@@ -210,7 +234,8 @@ async def update_page(
         if content is not None:
             current = await pool.fetchrow(
                 "SELECT content_hash FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
-                page_id, notebook_id,
+                page_id,
+                notebook_id,
             )
             if current is None:
                 return None
@@ -269,7 +294,8 @@ async def update_page(
             "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
             "created_by, updated_by, created_at, updated_at "
             "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
-            page_id, notebook_id,
+            page_id,
+            notebook_id,
         )
         if fresh is None:
             return None
@@ -277,18 +303,21 @@ async def update_page(
         fresh_page = dict(fresh)
         logger.info(
             "update_page conflict on page %s (attempt %d/%d)",
-            page_id, attempt + 1, MAX_UPDATE_RETRIES,
+            page_id,
+            attempt + 1,
+            MAX_UPDATE_RETRIES,
         )
         if on_conflict is None:
             raise ConcurrentEditError(fresh_page)
         content = await on_conflict(fresh_page)
-        await asyncio.sleep(0.02 * (2 ** attempt))
+        await asyncio.sleep(0.02 * (2**attempt))
 
     logger.warning("update_page exhausted retries for page %s", page_id)
     fresh = await pool.fetchrow(
         "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash "
         "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
-        page_id, notebook_id,
+        page_id,
+        notebook_id,
     )
     if fresh is None:
         return None
@@ -299,7 +328,8 @@ async def delete_page(page_id: UUID, notebook_id: UUID) -> bool:
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
-        page_id, notebook_id,
+        page_id,
+        notebook_id,
     )
     return result == "DELETE 1"
 
@@ -335,8 +365,6 @@ async def list_page_tree(notebook_id: UUID) -> dict:
     return {"folders": list(folder_map.values()), "root_files": root_files}
 
 
-
-
 async def search_pages_fts(notebook_id: UUID, query: str, limit: int = 10) -> list[dict]:
     """FTS search on notebook page content + keywords (keywords weighted A, content weighted B)."""
     pool = get_pool()
@@ -357,7 +385,9 @@ async def search_pages_fts(notebook_id: UUID, query: str, limit: int = 10) -> li
         f"WHERE notebook_id = $1 "
         f"AND ({vec_expr}) @@ websearch_to_tsquery('english', $2) "
         f"ORDER BY rank DESC LIMIT $3",
-        notebook_id, query, limit,
+        notebook_id,
+        query,
+        limit,
     )
     return [dict(r) for r in rows]
 
@@ -379,7 +409,8 @@ async def _resolve_page_name(notebook_id: UUID, page_name: str) -> UUID | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id FROM notebook_pages WHERE notebook_id = $1 AND name = $2",
-        notebook_id, page_name.strip(),
+        notebook_id,
+        page_name.strip(),
     )
     return row["id"] if row else None
 
@@ -390,7 +421,8 @@ async def _update_page_links(page_id: UUID, notebook_id: UUID, content: str) -> 
         pool = get_pool()
         # Delete existing outlinks from this page
         await pool.execute(
-            "DELETE FROM page_links WHERE source_page_id = $1", page_id,
+            "DELETE FROM page_links WHERE source_page_id = $1",
+            page_id,
         )
 
         link_names = _extract_wiki_links(content)
@@ -403,7 +435,9 @@ async def _update_page_links(page_id: UUID, notebook_id: UUID, content: str) -> 
                 await pool.execute(
                     "INSERT INTO page_links (source_page_id, target_page_id, link_text) "
                     "VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-                    page_id, target_id, name,
+                    page_id,
+                    target_id,
+                    name,
                 )
     except Exception:
         logger.debug("Failed to update page links for %s", page_id, exc_info=True)
@@ -418,13 +452,17 @@ async def _resolve_dangling_links(notebook_id: UUID, page_name: str, page_id: UU
         rows = await pool.fetch(
             "SELECT id, content_markdown FROM notebook_pages "
             "WHERE notebook_id = $1 AND id != $2 AND content_markdown LIKE $3",
-            notebook_id, page_id, pattern,
+            notebook_id,
+            page_id,
+            pattern,
         )
         for row in rows:
             await pool.execute(
                 "INSERT INTO page_links (source_page_id, target_page_id, link_text) "
                 "VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-                row["id"], page_id, page_name,
+                row["id"],
+                page_id,
+                page_name,
             )
     except Exception:
         logger.debug("Failed to resolve dangling links for %s", page_name, exc_info=True)
@@ -459,7 +497,8 @@ async def get_page_graph(notebook_id: UUID) -> dict:
     pool = get_pool()
     # Get all pages as nodes
     pages = await pool.fetch(
-        "SELECT id, name FROM notebook_pages WHERE notebook_id = $1", notebook_id,
+        "SELECT id, name FROM notebook_pages WHERE notebook_id = $1",
+        notebook_id,
     )
     nodes = [{"id": str(p["id"]), "name": p["name"]} for p in pages]
 
@@ -474,8 +513,11 @@ async def get_page_graph(notebook_id: UUID) -> dict:
         page_ids,
     )
     edges = [
-        {"source": str(e["source_page_id"]), "target": str(e["target_page_id"]),
-         "label": e["link_text"]}
+        {
+            "source": str(e["source_page_id"]),
+            "target": str(e["target_page_id"]),
+            "label": e["link_text"],
+        }
         for e in edges_rows
     ]
 
@@ -489,6 +531,7 @@ async def _embed_page(page_id: UUID, content: str) -> None:
     """Fire-and-forget: embed page content and store in database."""
     try:
         from . import embeddings as embedding_service
+
         if not embedding_service.is_configured():
             return
         embedding = await embedding_service.embed_text(content)
@@ -497,14 +540,17 @@ async def _embed_page(page_id: UUID, content: str) -> None:
         pool = get_pool()
         await pool.execute(
             "UPDATE notebook_pages SET embedding = $1 WHERE id = $2",
-            embedding, page_id,
+            embedding,
+            page_id,
         )
     except Exception:
         logger.debug("Failed to embed page %s", page_id, exc_info=True)
 
 
 async def search_pages_vector(
-    notebook_id: UUID, query_embedding, limit: int = 20,
+    notebook_id: UUID,
+    query_embedding,
+    limit: int = 20,
 ) -> list[dict]:
     """Semantic search on notebook pages using pgvector."""
     pool = get_pool()
@@ -514,8 +560,8 @@ async def search_pages_vector(
         "1 - (embedding <=> $2) AS similarity "
         "FROM notebook_pages WHERE notebook_id = $1 AND embedding IS NOT NULL "
         "ORDER BY embedding <=> $2 LIMIT $3",
-        notebook_id, query_embedding, limit,
+        notebook_id,
+        query_embedding,
+        limit,
     )
     return [dict(r) for r in rows]
-
-

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -35,7 +35,8 @@ async def check_access(
             table, col = table_map[object_type]
             row = await pool.fetchrow(
                 f"SELECT 1 FROM {table} WHERE id = $1 AND {col} = $2 AND workspace_id IS NULL",
-                object_id, user_id,
+                object_id,
+                user_id,
             )
             if row:
                 return True
@@ -61,7 +62,9 @@ async def check_access(
     share = await pool.fetchrow(
         "SELECT permission FROM object_shares "
         "WHERE object_type = $1 AND object_id = $2 AND user_id = $3",
-        object_type, object_id, user_id,
+        object_type,
+        object_id,
+        user_id,
     )
     if share:
         if not require_write:
@@ -76,7 +79,8 @@ async def get_workspace_role(workspace_id: UUID, user_id: UUID) -> str | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
-        workspace_id, user_id,
+        workspace_id,
+        user_id,
     )
     return row["role"] if row else None
 
@@ -89,9 +93,9 @@ async def get_visibility(object_type: str, object_id: UUID) -> str:
     """Get object visibility. Returns 'inherit' if no row exists."""
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT visibility FROM object_permissions "
-        "WHERE object_type = $1 AND object_id = $2",
-        object_type, object_id,
+        "SELECT visibility FROM object_permissions " "WHERE object_type = $1 AND object_id = $2",
+        object_type,
+        object_id,
     )
     return row["visibility"] if row else "inherit"
 
@@ -103,14 +107,17 @@ async def set_visibility(object_type: str, object_id: UUID, visibility: str) -> 
         # Remove the row (inherit is default)
         await pool.execute(
             "DELETE FROM object_permissions WHERE object_type = $1 AND object_id = $2",
-            object_type, object_id,
+            object_type,
+            object_id,
         )
     else:
         await pool.execute(
             "INSERT INTO object_permissions (object_type, object_id, visibility) "
             "VALUES ($1, $2, $3) "
             "ON CONFLICT (object_type, object_id) DO UPDATE SET visibility = $3",
-            object_type, object_id, visibility,
+            object_type,
+            object_id,
+            visibility,
         )
 
 
@@ -128,7 +135,11 @@ async def add_share(
         "VALUES ($1, $2, $3, $4, $5) "
         "ON CONFLICT (object_type, object_id, user_id) DO UPDATE SET permission = $4 "
         "RETURNING *",
-        object_type, object_id, user_id, permission, granted_by,
+        object_type,
+        object_id,
+        user_id,
+        permission,
+        granted_by,
     )
     return dict(row)
 
@@ -138,7 +149,9 @@ async def remove_share(object_type: str, object_id: UUID, user_id: UUID) -> bool
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM object_shares WHERE object_type = $1 AND object_id = $2 AND user_id = $3",
-        object_type, object_id, user_id,
+        object_type,
+        object_id,
+        user_id,
     )
     return result == "DELETE 1"
 
@@ -151,7 +164,8 @@ async def get_shares(object_type: str, object_id: UUID) -> list[dict]:
         "FROM object_shares os JOIN users u ON u.id = os.user_id "
         "WHERE os.object_type = $1 AND os.object_id = $2 "
         "ORDER BY os.created_at",
-        object_type, object_id,
+        object_type,
+        object_id,
     )
     return [dict(r) for r in rows]
 

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -6,6 +6,7 @@ Configured via environment variables.
 
 import logging
 import os
+from datetime import UTC
 from uuid import uuid4
 
 import httpx
@@ -55,9 +56,9 @@ async def upload_file(
     # For simplicity, use the S3 REST API directly via httpx
     import hashlib
     import hmac
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     date_stamp = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")
 
@@ -75,13 +76,9 @@ async def upload_file(
         "content-type": content_type,
     }
     signed_headers = ";".join(sorted(headers_to_sign.keys()))
-    canonical_headers = "".join(
-        f"{k}:{v}\n" for k, v in sorted(headers_to_sign.items())
-    )
+    canonical_headers = "".join(f"{k}:{v}\n" for k, v in sorted(headers_to_sign.items()))
 
-    canonical_request = (
-        f"PUT\n{uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
-    )
+    canonical_request = f"PUT\n{uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
 
     credential_scope = f"{date_stamp}/{S3_REGION}/s3/aws4_request"
     string_to_sign = (
@@ -102,9 +99,7 @@ async def upload_file(
         ),
         "aws4_request",
     )
-    signature = hmac.new(
-        signing_key, string_to_sign.encode(), hashlib.sha256
-    ).hexdigest()
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
 
     auth_header = (
         f"AWS4-HMAC-SHA256 Credential={S3_ACCESS_KEY}/{credential_scope}, "
@@ -136,10 +131,10 @@ async def get_file_url(key: str, expires_in: int = 3600) -> str:
 
     import hashlib
     import hmac
-    from datetime import datetime, timezone
+    from datetime import datetime
     from urllib.parse import quote
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     date_stamp = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")
 
@@ -158,9 +153,7 @@ async def get_file_url(key: str, expires_in: int = 3600) -> str:
         f"&X-Amz-SignedHeaders=host"
     )
 
-    canonical_request = (
-        f"GET\n{uri}\n{query_params}\nhost:{host}\n\nhost\nUNSIGNED-PAYLOAD"
-    )
+    canonical_request = f"GET\n{uri}\n{query_params}\nhost:{host}\n\nhost\nUNSIGNED-PAYLOAD"
 
     string_to_sign = (
         f"AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n"
@@ -180,9 +173,7 @@ async def get_file_url(key: str, expires_in: int = 3600) -> str:
         ),
         "aws4_request",
     )
-    signature = hmac.new(
-        signing_key, string_to_sign.encode(), hashlib.sha256
-    ).hexdigest()
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
 
     return f"{scheme}://{host}{uri}?{query_params}&X-Amz-Signature={signature}"
 
@@ -194,9 +185,9 @@ async def delete_file(key: str) -> None:
 
     import hashlib
     import hmac
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     date_stamp = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")
 
@@ -212,13 +203,9 @@ async def delete_file(key: str) -> None:
         "x-amz-date": amz_date,
     }
     signed_headers = ";".join(sorted(headers_to_sign.keys()))
-    canonical_headers = "".join(
-        f"{k}:{v}\n" for k, v in sorted(headers_to_sign.items())
-    )
+    canonical_headers = "".join(f"{k}:{v}\n" for k, v in sorted(headers_to_sign.items()))
 
-    canonical_request = (
-        f"DELETE\n{uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
-    )
+    canonical_request = f"DELETE\n{uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
 
     credential_scope = f"{date_stamp}/{S3_REGION}/s3/aws4_request"
     string_to_sign = (
@@ -239,9 +226,7 @@ async def delete_file(key: str) -> None:
         ),
         "aws4_request",
     )
-    signature = hmac.new(
-        signing_key, string_to_sign.encode(), hashlib.sha256
-    ).hexdigest()
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
 
     auth_header = (
         f"AWS4-HMAC-SHA256 Credential={S3_ACCESS_KEY}/{credential_scope}, "

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -15,8 +15,11 @@ logger = logging.getLogger(__name__)
 
 
 async def create_table(
-    workspace_id: UUID | None, name: str, description: str,
-    columns: list[dict], created_by: UUID,
+    workspace_id: UUID | None,
+    name: str,
+    description: str,
+    columns: list[dict],
+    created_by: UUID,
 ) -> dict:
     pool = get_pool()
     # Assign server-generated IDs and order to columns
@@ -29,7 +32,11 @@ async def create_table(
         "VALUES ($1, $2, $3, $4, $5, $5) "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        workspace_id, name, description, columns, created_by,
+        workspace_id,
+        name,
+        description,
+        columns,
+        created_by,
     )
     result = dict(row)
     result["row_count"] = 0
@@ -49,8 +56,10 @@ async def get_table(table_id: UUID) -> dict | None:
 
 
 async def update_table(
-    table_id: UUID, updated_by: UUID,
-    name: str | None = None, description: str | None = None,
+    table_id: UUID,
+    updated_by: UUID,
+    name: str | None = None,
+    description: str | None = None,
 ) -> dict | None:
     pool = get_pool()
     sets = ["updated_at = now()", "updated_by = $1"]
@@ -77,7 +86,8 @@ async def update_table(
         return None
     result = dict(row)
     count = await pool.fetchval(
-        "SELECT COUNT(*) FROM table_rows WHERE table_id = $1", table_id,
+        "SELECT COUNT(*) FROM table_rows WHERE table_id = $1",
+        table_id,
     )
     result["row_count"] = count
     return result
@@ -155,14 +165,18 @@ async def add_column(table_id: UUID, column: dict, updated_by: UUID) -> dict:
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        cols, updated_by, table_id,
+        cols,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
     return result
 
 
-async def update_column(table_id: UUID, column_id: str, updates: dict, updated_by: UUID) -> dict | None:
+async def update_column(
+    table_id: UUID, column_id: str, updates: dict, updated_by: UUID
+) -> dict | None:
     pool = get_pool()
     table = await get_table(table_id)
     if not table:
@@ -183,7 +197,9 @@ async def update_column(table_id: UUID, column_id: str, updates: dict, updated_b
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        cols, updated_by, table_id,
+        cols,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
@@ -204,7 +220,9 @@ async def delete_column(table_id: UUID, column_id: str, updated_by: UUID) -> dic
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        cols, updated_by, table_id,
+        cols,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
@@ -229,7 +247,9 @@ async def reorder_columns(table_id: UUID, column_ids: list[str], updated_by: UUI
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        reordered, updated_by, table_id,
+        reordered,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
@@ -247,7 +267,9 @@ async def create_row(table_id: UUID, data: dict, created_by: UUID) -> dict:
         "  COALESCE((SELECT MAX(row_order) FROM table_rows WHERE table_id = $1), -1) + 1, "
         "  $3, $3) "
         "RETURNING id, table_id, data, row_order, created_by, updated_by, created_at, updated_at",
-        table_id, data, created_by,
+        table_id,
+        data,
+        created_by,
     )
     result = dict(row)
     asyncio.create_task(maybe_embed_row(table_id, result["id"], data))
@@ -273,7 +295,10 @@ async def create_rows_batch(table_id: UUID, rows_data: list[dict], created_by: U
                     "INSERT INTO table_rows (table_id, data, row_order, created_by, updated_by) "
                     "VALUES ($1, $2, $3, $4, $4) "
                     "RETURNING id, table_id, data, row_order, created_by, updated_by, created_at, updated_at",
-                    table_id, data, max_order + 1 + i, created_by,
+                    table_id,
+                    data,
+                    max_order + 1 + i,
+                    created_by,
                 )
                 results.append(dict(row))
     return results
@@ -289,7 +314,9 @@ async def get_row(row_id: UUID) -> dict | None:
     return dict(row) if row else None
 
 
-async def update_row(row_id: UUID, data: dict, updated_by: UUID, table_id: UUID | None = None) -> dict | None:
+async def update_row(
+    row_id: UUID, data: dict, updated_by: UUID, table_id: UUID | None = None
+) -> dict | None:
     """Partial merge update — only specified keys are changed."""
     pool = get_pool()
     if table_id is not None:
@@ -297,14 +324,19 @@ async def update_row(row_id: UUID, data: dict, updated_by: UUID, table_id: UUID 
             "UPDATE table_rows SET data = data || $1, updated_by = $2, updated_at = now() "
             "WHERE id = $3 AND table_id = $4 "
             "RETURNING id, table_id, data, row_order, created_by, updated_by, created_at, updated_at",
-            data, updated_by, row_id, table_id,
+            data,
+            updated_by,
+            row_id,
+            table_id,
         )
     else:
         row = await pool.fetchrow(
             "UPDATE table_rows SET data = data || $1, updated_by = $2, updated_at = now() "
             "WHERE id = $3 "
             "RETURNING id, table_id, data, row_order, created_by, updated_by, created_at, updated_at",
-            data, updated_by, row_id,
+            data,
+            updated_by,
+            row_id,
         )
     if not row:
         return None
@@ -317,7 +349,9 @@ async def delete_row(row_id: UUID, table_id: UUID | None = None) -> bool:
     pool = get_pool()
     if table_id is not None:
         result = await pool.execute(
-            "DELETE FROM table_rows WHERE id = $1 AND table_id = $2", row_id, table_id,
+            "DELETE FROM table_rows WHERE id = $1 AND table_id = $2",
+            row_id,
+            table_id,
         )
     else:
         result = await pool.execute("DELETE FROM table_rows WHERE id = $1", row_id)
@@ -337,7 +371,10 @@ async def update_rows_batch(table_id: UUID, updates: list[dict], updated_by: UUI
                     "UPDATE table_rows SET data = data || $1, updated_by = $2, updated_at = now() "
                     "WHERE id = $3 AND table_id = $4 "
                     "RETURNING id, table_id, data, row_order, created_by, updated_by, created_at, updated_at",
-                    item["data"], updated_by, item["row_id"], table_id,
+                    item["data"],
+                    updated_by,
+                    item["row_id"],
+                    table_id,
                 )
                 if row:
                     results.append(dict(row))
@@ -350,7 +387,8 @@ async def delete_rows_batch(table_id: UUID, row_ids: list[UUID]) -> int:
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM table_rows WHERE table_id = $1 AND id = ANY($2)",
-        table_id, row_ids,
+        table_id,
+        row_ids,
     )
     try:
         return int(result.split()[-1])
@@ -444,7 +482,9 @@ async def list_rows(
     rows = await pool.fetch(
         f"SELECT id, table_id, data, row_order, created_by, updated_by, created_at, updated_at "
         f"FROM table_rows WHERE {where} ORDER BY {order} LIMIT ${idx} OFFSET ${idx + 1}",
-        *args, limit, offset,
+        *args,
+        limit,
+        offset,
     )
     return [dict(r) for r in rows], total
 
@@ -469,7 +509,9 @@ async def save_view(table_id: UUID, view: dict, updated_by: UUID) -> dict | None
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        views, updated_by, table_id,
+        views,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
@@ -487,7 +529,9 @@ async def delete_view(table_id: UUID, view_id: str, updated_by: UUID) -> dict | 
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, "
         "created_by, updated_by, created_at, updated_at",
-        views, updated_by, table_id,
+        views,
+        updated_by,
+        table_id,
     )
     result = dict(row)
     result["row_count"] = table["row_count"]
@@ -499,25 +543,37 @@ async def count_rows(table_id: UUID, filters: list[dict] | None = None) -> int:
     if not filters:
         pool = get_pool()
         return await pool.fetchval(
-            "SELECT COUNT(*) FROM table_rows WHERE table_id = $1", table_id,
+            "SELECT COUNT(*) FROM table_rows WHERE table_id = $1",
+            table_id,
         )
     # Reuse list_rows logic with limit=0 to get count
     _, total = await list_rows(table_id, filters=filters, limit=0, offset=0)
     return total
 
 
-async def export_rows_all(table_id: UUID, filters: list[dict] | None = None,
-                          sort_by: str | None = None, sort_order: str = "asc") -> list[dict]:
+async def export_rows_all(
+    table_id: UUID,
+    filters: list[dict] | None = None,
+    sort_by: str | None = None,
+    sort_order: str = "asc",
+) -> list[dict]:
     """Fetch ALL rows for export (no limit). Use for CSV export."""
     rows, _ = await list_rows(
-        table_id, filters=filters, sort_by=sort_by, sort_order=sort_order,
-        limit=2_000_000, offset=0,
+        table_id,
+        filters=filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=2_000_000,
+        offset=0,
     )
     return rows
 
 
 async def search_rows(
-    table_id: UUID, query: str, limit: int = 100, offset: int = 0,
+    table_id: UUID,
+    query: str,
+    limit: int = 100,
+    offset: int = 0,
 ) -> tuple[list[dict], int]:
     """Search across all text/email/url columns using ILIKE."""
     pool = get_pool()
@@ -531,17 +587,23 @@ async def search_rows(
     or_clauses = " OR ".join(f"data->>'{c['id']}' ILIKE $2" for c in text_cols)
     where = f"table_id = $1 AND ({or_clauses})"
     like_val = f"%{query}%"
-    total = await pool.fetchval(f"SELECT COUNT(*) FROM table_rows WHERE {where}", table_id, like_val)
+    total = await pool.fetchval(
+        f"SELECT COUNT(*) FROM table_rows WHERE {where}", table_id, like_val
+    )
     rows = await pool.fetch(
         f"SELECT id, table_id, data, row_order, created_by, updated_by, created_at, updated_at "
         f"FROM table_rows WHERE {where} ORDER BY row_order ASC LIMIT $3 OFFSET $4",
-        table_id, like_val, limit, offset,
+        table_id,
+        like_val,
+        limit,
+        offset,
     )
     return [dict(r) for r in rows], total
 
 
 async def summarize_rows(
-    table_id: UUID, filters: list[dict] | None = None,
+    table_id: UUID,
+    filters: list[dict] | None = None,
 ) -> dict:
     """Compute aggregates per column: count, sum, avg, min, max for numbers; count for all."""
     pool = get_pool()
@@ -599,7 +661,11 @@ async def summarize_rows(
                     "name": c["name"],
                     "filled": row[f"{cid}_count"],
                     "sum": float(row[f"{cid}_sum"]) if row[f"{cid}_sum"] is not None else None,
-                    "avg": round(float(row[f"{cid}_avg"]), 2) if row[f"{cid}_avg"] is not None else None,
+                    "avg": (
+                        round(float(row[f"{cid}_avg"]), 2)
+                        if row[f"{cid}_avg"] is not None
+                        else None
+                    ),
                     "min": float(row[f"{cid}_min"]) if row[f"{cid}_min"] is not None else None,
                     "max": float(row[f"{cid}_max"]) if row[f"{cid}_max"] is not None else None,
                 }
@@ -617,7 +683,6 @@ async def summarize_rows(
 
 async def duplicate_row(row_id: UUID, table_id: UUID, created_by: UUID) -> dict | None:
     """Duplicate a row — copy data with new ID and row_order."""
-    pool = get_pool()
     source = await get_row(row_id)
     if not source or source.get("table_id") != table_id:
         return None
@@ -631,7 +696,8 @@ async def get_embedding_config(table_id: UUID) -> dict | None:
     """Get embedding config for a table. Returns None if not configured."""
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT embedding_config FROM tables WHERE id = $1", table_id,
+        "SELECT embedding_config FROM tables WHERE id = $1",
+        table_id,
     )
     return row["embedding_config"] if row and row["embedding_config"] else None
 
@@ -647,7 +713,9 @@ async def set_embedding_config(table_id: UUID, config: dict, updated_by: UUID) -
         "WHERE id = $3 "
         "RETURNING id, workspace_id, name, description, columns, views, embedding_config, "
         "created_by, updated_by, created_at, updated_at",
-        config, updated_by, table_id,
+        config,
+        updated_by,
+        table_id,
     )
     return dict(row) if row else None
 
@@ -671,6 +739,7 @@ async def _embed_row(row_id: UUID, text: str) -> None:
     """Fire-and-forget: embed row text and store in database."""
     try:
         from . import embeddings as embedding_service
+
         if not embedding_service.is_configured():
             return
         embedding = await embedding_service.embed_text(text)
@@ -679,7 +748,8 @@ async def _embed_row(row_id: UUID, text: str) -> None:
         pool = get_pool()
         await pool.execute(
             "UPDATE table_rows SET embedding = $1 WHERE id = $2",
-            embedding, row_id,
+            embedding,
+            row_id,
         )
     except Exception:
         logger.debug("Failed to embed row %s", row_id, exc_info=True)
@@ -689,6 +759,7 @@ async def _embed_rows_batch(row_ids: list[UUID], texts: list[str]) -> None:
     """Fire-and-forget: batch embed rows."""
     try:
         from . import embeddings as embedding_service
+
         if not embedding_service.is_configured() or not texts:
             return
         embeddings = await embedding_service.embed_batch(texts)
@@ -699,7 +770,8 @@ async def _embed_rows_batch(row_ids: list[UUID], texts: list[str]) -> None:
             for row_id, emb in zip(row_ids, embeddings):
                 await conn.execute(
                     "UPDATE table_rows SET embedding = $1 WHERE id = $2",
-                    emb, row_id,
+                    emb,
+                    row_id,
                 )
     except Exception:
         logger.debug("Failed to batch embed rows", exc_info=True)
@@ -726,7 +798,9 @@ async def search_rows_vector(table_id: UUID, query_embedding, limit: int = 20) -
         "1 - (embedding <=> $2) AS similarity "
         "FROM table_rows WHERE table_id = $1 AND embedding IS NOT NULL "
         "ORDER BY embedding <=> $2 LIMIT $3",
-        table_id, query_embedding, limit,
+        table_id,
+        query_embedding,
+        limit,
     )
     return [dict(r) for r in rows]
 
@@ -743,7 +817,8 @@ async def backfill_embeddings(table_id: UUID) -> dict:
         return {"embedded": 0, "total": 0, "error": "table not found"}
 
     rows = await pool.fetch(
-        "SELECT id, data FROM table_rows WHERE table_id = $1", table_id,
+        "SELECT id, data FROM table_rows WHERE table_id = $1",
+        table_id,
     )
 
     texts = []

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -35,6 +35,7 @@ async def register_user(
     # Auto-provision a default workspace for new users.
     # workspaces.name is VARCHAR(128); trim the display so the suffix always fits.
     from . import workspace_service
+
     suffix = "'s Workspace"
     ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"
     await workspace_service.create_workspace(

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -7,7 +7,10 @@ from ..database import get_pool
 
 
 async def create_workspace(
-    name: str, description: str, creator_id: UUID, is_public: bool = False,
+    name: str,
+    description: str,
+    creator_id: UUID,
+    is_public: bool = False,
 ) -> dict:
     """Create a workspace with the creator as owner."""
     pool = get_pool()
@@ -15,7 +18,8 @@ async def create_workspace(
     for _ in range(5):
         invite_code = secrets.token_urlsafe(6)[:8]
         exists = await pool.fetchval(
-            "SELECT 1 FROM workspaces WHERE invite_code = $1", invite_code,
+            "SELECT 1 FROM workspaces WHERE invite_code = $1",
+            invite_code,
         )
         if not exists:
             break
@@ -24,13 +28,18 @@ async def create_workspace(
         "INSERT INTO workspaces (name, description, creator_id, invite_code, is_public) "
         "VALUES ($1, $2, $3, $4, $5) "
         "RETURNING id, name, description, creator_id, invite_code, is_public, created_at, updated_at",
-        name, description, creator_id, invite_code, is_public,
+        name,
+        description,
+        creator_id,
+        invite_code,
+        is_public,
     )
     ws = dict(row)
     # Auto-add creator as owner
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
-        ws["id"], creator_id,
+        ws["id"],
+        creator_id,
     )
     ws["member_count"] = 1
     return ws
@@ -68,7 +77,9 @@ async def list_user_workspaces(user_id: UUID) -> list[dict]:
 
 
 async def update_workspace(
-    workspace_id: UUID, name: str | None = None, description: str | None = None,
+    workspace_id: UUID,
+    name: str | None = None,
+    description: str | None = None,
 ) -> dict | None:
     pool = get_pool()
     sets, args, idx = [], [], 1
@@ -107,13 +118,15 @@ async def join_workspace(workspace_id: UUID, user_id: UUID) -> dict | None:
     pool = get_pool()
     exists = await pool.fetchval(
         "SELECT 1 FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
-        workspace_id, user_id,
+        workspace_id,
+        user_id,
     )
     if exists:
         return await get_workspace(workspace_id)
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
-        workspace_id, user_id,
+        workspace_id,
+        user_id,
     )
     return await get_workspace(workspace_id)
 
@@ -121,7 +134,8 @@ async def join_workspace(workspace_id: UUID, user_id: UUID) -> dict | None:
 async def join_by_invite(invite_code: str, user_id: UUID) -> dict | None:
     pool = get_pool()
     ws = await pool.fetchrow(
-        "SELECT id FROM workspaces WHERE invite_code = $1", invite_code,
+        "SELECT id FROM workspaces WHERE invite_code = $1",
+        invite_code,
     )
     if not ws:
         return None
@@ -132,12 +146,14 @@ async def leave_workspace(workspace_id: UUID, user_id: UUID) -> bool:
     pool = get_pool()
     result = await pool.execute(
         "DELETE FROM workspace_members WHERE workspace_id = $1 AND user_id = $2 AND role != 'owner'",
-        workspace_id, user_id,
+        workspace_id,
+        user_id,
     )
     if result == "DELETE 1":
         await pool.execute(
             "DELETE FROM webhooks WHERE workspace_id = $1 AND user_id = $2",
-            workspace_id, user_id,
+            workspace_id,
+            user_id,
         )
         return True
     return False
@@ -158,7 +174,8 @@ async def get_member_role(workspace_id: UUID, user_id: UUID) -> str | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
-        workspace_id, user_id,
+        workspace_id,
+        user_id,
     )
     return row["role"] if row else None
 
@@ -181,12 +198,14 @@ async def kick_member(workspace_id: UUID, target_user_id: UUID, kicker_id: UUID)
         return False
     result = await pool.execute(
         "DELETE FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
-        workspace_id, target_user_id,
+        workspace_id,
+        target_user_id,
     )
     if result == "DELETE 1":
         await pool.execute(
             "DELETE FROM webhooks WHERE workspace_id = $1 AND user_id = $2",
-            workspace_id, target_user_id,
+            workspace_id,
+            target_user_id,
         )
         return True
     return False

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,7 +15,6 @@ import os
 import uuid
 
 import asyncpg
-import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
@@ -26,8 +25,8 @@ _TEST_DB_URL = os.getenv(
 )
 os.environ["DATABASE_URL"] = _TEST_DB_URL
 
-from backend.main import app  # noqa: E402 — must come after env override
 from backend import database as db_module  # noqa: E402
+from backend.main import app  # noqa: E402 — must come after env override
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -43,8 +42,9 @@ async def _db_pool():
 
     def _run_alembic():
         ini_path = os.path.join(os.path.dirname(__file__), "..", "..", "alembic.ini")
-        from alembic.config import Config
         from alembic import command as alembic_cmd
+        from alembic.config import Config
+
         cfg = Config(ini_path)
         alembic_cmd.upgrade(cfg, "head")
 
@@ -53,16 +53,19 @@ async def _db_pool():
 
     # Create the shared pool used by the app
     import json
+
     from pgvector.asyncpg import register_vector
 
     async def _init_connection(conn):
         await register_vector(conn)
-        await conn.set_type_codec("jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog")
-        await conn.set_type_codec("json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog")
+        await conn.set_type_codec(
+            "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+        )
+        await conn.set_type_codec(
+            "json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+        )
 
-    pool = await asyncpg.create_pool(
-        _TEST_DB_URL, min_size=2, max_size=5, init=_init_connection
-    )
+    pool = await asyncpg.create_pool(_TEST_DB_URL, min_size=2, max_size=5, init=_init_connection)
     db_module.pool = pool
     yield pool
     await pool.close()
@@ -87,17 +90,29 @@ async def pool(_db_pool):
 
 
 _TRUNCATE_TABLES = [
-    "webhook_deliveries", "webhooks",
-    "documents", "files",
-    "object_shares", "object_permissions",
+    "webhook_deliveries",
+    "webhooks",
+    "documents",
+    "files",
+    "object_shares",
+    "object_permissions",
     "history_events",
-    "page_links", "notebook_pages", "notebook_folders",
-    "deck_share_page_views", "deck_share_views", "deck_shares",
+    "page_links",
+    "notebook_pages",
+    "notebook_folders",
+    "deck_share_page_views",
+    "deck_share_views",
+    "deck_shares",
     "table_rows",
     "chat_messages",
     "workspace_members",
-    "chats", "notebooks", "histories", "decks", "tables",
-    "workspaces", "users",
+    "chats",
+    "notebooks",
+    "histories",
+    "decks",
+    "tables",
+    "workspaces",
+    "users",
 ]
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,9 +9,13 @@ from .conftest import unique_name
 @pytest.mark.asyncio
 async def test_register_success(client: AsyncClient):
     name = unique_name()
-    resp = await client.post("/api/v1/users/register", json={
-        "name": name, "password": "securepassword1",
-    })
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": "securepassword1",
+        },
+    )
     assert resp.status_code == 201
     body = resp.json()
     assert body["name"] == name
@@ -29,9 +33,13 @@ async def test_register_duplicate_name(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_register_rejects_short_password(client: AsyncClient):
-    resp = await client.post("/api/v1/users/register", json={
-        "name": unique_name(), "password": "short",
-    })
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": unique_name(),
+            "password": "short",
+        },
+    )
     assert resp.status_code == 422
 
 
@@ -39,9 +47,13 @@ async def test_register_rejects_short_password(client: AsyncClient):
 async def test_login_success(client: AsyncClient):
     name = unique_name()
     password = "correctpassword1"
-    reg = await client.post("/api/v1/users/register", json={
-        "name": name, "password": password,
-    })
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": password,
+        },
+    )
     assert reg.status_code == 201
 
     login = await client.post("/api/v1/users/login", json={"name": name, "password": password})
@@ -52,19 +64,29 @@ async def test_login_success(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_login_wrong_password(client: AsyncClient):
     name = unique_name()
-    await client.post("/api/v1/users/register", json={
-        "name": name, "password": "correctpassword1",
-    })
-    resp = await client.post("/api/v1/users/login", json={"name": name, "password": "wrongpassword"})
+    await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": "correctpassword1",
+        },
+    )
+    resp = await client.post(
+        "/api/v1/users/login", json={"name": name, "password": "wrongpassword"}
+    )
     assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_api_key_auth(client: AsyncClient):
     name = unique_name()
-    reg = await client.post("/api/v1/users/register", json={
-        "name": name, "password": "securepassword1",
-    })
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": "securepassword1",
+        },
+    )
     api_key = reg.json()["api_key"]
 
     me = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {api_key}"})

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -8,9 +8,13 @@ from .conftest import unique_name
 
 async def _register(client: AsyncClient, name: str | None = None) -> tuple[str, dict]:
     name = name or unique_name()
-    resp = await client.post("/api/v1/users/register", json={
-        "name": name, "password": "securepassword1",
-    })
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": "securepassword1",
+        },
+    )
     assert resp.status_code == 201
     body = resp.json()
     return body["api_key"], body
@@ -83,9 +87,13 @@ async def test_send_and_retrieve_message(client: AsyncClient):
     ws = await _create_workspace(client, key)
     h = _auth(key)
 
-    chat = (await client.post(
-        f"/api/v1/workspaces/{ws['id']}/chats", json={"name": "general"}, headers=h,
-    )).json()
+    chat = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/chats",
+            json={"name": "general"},
+            headers=h,
+        )
+    ).json()
 
     msg_resp = await client.post(
         f"/api/v1/workspaces/{ws['id']}/chats/{chat['id']}/messages",
@@ -113,9 +121,13 @@ async def test_message_pagination(client: AsyncClient):
     ws = await _create_workspace(client, key)
     h = _auth(key)
 
-    chat = (await client.post(
-        f"/api/v1/workspaces/{ws['id']}/chats", json={"name": "busy"}, headers=h,
-    )).json()
+    chat = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/chats",
+            json={"name": "busy"},
+            headers=h,
+        )
+    ).json()
 
     for i in range(5):
         await client.post(
@@ -140,9 +152,13 @@ async def test_non_member_cannot_send_message(client: AsyncClient):
     ws = await _create_workspace(client, owner_key)
     h = _auth(owner_key)
 
-    chat = (await client.post(
-        f"/api/v1/workspaces/{ws['id']}/chats", json={"name": "private"}, headers=h,
-    )).json()
+    chat = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/chats",
+            json={"name": "private"},
+            headers=h,
+        )
+    ).json()
 
     resp = await client.post(
         f"/api/v1/workspaces/{ws['id']}/chats/{chat['id']}/messages",
@@ -161,9 +177,13 @@ async def test_owner_can_delete_chat(client: AsyncClient):
     ws = await _create_workspace(client, key)
     h = _auth(key)
 
-    chat = (await client.post(
-        f"/api/v1/workspaces/{ws['id']}/chats", json={"name": "temp"}, headers=h,
-    )).json()
+    chat = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/chats",
+            json={"name": "temp"},
+            headers=h,
+        )
+    ).json()
 
     resp = await client.delete(f"/api/v1/workspaces/{ws['id']}/chats/{chat['id']}", headers=h)
     assert resp.status_code == 204
@@ -177,12 +197,17 @@ async def test_member_cannot_delete_chat(client: AsyncClient):
 
     await client.post(f"/api/v1/workspaces/join/{ws['invite_code']}", headers=_auth(member_key))
 
-    chat = (await client.post(
-        f"/api/v1/workspaces/{ws['id']}/chats", json={"name": "protected"}, headers=_auth(owner_key),
-    )).json()
+    chat = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/chats",
+            json={"name": "protected"},
+            headers=_auth(owner_key),
+        )
+    ).json()
 
     resp = await client.delete(
-        f"/api/v1/workspaces/{ws['id']}/chats/{chat['id']}", headers=_auth(member_key),
+        f"/api/v1/workspaces/{ws['id']}/chats/{chat['id']}",
+        headers=_auth(member_key),
     )
     assert resp.status_code == 403
 
@@ -213,7 +238,9 @@ async def test_cannot_access_other_users_room(client: AsyncClient):
     owner_key, _ = await _register(client)
     other_key, _ = await _register(client)
 
-    room = (await client.post("/api/v1/rooms", json={"name": "secret"}, headers=_auth(owner_key))).json()
+    room = (
+        await client.post("/api/v1/rooms", json={"name": "secret"}, headers=_auth(owner_key))
+    ).json()
 
     resp = await client.delete(f"/api/v1/rooms/{room['id']}", headers=_auth(other_key))
     assert resp.status_code == 404

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -4,8 +4,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
 
 def test_alembic_upgrade_head():
     """alembic upgrade head completes without error on the test database."""
@@ -25,9 +23,9 @@ def test_alembic_upgrade_head():
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"alembic upgrade head failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"alembic upgrade head failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
 
 
 def test_alembic_history_is_linear():

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 from backend.services import permission_service
+
 from .conftest import unique_name
 
 
@@ -13,7 +14,8 @@ async def _make_user(pool, name=None):
     api_key_hash = "hash_" + uuid.uuid4().hex
     row = await pool.fetchrow(
         "INSERT INTO users (name, type, api_key_hash) VALUES ($1, 'human', $2) RETURNING id",
-        name, api_key_hash,
+        name,
+        api_key_hash,
     )
     return row["id"]
 
@@ -22,12 +24,14 @@ async def _make_workspace(pool, creator_id):
     invite = uuid.uuid4().hex[:12]
     row = await pool.fetchrow(
         "INSERT INTO workspaces (name, creator_id, invite_code) VALUES ('ws', $1, $2) RETURNING id",
-        creator_id, invite,
+        creator_id,
+        invite,
     )
     ws_id = row["id"]
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
-        ws_id, creator_id,
+        ws_id,
+        creator_id,
     )
     return ws_id
 
@@ -35,7 +39,8 @@ async def _make_workspace(pool, creator_id):
 async def _make_notebook(pool, workspace_id, created_by):
     row = await pool.fetchrow(
         "INSERT INTO notebooks (workspace_id, name, created_by) VALUES ($1, 'nb', $2) RETURNING id",
-        workspace_id, created_by,
+        workspace_id,
+        created_by,
     )
     return row["id"]
 
@@ -47,7 +52,9 @@ async def test_owner_has_access(pool):
     nb_id = await _make_notebook(pool, ws_id, user_id)
 
     assert await permission_service.check_access("notebook", nb_id, user_id, workspace_id=ws_id)
-    assert await permission_service.check_access("notebook", nb_id, user_id, workspace_id=ws_id, require_write=True)
+    assert await permission_service.check_access(
+        "notebook", nb_id, user_id, workspace_id=ws_id, require_write=True
+    )
 
 
 @pytest.mark.asyncio
@@ -57,7 +64,8 @@ async def test_member_read_inherit(pool):
     ws_id = await _make_workspace(pool, owner_id)
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
-        ws_id, member_id,
+        ws_id,
+        member_id,
     )
     nb_id = await _make_notebook(pool, ws_id, owner_id)
 
@@ -73,7 +81,8 @@ async def test_member_cannot_write_without_share(pool):
     ws_id = await _make_workspace(pool, owner_id)
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
-        ws_id, member_id,
+        ws_id,
+        member_id,
     )
     nb_id = await _make_notebook(pool, ws_id, owner_id)
 
@@ -91,7 +100,8 @@ async def test_member_can_write_with_share(pool):
     ws_id = await _make_workspace(pool, owner_id)
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
-        ws_id, member_id,
+        ws_id,
+        member_id,
     )
     nb_id = await _make_notebook(pool, ws_id, owner_id)
 
@@ -109,7 +119,9 @@ async def test_non_member_denied(pool):
     ws_id = await _make_workspace(pool, owner_id)
     nb_id = await _make_notebook(pool, ws_id, owner_id)
 
-    assert not await permission_service.check_access("notebook", nb_id, stranger_id, workspace_id=ws_id)
+    assert not await permission_service.check_access(
+        "notebook", nb_id, stranger_id, workspace_id=ws_id
+    )
 
 
 @pytest.mark.asyncio
@@ -130,9 +142,12 @@ async def test_private_visibility_denies_member(pool):
     ws_id = await _make_workspace(pool, owner_id)
     await pool.execute(
         "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
-        ws_id, member_id,
+        ws_id,
+        member_id,
     )
     nb_id = await _make_notebook(pool, ws_id, owner_id)
 
     await permission_service.set_visibility("notebook", nb_id, "private")
-    assert not await permission_service.check_access("notebook", nb_id, member_id, workspace_id=ws_id)
+    assert not await permission_service.check_access(
+        "notebook", nb_id, member_id, workspace_id=ws_id
+    )

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -9,9 +9,13 @@ from .conftest import unique_name
 async def _register(client: AsyncClient, name: str | None = None) -> tuple[str, dict]:
     """Register a user. Returns (api_key, response_body)."""
     name = name or unique_name()
-    resp = await client.post("/api/v1/users/register", json={
-        "name": name, "password": "securepassword1",
-    })
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": name,
+            "password": "securepassword1",
+        },
+    )
     assert resp.status_code == 201
     body = resp.json()
     return body["api_key"], body
@@ -27,9 +31,14 @@ def _auth(api_key: str) -> dict:
 @pytest.mark.asyncio
 async def test_create_workspace(client: AsyncClient):
     key, _ = await _register(client)
-    resp = await client.post("/api/v1/workspaces", json={
-        "name": "My Workspace", "description": "desc",
-    }, headers=_auth(key))
+    resp = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "My Workspace",
+            "description": "desc",
+        },
+        headers=_auth(key),
+    )
     assert resp.status_code == 201
     body = resp.json()
     assert body["name"] == "My Workspace"
@@ -79,18 +88,24 @@ async def test_join_by_invite_code(client: AsyncClient):
     owner_key, _ = await _register(client)
     joiner_key, _ = await _register(client)
 
-    ws = (await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))).json()
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))
+    ).json()
     invite_code = ws["invite_code"]
 
     resp = await client.post(
-        f"/api/v1/workspaces/join/{invite_code}", headers=_auth(joiner_key),
+        f"/api/v1/workspaces/join/{invite_code}",
+        headers=_auth(joiner_key),
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "Team"
 
-    members = (await client.get(
-        f"/api/v1/workspaces/{ws['id']}/members", headers=_auth(joiner_key),
-    )).json()
+    members = (
+        await client.get(
+            f"/api/v1/workspaces/{ws['id']}/members",
+            headers=_auth(joiner_key),
+        )
+    ).json()
     assert len(members) == 2
 
 
@@ -110,7 +125,9 @@ async def test_update_workspace(client: AsyncClient):
     ws = (await client.post("/api/v1/workspaces", json={"name": "Old"}, headers=_auth(key))).json()
 
     resp = await client.patch(
-        f"/api/v1/workspaces/{ws['id']}", json={"name": "New"}, headers=_auth(key),
+        f"/api/v1/workspaces/{ws['id']}",
+        json={"name": "New"},
+        headers=_auth(key),
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "New"
@@ -121,11 +138,15 @@ async def test_member_cannot_update_workspace(client: AsyncClient):
     owner_key, _ = await _register(client)
     member_key, _ = await _register(client)
 
-    ws = (await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))).json()
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))
+    ).json()
     await client.post(f"/api/v1/workspaces/join/{ws['invite_code']}", headers=_auth(member_key))
 
     resp = await client.patch(
-        f"/api/v1/workspaces/{ws['id']}", json={"name": "Hacked"}, headers=_auth(member_key),
+        f"/api/v1/workspaces/{ws['id']}",
+        json={"name": "Hacked"},
+        headers=_auth(member_key),
     )
     assert resp.status_code == 403
 
@@ -147,7 +168,9 @@ async def test_non_owner_cannot_delete_workspace(client: AsyncClient):
     owner_key, _ = await _register(client)
     member_key, _ = await _register(client)
 
-    ws = (await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))).json()
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))
+    ).json()
     await client.post(f"/api/v1/workspaces/join/{ws['invite_code']}", headers=_auth(member_key))
 
     resp = await client.delete(f"/api/v1/workspaces/{ws['id']}", headers=_auth(member_key))
@@ -162,15 +185,20 @@ async def test_member_can_leave(client: AsyncClient):
     owner_key, _ = await _register(client)
     member_key, _ = await _register(client)
 
-    ws = (await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))).json()
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Team"}, headers=_auth(owner_key))
+    ).json()
     await client.post(f"/api/v1/workspaces/join/{ws['invite_code']}", headers=_auth(member_key))
 
     resp = await client.post(f"/api/v1/workspaces/{ws['id']}/leave", headers=_auth(member_key))
     assert resp.status_code == 204
 
-    members = (await client.get(
-        f"/api/v1/workspaces/{ws['id']}/members", headers=_auth(owner_key),
-    )).json()
+    members = (
+        await client.get(
+            f"/api/v1/workspaces/{ws['id']}/members",
+            headers=_auth(owner_key),
+        )
+    ).json()
     assert len(members) == 1
 
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -82,9 +82,14 @@ class OctopusClient:
     # --- Workspaces ---
 
     def create_workspace(self, name: str, description: str = "", is_public: bool = False) -> dict:
-        return self._post("/api/v1/workspaces", json={
-            "name": name, "description": description, "is_public": is_public,
-        })
+        return self._post(
+            "/api/v1/workspaces",
+            json={
+                "name": name,
+                "description": description,
+                "is_public": is_public,
+            },
+        )
 
     def list_workspaces(self, mine: bool = False) -> list:
         path = "/api/v1/workspaces/mine" if mine else "/api/v1/workspaces"
@@ -105,9 +110,13 @@ class OctopusClient:
     # --- Chats (workspace-scoped) ---
 
     def create_chat(self, workspace_id: str, name: str, description: str = "") -> dict:
-        return self._post(f"/api/v1/workspaces/{workspace_id}/chats", json={
-            "name": name, "description": description,
-        })
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/chats",
+            json={
+                "name": name,
+                "description": description,
+            },
+        )
 
     def list_chats(self, workspace_id: str) -> list:
         return self._list(f"/api/v1/workspaces/{workspace_id}/chats", "chats")
@@ -118,14 +127,23 @@ class OctopusClient:
             json={"content": content},
         )
 
-    def read_messages(self, workspace_id: str, chat_id: str, limit: int = 50, after: str | None = None) -> list:
+    def read_messages(
+        self, workspace_id: str, chat_id: str, limit: int = 50, after: str | None = None
+    ) -> list:
         params: dict = {"limit": limit}
         if after:
             params["after"] = after
-        return self._list(f"/api/v1/workspaces/{workspace_id}/chats/{chat_id}/messages", "messages", **params)
+        return self._list(
+            f"/api/v1/workspaces/{workspace_id}/chats/{chat_id}/messages", "messages", **params
+        )
 
     def search_messages(self, workspace_id: str, chat_id: str, query: str, limit: int = 20) -> list:
-        return self._list(f"/api/v1/workspaces/{workspace_id}/chats/{chat_id}/messages/search", "messages", q=query, limit=limit)
+        return self._list(
+            f"/api/v1/workspaces/{workspace_id}/chats/{chat_id}/messages/search",
+            "messages",
+            q=query,
+            limit=limit,
+        )
 
     # --- Personal Rooms ---
 
@@ -179,9 +197,13 @@ class OctopusClient:
     # --- Notebooks (collections) ---
 
     def create_notebook(self, workspace_id: str, name: str, description: str = "") -> dict:
-        return self._post(f"/api/v1/workspaces/{workspace_id}/notebooks", json={
-            "name": name, "description": description,
-        })
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/notebooks",
+            json={
+                "name": name,
+                "description": description,
+            },
+        )
 
     def list_notebooks(self, workspace_id: str) -> list:
         return self._list(f"/api/v1/workspaces/{workspace_id}/notebooks", "notebooks")
@@ -197,26 +219,42 @@ class OctopusClient:
 
     # --- Notebook Pages ---
 
-    def create_page(self, workspace_id: str, notebook_id: str, name: str, content: str = "", folder_id: str | None = None) -> dict:
+    def create_page(
+        self,
+        workspace_id: str,
+        notebook_id: str,
+        name: str,
+        content: str = "",
+        folder_id: str | None = None,
+    ) -> dict:
         body: dict = {"name": name, "content": content}
         if folder_id:
             body["folder_id"] = folder_id
-        return self._post(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages", json=body)
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages", json=body
+        )
 
     def list_page_tree(self, workspace_id: str, notebook_id: str) -> dict:
         return self._get(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages")
 
     def get_page(self, workspace_id: str, notebook_id: str, page_id: str) -> dict:
-        return self._get(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages/{page_id}")
+        return self._get(
+            f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages/{page_id}"
+        )
 
     def update_page(self, workspace_id: str, notebook_id: str, page_id: str, **kwargs) -> dict:
-        return self._patch(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages/{page_id}", json=kwargs)
+        return self._patch(
+            f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages/{page_id}",
+            json=kwargs,
+        )
 
     def delete_page(self, workspace_id: str, notebook_id: str, page_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/pages/{page_id}")
 
     def create_personal_page(self, notebook_id: str, name: str, content: str = "") -> dict:
-        return self._post(f"/api/v1/notebooks/{notebook_id}/pages", json={"name": name, "content": content})
+        return self._post(
+            f"/api/v1/notebooks/{notebook_id}/pages", json={"name": name, "content": content}
+        )
 
     def list_personal_page_tree(self, notebook_id: str) -> dict:
         return self._get(f"/api/v1/notebooks/{notebook_id}/pages")
@@ -230,7 +268,10 @@ class OctopusClient:
     # --- Notebook Folders ---
 
     def create_folder(self, workspace_id: str, notebook_id: str, name: str) -> dict:
-        return self._post(f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/folders", json={"name": name})
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/notebooks/{notebook_id}/folders",
+            json={"name": name},
+        )
 
     def create_personal_folder(self, notebook_id: str, name: str) -> dict:
         return self._post(f"/api/v1/notebooks/{notebook_id}/folders", json={"name": name})
@@ -242,8 +283,13 @@ class OctopusClient:
         return data.get("agent_names", []) if isinstance(data, dict) else data
 
     def push_event(
-        self, workspace_id: str, agent_name: str, event_type: str, content: str,
-        session_id: str | None = None, tool_name: str | None = None,
+        self,
+        workspace_id: str,
+        agent_name: str,
+        event_type: str,
+        content: str,
+        session_id: str | None = None,
+        tool_name: str | None = None,
         metadata: dict | None = None,
     ) -> dict:
         body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
@@ -256,9 +302,12 @@ class OctopusClient:
         return self._post(f"/api/v1/workspaces/{workspace_id}/memory/events", json=body)
 
     def query_events(
-        self, workspace_id: str,
-        agent_name: str | None = None, event_type: str | None = None,
-        limit: int = 50, after: str | None = None,
+        self,
+        workspace_id: str,
+        agent_name: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        after: str | None = None,
     ) -> list:
         params: dict = {"limit": limit}
         if agent_name:
@@ -270,9 +319,16 @@ class OctopusClient:
         return self._list(f"/api/v1/workspaces/{workspace_id}/memory/events", "events", **params)
 
     def search_events(self, workspace_id: str, query: str, limit: int = 50) -> list:
-        return self._list(f"/api/v1/workspaces/{workspace_id}/memory/events/search", "events", q=query, limit=limit)
+        return self._list(
+            f"/api/v1/workspaces/{workspace_id}/memory/events/search",
+            "events",
+            q=query,
+            limit=limit,
+        )
 
-    def all_events(self, agent_name: str | None = None, event_type: str | None = None, limit: int = 50) -> list:
+    def all_events(
+        self, agent_name: str | None = None, event_type: str | None = None, limit: int = 50
+    ) -> list:
         params: dict = {"limit": limit}
         if agent_name:
             params["agent_name"] = agent_name
@@ -282,10 +338,23 @@ class OctopusClient:
 
     # --- Decks ---
 
-    def create_deck(self, workspace_id: str, name: str, description: str = "", html_content: str = "", deck_type: str = "freeform") -> dict:
-        return self._post(f"/api/v1/workspaces/{workspace_id}/decks", json={
-            "name": name, "description": description, "html_content": html_content, "deck_type": deck_type,
-        })
+    def create_deck(
+        self,
+        workspace_id: str,
+        name: str,
+        description: str = "",
+        html_content: str = "",
+        deck_type: str = "freeform",
+    ) -> dict:
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/decks",
+            json={
+                "name": name,
+                "description": description,
+                "html_content": html_content,
+                "deck_type": deck_type,
+            },
+        )
 
     def list_decks(self, workspace_id: str) -> list:
         return self._list(f"/api/v1/workspaces/{workspace_id}/decks", "decks")
@@ -299,10 +368,18 @@ class OctopusClient:
     def delete_deck(self, workspace_id: str, deck_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/decks/{deck_id}")
 
-    def create_personal_deck(self, name: str, description: str = "", html_content: str = "", deck_type: str = "freeform") -> dict:
-        return self._post("/api/v1/decks", json={
-            "name": name, "description": description, "html_content": html_content, "deck_type": deck_type,
-        })
+    def create_personal_deck(
+        self, name: str, description: str = "", html_content: str = "", deck_type: str = "freeform"
+    ) -> dict:
+        return self._post(
+            "/api/v1/decks",
+            json={
+                "name": name,
+                "description": description,
+                "html_content": html_content,
+                "deck_type": deck_type,
+            },
+        )
 
     def list_personal_decks(self) -> list:
         return self._list("/api/v1/decks", "decks")
@@ -323,11 +400,15 @@ class OctopusClient:
         base = f"/api/v1/workspaces/{workspace_id}/decks" if workspace_id else "/api/v1/decks"
         return self._list(f"{base}/{deck_id}/shares", "shares")
 
-    def update_deck_share(self, deck_id: str, share_id: str, workspace_id: str | None = None, **kwargs) -> dict:
+    def update_deck_share(
+        self, deck_id: str, share_id: str, workspace_id: str | None = None, **kwargs
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/decks" if workspace_id else "/api/v1/decks"
         return self._put(f"{base}/{deck_id}/shares/{share_id}", json=kwargs)
 
-    def get_share_analytics(self, deck_id: str, share_id: str, workspace_id: str | None = None) -> dict:
+    def get_share_analytics(
+        self, deck_id: str, share_id: str, workspace_id: str | None = None
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/decks" if workspace_id else "/api/v1/decks"
         return self._get(f"{base}/{deck_id}/shares/{share_id}/analytics")
 
@@ -344,7 +425,9 @@ class OctopusClient:
 
     # --- Tables ---
 
-    def create_table(self, workspace_id: str, name: str, description: str = "", columns: list | None = None) -> dict:
+    def create_table(
+        self, workspace_id: str, name: str, description: str = "", columns: list | None = None
+    ) -> dict:
         body: dict = {"name": name, "description": description, "columns": columns or []}
         return self._post(f"/api/v1/workspaces/{workspace_id}/tables", json=body)
 
@@ -360,7 +443,9 @@ class OctopusClient:
     def delete_table(self, workspace_id: str, table_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/tables/{table_id}")
 
-    def create_personal_table(self, name: str, description: str = "", columns: list | None = None) -> dict:
+    def create_personal_table(
+        self, name: str, description: str = "", columns: list | None = None
+    ) -> dict:
         body: dict = {"name": name, "description": description, "columns": columns or []}
         return self._post("/api/v1/tables", json=body)
 
@@ -370,7 +455,16 @@ class OctopusClient:
     def all_tables(self) -> list:
         return self._list("/api/v1/me/tables", "tables")
 
-    def list_table_rows(self, workspace_id: str | None, table_id: str, limit: int = 50, offset: int = 0, sort_by: str = "", sort_order: str = "asc", filters: str = "") -> dict:
+    def list_table_rows(
+        self,
+        workspace_id: str | None,
+        table_id: str,
+        limit: int = 50,
+        offset: int = 0,
+        sort_by: str = "",
+        sort_order: str = "asc",
+        filters: str = "",
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         params: dict = {"limit": limit, "offset": offset, "sort_order": sort_order}
         if sort_by:
@@ -383,11 +477,17 @@ class OctopusClient:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         return self._post(f"{base}/{table_id}/rows", json={"data": data})
 
-    def insert_table_rows_batch(self, workspace_id: str | None, table_id: str, rows: list[dict]) -> dict:
+    def insert_table_rows_batch(
+        self, workspace_id: str | None, table_id: str, rows: list[dict]
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
-        return self._post(f"{base}/{table_id}/rows/batch", json={"rows": [{"data": r} for r in rows]})
+        return self._post(
+            f"{base}/{table_id}/rows/batch", json={"rows": [{"data": r} for r in rows]}
+        )
 
-    def update_table_row(self, workspace_id: str | None, table_id: str, row_id: str, data: dict) -> dict:
+    def update_table_row(
+        self, workspace_id: str | None, table_id: str, row_id: str, data: dict
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         return self._patch(f"{base}/{table_id}/rows/{row_id}", json={"data": data})
 
@@ -395,7 +495,14 @@ class OctopusClient:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         self._delete(f"{base}/{table_id}/rows/{row_id}")
 
-    def add_table_column(self, workspace_id: str | None, table_id: str, name: str, col_type: str = "text", options: list | None = None) -> dict:
+    def add_table_column(
+        self,
+        workspace_id: str | None,
+        table_id: str,
+        name: str,
+        col_type: str = "text",
+        options: list | None = None,
+    ) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         body: dict = {"name": name, "type": col_type}
         if options:

--- a/cli/formatting.py
+++ b/cli/formatting.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
 
 from rich.console import Console
 from rich.panel import Panel

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 import typer
 
@@ -28,7 +27,9 @@ def _use_json(flag: bool) -> bool:
 def _default_workspace() -> str:
     ws = load_config().get("default_workspace", "")
     if not ws:
-        console.print("[red]No default workspace. Run [bold]octopus connect[/bold] or set manually: octopus config default_workspace <id>[/red]")
+        console.print(
+            "[red]No default workspace. Run [bold]octopus connect[/bold] or set manually: octopus config default_workspace <id>[/red]"
+        )
         raise typer.Exit(1)
     return ws
 
@@ -41,6 +42,7 @@ def _err(e: OctopusError) -> None:
 # ===========================================================================
 # Auth
 # ===========================================================================
+
 
 @app.command()
 def register(
@@ -60,11 +62,17 @@ def register(
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]Registered as {data['name']}[/green]  API key: [bold]{data['api_key']}[/bold]")
+        console.print(
+            f"[green]Registered as {data['name']}[/green]  API key: [bold]{data['api_key']}[/bold]"
+        )
 
 
 @app.command()
-def login(name: str = typer.Argument(...), password: str = typer.Option(..., prompt=True, hide_input=True), as_json: bool = typer.Option(False, "--json")):
+def login(
+    name: str = typer.Argument(...),
+    password: str = typer.Option(..., prompt=True, hide_input=True),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Login with password."""
     with _client() as c:
         try:
@@ -114,7 +122,9 @@ app.add_typer(ws_app, name="workspaces")
 
 
 @ws_app.command("list")
-def ws_list(mine: bool = typer.Option(False, "--mine"), as_json: bool = typer.Option(False, "--json")):
+def ws_list(
+    mine: bool = typer.Option(False, "--mine"), as_json: bool = typer.Option(False, "--json")
+):
     """List workspaces."""
     with _client() as c:
         try:
@@ -128,7 +138,12 @@ def ws_list(mine: bool = typer.Option(False, "--mine"), as_json: bool = typer.Op
 
 
 @ws_app.command("create")
-def ws_create(name: str = typer.Argument(...), description: str = typer.Option(""), public: bool = typer.Option(False, "--public"), as_json: bool = typer.Option(False, "--json")):
+def ws_create(
+    name: str = typer.Argument(...),
+    description: str = typer.Option(""),
+    public: bool = typer.Option(False, "--public"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Create workspace."""
     with _client() as c:
         try:
@@ -138,7 +153,9 @@ def ws_create(name: str = typer.Argument(...), description: str = typer.Option("
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]Created '{data['name']}'[/green]  ID: {data['id']}  Invite: {data['invite_code']}")
+        console.print(
+            f"[green]Created '{data['name']}'[/green]  ID: {data['id']}  Invite: {data['invite_code']}"
+        )
 
 
 @ws_app.command("join")
@@ -166,12 +183,16 @@ def ws_info(workspace_id: str = typer.Argument(...), as_json: bool = typer.Optio
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[bold]{data['name']}[/bold]  Members: {data.get('member_count', '?')}  Public: {data['is_public']}")
+        console.print(
+            f"[bold]{data['name']}[/bold]  Members: {data.get('member_count', '?')}  Public: {data['is_public']}"
+        )
         console.print(f"ID: {data['id']}  Invite: {data['invite_code']}")
 
 
 @ws_app.command("members")
-def ws_members(workspace_id: str = typer.Argument(...), as_json: bool = typer.Option(False, "--json")):
+def ws_members(
+    workspace_id: str = typer.Argument(...), as_json: bool = typer.Option(False, "--json")
+):
     """List workspace members."""
     with _client() as c:
         try:
@@ -193,11 +214,19 @@ app.add_typer(nb_app, name="notebooks")
 
 
 @nb_app.command("list")
-def nb_list(workspace_id: str = typer.Option(None, "--ws"), all_: bool = typer.Option(False, "--all"), as_json: bool = typer.Option(False, "--json")):
+def nb_list(
+    workspace_id: str = typer.Option(None, "--ws"),
+    all_: bool = typer.Option(False, "--all"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """List notebooks. --all for cross-workspace, --ws for single workspace."""
     with _client() as c:
         try:
-            data = c.all_notebooks() if all_ else c.list_notebooks(workspace_id or _default_workspace())
+            data = (
+                c.all_notebooks()
+                if all_
+                else c.list_notebooks(workspace_id or _default_workspace())
+            )
         except OctopusError as e:
             _err(e)
     if _use_json(as_json):
@@ -212,7 +241,13 @@ def nb_list(workspace_id: str = typer.Option(None, "--ws"), all_: bool = typer.O
 
 
 @nb_app.command("create")
-def nb_create(name: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), description: str = typer.Option(""), personal: bool = typer.Option(False, "--personal"), as_json: bool = typer.Option(False, "--json")):
+def nb_create(
+    name: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    description: str = typer.Option(""),
+    personal: bool = typer.Option(False, "--personal"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Create a notebook collection."""
     with _client() as c:
         try:
@@ -230,7 +265,11 @@ def nb_create(name: str = typer.Argument(...), workspace_id: str = typer.Option(
 
 
 @nb_app.command("pages")
-def nb_pages(notebook_id: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")):
+def nb_pages(
+    notebook_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """List pages in a notebook."""
     with _client() as c:
         try:
@@ -250,7 +289,13 @@ def nb_pages(notebook_id: str = typer.Argument(...), workspace_id: str = typer.O
 
 
 @nb_app.command("add-page")
-def nb_add_page(notebook_id: str = typer.Argument(...), name: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), content: str = typer.Option(""), as_json: bool = typer.Option(False, "--json")):
+def nb_add_page(
+    notebook_id: str = typer.Argument(...),
+    name: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    content: str = typer.Option(""),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Add a page to a notebook."""
     with _client() as c:
         try:
@@ -265,7 +310,12 @@ def nb_add_page(notebook_id: str = typer.Argument(...), name: str = typer.Argume
 
 
 @nb_app.command("read-page")
-def nb_read_page(notebook_id: str = typer.Argument(...), page_id: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")):
+def nb_read_page(
+    notebook_id: str = typer.Argument(...),
+    page_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Read a page's content."""
     with _client() as c:
         try:
@@ -281,7 +331,14 @@ def nb_read_page(notebook_id: str = typer.Argument(...), page_id: str = typer.Ar
 
 
 @nb_app.command("edit-page")
-def nb_edit_page(notebook_id: str = typer.Argument(...), page_id: str = typer.Argument(...), content: str = typer.Option(None, "--content"), name: str = typer.Option(None, "--name"), workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")):
+def nb_edit_page(
+    notebook_id: str = typer.Argument(...),
+    page_id: str = typer.Argument(...),
+    content: str = typer.Option(None, "--content"),
+    name: str = typer.Option(None, "--name"),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Update a page. Reads from stdin if --content not given."""
     if content is None and not sys.stdin.isatty():
         content = sys.stdin.read()
@@ -299,7 +356,7 @@ def nb_edit_page(notebook_id: str = typer.Argument(...), page_id: str = typer.Ar
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]Page updated.[/green]")
+        console.print("[green]Page updated.[/green]")
 
 
 # ===========================================================================
@@ -311,7 +368,9 @@ app.add_typer(hist_app, name="history")
 
 
 @hist_app.command("agents")
-def hist_agents(workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")):
+def hist_agents(
+    workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")
+):
     """List distinct agent names that have logged events in this workspace."""
     ws = workspace_id or _default_workspace()
     with _client() as c:
@@ -330,12 +389,27 @@ def hist_agents(workspace_id: str = typer.Option(None, "--ws"), as_json: bool = 
 
 
 @hist_app.command("push")
-def hist_push(content: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), agent_name: str = typer.Option("cli", "--agent"), event_type: str = typer.Option("message", "--type"), session_id: str = typer.Option(None, "--session"), tool_name: str = typer.Option(None, "--tool"), as_json: bool = typer.Option(False, "--json")):
+def hist_push(
+    content: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    agent_name: str = typer.Option("cli", "--agent"),
+    event_type: str = typer.Option("message", "--type"),
+    session_id: str = typer.Option(None, "--session"),
+    tool_name: str = typer.Option(None, "--tool"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Push an event to the workspace history."""
     ws = workspace_id or _default_workspace()
     with _client() as c:
         try:
-            data = c.push_event(ws, agent_name=agent_name, event_type=event_type, content=content, session_id=session_id, tool_name=tool_name)
+            data = c.push_event(
+                ws,
+                agent_name=agent_name,
+                event_type=event_type,
+                content=content,
+                session_id=session_id,
+                tool_name=tool_name,
+            )
         except OctopusError as e:
             _err(e)
     if _use_json(as_json):
@@ -345,7 +419,14 @@ def hist_push(content: str = typer.Argument(...), workspace_id: str = typer.Opti
 
 
 @hist_app.command("query")
-def hist_query(workspace_id: str = typer.Option(None, "--ws"), agent_name: str = typer.Option(None, "--agent"), event_type: str = typer.Option(None, "--type"), limit: int = typer.Option(50, "-n", "--limit"), all_: bool = typer.Option(False, "--all"), as_json: bool = typer.Option(False, "--json")):
+def hist_query(
+    workspace_id: str = typer.Option(None, "--ws"),
+    agent_name: str = typer.Option(None, "--agent"),
+    event_type: str = typer.Option(None, "--type"),
+    limit: int = typer.Option(50, "-n", "--limit"),
+    all_: bool = typer.Option(False, "--all"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Query events. --all for cross-workspace."""
     with _client() as c:
         try:
@@ -361,11 +442,18 @@ def hist_query(workspace_id: str = typer.Option(None, "--ws"), agent_name: str =
     else:
         for ev in data:
             tool = f" ({ev['tool_name']})" if ev.get("tool_name") else ""
-            console.print(f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}")
+            console.print(
+                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
+            )
 
 
 @hist_app.command("search")
-def hist_search(query: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), limit: int = typer.Option(50, "-n", "--limit"), as_json: bool = typer.Option(False, "--json")):
+def hist_search(
+    query: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    limit: int = typer.Option(50, "-n", "--limit"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Full-text search on events in a workspace."""
     ws = workspace_id or _default_workspace()
     with _client() as c:
@@ -377,7 +465,9 @@ def hist_search(query: str = typer.Argument(...), workspace_id: str = typer.Opti
         output_json(data)
     else:
         for ev in data:
-            console.print(f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}: {ev['content'][:200]}")
+            console.print(
+                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}: {ev['content'][:200]}"
+            )
 
 
 # ===========================================================================
@@ -426,7 +516,12 @@ def _resolve_sort_name(table: dict, sort_by: str) -> str:
 
 
 @tables_app.command("list")
-def tables_list(workspace_id: str = typer.Option(None, "--ws"), all_: bool = typer.Option(False, "--all"), personal: bool = typer.Option(False, "--personal"), as_json: bool = typer.Option(False, "--json")):
+def tables_list(
+    workspace_id: str = typer.Option(None, "--ws"),
+    all_: bool = typer.Option(False, "--all"),
+    personal: bool = typer.Option(False, "--personal"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """List tables. --all for cross-workspace, --personal for personal tables."""
     with _client() as c:
         try:
@@ -448,7 +543,9 @@ def tables_list(workspace_id: str = typer.Option(None, "--ws"), all_: bool = typ
                 ws = f" [{t.get('workspace_name', '')}]" if t.get("workspace_name") else ""
                 cols = len(t.get("columns", []))
                 rows = t.get("row_count", 0)
-                console.print(f"  {t['name']}{ws}  ({cols} cols, {rows} rows, id: {str(t['id'])[:8]})")
+                console.print(
+                    f"  {t['name']}{ws}  ({cols} cols, {rows} rows, id: {str(t['id'])[:8]})"
+                )
 
 
 @tables_app.command("create")
@@ -507,7 +604,11 @@ def tables_update(
 
 
 @tables_app.command("schema")
-def tables_schema(table_id: str = typer.Argument(...), workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")):
+def tables_schema(
+    table_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
     """Show a table's column schema."""
     with _client() as c:
         try:
@@ -540,7 +641,9 @@ def tables_rows(
     offset: int = typer.Option(0, "--offset"),
     sort_by: str = typer.Option("", "--sort", help="Column name or ID to sort by"),
     sort_order: str = typer.Option("asc", "--order"),
-    filters: str = typer.Option("", "--filter", help='JSON: [{"column_id":"Name","op":"eq","value":"Alice"}]'),
+    filters: str = typer.Option(
+        "", "--filter", help='JSON: [{"column_id":"Name","op":"eq","value":"Alice"}]'
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Read rows. --sort and --filter accept column names (auto-resolved)."""
@@ -551,7 +654,15 @@ def tables_rows(
             id_to_name = {col["id"]: col["name"] for col in table.get("columns", [])}
             resolved_sort = _resolve_sort_name(table, sort_by)
             resolved_filters = _resolve_filter_names(table, filters) if filters else ""
-            result = c.list_table_rows(ws, table_id, limit=limit, offset=offset, sort_by=resolved_sort, sort_order=sort_order, filters=resolved_filters)
+            result = c.list_table_rows(
+                ws,
+                table_id,
+                limit=limit,
+                offset=offset,
+                sort_by=resolved_sort,
+                sort_order=sort_order,
+                filters=resolved_filters,
+            )
         except OctopusError as e:
             _err(e)
     if _use_json(as_json):
@@ -591,8 +702,12 @@ def tables_insert(
 @tables_app.command("import")
 def tables_import(
     table_id: str = typer.Argument(...),
-    file: str = typer.Option(None, "--file", "-f", help="CSV or JSON file path (or pipe via stdin)"),
-    format_: str = typer.Option("auto", "--format", help="csv, json, or auto (detect from extension/content)"),
+    file: str = typer.Option(
+        None, "--file", "-f", help="CSV or JSON file path (or pipe via stdin)"
+    ),
+    format_: str = typer.Option(
+        "auto", "--format", help="csv, json, or auto (detect from extension/content)"
+    ),
     workspace_id: str = typer.Option(None, "--ws"),
     as_json: bool = typer.Option(False, "--json"),
 ):
@@ -612,7 +727,9 @@ def tables_import(
         raw = sys.stdin.read()
         if format_ == "auto":
             raw_stripped = raw.strip()
-            format_ = "json" if raw_stripped.startswith("[") or raw_stripped.startswith("{") else "csv"
+            format_ = (
+                "json" if raw_stripped.startswith("[") or raw_stripped.startswith("{") else "csv"
+            )
     else:
         console.print("[red]Provide --file or pipe data via stdin.[/red]")
         raise typer.Exit(1)
@@ -643,11 +760,13 @@ def tables_import(
             batch_size = 5000
             total_inserted = 0
             for i in range(0, len(resolved_rows), batch_size):
-                batch = resolved_rows[i:i + batch_size]
+                batch = resolved_rows[i : i + batch_size]
                 c.insert_table_rows_batch(ws, table_id, batch)
                 total_inserted += len(batch)
                 if len(resolved_rows) > batch_size:
-                    console.print(f"  [dim]Inserted {total_inserted}/{len(resolved_rows)} rows...[/dim]")
+                    console.print(
+                        f"  [dim]Inserted {total_inserted}/{len(resolved_rows)} rows...[/dim]"
+                    )
         except OctopusError as e:
             _err(e)
 
@@ -702,7 +821,9 @@ def tables_add_column(
     table_id: str = typer.Argument(...),
     name: str = typer.Argument(...),
     col_type: str = typer.Option("text", "--type"),
-    options: str = typer.Option("", "--options", help="Comma-separated options for select/multiselect"),
+    options: str = typer.Option(
+        "", "--options", help="Comma-separated options for select/multiselect"
+    ),
     workspace_id: str = typer.Option(None, "--ws"),
     as_json: bool = typer.Option(False, "--json"),
 ):
@@ -743,7 +864,7 @@ def tables_delete_column(
     if _use_json(as_json):
         output_json(result)
     else:
-        console.print(f"[green]Column deleted.[/green]")
+        console.print("[green]Column deleted.[/green]")
 
 
 @tables_app.command("count")
@@ -793,7 +914,9 @@ def tables_export(
                 if "table" not in dir():
                     table = c.get_table(ws, table_id)
                 params["filters"] = _resolve_filter_names(table, filters)
-            resp = c._request("GET", f"/api/v1/workspaces/{ws}/tables/{table_id}/export/csv", params=params)
+            resp = c._request(
+                "GET", f"/api/v1/workspaces/{ws}/tables/{table_id}/export/csv", params=params
+            )
             csv_content = resp.text
         except OctopusError as e:
             _err(e)
@@ -827,6 +950,7 @@ def tables_delete(
 # Connect wizard
 # ===========================================================================
 
+
 @app.command("connect")
 def connect():
     """Interactive first-time setup. Sets base URL, authenticates, and configures defaults."""
@@ -834,8 +958,12 @@ def connect():
 
     # --- Step 0: Scope ---
     console.print("[bold]Config scope[/bold]")
-    console.print("  [bold]project[/bold]  save to [cyan].octopus/config.json[/cyan] in this repo (overrides user config)")
-    console.print("  [bold]user[/bold]     save to [cyan]~/.octopus/config.json[/cyan] (applies everywhere)")
+    console.print(
+        "  [bold]project[/bold]  save to [cyan].octopus/config.json[/cyan] in this repo (overrides user config)"
+    )
+    console.print(
+        "  [bold]user[/bold]     save to [cyan]~/.octopus/config.json[/cyan] (applies everywhere)"
+    )
     console.print("  [dim]Auth (api_key) always goes to user scope — it's per-machine.[/dim]")
     scope_input = typer.prompt("Scope", default="project").strip().lower()
     scope = "project" if scope_input.startswith("p") else "user"
@@ -853,12 +981,16 @@ def connect():
         try:
             with OctopusClient(base_url=base_url, api_key=cfg["api_key"]) as c:
                 user = c.whoami()
-            console.print(f"  [green]✓[/green] Already authenticated as [bold]{user['name']}[/bold]")
+            console.print(
+                f"  [green]✓[/green] Already authenticated as [bold]{user['name']}[/bold]"
+            )
         except OctopusError:
             has_key = False
 
     if not has_key:
-        action = typer.prompt("Login or register? [login/register]", default="login").strip().lower()
+        action = (
+            typer.prompt("Login or register? [login/register]", default="login").strip().lower()
+        )
         name = typer.prompt("Username")
         if action == "register":
             password = typer.prompt("Password", hide_input=True, confirmation_prompt=True)
@@ -893,7 +1025,7 @@ def connect():
 
         workspace_id = cfg.get("default_workspace", "")
         if my_workspaces:
-            console.print(f"\n  Your workspaces:")
+            console.print("\n  Your workspaces:")
             for ws in my_workspaces[:5]:
                 marker = " [dim](current default)[/dim]" if str(ws["id"]) == workspace_id else ""
                 console.print(f"    [dim]{str(ws['id'])[:8]}…[/dim]  {ws['name']}{marker}")
@@ -904,28 +1036,35 @@ def connect():
         ).strip()
 
         if not ws_action:
-            console.print("[yellow]Skipping workspace setup. Run: octopus config default_workspace <id>[/yellow]")
+            console.print(
+                "[yellow]Skipping workspace setup. Run: octopus config default_workspace <id>[/yellow]"
+            )
         else:
             # Check if it looks like a UUID (existing) or a name (create new)
             import re
+
             is_uuid = bool(re.match(r"^[0-9a-f-]{32,36}$", ws_action, re.I))
             if is_uuid:
                 workspace_id = ws_action
                 save_config(default_workspace=workspace_id, scope=scope)
-                console.print(f"  [green]✓[/green] Default workspace set to [bold]{workspace_id[:8]}…[/bold]")
+                console.print(
+                    f"  [green]✓[/green] Default workspace set to [bold]{workspace_id[:8]}…[/bold]"
+                )
             else:
                 try:
                     ws_data = c.create_workspace(ws_action)
                     workspace_id = str(ws_data["id"])
                     save_config(default_workspace=workspace_id, scope=scope)
-                    console.print(f"  [green]✓[/green] Created workspace [bold]{ws_data['name']}[/bold]  invite: {ws_data['invite_code']}")
+                    console.print(
+                        f"  [green]✓[/green] Created workspace [bold]{ws_data['name']}[/bold]  invite: {ws_data['invite_code']}"
+                    )
                 except OctopusError as e:
                     console.print(f"[red]Could not create workspace: {e.detail}[/red]")
 
     # --- Done ---
     console.print("\n[bold green]Setup complete.[/bold green]")
     console.print("  Run [bold]octopus whoami[/bold] to confirm auth.")
-    console.print("  Run [bold]octopus history push \"hello\"[/bold] to push your first event.")
+    console.print('  Run [bold]octopus history push "hello"[/bold] to push your first event.')
     console.print("  Run [bold]octopus --help[/bold] to see all commands.\n")
 
 
@@ -959,13 +1098,15 @@ def status(as_json: bool = typer.Option(False, "--json")):
     plugins_seen = [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()]
 
     if as_json or cfg.get("output_format") == "json":
-        output_json({
-            "config": display_cfg,
-            "streaming_enabled": streaming_enabled,
-            "auto_curate": auto_curate,
-            "last_curate_at": last_curate_at,
-            "plugins_installed": plugins_seen,
-        })
+        output_json(
+            {
+                "config": display_cfg,
+                "streaming_enabled": streaming_enabled,
+                "auto_curate": auto_curate,
+                "last_curate_at": last_curate_at,
+                "plugins_installed": plugins_seen,
+            }
+        )
         return
 
     console.print("[bold]Octopus status[/bold]")
@@ -973,10 +1114,13 @@ def status(as_json: bool = typer.Option(False, "--json")):
     console.print(f"  Endpoint:   {cfg.get('base_url')}")
     console.print(f"  Workspace:  {cfg.get('default_workspace') or '(none)'}")
     console.print(f"  Store:      {cfg.get('default_store') or '(none)'}")
-    console.print(f"  Streaming:  {'enabled' if streaming_enabled else '[yellow]disabled[/yellow]'}")
+    console.print(
+        f"  Streaming:  {'enabled' if streaming_enabled else '[yellow]disabled[/yellow]'}"
+    )
     console.print(f"  Auto-curate: {'on' if auto_curate else 'off'}")
     if last_curate_at:
         import datetime as _dt
+
         ts = _dt.datetime.fromtimestamp(float(last_curate_at)).isoformat(timespec="seconds")
         console.print(f"  Last curate: {ts}")
     else:
@@ -992,11 +1136,14 @@ def disconnect(as_json: bool = typer.Option(False, "--json")):
         output_json({"streaming_enabled": False})
         return
     console.print("[yellow]Streaming disabled.[/yellow] Hooks will stop pushing events.")
-    console.print("  Re-enable with [bold]octopus connect[/bold] or edit [cyan]~/.octopus/config.json[/cyan].")
+    console.print(
+        "  Re-enable with [bold]octopus connect[/bold] or edit [cyan]~/.octopus/config.json[/cyan]."
+    )
 
 
 def _read_central_config() -> dict:
     from .config import USER_CONFIG_FILE
+
     if not USER_CONFIG_FILE.exists():
         return {}
     try:
@@ -1007,6 +1154,7 @@ def _read_central_config() -> dict:
 
 def _write_central_config(updates: dict) -> None:
     from .config import USER_CONFIG_FILE
+
     existing = _read_central_config()
     existing.update(updates)
     USER_CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -1019,11 +1167,14 @@ def _write_central_config(updates: dict) -> None:
 # Config
 # ===========================================================================
 
+
 @app.command("config")
 def config_cmd(
-    key: Optional[str] = typer.Argument(None),
-    value: Optional[str] = typer.Argument(None),
-    project: bool = typer.Option(False, "--project", help="Write to project-level config (.octopus/config.json in the repo)."),
+    key: str | None = typer.Argument(None),
+    value: str | None = typer.Argument(None),
+    project: bool = typer.Option(
+        False, "--project", help="Write to project-level config (.octopus/config.json in the repo)."
+    ),
 ):
     """Show or set config. Keys: base_url, default_workspace, output_format.
 
@@ -1031,12 +1182,14 @@ def config_cmd(
     .octopus/config.json in the current project (created if missing). Project
     config overrides user config when both exist.
     """
-    from .config import find_project_config, USER_CONFIG_FILE
+    from .config import USER_CONFIG_FILE, find_project_config
 
     if key and value:
         scope = "project" if project else "user"
         allowed = {
-            "base_url", "default_workspace", "default_chat",
+            "base_url",
+            "default_workspace",
+            "default_chat",
             "output_format",
         }
         if key not in allowed and key not in {"api_key", "username"}:


### PR DESCRIPTION
## Summary
- Fix all `ruff check backend/ cli/` violations (import sort, `datetime.UTC`, `X | None`, E402, F841)
- Apply `black` to 33 files across `backend/` and `cli/`
- Unblocks the `Backend lint (ruff + black)` CI job that has been red on `main`

Replaces stale #54 (closed after 20+ plugins/CLI commits landed on main).

## Notable non-mechanical fixes
- `backend/services/analytics_service.py` — moved `import re` from line 121 up into the top import block
- `backend/services/table_service.py:duplicate_row` — removed unused `pool = get_pool()`

## Test plan
- [x] `ruff check backend/ cli/` → clean
- [x] `black --check backend/ cli/` → clean
- [ ] CI `backend-lint` green
- [ ] CI `backend-test` still green