### PR TITLE
fix(cli): reflow welcome Q&A to terminal width

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import questionary
 import typer
+from rich.console import Group
 from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
 from .client import StashClient, StashError
 from .config import (
@@ -2436,13 +2439,13 @@ def _show_setup_complete_splash(
     else:
         console.print("  [bold green]You're all set up.[/bold green]\n")
 
-    body = (
+    intro = (
         "[bold]What just happened[/bold]\n"
-        "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
-        "It can read the transcripts your teammates' coding agents push to this\n"
+        "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH. "
+        "It can read the transcripts your teammates' coding agents push to this "
         "workspace — so it knows what the rest of your team is working on.\n"
         "\n"
-        "[bold]Examples of questions your agent might want answered [/bold] \n"
+        "[bold]Examples of questions your agent might want answered[/bold]\n"
         '  [dim]"Why did Sam bump the rate limit from 100 to 500?"[/dim]\n'
         '  [dim]"Has anyone already tried fixing the memory leak in our backend?"[/dim]\n'
         '  [dim]"Is anyone else currently working on our api gateway"[/dim]\n'
@@ -2456,26 +2459,50 @@ def _show_setup_complete_splash(
         "\n"
         "Run [bold]stash --help[/bold] to see everything.\n"
         "\n"
-        "[bold]Q&A[/bold]\n"
-        "  [bold]Q[/bold] Do you inject anything into my coding agent's context automatically?\n"
-        "  [bold]A[/bold] No.\n"
-        "\n"
-        "  [bold]Q[/bold] What gets pushed to the shared store?\n"
-        f"  [bold]A[/bold] {_pushed_scope_phrase()}\n"
-        "\n"
-        "  [bold]Q[/bold] How do I change scope or see a transcript?\n"
-        "  [bold]A[/bold] [#1e3a8a]stash config scope <repo|workspace|all>[/#1e3a8a]  (default: repo)\n"
-        "     [#1e3a8a]stash history transcript <session_id>[/#1e3a8a]  view a full transcript\n"
-        '     [#1e3a8a]stash history search "<query>"[/#1e3a8a]         search event content\n'
-        "\n"
-        "  [bold]Q[/bold] How do I share my workspace with my team?\n"
-        "  [bold]A[/bold] Share the invite code ([#1e3a8a]stash workspaces info <id>[/#1e3a8a] prints it).\n"
-        "     Teammates run [#1e3a8a]stash connect[/#1e3a8a] if needed, then\n"
-        "     [#1e3a8a]stash workspaces join <invite_code>[/#1e3a8a].\n"
+        "[bold]Q&A[/bold]"
     )
+
+    qa_pairs = [
+        (
+            "Do you inject anything into my coding agent's context automatically?",
+            "No.",
+        ),
+        (
+            "What gets pushed to the shared store?",
+            _pushed_scope_phrase(),
+        ),
+        (
+            "How do I change scope or see a transcript?",
+            "[#1e3a8a]stash config scope <repo|workspace|all>[/#1e3a8a]  (default: repo)\n"
+            "[#1e3a8a]stash history transcript <session_id>[/#1e3a8a]  view a full transcript\n"
+            '[#1e3a8a]stash history search "<query>"[/#1e3a8a]         search event content',
+        ),
+        (
+            "How do I share my workspace with my team?",
+            "Share the invite code ([#1e3a8a]stash workspaces info <id>[/#1e3a8a] prints it). "
+            "Teammates run [#1e3a8a]stash connect[/#1e3a8a] if needed, then "
+            "[#1e3a8a]stash workspaces join <invite_code>[/#1e3a8a].",
+        ),
+    ]
+
+    qa_table = Table(
+        show_header=False,
+        show_edge=False,
+        box=None,
+        pad_edge=False,
+        padding=(0, 1),
+    )
+    qa_table.add_column(style="bold", no_wrap=True)
+    qa_table.add_column(overflow="fold")
+    for i, (question, answer) in enumerate(qa_pairs):
+        if i > 0:
+            qa_table.add_row("", "")
+        qa_table.add_row("Q", question)
+        qa_table.add_row("A", answer)
+
     console.print(
         Panel(
-            body,
+            Group(Text.from_markup(intro), qa_table),
             title="[bold]Your team's shared agent memory[/bold]",
             border_style="#1e3a8a",
             padding=(1, 2),


### PR DESCRIPTION
## Summary
- Render the welcome panel's Q&A block as a Rich `Table` so answers wrap under the `A` column with a hanging indent instead of breaking alignment at narrow terminals
- Collapse hard `\n` breaks in the "What just happened" paragraph so it reflows with the panel width

## Test plan
- [ ] `cd octopus-settings && python -c "import cli.main as m; m._capture_install_repo=lambda:None; m._show_setup_complete_splash(workspace_name='demo', joined_via_invite=False)"` at terminal widths 40 / 60 / 80 / 100 — Q/A alignment holds, answers wrap with hanging indent
- [ ] Full `stash connect` flow still renders the splash without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)