### PR TITLE
chore(plugin): bump Claude plugin version to 0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "productivity",
       "homepage": "https://stash.ac",
       "author": {

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Connect Claude Code to Stash — stream activity to history and collaborate in workspaces.",
   "author": {
     "name": "Fergana Labs"


### PR DESCRIPTION
## Summary
- PR #94 shipped the shared-hook-library packaging fix on merge commit `1ecf8b5` but left `.claude-plugin/marketplace.json` and `plugins/claude-plugin/.claude-plugin/plugin.json` at `0.1.0`.
- Result: `claude plugin update stash` is a no-op for everyone still running the broken version — they'd have to `uninstall` + `install` to pick up the fix (verified during the PR 94 post-merge test).
- Bump both to `0.1.1` so a plain `claude plugin update stash` picks up the packaging fix.

## Test plan
- [ ] After merge, run `claude plugin marketplace update stash-plugins && claude plugin update stash` — should report an update to `0.1.1` instead of "already at latest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)