### PR TITLE
feat(cli): magic-link invites — one paste, zero browser

### DIFF
--- a/backend/migrations/versions/0008_workspace_invite_tokens.py
+++ b/backend/migrations/versions/0008_workspace_invite_tokens.py
@@ -1,0 +1,40 @@
+"""Add workspace_invite_tokens table for magic-link invites.
+
+Unlike workspaces.invite_code (a forever-secret anyone can redeem repeatedly),
+these tokens are single-use-or-capped, TTL-bounded, revocable, and hashed at
+rest. Used by `stash invite` + `stash connect --invite`.
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+CREATE TABLE IF NOT EXISTS workspace_invite_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    max_uses INT NOT NULL DEFAULT 1,
+    uses_count INT NOT NULL DEFAULT 0,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ
+)
+""")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workspace_invite_tokens_workspace "
+        "ON workspace_invite_tokens(workspace_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS workspace_invite_tokens CASCADE")

--- a/backend/models.py
+++ b/backend/models.py
@@ -84,6 +84,59 @@ class WorkspaceMember(BaseModel):
     joined_at: datetime
 
 
+# --- Invite tokens (magic-link onboarding) ---
+
+
+class InviteTokenCreateRequest(BaseModel):
+    max_uses: int = Field(1, ge=1, le=1000)
+    ttl_days: int = Field(7, ge=1, le=90)
+
+
+class InviteTokenCreateResponse(BaseModel):
+    id: UUID
+    token: str
+    workspace_id: UUID
+    workspace_name: str
+    max_uses: int
+    expires_at: datetime
+
+
+class InviteTokenSummary(BaseModel):
+    id: UUID
+    workspace_id: UUID
+    max_uses: int
+    uses_count: int
+    expires_at: datetime
+    created_at: datetime
+    revoked_at: datetime | None = None
+
+
+class InviteTokenListResponse(BaseModel):
+    tokens: list[InviteTokenSummary]
+
+
+class RedeemInviteRequest(BaseModel):
+    """Unauthenticated redemption: creates a fresh user + joins the workspace."""
+
+    token: str = Field(..., min_length=8, max_length=128)
+    display_name: str = Field(..., min_length=1, max_length=128)
+
+
+class RedeemInviteResponse(BaseModel):
+    api_key: str
+    user_id: UUID
+    username: str
+    display_name: str | None
+    workspace_id: UUID
+    workspace_name: str
+
+
+class RedeemInviteAuthedRequest(BaseModel):
+    """Authenticated redemption: just joins the existing user to the workspace."""
+
+    token: str = Field(..., min_length=8, max_length=128)
+
+
 # --- Notebooks (collections) ---
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -8,13 +8,15 @@ from ..config import settings
 from ..middleware import limiter
 from ..models import (
     LoginRequest,
+    RedeemInviteRequest,
+    RedeemInviteResponse,
     UserProfile,
     UserRegisterRequest,
     UserRegisterResponse,
     UserSearchResult,
     UserUpdateRequest,
 )
-from ..services import user_service
+from ..services import invite_token_service, user_service
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
 
@@ -141,6 +143,27 @@ async def poll_cli_auth_session(request: Request, session_id: str):
         del _cli_sessions[session_id]
         return {"status": "complete", "api_key": session["api_key"], "username": session["username"]}
     return {"status": "pending"}
+
+
+@router.post("/cli-auth/redeem-invite", response_model=RedeemInviteResponse)
+@limiter.limit("10/minute")
+async def redeem_invite_unauthenticated(request: Request, req: RedeemInviteRequest):
+    """Redeem a magic-link invite token with no prior auth.
+
+    Creates a brand-new user and joins them to the token's workspace. This is
+    the path used by `stash connect --invite` for people who don't yet have a
+    stash account.
+    """
+    result = await invite_token_service.redeem_as_new_user(
+        raw_token=req.token,
+        display_name=req.display_name,
+    )
+    if not result:
+        raise HTTPException(
+            status_code=404,
+            detail="Invite token is invalid, expired, or exhausted",
+        )
+    return RedeemInviteResponse(**result)
 
 
 @router.post("/cli-auth/sessions/{session_id}/approve")

