### PR TITLE
feat(cli): swap scope/transcript Q&A for a direct link to the web UI (v0.1.9)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2366,25 +2366,35 @@ def _invite_url(invite_code: str) -> str:
     return f"{frontend}/join/{invite_code}"
 
 
-def _workspace_url(ws_id: str) -> str:
-    """Build the user-facing URL for a workspace's page on the configured
-    frontend. Managed backend → app.stash.ac (the marketing site at stash.ac
-    has no /workspaces redirect); localhost backend → :3457; any other
-    self-host → whatever the configured base_url is."""
+def _frontend_base_url() -> str:
+    """Return the frontend root for the currently configured backend. Managed
+    backend → app.stash.ac (the marketing site at stash.ac has no /workspaces
+    redirect); localhost backend → :3457; any other self-host → whatever the
+    configured base_url is."""
     base_url = (load_config().get("base_url") or "").rstrip("/")
     if "localhost" in base_url or "127.0.0.1" in base_url:
-        frontend = base_url.replace(":3456", ":3457")
-    elif base_url == "https://api.stash.ac":
-        frontend = "https://app.stash.ac"
-    else:
-        frontend = base_url
-    return f"{frontend}/workspaces/{ws_id}"
+        return base_url.replace(":3456", ":3457")
+    if base_url == "https://api.stash.ac":
+        return "https://app.stash.ac"
+    return base_url
+
+
+def _workspace_url(ws_id: str) -> str:
+    """Build the user-facing URL for a workspace's page on the configured frontend."""
+    return f"{_frontend_base_url()}/workspaces/{ws_id}"
 
 
 def _current_workspace_url() -> str:
     """Return the link to the user's default workspace, or "" if none configured."""
     ws_id = load_config().get("default_workspace") or ""
     return _workspace_url(ws_id) if ws_id else ""
+
+
+def _transcripts_url() -> str:
+    """Best-effort link to where the user can see their transcripts in the web
+    UI. Prefers the workspace-specific URL when default_workspace is set; falls
+    back to the frontend root so we still hand the user a usable link."""
+    return _current_workspace_url() or _frontend_base_url()
 
 
 def _welcome_markdown() -> str:
@@ -2594,10 +2604,8 @@ def _show_setup_complete_splash(
             _pushed_scope_phrase(),
         ),
         (
-            "How do I change scope or see a transcript?",
-            "[#1e3a8a]stash config scope <repo|workspace|all>[/#1e3a8a]  (default: repo)\n"
-            "[#1e3a8a]stash history transcript <session_id>[/#1e3a8a]  view a full transcript\n"
-            '[#1e3a8a]stash history search "<query>"[/#1e3a8a]         search event content',
+            "Where can I see my conversation transcripts?",
+            f"[link={_transcripts_url()}][bold #1e3a8a]{_transcripts_url()}[/bold #1e3a8a][/link]",
         ),
         (
             "How do I share my workspace with my team?",

--- a/plugins/claude-plugin/commands/welcome.md
+++ b/plugins/claude-plugin/commands/welcome.md
@@ -37,8 +37,8 @@ Run `stash --help` to see everything.
 **Q:** What gets pushed to the shared store?
 **A:** For sessions in this repo (and its worktrees): prompts, assistant replies, summarized tool activity, and the full session transcript (.jsonl) at session end. Other repos push nothing unless you widen scope. Transcripts are stored verbatim — no secret scrubbing yet.
 
-**Q:** How do I change scope or see a transcript?
-**A:** `stash config scope <repo|workspace|all>` (default: `repo`). `stash history transcript <session_id>` fetches a full transcript.
+**Q:** Where can I see my conversation transcripts?
+**A:** Open your workspace in the browser: [app.stash.ac](https://app.stash.ac). (If you self-host, browse to your own frontend instead.)
 
 **Q:** How do I share my workspace with my team?
 **A:** Share the invite code (`stash workspaces info <id>` prints it). Teammates run `stash connect` if needed, then `stash workspaces join <invite_code>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.8"
+version = "0.1.9"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Replace the post-install Q&A entry "How do I change scope or see a transcript?" (CLI-only answer) with "Where can I see my conversation transcripts?" → a direct link to the workspace in the web UI. Mirror the same swap in the Claude Code plugin's `/welcome` markdown.
- Add `_frontend_base_url()` and `_transcripts_url()` helpers so the link falls back to the frontend root when `default_workspace` isn't set — the user always gets a usable URL, whether on managed (`app.stash.ac`) or self-hosted.
- Bump `stashai` to `0.1.9` so this and the workspace-link section from #159 actually reach pipx users (current PyPI release is 0.1.8 and predates #159).

## Why

Multiple users have asked "is there a link where I can see my transcripts?" even though we already print one in the splash above the Q&A — that section only renders when `default_workspace` is set, and on stale installs (anything before #159) it isn't there at all. Putting the link inside the Q&A makes it discoverable in the place users actually look.

## Test plan

- [x] `python -c "from cli.main import _show_setup_complete_splash; _show_setup_complete_splash()"` renders the new Q row with a live link
- [x] `_transcripts_url()` falls back to `https://app.stash.ac` when `default_workspace` is empty
- [ ] After merge, GHA `publish.yml` tags `v0.1.9` and uploads to PyPI
- [ ] `pipx upgrade stashai --force` picks up 0.1.9 and `stash connect` shows both the "See your workspace" section and the new Q row

🤖 Generated with [Claude Code](https://claude.com/claude-code)