### PR TITLE
fix(www): point nav Sign in at managed app /login

### DIFF
--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -55,7 +55,7 @@ function Nav() {
           <Link href="/docs" className="hover:text-ink">
             Docs
           </Link>
-          <Link href="/connect-token" className="hover:text-ink">
+          <Link href="/login" className="hover:text-ink">
             Sign in
           </Link>
           <Link

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -17,6 +17,11 @@ const nextConfig: NextConfig = {
         destination: `${MANAGED_APP_URL}/join/:code`,
         permanent: false,
       },
+      {
+        source: "/login",
+        destination: `${MANAGED_APP_URL}/login`,
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- Nav "Sign in" link sent users to `/connect-token`, which is the CLI handshake page; without a `?session=<id>` it renders terminal copy ("Open this page from the CLI"). Real-website visitors had no way to sign in.
- Add a `/login` redirect to `MANAGED_APP_URL/login`, mirroring the existing `/join/:code` redirect.
- Update nav `Link href` from `/connect-token` to `/login`.

## Test plan
- [x] `curl -sI http://localhost:3100/login` → `307` to `https://stash-web-dr40.onrender.com/login`
- [x] `curl -sI https://stash-web-dr40.onrender.com/login` → `200`
- [x] Rendered home page nav contains `href="/login">Sign in`
- [ ] After deploy: click "Sign in" on stash.ac and confirm it lands on the managed login

🤖 Generated with [Claude Code](https://claude.com/claude-code)