### PR TITLE
fix(auth0): pass AUTH0_AUDIENCE to managed frontend Auth0 client

### DIFF
--- a/frontend/managed/auth0/client.ts
+++ b/frontend/managed/auth0/client.ts
@@ -2,4 +2,13 @@ import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 // Reads AUTH0_DOMAIN / AUTH0_CLIENT_ID / AUTH0_CLIENT_SECRET / AUTH0_SECRET /
 // APP_BASE_URL from env. Never imported when NEXT_PUBLIC_AUTH0_ENABLED !== "true".
-export const auth0 = new Auth0Client();
+//
+// AUTH0_AUDIENCE is passed explicitly so the access token Auth0 issues is
+// scoped to the Stash backend API (whose `/auth0/exchange` endpoint validates
+// the audience claim). Without it, the SDK requests a token only valid at the
+// userinfo endpoint — exchange would 401 with "Missing kid".
+const audience = process.env.AUTH0_AUDIENCE;
+
+export const auth0 = new Auth0Client(
+  audience ? { authorizationParameters: { audience } } : undefined,
+);


### PR DESCRIPTION
## Summary
- Fixes the \"Missing kid\" 401 Sam saw on the CLI authorize page at `stash-web-dr40.onrender.com/login?cli=...`.
- Managed frontend constructed `new Auth0Client()` with no `authorizationParameters.audience`, so the SDK asked Auth0 for an access token scoped only to `/userinfo`. That token isn't signed against the tenant JWKS, so backend `/api/v1/auth0/exchange` rejected it at `backend/managed/auth0/jwt.py:46`.
- Mirrors the conditional-audience pattern already in `www/managed/auth0/client.ts`.

`AUTH0_AUDIENCE=https://moltchat.onrender.com` already set on Render service `srv-d7g6f8s71suc73a27170` (`stash-web`).

## Test plan
- [ ] Merge + wait for Render redeploy
- [ ] Run `stash signin`, complete Auth0 login, confirm CLI gets approved (no \"Missing kid\")
- [ ] Verify Render backend logs show a 200 on `/api/v1/auth0/exchange` from the browser UA

🤖 Generated with [Claude Code](https://claude.com/claude-code)