### PR TITLE
feat(managed): Auth0 login in managed/ overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+node_modules
 .next/
 __pycache__/
 *.pyc

--- a/backend/config.py
+++ b/backend/config.py
@@ -46,5 +46,13 @@ class Settings:
     S3_SECRET_KEY: str | None = os.getenv("S3_SECRET_KEY")
     S3_REGION: str = os.getenv("S3_REGION", "auto")
 
+    # --- Auth0 (managed deployment only) ---
+    # When AUTH0_ENABLED=true, password login/register is disabled and the
+    # managed auth0 router is mounted at /api/v1/auth0/. Requires the
+    # managed/ directory to be present in the deployment.
+    AUTH0_ENABLED: bool = os.getenv("AUTH0_ENABLED", "false").lower() == "true"
+    AUTH0_DOMAIN: str | None = os.getenv("AUTH0_DOMAIN")
+    AUTH0_AUDIENCE: str | None = os.getenv("AUTH0_AUDIENCE")
+
 
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -69,6 +69,11 @@ app.include_router(files.personal_router)
 app.include_router(aggregate.router)
 app.include_router(skill.router)
 
+if settings.AUTH0_ENABLED:
+    from managed.backend.auth0 import router as auth0_router
+
+    app.include_router(auth0_router)
+
 
 @app.get("/health")
 async def health():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.6
 uvicorn[standard]==0.34.0
 asyncpg==0.30.0
 pydantic==2.10.4
+python-multipart>=0.0.9
 httpx>=0.27.0
 bcrypt>=4.0.0
 pgvector>=0.3.0
@@ -9,3 +10,4 @@ slowapi>=0.1.9
 alembic>=1.14.0
 sqlalchemy[asyncio]>=2.0.0
 umap-learn>=0.5.0
+python-jose[cryptography]>=3.3.0

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -4,6 +4,7 @@ import time
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from ..auth import get_current_user
+from ..config import settings
 from ..middleware import limiter
 from ..models import (
     LoginRequest,
@@ -32,9 +33,18 @@ def _prune_cli_sessions() -> None:
         del _cli_sessions[k]
 
 
+def _require_password_auth() -> None:
+    if settings.AUTH0_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password auth is disabled; use Auth0",
+        )
+
+
 @router.post("/register", response_model=UserRegisterResponse, status_code=201)
 @limiter.limit("5/minute")
 async def register(request: Request, req: UserRegisterRequest):
