### PR TITLE
fix(plugin): re-exec hooks under stashai's venv python (pipx/uv compat)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "productivity",
       "homepage": "https://stash.ac",
       "author": {

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Connect Claude Code to Stash — stream activity to history and collaborate in workspaces.",
   "author": {
     "name": "Fergana Labs"

--- a/plugins/claude-plugin/hooks/hooks.json
+++ b/plugins/claude-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_session_start.py",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/_run.sh on_session_start",
             "timeout": 5000
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_prompt.py",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/_run.sh on_prompt",
             "timeout": 3000
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_tool_use.py",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/_run.sh on_tool_use",
             "async": true
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_stop.py",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/_run.sh on_stop",
             "timeout": 10000
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/on_session_end.py",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/_run.sh on_session_end",
             "timeout": 5000
           }
         ]

--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"


### PR DESCRIPTION
## Summary

Reported by @htdowling — every Claude Code hook from the stash plugin crashes with:

\`\`\`
ModuleNotFoundError: No module named 'stashai'
  File "…/scripts/on_stop.py"
  from config import …
  File "…/scripts/config.py", line 14
  from stashai.plugin.stash_client import StashClient
\`\`\`

Root cause: hooks.json invokes \`python3 …/on_*.py\`, and the user's \`python3\` is a pyenv shim with no \`stashai\` installed. \`stashai\` lives in pipx's isolated venv (the default our \`install.sh\` uses), so the hook scripts can't import their own modules.

Fix: a tiny \`_run.sh\` wrapper that resolves the \`stash\` symlink, finds the venv's \`python\` (sibling of \`stash\` in the bin dir), and execs the named hook under it. Falls back to system \`python3\` for the \`pip install --user\` case where stashai is on system site-packages directly.

\`\`\`bash
PY=""
if command -v stash >/dev/null 2>&1; then
  STASH_REAL="\$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
  if [ -n "\$STASH_REAL" ]; then
    CANDIDATE="\$(dirname "\$STASH_REAL")/python"
    [ -x "\$CANDIDATE" ] && PY="\$CANDIDATE"
  fi
fi
[ -z "\$PY" ] && PY="python3"
exec "\$PY" "\$TARGET" "\$@"
\`\`\`

Bumps plugin 0.1.2 → 0.1.3 (plugin.json + marketplace.json) so cached installs invalidate.

## Test plan

- [x] \`bash -n _run.sh\` clean
- [x] On my machine the resolver finds \`/Users/henrydowling/.local/pipx/venvs/stashai/bin/python\` correctly
- [ ] Reviewer: after merge, \`claude plugin install stash@stash-plugins\` then trigger any hook (just send a prompt) — no ModuleNotFoundError

🤖 Generated with [Claude Code](https://claude.com/claude-code)