### PR TITLE
fix(auth): multi-key API auth so logins stop 401ing other devices

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,7 +194,7 @@ Most routers are split into `ws_router` (workspace-scoped, `/workspaces/{id}/...
 
 Two credential types accepted on the same endpoints:
 
-- **API key** — issued at registration; sent as `Authorization: Bearer <key>`. Stored as a SHA-256 hash in `users.api_key_hash`.
+- **API key** — sent as `Authorization: Bearer <key>`. Each login mints a new row in `user_api_keys` (sha256 of the key, plus a device name); prior keys stay valid so multiple devices coexist. Users can list/revoke via `stash keys` or `GET|DELETE /api/v1/users/me/keys`.
 - **JWT** — issued by `/users/login`; used by the web UI.
 
 `get_current_user` resolves either.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -51,6 +51,19 @@ def hash_api_key(key: str) -> str:
     return hashlib.sha256(key.encode()).hexdigest()
 
 
+async def create_api_key(user_id, name: str = "default") -> str:
+    """Mint a new API key for the user and persist its hash. Returns the raw key."""
+    pool = get_pool()
+    api_key = generate_api_key()
+    await pool.execute(
+        "INSERT INTO user_api_keys (user_id, key_hash, name) VALUES ($1, $2, $3)",
+        user_id,
+        hash_api_key(api_key),
+        name[:128],
+    )
+    return api_key
+
+
 def hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
@@ -75,20 +88,25 @@ async def get_current_user(
     key_hash = hash_api_key(token)
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, description, "
-        "       created_at, last_seen "
-        "FROM users WHERE api_key_hash = $1",
+        "SELECT u.id, u.name, u.display_name, u.description, "
+        "       u.created_at, u.last_seen, k.id AS key_id "
+        "FROM user_api_keys k JOIN users u ON u.id = k.user_id "
+        "WHERE k.key_hash = $1 AND k.revoked_at IS NULL",
         key_hash,
     )
     if not row:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-    user = dict(row)
+    user = {k: v for k, v in dict(row).items() if k != "key_id"}
+    key_id = row["key_id"]
 
     uid = str(user["id"])
     now = time.monotonic()
     if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:
         _last_seen_written.set(uid, now)
         await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", user["id"])
+        await pool.execute(
+            "UPDATE user_api_keys SET last_used_at = now() WHERE id = $1", key_id
+        )
     return user
 
 

--- a/backend/managed/auth0/router.py
+++ b/backend/managed/auth0/router.py
@@ -33,10 +33,13 @@ async def exchange(
 ):
     claims = await validate_auth0_token(credentials.credentials)
     profile = await _fetch_userinfo(credentials.credentials)
+    device = request.query_params.get("device", "").strip()[:96]
+    key_name = f"CLI ({device})" if device else "Auth0 login"
     user, api_key = await get_or_create_user_from_auth0(
         auth0_sub=claims["sub"],
         email=profile.get("email"),
         name=profile.get("name"),
+        key_name=key_name,
     )
     return UserRegisterResponse(
         id=user["id"],

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -2,7 +2,7 @@
 
 import re
 
-from backend.auth import generate_api_key, hash_api_key
+from backend.auth import create_api_key
 from backend.database import get_pool
 from backend.services import workspace_service
 
@@ -28,11 +28,10 @@ async def get_or_create_user_from_auth0(
     auth0_sub: str,
     email: str | None,
     name: str | None,
+    key_name: str = "Auth0 login",
 ) -> tuple[dict, str]:
-    """Return (user_row, new_api_key). Rotates api_key on every login."""
+    """Return (user_row, new_api_key). Mints a fresh key per exchange; prior keys stay valid."""
     pool = get_pool()
-    api_key = generate_api_key()
-    key_hash = hash_api_key(api_key)
 
     row = await pool.fetchrow(
         "SELECT id, name, display_name, description, created_at, last_seen "
@@ -40,11 +39,8 @@ async def get_or_create_user_from_auth0(
         auth0_sub,
     )
     if row:
-        await pool.execute(
-            "UPDATE users SET api_key_hash = $1, last_seen = now() WHERE id = $2",
-            key_hash,
-            row["id"],
-        )
+        await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
+        api_key = await create_api_key(row["id"], name=key_name)
         return dict(row), api_key
 
     base = _slugify_name((email or "").split("@")[0] or name or "user")
@@ -52,15 +48,15 @@ async def get_or_create_user_from_auth0(
     display_name = name or username
 
     row = await pool.fetchrow(
-        "INSERT INTO users (name, display_name, api_key_hash, auth0_sub, description) "
-        "VALUES ($1, $2, $3, $4, '') "
+        "INSERT INTO users (name, display_name, auth0_sub, description) "
+        "VALUES ($1, $2, $3, '') "
         "RETURNING id, name, display_name, description, created_at, last_seen",
         username,
         display_name,
-        key_hash,
         auth0_sub,
     )
     user = dict(row)
+    api_key = await create_api_key(user["id"], name=key_name)
 
     suffix = "'s Workspace"
     ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"

--- a/backend/migrations/versions/0010_multi_api_keys.py
+++ b/backend/migrations/versions/0010_multi_api_keys.py
@@ -1,0 +1,62 @@
+"""Multi-key auth: user_api_keys table, drop users.api_key_hash.
+
+Revision ID: 0010
+Revises: 0009
+"""
+
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+CREATE TABLE IF NOT EXISTS user_api_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    name VARCHAR(128) NOT NULL DEFAULT 'default',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ
+)
+""")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_api_keys_user "
+        "ON user_api_keys(user_id) WHERE revoked_at IS NULL"
+    )
+
+    # Backfill from users.api_key_hash — a user's current key keeps working.
+    op.execute("""
+INSERT INTO user_api_keys (user_id, key_hash, name)
+SELECT id, api_key_hash, 'migrated'
+FROM users
+WHERE api_key_hash IS NOT NULL
+ON CONFLICT (key_hash) DO NOTHING
+""")
+
+    op.execute("DROP INDEX IF EXISTS idx_users_api_key_hash")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS api_key_hash")
+
+
+def downgrade() -> None:
+    # Restore the column and repopulate from the newest surviving key per user.
+    op.execute("ALTER TABLE users ADD COLUMN api_key_hash VARCHAR(64) UNIQUE")
+    op.execute("""
+UPDATE users u
+SET api_key_hash = k.key_hash
+FROM (
+    SELECT DISTINCT ON (user_id) user_id, key_hash
+    FROM user_api_keys
+    WHERE revoked_at IS NULL
+    ORDER BY user_id, created_at DESC
+) k
+WHERE u.id = k.user_id
+""")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_users_api_key_hash ON users(api_key_hash)"
+    )
+    op.execute("DROP TABLE IF EXISTS user_api_keys CASCADE")

--- a/backend/models.py
+++ b/backend/models.py
@@ -46,6 +46,13 @@ class UserSearchResult(BaseModel):
     display_name: str | None
 
 
+class ApiKeyInfo(BaseModel):
+    id: UUID
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None
+
+
 # --- Workspaces ---
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -7,6 +7,7 @@ from ..auth import get_current_user
 from ..config import settings
 from ..middleware import limiter
 from ..models import (
+    ApiKeyInfo,
     LoginRequest,
     RedeemInviteRequest,
     RedeemInviteResponse,
@@ -118,6 +119,42 @@ async def search_users(
 
 
 # ---------------------------------------------------------------------------
+# API keys — list and revoke
+# ---------------------------------------------------------------------------
+
+
+@router.get("/me/keys", response_model=list[ApiKeyInfo])
+async def list_my_keys(current_user: dict = Depends(get_current_user)):
+    from ..database import get_pool
+
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, name, created_at, last_used_at "
+        "FROM user_api_keys "
+        "WHERE user_id = $1 AND revoked_at IS NULL "
+        "ORDER BY created_at DESC",
+        current_user["id"],
+    )
+    return [ApiKeyInfo(**dict(r)) for r in rows]
+
+
+@router.delete("/me/keys/{key_id}", status_code=204)
+async def revoke_my_key(key_id: str, current_user: dict = Depends(get_current_user)):
+    from ..database import get_pool
+
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE user_api_keys SET revoked_at = now() "
+        "WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL",
+        key_id,
+        current_user["id"],
+    )
+    if not result.endswith(" 1"):
+        raise HTTPException(status_code=404, detail="Key not found")
+    return None
+
+
+# ---------------------------------------------------------------------------
 # CLI browser-based auth flow
 # ---------------------------------------------------------------------------
 
@@ -125,11 +162,21 @@ async def search_users(
 @router.post("/cli-auth/sessions")
 @limiter.limit("10/minute")
 async def create_cli_auth_session(request: Request):
-    """Create a CLI auth session. Returns a session_id the CLI uses to poll."""
+    """Create a CLI auth session. Returns a session_id the CLI uses to poll.
+
+    Optional body `{"device_name": "..."}` names the key that'll be minted,
+    so users can tell devices apart in `stash keys list`.
+    """
     _prune_cli_sessions()
     session_id = secrets.token_urlsafe(32)
-    _cli_sessions[session_id] = {"created_at": time.time()}
-    return {"session_id": session_id}
+    device_name = ""
+    try:
+        body = await request.json()
+        device_name = str(body.get("device_name") or "")[:128]
+    except Exception:
+        pass
+    _cli_sessions[session_id] = {"created_at": time.time(), "device_name": device_name}
+    return {"session_id": session_id, "device_name": device_name}
 
 
 @router.get("/cli-auth/sessions/{session_id}")

--- a/backend/services/invite_token_service.py
+++ b/backend/services/invite_token_service.py
@@ -10,7 +10,7 @@ import secrets
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from ..auth import generate_api_key, hash_api_key
+from ..auth import create_api_key
 from ..database import get_pool
 from . import workspace_service
 
@@ -120,19 +120,16 @@ async def redeem_as_new_user(raw_token: str, display_name: str) -> dict | None:
         return None
 
     pool = get_pool()
-    api_key = generate_api_key()
-    key_hash = hash_api_key(api_key)
     username = await _pick_unique_username(display_name)
 
     async with pool.acquire() as conn:
         async with conn.transaction():
             user_row = await conn.fetchrow(
-                "INSERT INTO users (name, display_name, api_key_hash, description) "
-                "VALUES ($1, $2, $3, '') "
+                "INSERT INTO users (name, display_name, description) "
+                "VALUES ($1, $2, '') "
                 "RETURNING id, name, display_name",
                 username,
                 display_name[:128],
-                key_hash,
             )
             # Mark token as consumed first — if the join/member insert somehow fails
             # we don't want the token to stay usable.
@@ -150,6 +147,7 @@ async def redeem_as_new_user(raw_token: str, display_name: str) -> dict | None:
                 token_row["workspace_id"],
                 user_row["id"],
             )
+    api_key = await create_api_key(user_row["id"], name="invite redeem")
 
     ws = await workspace_service.get_workspace(token_row["workspace_id"])
     return {

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from ..auth import generate_api_key, hash_api_key, hash_password, verify_password
+from ..auth import create_api_key, hash_password, verify_password
 from ..database import get_pool
 
 
@@ -12,17 +12,14 @@ async def register_user(
 ) -> tuple[dict, str]:
     """Register a new user. Returns (user_row, raw_api_key)."""
     pool = get_pool()
-    api_key = generate_api_key()
-    key_hash = hash_api_key(api_key)
     pw_hash = hash_password(password) if password else None
     try:
         row = await pool.fetchrow(
-            "INSERT INTO users (name, display_name, api_key_hash, password_hash, description) "
-            "VALUES ($1, $2, $3, $4, $5) "
+            "INSERT INTO users (name, display_name, password_hash, description) "
+            "VALUES ($1, $2, $3, $4) "
             "RETURNING id, name, display_name, description, created_at, last_seen",
             name,
             display_name or name,
-            key_hash,
             pw_hash,
             description,
         )
@@ -31,6 +28,7 @@ async def register_user(
             raise ValueError(f"Username '{name}' is already taken")
         raise
     user = dict(row)
+    api_key = await create_api_key(user["id"], name="password register")
 
     # Auto-provision a default workspace for new users.
     # workspaces.name is VARCHAR(128); trim the display so the suffix always fits.
@@ -107,13 +105,9 @@ async def authenticate_by_password(name: str, password: str) -> tuple[dict, str]
         raise ValueError("Invalid username or password")
     if not verify_password(password, row["password_hash"]):
         raise ValueError("Invalid username or password")
-    # Generate new API key on login
-    api_key = generate_api_key()
-    key_hash = hash_api_key(api_key)
-    await pool.execute(
-        "UPDATE users SET api_key_hash = $1, last_seen = now() WHERE id = $2",
-        key_hash,
-        row["id"],
-    )
+    # Each login mints a fresh key — prior keys keep working so other devices
+    # don't get logged out.
+    api_key = await create_api_key(row["id"], name="password login")
+    await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
     user = {k: v for k, v in dict(row).items() if k != "password_hash"}
     return user, api_key

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -11,13 +11,17 @@ from .conftest import unique_name
 
 async def _make_user(pool, name=None):
     name = name or unique_name()
-    api_key_hash = "hash_" + uuid.uuid4().hex
     row = await pool.fetchrow(
-        "INSERT INTO users (name, api_key_hash) VALUES ($1, $2) RETURNING id",
+        "INSERT INTO users (name) VALUES ($1) RETURNING id",
         name,
-        api_key_hash,
     )
-    return row["id"]
+    user_id = row["id"]
+    await pool.execute(
+        "INSERT INTO user_api_keys (user_id, key_hash, name) VALUES ($1, $2, 'test')",
+        user_id,
+        "hash_" + uuid.uuid4().hex,
+    )
+    return user_id
 
 
 async def _make_workspace(pool, creator_id):

--- a/cli/client.py
+++ b/cli/client.py
@@ -79,6 +79,12 @@ class StashClient:
     def whoami(self) -> dict:
         return self._get("/api/v1/users/me")
 
+    def list_api_keys(self) -> list:
+        return self._get("/api/v1/users/me/keys")
+
+    def revoke_api_key(self, key_id: str) -> None:
+        self._delete(f"/api/v1/users/me/keys/{key_id}")
+
     # --- Workspaces ---
 
     def create_workspace(self, name: str, description: str = "", is_public: bool = False) -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -128,15 +128,21 @@ def signin(
     default workspace if the user has exactly one.
     """
     import os
+    import socket
     import time
     import webbrowser
+    from urllib.parse import quote
 
     import httpx
+
+    device_name = socket.gethostname() or ""
 
     # Create the CLI auth session.
     with httpx.Client(base_url=api, timeout=10) as c:
         try:
-            r = c.post("/api/v1/users/cli-auth/sessions")
+            r = c.post(
+                "/api/v1/users/cli-auth/sessions", json={"device_name": device_name}
+            )
             r.raise_for_status()
             session_id = r.json()["session_id"]
         except (httpx.HTTPError, KeyError) as e:
@@ -145,6 +151,8 @@ def signin(
 
     sep = "&" if "?" in page else "?"
     url = f"{page}{sep}session={session_id}"
+    if device_name:
+        url += f"&device={quote(device_name)}"
 
     ssh = any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"))
     opened = False if (no_browser or ssh) else webbrowser.open(url)
@@ -2808,6 +2816,44 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             new_url = questionary.text("Endpoint base URL", default=base_url).ask()
             if new_url:
                 save_config(base_url=new_url.strip().rstrip("/"))
+
+
+keys_app = typer.Typer(help="Manage your API keys across devices.")
+app.add_typer(keys_app, name="keys")
+
+
+@keys_app.command("list")
+def keys_list(as_json: bool = typer.Option(False, "--json")):
+    """List your active API keys (one per device / login)."""
+    with _client() as c:
+        try:
+            keys = c.list_api_keys()
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(keys)
+        return
+    if not keys:
+        console.print("[dim]No active API keys.[/dim]")
+        return
+    for k in keys:
+        last = k.get("last_used_at") or "never"
+        console.print(
+            f"  [bold]{k['name']}[/bold]  "
+            f"[dim]id: {k['id']}  created: {str(k['created_at'])[:10]}  "
+            f"last used: {str(last)[:10]}[/dim]"
+        )
+
+
+@keys_app.command("revoke")
+def keys_revoke(key_id: str = typer.Argument(..., help="Key id to revoke.")):
+    """Revoke an API key by id. Any device using it will 401 on next call."""
+    with _client() as c:
+        try:
+            c.revoke_api_key(key_id)
+        except StashError as e:
+            _err(e)
+    console.print(f"[green]Revoked key {key_id}.[/green]")
 
 
 @app.command("disconnect")

--- a/www/app/connect-token/page.tsx
+++ b/www/app/connect-token/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.stash.ac";
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
-type Search = { session?: string };
+type Search = { session?: string; device?: string };
 
 // Server component. Expects `?session=<id>` from `stash signin`: mints a token
 // and POSTs it to /cli-auth/sessions/<id>/approve so the CLI (which is polling)
@@ -16,7 +16,7 @@ export default async function ConnectTokenPage({
 }: {
   searchParams: Promise<Search>;
 }) {
-  const { session: sessionId } = await searchParams;
+  const { session: sessionId, device } = await searchParams;
 
   if (!AUTH0_ENABLED) {
     return (
@@ -47,12 +47,16 @@ export default async function ConnectTokenPage({
   const { auth0 } = await import("@managed/auth0/client");
   const session = await auth0.getSession();
   if (!session) {
-    const returnTo = `/connect-token?session=${encodeURIComponent(sessionId)}`;
+    const qs = new URLSearchParams({ session: sessionId });
+    if (device) qs.set("device", device);
+    const returnTo = `/connect-token?${qs.toString()}`;
     redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
   }
 
   const accessToken = session.tokenSet.accessToken;
-  const res = await fetch(`${API_URL}/api/v1/auth0/exchange`, {
+  const exchangeUrl = new URL(`${API_URL}/api/v1/auth0/exchange`);
+  if (device) exchangeUrl.searchParams.set("device", device);
+  const res = await fetch(exchangeUrl.toString(), {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",


### PR DESCRIPTION
## Summary
- Every Auth0/password login used to `UPDATE users.api_key_hash`, silently invalidating every other device's key. Sam's CLI kept 401ing because opening the web app (or running `stash signin` on a second machine) nuked the terminal's key.
- Replaces the single `users.api_key_hash` column with a `user_api_keys` table. Each login/exchange now inserts a new row — prior keys stay valid until explicitly revoked.
- Adds `GET/DELETE /api/v1/users/me/keys` and `stash keys list | revoke <id>` so users can see and cull keys.
- CLI sends `socket.gethostname()` as the device name during sign-in, so keys show up as `CLI (sam-mbp)` instead of `default`.

## What changed
- `backend/migrations/versions/0010_multi_api_keys.py` — new table, backfill from `users.api_key_hash`, drop the column (reversible).
- `backend/auth.py` — `create_api_key()` helper; `get_current_user` JOINs `user_api_keys WHERE revoked_at IS NULL`; updates `last_used_at` alongside `last_seen`.
- `backend/services/user_service.py`, `backend/managed/auth0/users.py`, `backend/services/invite_token_service.py` — all switched from UPDATE to INSERT.
- `backend/routers/users.py` — list/revoke endpoints + `device_name` on CLI auth sessions.
- `backend/managed/auth0/router.py` — `/exchange` reads optional `?device=` and names the minted key.
- `www/app/connect-token/page.tsx` — forwards `device` through Auth0 round-trip.
- `cli/main.py`, `cli/client.py` — `stash keys list|revoke` + threads hostname through `stash signin`.
- `backend/tests/test_permissions.py` — `_make_user` helper now inserts into `user_api_keys`.
- `ARCHITECTURE.md` — auth section updated.

## Test plan
- [ ] CI: pytest green (local postgres/pgvector versions didn't cooperate, so DB-backed tests were not run locally).
- [ ] Deploy to Render, run `stash signin` from two machines — both CLIs stay authenticated.
- [ ] `stash keys list` shows both devices with their hostnames; `stash keys revoke <id>` 401s the revoked device only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)