### PR TITLE
feat(www): ship bash one-liner installer at stash.ac/install

### DIFF
--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -7,6 +7,11 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.dirname(fileURLToPath(import.meta.url)),
   },
+  // `curl -fsSL https://stash.ac/install | bash` — same script as
+  // /install.sh, served at the no-extension path most CLI installers use.
+  async rewrites() {
+    return [{ source: "/install", destination: "/install.sh" }];
+  },
 };
 
 export default nextConfig;

--- a/www/public/install.sh
+++ b/www/public/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# stash.ac/install — install the stashai CLI and run the interactive
+# `stash connect` questionnaire (scope, managed-vs-self-host, browser auth,
+# workspace, agent plugin).
+#
+# Usage:
+#   curl -fsSL https://stash.ac/install | bash
+#
+# Re-run safe (idempotent): if stashai is already installed, the picked
+# package manager will upgrade it to the latest version.
+set -euo pipefail
+
+PACKAGE="stashai"
+
+if command -v pipx >/dev/null 2>&1; then
+  INSTALLER="pipx"
+  INSTALL_CMD=(pipx install "$PACKAGE" --force)
+elif command -v uv >/dev/null 2>&1; then
+  INSTALLER="uv"
+  INSTALL_CMD=(uv tool install "$PACKAGE" --force)
+elif command -v pip3 >/dev/null 2>&1; then
+  INSTALLER="pip3"
+  INSTALL_CMD=(pip3 install --user --upgrade "$PACKAGE")
+else
+  cat >&2 <<'MSG'
+stash needs a Python package manager to install. None found on PATH.
+
+Pick one and re-run:
+  brew install pipx          # macOS / Homebrew
+  python3 -m pip install pipx
+  curl -LsSf https://astral.sh/uv/install.sh | sh    # uv
+MSG
+  exit 1
+fi
+
+printf '→ Installing %s via %s…\n' "$PACKAGE" "$INSTALLER"
+"${INSTALL_CMD[@]}" >/dev/null
+
+# pipx + uv put binaries in ~/.local/bin; pip --user puts them somewhere
+# similar. If the shell hasn't picked up PATH yet, surface the fix instead
+# of silently failing.
+if ! command -v stash >/dev/null 2>&1; then
+  cat >&2 <<'MSG'
+stash installed, but it isn't on PATH yet. Add this to your shell rc and
+re-open the terminal (or `source` your rc):
+
+  export PATH="$HOME/.local/bin:$PATH"
+
+Then re-run: curl -fsSL https://stash.ac/install | bash
+MSG
+  exit 1
+fi
+
+# Hand off to the questionnaire. `stash connect` asks scope, managed-vs-
+# self-host, browser sign-in, workspace, and Claude Code plugin install
+# (when detected). `exec` so the script's stdin/stdout pass through cleanly.
+exec stash connect


### PR DESCRIPTION
## Summary

Phase 2 of \`plans/installer-one-liner.md\`. Ships \`https://stash.ac/install\` as a single-paste bash installer that mirrors how \`fly\` / \`bun\` / \`opencode\` ship.

\`\`\`bash
curl -fsSL https://stash.ac/install | bash
\`\`\`

The script:
1. Picks \`pipx\` > \`uv\` > \`pip3 --user\` (whichever's on PATH)
2. Installs or upgrades \`stashai\` via that manager
3. Bails with actionable hints if none of those are installed
4. Verifies \`stash\` is on PATH (catches the macOS \`~/.local/bin\` not-in-PATH gotcha)
5. \`exec\`s \`stash connect\` — the existing questionnaire handles scope, managed-vs-self-host, browser auth, workspace, and Claude Code plugin install (the step 4 added in 0.1.4)

Both \`/install\` and \`/install.sh\` serve the same content (the no-extension URL goes through a Next.js rewrite).

## Test plan

- [x] \`bash -n www/public/install.sh\` syntax-checks
- [x] Local dev: \`curl -sL http://localhost:3100/install\` returns the script body
- [x] \`/install.sh\` and \`/install\` both serve the script
- [x] \`Content-Type: application/x-sh\` (fine for \`curl | bash\`)
- [ ] Reviewer: after merge, run \`curl -fsSL https://stash.ac/install | bash\` on a fresh box

## Followups

- Phase 3: swap landing-page hero CTA from the agent-prompt-paste to the one-liner
- Codex / Cursor / Gemini / opencode / openclaw plugin auto-install (currently only Claude Code is wired in step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)