### PR TITLE
feat(cli): add stash signin to open the sign-in page in the browser

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -97,6 +97,35 @@ def login(
 
 
 @app.command()
+def signin(
+    page: str = typer.Option(
+        "https://stash.ac/connect-token",
+        "--page",
+        help="Sign-in page to open. Override for self-hosted deployments.",
+    ),
+):
+    """Open the sign-in page in your default browser to grab a token.
+
+    The page returns a single-use token; paste it back into your shell with
+    `stash auth <endpoint> --api-key <token>`. Designed to be agent-driven:
+    opens the browser non-interactively and exits, so a coding agent can
+    show the user where to sign in, then collect the pasted token via its
+    own UI (e.g. AskUserQuestion) and call `stash auth` to persist it.
+    """
+    import webbrowser
+
+    opened = webbrowser.open(page)
+    if opened:
+        console.print(f"  [green]✓[/green] Opened [bold]{page}[/bold] in your default browser.")
+    else:
+        console.print(f"  [yellow]Could not auto-open a browser.[/yellow] Visit: [bold]{page}[/bold]")
+    console.print(
+        f"  Copy the token from the page, then run: "
+        f"[cyan]stash auth <endpoint> --api-key <token>[/cyan]"
+    )
+
+
+@app.command()
 def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "--api-key")):
     """Store existing credentials."""
     save_config(base_url=base_url, api_key=api_key)

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -64,7 +64,7 @@ function Nav() {
 }
 
 function Hero() {
-  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install the CLI if it isn't already: \`command -v stash || pipx install stashai\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Open https://stash.ac/connect-token in my browser for me — use \`open\` on macOS, \`xdg-open\` on Linux, or \`start\` on Windows. Then ask me to paste the token back, and run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
+  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install the CLI if it isn't already: \`command -v stash || pipx install stashai\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
   return (
     <section id="install" className="border-b border-border-subtle">
       <div className="mx-auto grid max-w-[1120px] gap-12 px-6 pb-16 pt-20 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:gap-16">


### PR DESCRIPTION
## Summary

- New CLI command: \`stash signin\` — wraps \`webbrowser.open()\` to launch the sign-in page (default \`https://stash.ac/connect-token\`, overridable via \`--page\` for self-hosters).
- Updates the install prompt on the landing page to use \`stash signin\` instead of telling Claude to run \`open\`/\`xdg-open\`/\`start\` itself.

Supersedes #107.

## Why

When a user pasted the install prompt, Claude rendered the connect-token URL as a clickable link instead of launching the browser, requiring a manual click. The agent had shell access but the prompt's "Send me to <url>" wording was ambiguous. A dedicated CLI command removes the guesswork — \`webbrowser.open()\` already handles cross-platform browser launching (the same primitive the legacy interactive \`stash connect\` flow uses at \`cli/main.py:1336\`).

## Test plan

- [x] \`stash signin --help\` renders correctly
- [x] \`stash signin\` opens the default browser to \`https://stash.ac/connect-token\`
- [x] \`stash signin --page <url>\` honors the override
- [x] Falls back to a printed URL hint when \`webbrowser.open()\` returns False (headless env)
- [ ] Reviewer: dogfood the install prompt end-to-end after merge — the manual-click step should be gone

## Followup

After merge: close #107 (the prompt-only fix this supersedes), and bump \`stashai\` on PyPI so \`pipx install stashai\` picks up the new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)