### PR TITLE
docs: fix pip install command to use correct PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Go to [stash.ac](https://stash.ac) and register. Save your API key.
 ### 2. Install the CLI
 
 ```bash
-pip install stash
+pip install stashai         # installs the `stash` CLI
 stash connect               # Interactive: paste API key, pick a default workspace
 ```
 
@@ -68,7 +68,7 @@ For cross-resource agentic search, install the [Claude Code plugin](#integration
 ## CLI
 
 ```bash
-pip install stash
+pip install stashai                    # installs the `stash` CLI
 stash connect                          # Configure API key + default workspace
 stash history push <content>         # Push an event
 stash history search <query>         # Full-text search over history events

--- a/frontend/src/app/docs/cli/page.tsx
+++ b/frontend/src/app/docs/cli/page.tsx
@@ -10,7 +10,7 @@ export default function CLIPage() {
       </Subtitle>
 
       <H3>Install</H3>
-      <CodeBlock>{`pip install stash`}</CodeBlock>
+      <CodeBlock>{`pip install stashai`}</CodeBlock>
 
       <H3>First-time setup</H3>
       <P>

--- a/frontend/src/app/docs/quickstart/page.tsx
+++ b/frontend/src/app/docs/quickstart/page.tsx
@@ -23,7 +23,7 @@ export default function QuickstartPage() {
       <P>
         <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
         <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
-        <code className="text-brand font-mono text-[13px]">pip install stash</code>. The
+        <code className="text-brand font-mono text-[13px]">pip install stashai</code>. The
         interactive wizard covers account creation, workspace creation, and history store setup
         in one shot — then come back to step 2.
       </P>
@@ -34,7 +34,7 @@ export default function QuickstartPage() {
       </Callout>
 
       <H3>2. Install the CLI</H3>
-      <CodeBlock>{`pip install stash
+      <CodeBlock>{`pip install stashai
 stash login`}</CodeBlock>
 
       <H3>3. Try these commands</H3>

--- a/frontend/src/components/SetupCard.tsx
+++ b/frontend/src/components/SetupCard.tsx
@@ -34,7 +34,7 @@ export default function SetupCard({ workspaceId, apiKey }: SetupCardProps) {
     setTimeout(() => setCopied(null), 2000);
   };
 
-  const cliCmd = "pip install stash && stash login";
+  const cliCmd = "pip install stashai && stash login";
 
   return (
     <div className="bg-[#1a2332] border border-white/10 rounded-lg overflow-hidden mb-8">

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -6,7 +6,7 @@ point).
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stash && stash login`)
+- `stash` CLI installed and logged in (`pip install stashai && stash login`)
 - `stash config default_workspace <id>` set
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -6,7 +6,7 @@ point).
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stash && stash login`)
+- `stash` CLI installed and logged in (`pip install stashai && stash login`)
 - `stash config default_workspace <id>` set
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -10,7 +10,7 @@ export default function CLIPage() {
       </Subtitle>
 
       <H3>Install</H3>
-      <CodeBlock>{`pip install stash`}</CodeBlock>
+      <CodeBlock>{`pip install stashai`}</CodeBlock>
 
       <H3>First-time setup</H3>
       <P>

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -23,7 +23,7 @@ export default function QuickstartPage() {
       <P>
         <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
         <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
-        <code className="text-brand font-mono text-[13px]">pip install stash</code>. The
+        <code className="text-brand font-mono text-[13px]">pip install stashai</code>. The
         interactive wizard covers account creation, workspace creation, and history store setup
         in one shot — then come back to step 2.
       </P>
@@ -34,7 +34,7 @@ export default function QuickstartPage() {
       </Callout>
 
       <H3>2. Install the CLI</H3>
-      <CodeBlock>{`pip install stash
+      <CodeBlock>{`pip install stashai
 stash login`}</CodeBlock>
 
       <H3>3. Try these commands</H3>


### PR DESCRIPTION
## Summary
- The PyPI package is `stashai` (see `pyproject.toml:2`); the `stash` binary is what it installs. Docs were telling users `pip install stash`, which resolves to an unrelated squatter package on PyPI.
- Swept every occurrence across README, plugin READMEs, and both docs sites (`frontend/` and `www/`).

## Test plan
- [ ] Visual check: `README.md` quick-start block reads `pip install stashai         # installs the \`stash\` CLI`.
- [ ] `grep -r "pip install stash[^a]" .` returns no matches.
- [ ] Build `frontend` and `www` — docs pages render without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)