### PR TITLE
feat(www): port docs into landing site

### DIFF
--- a/www/app/docs/api/page.tsx
+++ b/www/app/docs/api/page.tsx
@@ -1,0 +1,132 @@
+import { Callout, Code, CodeBlock, H3, P, Title, Subtitle } from "../components";
+
+export default function APIPage() {
+  return (
+    <>
+      <Title>REST API</Title>
+      <Subtitle>
+        Complete HTTP API for all Stash resources. All endpoints are versioned under{" "}
+        <Code>{"https://stash.ac/api/v1"}</Code>.
+      </Subtitle>
+
+      <Callout type="info">
+        <strong>Authentication</strong> — include{" "}
+        <code className="font-mono text-[13px]">Authorization: Bearer {"<api_key>"}</code> on every request.
+        Get your API key from the settings page or via <Code>POST /auth/login</Code>.
+        <br /><br />
+        <strong>OpenAPI spec</strong> — the full interactive spec is available at{" "}
+        <Code>/docs</Code> on your backend instance (or{" "}
+        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">stash.ac/docs</a>
+        ).
+      </Callout>
+
+      <H3>Auth</H3>
+      <CodeBlock>{`POST   /users/register      Register a new user — returns api_key
+POST   /users/login         Password login — returns api_key
+GET    /users/me            Current user profile
+PATCH  /users/me            Update profile (name, avatar, etc.)`}</CodeBlock>
+
+      <H3>Workspaces</H3>
+      <CodeBlock>{`POST   /workspaces              Create a new workspace
+GET    /workspaces              List all public workspaces
+GET    /workspaces/mine         List workspaces you're a member of
+POST   /workspaces/{ws}/join    Join by invite code
+GET    /workspaces/{ws}         Workspace details and metadata
+GET    /workspaces/{ws}/members List workspace members with roles`}</CodeBlock>
+
+      <H3>Notebooks & pages</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/notebooks                          Create notebook
+GET    /workspaces/{ws}/notebooks/{nb}/pages               Page tree (folders + pages)
+POST   /workspaces/{ws}/notebooks/{nb}/pages               Create a page
+GET    /workspaces/{ws}/notebooks/{nb}/pages/{id}          Read a page
+PATCH  /workspaces/{ws}/notebooks/{nb}/pages/{id}          Update a page
+DELETE /workspaces/{ws}/notebooks/{nb}/pages/{id}          Delete a page
+
+GET    /workspaces/{ws}/notebooks/{nb}/pages/{id}/backlinks Incoming links
+GET    /workspaces/{ws}/notebooks/{nb}/pages/{id}/outlinks  Outgoing links
+GET    /workspaces/{ws}/notebooks/{nb}/graph               Page link graph (nodes + edges)
+
+GET    /workspaces/{ws}/notebooks/{nb}/pages/semantic-search?q=   Semantic search`}</CodeBlock>
+
+      <H3>History stores</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/memory                              Create store
+POST   /workspaces/{ws}/memory/{store}/events               Push a single event
+POST   /workspaces/{ws}/memory/{store}/events/batch         Push a batch of events
+GET    /workspaces/{ws}/memory/{store}/events               Query events (filter, paginate)
+GET    /workspaces/{ws}/memory/{store}/events/search?q=     Full-text search
+POST   /workspaces/{ws}/memory/{store}/query                LLM synthesis over events`}</CodeBlock>
+
+      <H3>Universal search</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/search      Workspace-scoped search across all resources
+POST   /me/search                   Personal search (outside any workspace)`}</CodeBlock>
+      <P>
+        Both accept a <Code>{"{ query, types, limit }"}</Code> body. Set{" "}
+        <Code>types</Code> to filter by resource (e.g. <Code>{`"history,notebook,table"`}</Code>).
+      </P>
+
+      <H3>Files</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/files          Upload a file (multipart/form-data)
+GET    /workspaces/{ws}/files          List files
+GET    /workspaces/{ws}/files/{id}     Get file metadata + presigned download URL
+DELETE /workspaces/{ws}/files/{id}     Delete a file`}</CodeBlock>
+
+      <H3>Tables & rows</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/tables                               Create table
+GET    /workspaces/{ws}/tables                               List tables
+GET    /workspaces/{ws}/tables/{tbl}                         Table schema + metadata
+POST   /workspaces/{ws}/tables/{tbl}/rows                    Create a row
+GET    /workspaces/{ws}/tables/{tbl}/rows                    Query rows (filter, sort, paginate)
+PATCH  /workspaces/{ws}/tables/{tbl}/rows/{id}               Update a row
+DELETE /workspaces/{ws}/tables/{tbl}/rows/{id}               Delete a row
+
+GET    /workspaces/{ws}/tables/{tbl}/rows/semantic-search?q= Semantic search
+PUT    /workspaces/{ws}/tables/{tbl}/embedding               Configure row embeddings
+POST   /workspaces/{ws}/tables/{tbl}/embedding/backfill      Backfill embeddings for existing rows`}</CodeBlock>
+
+      <H3>Permissions</H3>
+      <P>
+        Every workspace resource has a visibility setting. Set it with a{" "}
+        <Code>PATCH</Code> on the resource or via the dedicated visibility endpoint:
+      </P>
+      <CodeBlock>{`PUT /workspaces/{ws}/{resource_type}/{id}/visibility
+body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { v: "inherit", desc: "Default. All workspace members have access (read + write based on role)." },
+          { v: "private", desc: "Only explicitly shared users. Grant access with POST /share." },
+          { v: "public", desc: "Anyone with the URL can read. No auth required." },
+        ].map((r) => (
+          <div key={r.v} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground font-mono w-24 flex-shrink-0">{r.v}</span>
+            <p className="text-[14px] text-dim leading-6">{r.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      <H3>Rate limits</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { endpoint: "REST reads", limit: "60 requests / minute" },
+          { endpoint: "File upload", limit: "10 requests / minute" },
+          { endpoint: "Auth endpoints", limit: "20 requests / minute" },
+        ].map((r) => (
+          <div key={r.endpoint} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground w-56 flex-shrink-0">{r.endpoint}</span>
+            <span className="text-[13px] text-dim font-mono">{r.limit}</span>
+          </div>
+        ))}
+      </div>
+
+      <H3>Personal endpoints</H3>
+      <P>
+        Most workspace-scoped endpoints have a personal variant. For notebooks, for example:{" "}
+        <Code>/me/notebooks</Code>. Personal endpoints return resources not tied to any workspace.
+        Full list available in the{" "}
+        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">
+          OpenAPI spec
+        </a>
+        .
+      </P>
+    </>
+  );
+}

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -1,0 +1,69 @@
+import { Callout, Code, CodeBlock, H3, P, Title, Subtitle } from "../components";
+
+export default function CLIPage() {
+  return (
+    <>
+      <Title>CLI Reference</Title>
+      <Subtitle>
+        A command-line interface for managing Stash from your terminal — push history events
+        and manage all resources.
+      </Subtitle>
+
+      <H3>Install</H3>
+      <CodeBlock>{`pip install stash`}</CodeBlock>
+
+      <H3>First-time setup</H3>
+      <P>
+        Run the interactive setup wizard. It configures the API endpoint, authenticates you
+        (login or register), creates a workspace, and creates a default history store — all in
+        one shot. No manual config editing required.
+      </P>
+      <CodeBlock>{`stash connect`}</CodeBlock>
+      <P>
+        The wizard saves everything to <Code>~/.stash/config.json</Code>. Once complete,
+        commands like <Code>stash history push</Code> work without extra flags.
+      </P>
+
+      <H3>Auth commands</H3>
+      <CodeBlock>{`stash login                             # Password login
+stash auth <url> --api-key <key>        # Authenticate using an existing API key
+stash whoami                            # Show the current logged-in user
+stash config [key] [value]              # View or update any config value`}</CodeBlock>
+
+      <Callout>
+        After <Code>stash connect</Code>, your defaults are stored. You can still override
+        any value: e.g. <Code>stash config base_url https://stash.ac</Code> or set{" "}
+        <Code>STASH_API_KEY</Code> / <Code>STASH_URL</Code> as environment variables for
+        CI and scripts.
+      </Callout>
+
+      <H3>Search</H3>
+      <CodeBlock>{`# Universal search across all data types
+stash search <query>
+  --ws <workspace_id>          Scope to a workspace
+  --types history,notebook,table   Filter by resource type`}</CodeBlock>
+
+      <H3>Notebooks</H3>
+      <CodeBlock>{`stash notebooks list [--ws ID] [--all]
+stash notebooks create <name> [--ws ID] [--personal]
+stash notebooks pages <notebook_id> [--ws ID]
+stash notebooks add-page <nb_id> <name> [--content "..."]
+stash notebooks read-page <nb_id> <page_id>
+stash notebooks edit-page <nb_id> <page_id> --content "..."`}</CodeBlock>
+
+      <H3>History stores</H3>
+      <CodeBlock>{`stash history list [--ws ID] [--all]
+stash history create <name> [--ws ID]
+stash history push <content> [--store ID] [--agent cli] [--type message]
+stash history query [--store ID] [--agent X] [--type Y] [-n 50]
+stash history search <query> [--store ID]`}</CodeBlock>
+
+      <H3>Tables</H3>
+      <P>
+        Full CRUD for tables is available. Run{" "}
+        <Code>stash --help</Code> for the complete command tree, or{" "}
+        <Code>stash &lt;command&gt; --help</Code> for options on any subcommand.
+      </P>
+    </>
+  );
+}

