### PR TITLE
feat(plugin): add /stash:welcome slash command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "productivity",
       "homepage": "https://stash.ac",
       "author": {

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connect Claude Code to Stash — stream activity to history and collaborate in workspaces.",
   "author": {
     "name": "Fergana Labs"

--- a/plugins/claude-plugin/commands/welcome.md
+++ b/plugins/claude-plugin/commands/welcome.md
@@ -1,0 +1,40 @@
+---
+description: Show the Stash post-install welcome message
+---
+
+Render the markdown block below to the user verbatim. Do not summarize, paraphrase, or add commentary — your entire response should be the rendered markdown and nothing else.
+
+# You're all set up.
+
+## What just happened
+
+Your coding agent now has the `stash` CLI on its PATH. It can read the transcripts your teammates' coding agents push to this workspace — so it knows what the rest of your team is working on.
+
+## Examples of questions your agent might want answered
+
+- "Why did Sam bump the rate limit from 100 to 500?"
+- "Has anyone already tried fixing the memory leak in our backend?"
+- "Is anyone else currently working on our api gateway?"
+
+You can read a blog post about it here: [Agent velocity for coding teams](https://henrydowling.com/agent-velocity.html)
+
+## Commands your agent can now use
+
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --agent <name>` — pull a specific agent's events
+
+Run `stash --help` to see everything.
+
+## Q&A
+
+**Q:** Do you inject anything into my coding agent's context automatically?
+**A:** No.
+
+**Q:** What gets pushed to the shared store?
+**A:** For sessions in this repo (and its worktrees): prompts, assistant replies, summarized tool activity, and the full session transcript (.jsonl) at session end. Other repos push nothing unless you widen scope. Transcripts are stored verbatim — no secret scrubbing yet.
+
+**Q:** How do I change scope or see a transcript?
+**A:** `stash config scope <repo|workspace|all>` (default: `repo`). `stash history transcript <session_id>` fetches a full transcript.
+
+**Q:** How do I share my workspace with my team?
+**A:** Share the invite code (`stash workspaces info <id>` prints it). Teammates run `stash connect` if needed, then `stash workspaces join <invite_code>`.

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -64,7 +64,7 @@ function Nav() {
 }
 
 function Hero() {
-  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install or upgrade the CLI: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` to show me the onboarding.`;
+  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install or upgrade the CLI: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://moltchat.onrender.com --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Tell me to run \`/stash:welcome\` to see the onboarding.`;
   return (
     <section id="install" className="border-b border-border-subtle">
       <div className="mx-auto grid max-w-[1120px] gap-12 px-6 pb-16 pt-20 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:gap-16">


### PR DESCRIPTION
## Summary

- Adds \`/stash:welcome\` slash command to the Claude Code plugin — same content \`stash connect --welcome\` prints, but rendered directly in the chat instead of buried in a collapsed Bash result.
- Bumps plugin \`0.1.1\` → \`0.1.2\` (both plugin.json and marketplace.json).
- Step 5 of the install prompt changes from "Run \`stash connect --welcome\`" to "Tell me to run \`/stash:welcome\`" — Claude can't invoke slash commands itself, so the user types it.

## Why

Reported by @htdowling after smoke-testing the install flow: the welcome rendered into a collapsed Bash result block ("(+N lines, ctrl+o to expand)"), so the actual onboarding was invisible by default.

## Trade-off

The welcome markdown now lives in two places: \`cli/main.py:_WELCOME_MARKDOWN\` (canonical, used by \`stash connect --welcome\` and non-Claude-Code agents) and \`plugins/claude-plugin/commands/welcome.md\`. Sync drift is the cost; rendering quality in Claude Code is the benefit. Worth it for now — if the content starts changing often we can generate the slash-command file from the CLI source.

## Test plan

- [ ] After merge: \`claude plugin install stash@stash-plugins\` picks up 0.1.2
- [ ] In a fresh Claude Code session, type \`/stash:welcome\` — content renders inline as a markdown block, not collapsed
- [ ] Re-paste the install prompt; step 5 now ends with "type \`/stash:welcome\`"

🤖 Generated with [Claude Code](https://claude.com/claude-code)