### PR TITLE
chore(domain): point managed frontend at app.stash.ac

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1845,11 +1845,11 @@ def connect(
 
         # Build the login URL. The backend and frontend are separate deployments.
         # - Local self-host: backend on :3456, frontend on :3457.
-        # - Managed: frontend lives at stash-web-dr40.onrender.com.
+        # - Managed: frontend lives at app.stash.ac.
         if "localhost" in base_url or "127.0.0.1" in base_url:
             frontend_url = base_url.replace(":3456", ":3457")
         elif base_url == "https://api.stash.ac":
-            frontend_url = "https://stash-web-dr40.onrender.com"
+            frontend_url = "https://app.stash.ac"
         else:
             frontend_url = base_url
         login_url = f"{frontend_url}/login?cli={session_id}"

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const MANAGED_APP_URL =
-  process.env.MANAGED_APP_URL || "https://stash-web-dr40.onrender.com";
+  process.env.MANAGED_APP_URL || "https://app.stash.ac";
 
 const nextConfig: NextConfig = {
   output: "standalone",


### PR DESCRIPTION
## Summary
- Replaces hardcoded \`stash-web-dr40.onrender.com\` with the new custom domain \`app.stash.ac\` in the two places the URL was baked in:
  - \`cli/main.py\` — CLI login redirect target for the managed backend
  - \`www/next.config.ts\` — default \`MANAGED_APP_URL\` used by the \`/join/:code\` redirect
- DNS + Render custom domain + TLS cert are already live (\`curl https://app.stash.ac\` returns the Next.js app).

## Test plan
- [ ] After merge + CLI release, \`stashai login\` against \`api.stash.ac\` opens \`https://app.stash.ac/login?cli=...\`
- [ ] \`https://stash.ac/join/ABC\` still redirects to the app (now via \`app.stash.ac\`)
- [ ] Old \`stash-web-dr40.onrender.com\` remains reachable as a fallback (Render keeps the \`.onrender.com\` URL alive alongside the custom domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)