### PR TITLE
feat(plugins): add openclaw plugin (redo of #46 on current main)

### DIFF
--- a/plugins/openclaw-plugin/HOOK.md
+++ b/plugins/openclaw-plugin/HOOK.md
@@ -1,0 +1,94 @@
+---
+name: stash
+description: "Stream Openclaw gateway sessions to a Stash workspace"
+homepage: https://github.com/Fergana-Labs/octopus/tree/main/plugins/openclaw-plugin
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🐙",
+        "events": ["command", "message"],
+        "install": [{ "id": "stash", "kind": "external", "label": "Stash plugin repo" }],
+      },
+  }
+---
+
+# Stash Hook for Openclaw
+
+Streams every inbound/outbound gateway message and session boundary to your
+Stash workspace so you (or your teammates) can read the history from the
+`stash` CLI or the Assert review app.
+
+## What it captures
+
+| Openclaw event | Stash event |
+|---|---|
+| `command:new` | `session_start` |
+| `message:received` | `user_message` (body from the channel) |
+| `message:sent` (success=true) | `assistant_message` |
+| `command:reset`, `command:stop` | `session_end` |
+
+Skipped: `message:sent` where `success=false`, audio-only messages prior to
+transcription.
+
+## Known gaps vs the IDE-side plugins
+
+- **No `tool_use` stream.** Openclaw's gateway has no visibility into tool
+  calls; those happen inside the delegated coding agent (Claude Code / Codex
+  / etc.). Install the matching Stash plugin for that agent to get
+  tool-level history.
+- **No context injection.** Openclaw routes raw channel messages to the
+  underlying agent; context injection is the underlying agent's job.
+- **Session IDs use Openclaw's `sessionKey`** (e.g. `agent:main:main`), not
+  a Stash session UUID. They are stable per-agent-per-conversation.
+
+## Requirements
+
+- Openclaw `>= 0.9` (internal hooks API)
+- Python 3.10+ on PATH (this hook shells out to Python for the Stash API client)
+- `httpx` installed (`pip install httpx`)
+- `stash` CLI logged in (`pip install stash-cli && stash connect`)
+- `stash config default_workspace <id>` set
+
+## Install
+
+```bash
+openclaw plugins install github:Fergana-Labs/octopus#plugins/openclaw-plugin
+openclaw hooks enable stash
+# restart the gateway
+```
+
+Or from a local checkout:
+
+```bash
+openclaw plugins install ./plugins/openclaw-plugin
+openclaw hooks enable stash
+```
+
+## Config
+
+Reads from `~/.stash/config.json` (populated by `stash connect` + `stash
+config …`). Override with env vars in the gateway's environment:
+
+- `STASH_OPENCLAW_DATA=<path>` — custom state dir (default `~/.stash/plugins/openclaw`)
+- `STASH_PYTHON=<path>` — Python interpreter to spawn (default `python3`)
+
+## Disable
+
+```bash
+openclaw hooks disable stash
+```
+
+Or via `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "stash": { "enabled": false }
+      }
+    }
+  }
+}
+```

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -1,0 +1,75 @@
+# Stash Plugin for Openclaw
+
+Streams Openclaw gateway sessions to a Stash workspace so you can read
+history from the `stash` CLI or the Assert review app.
+
+**Openclaw is a self-hosted chat-app gateway**, not an IDE — it bridges
+WhatsApp / Telegram / Slack / iMessage / etc. to a coding agent running on
+your own machine. This plugin registers against Openclaw's internal hook
+system (`command:*`, `message:*`) and streams the gateway-visible slice of
+each session to Stash.
+
+Tool-call history (`edit`, `bash`, etc.) is captured by the IDE-side plugin
+for whichever agent Openclaw delegates to (Claude Code / Codex / etc.).
+Install that plugin too if you want full-fidelity history.
+
+## Layout
+
+```
+openclaw-plugin/
+├── HOOK.md          # Openclaw hook manifest (frontmatter matches openclaw/openclaw)
+├── handler.ts       # Hook entrypoint — exports default HookHandler
+├── package.json
+├── scripts/         # Python scripts reusing plugins/shared/
+│   ├── adapt.py
+│   ├── config.py
+│   ├── on_session_start.py
+│   ├── on_prompt.py
+│   ├── on_stop.py
+│   └── on_session_end.py
+└── README.md
+```
+
+`handler.ts` runs inside the Openclaw Node process, filters the events it
+cares about, and pipes a flat JSON payload into the matching Python script.
+The Python side reuses `plugins/shared/` just like every other agent's plugin.
+
+## Install
+
+See `HOOK.md` for the full install flow. Short version:
+
+```bash
+openclaw plugins install github:Fergana-Labs/octopus#plugins/openclaw-plugin
+openclaw hooks enable stash
+# restart the gateway
+```
+
+## Event mapping
+
+| Openclaw event | Stash event |
+|---|---|
+| `command:new` | `session_start` |
+| `message:received` | `user_message` |
+| `message:sent` (success=true) | `assistant_message` |
+| `command:reset`, `command:stop` | `session_end` |
+
+## Known gaps
+
+- **No `tool_use` stream** — Openclaw's gateway has no tool-call visibility.
+  Rely on the delegated agent's own Stash plugin.
+- **No prompt injection** — Openclaw forwards raw channel messages; context
+  injection is the underlying agent's job.
+- **Session IDs are Openclaw `sessionKey`s**, not Stash UUIDs.
+
+## Retrieval
+
+Openclaw routes messages to a coding agent. That agent has shell access, so
+point it at the `stash` CLI for reads mid-conversation — all commands support
+`--json`:
+
+```
+stash history query --ws <id> --limit 20 --json
+stash history search "<query>" --ws <id> --json
+stash whoami --json
+stash workspaces list --mine --json
+```

