### PR TITLE
feat(cli): detect all coding agents in stash connect

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1860,19 +1860,32 @@ def connect(
 
     # --- Step 4: Coding-agent plugin ---
     # Detect installed coding agents on PATH and offer to install the matching
-    # stash plugin. Currently handles Claude Code only — Codex/Cursor/Gemini
-    # plugins require bundled hooks files served from the source repo, which
-    # is tracked separately in plans/installer-one-liner.md. Silently skipped
-    # when no supported agent is detected.
-    if _detect_claude_code():
+    # stash plugins. Silently skipped when no supported agent is detected.
+    detected = _detected_agents()
+    if detected:
         _reserve_bottom_padding(4)
+        agent_label = {
+            "claude": "Claude Code",
+            "cursor": "Cursor",
+            "codex": "Codex",
+            "opencode": "opencode",
+        }
+        pretty = ", ".join(agent_label[a] for a in detected)
         install_plugin = questionary.confirm(
-            "Detected Claude Code on this machine. Install the stash plugin?\n"
-            "  (Streams every Claude Code session here to your shared history.)",
+            f"Detected {pretty} on this machine. Install the stash plugin?\n"
+            "  (Streams every session here to your shared history.)",
             default=True,
         ).ask()
         if install_plugin:
-            _install_claude_plugin()
+            for agent in detected:
+                try:
+                    status_, detail = _INSTALLERS[agent](False)
+                except Exception as e:
+                    status_, detail = ("failed", f"{type(e).__name__}: {e}")
+                color = {"installed": "green", "skipped": "yellow", "failed": "red"}[status_]
+                console.print(
+                    f"  [{color}]{status_:9}[/{color}] {agent:8} {detail}"
+                )
 
     # --- Done ---
     _show_setup_complete_splash(
@@ -2237,13 +2250,6 @@ def _capture_install_repo() -> None:
         _write_central_config({"scope": "all"})
     else:
         _write_central_config({"scope": "repo"})
-
-
-def _detect_claude_code() -> bool:
-    """Return True if the Claude Code CLI is on PATH."""
-    import shutil
-
-    return shutil.which("claude") is not None
 
 
 def _install_claude_plugin() -> bool:


### PR DESCRIPTION
## Summary
- Step 4 of `stash connect` only detected Claude Code, even though PR #124 bundled hook templates for Cursor/Codex/opencode and `stash install` already handles all four. Landing-page users running the one-liner on a Codex/opencode/Cursor machine were silently left without a plugin install.
- Switch `connect` to the same `_detected_agents()` + `_INSTALLERS` pair `stash install` uses. Prompt now reads e.g. `Detected Claude Code, Codex on this machine. Install the stash plugin?` and per-agent result lines mirror the `stash install` format.
- Drops the now-unused `_detect_claude_code()` helper.

## Test plan
- [ ] Fresh-machine repro: `mv ~/.stash ~/.stash.bak && rm -rf ~/.claude/plugins/data/stash && claude plugin uninstall stash`, then `stash connect` — confirm every agent on \$PATH is listed in the prompt and gets an `installed`/`skipped` line.
- [ ] Machine with no supported agents on \$PATH: Step 4 is silently skipped (no prompt).
- [ ] Re-run `stash connect` on the same machine: per-agent lines report `skipped` (idempotent).
- [ ] Decline the prompt: no installers run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)