### PR TITLE
fix(install.sh): redirect stdin from /dev/tty so questionary works under curl|bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,5 +53,16 @@ fi
 
 # Hand off to the questionnaire. `stash connect` asks scope, managed-vs-
 # self-host, browser sign-in, workspace, and Claude Code plugin install
-# (when detected). `exec` so the script's stdin/stdout pass through cleanly.
-exec stash connect
+# (when detected).
+#
+# When the script runs via `curl … | bash`, our stdin is the script body,
+# so questionary aborts with "Input is not a terminal". Re-attach stdin
+# to the controlling terminal before exec'ing if /dev/tty is available
+# (interactive shells); fall back to plain exec otherwise (CI, Docker
+# without -it — those will just hit the same questionary error, which is
+# the right signal that this isn't an interactive context).
+if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+  exec </dev/tty stash connect
+else
+  exec stash connect
+fi


### PR DESCRIPTION
## Summary

Reported by @htdowling testing the new one-liner:

\`\`\`
~/projects/scheduler ⚡ curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh | bash
→ Installing stashai via pipx…
done! ✨ 🌟 ✨

Stash connect  (press Enter to accept defaults)
Warning: Input is not a terminal (fd=0).
? Where do you want to install stash? (Use shortcuts or arrow keys)
^[[15;1R
Aborted.
\`\`\`

Under \`curl … | bash\`, bash's stdin is the script body, so when we exec into \`stash connect\`, questionary sees a non-terminal stdin and aborts. Re-attach stdin to \`/dev/tty\` before the exec so questionary gets a real terminal back.

Falls back to plain exec when \`/dev/tty\` isn't readable (CI / Docker without \`-it\`) — those weren't going to be interactive anyway.

## Test plan

- [x] \`bash -n install.sh\` syntax-checks
- [ ] Reviewer: \`curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh | bash\` runs the questionnaire end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)