### PR TITLE
fix(frontend): render FastAPI validation errors as readable text

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -9,6 +9,19 @@ import { setToken, listMyWorkspaces } from "../../lib/api";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
+// FastAPI returns `detail` as either a string or an array of validation errors
+// like [{ loc, msg, type }]. Flatten to a human-readable string.
+function formatApiError(detail: unknown, fallback: string): string {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((d) => (d && typeof d === "object" && "msg" in d ? String(d.msg) : ""))
+      .filter(Boolean);
+    if (msgs.length > 0) return msgs.join("; ");
+  }
+  return fallback;
+}
+
 export default function LoginPage() {
   return (
     <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>}>
@@ -105,7 +118,7 @@ function LoginPageInner() {
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || "Sign-in failed");
+        throw new Error(formatApiError(data.detail, "Sign-in failed"));
       }
 
       const data = await res.json();


### PR DESCRIPTION
## Summary
- Login page used to show `[object Object]` whenever the backend returned a 422 with `detail` as an array of validation errors (e.g. `POST /users/register` with a too-short password).
- Adds a `formatApiError` helper in `frontend/src/app/login/page.tsx` that handles both string and array forms and joins the `msg` fields, so the user now sees the real reason (e.g. "String should have at least 8 characters").

## Test plan
- [x] Reproduced locally: `POST /users/register` with `password: "."` returns `detail: [{msg: "String should have at least 8 characters", ...}]`.
- [x] Verified via Chrome DevTools MCP on the CLI auth page (`/login?cli=...`):
  - `henry` / `.` → renders `String should have at least 8 characters` (was `[object Object]`).
  - `henry` / `correcthorse` → registers, approves CLI session, shows "CLI authorized ✓".

🤖 Generated with [Claude Code](https://claude.com/claude-code)