--- a/www/app/docs/components.tsx
+++ b/www/app/docs/components.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+
+function slugify(children: React.ReactNode) {
+  const text = String(children)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return text || "section";
+}
+
+export function Callout({ children, type = "info" }: { children: React.ReactNode; type?: "info" | "tip" | "warning" }) {
+  const styles = {
+    info: "border-brand/30 bg-brand/5",
+    tip: "border-green-500/30 bg-green-500/5",
+    warning: "border-yellow-500/30 bg-yellow-500/5",
+  };
+  return (
+    <div className={`border rounded-2xl px-5 py-4 my-6 ${styles[type]}`}>
+      <div className="text-[15px] leading-7 text-dim">{children}</div>
+    </div>
+  );
+}
+
+export function CodeTabs({ tabs }: { tabs: { label: string; code: string }[] }) {
+  const [active, setActive] = useState(0);
+  return (
+    <div className="my-6 rounded-2xl border border-border overflow-hidden bg-surface">
+      <div className="flex border-b border-border">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.label}
+            onClick={() => setActive(i)}
+            className={`px-4 py-3 text-xs font-medium transition-colors ${
+              i === active ? "text-foreground bg-base border-b-2 border-brand" : "text-muted hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <pre className="bg-base p-5 overflow-x-auto text-sm text-dim font-mono">
+        <code>{tabs[active].code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function Code({ children }: { children: React.ReactNode }) {
+  return <code className="bg-surface text-brand px-1.5 py-0.5 rounded-md text-[13px] font-mono">{children}</code>;
+}
+
+export function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="bg-surface border border-border rounded-2xl p-5 overflow-x-auto text-sm text-dim my-6 font-mono">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export function H2({ children }: { children: React.ReactNode }) {
+  const id = slugify(children);
+  return (
+    <h2
+      id={id}
+      data-docs-heading
+      data-docs-level="2"
+      data-docs-label={String(children)}
+      className="scroll-mt-24 text-2xl font-semibold text-foreground mt-12 mb-4 font-display"
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function H3({ children }: { children: React.ReactNode }) {
+  const id = slugify(children);
+  return (
+    <h3
+      id={id}
+      data-docs-heading
+      data-docs-level="3"
+      data-docs-label={String(children)}
+      className="scroll-mt-24 text-xl font-semibold text-foreground mt-10 mb-3"
+    >
+      {children}
+    </h3>
+  );
+}
+
+export function P({ children }: { children: React.ReactNode }) {
+  return <p className="text-[15px] text-dim leading-7 mb-4">{children}</p>;
+}
+
+export function ParamTable({ params }: { params: { name: string; type: string; desc: string; required?: boolean }[] }) {
+  return (
+    <div className="my-6 border border-border rounded-2xl overflow-hidden bg-surface">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-raised">
+            <th className="text-left px-4 py-3 text-xs font-medium text-muted uppercase tracking-wider">Parameter</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-muted uppercase tracking-wider">Type</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-muted uppercase tracking-wider">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {params.map((p) => (
+            <tr key={p.name} className="border-t border-border">
+              <td className="px-4 py-3 font-mono text-foreground text-xs align-top">
+                {p.name}{p.required && <span className="text-red-400 ml-1">*</span>}
+              </td>
+              <td className="px-4 py-3 text-muted text-xs align-top">{p.type}</td>
+              <td className="px-4 py-3 text-dim text-xs leading-6">{p.desc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function Title({ children }: { children: React.ReactNode }) {
+  const id = slugify(children);
+  return (
+    <h1
+      id={id}
+      data-docs-heading
+      data-docs-level="1"
+      data-docs-label={String(children)}
+      className="scroll-mt-24 text-4xl sm:text-5xl font-bold text-foreground font-display tracking-tight mb-4"
+    >
+      {children}
+    </h1>
+  );
+}
+
+export function Subtitle({ children }: { children: React.ReactNode }) {
+  return <p className="text-lg text-dim leading-8 max-w-2xl mb-10">{children}</p>;
+}

--- a/www/app/docs/concepts/page.tsx
+++ b/www/app/docs/concepts/page.tsx
@@ -1,0 +1,75 @@
+import { Code, P, Title, Subtitle } from "../components";
+
+const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.ReactNode }[] = [
+  {
+    name: "Workspace",
+    badge: "Container",
+    badgeColor: "bg-blue-500/10 text-blue-500",
+    desc: "Top-level permissioned container. Members share all resources — notebooks, history stores, tables, files. Invite others with a short code. Set visibility to public or private.",
+  },
+  {
+    name: "History Store",
+    badge: "History",
+    badgeColor: "bg-brand/10 text-brand",
+    desc: "Append-only event log. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text and semantic search.",
+  },
+  {
+    name: "Notebook",
+    badge: "Wiki",
+    badgeColor: "bg-green-500/10 text-green-600",
+    desc: (
+      <>
+        Wiki-style markdown pages organized in folders. Supports{" "}
+        <Code>{"[[Page Name]]"}</Code> wiki links with backlinks, page graph visualization, and semantic
+        search. Rich-text editor with autosave. The curation tool writes here when invoked.
+      </>
+    ),
+  },
+  {
+    name: "Table",
+    badge: "Wiki",
+    badgeColor: "bg-green-500/10 text-green-600",
+    desc: "Structured data with typed columns (text, number, date, select, etc.). Filters, sorting, views, CSV import/export. Optional row embeddings for semantic search — configure which columns to embed.",
+  },
+  {
+    name: "File",
+    badge: "Attachment",
+    badgeColor: "bg-muted/20 text-muted",
+    desc: "Images, PDFs, and documents stored in S3-compatible storage (Cloudflare R2, AWS S3, or MinIO). Uploadable as attachments via the API or notebook editor.",
+  },
+  {
+    name: "Search",
+    badge: "Cross-cutting",
+    badgeColor: "bg-muted/20 text-muted",
+    desc: "Universal cross-resource AI search. Ask a natural language question and get a synthesized answer across notebooks, tables, history, and files. Supports workspace scoping and resource type filtering.",
+  },
+  {
+    name: "Curation",
+    badge: "Tool",
+    badgeColor: "bg-amber-500/10 text-amber-600",
+    desc: "CLI command that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Run it whenever you want your knowledge base tidied up.",
+  },
+];
+
+export default function ConceptsPage() {
+  return (
+    <>
+      <Title>Concepts</Title>
+      <Subtitle>Every resource in Stash, clearly defined.</Subtitle>
+
+      <div className="space-y-3">
+        {CONCEPTS.map((c) => (
+          <div key={c.name} className="rounded-2xl border border-border bg-surface px-5 py-4">
+            <div className="flex items-center gap-3 mb-2">
+              <span className="text-[15px] font-semibold text-foreground">{c.name}</span>
+              <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${c.badgeColor}`}>
+                {c.badge}
+              </span>
+            </div>
+            <P>{c.desc}</P>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/www/app/docs/consume/page.tsx
+++ b/www/app/docs/consume/page.tsx
@@ -1,0 +1,41 @@
+import { CodeTabs, H3, P, Title, Subtitle } from "../components";
+
+export default function ConsumePage() {
+  return (
+    <>
+      <Title>History & Files</Title>
+      <Subtitle>
+        Getting data into Stash. Push events via the CLI or REST API.
+      </Subtitle>
+
+      <H3>History stores</H3>
+      <P>
+        History stores are append-only event logs. Events are grouped by{" "}
+        <code className="text-brand font-mono text-[13px]">agent_name</code> and{" "}
+        <code className="text-brand font-mono text-[13px]">session_id</code>, giving you a
+        conversation-like view of each agent session. Push events via the CLI or REST API.
+      </P>
+      <CodeTabs tabs={[
+        {
+          label: "CLI",
+          code: `stash history push "Searched for auth best practices" \\
+  --agent my-agent --type tool_use`,
+        },
+        {
+          label: "curl",
+          code: `curl -X POST https://stash.ac/api/v1/workspaces/{ws}/memory/{store}/events \\
+  -H "Authorization: Bearer $API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"agent_name":"my-agent","event_type":"tool_use","content":"..."}'`,
+        },
+      ]} />
+
+      <H3>File uploads</H3>
+      <P>
+        Upload images, PDFs, and documents through the REST API or the image button in the
+        notebook editor. Files are stored in S3-compatible storage (Cloudflare R2, AWS S3, or
+        MinIO depending on your deployment).
+      </P>
+    </>
+  );
+}

--- a/www/app/docs/contributing/page.tsx
+++ b/www/app/docs/contributing/page.tsx
@@ -1,0 +1,124 @@
+import { Callout, Code, CodeBlock, H3, P, Title, Subtitle } from "../components";
+
+export default function ContributingPage() {
+  return (
+    <>
+      <Title>Contributing</Title>
+      <Subtitle>
+        How to set up a local development environment, run the test suites, and
+        submit a pull request to Stash.
+      </Subtitle>
+
+      <H3>Prerequisites</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { tool: "Python", version: "3.12+" },
+          { tool: "Node.js", version: "20+" },
+          { tool: "Docker + Docker Compose", version: "24+" },
+          { tool: "PostgreSQL with pgvector", version: "16 (via Docker)" },
+        ].map((r) => (
+          <div key={r.tool} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground w-52 flex-shrink-0">{r.tool}</span>
+            <span className="text-[13px] text-dim">{r.version}</span>
+          </div>
+        ))}
+      </div>
+
+      <H3>Local development setup</H3>
+      <CodeBlock>{`# 1. Clone
+git clone https://github.com/Fergana-Labs/stash.git
+cd stash
+
+# 2. Start Postgres
+docker compose up -d postgres
+
+# 3. Backend dependencies (includes test tooling)
+pip install -r backend/requirements-dev.txt
+
+# 4. Configure environment
+cp .env.example .env
+# Set ANTHROPIC_API_KEY and OPENAI_API_KEY if you need curation / search
+
+# 5. Apply database migrations
+python -m alembic upgrade head
+
+# 6. Frontend dependencies
+cd frontend && npm ci && cd ..
+
+# 7. Start both services
+./start.sh
+#   Backend  → http://localhost:3456
+#   Frontend → http://localhost:3457`}</CodeBlock>
+
+      <H3>Running tests</H3>
+      <P>Both suites must pass before a PR can be merged.</P>
+      <CodeBlock>{`# Backend — create a separate test database
+psql postgresql://stash:stash@localhost:5432/postgres -c "CREATE DATABASE stash_test;"
+
+# Run migrations against the test DB
+DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+  python -m alembic upgrade head
+
+# Run the full test suite
+DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+  python -m pytest backend/tests/ -v
+
+# Frontend
+cd frontend && npm test`}</CodeBlock>
+
+      <H3>Making changes</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { rule: "One change per PR", detail: "Keep pull requests focused on a single logical change." },
+          { rule: "Tests required", detail: "Add or update tests for any behaviour you change. The minimum coverage threshold is enforced by CI." },
+          { rule: "Schema changes", detail: "Create an Alembic migration (python -m alembic revision -m \"description\"). Write both upgrade() and downgrade() using op.execute() with raw SQL." },
+          { rule: "Naming", detail: "Use Stash for the product. The name moltchat is deprecated — do not introduce it in new code or comments." },
+          { rule: "SQL safety", detail: "All queries must use parameterised placeholders ($1, $2, …). No string interpolation in SQL." },
+          { rule: "Python style", detail: "PEP 8, type annotations on all public functions." },
+          { rule: "TypeScript style", detail: "ESLint with eslint-config-next. Run npm run lint before pushing." },
+          { rule: "Comments", detail: "Explain why, not what. Avoid narrating obvious code." },
+        ].map((r) => (
+          <div key={r.rule} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground w-44 flex-shrink-0">{r.rule}</span>
+            <p className="text-[14px] text-dim leading-6">{r.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <H3>Submitting a pull request</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          "Fork the repository and create a feature branch off main.",
+          "Ensure both test suites pass locally.",
+          "Open a PR against main. The CI pipeline runs both suites automatically.",
+          "Describe the motivation for the change in the PR body. Link any related issues.",
+          "A maintainer will review and merge once CI is green.",
+        ].map((step, i) => (
+          <div key={i} className="flex gap-5 px-5 py-4">
+            <span className="text-[11px] font-mono text-muted pt-0.5 flex-shrink-0">0{i + 1}</span>
+            <p className="text-[14px] text-dim leading-6">{step}</p>
+          </div>
+        ))}
+      </div>
+
+      <H3>Adding a schema change</H3>
+      <CodeBlock>{`# 1. Create a new migration
+python -m alembic revision -m "add_my_column"
+
+# 2. Edit backend/migrations/versions/<hash>_add_my_column.py
+#    Write both upgrade() and downgrade() using op.execute() with raw SQL.
+
+# 3. Apply and verify locally
+python -m alembic upgrade head
+
+# 4. Add a migration test if there is non-trivial data logic
+#    → backend/tests/test_migrations.py`}</CodeBlock>
+
+      <Callout type="info">
+        Questions? Open a GitHub Discussion or drop a message in the workspace chat. We
+        review PRs on a best-effort basis and aim to respond within 48 hours on weekdays.
+      </Callout>
+    </>
+  );
+}

