### PR TITLE
ci(publish): auto-tag and publish on pyproject version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,13 @@
 name: Publish stashai to PyPI
 
+# Fires on every push to main. If pyproject.toml carries a version whose
+# `v<version>` tag doesn't exist yet, the job tags the commit and publishes
+# the sdist + wheel to PyPI. Existing versions are a no-op, so the workflow
+# is safe to re-run (including via workflow_dispatch).
+
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -12,27 +16,49 @@ jobs:
     environment: pypi
     permissions:
       id-token: write    # required for PyPI trusted publishing (OIDC)
-      contents: read
+      contents: write    # required to push the release tag
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
+      - name: Detect version bump
+        id: check
+        run: |
+          VER=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          TAG="v$VER"
+          echo "pyproject version: $VER"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New version $VER — will tag and publish."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag release
+        if: steps.check.outputs.release == 'true'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
       - name: Install build tooling
+        if: steps.check.outputs.release == 'true'
         run: python -m pip install --upgrade build
 
-      - name: Verify tag matches pyproject version
-        run: |
-          TAG="${GITHUB_REF##*/v}"
-          PYVER=$(python -c "import tomllib,sys; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
-          echo "git tag version: $TAG"
-          echo "pyproject version: $PYVER"
-          test "$TAG" = "$PYVER" || (echo "tag must match pyproject version" && exit 1)
-
       - name: Build sdist + wheel
+        if: steps.check.outputs.release == 'true'
         run: python -m build
 
       - name: Publish to PyPI
+        if: steps.check.outputs.release == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Switches `publish.yml` from a tag-push trigger to a main-push trigger with built-in version-bump detection. After this merges, a PR that bumps `pyproject.toml` ships to PyPI automatically — no more forgetting to cut the tag.
- Re-running the workflow on an already-released version is a no-op (tag-exists check).

## Why
`0.1.8` was bumped in #146 but never tagged, so `pipx install stashai` kept pulling 0.1.7 (which predates the octopus splash). This removes the manual tag step entirely.

## Expected effect on merge
- Workflow sees `pyproject.toml` at `0.1.8`, no `v0.1.8` tag exists → tags the commit and publishes 0.1.8 to PyPI via the existing OIDC trusted-publisher config.

## Test plan
- [ ] Merge triggers the workflow
- [ ] `v0.1.8` tag appears on the repo
- [ ] `stashai 0.1.8` appears on https://pypi.org/project/stashai/
- [ ] Fresh `install.sh` pulls 0.1.8 and the setup splash shows the octopus

🤖 Generated with [Claude Code](https://claude.com/claude-code)