### PR TITLE
chore(release): bump stashai to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.6"
+version = "0.1.7"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Ships #134 — welcome panel text now renders in navy (`#1e3a8a`) instead of bright cyan, so the STASH logo and command snippets stay legible on light-background terminals.

## Test plan
- [ ] `pipx upgrade stashai` picks up 0.1.7 once published
- [ ] `stash connect` welcome panel renders in navy on a light-mode terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)