### PR TITLE
fix(cli): center octopus and STASH logo in setup splash

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import sys
+import textwrap
 from pathlib import Path
 
 import questionary
 import typer
+from rich.align import Align
 from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
@@ -2524,8 +2526,11 @@ def _show_setup_complete_splash(
     """Clear the onboarding transcript and show a clean success splash."""
     _capture_install_repo()
     console.clear()
-    console.print(f"[bold #F97316]{STASH_OCTOPUS}[/bold #F97316]")
-    console.print(f"[bold #1e3a8a]{STASH_LOGO}[/bold #1e3a8a]")
+    octopus = textwrap.dedent(STASH_OCTOPUS.strip("\n"))
+    logo = textwrap.dedent(STASH_LOGO.strip("\n"))
+    console.print(Align.center(Text.from_markup(f"[bold #F97316]{octopus}[/bold #F97316]")))
+    console.print()
+    console.print(Align.center(Text.from_markup(f"[bold #1e3a8a]{logo}[/bold #1e3a8a]")))
     if (joined_via_invite or joined_via_manifest) and workspace_name:
         console.print(f"  [bold green]You joined[/bold green] [bold]{workspace_name}[/bold].\n")
     else:


### PR DESCRIPTION
## Summary
- Wrap the octopus and STASH ASCII blocks in `Align.center` so they sit on the terminal's vertical center axis
- Dedent each block first so the leading whitespace baked into the source doesn't skew the measured width (which was making the two blocks center on different axes)
- Add a blank line between octopus and logo for breathing room

## Test plan
- [x] `_show_setup_complete_splash` renders both blocks centered on the same axis at 120-col width
- [ ] Verify in a real terminal during onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)