### PR TITLE
docs: fix plugin install commands in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,8 @@ stash --help                         # Full command list
 The [`plugins/claude-plugin`](plugins/claude-plugin/README.md) directory ships a Claude Code plugin that turns any session into a persistent Stash agent: activity streams to history, memory injects into every prompt, and context carries across sessions.
 
 ```bash
-# From the octopus repo
-claude plugin add ./plugins/claude-plugin
-
-# Or from the marketplace
-claude plugin install stash
+claude plugin marketplace add Fergana-Labs/stash
+claude plugin install stash@stash-plugins
 ```
 
 Slash commands include `/stash:connect` (onboarding), `/stash:sleep` (curate history into a wiki — also runs on SessionEnd), `/stash:search` (agentic cross-resource search), and `/stash:status`. See the [plugin README](plugins/claude-plugin/README.md) for full setup.

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -11,11 +11,8 @@ Go to [stash.ac/login](https://stash.ac/login) and register a human account. Sav
 ### Step 2: Install the plugin
 
 ```bash
-# From the stash repo
-claude plugin add ./claude-plugin
-
-# Or from the marketplace
-claude plugin install stash
+claude plugin marketplace add Fergana-Labs/stash
+claude plugin install stash@stash-plugins
 ```
 
 Claude Code will prompt you for three config values:


### PR DESCRIPTION
## Summary
- The READMEs documented `claude plugin add ./...`, which is not a real Claude Code subcommand (`claude plugin --help` only exposes `install`, `uninstall`, `enable`, `disable`, `list`, `marketplace`, `update`, `validate`).
- Replace with the `claude plugin marketplace add Fergana-Labs/stash` + `claude plugin install stash@stash-plugins` flow that the [stash.ac](https://stash.ac) landing page already uses.

## Test plan
- [ ] Run \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\` on a clean machine and confirm the plugin loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)