### PR TITLE
feat(www): add Sign in link to landing page nav

### DIFF
--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -55,6 +55,9 @@ function Nav() {
           <Link href="/docs" className="hover:text-ink">
             Docs
           </Link>
+          <Link href="/connect-token" className="hover:text-ink">
+            Sign in
+          </Link>
           <Link
             href="#install"
             className="inline-flex h-9 items-center rounded-md bg-brand px-4 font-medium text-white shadow-sm transition hover:bg-brand-hover"


### PR DESCRIPTION
## Summary
- Adds a **Sign in** entry to the landing page nav between Docs and Install
- Links to `/connect-token`, which already handles the Auth0 redirect (bounces unauthed users through `/auth/login?returnTo=/connect-token` and either hands the minted key to a waiting CLI session or renders the paste-back UI)

## Test plan
- [ ] Visit stash.ac — confirm "Sign in" shows in the nav
- [ ] Click "Sign in" while signed out → lands on Auth0 login, returns to `/connect-token`
- [ ] Click "Sign in" while signed in → `/connect-token` renders directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)