--- a/backend/routers/workspaces.py
+++ b/backend/routers/workspaces.py
@@ -6,13 +6,18 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ..auth import get_current_user, get_current_user_optional
 from ..models import (
+    InviteTokenCreateRequest,
+    InviteTokenCreateResponse,
+    InviteTokenListResponse,
+    InviteTokenSummary,
+    RedeemInviteAuthedRequest,
     WorkspaceCreateRequest,
     WorkspaceListResponse,
     WorkspaceMember,
     WorkspaceResponse,
     WorkspaceUpdateRequest,
 )
-from ..services import workspace_service
+from ..services import invite_token_service, workspace_service
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
@@ -57,6 +62,18 @@ async def list_workspaces(current_user: dict | None = Depends(get_current_user_o
 async def list_my_workspaces(current_user: dict = Depends(get_current_user)):
     workspaces = await workspace_service.list_user_workspaces(current_user["id"])
     return WorkspaceListResponse(workspaces=[WorkspaceResponse(**w) for w in workspaces])
+
+
+@router.post("/redeem-invite", response_model=WorkspaceResponse)
+async def redeem_invite_authed(
+    req: RedeemInviteAuthedRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Authenticated redeem: join the signed-in user to the workspace."""
+    ws = await invite_token_service.redeem_as_existing_user(req.token, current_user["id"])
+    if not ws:
+        raise HTTPException(status_code=404, detail="Invite token is invalid, expired, or exhausted")
+    return WorkspaceResponse(**ws)
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)
@@ -166,3 +183,62 @@ async def kick_member(
     kicked = await workspace_service.kick_member(workspace_id, user_id, current_user["id"])
     if not kicked:
         raise HTTPException(status_code=403, detail="Cannot kick this member")
+
+
+# ---------------------------------------------------------------------------
+# Magic-link invite tokens (distinct from the workspace.invite_code shared secret)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{workspace_id}/invite-tokens", response_model=InviteTokenCreateResponse, status_code=201)
+async def create_invite_token(
+    workspace_id: UUID,
+    req: InviteTokenCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    if not await workspace_service.is_member(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    ws = await workspace_service.get_workspace(workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    row, raw = await invite_token_service.create_token(
+        workspace_id=workspace_id,
+        creator_id=current_user["id"],
+        max_uses=req.max_uses,
+        ttl_days=req.ttl_days,
+    )
+    return InviteTokenCreateResponse(
+        id=row["id"],
+        token=raw,
+        workspace_id=row["workspace_id"],
+        workspace_name=ws["name"],
+        max_uses=row["max_uses"],
+        expires_at=row["expires_at"],
+    )
+
+
+@router.get("/{workspace_id}/invite-tokens", response_model=InviteTokenListResponse)
+async def list_invite_tokens(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    if not await workspace_service.is_member(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    tokens = await invite_token_service.list_tokens(workspace_id)
+    return InviteTokenListResponse(tokens=[InviteTokenSummary(**t) for t in tokens])
+
+
+@router.delete("/{workspace_id}/invite-tokens/{token_id}", status_code=204)
+async def revoke_invite_token(
+    workspace_id: UUID,
+    token_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    role = await workspace_service.get_member_role(workspace_id, current_user["id"])
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Only owner/admin can revoke invite tokens")
+    ok = await invite_token_service.revoke_token(token_id, workspace_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Token not found or already revoked")
+
+

--- a/backend/services/invite_token_service.py
+++ b/backend/services/invite_token_service.py
@@ -1,0 +1,195 @@
+"""Workspace invite tokens: mint, list, revoke, redeem.
+
+Tokens are stored as sha256 hashes (raw token returned only at mint time),
+TTL-bounded, and usage-counted. This is the magic-link path — distinct from
+the forever-secret workspaces.invite_code used by `stash workspaces join`.
+"""
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from ..auth import generate_api_key, hash_api_key
+from ..database import get_pool
+from . import workspace_service
+
+TOKEN_PREFIX = "stash_inv_"
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _generate_token() -> str:
+    return TOKEN_PREFIX + secrets.token_urlsafe(32)
+
+
+async def create_token(
+    workspace_id: UUID,
+    creator_id: UUID,
+    max_uses: int = 1,
+    ttl_days: int = 7,
+) -> tuple[dict, str]:
+    """Mint a new invite token. Returns (row, raw_token). Raw is only seen once."""
+    pool = get_pool()
+    raw = _generate_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(days=ttl_days)
+    row = await pool.fetchrow(
+        "INSERT INTO workspace_invite_tokens "
+        "  (workspace_id, token_hash, max_uses, expires_at, created_by) "
+        "VALUES ($1, $2, $3, $4, $5) "
+        "RETURNING id, workspace_id, max_uses, uses_count, expires_at, created_at, revoked_at",
+        workspace_id,
+        _hash_token(raw),
+        max_uses,
+        expires_at,
+        creator_id,
+    )
+    return dict(row), raw
+
+
+async def list_tokens(workspace_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, max_uses, uses_count, expires_at, created_at, revoked_at "
+        "FROM workspace_invite_tokens "
+        "WHERE workspace_id = $1 "
+        "ORDER BY created_at DESC",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def revoke_token(token_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE workspace_invite_tokens SET revoked_at = now() "
+        "WHERE id = $1 AND workspace_id = $2 AND revoked_at IS NULL",
+        token_id,
+        workspace_id,
+    )
+    return result.endswith(" 1")
+
+
+async def _lookup_valid_token(raw: str) -> dict | None:
+    """Return the token row if it's usable, else None."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, max_uses, uses_count, expires_at, revoked_at "
+        "FROM workspace_invite_tokens "
+        "WHERE token_hash = $1",
+        _hash_token(raw),
+    )
+    if not row:
+        return None
+    if row["revoked_at"] is not None:
+        return None
+    if row["uses_count"] >= row["max_uses"]:
+        return None
+    if row["expires_at"] <= datetime.now(timezone.utc):
+        return None
+    return dict(row)
+
+
+async def _pick_unique_username(base: str) -> str:
+    """Find a unique `users.name` by suffixing -2, -3, ... on collision."""
+    pool = get_pool()
+    # Users.name is [a-zA-Z0-9_-]+, 1-64 chars. Sanitize the caller's display name.
+    import re
+
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", base).strip("-") or "teammate"
+    cleaned = cleaned[:60]  # leave room for a suffix
+    candidate = cleaned
+    for i in range(2, 1000):
+        exists = await pool.fetchval("SELECT 1 FROM users WHERE name = $1", candidate)
+        if not exists:
+            return candidate
+        candidate = f"{cleaned}-{i}"
+    # Fallback: append random suffix
+    return f"{cleaned}-{secrets.token_hex(3)}"
+
+
+async def redeem_as_new_user(raw_token: str, display_name: str) -> dict | None:
+    """Unauthenticated redeem: create a user, join workspace, return API key.
+
+    Returns None if the token is invalid/expired/exhausted/revoked.
+    """
+    token_row = await _lookup_valid_token(raw_token)
+    if not token_row:
+        return None
+
+    pool = get_pool()
+    api_key = generate_api_key()
+    key_hash = hash_api_key(api_key)
+    username = await _pick_unique_username(display_name)
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            user_row = await conn.fetchrow(
+                "INSERT INTO users (name, display_name, api_key_hash, description) "
+                "VALUES ($1, $2, $3, '') "
+                "RETURNING id, name, display_name",
+                username,
+                display_name[:128],
+                key_hash,
+            )
+            # Mark token as consumed first — if the join/member insert somehow fails
+            # we don't want the token to stay usable.
+            consumed = await conn.execute(
+                "UPDATE workspace_invite_tokens SET uses_count = uses_count + 1 "
+                "WHERE id = $1 AND uses_count < max_uses "
+                "  AND revoked_at IS NULL AND expires_at > now()",
+                token_row["id"],
+            )
+            if not consumed.endswith(" 1"):
+                raise RuntimeError("invite token was consumed concurrently")
+            await conn.execute(
+                "INSERT INTO workspace_members (workspace_id, user_id, role) "
+                "VALUES ($1, $2, 'member')",
+                token_row["workspace_id"],
+                user_row["id"],
+            )
+
+    ws = await workspace_service.get_workspace(token_row["workspace_id"])
+    return {
+        "api_key": api_key,
+        "user_id": user_row["id"],
+        "username": user_row["name"],
+        "display_name": user_row["display_name"],
+        "workspace_id": ws["id"],
+        "workspace_name": ws["name"],
+    }
+
+
+async def redeem_as_existing_user(raw_token: str, user_id: UUID) -> dict | None:
+    """Authenticated redeem: join the existing user to the workspace.
+
+    Returns the workspace dict, or None if the token is invalid/exhausted.
+    If the user is already a member, we still consume a use but return success.
+    """
+    token_row = await _lookup_valid_token(raw_token)
+    if not token_row:
+        return None
+
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            consumed = await conn.execute(
+                "UPDATE workspace_invite_tokens SET uses_count = uses_count + 1 "
+                "WHERE id = $1 AND uses_count < max_uses "
+                "  AND revoked_at IS NULL AND expires_at > now()",
+                token_row["id"],
+            )
+            if not consumed.endswith(" 1"):
+                raise RuntimeError("invite token was consumed concurrently")
+            # Idempotent membership insert.
+            await conn.execute(
+                "INSERT INTO workspace_members (workspace_id, user_id, role) "
+                "VALUES ($1, $2, 'member') "
+                "ON CONFLICT (workspace_id, user_id) DO NOTHING",
+                token_row["workspace_id"],
+                user_id,
+            )
+
+    return await workspace_service.get_workspace(token_row["workspace_id"])

--- a/cli/client.py
+++ b/cli/client.py
@@ -107,6 +107,43 @@ class StashClient:
     def workspace_members(self, workspace_id: str) -> list:
         return self._get(f"/api/v1/workspaces/{workspace_id}/members")
 
+    # --- Magic-link invite tokens ---
+
+    def create_invite_token(
+        self, workspace_id: str, max_uses: int = 1, ttl_days: int = 7
+    ) -> dict:
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/invite-tokens",
+            json={"max_uses": max_uses, "ttl_days": ttl_days},
+        )
+
+    def list_invite_tokens(self, workspace_id: str) -> list:
+        return self._list(f"/api/v1/workspaces/{workspace_id}/invite-tokens", "tokens")
+
+    def revoke_invite_token(self, workspace_id: str, token_id: str) -> None:
+        self._delete(f"/api/v1/workspaces/{workspace_id}/invite-tokens/{token_id}")
+
+    def redeem_invite_authed(self, token: str) -> dict:
+        return self._post("/api/v1/workspaces/redeem-invite", json={"token": token})
+
+    @staticmethod
+    def redeem_invite_unauthenticated(base_url: str, token: str, display_name: str) -> dict:
+        """One-shot, no api_key required — creates a new user + joins workspace."""
+        resp = httpx.post(
+            f"{base_url.rstrip('/')}/api/v1/users/cli-auth/redeem-invite",
+            json={"token": token, "display_name": display_name},
+            timeout=30,
+            follow_redirects=True,
+        )
+        if not resp.is_success:
+            detail = ""
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise StashError(resp.status_code, detail)
+        return resp.json()
+
     # --- Chats (workspace-scoped) ---
 
     def create_chat(self, workspace_id: str, name: str, description: str = "") -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -209,6 +209,125 @@ def ws_members(
 
 
 # ===========================================================================
+# Magic-link invites
+# ===========================================================================
+
+invite_app = typer.Typer(
+    help="Magic-link invites — single-use, TTL-bounded tokens for zero-friction workspace onboarding.",
+    invoke_without_command=True,
+)
+app.add_typer(invite_app, name="invite")
+
+
+def _format_invite_share_block(
+    token: str, base_url: str, workspace_name: str, max_uses: int, expires_at: str
+) -> str:
+    """The prose the sender copies into Slack/DMs to share a workspace."""
+    uses_blurb = "single-use" if max_uses == 1 else f"up to {max_uses} uses"
+    return (
+        f"Hey — I'm inviting you to my Stash workspace (\"{workspace_name}\").\n"
+        "Stash is a shared memory layer for our coding agents, so we can see\n"
+        "what each other is working on.\n"
+        "\n"
+        "To join, paste this into your coding agent (or run it yourself):\n"
+        "\n"
+        f"  pipx install stash-cli && \\\n"
+        f"    stash connect --invite {token} --endpoint {base_url.rstrip('/')}\n"
+        "\n"
+        "You'll be prompted for a display name. No browser sign-in needed.\n"
+        f"({uses_blurb}, expires {expires_at})\n"
+    )
+
+
+@invite_app.callback()
+def invite_default(
+    ctx: typer.Context,
+    workspace_id: str = typer.Option(None, "--ws"),
+    uses: int = typer.Option(1, "--uses", help="Maximum times the link can be redeemed."),
+    days: int = typer.Option(7, "--days", help="Days until the link expires."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Mint a shareable invite link for a workspace (default: your default workspace)."""
+    if ctx.invoked_subcommand is not None:
+        return
+    ws = workspace_id or _default_workspace()
+    cfg = load_config()
+    with _client() as c:
+        try:
+            data = c.create_invite_token(ws, max_uses=uses, ttl_days=days)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+        return
+    share_block = _format_invite_share_block(
+        token=data["token"],
+        base_url=cfg.get("base_url", ""),
+        workspace_name=data["workspace_name"],
+        max_uses=data["max_uses"],
+        expires_at=str(data["expires_at"])[:10],
+    )
+    console.print(
+        f"\n[green]Generated invite for [bold]{data['workspace_name']}[/bold][/green]"
+        f"  [dim](id: {data['id']})[/dim]\n"
+    )
+    console.print(
+        Panel(
+            share_block,
+            title="[bold]Copy this and send it to a teammate[/bold]",
+            border_style="green",
+            padding=(1, 2),
+        )
+    )
+    console.print(
+        "\n[dim]Revoke anytime with:[/dim] "
+        f"[cyan]stash invite revoke {data['id']}[/cyan]\n"
+    )
+
+
+@invite_app.command("list")
+def invite_list(
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """List active invite tokens for a workspace."""
+    ws = workspace_id or _default_workspace()
+    with _client() as c:
+        try:
+            tokens = c.list_invite_tokens(ws)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(tokens)
+        return
+    if not tokens:
+        console.print("[dim]No invite tokens.[/dim]")
+        return
+    console.print(f"[bold]Invite tokens for workspace {ws[:8]}…[/bold]\n")
+    for t in tokens:
+        status = "revoked" if t.get("revoked_at") else f"{t['uses_count']}/{t['max_uses']} used"
+        console.print(
+            f"  [dim]{str(t['id'])[:8]}…[/dim]  {status}  "
+            f"expires {str(t['expires_at'])[:10]}"
+        )
+
+
+@invite_app.command("revoke")
+def invite_revoke(
+    token_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Revoke an invite token so it can no longer be redeemed."""
+    ws = workspace_id or _default_workspace()
+    with _client() as c:
+        try:
+            c.revoke_invite_token(ws, token_id)
+        except StashError as e:
+            _err(e)
+    console.print(f"[green]Revoked invite token {token_id[:8]}…[/green]")
+
+
+# ===========================================================================
 # Notebooks
 # ===========================================================================
 
@@ -982,9 +1101,104 @@ def _self_host_walkthrough(cfg: dict) -> str:
 
 
 
+def _git_or_env_username_default() -> str:
+    """Best-effort default for the display name prompt on magic-link redeem."""
+    import os
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            capture_output=True, text=True, timeout=2,
+        )
+        candidate = out.stdout.strip()
+        if candidate:
+            return candidate
+    except Exception:
+        pass
+    return os.environ.get("USER") or os.environ.get("USERNAME") or "teammate"
+
+
+def _connect_via_invite(token: str, endpoint: str | None, scope_flag: str | None) -> None:
+    """Non-interactive connect path: redeem a magic-link token, save config, show splash.
+
+    Auto-detects whether the user already has a stash account on this machine and
+    picks the authenticated or unauthenticated redeem endpoint accordingly.
+    """
+    cfg = load_config()
+    base_url = (endpoint or cfg.get("base_url") or "").rstrip("/")
+    if not base_url:
+        console.print(
+            "[red]--endpoint is required (or run `stash connect` once without --invite first).[/red]"
+        )
+        raise typer.Exit(1)
+    scope = scope_flag or "user"
+
+    existing_key = cfg.get("api_key", "")
+    if existing_key:
+        # Authenticated redeem — just join the workspace on top of existing identity.
+        try:
+            with StashClient(base_url=base_url, api_key=existing_key) as c:
+                ws = c.redeem_invite_authed(token)
+        except StashError as e:
+            console.print(f"[red]Could not redeem invite: {e.detail}[/red]")
+            raise typer.Exit(1)
+        save_config(base_url=base_url, default_workspace=str(ws["id"]), scope=scope)
+        _show_setup_complete_splash(
+            workspace_name=ws["name"], joined_via_invite=True
+        )
+        return
+
+    # No existing auth — unauthenticated redeem creates a fresh user.
+    default_name = _git_or_env_username_default()
+    _reserve_bottom_padding(4)
+    display_name = typer.prompt(
+        "What display name should your teammates see?", default=default_name
+    ).strip()
+    if not display_name:
+        console.print("[red]Display name is required.[/red]")
+        raise typer.Exit(1)
+
+    try:
+        result = StashClient.redeem_invite_unauthenticated(
+            base_url=base_url, token=token, display_name=display_name
+        )
+    except StashError as e:
+        console.print(f"[red]Could not redeem invite: {e.detail}[/red]")
+        raise typer.Exit(1)
+
+    save_config(
+        base_url=base_url,
+        api_key=result["api_key"],
+        username=result["username"],
+        default_workspace=str(result["workspace_id"]),
+        scope=scope,
+    )
+    console.print(
+        f"  [green]✓[/green] Signed in as [bold]{result.get('display_name') or result['username']}[/bold]"
+    )
+    _show_setup_complete_splash(
+        workspace_name=result["workspace_name"], joined_via_invite=True
+    )
+
+
 @app.command("connect")
-def connect():
+def connect(
+    invite: str = typer.Option(
+        None, "--invite", help="Redeem a magic-link invite token (skips the interactive flow)."
+    ),
+    endpoint: str = typer.Option(
+        None, "--endpoint", help="Stash API URL (required with --invite if not already configured)."
+    ),
+    scope: str = typer.Option(
+        None, "--scope", help="Where to write config (user | project). Only used with --invite."
+    ),
+):
     """Interactive first-time setup. Sets base URL, authenticates, and configures defaults."""
+    if invite:
+        _connect_via_invite(token=invite, endpoint=endpoint, scope_flag=scope)
+        return
+
     console.print("\n[bold]Stash connect[/bold]  (press Enter to accept defaults)\n")
 
     # --- Step 0: Scope ---
@@ -1172,11 +1386,18 @@ STASH_LOGO = r"""
 """
 
 
-def _show_setup_complete_splash() -> None:
+def _show_setup_complete_splash(
+    workspace_name: str = "", joined_via_invite: bool = False
+) -> None:
     """Clear the onboarding transcript and show a clean success splash."""
     console.clear()
     console.print(f"[bold cyan]{STASH_LOGO}[/bold cyan]")
-    console.print("  [bold green]You're all set up.[/bold green]\n")
+    if joined_via_invite and workspace_name:
+        console.print(
+            f"  [bold green]You joined[/bold green] [bold]{workspace_name}[/bold].\n"
+        )
+    else:
+        console.print("  [bold green]You're all set up.[/bold green]\n")
 
     body = (
         "[bold]What just happened[/bold]\n"
@@ -1225,6 +1446,25 @@ def _show_setup_complete_splash() -> None:
             padding=(1, 2),
         )
     )
+
+    if joined_via_invite and workspace_name:
+        joined_body = (
+            f"You're now a member of [bold]{workspace_name}[/bold] and your default\n"
+            "workspace is set. Try one of these to see what your teammates are up to:\n"
+            "\n"
+            "  [cyan]stash history agents[/cyan]           who's been active in this workspace\n"
+            '  [cyan]stash history search "<query>"[/cyan]   full-text search across transcripts\n'
+            "  [cyan]stash history query --limit 20[/cyan]    latest events in your new workspace"
+        )
+        console.print(
+            Panel(
+                joined_body,
+                title=f"[bold]Welcome to {workspace_name}[/bold]",
+                border_style="green",
+                padding=(1, 2),
+            )
+        )
+
     console.print()
 
 


### PR DESCRIPTION
## Summary

Replaces the two-step \"share an invite link → recipient runs stash connect separately\" dance with a single copy-pasteable block that the recipient's coding agent can execute to be signed up and added to the sender's workspace — no browser sign-in, no account creation flow.

### Sender
```
$ stash invite
Generated invite for "acme-eng" (id: 8f3a...)

──── Copy this and send it to a teammate ────
Hey — I'm inviting you to my Stash workspace ("acme-eng")...
  pipx install stash-cli && \
    stash connect --invite stash_inv_... --endpoint https://moltchat.onrender.com
...
```
Plus \`stash invite list\` and \`stash invite revoke <id>\`.

### Recipient
\`stash connect --invite <TOKEN> --endpoint <URL>\` skips scope/endpoint/browser/workspace steps, prompts only for a display name (default = \`git config user.name\`), creates a user, joins the workspace, saves config, shows a \"Welcome to <ws>\" splash variant. If the recipient already has a stash account, it takes the authenticated redeem path instead and just joins the existing identity to the workspace.

## What's in this PR

**Backend**
- Migration 0008: \`workspace_invite_tokens\` (hashed tokens, \`max_uses\`, \`expires_at\`, \`revoked_at\`, \`created_by\`).
- \`invite_token_service\`: create / list / revoke / \`redeem_as_new_user\` / \`redeem_as_existing_user\`. Redemption is transactional and atomically consumes a use before joining so concurrent redeems can't exceed \`max_uses\`.
- Routes: \`POST/GET /workspaces/{id}/invite-tokens\`, \`DELETE /.../{token_id}\`, \`POST /workspaces/redeem-invite\` (authed), \`POST /users/cli-auth/redeem-invite\` (unauthenticated — creates the fresh user + joins).

**CLI**
- \`stash invite\` sub-app (default mints, \`list\`, \`revoke\`).
- \`stash connect --invite <TOKEN> [--endpoint URL] [--scope user|project]\`.
- New \`_connect_via_invite\` helper auto-picks authenticated vs unauthenticated redeem based on existing \`api_key\` in config.
- Splash gains optional \`workspace_name\` + \`joined_via_invite\` params; when set, renders a \"Welcome to <ws>\" green panel with history-search hints.

## Security

- Tokens are sha256-hashed at rest (like API keys — raw returned only at mint time).
- Default 1-use, 7-day TTL. Both configurable via \`--uses N\` and \`--days N\` (capped at 1000/90 server-side).
- Revocable via \`stash invite revoke\` (sets \`revoked_at\`; validity check excludes revoked tokens).
- Display-name collisions auto-suffix (\`alice → alice-2 → …\`).
- Only members can mint/list; only owner/admin can revoke.

## Tradeoffs

- The coexisting forever-secret \`workspaces.invite_code\` + \`stash workspaces join <code>\` flow is untouched — this is additive, not a replacement.
- Plugin install for the recipient's coding agent (claude/codex/cursor/etc) is still a separate step; called out in the plan as a follow-up.

## Test plan
- [ ] Run alembic \`upgrade head\` against a fresh DB — 0008 applies cleanly.
- [ ] Sender: \`stash invite\` mints, prints a share block with the right endpoint + token.
- [ ] Recipient on a fresh machine: \`stash connect --invite <T> --endpoint <URL>\` prompts for display name, signs in, lands on the \"Welcome to <ws>\" splash.
- [ ] Recipient with existing config: same command just adds the workspace and skips the display-name prompt.
- [ ] Token exhausted: second redeem returns 404 \"invalid, expired, or exhausted\".
- [ ] Revoked token: redeem returns 404.
- [ ] Expired token: redeem returns 404.
- [ ] Concurrent redeem of a 1-use token: exactly one succeeds (transactional consume).
- [ ] \`stash invite list\` shows uses_count / revoked status correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)