### PR TITLE
fix: unblock backend deploy + point CLI at real managed URL

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.6
+python-multipart>=0.0.18
 uvicorn[standard]==0.34.0
 asyncpg==0.30.0
 pydantic==2.10.4

--- a/cli/main.py
+++ b/cli/main.py
@@ -974,7 +974,8 @@ def _self_host_walkthrough(cfg: dict) -> str:
         raise typer.Exit(0)
 
     current_url = cfg.get("base_url", "http://localhost:3456")
-    default_url = current_url if "localhost" in current_url or current_url != "https://stash.ac" else "http://localhost:3456"
+    managed_hosts = ("https://stash.ac", "https://www.stash.ac", "https://moltchat.onrender.com")
+    default_url = "http://localhost:3456" if current_url in managed_hosts else current_url
     return typer.prompt("URL of your instance", default=default_url).rstrip("/")
 
 
@@ -1005,7 +1006,7 @@ def connect():
     # --- Step 1: API endpoint ---
     cfg = load_config()
     mode_options = [
-        ("Managed", "hosted at stash.ac", "managed"),
+        ("Managed", "hosted by Stash", "managed"),
         ("Self-host", "run on your own machine", "self"),
     ]
     mode_label_w = max(len(label) for label, _, _ in mode_options)
@@ -1022,7 +1023,7 @@ def connect():
         raise typer.Exit(1)
 
     if mode == "managed":
-        base_url = "https://stash.ac"
+        base_url = "https://moltchat.onrender.com"
     else:
         base_url = _self_host_walkthrough(cfg)
     save_config(base_url=base_url, scope=scope)
@@ -1047,7 +1048,11 @@ def connect():
 
         # Create a CLI auth session
         try:
-            resp = httpx.post(f"{base_url}/api/v1/users/cli-auth/sessions", timeout=10)
+            resp = httpx.post(
+                f"{base_url}/api/v1/users/cli-auth/sessions",
+                timeout=10,
+                follow_redirects=True,
+            )
             resp.raise_for_status()
             session_id = resp.json()["session_id"]
         except Exception as e:
@@ -1073,7 +1078,11 @@ def connect():
             for _ in range(120):  # 2 minutes max
                 _time.sleep(1)
                 try:
-                    poll = httpx.get(f"{base_url}/api/v1/users/cli-auth/sessions/{session_id}", timeout=5)
+                    poll = httpx.get(
+                        f"{base_url}/api/v1/users/cli-auth/sessions/{session_id}",
+                        timeout=5,
+                        follow_redirects=True,
+                    )
                     if poll.status_code == 200:
                         result = poll.json()
                         if result["status"] == "complete":


### PR DESCRIPTION
## Summary

Two connected fixes so `stash connect` actually works in managed mode:

- **Unblock the backend deploy.** `backend/routers/files.py:43` uses FastAPI `UploadFile`, which requires `python-multipart`. The dep was missing from `backend/requirements.txt`, so every container on Render was crashing at startup with `RuntimeError: Form data requires "python-multipart" to be installed.` The last 3 deploys on the `moltchat` Render service all show `update_failed` for this reason — meaning prod has been frozen at whatever last deployed before the files router landed. Adding `python-multipart>=0.0.18` to requirements fixes it.
- **Point managed mode at the real backend URL.** `cli/main.py` had managed mode hardcoded to `https://stash.ac`, but that domain currently serves a different product (an AI slides tool) and 404s our API. Until the rename/cutover happens, the actual backend lives at `https://moltchat.onrender.com`. Pointed the CLI there, updated the label copy, fixed a related bug in `_self_host_walkthrough` where a saved `https://stash.ac` wasn't being reset to localhost, and added `follow_redirects=True` on the CLI auth POST/GET so a future DNS redirect won't silently break things again.

## Test plan

- [ ] Render auto-deploys the backend fix; verify `moltchat` service deploy goes from `update_failed` → `live`
- [ ] Hit `https://moltchat.onrender.com/api/v1/users/cli-auth/sessions` (POST) and confirm it returns a session instead of 404
- [ ] Run `stash connect`, pick Managed, verify the browser opens to `moltchat.onrender.com/login?cli=…` and the CLI completes auth
- [ ] Self-host flow still lands on `http://localhost:3456` default when previous config was managed

## Known follow-ups (not in this PR)

- README, docs (`frontend/src/app/docs/api/page.tsx`), plugin READMEs, and `.github/ISSUE_TEMPLATE/bug_report.yml` still reference `stash.ac`. They'll need updating when the domain either cuts over or the product-facing URL is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)