### PR TITLE
fix(auth0): populate email/name via /userinfo

### DIFF
--- a/backend/managed/auth0/router.py
+++ b/backend/managed/auth0/router.py
@@ -1,8 +1,10 @@
 """POST /api/v1/auth0/exchange — swap an Auth0 access token for an octopus api_key."""
 
+import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from backend.config import settings
 from backend.middleware import limiter
 from backend.models import UserRegisterResponse
 
@@ -14,6 +16,15 @@ router = APIRouter(prefix="/api/v1/auth0", tags=["auth0"])
 _security = HTTPBearer()
 
 
+async def _fetch_userinfo(access_token: str) -> dict:
+    url = f"https://{settings.AUTH0_DOMAIN}/userinfo"
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
+    if resp.status_code != 200:
+        return {}
+    return resp.json()
+
+
 @router.post("/exchange", response_model=UserRegisterResponse)
 @limiter.limit("30/minute")
 async def exchange(
@@ -21,10 +32,11 @@ async def exchange(
     credentials: HTTPAuthorizationCredentials = Depends(_security),
 ):
     claims = await validate_auth0_token(credentials.credentials)
+    profile = await _fetch_userinfo(credentials.credentials)
     user, api_key = await get_or_create_user_from_auth0(
         auth0_sub=claims["sub"],
-        email=claims.get("email"),
-        name=claims.get("name"),
+        email=profile.get("email"),
+        name=profile.get("name"),
     )
     return UserRegisterResponse(
         id=user["id"],


### PR DESCRIPTION
## Summary

- Auth0 access tokens issued against a custom API audience don't include `email` or `name` claims, so `/api/v1/auth0/exchange` always saw `None` for both.
- New users fell through to the slug fallback in `users.py` and ended up as `user_2`, `user_3`, etc., with workspaces named `"user_2's Workspace"`.
- Fix: call Auth0's OIDC `/userinfo` endpoint with the same access token and read `email`/`name` from the response.

## Test plan

- [ ] Merge + let Render auto-deploy `moltchat`
- [ ] Sign up at stash.ac with a fresh email (Google/GitHub)
- [ ] Confirm the new `users` row has real `display_name` and the default workspace is `"<Real Name>'s Workspace"` instead of `user_N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)