+    _require_password_auth()
     try:
         user, api_key = await user_service.register_user(
             name=req.name,
@@ -55,6 +65,7 @@ async def register(request: Request, req: UserRegisterRequest):
 @router.post("/login", response_model=UserRegisterResponse)
 @limiter.limit("10/minute")
 async def login(request: Request, req: LoginRequest):
+    _require_password_auth()
     try:
         user, api_key = await user_service.authenticate_by_password(
             name=req.name, password=req.password

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
+
+export async function middleware(request: NextRequest) {
+  if (!AUTH0_ENABLED) return NextResponse.next();
+  const { runAuth0Middleware } = await import("@managed/auth0/middleware");
+  return runAuth0Middleware(request);
+}
+
+export const config = {
+  matcher: [
+    // Run on all routes except Next.js internals, static assets, and our own API.
+    "/((?!_next/static|_next/image|favicon.ico|icon.svg|api/v1/).*)",
+  ],
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "octopus",
       "version": "0.1.0",
       "dependencies": {
+        "@auth0/nextjs-auth0": "^4.17.0",
         "@tiptap/extension-image": "^3.22.2",
         "@tiptap/extension-link": "3.6.6",
         "@tiptap/extension-placeholder": "3.6.6",
@@ -122,6 +123,25 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@auth0/nextjs-auth0": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-4.17.0.tgz",
+      "integrity": "sha512-AGlbyl3ymOMN4+aAVFdZ01nsmXuFv5H5JS71ggMQFmiaFZsfXxH/elx2GfAPgeNafX9L1D1oE99/sRNCK8UAeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@edge-runtime/cookies": "^5.0.1",
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.11",
+        "oauth4webapi": "^3.8.2",
+        "openid-client": "^6.8.0",
+        "swr": "^2.2.5"
+      },
+      "peerDependencies": {
+        "next": "^14.2.35 || ~15.0.7 || ~15.1.11 || ~15.2.8 || ~15.3.8 || ~15.4.10 || ~15.5.9 || ^16.0.10",
+        "react": "^18.0.0 || ~19.0.1 ||  ~19.1.2 || ^19.2.1",
+        "react-dom": "^18.0.0 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -524,6 +544,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@edge-runtime/cookies": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-5.0.2.tgz",
+      "integrity": "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1530,6 +1559,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@popperjs/core": {
@@ -6284,6 +6322,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7891,6 +7938,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8024,6 +8080,19 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.3.tgz",
+      "integrity": "sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -9413,6 +9482,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@auth0/nextjs-auth0": "^4.17.0",
     "@tiptap/extension-image": "^3.22.2",
     "@tiptap/extension-link": "3.6.6",
     "@tiptap/extension-placeholder": "3.6.6",

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "../../hooks/useAuth";
 import { setToken, listMyWorkspaces } from "../../lib/api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -69,6 +70,17 @@ export default function LoginPage() {
 
   if (user && !cliSession) {
     return null;
+  }
+
+  if (AUTH0_ENABLED) {
+    return (
+      <Auth0LoginPanel
+        user={user}
+        logout={logout}
+        cliSession={cliSession}
+        onCliApproved={() => setCliApproved(true)}
+      />
+    );
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -162,4 +174,74 @@ export default function LoginPage() {
       </main>
     </div>
   );
+}
+
+type Auth0PanelProps = {
+  user: ReturnType<typeof useAuth>["user"];
+  logout: ReturnType<typeof useAuth>["logout"];
+  cliSession: string | null;
+  onCliApproved: () => void;
+};
+
+function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0PanelProps) {
+  const [hasSession, setHasSession] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/auth/profile", { credentials: "include" });
+        if (!cancelled) setHasSession(res.ok);
+      } catch {
+        if (!cancelled) setHasSession(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header user={user} onLogout={logout} />
+      <main className="flex-1 flex items-center justify-center px-4 py-12">
+        <div className="w-full max-w-sm space-y-4">
+          <div className="rounded-2xl border border-border bg-surface p-6">
+            <h2 className="text-base font-semibold text-foreground mb-4">
+              {cliSession ? "Sign in to authorize the CLI" : "Sign in"}
+            </h2>
+            {hasSession === null ? (
+              <p className="text-sm text-muted text-center">Loading…</p>
+            ) : hasSession ? (
+              <Auth0Exchange cliSession={cliSession} onCliApproved={onCliApproved} />
+            ) : (
+              <Auth0LoginButton cliSession={cliSession} />
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// Lazy re-exports so the managed/ code is never loaded in OSS builds.
+function Auth0LoginButton(props: { cliSession: string | null }) {
+  const [Comp, setComp] = useState<React.ComponentType<{ cliSession: string | null }> | null>(null);
+  useEffect(() => {
+    import("@managed/auth0/LoginButton").then((m) => setComp(() => m.default));
+  }, []);
+  if (!Comp) return null;
+  return <Comp cliSession={props.cliSession} />;
+}
+
+function Auth0Exchange(props: { cliSession: string | null; onCliApproved: () => void }) {
+  const [Comp, setComp] = useState<React.ComponentType<{
+    cliSession: string | null;
+    onCliApproved: () => void;
+  }> | null>(null);
+  useEffect(() => {
+    import("@managed/auth0/ExchangeAndRedirect").then((m) => setComp(() => m.default));
+  }, []);
+  if (!Comp) return null;
+  return <Comp cliSession={props.cliSession} onCliApproved={props.onCliApproved} />;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@managed/*": ["../managed/frontend/*"]
     }
   },
   "include": [
@@ -28,7 +29,9 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    "../managed/frontend/**/*.ts",
+    "../managed/frontend/**/*.tsx"
   ],
   "exclude": ["node_modules"]
 }

--- a/managed/README.md
+++ b/managed/README.md
@@ -14,3 +14,31 @@ Stash will eventually live in two repos:
 When the public repo is created, everything outside `managed/` will be mirrored to it via `git subtree`. Everything inside `managed/` stays here.
 
 Keeping the boundary clean now means the eventual open-sourcing step is mechanical instead of a big refactor.
+
+## Currently inside
+
+- `backend/auth0/` — Auth0 JWT validation + `/api/v1/auth0/exchange` endpoint that swaps an Auth0 access token for an octopus api_key.
+- `backend/migrations/` — separate alembic environment (`alembic_version_managed`) holding `m0001_add_auth0_sub.py`.
+- `frontend/auth0/` — Next.js-side Auth0 login button and post-login exchange component.
+
+## Running with Auth0
+
+Set these env vars in a managed deploy (in addition to the OSS ones):
+
+```
+AUTH0_ENABLED=true
+AUTH0_DOMAIN=<tenant>.us.auth0.com
+AUTH0_AUDIENCE=<your API identifier>
+
+# Next.js SDK (see https://github.com/auth0/nextjs-auth0)
+AUTH0_SECRET=<64-hex random bytes>
+AUTH0_CLIENT_ID=<from Auth0 dashboard>
+AUTH0_CLIENT_SECRET=<from Auth0 dashboard>
+APP_BASE_URL=https://www.stash.ac
+AUTH0_DOMAIN=<tenant>.us.auth0.com
+
+NEXT_PUBLIC_AUTH0_ENABLED=true
+```
+
+`start.sh` runs the managed alembic chain automatically when `AUTH0_ENABLED=true`.
+

--- a/managed/backend/alembic.ini
+++ b/managed/backend/alembic.ini
@@ -1,0 +1,41 @@
+[alembic]
+script_location = managed/backend/migrations
+prepend_sys_path = .
+version_path_separator = os
+
+# URL is set dynamically from DATABASE_URL env var in env.py.
+sqlalchemy.url = driver://user:pass@host/db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/managed/backend/auth0/__init__.py
+++ b/managed/backend/auth0/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/managed/backend/auth0/jwt.py
+++ b/managed/backend/auth0/jwt.py
@@ -1,0 +1,69 @@
+"""Validate Auth0-issued JWTs against the tenant's JWKS."""
+
+import time
+
+import httpx
+from fastapi import HTTPException, status
+from jose import jwt
+from jose.exceptions import JWTError
+
+from backend.config import settings
+
+_JWKS_TTL_SECONDS = 600
+
+_jwks_cache: dict = {"keys": None, "fetched_at": 0.0}
+
+
+async def _fetch_jwks() -> dict:
+    now = time.monotonic()
+    if _jwks_cache["keys"] and now - _jwks_cache["fetched_at"] < _JWKS_TTL_SECONDS:
+        return _jwks_cache["keys"]
+    url = f"https://{settings.AUTH0_DOMAIN}/.well-known/jwks.json"
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        keys = resp.json()
+    _jwks_cache["keys"] = keys
+    _jwks_cache["fetched_at"] = now
+    return keys
+
+
+async def validate_auth0_token(token: str) -> dict:
+    """Validate an Auth0 access token. Returns the decoded claims."""
+    if not settings.AUTH0_DOMAIN or not settings.AUTH0_AUDIENCE:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Auth0 not configured",
+        )
+
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Malformed token")
+
+    kid = header.get("kid")
+    if not kid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing kid")
+
+    jwks = await _fetch_jwks()
+    signing_key = next((k for k in jwks.get("keys", []) if k.get("kid") == kid), None)
+    if not signing_key:
+        # Key rotation — bust cache once and retry
+        _jwks_cache["keys"] = None
+        jwks = await _fetch_jwks()
+        signing_key = next((k for k in jwks.get("keys", []) if k.get("kid") == kid), None)
+    if not signing_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown key id")
+
+    try:
+        claims = jwt.decode(
+            token,
+            signing_key,
+            algorithms=["RS256"],
+            audience=settings.AUTH0_AUDIENCE,
+            issuer=f"https://{settings.AUTH0_DOMAIN}/",
+        )
+    except JWTError as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid token: {e}")
+
+    return claims

--- a/managed/backend/auth0/router.py
+++ b/managed/backend/auth0/router.py
@@ -1,0 +1,34 @@
+"""POST /api/v1/auth0/exchange — swap an Auth0 access token for an octopus api_key."""
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from backend.middleware import limiter
+from backend.models import UserRegisterResponse
+
+from .jwt import validate_auth0_token
+from .users import get_or_create_user_from_auth0
+
+router = APIRouter(prefix="/api/v1/auth0", tags=["auth0"])
+
+_security = HTTPBearer()
+
+
+@router.post("/exchange", response_model=UserRegisterResponse)
+@limiter.limit("30/minute")
+async def exchange(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(_security),
+):
+    claims = await validate_auth0_token(credentials.credentials)
+    user, api_key = await get_or_create_user_from_auth0(
+        auth0_sub=claims["sub"],
+        email=claims.get("email"),
+        name=claims.get("name"),
+    )
+    return UserRegisterResponse(
+        id=user["id"],
+        name=user["name"],
+        display_name=user["display_name"],
+        api_key=api_key,
+    )

--- a/managed/backend/auth0/users.py
+++ b/managed/backend/auth0/users.py
@@ -1,0 +1,74 @@
+"""Provision / rotate users from Auth0 identities."""
+
+import re
+
+from backend.auth import generate_api_key, hash_api_key
+from backend.database import get_pool
+from backend.services import workspace_service
+
+
+_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _slugify_name(raw: str) -> str:
+    slug = _NAME_CHARS.sub("", raw)[:60] or "user"
+    return slug
+
+
+async def _unique_name(base: str) -> str:
+    pool = get_pool()
+    candidate = base
+    suffix = 2
+    while await pool.fetchval("SELECT 1 FROM users WHERE name = $1", candidate):
+        candidate = f"{base}_{suffix}"[:64]
+        suffix += 1
+    return candidate
+
+
+async def get_or_create_user_from_auth0(
+    auth0_sub: str,
+    email: str | None,
+    name: str | None,
+) -> tuple[dict, str]:
+    """Return (user_row, new_api_key). Rotates api_key on every login."""
+    pool = get_pool()
+    api_key = generate_api_key()
+    key_hash = hash_api_key(api_key)
+
+    row = await pool.fetchrow(
+        "SELECT id, name, display_name, description, created_at, last_seen "
+        "FROM users WHERE auth0_sub = $1",
+        auth0_sub,
+    )
+    if row:
+        await pool.execute(
+            "UPDATE users SET api_key_hash = $1, last_seen = now() WHERE id = $2",
+            key_hash,
+            row["id"],
+        )
+        return dict(row), api_key
+
+    base = _slugify_name((email or "").split("@")[0] or name or "user")
+    username = await _unique_name(base)
+    display_name = name or username
+
+    row = await pool.fetchrow(
+        "INSERT INTO users (name, display_name, api_key_hash, auth0_sub, description) "
+        "VALUES ($1, $2, $3, $4, '') "
+        "RETURNING id, name, display_name, description, created_at, last_seen",
+        username,
+        display_name,
+        key_hash,
+        auth0_sub,
+    )
+    user = dict(row)
+
+    suffix = "'s Workspace"
+    ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"
+    await workspace_service.create_workspace(
+        name=ws_name,
+        description="",
+        creator_id=user["id"],
+        is_public=False,
+    )
+    return user, api_key

--- a/managed/backend/migrations/env.py
+++ b/managed/backend/migrations/env.py
@@ -1,0 +1,59 @@
+"""Alembic env for managed-only migrations.
+
+Runs against the same Postgres instance as the OSS migrations, but tracks
+its own revision chain in `alembic_version_managed` so the two don't collide.
+"""
+
+import asyncio
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# Add project root to sys.path so we can import backend.config
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from backend.config import settings  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+_db_url = settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1).replace(
+    "postgres://", "postgresql+asyncpg://", 1
+)
+
+_VERSION_TABLE = "alembic_version_managed"
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=_db_url,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        version_table=_VERSION_TABLE,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection):
+    context.configure(connection=connection, version_table=_VERSION_TABLE)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    engine = create_async_engine(_db_url, echo=False)
+    async with engine.connect() as conn:
+        await conn.run_sync(do_run_migrations)
+    await engine.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/managed/backend/migrations/script.py.mako
+++ b/managed/backend/migrations/script.py.mako
@@ -1,0 +1,22 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/managed/backend/migrations/versions/m0001_add_auth0_sub.py
+++ b/managed/backend/migrations/versions/m0001_add_auth0_sub.py
@@ -1,0 +1,22 @@
+"""Add auth0_sub column to users (managed-only).
+
+Revision ID: m0001
+Revises:
+"""
+
+from alembic import op
+
+revision = "m0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS auth0_sub VARCHAR(128) UNIQUE")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_users_auth0_sub ON users(auth0_sub) WHERE auth0_sub IS NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_users_auth0_sub")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS auth0_sub")

--- a/managed/frontend/auth0/ExchangeAndRedirect.tsx
+++ b/managed/frontend/auth0/ExchangeAndRedirect.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { listMyWorkspaces, setToken } from "@/lib/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+type Props = {
+  cliSession?: string | null;
+  onCliApproved?: () => void;
+};
+
+export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props) {
+  const router = useRouter();
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      try {
+        const tokenRes = await fetch("/auth/access-token");
+        if (!tokenRes.ok) throw new Error("Auth0 session missing");
+        const { token } = await tokenRes.json();
+
+        const res = await fetch(`${API_URL}/api/v1/auth0/exchange`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.detail || "Token exchange failed");
+        }
+        const data = await res.json();
+        if (cancelled) return;
+
+        setToken(data.api_key);
+
+        if (cliSession) {
+          await fetch(`${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ api_key: data.api_key, username: data.name }),
+          });
+          onCliApproved?.();
+          return;
+        }
+
+        const { workspaces } = await listMyWorkspaces();
+        router.push(workspaces.length === 1 ? `/workspaces/${workspaces[0].id}` : "/");
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Sign-in failed");
+      }
+    }
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [cliSession, onCliApproved, router]);
+
+  if (error) {
+    return (
+      <div className="text-center space-y-3">
+        <p className="text-sm text-red-400">{error}</p>
+        <a href="/auth/login" className="text-sm text-brand hover:underline">
+          Try again
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center">
+      <p className="text-sm text-muted">Finishing sign-in…</p>
+    </div>
+  );
+}

--- a/managed/frontend/auth0/LoginButton.tsx
+++ b/managed/frontend/auth0/LoginButton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function LoginButton({ cliSession }: { cliSession?: string | null }) {
+  const returnTo = cliSession ? `/login?cli=${encodeURIComponent(cliSession)}` : "/login";
+  const href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+  return (
+    <a
+      href={href}
+      className="block w-full bg-surface-hover hover:bg-border text-foreground py-2.5 rounded-xl text-sm font-medium text-center transition-colors"
+    >
+      Sign in with Auth0
+    </a>
+  );
+}

--- a/managed/frontend/auth0/client.ts
+++ b/managed/frontend/auth0/client.ts
@@ -1,0 +1,5 @@
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
+
+// Reads AUTH0_DOMAIN / AUTH0_CLIENT_ID / AUTH0_CLIENT_SECRET / AUTH0_SECRET /
+// APP_BASE_URL from env. Never imported when NEXT_PUBLIC_AUTH0_ENABLED !== "true".
+export const auth0 = new Auth0Client();

--- a/managed/frontend/auth0/hasSession.ts
+++ b/managed/frontend/auth0/hasSession.ts
@@ -1,0 +1,8 @@
+export async function hasAuth0Session(): Promise<boolean> {
+  try {
+    const res = await fetch("/auth/profile", { credentials: "include" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/managed/frontend/auth0/middleware.ts
+++ b/managed/frontend/auth0/middleware.ts
@@ -1,0 +1,7 @@
+import type { NextRequest } from "next/server";
+
+import { auth0 } from "./client";
+
+export async function runAuth0Middleware(request: NextRequest) {
+  return auth0.middleware(request);
+}

--- a/start.sh
+++ b/start.sh
@@ -38,9 +38,18 @@ fi
 echo "Starting Octopus services..."
 echo "================================"
 
+# --- Migrations ---
+cd "$PROJECT_ROOT"
+echo "[migrate]  Running OSS migrations..."
+alembic upgrade head
+
+if [ "${AUTH0_ENABLED:-false}" = "true" ]; then
+    echo "[migrate]  Running managed migrations..."
+    alembic -c managed/backend/alembic.ini upgrade head
+fi
+
 # --- Backend (FastAPI) ---
 echo "[backend]  Starting on port ${BACKEND_PORT}..."
-cd "$PROJECT_ROOT"
 uvicorn backend.main:app --host 0.0.0.0 --port "$BACKEND_PORT" &
 PIDS+=($!)
 


### PR DESCRIPTION
## Summary

- Adds Auth0 login for the managed (hosted) deployment. All Auth0 code lives under `managed/` — OSS/self-hosted continues to use username+password unchanged.
- New `managed/backend/auth0/` with JWKS-based JWT validation and `POST /api/v1/auth0/exchange` that swaps an Auth0 access token for an octopus api_key.
- Separate alembic env under `managed/backend/migrations/` (version table `alembic_version_managed`) keeps `auth0_sub` out of the OSS schema.
- New `managed/frontend/auth0/` with `@auth0/nextjs-auth0` v4 client, middleware, login button, and post-login token-exchange component. Shared login page / middleware conditionally load them when `NEXT_PUBLIC_AUTH0_ENABLED=true`.
- When `AUTH0_ENABLED=true`, `/api/v1/users/{login,register}` return 403; password auth is disabled.

## Design

Auth0 is login-only. After exchange, the frontend holds an `mc_...` api_key like today, and every downstream request (including the CLI approve flow) works without modification.

```
Auth0 hosted login → Next.js callback (SDK) → session cookie
  → GET /auth/access-token
  → POST /api/v1/auth0/exchange (Bearer auth0_token)
  → validate JWT against JWKS → get_or_create user by auth0_sub → mint api_key
  → frontend stores api_key in localStorage → normal app continues
```

## Env vars (managed only)

```
AUTH0_ENABLED=true
AUTH0_DOMAIN=<tenant>.us.auth0.com
AUTH0_AUDIENCE=<API identifier>
AUTH0_SECRET=<random hex>
AUTH0_CLIENT_ID=<from dashboard>
AUTH0_CLIENT_SECRET=<from dashboard>
APP_BASE_URL=https://www.stash.ac
NEXT_PUBLIC_AUTH0_ENABLED=true
```

Dashboard: add `<APP_BASE_URL>/auth/callback` as an allowed callback URL.

## Pre-existing fix included

Adds `python-multipart` to `backend/requirements.txt` — `backend/routers/files.py` uses form data, so the app fails to boot without it. Unrelated to Auth0 but blocked verification.

## Test plan

- [ ] OSS mode (`AUTH0_ENABLED` unset): `/login` shows password form; `/api/v1/auth0/exchange` returns 404; `users.auth0_sub` column does not exist
- [ ] Managed mode (`AUTH0_ENABLED=true`): `./start.sh` runs both alembic chains; `/login` shows only Auth0 button; Auth0 round-trip → user row created with `auth0_sub` set, `password_hash` NULL; default workspace auto-provisioned
- [ ] Second login: same user, api_key rotated (`api_key_hash` changes in DB)
- [ ] CLI flow (`/login?cli=<id>`): browser finishes Auth0 login → POST to `cli-auth/sessions/:id/approve` → CLI picks up api_key

## Verified locally

- `tsc --noEmit` passes (managed/ included via `@managed/*` path alias + symlinked node_modules)
- `alembic history` clean on both chains
- Python imports: routes present only when `AUTH0_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)