### PR TITLE
fix(cli): simplify workspace prompt in stash connect

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1119,30 +1119,35 @@ def connect():
                 marker = " [dim](current default)[/dim]" if str(ws["id"]) == workspace_id else ""
                 console.print(f"    [dim]{str(ws['id'])[:8]}…[/dim]  {ws['name']}{marker}")
 
+        # Pick a default workspace: prefer the configured one, else the first in the list.
+        default_ws = None
+        if workspace_id:
+            default_ws = next((ws for ws in my_workspaces if str(ws["id"]) == workspace_id), None)
+        if not default_ws and my_workspaces:
+            default_ws = my_workspaces[0]
+
+        default_name = default_ws["name"] if default_ws else ""
+
         _reserve_bottom_padding(4)
-        ws_action = typer.prompt(
-            "\nUse existing workspace ID, or type a name to create new one",
-            default=workspace_id or "",
+        ws_name = typer.prompt(
+            "\nPress Enter to accept the default workspace name, or type a new name",
+            default=default_name,
         ).strip()
 
-        if not ws_action:
-            console.print(
-                "[yellow]Skipping workspace setup. Run: stash config default_workspace <id>[/yellow]"
-            )
+        if not ws_name:
+            console.print("[yellow]Skipping workspace setup.[/yellow]")
         else:
-            # Check if it looks like a UUID (existing) or a name (create new)
-            import re
-
-            is_uuid = bool(re.match(r"^[0-9a-f-]{32,36}$", ws_action, re.I))
-            if is_uuid:
-                workspace_id = ws_action
+            # If the name matches an existing workspace, reuse it. Otherwise, create a new one.
+            matched = next((ws for ws in my_workspaces if ws["name"] == ws_name), None)
+            if matched:
+                workspace_id = str(matched["id"])
                 save_config(default_workspace=workspace_id, scope=scope)
                 console.print(
-                    f"  [green]✓[/green] Default workspace set to [bold]{workspace_id[:8]}…[/bold]"
+                    f"  [green]✓[/green] Using workspace [bold]{matched['name']}[/bold]"
                 )
             else:
                 try:
-                    ws_data = c.create_workspace(ws_action)
+                    ws_data = c.create_workspace(ws_name)
                     workspace_id = str(ws_data["id"])
                     save_config(default_workspace=workspace_id, scope=scope)
                     console.print(

--- a/cli/main.py
+++ b/cli/main.py
@@ -1119,6 +1119,7 @@ def connect():
                 marker = " [dim](current default)[/dim]" if str(ws["id"]) == workspace_id else ""
                 console.print(f"    [dim]{str(ws['id'])[:8]}…[/dim]  {ws['name']}{marker}")
 
+        _reserve_bottom_padding(4)
         ws_action = typer.prompt(
             "\nUse existing workspace ID, or type a name to create new one",
             default=workspace_id or "",
@@ -1151,10 +1152,25 @@ def connect():
                     console.print(f"[red]Could not create workspace: {e.detail}[/red]")
 
     # --- Done ---
-    console.print("\n[bold green]Setup complete.[/bold green]")
-    console.print("  Run [bold]stash whoami[/bold] to confirm auth.")
-    console.print('  Run [bold]stash history push "hello"[/bold] to push your first event.')
-    console.print("  Run [bold]stash --help[/bold] to see all commands.\n")
+    _show_setup_complete_splash()
+
+
+STASH_LOGO = r"""
+ ███████╗████████╗ █████╗ ███████╗██╗  ██╗
+ ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║  ██║
+ ███████╗   ██║   ███████║███████╗███████║
+ ╚════██║   ██║   ██╔══██║╚════██║██╔══██║
+ ███████║   ██║   ██║  ██║███████║██║  ██║
+ ╚══════╝   ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
+"""
+
+
+def _show_setup_complete_splash() -> None:
+    """Clear the onboarding transcript and show a clean success splash."""
+    console.clear()
+    console.print(f"[bold cyan]{STASH_LOGO}[/bold cyan]")
+    console.print("  [bold green]You're all set up.[/bold green]\n")
+    console.print("  Run [bold]stash --help[/bold] to see what's next.\n")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Simplify the workspace picker in `stash connect`: default to the configured (or first) workspace name, accept Enter to confirm, or type a new name to create one.
- Reuse existing workspace when the typed name matches; otherwise create new. Drops the UUID-vs-name branching.
- Show the Stash splash screen at the end of `stash connect` via `_show_setup_complete_splash()`.

## Test plan
- [ ] Run `stash connect` on a fresh config — confirm default workspace name is offered and splash renders.
- [ ] Run `stash connect` with an existing default workspace — confirm Enter reuses it.
- [ ] Type a new workspace name — confirm it creates and sets default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)