### PR TITLE
chore: bump stashai to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.7"
+version = "0.1.8"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps `stashai` to 0.1.8 so the next PyPI release picks up CLI welcome changes that landed after 0.1.7.

## Why
PyPI's 0.1.7 predates #138 (scope-varying welcome Q&A), #139 (blue border), and #140 (interactive settings page). Users who `pipx install stashai` still see the old static "Transcripts are stored verbatim — no secret scrubbing yet" answer.

## Test plan
- [ ] Publish to PyPI after merge
- [ ] `pipx install --force "stashai==0.1.8" --pip-args="--no-cache-dir"`
- [ ] Confirm `stash connect --welcome` renders the scope-varying Q&A + blue border