### PR TITLE
fix(www): rename middleware.ts → proxy.ts (unblocks /auth/login on prod)

### DIFF
--- a/www/proxy.ts
+++ b/www/proxy.ts
@@ -2,7 +2,9 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
-export async function middleware(request: NextRequest) {
+// Next.js 16 renamed `middleware` → `proxy`; the export must also be named
+// `proxy` for the convention to apply.
+export async function proxy(request: NextRequest) {
   if (!AUTH0_ENABLED) return NextResponse.next();
   const { runAuth0Middleware } = await import("@managed/auth0/middleware");
   return runAuth0Middleware(request);


### PR DESCRIPTION
## Summary

Hotfix for #103. After deploy, `stash.ac/connect-token` correctly redirects to `/auth/login`, but `/auth/login` itself 404s because the Auth0 middleware isn't intercepting auth routes.

Root cause: Next 16 deprecated the `middleware` file convention in favor of `proxy` (build emitted a deprecation warning). Combined with `NEXT_PUBLIC_*` env vars being inlined into the edge bundle at build time and the prior production build having a stale `"true\n"` value baked in (my fault — the original `vercel env add` via `echo "value" |` appended a newline), the previous deployment's edge bundle never re-evaluated `AUTH0_ENABLED === "true"` correctly even after the env var was fixed in the project settings.

This rename forces a fresh edge bundle compile with the cleaned env value, and aligns with the new convention so the warning goes away.

## Test plan

- [x] `npm run build` succeeds
- [ ] After merge: `curl -sI https://stash.ac/auth/login` returns 302 → Auth0 (not 404)
- [ ] Manual: visit `stash.ac/connect-token`, sign in via Auth0, see the token render

🤖 Generated with [Claude Code](https://claude.com/claude-code)