### PR TITLE
Browser-based auth for CLI onboarding

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,3 +1,6 @@
+import secrets
+import time
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from ..auth import get_current_user
@@ -13,6 +16,20 @@ from ..models import (
 from ..services import user_service
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
+
+# ---------------------------------------------------------------------------
+# CLI auth sessions — in-memory, short-lived (10 min TTL)
+# ---------------------------------------------------------------------------
+
+_CLI_AUTH_TTL = 600  # seconds
+_cli_sessions: dict[str, dict] = {}  # session_id → {created_at, api_key?, username?}
+
+
+def _prune_cli_sessions() -> None:
+    cutoff = time.time() - _CLI_AUTH_TTL
+    expired = [k for k, v in _cli_sessions.items() if v["created_at"] < cutoff]
+    for k in expired:
+        del _cli_sessions[k]
 
 
 @router.post("/register", response_model=UserRegisterResponse, status_code=201)
@@ -88,3 +105,49 @@ async def search_users(
         current_user["id"],
     )
     return [UserSearchResult(**dict(r)) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# CLI browser-based auth flow
+# ---------------------------------------------------------------------------
+
+@router.post("/cli-auth/sessions")
+@limiter.limit("10/minute")
+async def create_cli_auth_session(request: Request):
+    """Create a CLI auth session. Returns a session_id the CLI uses to poll."""
+    _prune_cli_sessions()
+    session_id = secrets.token_urlsafe(32)
+    _cli_sessions[session_id] = {"created_at": time.time()}
+    return {"session_id": session_id}
+
+
+@router.get("/cli-auth/sessions/{session_id}")
+@limiter.limit("60/minute")
+async def poll_cli_auth_session(request: Request, session_id: str):
+    """Poll for CLI auth result. Returns pending or complete with api_key."""
+    _prune_cli_sessions()
+    session = _cli_sessions.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if "api_key" in session:
+        del _cli_sessions[session_id]
+        return {"status": "complete", "api_key": session["api_key"], "username": session["username"]}
+    return {"status": "pending"}
+
+
+@router.post("/cli-auth/sessions/{session_id}/approve")
+@limiter.limit("10/minute")
+async def approve_cli_auth_session(request: Request, session_id: str):
+    """Called by the frontend after login to approve the CLI session."""
+    body = await request.json()
+    api_key = body.get("api_key")
+    username = body.get("username")
+    if not api_key or not username:
+        raise HTTPException(status_code=400, detail="api_key and username required")
+    _prune_cli_sessions()
+    session = _cli_sessions.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    session["api_key"] = api_key
+    session["username"] = username
+    return {"status": "approved"}

--- a/cli/main.py
+++ b/cli/main.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import questionary
 import typer
 
 from .client import OctopusClient, OctopusError
@@ -833,18 +834,41 @@ def connect():
     console.print("\n[bold]Octopus connect[/bold]  (press Enter to accept defaults)\n")
 
     # --- Step 0: Scope ---
-    console.print("[bold]Config scope[/bold]")
-    console.print("  [bold]project[/bold]  save to [cyan].octopus/config.json[/cyan] in this repo (overrides user config)")
-    console.print("  [bold]user[/bold]     save to [cyan]~/.octopus/config.json[/cyan] (applies everywhere)")
-    console.print("  [dim]Auth (api_key) always goes to user scope — it's per-machine.[/dim]")
-    scope_input = typer.prompt("Scope", default="project").strip().lower()
-    scope = "project" if scope_input.startswith("p") else "user"
+    scope_options = [
+        ("Everywhere on this machine (default)", "~/.octopus/config.json", "user"),
+        ("Only this directory", "./.octopus/config.json", "project"),
+    ]
+    label_width = max(len(label) for label, _, _ in scope_options)
+    scope = questionary.select(
+        "Where do you want to install octopus?",
+        choices=[
+            questionary.Choice(f"{label:<{label_width}}   {path}", value=value)
+            for label, path, value in scope_options
+        ],
+        use_shortcuts=True,
+    ).ask()
+    if scope is None:
+        raise typer.Exit(1)
 
     # --- Step 1: API endpoint ---
     cfg = load_config()
-    current_url = cfg.get("base_url", "http://localhost:3456")
-    default_url = "https://getoctopus.com" if "localhost" in current_url else current_url
-    base_url = typer.prompt("API endpoint", default=default_url).rstrip("/")
+    mode = questionary.select(
+        "How do you want to use Octopus?",
+        choices=[
+            questionary.Choice("Managed      (hosted at getoctopus.com)", value="managed"),
+            questionary.Choice("Self-hosted  (your own backend)", value="self"),
+        ],
+        use_shortcuts=True,
+    ).ask()
+    if mode is None:
+        raise typer.Exit(1)
+
+    if mode == "managed":
+        base_url = "https://getoctopus.com"
+    else:
+        current_url = cfg.get("base_url", "http://localhost:3456")
+        default_url = current_url if "localhost" not in current_url else "http://localhost:3456"
+        base_url = typer.prompt("Self-hosted URL", default=default_url).rstrip("/")
     save_config(base_url=base_url, scope=scope)
 
     # --- Step 2: Auth ---

--- a/cli/main.py
+++ b/cli/main.py
@@ -903,7 +903,7 @@ def connect():
         base_url = _self_host_walkthrough(cfg)
     save_config(base_url=base_url, scope=scope)
 
-    # --- Step 2: Auth ---
+    # --- Step 2: Auth (browser-based) ---
     has_key = bool(cfg.get("api_key"))
     if has_key:
         try:
@@ -914,28 +914,54 @@ def connect():
             has_key = False
 
     if not has_key:
-        action = typer.prompt("Login or register? [login/register]", default="login").strip().lower()
-        name = typer.prompt("Username")
-        if action == "register":
-            password = typer.prompt("Password", hide_input=True, confirmation_prompt=True)
-            with OctopusClient(base_url=base_url, api_key="") as c:
-                try:
-                    data = c.register(name, description="", password=password)
-                except OctopusError as e:
-                    console.print(f"[red]Registration failed: {e.detail}[/red]")
-                    raise typer.Exit(1)
-            save_config(api_key=data["api_key"], username=data["name"])
-            console.print(f"  [green]✓[/green] Registered as [bold]{data['name']}[/bold]")
+        import time as _time
+        import webbrowser
+
+        import httpx
+
+        # Create a CLI auth session
+        try:
+            resp = httpx.post(f"{base_url}/api/v1/users/cli-auth/sessions", timeout=10)
+            resp.raise_for_status()
+            session_id = resp.json()["session_id"]
+        except Exception as e:
+            console.print(f"[red]Could not reach {base_url}: {e}[/red]")
+            raise typer.Exit(1)
+
+        # Build the login URL — for self-hosted, frontend is on port 3000
+        if "localhost" in base_url or "127.0.0.1" in base_url:
+            frontend_url = base_url.replace(":3456", ":3000")
         else:
-            password = typer.prompt("Password", hide_input=True)
-            with OctopusClient(base_url=base_url, api_key="") as c:
+            frontend_url = base_url
+        login_url = f"{frontend_url}/login?cli={session_id}"
+
+        console.print(f"\n  Opening browser to sign in...")
+        console.print(f"  [dim]{login_url}[/dim]\n")
+        webbrowser.open(login_url)
+
+        _reserve_bottom_padding(4)
+        console.print("  Waiting for authentication... [dim](press Ctrl+C to cancel)[/dim]")
+
+        # Poll for the result
+        try:
+            for _ in range(120):  # 2 minutes max
+                _time.sleep(1)
                 try:
-                    data = c.login(name, password)
-                except OctopusError as e:
-                    console.print(f"[red]Login failed: {e.detail}[/red]")
-                    raise typer.Exit(1)
-            save_config(api_key=data["api_key"], username=data["name"])
-            console.print(f"  [green]✓[/green] Logged in as [bold]{data['name']}[/bold]")
+                    poll = httpx.get(f"{base_url}/api/v1/users/cli-auth/sessions/{session_id}", timeout=5)
+                    if poll.status_code == 200:
+                        result = poll.json()
+                        if result["status"] == "complete":
+                            save_config(api_key=result["api_key"], username=result["username"])
+                            console.print(f"  [green]✓[/green] Logged in as [bold]{result['username']}[/bold]")
+                            break
+                except httpx.HTTPError:
+                    pass
+            else:
+                console.print("[red]Timed out waiting for authentication.[/red]")
+                raise typer.Exit(1)
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Cancelled.[/yellow]")
+            raise typer.Exit(1)
 
     # Reload config after auth
     cfg = load_config()

--- a/cli/main.py
+++ b/cli/main.py
@@ -828,6 +828,26 @@ def tables_delete(
 # Connect wizard
 # ===========================================================================
 
+def _self_host_walkthrough(cfg: dict) -> str:
+    """Walk the user through standing up a local Octopus instance, then return its URL."""
+    console.print("\n[bold cyan]Self-hosting Octopus[/bold cyan]\n")
+    console.print("You'll need [bold]Docker[/bold] installed.  https://docker.com/get-started\n")
+    console.print("Run these commands in a separate terminal:\n")
+    console.print("  [dim]1.[/dim] [cyan]git clone https://github.com/Fergana-Labs/octopus.git[/cyan]")
+    console.print("  [dim]2.[/dim] [cyan]cd octopus[/cyan]")
+    console.print("  [dim]3.[/dim] [cyan]docker compose up -d[/cyan]")
+    console.print("\n  [dim]Already running? Skip to the URL prompt below.[/dim]\n")
+
+    ready = questionary.confirm("Is your instance running?", default=True).ask()
+    if ready is None or not ready:
+        console.print("\n[yellow]No problem — run [bold]octopus connect[/bold] again when ready.[/yellow]")
+        raise typer.Exit(0)
+
+    current_url = cfg.get("base_url", "http://localhost:3456")
+    default_url = current_url if "localhost" in current_url or current_url != "https://getoctopus.com" else "http://localhost:3456"
+    return typer.prompt("URL of your instance", default=default_url).rstrip("/")
+
+
 @app.command("connect")
 def connect():
     """Interactive first-time setup. Sets base URL, authenticates, and configures defaults."""
@@ -855,8 +875,8 @@ def connect():
     mode = questionary.select(
         "How do you want to use Octopus?",
         choices=[
-            questionary.Choice("Managed      (hosted at getoctopus.com)", value="managed"),
-            questionary.Choice("Self-hosted  (your own backend)", value="self"),
+            questionary.Choice("Use the hosted version  (getoctopus.com — recommended)", value="managed"),
+            questionary.Choice("Self-host               (run on your own machine)", value="self"),
         ],
         use_shortcuts=True,
     ).ask()
@@ -866,9 +886,7 @@ def connect():
     if mode == "managed":
         base_url = "https://getoctopus.com"
     else:
-        current_url = cfg.get("base_url", "http://localhost:3456")
-        default_url = current_url if "localhost" not in current_url else "http://localhost:3456"
-        base_url = typer.prompt("Self-hosted URL", default=default_url).rstrip("/")
+        base_url = _self_host_walkthrough(cfg)
     save_config(base_url=base_url, scope=scope)
 
     # --- Step 2: Auth ---

--- a/cli/main.py
+++ b/cli/main.py
@@ -828,6 +828,12 @@ def tables_delete(
 # Connect wizard
 # ===========================================================================
 
+def _reserve_bottom_padding(lines: int = 4) -> None:
+    """Scroll the terminal up `lines` rows so prompts don't render flush against the bottom."""
+    sys.stdout.write("\n" * lines + f"\033[{lines}A")
+    sys.stdout.flush()
+
+
 def _self_host_walkthrough(cfg: dict) -> str:
     """Walk the user through standing up a local Octopus instance, then return its URL."""
     console.print("\n[bold cyan]Self-hosting Octopus[/bold cyan]\n")
@@ -838,6 +844,7 @@ def _self_host_walkthrough(cfg: dict) -> str:
     console.print("  [dim]3.[/dim] [cyan]docker compose up -d[/cyan]")
     console.print("\n  [dim]Already running? Skip to the URL prompt below.[/dim]\n")
 
+    _reserve_bottom_padding(6)
     ready = questionary.confirm("Is your instance running?", default=True).ask()
     if ready is None or not ready:
         console.print("\n[yellow]No problem — run [bold]octopus connect[/bold] again when ready.[/yellow]")
@@ -859,6 +866,7 @@ def connect():
         ("Only this directory", "./.octopus/config.json", "project"),
     ]
     label_width = max(len(label) for label, _, _ in scope_options)
+    _reserve_bottom_padding(8)
     scope = questionary.select(
         "Where do you want to install octopus?",
         choices=[
@@ -872,11 +880,18 @@ def connect():
 
     # --- Step 1: API endpoint ---
     cfg = load_config()
+    mode_options = [
+        ("Managed", "hosted at getoctopus.com", "managed"),
+        ("Self-host", "run on your own machine", "self"),
+    ]
+    mode_label_w = max(len(label) for label, _, _ in mode_options)
+    mode_desc_w = max(len(desc) for _, desc, _ in mode_options)
+    _reserve_bottom_padding(8)
     mode = questionary.select(
         "How do you want to use Octopus?",
         choices=[
-            questionary.Choice("Use the hosted version  (getoctopus.com — recommended)", value="managed"),
-            questionary.Choice("Self-host               (run on your own machine)", value="self"),
+            questionary.Choice(f"{label:<{mode_label_w}}   ({desc:<{mode_desc_w}})", value=value)
+            for label, desc, value in mode_options
         ],
         use_shortcuts=True,
     ).ask()

--- a/cli/main.py
+++ b/cli/main.py
@@ -885,12 +885,11 @@ def connect():
         ("Self-host", "run on your own machine", "self"),
     ]
     mode_label_w = max(len(label) for label, _, _ in mode_options)
-    mode_desc_w = max(len(desc) for _, desc, _ in mode_options)
     _reserve_bottom_padding(8)
     mode = questionary.select(
         "How do you want to use Octopus?",
         choices=[
-            questionary.Choice(f"{label:<{mode_label_w}}   ({desc:<{mode_desc_w}})", value=value)
+            questionary.Choice(f"{label:<{mode_label_w}}   ({desc})", value=value)
             for label, desc, value in mode_options
         ],
         use_shortcuts=True,

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../../components/Header";
 import { useAuth } from "../../hooks/useAuth";
 import { setToken, listMyWorkspaces } from "../../lib/api";
@@ -10,14 +10,36 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const cliSession = searchParams.get("cli");
   const { user, logout, refresh } = useAuth();
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [cliApproved, setCliApproved] = useState(false);
+  const [isRegister, setIsRegister] = useState(false);
 
+  // If already logged in and this is a CLI auth request, approve immediately
   useEffect(() => {
-    if (!user) return;
+    if (!user || !cliSession || cliApproved) return;
+    const token = localStorage.getItem("octopus_token");
+    if (!token) return;
+
+    fetch(`${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: token, username: user.name }),
+    })
+      .then((res) => {
+        if (res.ok) setCliApproved(true);
+      })
+      .catch(() => {});
+  }, [user, cliSession, cliApproved]);
+
+  // Normal redirect for non-CLI logins
+  useEffect(() => {
+    if (!user || cliSession) return;
 
     listMyWorkspaces().then(({ workspaces }) => {
       if (workspaces.length === 1) {
@@ -28,31 +50,61 @@ export default function LoginPage() {
     }).catch(() => {
       router.push("/");
     });
-  }, [user, router]);
+  }, [user, cliSession, router]);
 
-  if (user) {
+  if (cliApproved) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header user={user} onLogout={logout} />
+        <main className="flex-1 flex items-center justify-center px-4 py-12">
+          <div className="w-full max-w-sm text-center space-y-3">
+            <div className="text-3xl">&#10003;</div>
+            <h2 className="text-base font-semibold text-foreground">CLI authenticated</h2>
+            <p className="text-sm text-muted">You can close this tab and return to your terminal.</p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (user && !cliSession) {
     return null;
   }
 
-  async function handlePasswordLogin(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/users/login`, {
+      const endpoint = isRegister ? "/api/v1/users/register" : "/api/v1/users/login";
+      const body = isRegister
+        ? { name, display_name: name, description: "", password }
+        : { name, password };
+      const res = await fetch(`${API_URL}${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, password }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || "Login failed");
+        throw new Error(data.detail || (isRegister ? "Registration failed" : "Login failed"));
       }
       const data = await res.json();
       setToken(data.api_key);
+
+      // If this is a CLI auth flow, approve the session
+      if (cliSession) {
+        await fetch(`${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ api_key: data.api_key, username: data.name }),
+        });
+        setCliApproved(true);
+      }
+
       refresh();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Login failed");
+      setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       setSubmitting(false);
     }
@@ -64,8 +116,12 @@ export default function LoginPage() {
       <main className="flex-1 flex items-center justify-center px-4 py-12">
         <div className="w-full max-w-sm space-y-4">
           <div className="rounded-2xl border border-border bg-surface p-6">
-            <h2 className="text-base font-semibold text-foreground mb-4">Sign in</h2>
-            <form onSubmit={handlePasswordLogin} className="space-y-3">
+            <h2 className="text-base font-semibold text-foreground mb-4">
+              {cliSession
+                ? isRegister ? "Create an account to authorize the CLI" : "Sign in to authorize the CLI"
+                : isRegister ? "Create an account" : "Sign in"}
+            </h2>
+            <form onSubmit={handleSubmit} className="space-y-3">
               <input
                 type="text"
                 placeholder="Username"
@@ -88,9 +144,19 @@ export default function LoginPage() {
                 disabled={submitting}
                 className="w-full bg-surface-hover hover:bg-border text-foreground py-2.5 rounded-xl text-sm font-medium transition-colors disabled:opacity-50"
               >
-                {submitting ? "Signing in..." : "Sign in"}
+                {submitting ? (isRegister ? "Creating account..." : "Signing in...") : (isRegister ? "Create account" : "Sign in")}
               </button>
             </form>
+            <p className="mt-3 text-center text-xs text-muted">
+              {isRegister ? "Already have an account?" : "Don\u2019t have an account?"}{" "}
+              <button
+                type="button"
+                onClick={() => { setIsRegister(!isRegister); setError(""); }}
+                className="text-brand hover:underline"
+              >
+                {isRegister ? "Sign in" : "Create one"}
+              </button>
+            </p>
           </div>
         </div>
       </main>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "typer>=0.12.0",
     "httpx>=0.27.0",
     "rich>=13.0.0",
+    "questionary>=2.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Replaces the CLI's username/password prompts during `octopus connect` with a browser-based auth flow (like `gh auth login`)
- CLI creates a session, opens the browser to `/login?cli=<session_id>`, and polls until the user authenticates
- Adds CLI auth session endpoints to the backend (`POST/GET /api/v1/users/cli-auth/sessions`)
- Updates the frontend login page with sign-in/sign-up toggle and CLI session approval
- If the user is already logged in on the web, opening the CLI link auto-approves immediately

## Files changed
- `backend/routers/users.py` — CLI auth session endpoints (in-memory, 10min TTL)
- `cli/main.py` — `connect` command uses `webbrowser.open` + polling instead of terminal prompts
- `frontend/src/app/login/page.tsx` — handles `?cli=` param, sign-in/sign-up toggle, approval flow

## Test plan
- [ ] Run `octopus connect`, verify browser opens to login page
- [ ] Sign in on the web, verify CLI picks up the API key and prints success
- [ ] Test with an already-logged-in browser session (should auto-approve)
- [ ] Test the register flow from the login page toggle
- [ ] Verify Ctrl+C cancels the polling cleanly
- [ ] Verify timeout after 2 minutes if no auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)