### PR TITLE
fix(cli): replace cyan welcome panel border with brand blue

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2477,7 +2477,7 @@ def _show_setup_complete_splash(
         Panel(
             body,
             title="[bold]Your team's shared agent memory[/bold]",
-            border_style="cyan",
+            border_style="#1e3a8a",
             padding=(1, 2),
         )
     )


### PR DESCRIPTION
## Summary
- Swap the \"Your team's shared agent memory\" panel border from `cyan` to the `#1e3a8a` brand blue already used elsewhere in the splash, so the title no longer clashes against the logo and body text.

## Test plan
- [x] `python -c \"from cli.main import _show_setup_complete_splash; _show_setup_complete_splash()\"` — title + border render in brand blue, rest of panel unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)