### PR TITLE
fix(www): install prompt now detects stale stash and upgrades

### DIFF
--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -64,7 +64,7 @@ function Nav() {
 }
 
 function Hero() {
-  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install the CLI if it isn't already: \`command -v stash || pipx install stashai\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
+  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install or upgrade the CLI: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
   return (
     <section id="install" className="border-b border-border-subtle">
       <div className="mx-auto grid max-w-[1120px] gap-12 px-6 pb-16 pt-20 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:gap-16">


### PR DESCRIPTION
## Summary

Step 1 of the install prompt was \`command -v stash || pipx install stashai\` — it short-circuits on any existing install regardless of version. Users like @htdowling (and likely others who tried stashai before \`signin\` shipped) hit a hard failure at step 3 with "No such command 'signin'".

New step 1: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. Feature-detects via the new command's presence, then upgrades through whichever package manager is on the box.

## Test plan

- [x] Reproduced @htdowling's failure (uv-installed stashai 0.1.0 shadowing pipx 0.1.1) — old prompt skipped install entirely
- [x] Ran new step 1 against same setup — \`pipx install stashai --force\` cleanly replaced the uv symlink, \`stash signin --help\` works
- [ ] Reviewer: smoke a fresh paste in a new repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)