### PR TITLE
fix(backend): run managed alembic migrations on startup when AUTH0_ENABLED

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -36,12 +36,21 @@ async def init_db() -> None:
 
     def _run_alembic():
         # alembic.ini lives next to pyproject.toml at the repo root
-        ini_path = os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
         from alembic import command as alembic_cmd
         from alembic.config import Config
 
-        cfg = Config(ini_path)
+        repo_root = os.path.join(os.path.dirname(__file__), "..")
+        cfg = Config(os.path.join(repo_root, "alembic.ini"))
         alembic_cmd.upgrade(cfg, "head")
+
+        # Managed env tracks its own revision chain in `alembic_version_managed`
+        # — only relevant when Auth0 is wired up. Run it here so deploys don't
+        # need a separate migration step (start.sh handles this for local dev).
+        if settings.AUTH0_ENABLED:
+            managed_ini = os.path.join(repo_root, "backend", "managed", "alembic.ini")
+            if os.path.exists(managed_ini):
+                managed_cfg = Config(managed_ini)
+                alembic_cmd.upgrade(managed_cfg, "head")
 
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, functools.partial(_run_alembic))


### PR DESCRIPTION
## Summary

The OSS alembic chain runs on backend startup (\`init_db\` → \`_run_alembic\`), but the managed env at \`backend/managed/migrations/\` was never invoked outside \`start.sh\`. Production missed \`m0001_add_auth0_sub\`, so the first new-user sign-in via the install prompt blew up with \`column users.auth0_sub does not exist\` (had to patch manually via Neon).

This adds a second \`alembic upgrade head\` for the managed env to \`init_db\`, gated on \`settings.AUTH0_ENABLED\` (matching \`start.sh\` behavior). Both chains share the same DB but use different version tables (\`alembic_version\` vs \`alembic_version_managed\`), so they don't collide.

## Test plan

- [x] \`from backend.database import init_db\` imports cleanly
- [ ] Reviewer: deploy to a Render preview / staging with a fresh DB and AUTH0_ENABLED=true — both \`alembic_version\` and \`alembic_version_managed\` should be populated after first boot

## Followup

Probably also worth backfilling the auth0_sub column existence into the OSS chain — keeping it in the managed env is a defensible choice (Auth0 is a managed-only feature) but means anyone self-hosting with \`AUTH0_ENABLED=true\` carries the same deployment-step risk we just bit. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)