### PR TITLE
chore: bump stashai to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.1"
+version = "0.1.2"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the package version so PyPI picks up the two new commands needed by the landing-page install prompt:

- \`stash signin\` (#108)
- \`stash workspaces use\` (#102)

Without this bump, anyone running \`pipx install stashai\` today gets \`0.1.1\` and Claude hits "no such command" at step 3 / step 4 of the install prompt.

After merge, push the \`v0.1.2\` tag — \`.github/workflows/publish.yml\` fires on \`v*.*.*\` tags and publishes via PyPI trusted publishing (no secrets needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)