### PR TITLE
chore(release): bump stashai to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.5"
+version = "0.1.6"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to `0.1.6` so PyPI picks up #131 (per-agent yes/no prompts in `stash connect`).
- After merge, push tag `v0.1.6` to trigger the publish workflow.

## Test plan
- [ ] Merge, then `git tag v0.1.6 && git push origin v0.1.6`.
- [ ] Confirm `.github/workflows/publish.yml` run succeeds.
- [ ] `pipx install stashai --force` and re-run `stash connect` on a machine with multiple agents on PATH — verify one prompt per agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)