### PR TITLE
fix(cli): correct cd path in self-host walkthrough

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1489,7 +1489,7 @@ def _self_host_walkthrough(cfg: dict) -> str:
     console.print(
         "  [dim]1.[/dim] [cyan]git clone https://github.com/Fergana-Labs/stash.git[/cyan]"
     )
-    console.print("  [dim]2.[/dim] [cyan]cd octopus[/cyan]")
+    console.print("  [dim]2.[/dim] [cyan]cd stash[/cyan]")
     console.print("  [dim]3.[/dim] [cyan]docker compose up -d[/cyan]")
     console.print("\n  [dim]Already running? Skip to the URL prompt below.[/dim]\n")
 


### PR DESCRIPTION
## Summary
- Self-host walkthrough told users to `cd octopus` after cloning `stash.git`, which drops them in a nonexistent directory. Now says `cd stash` to match the clone target.

## Test plan
- [ ] Run `stash connect`, pick Self-host, confirm the printed steps are copy-pasteable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)