### PR TITLE
fix(plugins): re-exec cursor/codex/opencode hooks under stashai venv

### DIFF
--- a/plugins/codex-plugin/config.toml.snippet
+++ b/plugins/codex-plugin/config.toml.snippet
@@ -10,4 +10,4 @@ suppress_unstable_features_warning = true
 
 # Variant B (fallback) — only if your Codex build lacks features.codex_hooks.
 # Comment out Variant A above, then uncomment this line:
-# notify = ["python3", "${PLUGIN_ROOT}/scripts/on_notify.py"]
+# notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]

--- a/plugins/codex-plugin/hooks.json
+++ b/plugins/codex-plugin/hooks.json
@@ -4,14 +4,14 @@
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_start.py", "timeout": 5 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_start", "timeout": 5 }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_prompt.py", "timeout": 3 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_prompt", "timeout": 3 }
         ]
       }
     ],
@@ -19,14 +19,14 @@
       {
         "matcher": "^Bash$",
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_tool_use.py", "timeout": 5 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_tool_use", "timeout": 5 }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_stop.py", "timeout": 10 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_stop", "timeout": 10 }
         ]
       }
     ]

--- a/plugins/codex-plugin/scripts/_run.sh
+++ b/plugins/codex-plugin/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/plugins/cursor-plugin/hooks.json
+++ b/plugins/cursor-plugin/hooks.json
@@ -3,19 +3,19 @@
   "version": 1,
   "hooks": {
     "sessionStart": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_start.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_start", "timeout": 5 }
     ],
     "beforeSubmitPrompt": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_prompt.py", "timeout": 3 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_prompt", "timeout": 3 }
     ],
     "postToolUse": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_tool_use.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_tool_use", "timeout": 5 }
     ],
     "afterAgentResponse": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_agent_response.py", "timeout": 10 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_agent_response", "timeout": 10 }
     ],
     "sessionEnd": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_end.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_end", "timeout": 5 }
     ]
   }
 }

--- a/plugins/cursor-plugin/scripts/_run.sh
+++ b/plugins/cursor-plugin/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/plugins/opencode-plugin/plugin.ts
+++ b/plugins/opencode-plugin/plugin.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 
 const PLUGIN_ROOT = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = join(PLUGIN_ROOT, "scripts");
-const PYTHON = process.env.STASH_PYTHON ?? "python3";
+const RUN_SH = join(SCRIPTS, "_run.sh");
 
 // opencode never emits a clean session-end signal. After this much idle time
 // inside a live opencode process, treat the session as ended and fire
@@ -51,12 +51,14 @@ function runHook(script: string, payload: unknown): void {
   // Fire-and-forget. We never want a flaky Stash backend to stall opencode.
   // detached + unref so the child belongs to its own process group and gets
   // reaped independently — otherwise zombies accumulate over long sessions.
+  // _run.sh resolves the stashai venv's python so hooks work under pipx/uv.
+  const hookName = script.replace(/\.py$/, "");
   try {
-    const child = spawn(PYTHON, [join(SCRIPTS, script)], {
+    const child = spawn("bash", [RUN_SH, hookName], {
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
     });
-    child.on("error", () => { /* python missing / crash — swallow */ });
+    child.on("error", () => { /* bash missing / crash — swallow */ });
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
     child.unref();

--- a/plugins/opencode-plugin/scripts/_run.sh
+++ b/plugins/opencode-plugin/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/stashai/plugin/assets/codex/config.toml.snippet
+++ b/stashai/plugin/assets/codex/config.toml.snippet
@@ -10,4 +10,4 @@ suppress_unstable_features_warning = true
 
 # Variant B (fallback) — only if your Codex build lacks features.codex_hooks.
 # Comment out Variant A above, then uncomment this line:
-# notify = ["python3", "${PLUGIN_ROOT}/scripts/on_notify.py"]
+# notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]

--- a/stashai/plugin/assets/codex/hooks.json
+++ b/stashai/plugin/assets/codex/hooks.json
@@ -4,14 +4,14 @@
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_start.py", "timeout": 5 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_start", "timeout": 5 }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_prompt.py", "timeout": 3 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_prompt", "timeout": 3 }
         ]
       }
     ],
@@ -19,14 +19,14 @@
       {
         "matcher": "^Bash$",
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_tool_use.py", "timeout": 5 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_tool_use", "timeout": 5 }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "python3 ${PLUGIN_ROOT}/scripts/on_stop.py", "timeout": 10 }
+          { "type": "command", "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_stop", "timeout": 10 }
         ]
       }
     ]

