### PR TITLE
chore(www): add octopus-logo.svg for Auth0 branding

### DIFF
--- a/www/public/octopus-logo.svg
+++ b/www/public/octopus-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 72" width="200" height="225">
+  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316"/>
+  <circle cx="25" cy="22" r="4" fill="#fff"/>
+  <circle cx="39" cy="22" r="4" fill="#fff"/>
+  <circle cx="26" cy="22" r="2" fill="#0F172A"/>
+  <circle cx="40" cy="22" r="2" fill="#0F172A"/>
+  <path d="M12 38 Q8 52 4 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M20 40 Q18 54 14 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M32 42 Q32 56 32 64" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M44 40 Q46 54 50 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M52 38 Q56 52 60 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+</svg>


### PR DESCRIPTION
Static SVG asset used by the Auth0 universal-login page so it shows the Stash octopus instead of the leftover Scheduled wordmark.

Same shape as the inline `Logo()` component on the homepage. Goes live at `https://stash.ac/octopus-logo.svg` after merge — once that's reachable, I'll update the tenant's `logo_url` via `auth0 ul update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)