### PR TITLE
fix(www): tell Claude to actually open the browser in the install prompt

### DIFF
--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -64,7 +64,7 @@ function Nav() {
 }
 
 function Hero() {
-  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install the CLI if it isn't already: \`command -v stash || pipx install stashai\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Send me to https://stash.ac/connect-token to copy a sign-in token, then ask me to paste it back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
+  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install the CLI if it isn't already: \`command -v stash || pipx install stashai\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Open https://stash.ac/connect-token in my browser for me — use \`open\` on macOS, \`xdg-open\` on Linux, or \`start\` on Windows. Then ask me to paste the token back, and run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
   return (
     <section id="install" className="border-b border-border-subtle">
       <div className="mx-auto grid max-w-[1120px] gap-12 px-6 pb-16 pt-20 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:gap-16">


### PR DESCRIPTION
## Summary

Reported by @htdowling after running the install prompt — Claude printed the connect-token URL as a clickable link instead of launching the browser, forcing a manual click.

The previous wording \`"Send me to https://stash.ac/connect-token to copy a sign-in token"\` was ambiguous. Spelling out the OS-specific commands (\`open\` / \`xdg-open\` / \`start\`) removes the guesswork — Claude has shell access and will use whichever fits the platform.

## Followup (not in this PR)

A nicer long-term fix is a CLI command that wraps it: \`stash auth --browser\` (or similar) that calls \`webbrowser.open()\` and prompts for the token. The CLI already does this for the existing interactive \`stash connect\` flow at \`cli/main.py:1336\`, so the primitives exist. Worth a separate issue if we want to shrink the install prompt further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)