--- a/plugins/openclaw-plugin/handler.ts
+++ b/plugins/openclaw-plugin/handler.ts
@@ -1,0 +1,85 @@
+/**
+ * Stash hook for Openclaw.
+ *
+ * Registered against Openclaw's `command` and `message` internal events.
+ * Branches on event.type + event.action and pipes a flat JSON payload into
+ * the matching Python hook script. All Stash API work happens in
+ * plugins/shared/ (Python), reused from every other agent's plugin.
+ *
+ * Upstream types: openclaw/openclaw src/hooks/internal-hook-types.ts
+ * Event catalog:  openclaw/openclaw src/hooks/internal-hooks.ts
+ */
+
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { HookHandler, InternalHookEvent } from "@openclaw/sdk";
+
+const PLUGIN_ROOT = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = join(PLUGIN_ROOT, "scripts");
+const PYTHON = process.env.STASH_PYTHON ?? "python3";
+
+function runHook(script: string, payload: unknown): void {
+  // Fire-and-forget. A flaky Stash backend must never stall Openclaw's gateway.
+  // detached + unref so the child belongs to its own process group and gets
+  // reaped independently — otherwise zombies accumulate over long sessions.
+  try {
+    const child = spawn(PYTHON, [join(SCRIPTS, script)], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+    });
+    child.on("error", () => { /* python missing / crash — swallow */ });
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+    child.unref();
+  } catch {
+    // spawn failed synchronously — swallow
+  }
+}
+
+function cwdOf(event: InternalHookEvent): string {
+  const ctx = event.context as Record<string, unknown>;
+  const wd = ctx?.workspaceDir;
+  return typeof wd === "string" ? wd : "";
+}
+
+const stashHandler: HookHandler = async (event) => {
+  if (event.type === "command" && event.action === "new") {
+    runHook("on_session_start.py", {
+      session_id: event.sessionKey,
+      cwd: cwdOf(event),
+    });
+    return;
+  }
+
+  if (event.type === "command" && (event.action === "reset" || event.action === "stop")) {
+    runHook("on_session_end.py", { session_id: event.sessionKey });
+    return;
+  }
+
+  if (event.type === "message" && event.action === "received") {
+    const ctx = event.context as { content?: string; channelId?: string };
+    runHook("on_prompt.py", {
+      session_id: event.sessionKey,
+      prompt: ctx?.content ?? "",
+      cwd: cwdOf(event),
+      channel_id: ctx?.channelId ?? "",
+    });
+    return;
+  }
+
+  if (event.type === "message" && event.action === "sent") {
+    const ctx = event.context as { content?: string; success?: boolean; channelId?: string };
+    if (ctx?.success === false) return;
+    runHook("on_stop.py", {
+      session_id: event.sessionKey,
+      last_assistant_message: ctx?.content ?? "",
+      cwd: cwdOf(event),
+      channel_id: ctx?.channelId ?? "",
+    });
+    return;
+  }
+};
+
+export default stashHandler;

