### PR TITLE
fix(cli): point self-host login at frontend port 3457

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1792,10 +1792,10 @@ def connect(
             raise typer.Exit(1)
 
         # Build the login URL. The backend and frontend are separate deployments.
-        # - Local self-host: backend on :3456, frontend on :3000.
+        # - Local self-host: backend on :3456, frontend on :3457.
         # - Managed: frontend lives at stash-web-dr40.onrender.com.
         if "localhost" in base_url or "127.0.0.1" in base_url:
-            frontend_url = base_url.replace(":3456", ":3000")
+            frontend_url = base_url.replace(":3456", ":3457")
         elif base_url == "https://moltchat.onrender.com":
             frontend_url = "https://stash-web-dr40.onrender.com"
         else:


### PR DESCRIPTION
## Summary
- Frontend Dockerfile and docker-compose both publish Next.js on `:3457`, but the CLI rewrote `:3456` → `:3000` when building the login URL, sending self-hosters to a dead port.
- Comment updated to match.

## Test plan
- [ ] `docker compose up --build -d` from repo root
- [ ] `stash connect` → pick Self-host → accept `http://localhost:3456`
- [ ] Browser opens `http://localhost:3457/login?cli=<id>`, auth completes, CLI prints `✓ Logged in as …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)