### PR TITLE
fix(frontend): render FastAPI validation errors as readable text

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -9,6 +9,19 @@ import { setToken, listMyWorkspaces } from "../../lib/api";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
+// FastAPI returns `detail` as either a string or an array of validation errors
+// like [{ loc, msg, type }]. Flatten to a human-readable string.
+function formatApiError(detail: unknown, fallback: string): string {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((d) => (d && typeof d === "object" && "msg" in d ? String(d.msg) : ""))
+      .filter(Boolean);
+    if (msgs.length > 0) return msgs.join("; ");
+  }
+  return fallback;
+}
+
 export default function LoginPage() {
   return (
     <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>}>
@@ -105,7 +118,7 @@ function LoginPageInner() {
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || "Sign-in failed");
+        throw new Error(formatApiError(data.detail, "Sign-in failed"));
       }
 
       const data = await res.json();


### PR DESCRIPTION
## Summary
- The login page was calling `new Error(data.detail)` directly, but FastAPI returns `detail` as an array of `{loc, msg, type}` objects for 422 validation errors. Passing an array to the Error constructor yielded `err.message = \"[object Object]\"` — so a 1-char password (which hits register's `min_length=8`) showed \"[object Object]\" instead of the real reason.
- Added `formatApiError(detail, fallback)` that handles both the string form and the validation-array form, joining `msg` fields.

## Test plan
- [x] Local build passes
- [x] `curl https://moltchat.onrender.com/api/v1/users/register` with `password: \".\"` returns `{detail: [{msg: \"String should have at least 8 characters\", ...}]}`; the new helper surfaces that message

🤖 Generated with [Claude Code](https://claude.com/claude-code)