### PR TITLE
feat(cli): surface scope + install_repo in stash status

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1614,6 +1614,8 @@ def status(as_json: bool = typer.Option(False, "--json")):
     streaming_enabled = bool(central.get("streaming_enabled", True))
     auto_curate = bool(central.get("auto_curate", True))
     last_curate_at = central.get("last_curate_at")
+    scope = (central.get("scope") or "repo").strip().lower()
+    install_repo = central.get("install_repo_common_dir") or ""
 
     plugins_seen = [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()]
 
@@ -1625,6 +1627,8 @@ def status(as_json: bool = typer.Option(False, "--json")):
                 "auto_curate": auto_curate,
                 "last_curate_at": last_curate_at,
                 "plugins_installed": plugins_seen,
+                "scope": scope,
+                "install_repo_common_dir": install_repo,
             }
         )
         return
@@ -1646,6 +1650,9 @@ def status(as_json: bool = typer.Option(False, "--json")):
     else:
         console.print("  Last curate: (never)")
     console.print(f"  Plugins installed: {', '.join(plugins_seen) or '(none detected)'}")
+    console.print(f"  Scope:      {scope}")
+    if scope == "repo":
+        console.print(f"  Install repo: {install_repo or '(none)'}")
 
 
 @app.command("disconnect")


### PR DESCRIPTION
## Summary
- When \`scope=repo\` (default) and \`install_repo_common_dir\` is empty, \`cwd_in_scope\` returns False for every event — hooks drop silently. Neither field was shown in \`stash status\`, so the failure mode is invisible.
- Add both to the human-readable output (only show \`Install repo\` when scope is \`repo\`, since it's irrelevant for \`all\`/\`workspace\`).
- Also add both to the \`--json\` output.

## Test plan
- [x] \`stash status\` — shows new \`Scope\` and \`Install repo\` lines
- [x] \`stash status --json\` — includes \`scope\` and \`install_repo_common_dir\` at top level

🤖 Generated with [Claude Code](https://claude.com/claude-code)