### PR TITLE
fix(cli): don't show prompt hint when connect already short-circuits

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1743,18 +1743,19 @@ def connect(
         )
         return
 
-    console.print("\n[bold]Stash connect[/bold]  (press Enter to accept defaults)\n")
-
     # --- Manifest detection: runs first so it can steer the later prompts. ---
     manifest = load_manifest()
+
+    if _already_fully_connected(manifest):
+        return
+
+    console.print("\n[bold]Stash connect[/bold]  (press Enter to accept defaults)\n")
+
     if manifest:
         console.print(
             f"  [cyan]Detected .stash/stash.json[/cyan] — this repo is set up for "
             f"[bold]{manifest.get('workspace_name') or 'a stash workspace'}[/bold].\n"
         )
-
-    if _already_fully_connected(manifest):
-        return
 
     # --- Step 0: Scope ---
     # Preserve the previous choice on re-runs so `stash connect` doesn't


### PR DESCRIPTION
## Summary
- \`stash connect\` printed \"Stash connect (press Enter to accept defaults)\" before the \`_already_fully_connected\` short-circuit, so a re-run with valid config flashed a prompt hint and then immediately exited — looked like the wizard skipped waiting for input.
- Move the banner (and the manifest-detected line) below the short-circuit so they only print when the interactive wizard actually runs.

## Test plan
- [ ] Fresh machine: \`stash connect\` still shows banner and prompts work
- [ ] Already-connected machine: re-run shows only the \"Already connected\" block, no banner
- [ ] Manifest repo: detected message appears above the prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)