--- a/www/app/docs/curate/page.tsx
+++ b/www/app/docs/curate/page.tsx
@@ -1,0 +1,70 @@
+import { Callout, Code, H3, P, Title, Subtitle } from "../components";
+
+export default function CuratePage() {
+  return (
+    <>
+      <Title>Wiki & Curation</Title>
+      <Subtitle>
+        Notebooks and tables form your wiki. The curation tool organizes raw data into
+        structured, searchable wiki pages on demand.
+      </Subtitle>
+
+      <H3>Notebooks</H3>
+      <P>
+        Wiki-style markdown pages organized in folders. Supports{" "}
+        <Code>{"[[Page Name]]"}</Code> wiki links with backlinks, page graph visualization, and
+        semantic search. Rich-text editor with autosave.
+      </P>
+
+      <H3>Tables</H3>
+      <P>
+        Structured data with typed columns (text, number, date, select, relation).
+        Import CSV files directly. Optionally enable row embeddings for semantic search —
+        configure which columns to use in the table settings panel.
+      </P>
+
+      <H3>Curation tool</H3>
+      <P>
+        Run <Code>stash curate</Code> to organize your workspace data into wiki pages.
+        It reads history stores, notebooks, and tables, then calls Claude to create structured content:
+      </P>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { step: "01", title: "Category index pages", desc: "Creates top-level pages per topic with [[wiki links]] to content pages below." },
+          { step: "02", title: "Content pages", desc: "Writes summaries of topics, discoveries, and research found in your data." },
+          { step: "03", title: "Pattern cards", desc: "Surfaces recurring situations — patterns, anti-patterns, and decisions." },
+          { step: "04", title: "Folder organization", desc: "Groups everything into folders by category so the wiki stays navigable." },
+          { step: "05", title: "Merge and prune", desc: "Merges duplicates, updates stale content, deletes pages that no longer apply." },
+        ].map((item) => (
+          <div key={item.step} className="flex gap-5 px-5 py-4">
+            <span className="text-[11px] font-mono text-muted pt-0.5 flex-shrink-0">{item.step}</span>
+            <div>
+              <div className="text-[14px] font-semibold text-foreground mb-1">{item.title}</div>
+              <p className="text-[14px] text-dim leading-6">{item.desc}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Callout type="tip">
+        Run curation whenever you want your knowledge base tidied up. The tool processes
+        new data since the last run and writes organized wiki pages into the target notebook.
+      </Callout>
+
+      <H3>Wiki features</H3>
+      <P>
+        Notebook pages support <Code>{"[[Page Name]]"}</Code> wiki links. Type{" "}
+        <Code>{"[["}</Code> in the editor for autocomplete. Backlinks appear at the bottom
+        of each page showing which pages reference it. The page graph visualizes connections.
+        Auto-index generates a table of contents with backlink counts for the whole notebook.
+      </P>
+
+      <H3>Semantic search</H3>
+      <P>
+        All notebook pages and table rows can be embedded (OpenAI text-embedding-3-small by
+        default). Search by meaning, not just keywords — ask a question and get the most
+        semantically relevant pages back.
+      </P>
+    </>
+  );
+}

--- a/www/app/docs/layout.tsx
+++ b/www/app/docs/layout.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface NavSection {
+  title: string;
+  items: { href: string; label: string }[];
+}
+
+const NAV: NavSection[] = [
+  {
+    title: "Getting Started",
+    items: [
+      { href: "/docs", label: "Overview" },
+      { href: "/docs/quickstart", label: "Quickstart" },
+      { href: "/docs/concepts", label: "Concepts" },
+      { href: "/docs/self-hosting", label: "Self-Hosting" },
+    ],
+  },
+  {
+    title: "Guides",
+    items: [
+      { href: "/docs/consume", label: "History & Files" },
+      { href: "/docs/curate", label: "Wiki & Curation" },
+      { href: "/docs/workspaces", label: "Workspaces" },
+    ],
+  },
+  {
+    title: "Reference",
+    items: [
+      { href: "/docs/cli", label: "CLI" },
+      { href: "/docs/api", label: "REST API" },
+    ],
+  },
+  {
+    title: "Project",
+    items: [
+      { href: "/docs/contributing", label: "Contributing" },
+    ],
+  },
+];
+
+interface TocItem {
+  id: string;
+  label: string;
+  level: number;
+}
+
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const [toc, setToc] = useState<TocItem[]>([]);
+
+  useEffect(() => {
+    const readToc = () => {
+      const headings = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-docs-heading]")
+      ).map((el) => ({
+        id: el.id,
+        label: el.dataset.docsLabel || el.innerText,
+        level: Number(el.dataset.docsLevel || "2"),
+      })).filter((item) => item.id && item.label);
+
+      setToc(headings);
+    };
+
+    readToc();
+    const timeout = window.setTimeout(readToc, 50);
+    return () => window.clearTimeout(timeout);
+  }, [pathname, children]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 border-b border-border-subtle bg-background/95 backdrop-blur">
+        <div className="h-16 max-w-[1440px] mx-auto px-6 lg:px-8 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link href="/" className="font-display text-[22px] font-bold tracking-tight text-brand">
+              stash
+            </Link>
+            <span className="text-[11px] text-muted font-mono uppercase tracking-[0.14em]">
+              Documentation
+            </span>
+          </div>
+          <nav className="flex items-center gap-8 text-[14px] text-dim">
+            <Link href="https://github.com/Fergana-Labs/stash" className="hover:text-ink">
+              GitHub
+            </Link>
+            <Link href="/" className="hover:text-ink">
+              Home
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <div className="max-w-[1440px] mx-auto px-6 lg:px-8 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] gap-8 lg:gap-10">
+          <aside className="hidden lg:block">
+            <div className="sticky top-24 rounded-2xl border border-border bg-surface p-4">
+              {NAV.map((section) => (
+                <div key={section.title} className="mb-5 last:mb-0">
+                  <div className="px-2 pb-2 text-[10px] font-semibold text-muted uppercase tracking-[0.2em]">
+                    {section.title}
+                  </div>
+                  <div className="space-y-1">
+                    {section.items.map((item) => {
+                      const isActive = pathname === item.href;
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          className={`block rounded-lg px-3 py-2 text-[13px] transition-colors ${
+                            isActive
+                              ? "bg-brand/10 text-brand font-medium"
+                              : "text-dim hover:text-ink hover:bg-raised"
+                          }`}
+                        >
+                          {item.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          <main className="min-w-0">
+            <article
+              data-docs-content
+              className="rounded-[28px] border border-border bg-background px-6 py-8 sm:px-8 md:px-10"
+            >
+              {children}
+            </article>
+          </main>
+
+          <aside className="hidden xl:block">
+            <div className="sticky top-24 rounded-2xl border border-border bg-surface p-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted">
+                On this page
+              </div>
+              {toc.length > 0 ? (
+                <div className="mt-3 space-y-1">
+                  {toc.map((item) => (
+                    <a
+                      key={item.id}
+                      href={`#${item.id}`}
+                      className={`block text-[13px] leading-5 transition-colors hover:text-ink ${
+                        item.level > 2 ? "pl-3 text-muted" : "text-dim"
+                      }`}
+                    >
+                      {item.label}
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-3 text-xs text-muted">Article summary and headings will appear here.</p>
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { Callout, H3, P, Title, Subtitle } from "./components";
+
+const PILLARS = [
+  {
+    label: "Consume",
+    color: "bg-brand/8 border-brand/20 text-brand",
+    dot: "bg-brand",
+    description: "Agents push data in automatically — sessions, files, and structured data.",
+    links: [
+      { href: "/docs/consume", label: "Consume guide →" },
+    ],
+  },
+  {
+    label: "Curate",
+    color: "bg-green-500/8 border-green-500/20 text-green-600",
+    dot: "bg-green-500",
+    description: "Use the curate tool to organize everything into a wiki with categories and backlinks.",
+    links: [
+      { href: "/docs/curate", label: "Curate guide →" },
+    ],
+  },
+  {
+    label: "Connect",
+    color: "bg-violet-500/8 border-violet-500/20 text-violet-600",
+    dot: "bg-violet-500",
+    description: "Share workspaces across your team and hand sessions off between agents.",
+    links: [
+      { href: "/docs/workspaces", label: "Workspaces guide →" },
+    ],
+  },
+];
+
+const QUICK_LINKS = [
+  { href: "/docs/quickstart", label: "Quickstart", desc: "Connect Claude Code and start in 5 minutes." },
+  { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history stores are." },
+  { href: "/docs/api", label: "REST API", desc: "Full HTTP reference for all resources." },
+  { href: "/docs/cli", label: "CLI", desc: "Push events and manage resources from the terminal." },
+  { href: "/docs/self-hosting", label: "Self-Hosting", desc: "Run stash on your own infra with Postgres + pgvector." },
+];
+
+export default function DocsOverview() {
+  return (
+    <>
+      <Title>Stash Documentation</Title>
+      <Subtitle>
+        A collaborative memory platform for teams of AI agents. Agents push in their work automatically.
+        The curate tool organizes it into a shared, searchable knowledge base.
+      </Subtitle>
+
+      <Callout type="tip">
+        <strong>New here?</strong> Go straight to the{" "}
+        <Link href="/docs/quickstart" className="text-brand underline underline-offset-2">
+          Quickstart
+        </Link>{" "}
+        — connect Claude Code and start building shared knowledge in under 5 minutes.
+      </Callout>
+
+      <H3>How Stash works</H3>
+      <P>
+        Stash sits between your agents and the knowledge they generate. Every Claude Code session
+        streams automatically. Every research result, file, and message lands in a shared workspace.
+        The curate tool organizes it into a categorized wiki —
+        with backlinks, summaries, and semantic search — so any agent on your team can find and
+        build on what others have learned.
+      </P>
+      <P>
+        You don&apos;t use Stash directly. Your agents do. You configure workspaces and agent names,
+        then watch the wiki grow.
+      </P>
+
+      <H3>Three modes of use</H3>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 my-6">
+        {PILLARS.map((p) => (
+          <div key={p.label} className={`rounded-2xl border px-5 py-4 ${p.color}`}>
+            <div className="flex items-center gap-2 mb-2">
+              <span className={`w-2 h-2 rounded-full ${p.dot}`} />
+              <span className="font-semibold text-sm">{p.label}</span>
+            </div>
+            <p className="text-[14px] text-dim leading-6 mb-3">{p.description}</p>
+            {p.links.map((l) => (
+              <Link key={l.href} href={l.href} className="text-[13px] font-medium hover:underline underline-offset-2">
+                {l.label}
+              </Link>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <H3>Quick links</H3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
+        {QUICK_LINKS.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="group rounded-2xl border border-border bg-surface px-5 py-4 hover:border-brand/40 hover:bg-brand/3 transition-colors"
+          >
+            <div className="text-[14px] font-semibold text-foreground group-hover:text-brand transition-colors mb-1">
+              {l.label}
+            </div>
+            <div className="text-[13px] text-dim">{l.desc}</div>
+          </Link>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -1,0 +1,63 @@
+import { Callout, CodeBlock, H3, P, Title, Subtitle } from "../components";
+
+const PROMPTS = [
+  { label: "Push knowledge in", prompt: '"Search the web for the latest research on RAG architectures and save a summary to my Stash knowledge base"' },
+  { label: "Search across everything", prompt: '"Check my Stash knowledge base — what do we know about authentication patterns?"' },
+  { label: "Create a report", prompt: '"Create a Stash page summarizing our key findings on database performance"' },
+];
+
+export default function QuickstartPage() {
+  return (
+    <>
+      <Title>Quickstart</Title>
+      <Subtitle>Install the CLI and start building shared knowledge in 5 minutes.</Subtitle>
+
+      <H3>1. Create an account</H3>
+      <P>
+        Register at{" "}
+        <a href="https://stash.ac" className="text-brand underline underline-offset-2">
+          stash.ac
+        </a>{" "}
+        and save your API key.
+      </P>
+      <P>
+        <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
+        <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
+        <code className="text-brand font-mono text-[13px]">pip install stash</code>. The
+        interactive wizard covers account creation, workspace creation, and history store setup
+        in one shot — then come back to step 2.
+      </P>
+
+      <Callout>
+        <strong>Agent names</strong> are just strings on history events that identify which agent produced them.
+        Multiple team members can use different agent names in a shared workspace.
+      </Callout>
+
+      <H3>2. Install the CLI</H3>
+      <CodeBlock>{`pip install stash
+stash login`}</CodeBlock>
+
+      <H3>3. Try these commands</H3>
+      <P>Use the CLI to interact with your workspace:</P>
+      <div className="space-y-3 my-6">
+        {PROMPTS.map((p) => (
+          <div key={p.label} className="rounded-2xl border border-border bg-surface px-5 py-4">
+            <div className="text-[11px] font-semibold text-muted uppercase tracking-[0.2em] mb-2">{p.label}</div>
+            <div className="text-[15px] text-foreground italic leading-7">{p.prompt}</div>
+          </div>
+        ))}
+      </div>
+
+      <H3>4. Curate your knowledge base</H3>
+      <P>
+        Use the <code className="text-brand font-mono text-[13px]">stash curate</code> CLI command to organize
+        ingested data into a categorized wiki with <code className="text-brand font-mono text-[13px]">[[backlinks]]</code>,
+        folders, and summaries.
+      </P>
+      <Callout type="tip">
+        The more data you push, the richer the wiki gets. The curation tool merges
+        duplicates, creates category pages, and links related content automatically.
+      </Callout>
+    </>
+  );
+}

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -1,0 +1,146 @@
+import { Callout, Code, CodeBlock, H3, P, ParamTable, Title, Subtitle } from "../components";
+
+export default function SelfHostingPage() {
+  return (
+    <>
+      <Title>Self-Hosting</Title>
+      <Subtitle>
+        Run the full Stash stack on your own infrastructure in under ten minutes.
+        One Docker Compose file covers everything.
+      </Subtitle>
+
+      <H3>Prerequisites</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { tool: "Docker + Compose", version: "24+" },
+          { tool: "Python", version: "3.12+ (CLI only)" },
+          { tool: "Node.js", version: "20+ (frontend dev only)" },
+        ].map((r) => (
+          <div key={r.tool} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground w-52 flex-shrink-0">{r.tool}</span>
+            <span className="text-[13px] text-dim">{r.version}</span>
+          </div>
+        ))}
+      </div>
+
+      <H3>1. Clone and configure</H3>
+      <CodeBlock>{`git clone https://github.com/Fergana-Labs/stash.git
+cd stash
+
+# Copy the env template and fill in your values
+cp .env.example .env`}</CodeBlock>
+      <P>
+        At minimum set <Code>POSTGRES_USER</Code>, <Code>POSTGRES_PASSWORD</Code>,{" "}
+        <Code>OPENAI_API_KEY</Code> (semantic search), and <Code>PUBLIC_URL</Code> (your domain).
+      </P>
+      <P>
+        Edit <Code>Caddyfile</Code> and replace <Code>app.example.com</Code> with your actual domain.
+        Caddy handles TLS automatically via Let&apos;s Encrypt — no certificate management needed.
+      </P>
+
+      <H3>2. Start everything</H3>
+      <CodeBlock>{`docker compose -f docker-compose.prod.yml up -d`}</CodeBlock>
+      <P>This starts three containers:</P>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { svc: "postgres", port: "5432", desc: "PostgreSQL 16 with pgvector — stores all workspace data" },
+          { svc: "backend", port: "3456", desc: "FastAPI — REST API" },
+          { svc: "frontend", port: "3457", desc: "Next.js UI — dashboard, docs" },
+        ].map((s) => (
+          <div key={s.svc} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground font-mono w-24 flex-shrink-0">{s.svc}</span>
+            <span className="text-[13px] text-dim w-12 flex-shrink-0">:{s.port}</span>
+            <span className="text-[13px] text-dim">{s.desc}</span>
+          </div>
+        ))}
+      </div>
+      <P>
+        Alembic migrations run automatically on backend startup. Visit{" "}
+        <Code>http://localhost:3457</Code> to open the UI.
+      </P>
+
+      <H3>Environment variables</H3>
+      <ParamTable params={[
+        { name: "POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB", type: "string", desc: "Postgres credentials. Defaults are stash/stash/stash — change before going to production." },
+        { name: "DATABASE_URL", type: "string", desc: "Full PostgreSQL connection string. Defaults to postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}.", required: true },
+        { name: "OPENAI_API_KEY", type: "string", desc: "Required for semantic search (text-embedding-3-small)." },
+        { name: "PUBLIC_URL", type: "string", desc: "Frontend origin. Used in invite links and CORS config. Default: http://localhost:3457" },
+        { name: "CORS_ORIGINS", type: "string", desc: "Comma-separated allowed origins. Default: http://localhost:3457,http://localhost:3456" },
+        { name: "PORT", type: "number", desc: "Backend port. Default: 3456" },
+        { name: "DB_POOL_MIN / DB_POOL_MAX", type: "number", desc: "Database connection pool size. Raise DB_POOL_MAX for high-traffic deployments." },
+        { name: "S3_ENDPOINT", type: "string", desc: "S3-compatible endpoint for file uploads (AWS, Cloudflare R2, MinIO). Leave blank to disable." },
+        { name: "S3_BUCKET", type: "string", desc: "S3 bucket name." },
+        { name: "S3_ACCESS_KEY / S3_SECRET_KEY", type: "string", desc: "S3 credentials." },
+      ]} />
+
+      <H3>Optional: file storage</H3>
+      <P>
+        Stash uses any S3-compatible store for file uploads (images, PDFs, attachments).
+        Set <Code>S3_ENDPOINT</Code>, <Code>S3_BUCKET</Code>, <Code>S3_ACCESS_KEY</Code>, and{" "}
+        <Code>S3_SECRET_KEY</Code> in your <Code>.env</Code>. MinIO works well for fully
+        local deployments:
+      </P>
+      <CodeBlock>{`# Add to docker-compose.yml services:
+minio:
+  image: minio/minio
+  ports:
+    - "9000:9000"
+    - "9001:9001"
+  environment:
+    MINIO_ROOT_USER: stash
+    MINIO_ROOT_PASSWORD: stashdev
+  command: server /data --console-address ":9001"
+  volumes:
+    - minio_data:/data`}</CodeBlock>
+      <P>Then in <Code>.env</Code>:</P>
+      <CodeBlock>{`S3_ENDPOINT=http://localhost:9000
+S3_BUCKET=stash
+S3_ACCESS_KEY=stash
+S3_SECRET_KEY=stashdev
+S3_REGION=us-east-1`}</CodeBlock>
+
+      <H3>Production checklist</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { item: "Change default Postgres credentials", detail: "Set POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB in your .env before first run. Docker Compose and DATABASE_URL both pick them up automatically." },
+          { item: "Set a strong SECRET_KEY", detail: "Used for signing tokens. Generate with: python -c \"import secrets; print(secrets.token_hex(32))\"" },
+          { item: "Configure CORS_ORIGINS", detail: "Set to your production frontend domain(s) only." },
+          { item: "Set PUBLIC_URL", detail: "Set to your production frontend URL so invite links and share links resolve correctly." },
+          { item: "Enable TLS", detail: "Put Nginx or Caddy in front of both services." },
+          { item: "Tune DB_POOL_MAX", detail: "Raise to 50–100 for production load. Ensure your Postgres max_connections is higher." },
+          { item: "External Postgres", detail: "For production, use a managed database (RDS, Supabase) with pgvector enabled. Remove the postgres service from docker-compose.yml." },
+        ].map((c) => (
+          <div key={c.item} className="flex gap-5 px-5 py-4">
+            <span className="text-[13px] font-semibold text-foreground w-60 flex-shrink-0">{c.item}</span>
+            <p className="text-[14px] text-dim leading-6">{c.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <Callout type="info">
+        The backend exposes an interactive OpenAPI spec at <Code>/docs</Code> (e.g.{" "}
+        <Code>http://localhost:3456/docs</Code>). Disable this in production by setting{" "}
+        <Code>{"DOCS_ENABLED=false"}</Code> or filtering it in your reverse proxy.
+      </Callout>
+
+      <H3>Upgrading</H3>
+      <CodeBlock>{`git pull
+docker compose build
+docker compose up -d
+# Migrations run automatically on backend startup`}</CodeBlock>
+
+      <H3>Running tests</H3>
+      <CodeBlock>{`# Backend — requires a separate test database
+docker compose up -d postgres
+psql postgresql://stash:stash@localhost:5432/postgres -c "CREATE DATABASE stash_test;"
+DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+  python -m alembic upgrade head
+DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test \\
+  python -m pytest backend/tests/ -v
+
+# Frontend
+cd frontend && npm test`}</CodeBlock>
+    </>
+  );
+}

--- a/www/app/docs/workspaces/page.tsx
+++ b/www/app/docs/workspaces/page.tsx
@@ -1,0 +1,63 @@
+import { Callout, H3, P, Title, Subtitle } from "../components";
+
+export default function WorkspacesPage() {
+  return (
+    <>
+      <Title>Workspaces</Title>
+      <Subtitle>
+        Permissioned containers for teams. All Stash resources live inside a workspace.
+      </Subtitle>
+
+      <P>
+        Create a workspace, invite team members, and everything you
+        build — notebooks, chats, history stores, tables, files, pages — is shared and scoped
+        to that workspace. Workspaces are isolated: no resource leaks between them.
+      </P>
+
+      <H3>Member roles</H3>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { role: "owner", desc: "Full control. Can delete the workspace. Assigned to the creator." },
+          { role: "admin", desc: "Manage members, change settings, and invite new users." },
+          { role: "member", desc: "Read and write all workspace resources." },
+        ].map((r) => (
+          <div key={r.role} className="flex gap-5 px-5 py-4">
+            <code className="text-brand font-mono text-[13px] w-20 flex-shrink-0">{r.role}</code>
+            <p className="text-[14px] text-dim leading-6">{r.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      <H3>Object-level permissions</H3>
+      <P>
+        Individual objects can override the workspace default. Useful for private research
+        or publicly shared pages.
+      </P>
+      <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
+        {[
+          { vis: "inherit", desc: "All workspace members have access (default for everything)." },
+          { vis: "private", desc: "Only explicitly granted users can see it." },
+          { vis: "public", desc: "Anyone can read — no login required." },
+        ].map((r) => (
+          <div key={r.vis} className="flex gap-5 px-5 py-4">
+            <code className="text-brand font-mono text-[13px] w-20 flex-shrink-0">{r.vis}</code>
+            <p className="text-[14px] text-dim leading-6">{r.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      <Callout type="tip">
+        The curation tool uses <strong>object-level permissions</strong> — it writes
+        to a <em>personal</em> notebook (private by default) and only publishes summaries
+        to shared workspace notebooks when configured to do so.
+      </Callout>
+
+      <H3>Personal resources</H3>
+      <P>
+        Notebooks, tables, history stores, and files can also exist outside any workspace as
+        personal resources. The curation tool writes to the user&apos;s personal notebook by default.
+        You can query personal resources via the API without specifying a workspace ID.
+      </P>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Mirror Triumphant's docs (from PR #3) into `www/app/docs/*` so `stash.ac/docs` serves the full documentation alongside the marketing site — 10 routes total: overview, quickstart, concepts, self-hosting, consume, curate, workspaces, cli, api, contributing.
- Adapt `layout.tsx` to drop the `useAuth` dependency (frontend-only hook, not available in `www/`) and match the landing's nav style (stash logo, GitHub + Home links).
- Fix two dead links on the overview page — `/docs/collaborate` and `/docs/webhooks` were referenced but never merged from PR #3. Point them at `/docs/workspaces` and `/docs/self-hosting` instead.

Landing nav already linked to `/docs` and the hero CTA already pointed at `/docs/quickstart`, so no changes needed in `www/app/page.tsx`.

## Test plan
- [x] `next build` succeeds in `www/` — all 10 routes prerendered
- [x] Dev server serves 200 for every docs route
- [x] Overview page renders expected markers (Quickstart, REST API, Self-Hosting)
- [ ] Review the styling on a real browser once the Vercel preview lands