--- a/plugins/openclaw-plugin/package.json
+++ b/plugins/openclaw-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@stash/openclaw-plugin",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "handler.ts",
+  "description": "Stream Openclaw gateway sessions to a Stash workspace.",
+  "peerDependencies": {
+    "@openclaw/sdk": ">=0.9.0"
+  },
+  "dependencies": {}
+}

--- a/plugins/openclaw-plugin/scripts/adapt.py
+++ b/plugins/openclaw-plugin/scripts/adapt.py
@@ -1,0 +1,55 @@
+"""Openclaw post-shim payload -> canonical HookEvent.
+
+Openclaw's real hook event shape is an `InternalHookEvent` from
+openclaw/openclaw src/hooks/internal-hook-types.ts:
+  { type, action, sessionKey, context, timestamp, messages }
+
+Our TS handler (handler.ts) branches on `type`+`action` and normalizes each
+supported case to a flat JSON payload which it pipes into the matching Python
+hook script. Event mapping:
+
+  command:new                 -> on_session_start.py {session_id, cwd}
+  message:received            -> on_prompt.py        {session_id, prompt, cwd, channel_id}
+  message:sent (success=true) -> on_stop.py          {session_id, last_assistant_message, cwd, channel_id}
+  command:reset/stop          -> on_session_end.py   {session_id}
+
+Openclaw's gateway has no tool-call visibility (coding agents run out-of-proc
+and have their own Stash plugins), so there is no tool_use adapter.
+"""
+
+from __future__ import annotations
+
+from event import HookEvent
+
+
+def adapt_session_start(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_start",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+    )
+
+
+def adapt_prompt(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="prompt",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        prompt_text=data.get("prompt", ""),
+    )
+
+
+def adapt_stop(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="stop",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        last_assistant_message=data.get("last_assistant_message", ""),
+    )
+
+
+def adapt_session_end(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_end",
+        session_id=data.get("session_id", ""),
+    )

--- a/plugins/openclaw-plugin/scripts/config.py
+++ b/plugins/openclaw-plugin/scripts/config.py
@@ -1,0 +1,90 @@
+"""openclaw plugin config. Reads from ~/.stash/config.json (CLI config)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(SHARED) not in sys.path:
+    sys.path.insert(0, str(SHARED))
+
+from stash_client import StashClient  # noqa: E402
+
+DATA_DIR = Path(os.environ.get(
+    "STASH_OPENCLAW_DATA",
+    Path.home() / ".stash/plugins/openclaw",
+))
+
+
+def get_stdin_data() -> dict:
+    try:
+        return json.loads(sys.stdin.read())
+    except Exception:
+        return {}
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def _project_config() -> Path | None:
+    try:
+        cur = Path.cwd().resolve()
+    except Exception:
+        return None
+    for parent in [cur, *cur.parents]:
+        candidate = parent / ".stash" / "config.json"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+# base_url + api_key are user-only to prevent a .stash/config.json in any
+# writable ancestor dir from hijacking the transport endpoint.
+_USER_ONLY_KEYS = {"base_url", "api_key"}
+
+
+def _cli_config() -> dict:
+    """User config (~/.stash/config.json) overlaid with project config.
+
+    Project config may not override base_url / api_key.
+    """
+    merged: dict = {}
+    user_path = Path.home() / ".stash" / "config.json"
+    if user_path.exists():
+        merged.update(_read_json(user_path))
+    project_path = _project_config()
+    if project_path:
+        project = _read_json(project_path)
+        for key in _USER_ONLY_KEYS:
+            project.pop(key, None)
+        merged.update(project)
+    return merged
+
+
+def get_config() -> dict:
+    cli = _cli_config()
+    return {
+        "api_endpoint": cli.get("base_url", "https://stash.ac"),
+        "api_key": cli.get("api_key", ""),
+        "agent_name": cli.get("username", ""),
+        "workspace_id": cli.get("default_workspace", ""),
+        "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
+        "client": "openclaw",
+    }
+
+
+def get_client() -> StashClient:
+    cfg = get_config()
+    return StashClient(base_url=cfg["api_endpoint"], api_key=cfg["api_key"], data_dir=DATA_DIR)
+
+
+def is_configured() -> bool:
+    cfg = get_config()
+    return bool(cfg["api_key"] and cfg["agent_name"])

--- a/plugins/openclaw-plugin/scripts/on_prompt.py
+++ b/plugins/openclaw-plugin/scripts/on_prompt.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""message:received -> stream user prompt.
+
+Openclaw has no prompt-modification protocol at the gateway level (messages
+are forwarded raw to the underlying coding agent), so this hook only streams.
+Context injection is the delegated agent's responsibility.
+"""
+
+from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from hooks import stream_user_message
+from state import load_state
+
+from adapt import adapt_prompt
+
+
+def main():
+    if not is_configured():
+        return
+
+    event = adapt_prompt(get_stdin_data())
+    cfg = get_config()
+    state = load_state(DATA_DIR)
+
+    if not state.get("streaming_enabled", True):
+        return
+
+    try:
+        with get_client() as client:
+            stream_user_message(client, cfg, state, event.prompt_text)
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openclaw-plugin/scripts/on_session_end.py
+++ b/plugins/openclaw-plugin/scripts/on_session_end.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""command:reset / command:stop -> push session_end, clear state.
+
+No auto-curation spawn: Openclaw is a chat gateway, not a coding agent with
+a headless entry point. Users who want curation should run it manually or
+on a cron via the matching IDE plugin for whichever agent Openclaw delegates
+to (Claude Code, Codex, etc.).
+"""
+
+from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from hooks import stream_session_end
+from state import load_state, save_state
+
+from adapt import adapt_session_end
+
+
+def main():
+    if not is_configured():
+        return
+
+    state = load_state(DATA_DIR)
+    cfg = get_config()
+
+    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+        event = adapt_session_end(get_stdin_data())
+        try:
+            with get_client() as client:
+                stream_session_end(client, cfg, state, event)
+        except Exception:
+            pass
+
+    state["session_id"] = ""
+    save_state(DATA_DIR, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openclaw-plugin/scripts/on_session_start.py
+++ b/plugins/openclaw-plugin/scripts/on_session_start.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""command:new -> record session id, reset per-session counters."""
+
+from config import DATA_DIR, get_stdin_data, is_configured
+from state import load_state, reset_stats, save_state
+
+from adapt import adapt_session_start
+
+
+def main():
+    if not is_configured():
+        return
+    event = adapt_session_start(get_stdin_data())
+    state = load_state(DATA_DIR)
+    state["session_id"] = event.session_id
+    save_state(DATA_DIR, state)
+    reset_stats(DATA_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openclaw-plugin/scripts/on_stop.py
+++ b/plugins/openclaw-plugin/scripts/on_stop.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""message:sent (success=true) -> stream the assistant's outbound message.
+
+Openclaw emits `message:sent` per turn (every time the agent responds on a
+channel). This hook pushes `assistant_message`; session_end is separate
+(command:reset / command:stop) so we never emit a bogus session_end here.
+"""
+
+from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from hooks import stream_assistant_message
+from state import load_state
+
+from adapt import adapt_stop
+
+
+def main():
+    if not is_configured():
+        return
+
+    state = load_state(DATA_DIR)
+    if not state.get("streaming_enabled", True):
+        return
+
+    event = adapt_stop(get_stdin_data())
+    cfg = get_config()
+
+    try:
+        with get_client() as client:
+            stream_assistant_message(client, cfg, state, event)
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tests/fixtures/openclaw/prompt.json
+++ b/plugins/tests/fixtures/openclaw/prompt.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "agent:main:main",
+  "prompt": "add a test",
+  "cwd": "/Users/alice/.openclaw/workspace",
+  "channel_id": "telegram"
+}

--- a/plugins/tests/fixtures/openclaw/session_start.json
+++ b/plugins/tests/fixtures/openclaw/session_start.json
@@ -1,0 +1,4 @@
+{
+  "session_id": "agent:main:main",
+  "cwd": "/Users/alice/.openclaw/workspace"
+}

--- a/plugins/tests/fixtures/openclaw/stop.json
+++ b/plugins/tests/fixtures/openclaw/stop.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "agent:main:main",
+  "last_assistant_message": "All done.",
+  "cwd": "/Users/alice/.openclaw/workspace",
+  "channel_id": "telegram"
+}

--- a/plugins/tests/test_adapters.py
+++ b/plugins/tests/test_adapters.py
@@ -34,7 +34,12 @@ def _load_fixture(plugin: str, name: str) -> dict:
     return json.loads((FIXTURES / plugin / f"{name}.json").read_text())
 
 
-PLUGINS = ["claude", "cursor", "gemini", "codex", "opencode"]
+PLUGINS = ["claude", "cursor", "gemini", "codex", "opencode", "openclaw"]
+
+# Openclaw's gateway has no tool-call visibility (tool_use comes from the
+# delegated coding agent's own plugin), so its adapter intentionally omits
+# adapt_tool_use.
+_PLUGINS_WITH_TOOL_USE = [p for p in PLUGINS if p != "openclaw"]
 
 
 @pytest.mark.parametrize("plugin", PLUGINS)
@@ -61,7 +66,7 @@ def test_prompt(plugin):
     assert event.prompt_text  # non-empty
 
 
-@pytest.mark.parametrize("plugin", PLUGINS)
+@pytest.mark.parametrize("plugin", _PLUGINS_WITH_TOOL_USE)
 def test_tool_use(plugin):
     adapt = _load_adapt(plugin)
     event = adapt.adapt_tool_use(_load_fixture(plugin, "tool_use"))
@@ -74,7 +79,7 @@ def test_tool_use(plugin):
     assert isinstance(event.tool_input, dict)
 
 
-@pytest.mark.parametrize("plugin", ["claude", "gemini", "codex", "opencode"])
+@pytest.mark.parametrize("plugin", ["claude", "gemini", "codex", "opencode", "openclaw"])
 def test_stop(plugin):
     # Cursor intentionally has no stop hook — afterAgentResponse + sessionEnd
     # cover what used to be Cursor's `stop`. See cursor-plugin/hooks.json.


### PR DESCRIPTION
## Summary

Redo of #46 on top of current `main` — the original branch predated the Stash rename, the personas removal, the shared-lib refactor, and the P0/P1 hardening work. Rather than rebase a stale branch through all of that, this re-ports the openclaw plugin to match today's plugin conventions.

**Openclaw is a self-hosted chat-app gateway** (WhatsApp / Telegram / Slack / iMessage → coding agent), not an IDE — so its hook surface is a Node `HookHandler` registered against internal events, not a `hooks.json`. Plugin layout follows openclaw's bundled hooks (`HOOK.md` frontmatter + `handler.ts`); Python side reuses `plugins/shared/` like every other agent.

### Event mapping

| Openclaw event | Stash event |
|---|---|
| `command:new` | `session_start` |
| `message:received` | `user_message` |
| `message:sent` (success=true) | `assistant_message` |
| `command:reset`, `command:stop` | `session_end` |

### What's different from #46

- Stash branding throughout (hook name = `stash`, config path `~/.stash/config.json`, `@stash/openclaw-plugin`, etc.)
- Uses `stash_client.StashClient` + the current `stream_*` helpers in `plugins/shared/hooks.py`. `on_stop.py` calls `stream_assistant_message` (turn-scoped) rather than a now-gone `stream_stop`.
- `STASH_PYTHON` env var + `detached: true` + `unref()` in `handler.ts`, matching the opencode shim hardening that landed after #46 was opened.
- `on_session_start.py` drops the `warm_cache` call (personas removed in #48).
- Test suite updates use `_PLUGINS_WITH_TOOL_USE = [p for p in PLUGINS if p != "openclaw"]` — follows the existing `_PLUGINS_WITH_PROMPT_SID` pattern.

### Known gaps (intentional)

- **No `tool_use` stream** — Openclaw's gateway has no tool-call visibility. Tool history comes from the delegated agent's own Stash plugin.
- **No context injection** — Openclaw forwards raw channel messages; injection is the underlying agent's job.
- **Session IDs use Openclaw's `sessionKey`** (e.g. `agent:main:main`), not Stash UUIDs.

## Test plan

- [x] `pytest plugins/tests/ --override-ini='addopts='` — 50/50 pass
- [x] Each `on_*.py` imports clean against `plugins/shared/`
- [ ] Real end-to-end: `openclaw plugins install ./plugins/openclaw-plugin && openclaw hooks enable stash` — needs a reviewer with a gateway running

## References

- Upstream hook types: [openclaw/openclaw src/hooks/internal-hook-types.ts](https://github.com/openclaw/openclaw/blob/main/src/hooks/internal-hook-types.ts)
- Event catalog: [openclaw/openclaw src/hooks/internal-hooks.ts](https://github.com/openclaw/openclaw/blob/main/src/hooks/internal-hooks.ts)
- Original PR: #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)