### PR TITLE
feat(cli): auto-set default workspace on stash auth (fixes new-user e2e gap)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -136,6 +136,23 @@ def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "
             console.print(f"[green]Authenticated as {user['name']}[/green]")
         except StashError:
             console.print("[yellow]Saved but could not verify.[/yellow]")
+            return
+        # Auto-set default workspace when the user has exactly one and none is
+        # configured yet — otherwise a fresh `stash auth` leaves new users in a
+        # state where every command needing workspace context (`stash history`,
+        # plugin SessionEnd hooks) errors with "no default workspace". Don't
+        # touch an existing default; multi-workspace users still need to pick
+        # explicitly via `stash workspaces use`.
+        if load_config().get("default_workspace"):
+            return
+        try:
+            workspaces = c.list_workspaces(mine=True)
+        except StashError:
+            return
+        if len(workspaces) == 1:
+            ws = workspaces[0]
+            save_config(default_workspace=str(ws["id"]))
+            console.print(f"  Default workspace set to [bold]{ws['name']}[/bold]")
 
 
 @app.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.2"
+version = "0.1.3"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- \`stash auth\` now auto-sets \`default_workspace\` after credential save, *if* the user has exactly one workspace and no default is currently configured.
- Bumps \`stashai\` to 0.1.3.

## Why

For new users running the landing-page install prompt, sign-in auto-provisions a single workspace on the backend (via \`get_or_create_user_from_auth0\` → \`workspace_service.create_workspace\`). The install prompt's step 4 only writes \`default_workspace\` when there are multiple workspaces — single-workspace new users completed all 5 install steps successfully, then hit "no default workspace" the first time anything actually used stash (history search, \`/stash:sleep\`, etc.).

Putting the auto-default in \`stash auth\` means:
- New user: backend creates 1 workspace → \`auth\` adopts it as default → first real command Just Works.
- Existing user with a configured default: untouched.
- Multi-workspace user: untouched, still picks via \`stash workspaces use\`.

## Test plan

- [x] \`auth\` skips the auto-default block when \`default_workspace\` already set in config (verified my own machine — default unchanged after re-auth)
- [x] Module imports cleanly
- [ ] Reviewer: smoke a fresh sign-in end-to-end — \`stash status\` should show a non-empty default workspace immediately after \`stash auth\`

After merge: tag \`v0.1.3\` to fire the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)