### PR TITLE
chore: rename PyPI package stash-cli → stashai

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish stash-cli to PyPI
+name: Publish stashai to PyPI
 
 on:
   push:

--- a/cli/main.py
+++ b/cli/main.py
@@ -226,7 +226,7 @@ def _format_invite_share_block(
     uses_blurb = "single-use" if max_uses == 1 else f"up to {max_uses} uses"
     return (
         "\n"
-        f"  pipx install stash-cli && \\\n"
+        f"  pipx install stashai && \\\n"
         f"    stash connect --invite {token} --endpoint {base_url.rstrip('/')}\n"
         "\n"
     )

--- a/plugins/openclaw-plugin/HOOK.md
+++ b/plugins/openclaw-plugin/HOOK.md
@@ -47,7 +47,7 @@ transcription.
 - Openclaw `>= 0.9` (internal hooks API)
 - Python 3.10+ on PATH (this hook shells out to Python for the Stash API client)
 - `httpx` installed (`pip install httpx`)
-- `stash` CLI logged in (`pip install stash-cli && stash connect`)
+- `stash` CLI logged in (`pip install stashai && stash connect`)
 - `stash config default_workspace <id>` set
 
 ## Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "stash-cli"
+name = "stashai"
 version = "0.1.0"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"


### PR DESCRIPTION
PyPI rejected \`stash-cli\` as too similar to the existing \`stash\` package. \`stashai\` passes the similarity check and is already registered as a pending Trusted Publisher. Install becomes \`pipx install stashai && stash <cmd>\`.

Raced #89's merge by ~1 second, so this is the leftover commit.

Auto-merge enabled so the first PyPI release can go out.