--- a/stashai/plugin/assets/codex/scripts/_run.sh
+++ b/stashai/plugin/assets/codex/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/stashai/plugin/assets/cursor/hooks.json
+++ b/stashai/plugin/assets/cursor/hooks.json
@@ -3,19 +3,19 @@
   "version": 1,
   "hooks": {
     "sessionStart": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_start.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_start", "timeout": 5 }
     ],
     "beforeSubmitPrompt": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_prompt.py", "timeout": 3 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_prompt", "timeout": 3 }
     ],
     "postToolUse": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_tool_use.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_tool_use", "timeout": 5 }
     ],
     "afterAgentResponse": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_agent_response.py", "timeout": 10 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_agent_response", "timeout": 10 }
     ],
     "sessionEnd": [
-      { "command": "python3 ${PLUGIN_ROOT}/scripts/on_session_end.py", "timeout": 5 }
+      { "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_end", "timeout": 5 }
     ]
   }
 }

--- a/stashai/plugin/assets/cursor/scripts/_run.sh
+++ b/stashai/plugin/assets/cursor/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/stashai/plugin/assets/opencode/plugin.ts
+++ b/stashai/plugin/assets/opencode/plugin.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 
 const PLUGIN_ROOT = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = join(PLUGIN_ROOT, "scripts");
-const PYTHON = process.env.STASH_PYTHON ?? "python3";
+const RUN_SH = join(SCRIPTS, "_run.sh");
 
 // opencode never emits a clean session-end signal. After this much idle time
 // inside a live opencode process, treat the session as ended and fire
@@ -51,12 +51,14 @@ function runHook(script: string, payload: unknown): void {
   // Fire-and-forget. We never want a flaky Stash backend to stall opencode.
   // detached + unref so the child belongs to its own process group and gets
   // reaped independently — otherwise zombies accumulate over long sessions.
+  // _run.sh resolves the stashai venv's python so hooks work under pipx/uv.
+  const hookName = script.replace(/\.py$/, "");
   try {
-    const child = spawn(PYTHON, [join(SCRIPTS, script)], {
+    const child = spawn("bash", [RUN_SH, hookName], {
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
     });
-    child.on("error", () => { /* python missing / crash — swallow */ });
+    child.on("error", () => { /* bash missing / crash — swallow */ });
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
     child.unref();

--- a/stashai/plugin/assets/opencode/scripts/_run.sh
+++ b/stashai/plugin/assets/opencode/scripts/_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+TARGET="$(dirname "$0")/$SCRIPT.py"
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  if [ -n "$STASH_REAL" ]; then
+    CANDIDATE="$(dirname "$STASH_REAL")/python"
+    if [ -x "$CANDIDATE" ]; then
+      PY="$CANDIDATE"
+    fi
+  fi
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"


### PR DESCRIPTION
## Summary

Follow-up to #124. PR #122 added `_run.sh` to the claude plugin so hooks work when stashai is installed via pipx or uv (the `install.sh` defaults) — the system `python3` can't import `stashai.plugin.*` from the isolated venv. That fix was never ported to the other three plugins, so every hook wired up by `stash install` on a pipx-based box crashes with `ModuleNotFoundError: No module named 'stashai'`.

This ports the shim to cursor, codex, and opencode:

- Copies `scripts/_run.sh` (identical to `plugins/claude-plugin/scripts/_run.sh`) into each plugin dir.
- Updates every hook invocation to `bash ${PLUGIN_ROOT}/scripts/_run.sh <hook>` instead of `python3 ${PLUGIN_ROOT}/scripts/<hook>.py`: `cursor/hooks.json` (5 hooks), `codex/hooks.json` (4 hooks) + `codex/config.toml.snippet` (notify fallback), `opencode/plugin.ts` (drops its `STASH_PYTHON` env var in favor of `_run.sh`'s built-in fallback).
- Re-vendors each plugin into `stashai/plugin/assets/<agent>/` so `stash install` ships the shim.

## Test plan

- [x] `pytest plugins/tests/ --no-cov -q` → 57 passed (drift test confirms assets still byte-identical to source plugins)
- [x] `ruff check plugins/tests/test_assets_in_sync.py` → clean
- [x] Against a pipx-installed `stash` (where the system `python3` lacks stashai): ran `stash install --skip claude`, then invoked every `on_*.py` hook across all three agents via the generated `_run.sh` path — every one exited rc=0, no traceback. Without this fix, every hook crashed with `ModuleNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)