### PR TITLE
refactor(frontend): collapse duplicated workspace/personal API pairs

### DIFF
--- a/frontend/src/app/memory/[storeId]/page.tsx
+++ b/frontend/src/app/memory/[storeId]/page.tsx
@@ -7,11 +7,9 @@ import { useAuth } from "../../../hooks/useAuth";
 import {
   getHistory,
   listAllHistories,
-  queryPersonalHistoryEvents,
   queryHistoryEvents,
   searchHistoryEvents,
-  searchPersonalHistoryEvents,
-  deletePersonalHistory,
+  deleteHistory,
 } from "../../../lib/api";
 import { HistoryEvent, History, HistoryWithWorkspace } from "../../../lib/types";
 
@@ -157,15 +155,11 @@ export default function HistoryDetailPage() {
     setEventsLoading(true);
     try {
       if (searchQuery.trim()) {
-        const res = workspaceId
-          ? await searchHistoryEvents(workspaceId, storeId, searchQuery.trim())
-          : await searchPersonalHistoryEvents(storeId, searchQuery.trim());
+        const res = await searchHistoryEvents(workspaceId, storeId, searchQuery.trim());
         setEvents(res.events);
         setHasMore(res.has_more);
       } else {
-        const res = workspaceId
-          ? await queryHistoryEvents(workspaceId, storeId, { limit: 200 })
-          : await queryPersonalHistoryEvents(storeId, { limit: 200 });
+        const res = await queryHistoryEvents(workspaceId, storeId, { limit: 200 });
         setEvents(res.events);
         setHasMore(res.has_more);
       }
@@ -235,7 +229,7 @@ export default function HistoryDetailPage() {
               if (!confirm("Delete this history store? All events will be lost."))
                 return;
               try {
-                await deletePersonalHistory(storeId);
+                await deleteHistory(null, storeId);
                 router.push("/memory");
               } catch (err) {
                 setError(

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -10,31 +10,22 @@ import { useAuth } from "../../hooks/useAuth";
 import {
   listAllNotebooks,
   listNotebooks,
-  createPersonalNotebook,
-  deletePersonalNotebook,
-  listPersonalPageTree,
+  createNotebook,
+  deleteNotebook,
   listPageTree,
-  createPersonalPage,
   createPage,
-  getPersonalPage,
   getPage,
-  updatePersonalPage,
   updatePage,
-  deletePersonalPage,
   deletePage,
-  createPersonalPageFolder,
   createPageFolder,
-  renamePersonalPageFolder,
   renamePageFolder,
-  deletePersonalPageFolder,
   deletePageFolder,
   getBacklinks,
-  getPersonalBacklinks,
   semanticSearchPages,
   listAllTables,
   listTables,
-  createPersonalTable,
-  deletePersonalTable,
+  createTable,
+  deleteTable,
 } from "../../lib/api";
 import { Notebook, NotebookPage, NotebookWithWorkspace, PageLink, PageTree, TableWithWorkspace } from "../../lib/types";
 
@@ -146,9 +137,7 @@ export default function WikiPage() {
   // Load page tree when notebook is selected
   const loadTree = useCallback(async (nb: NotebookWithWorkspace) => {
     try {
-      const t = nb.workspace_id
-        ? await listPageTree(nb.workspace_id, nb.id)
-        : await listPersonalPageTree(nb.id);
+      const t = await listPageTree(nb.workspace_id, nb.id);
       setTree(t);
     } catch { /* ignore */ }
   }, []);
@@ -165,15 +154,11 @@ export default function WikiPage() {
     setSelectedPageId(pageId);
     setBacklinks([]);
     try {
-      const p = selectedNotebook.workspace_id
-        ? await getPage(selectedNotebook.workspace_id, selectedNotebook.id, pageId)
-        : await getPersonalPage(selectedNotebook.id, pageId);
+      const p = await getPage(selectedNotebook.workspace_id, selectedNotebook.id, pageId);
       setSelectedPage(p);
       // Load backlinks
       try {
-        const bl = selectedNotebook.workspace_id
-          ? await getBacklinks(selectedNotebook.workspace_id, selectedNotebook.id, pageId)
-          : await getPersonalBacklinks(selectedNotebook.id, pageId);
+        const bl = await getBacklinks(selectedNotebook.workspace_id, selectedNotebook.id, pageId);
         setBacklinks(bl);
       } catch { /* backlinks are optional */ }
     } catch { setError("Failed to load page"); }
@@ -264,7 +249,7 @@ export default function WikiPage() {
     const name = prompt("Notebook name:");
     if (!name) return;
     try {
-      const nb = await createPersonalNotebook(name);
+      const nb = await createNotebook(null, name);
       await loadNotebooks();
       handleSelectNotebook({ ...nb, workspace_name: null } as NotebookWithWorkspace);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to create notebook"); }
@@ -275,9 +260,7 @@ export default function WikiPage() {
     const name = prompt("Page name:");
     if (!name) return;
     try {
-      const p = selectedNotebook.workspace_id
-        ? await createPage(selectedNotebook.workspace_id, selectedNotebook.id, name, folderId || undefined)
-        : await createPersonalPage(selectedNotebook.id, name, folderId || undefined);
+      const p = await createPage(selectedNotebook.workspace_id, selectedNotebook.id, name, folderId || undefined);
       await loadTree(selectedNotebook);
       setSelectedPageId(p.id);
       setSelectedPage(p);
@@ -289,9 +272,7 @@ export default function WikiPage() {
     const name = prompt("Folder name:");
     if (!name) return;
     try {
-      selectedNotebook.workspace_id
-        ? await createPageFolder(selectedNotebook.workspace_id, selectedNotebook.id, name)
-        : await createPersonalPageFolder(selectedNotebook.id, name);
+      await createPageFolder(selectedNotebook.workspace_id, selectedNotebook.id, name);
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to create folder"); }
   }, [selectedNotebook, loadTree]);
@@ -299,9 +280,7 @@ export default function WikiPage() {
   const handleDeletePage = useCallback(async (pageId: string) => {
     if (!selectedNotebook || !confirm("Delete this page?")) return;
     try {
-      selectedNotebook.workspace_id
-        ? await deletePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId)
-        : await deletePersonalPage(selectedNotebook.id, pageId);
+      await deletePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId);
       if (selectedPageId === pageId) { setSelectedPageId(null); setSelectedPage(null); }
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to delete"); }
@@ -310,9 +289,7 @@ export default function WikiPage() {
   const handleDeleteFolder = useCallback(async (folderId: string) => {
     if (!selectedNotebook || !confirm("Delete this folder?")) return;
     try {
-      selectedNotebook.workspace_id
-        ? await deletePageFolder(selectedNotebook.workspace_id, selectedNotebook.id, folderId)
-        : await deletePersonalPageFolder(selectedNotebook.id, folderId);
+      await deletePageFolder(selectedNotebook.workspace_id, selectedNotebook.id, folderId);
       setSelectedPageId(null); setSelectedPage(null);
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to delete folder"); }
@@ -323,9 +300,7 @@ export default function WikiPage() {
     const name = prompt("New name:", currentName);
     if (!name || name === currentName) return;
     try {
-      const updated = selectedNotebook.workspace_id
-        ? await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId, { name })
-        : await updatePersonalPage(selectedNotebook.id, pageId, { name });
+      const updated = await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId, { name });
       if (selectedPageId === pageId) setSelectedPage(updated);
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to rename"); }
@@ -334,9 +309,7 @@ export default function WikiPage() {
   const handleInlineRename = useCallback(async (name: string) => {
     if (!selectedNotebook || !selectedPageId) return;
     try {
-      const updated = selectedNotebook.workspace_id
-        ? await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, selectedPageId, { name })
-        : await updatePersonalPage(selectedNotebook.id, selectedPageId, { name });
+      const updated = await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, selectedPageId, { name });
       setSelectedPage(updated);
       await loadTree(selectedNotebook);
     } catch { /* silent — title updates are best-effort */ }
@@ -347,9 +320,7 @@ export default function WikiPage() {
     const name = prompt("New name:", currentName);
     if (!name || name === currentName) return;
     try {
-      selectedNotebook.workspace_id
-        ? await renamePageFolder(selectedNotebook.workspace_id, selectedNotebook.id, folderId, name)
-        : await renamePersonalPageFolder(selectedNotebook.id, folderId, name);
+      await renamePageFolder(selectedNotebook.workspace_id, selectedNotebook.id, folderId, name);
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to rename folder"); }
   }, [selectedNotebook, loadTree]);
@@ -358,9 +329,7 @@ export default function WikiPage() {
     if (!selectedNotebook) return;
     try {
       const data = folderId ? { folder_id: folderId } : { move_to_root: true };
-      const updated = selectedNotebook.workspace_id
-        ? await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId, data)
-        : await updatePersonalPage(selectedNotebook.id, pageId, data);
+      const updated = await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, pageId, data);
       if (selectedPageId === pageId) setSelectedPage(updated);
       await loadTree(selectedNotebook);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to move"); }
@@ -369,9 +338,7 @@ export default function WikiPage() {
   const handleSavePage = useCallback(async (content: string) => {
     if (!selectedNotebook || !selectedPageId) return;
     try {
-      selectedNotebook.workspace_id
-        ? await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, selectedPageId, { content })
-        : await updatePersonalPage(selectedNotebook.id, selectedPageId, { content });
+      await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, selectedPageId, { content });
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to save"); }
   }, [selectedNotebook, selectedPageId]);
 
@@ -379,7 +346,7 @@ export default function WikiPage() {
     const name = prompt("Table name:");
     if (!name) return;
     try {
-      const table = await createPersonalTable(name);
+      const table = await createTable(null, name);
       router.push(`/tables/${table.id}`);
     } catch (err) { setTablesError(err instanceof Error ? err.message : "Failed to create table"); }
   };
@@ -654,7 +621,7 @@ export default function WikiPage() {
                                 e.stopPropagation();
                                 if (!confirm("Delete this table?")) return;
                                 try {
-                                  await deletePersonalTable(table.id);
+                                  await deleteTable(null, table.id);
                                   loadTables();
                                 } catch (err) { setTablesError(err instanceof Error ? err.message : "Failed to delete"); }
                               }}

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -5,8 +5,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "../../../components/AppShell";
 import { useAuth } from "../../../hooks/useAuth";
 import {
-  getTable, getPersonalTable, updateTable, updatePersonalTable,
-  deleteTable, deletePersonalTable, addTableColumn, updateTableColumn,
+  getTable, updateTable,
+  deleteTable, addTableColumn, updateTableColumn,
   deleteTableColumn, reorderTableColumns, listTableRows, searchTableRows,
   createTableRow, createTableRowsBatch, updateTableRow, deleteTableRow,
   deleteTableRowsBatch, duplicateTableRow, summarizeTableRows,
@@ -104,7 +104,7 @@ export default function TableEditorPage() {
   // CSV import
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const wsId = resolvedWorkspaceId || undefined;
+  const wsId = resolvedWorkspaceId;
   const sortedColumns = table?.columns ? [...table.columns].sort((a, b) => a.order - b.order) : [];
   const visibleColumns = sortedColumns.filter((c) => !hiddenCols.has(c.id));
   const hasMore = offset < totalCount;
@@ -114,15 +114,18 @@ export default function TableEditorPage() {
     try {
       if (resolvedWorkspaceId) {
         setTable(await getTable(resolvedWorkspaceId, tableId));
-      } else {
-        try { setTable(await getPersonalTable(tableId)); }
-        catch {
-          const all = await listAllTables();
-          const match = all?.tables?.find((t) => t.id === tableId);
-          if (match?.workspace_id) {
-            setResolvedWorkspaceId(match.workspace_id);
-            setTable(await getTable(match.workspace_id, tableId));
-          } else { setError("Table not found"); }
+        return;
+      }
+      try {
+        setTable(await getTable(null, tableId));
+      } catch {
+        const all = await listAllTables();
+        const match = all?.tables?.find((t) => t.id === tableId);
+        if (match?.workspace_id) {
+          setResolvedWorkspaceId(match.workspace_id);
+          setTable(await getTable(match.workspace_id, tableId));
+        } else {
+          setError("Table not found");
         }
       }
     } catch { setError("Table not found"); }
@@ -140,10 +143,10 @@ export default function TableEditorPage() {
   const loadRows = useCallback(async () => {
     try {
       if (searchQuery) {
-        const res = await searchTableRows(tableId, searchQuery, { limit: PAGE_SIZE, offset: 0 }, wsId);
+        const res = await searchTableRows(wsId, tableId, searchQuery, { limit: PAGE_SIZE, offset: 0 });
         setRows(res?.rows ?? []); setTotalCount(res?.total_count ?? 0); setOffset(res?.rows?.length ?? 0);
       } else {
-        const res = await listTableRows(tableId, buildRowParams(0), wsId);
+        const res = await listTableRows(wsId, tableId, buildRowParams(0));
         setRows(res?.rows ?? []); setTotalCount(res?.total_count ?? 0); setOffset(res?.rows?.length ?? 0);
       }
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to load rows"); }
@@ -154,8 +157,8 @@ export default function TableEditorPage() {
     setLoadingMore(true);
     try {
       const res = searchQuery
-        ? await searchTableRows(tableId, searchQuery, { limit: PAGE_SIZE, offset }, wsId)
-        : await listTableRows(tableId, buildRowParams(offset), wsId);
+        ? await searchTableRows(wsId, tableId, searchQuery, { limit: PAGE_SIZE, offset })
+        : await listTableRows(wsId, tableId, buildRowParams(offset));
       const newRows = res?.rows ?? [];
       setRows((prev) => [...prev, ...newRows]);
       setOffset((prev) => prev + newRows.length);
@@ -166,7 +169,7 @@ export default function TableEditorPage() {
   const loadSummary = useCallback(async () => {
     if (!showSummary) return;
     try {
-      const s = await summarizeTableRows(tableId, filters.length > 0 ? filters : undefined, wsId);
+      const s = await summarizeTableRows(wsId, tableId, filters.length > 0 ? filters : undefined);
       setSummary(s);
     } catch { /* ignore */ }
   }, [tableId, wsId, filters, showSummary]);
@@ -230,15 +233,14 @@ export default function TableEditorPage() {
   const handleRename = async () => {
     if (!table || !nameInput.trim()) return;
     try {
-      const updated = resolvedWorkspaceId ? await updateTable(resolvedWorkspaceId, tableId, { name: nameInput.trim() }) : await updatePersonalTable(tableId, { name: nameInput.trim() });
+      const updated = await updateTable(resolvedWorkspaceId, tableId, { name: nameInput.trim() });
       setTable(updated); setEditingName(false);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to rename"); }
   };
   const handleDelete = async () => {
     if (!confirm("Delete this table and all its data?")) return;
     try {
-      if (resolvedWorkspaceId) await deleteTable(resolvedWorkspaceId, tableId);
-      else await deletePersonalTable(tableId);
+      await deleteTable(resolvedWorkspaceId, tableId);
       router.push("/tables");
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to delete"); }
   };
@@ -249,20 +251,20 @@ export default function TableEditorPage() {
     try {
       const col: { name: string; type: string; options?: string[] } = { name: newColName.trim(), type: newColType };
       if ((newColType === "select" || newColType === "multiselect") && newColOptions.trim()) col.options = newColOptions.split(",").map((o) => o.trim()).filter(Boolean);
-      setTable(await addTableColumn(tableId, col, wsId));
+      setTable(await addTableColumn(wsId, tableId, col));
       setShowAddCol(false); setNewColName(""); setNewColType("text"); setNewColOptions("");
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to add column"); }
   };
   const handleDeleteColumn = async (colId: string) => {
     if (!confirm("Delete this column?")) return;
-    try { setTable(await deleteTableColumn(tableId, colId, wsId)); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
+    try { setTable(await deleteTableColumn(wsId, tableId, colId)); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
   const handleRenameColumn = async (colId: string) => {
     const col = sortedColumns.find((c) => c.id === colId);
     if (!col) return;
     const name = prompt("Column name:", col.name);
     if (!name || name === col.name) return;
-    try { setTable(await updateTableColumn(tableId, colId, { name }, wsId)); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
+    try { setTable(await updateTableColumn(wsId, tableId, colId, { name })); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
   const handleColumnDrop = async (targetColId: string) => {
     if (!dragCol || dragCol === targetColId) { setDragCol(null); return; }
@@ -271,25 +273,25 @@ export default function TableEditorPage() {
     const toIdx = ids.indexOf(targetColId);
     if (fromIdx === -1 || toIdx === -1) { setDragCol(null); return; }
     ids.splice(fromIdx, 1); ids.splice(toIdx, 0, dragCol); setDragCol(null);
-    try { setTable(await reorderTableColumns(tableId, ids, wsId)); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
+    try { setTable(await reorderTableColumns(wsId, tableId, ids)); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
 
   // --- Row ops ---
   const handleAddRow = async () => {
-    try { const row = await createTableRow(tableId, {}, wsId); setRows((prev) => [...prev, row]); setTotalCount((c) => c + 1); }
+    try { const row = await createTableRow(wsId, tableId, {}); setRows((prev) => [...prev, row]); setTotalCount((c) => c + 1); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed to add row"); }
   };
   const handleDeleteRow = async (rowId: string) => {
-    try { await deleteTableRow(tableId, rowId, wsId); setRows((prev) => prev.filter((r) => r.id !== rowId)); setTotalCount((c) => c - 1); setSelectedRows((prev) => { const n = new Set(prev); n.delete(rowId); return n; }); }
+    try { await deleteTableRow(wsId, tableId, rowId); setRows((prev) => prev.filter((r) => r.id !== rowId)); setTotalCount((c) => c - 1); setSelectedRows((prev) => { const n = new Set(prev); n.delete(rowId); return n; }); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
   const handleDuplicateRow = async (rowId: string) => {
-    try { const row = await duplicateTableRow(tableId, rowId, wsId); setRows((prev) => [...prev, row]); setTotalCount((c) => c + 1); }
+    try { const row = await duplicateTableRow(wsId, tableId, rowId); setRows((prev) => [...prev, row]); setTotalCount((c) => c + 1); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed to duplicate"); }
   };
   const handleBulkDelete = async () => {
     if (selectedRows.size === 0 || !confirm(`Delete ${selectedRows.size} rows?`)) return;
-    try { await deleteTableRowsBatch(tableId, Array.from(selectedRows), wsId); setRows((prev) => prev.filter((r) => !selectedRows.has(r.id))); setTotalCount((c) => c - selectedRows.size); setSelectedRows(new Set()); }
+    try { await deleteTableRowsBatch(wsId, tableId, Array.from(selectedRows)); setRows((prev) => prev.filter((r) => !selectedRows.has(r.id))); setTotalCount((c) => c - selectedRows.size); setSelectedRows(new Set()); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
 
@@ -306,7 +308,7 @@ export default function TableEditorPage() {
       if (col.type === "number") typedValue = cellValue === "" ? null : Number(cellValue);
       else if (col.type === "boolean") typedValue = cellValue === "true" || cellValue === "1";
     }
-    try { const updated = await updateTableRow(tableId, rowId, { [colId]: typedValue }, wsId); setRows((prev) => prev.map((r) => (r.id === rowId ? updated : r))); }
+    try { const updated = await updateTableRow(wsId, tableId, rowId, { [colId]: typedValue }); setRows((prev) => prev.map((r) => (r.id === rowId ? updated : r))); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
     setEditingCell(null);
   };
@@ -328,7 +330,7 @@ export default function TableEditorPage() {
       else if (c.type === "boolean") data[c.id] = v === "true" || v === "1";
       else data[c.id] = v;
     });
-    try { const updated = await updateTableRow(tableId, detailRow.id, data, wsId); setRows((prev) => prev.map((r) => (r.id === detailRow.id ? updated : r))); setDetailRow(null); }
+    try { const updated = await updateTableRow(wsId, tableId, detailRow.id, data); setRows((prev) => prev.map((r) => (r.id === detailRow.id ? updated : r))); setDetailRow(null); }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
 
@@ -338,7 +340,7 @@ export default function TableEditorPage() {
     if (!name) return;
     try {
       const view = { name, filters: filters.length > 0 ? filters : undefined, sort_by: sortBy || undefined, sort_order: sortBy ? sortOrder : undefined, visible_columns: hiddenCols.size > 0 ? visibleColumns.map((c) => c.id) : undefined };
-      const updated = await saveTableView(tableId, view, wsId);
+      const updated = await saveTableView(wsId, tableId, view);
       setTable(updated);
       const saved = updated.views?.find((v: TableView) => v.name === name);
       if (saved) setActiveViewId(saved.id);
@@ -352,7 +354,7 @@ export default function TableEditorPage() {
     if (view.filters && view.filters.length > 0) setShowFilterBar(true); else setShowFilterBar(false);
   };
   const handleDeleteView = async (viewId: string) => {
-    try { const updated = await deleteTableView(tableId, viewId, wsId); setTable(updated); if (activeViewId === viewId) { setActiveViewId(null); setFilters([]); setSortBy(""); setSortOrder("asc"); setShowFilterBar(false); setHiddenCols(new Set()); } }
+    try { const updated = await deleteTableView(wsId, tableId, viewId); setTable(updated); if (activeViewId === viewId) { setActiveViewId(null); setFilters([]); setSortBy(""); setSortOrder("asc"); setShowFilterBar(false); setHiddenCols(new Set()); } }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
 
@@ -365,7 +367,7 @@ export default function TableEditorPage() {
       const headers = lines[0].split(",").map((h) => h.trim().replace(/^"|"$/g, ""));
       const existingNames = new Set(sortedColumns.map((c) => c.name));
       let currentTable = table!;
-      for (const h of headers) { if (!existingNames.has(h)) currentTable = await addTableColumn(tableId, { name: h, type: "text" }, wsId); }
+      for (const h of headers) { if (!existingNames.has(h)) currentTable = await addTableColumn(wsId, tableId, { name: h, type: "text" }); }
       setTable(currentTable);
       const colMap: Record<string, string> = {}; for (const col of currentTable.columns) colMap[col.name] = col.id;
       const rowsData: Record<string, unknown>[] = [];
@@ -375,7 +377,7 @@ export default function TableEditorPage() {
         headers.forEach((h, idx) => { if (colMap[h] && idx < values.length) data[colMap[h]] = values[idx]; });
         rowsData.push(data);
       }
-      for (let i = 0; i < rowsData.length; i += 5000) { await createTableRowsBatch(tableId, rowsData.slice(i, i + 5000).map((d) => ({ data: d })), wsId); }
+      for (let i = 0; i < rowsData.length; i += 5000) { await createTableRowsBatch(wsId, tableId, rowsData.slice(i, i + 5000).map((d) => ({ data: d }))); }
       await loadRows(); await loadTable();
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to import"); }
   };

--- a/frontend/src/app/tables/page.tsx
+++ b/frontend/src/app/tables/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import AppShell from "../../components/AppShell";
 import { useAuth } from "../../hooks/useAuth";
-import { listAllTables, listTables, createPersonalTable, deletePersonalTable } from "../../lib/api";
+import { listAllTables, listTables, createTable, deleteTable } from "../../lib/api";
 import { TableWithWorkspace } from "../../lib/types";
 
 export default function TablesPage() {
@@ -44,7 +44,7 @@ export default function TablesPage() {
     const name = prompt("Table name:");
     if (!name) return;
     try {
-      const table = await createPersonalTable(name);
+      const table = await createTable(null, name);
       router.push(`/tables/${table.id}`);
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to create table"); }
   };
@@ -99,7 +99,7 @@ export default function TablesPage() {
                           e.stopPropagation();
                           if (!confirm("Delete this table?")) return;
                           try {
-                            await deletePersonalTable(table.id);
+                            await deleteTable(null, table.id);
                             loadTables();
                           } catch (err) { setError(err instanceof Error ? err.message : "Failed to delete"); }
                         }}

--- a/frontend/src/components/workspace/EditorToolbar.tsx
+++ b/frontend/src/components/workspace/EditorToolbar.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import { Editor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { uploadFile, uploadPersonalFile } from "../../lib/api";
+import { uploadFile } from "../../lib/api";
 
 interface EditorToolbarProps {
   editor: Editor | null;
@@ -52,9 +52,7 @@ export default function EditorToolbar({ editor, workspaceId }: EditorToolbarProp
     if (!file || !editor) return;
     setUploading(true);
     try {
-      const result = workspaceId
-        ? await uploadFile(workspaceId, file)
-        : await uploadPersonalFile(file);
+      const result = await uploadFile(workspaceId ?? null, file);
       if (result.content_type.startsWith("image/")) {
         editor.chain().focus().setImage({ src: result.url, alt: result.name }).run();
       } else {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -320,24 +320,6 @@ export async function deleteHistory(
   await apiFetch(`${scope(workspaceId)}/memory/${storeId}`, { method: "DELETE" });
 }
 
-export async function pushHistoryEvent(
-  workspaceId: string | null,
-  storeId: string,
-  event: {
-    agent_name: string;
-    event_type: string;
-    content: string;
-    session_id?: string;
-    tool_name?: string;
-    metadata?: Record<string, unknown>;
-  }
-): Promise<HistoryEvent> {
-  return apiFetch(`${scope(workspaceId)}/memory/${storeId}/events`, {
-    method: "POST",
-    body: JSON.stringify(event),
-  });
-}
-
 export async function queryHistoryEvents(
   workspaceId: string | null,
   storeId: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,7 @@ import {
 } from "./types";
 
 const TOKEN_KEY = "stash_token";
+const API_BASE = "";
 
 // --- Token management (for CLI API key fallback) ---
 
@@ -42,7 +43,12 @@ export function clearToken() {
   localStorage.removeItem(TOKEN_KEY);
 }
 
-const API_BASE = "";
+// Scope = workspace-scoped when workspaceId is set, personal otherwise.
+// Used everywhere a resource has both /api/v1/workspaces/{ws}/... and /api/v1/... variants.
+function scope(workspaceId: string | null): string {
+  if (workspaceId) return `/api/v1/workspaces/${workspaceId}`;
+  return "/api/v1";
+}
 
 export async function apiFetch<T>(
   path: string,
@@ -173,247 +179,149 @@ export async function kickWorkspaceMember(workspaceId: string, userId: string): 
   await apiFetch(`/api/v1/workspaces/${workspaceId}/kick/${userId}`, { method: "POST" });
 }
 
-// --- Notebooks (workspace-scoped) ---
+// --- Notebooks ---
+// workspaceId = string for workspace-scoped, null for personal.
 
-export async function listNotebooks(workspaceId: string): Promise<{ notebooks: Notebook[] }> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks`);
+export async function listNotebooks(workspaceId: string | null): Promise<{ notebooks: Notebook[] }> {
+  return apiFetch(`${scope(workspaceId)}/notebooks`);
 }
 
 export async function createNotebook(
-  workspaceId: string,
+  workspaceId: string | null,
   name: string,
   description?: string
 ): Promise<Notebook> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks`, {
+  return apiFetch(`${scope(workspaceId)}/notebooks`, {
     method: "POST",
     body: JSON.stringify({ name, description: description || "" }),
   });
 }
 
-export async function deleteNotebook(workspaceId: string, notebookId: string): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}`, { method: "DELETE" });
+export async function deleteNotebook(
+  workspaceId: string | null,
+  notebookId: string
+): Promise<void> {
+  await apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}`, { method: "DELETE" });
 }
 
-// --- Notebook Pages (workspace-scoped) ---
+// --- Notebook Pages ---
 
-export async function listPageTree(workspaceId: string, notebookId: string): Promise<PageTree> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages`);
+export async function listPageTree(
+  workspaceId: string | null,
+  notebookId: string
+): Promise<PageTree> {
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages`);
 }
 
 export async function createPage(
-  workspaceId: string,
+  workspaceId: string | null,
   notebookId: string,
   name: string,
   folderId?: string,
   content?: string
 ): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages`, {
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages`, {
     method: "POST",
     body: JSON.stringify({ name, folder_id: folderId || null, content: content || "" }),
   });
 }
 
 export async function getPage(
-  workspaceId: string, notebookId: string, pageId: string
+  workspaceId: string | null,
+  notebookId: string,
+  pageId: string
 ): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/${pageId}`);
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}`);
 }
 
 export async function updatePage(
-  workspaceId: string, notebookId: string, pageId: string,
+  workspaceId: string | null,
+  notebookId: string,
+  pageId: string,
   data: { name?: string; folder_id?: string; content?: string; move_to_root?: boolean }
 ): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/${pageId}`, {
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}`, {
     method: "PATCH",
     body: JSON.stringify(data),
   });
 }
 
 export async function deletePage(
-  workspaceId: string, notebookId: string, pageId: string
+  workspaceId: string | null,
+  notebookId: string,
+  pageId: string
 ): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/${pageId}`, { method: "DELETE" });
+  await apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}`, { method: "DELETE" });
 }
 
+// --- Page Folders ---
+
 export async function createPageFolder(
-  workspaceId: string, notebookId: string, name: string
+  workspaceId: string | null,
+  notebookId: string,
+  name: string
 ): Promise<NotebookFolder> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/folders`, {
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/folders`, {
     method: "POST",
     body: JSON.stringify({ name }),
   });
 }
 
 export async function renamePageFolder(
-  workspaceId: string, notebookId: string, folderId: string, name: string
+  workspaceId: string | null,
+  notebookId: string,
+  folderId: string,
+  name: string
 ): Promise<NotebookFolder> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/folders/${folderId}`, {
+  return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/folders/${folderId}`, {
     method: "PATCH",
     body: JSON.stringify({ name }),
   });
 }
 
 export async function deletePageFolder(
-  workspaceId: string, notebookId: string, folderId: string
+  workspaceId: string | null,
+  notebookId: string,
+  folderId: string
 ): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/folders/${folderId}`, { method: "DELETE" });
+  await apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/folders/${folderId}`, { method: "DELETE" });
 }
 
-// --- Personal Notebooks ---
-
-export async function listPersonalNotebooks(): Promise<{ notebooks: Notebook[] }> {
-  return apiFetch("/api/v1/notebooks");
-}
-
-export async function createPersonalNotebook(
-  name: string,
-  description?: string
-): Promise<Notebook> {
-  return apiFetch("/api/v1/notebooks", {
-    method: "POST",
-    body: JSON.stringify({ name, description: description || "" }),
-  });
-}
-
-export async function deletePersonalNotebook(notebookId: string): Promise<void> {
-  await apiFetch(`/api/v1/notebooks/${notebookId}`, { method: "DELETE" });
-}
-
-// --- Personal Notebook Pages ---
-
-export async function listPersonalPageTree(notebookId: string): Promise<PageTree> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/pages`);
-}
-
-export async function createPersonalPage(
-  notebookId: string, name: string, folderId?: string, content?: string
-): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/pages`, {
-    method: "POST",
-    body: JSON.stringify({ name, folder_id: folderId || null, content: content || "" }),
-  });
-}
-
-export async function getPersonalPage(notebookId: string, pageId: string): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/pages/${pageId}`);
-}
-
-export async function updatePersonalPage(
-  notebookId: string, pageId: string,
-  data: { name?: string; folder_id?: string; content?: string; move_to_root?: boolean }
-): Promise<NotebookPage> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/pages/${pageId}`, {
-    method: "PATCH",
-    body: JSON.stringify(data),
-  });
-}
-
-export async function deletePersonalPage(notebookId: string, pageId: string): Promise<void> {
-  await apiFetch(`/api/v1/notebooks/${notebookId}/pages/${pageId}`, { method: "DELETE" });
-}
-
-export async function createPersonalPageFolder(notebookId: string, name: string): Promise<NotebookFolder> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/folders`, {
-    method: "POST",
-    body: JSON.stringify({ name }),
-  });
-}
-
-export async function renamePersonalPageFolder(
-  notebookId: string, folderId: string, name: string
-): Promise<NotebookFolder> {
-  return apiFetch(`/api/v1/notebooks/${notebookId}/folders/${folderId}`, {
-    method: "PATCH",
-    body: JSON.stringify({ name }),
-  });
-}
-
-export async function deletePersonalPageFolder(notebookId: string, folderId: string): Promise<void> {
-  await apiFetch(`/api/v1/notebooks/${notebookId}/folders/${folderId}`, { method: "DELETE" });
-}
-
-// --- History (workspace-scoped) ---
+// --- History ---
 
 export async function createHistory(
-  workspaceId: string,
+  workspaceId: string | null,
   name: string,
   description?: string
 ): Promise<History> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/memory`, {
+  return apiFetch(`${scope(workspaceId)}/memory`, {
     method: "POST",
     body: JSON.stringify({ name, description: description || "" }),
   });
 }
 
-export async function listHistories(workspaceId: string): Promise<{ stores: History[] }> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/memory`);
+export async function listHistories(
+  workspaceId: string | null
+): Promise<{ stores: History[] }> {
+  return apiFetch(`${scope(workspaceId)}/memory`);
 }
 
-export async function getHistory(workspaceId: string, storeId: string): Promise<History> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/memory/${storeId}`);
-}
-
-export async function queryHistoryEvents(
-  workspaceId: string,
-  storeId: string,
-  params?: {
-    agent_name?: string;
-    session_id?: string;
-    event_type?: string;
-    after?: string;
-    before?: string;
-    limit?: number;
-  }
-): Promise<{ events: HistoryEvent[]; has_more: boolean }> {
-  const searchParams = new URLSearchParams();
-  if (params?.agent_name) searchParams.set("agent_name", params.agent_name);
-  if (params?.session_id) searchParams.set("session_id", params.session_id);
-  if (params?.event_type) searchParams.set("event_type", params.event_type);
-  if (params?.after) searchParams.set("after", params.after);
-  if (params?.before) searchParams.set("before", params.before);
-  if (params?.limit) searchParams.set("limit", String(params.limit));
-  const qs = searchParams.toString();
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/memory/${storeId}/events${qs ? `?${qs}` : ""}`);
-}
-
-export async function searchHistoryEvents(
-  workspaceId: string,
-  storeId: string,
-  query: string,
-  limit?: number
-): Promise<{ events: HistoryEvent[]; has_more: boolean }> {
-  const searchParams = new URLSearchParams({ q: query });
-  if (limit) searchParams.set("limit", String(limit));
-  return apiFetch(
-    `/api/v1/workspaces/${workspaceId}/memory/${storeId}/events/search?${searchParams.toString()}`
-  );
-}
-
-// --- Personal History ---
-
-export async function createPersonalHistory(
-  name: string,
-  description?: string
+export async function getHistory(
+  workspaceId: string | null,
+  storeId: string
 ): Promise<History> {
-  return apiFetch("/api/v1/memory", {
-    method: "POST",
-    body: JSON.stringify({ name, description: description || "" }),
-  });
+  return apiFetch(`${scope(workspaceId)}/memory/${storeId}`);
 }
 
-export async function listPersonalHistories(): Promise<{ stores: History[] }> {
-  return apiFetch("/api/v1/memory");
+export async function deleteHistory(
+  workspaceId: string | null,
+  storeId: string
+): Promise<void> {
+  await apiFetch(`${scope(workspaceId)}/memory/${storeId}`, { method: "DELETE" });
 }
 
-export async function getPersonalHistory(storeId: string): Promise<History> {
-  return apiFetch(`/api/v1/memory/${storeId}`);
-}
-
-export async function deletePersonalHistory(storeId: string): Promise<void> {
-  await apiFetch(`/api/v1/memory/${storeId}`, { method: "DELETE" });
-}
-
-export async function pushPersonalHistoryEvent(
+export async function pushHistoryEvent(
+  workspaceId: string | null,
   storeId: string,
   event: {
     agent_name: string;
@@ -424,13 +332,14 @@ export async function pushPersonalHistoryEvent(
     metadata?: Record<string, unknown>;
   }
 ): Promise<HistoryEvent> {
-  return apiFetch(`/api/v1/memory/${storeId}/events`, {
+  return apiFetch(`${scope(workspaceId)}/memory/${storeId}/events`, {
     method: "POST",
     body: JSON.stringify(event),
   });
 }
 
-export async function queryPersonalHistoryEvents(
+export async function queryHistoryEvents(
+  workspaceId: string | null,
   storeId: string,
   params?: {
     agent_name?: string;
@@ -449,19 +358,18 @@ export async function queryPersonalHistoryEvents(
   if (params?.before) searchParams.set("before", params.before);
   if (params?.limit) searchParams.set("limit", String(params.limit));
   const qs = searchParams.toString();
-  return apiFetch(`/api/v1/memory/${storeId}/events${qs ? `?${qs}` : ""}`);
+  return apiFetch(`${scope(workspaceId)}/memory/${storeId}/events${qs ? `?${qs}` : ""}`);
 }
 
-export async function searchPersonalHistoryEvents(
+export async function searchHistoryEvents(
+  workspaceId: string | null,
   storeId: string,
   query: string,
   limit?: number
 ): Promise<{ events: HistoryEvent[]; has_more: boolean }> {
   const searchParams = new URLSearchParams({ q: query });
   if (limit) searchParams.set("limit", String(limit));
-  return apiFetch(
-    `/api/v1/memory/${storeId}/events/search?${searchParams.toString()}`
-  );
+  return apiFetch(`${scope(workspaceId)}/memory/${storeId}/events/search?${searchParams.toString()}`);
 }
 
 // --- Aggregate (cross-workspace) ---
@@ -518,74 +426,87 @@ export async function getEmbeddingProjection(
   return apiFetch(`/api/v1/me/embedding-projection?max_points=${maxPoints}${qs}`);
 }
 
-// --- Tables (workspace-scoped) ---
+// --- Tables ---
 
 export async function createTable(
-  workspaceId: string, name: string, description?: string,
+  workspaceId: string | null,
+  name: string,
+  description?: string,
   columns?: { name: string; type: string; options?: string[] }[]
 ): Promise<Table> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/tables`, {
+  return apiFetch(`${scope(workspaceId)}/tables`, {
     method: "POST",
     body: JSON.stringify({ name, description: description || "", columns: columns || [] }),
   });
 }
 
-export async function listTables(workspaceId: string): Promise<{ tables: Table[] }> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/tables`);
+export async function listTables(
+  workspaceId: string | null
+): Promise<{ tables: Table[] }> {
+  return apiFetch(`${scope(workspaceId)}/tables`);
 }
 
-export async function getTable(workspaceId: string, tableId: string): Promise<Table> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/tables/${tableId}`);
+export async function getTable(
+  workspaceId: string | null,
+  tableId: string
+): Promise<Table> {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}`);
 }
 
 export async function updateTable(
-  workspaceId: string, tableId: string,
+  workspaceId: string | null,
+  tableId: string,
   data: { name?: string; description?: string }
 ): Promise<Table> {
-  return apiFetch(`/api/v1/workspaces/${workspaceId}/tables/${tableId}`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}`, {
     method: "PATCH", body: JSON.stringify(data),
   });
 }
 
-export async function deleteTable(workspaceId: string, tableId: string): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/tables/${tableId}`, { method: "DELETE" });
+export async function deleteTable(
+  workspaceId: string | null,
+  tableId: string
+): Promise<void> {
+  await apiFetch(`${scope(workspaceId)}/tables/${tableId}`, { method: "DELETE" });
 }
 
 // --- Table Columns ---
 
 export async function addTableColumn(
-  tableId: string, column: { name: string; type: string; required?: boolean; default?: unknown; options?: string[] },
-  workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  column: { name: string; type: string; required?: boolean; default?: unknown; options?: string[] }
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/columns`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns`, {
     method: "POST", body: JSON.stringify(column),
   });
 }
 
 export async function updateTableColumn(
-  tableId: string, columnId: string,
-  updates: { name?: string; type?: string; required?: boolean; default?: unknown; options?: string[] },
-  workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  columnId: string,
+  updates: { name?: string; type?: string; required?: boolean; default?: unknown; options?: string[] }
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/columns/${columnId}`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns/${columnId}`, {
     method: "PATCH", body: JSON.stringify(updates),
   });
 }
 
 export async function deleteTableColumn(
-  tableId: string, columnId: string, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  columnId: string
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/columns/${columnId}`, { method: "DELETE" });
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns/${columnId}`, { method: "DELETE" });
 }
 
 export async function reorderTableColumns(
-  tableId: string, columnIds: string[], workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  columnIds: string[]
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/columns/reorder`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns/reorder`, {
     method: "PUT", body: JSON.stringify({ column_ids: columnIds }),
   });
 }
@@ -593,11 +514,10 @@ export async function reorderTableColumns(
 // --- Table Rows ---
 
 export async function listTableRows(
+  workspaceId: string | null,
   tableId: string,
-  params?: { sort_by?: string; sort_order?: string; limit?: number; offset?: number; filters?: object[] },
-  workspaceId?: string
+  params?: { sort_by?: string; sort_order?: string; limit?: number; offset?: number; filters?: object[] }
 ): Promise<{ rows: TableRow[]; total_count: number; has_more: boolean }> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
   const query = new URLSearchParams();
   if (params?.sort_by) query.set("sort_by", params.sort_by);
   if (params?.sort_order) query.set("sort_order", params.sort_order);
@@ -605,129 +525,112 @@ export async function listTableRows(
   if (params?.offset) query.set("offset", String(params.offset));
   if (params?.filters) query.set("filters", JSON.stringify(params.filters));
   const qs = query.toString();
-  return apiFetch(`${base}/${tableId}/rows${qs ? "?" + qs : ""}`);
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows${qs ? "?" + qs : ""}`);
 }
 
 export async function createTableRow(
-  tableId: string, data: Record<string, unknown>, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  data: Record<string, unknown>
 ): Promise<TableRow> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/rows`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows`, {
     method: "POST", body: JSON.stringify({ data }),
   });
 }
 
 export async function createTableRowsBatch(
-  tableId: string, rows: { data: Record<string, unknown> }[], workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  rows: { data: Record<string, unknown> }[]
 ): Promise<{ rows: TableRow[] }> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/rows/batch`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/batch`, {
     method: "POST", body: JSON.stringify({ rows }),
   });
 }
 
 export async function updateTableRow(
-  tableId: string, rowId: string, data: Record<string, unknown>, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  rowId: string,
+  data: Record<string, unknown>
 ): Promise<TableRow> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/rows/${rowId}`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/${rowId}`, {
     method: "PATCH", body: JSON.stringify({ data }),
   });
 }
 
 export async function deleteTableRow(
-  tableId: string, rowId: string, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  rowId: string
 ): Promise<void> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  await apiFetch(`${base}/${tableId}/rows/${rowId}`, { method: "DELETE" });
+  await apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/${rowId}`, { method: "DELETE" });
 }
 
 export async function deleteTableRowsBatch(
-  tableId: string, rowIds: string[], workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  rowIds: string[]
 ): Promise<{ deleted: number }> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/rows/delete`, {
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/delete`, {
     method: "POST", body: JSON.stringify({ row_ids: rowIds }),
   });
-}
-
-// --- Personal Tables ---
-
-export async function createPersonalTable(
-  name: string, description?: string,
-  columns?: { name: string; type: string; options?: string[] }[]
-): Promise<Table> {
-  return apiFetch("/api/v1/tables", {
-    method: "POST",
-    body: JSON.stringify({ name, description: description || "", columns: columns || [] }),
-  });
-}
-
-export async function listPersonalTables(): Promise<{ tables: Table[] }> {
-  return apiFetch("/api/v1/tables");
-}
-
-export async function getPersonalTable(tableId: string): Promise<Table> {
-  return apiFetch(`/api/v1/tables/${tableId}`);
-}
-
-export async function updatePersonalTable(
-  tableId: string, data: { name?: string; description?: string }
-): Promise<Table> {
-  return apiFetch(`/api/v1/tables/${tableId}`, { method: "PATCH", body: JSON.stringify(data) });
-}
-
-export async function deletePersonalTable(tableId: string): Promise<void> {
-  await apiFetch(`/api/v1/tables/${tableId}`, { method: "DELETE" });
 }
 
 // --- Table Search, Summary, Duplicate ---
 
 export async function searchTableRows(
-  tableId: string, query: string, params?: { limit?: number; offset?: number }, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  query: string,
+  params?: { limit?: number; offset?: number }
 ): Promise<{ rows: TableRow[]; total_count: number; has_more: boolean }> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
   const qs = new URLSearchParams({ q: query });
   if (params?.limit) qs.set("limit", String(params.limit));
   if (params?.offset) qs.set("offset", String(params.offset));
-  return apiFetch(`${base}/${tableId}/rows/search?${qs}`);
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/search?${qs}`);
 }
 
 export async function summarizeTableRows(
-  tableId: string, filters?: object[], workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  filters?: object[]
 ): Promise<{ total_rows: number; columns: Record<string, { name: string; filled: number; sum?: number; avg?: number; min?: number; max?: number }> }> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
   const qs = new URLSearchParams();
   if (filters && filters.length > 0) qs.set("filters", JSON.stringify(filters));
   const qsStr = qs.toString();
-  return apiFetch(`${base}/${tableId}/rows/summary${qsStr ? "?" + qsStr : ""}`);
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/summary${qsStr ? "?" + qsStr : ""}`);
 }
 
 export async function duplicateTableRow(
-  tableId: string, rowId: string, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  rowId: string
 ): Promise<TableRow> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/rows/${rowId}/duplicate`, { method: "POST" });
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/rows/${rowId}/duplicate`, { method: "POST" });
 }
 
 // --- Table Views ---
 
 export async function saveTableView(
-  tableId: string, view: { id?: string; name: string; filters?: object[]; sort_by?: string; sort_order?: string; visible_columns?: string[] },
-  workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  view: { id?: string; name: string; filters?: object[]; sort_by?: string; sort_order?: string; visible_columns?: string[] }
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/views`, { method: "POST", body: JSON.stringify(view) });
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/views`, {
+    method: "POST", body: JSON.stringify(view),
+  });
 }
 
 export async function deleteTableView(
-  tableId: string, viewId: string, workspaceId?: string
+  workspaceId: string | null,
+  tableId: string,
+  viewId: string
 ): Promise<Table> {
-  const base = workspaceId ? `/api/v1/workspaces/${workspaceId}/tables` : "/api/v1/tables";
-  return apiFetch(`${base}/${tableId}/views/${viewId}`, { method: "DELETE" });
+  return apiFetch(`${scope(workspaceId)}/tables/${tableId}/views/${viewId}`, { method: "DELETE" });
 }
 
-// --- Permissions ---
+// --- Permissions (workspace-only) ---
 
 export async function getPermissions(
   workspaceId: string,
@@ -776,27 +679,14 @@ export async function removeShare(
 
 // --- Files ---
 
-export async function uploadFile(workspaceId: string, file: File): Promise<FileInfo> {
+export async function uploadFile(
+  workspaceId: string | null,
+  file: File
+): Promise<FileInfo> {
   const token = getToken();
   const formData = new FormData();
   formData.append("file", file);
-  const resp = await fetch(`${API_BASE}/api/v1/workspaces/${workspaceId}/files`, {
-    method: "POST",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    body: formData,
-  });
-  if (!resp.ok) {
-    const detail = await resp.json().then((d) => d.detail).catch(() => resp.statusText);
-    throw new Error(detail);
-  }
-  return resp.json();
-}
-
-export async function uploadPersonalFile(file: File): Promise<FileInfo> {
-  const token = getToken();
-  const formData = new FormData();
-  formData.append("file", file);
-  const resp = await fetch(`${API_BASE}/api/v1/files`, {
+  const resp = await fetch(`${API_BASE}${scope(workspaceId)}/files`, {
     method: "POST",
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: formData,
@@ -817,89 +707,51 @@ export async function deleteFile(workspaceId: string, fileId: string): Promise<v
   await apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}`, { method: "DELETE" });
 }
 
-// --- Wiki: Backlinks, Page Graph, Semantic Search ---
+// --- Wiki: Backlinks, Outlinks, Page Graph, Semantic Search ---
 
 export async function getBacklinks(
-  workspaceId: string,
+  workspaceId: string | null,
   notebookId: string,
   pageId: string
 ): Promise<PageLink[]> {
   const data = await apiFetch<{ backlinks: PageLink[] }>(
-    `/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/${pageId}/backlinks`
-  );
-  return data.backlinks;
-}
-
-export async function getPersonalBacklinks(
-  notebookId: string,
-  pageId: string
-): Promise<PageLink[]> {
-  const data = await apiFetch<{ backlinks: PageLink[] }>(
-    `/api/v1/notebooks/${notebookId}/pages/${pageId}/backlinks`
+    `${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}/backlinks`
   );
   return data.backlinks;
 }
 
 export async function getOutlinks(
-  workspaceId: string,
+  workspaceId: string | null,
   notebookId: string,
   pageId: string
 ): Promise<PageLink[]> {
   const data = await apiFetch<{ outlinks: PageLink[] }>(
-    `/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/${pageId}/outlinks`
+    `${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}/outlinks`
   );
   return data.outlinks;
 }
 
 export async function getPageGraph(
-  workspaceId: string,
+  workspaceId: string | null,
   notebookId: string
 ): Promise<PageGraph> {
-  return apiFetch<PageGraph>(
-    `/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/graph`
-  );
-}
-
-export async function getPersonalOutlinks(
-  notebookId: string,
-  pageId: string
-): Promise<PageLink[]> {
-  const data = await apiFetch<{ outlinks: PageLink[] }>(
-    `/api/v1/notebooks/${notebookId}/pages/${pageId}/outlinks`
-  );
-  return data.outlinks;
-}
-
-export async function getPersonalPageGraph(notebookId: string): Promise<PageGraph> {
-  return apiFetch<PageGraph>(`/api/v1/notebooks/${notebookId}/graph`);
-}
-
-export async function semanticSearchPersonalPages(
-  notebookId: string,
-  query: string,
-  limit = 20
-): Promise<NotebookPage[]> {
-  const params = new URLSearchParams({ q: query, limit: String(limit) });
-  const data = await apiFetch<{ pages: NotebookPage[] }>(
-    `/api/v1/notebooks/${notebookId}/pages/semantic-search?${params}`
-  );
-  return data.pages;
+  return apiFetch<PageGraph>(`${scope(workspaceId)}/notebooks/${notebookId}/graph`);
 }
 
 export async function semanticSearchPages(
-  workspaceId: string,
+  workspaceId: string | null,
   notebookId: string,
   query: string,
   limit = 20
 ): Promise<NotebookPage[]> {
   const params = new URLSearchParams({ q: query, limit: String(limit) });
   const data = await apiFetch<{ pages: NotebookPage[] }>(
-    `/api/v1/workspaces/${workspaceId}/notebooks/${notebookId}/pages/semantic-search?${params}`
+    `${scope(workspaceId)}/notebooks/${notebookId}/pages/semantic-search?${params}`
   );
   return data.pages;
 }
 
-// --- Table Embeddings ---
+// --- Table Embeddings (workspace-only) ---
 
 export async function setTableEmbeddingConfig(
   workspaceId: string,


### PR DESCRIPTION
## Summary

`frontend/src/lib/api.ts` had two near-identical functions for every resource — one workspace-scoped (`listNotebooks(ws)`) and one personal (`listPersonalNotebooks()`) — paired at every call site with ternaries like `ws ? fooWs(ws, x) : fooPersonal(x)`.

This PR collapses each pair into a single function that takes `workspaceId: string | null` as the first argument, using a small `scope()` helper to pick between `/api/v1/workspaces/{ws}` and `/api/v1`.

- `lib/api.ts`: 944 → 796 lines, ~30 duplicate functions removed
- Table row/column functions move from `workspaceId?: string` (last, optional) to `workspaceId: string \| null` (first) for consistency
- Every caller simplifies: `workspace_id` is already `string \| null` in state, so the ternary collapses to a single call
- Wire-level URLs are unchanged — no backend change needed

Net diff: **6 files, +244 / -431 (-187 lines)**.

### Example

Before:
\`\`\`ts
const p = selectedNotebook.workspace_id
  ? await getPage(selectedNotebook.workspace_id, selectedNotebook.id, pageId)
  : await getPersonalPage(selectedNotebook.id, pageId);
\`\`\`

After:
\`\`\`ts
const p = await getPage(selectedNotebook.workspace_id, selectedNotebook.id, pageId);
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` passes
- [x] \`vitest run\` passes (5/5)
- [x] \`eslint\` introduces no new errors vs baseline on origin/main (same 13 errors, fewer warnings)
- [ ] Smoke-test the notebooks, tables, and memory pages in both personal and workspace scope in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)