### PR TITLE
feat(plugins): tell agents they have the stash CLI on their PATH

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -353,10 +353,36 @@ def _install_cursor(force: bool) -> tuple[str, str]:
     dest = Path.home() / ".cursor" / "hooks.json"
     template = (root / "hooks.json").read_text()
     status_ = _merge_json_hooks(dest, template, root)
-    return (status_, f"{dest}")
+
+    rule_src = root / "stash.mdc"
+    rule_dest = Path.home() / ".cursor" / "rules" / "stash.mdc"
+    if rule_src.exists():
+        rule_dest.parent.mkdir(parents=True, exist_ok=True)
+        rule_dest.write_text(rule_src.read_text())
+
+    return (status_, f"{dest} + {rule_dest}")
 
 
 _CODEX_MARKER = "# stash-plugin"
+_AGENTS_MD_BEGIN = "<!-- stash-plugin:begin -->"
+_AGENTS_MD_END = "<!-- stash-plugin:end -->"
+
+
+def _upsert_agents_md(path: Path, body: str) -> None:
+    """Idempotently write a stash-owned block into an AGENTS.md-style file."""
+    block = f"{_AGENTS_MD_BEGIN}\n{body.rstrip()}\n{_AGENTS_MD_END}"
+    existing = path.read_text() if path.exists() else ""
+
+    if _AGENTS_MD_BEGIN in existing and _AGENTS_MD_END in existing:
+        pre, rest = existing.split(_AGENTS_MD_BEGIN, 1)
+        _, post = rest.split(_AGENTS_MD_END, 1)
+        new = f"{pre}{block}{post}"
+    else:
+        sep = "" if not existing or existing.endswith("\n") else "\n"
+        new = f"{existing}{sep}{block}\n"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new)
 
 
 def _install_codex(force: bool) -> tuple[str, str]:
@@ -381,7 +407,13 @@ def _install_codex(force: bool) -> tuple[str, str]:
             if existing and not existing.endswith("\n"):
                 f.write("\n")
             f.write(f"\n{_CODEX_MARKER}\n{snippet}\n")
-    return (status_, f"{hooks_dest} + merged {cfg_path}")
+
+    agents_src = root / "AGENTS.md"
+    agents_dest = Path.home() / ".codex" / "AGENTS.md"
+    if agents_src.exists():
+        _upsert_agents_md(agents_dest, agents_src.read_text())
+
+    return (status_, f"{hooks_dest} + merged {cfg_path} + {agents_dest}")
 
 
 def _install_opencode(force: bool) -> tuple[str, str]:
@@ -400,13 +432,20 @@ def _install_opencode(force: bool) -> tuple[str, str]:
             return ("failed", f"{cfg_path} is not valid JSON; fix by hand")
 
     plugins = cfg.get("plugin", [])
-    if plugin_path in plugins and not force:
-        return ("skipped", f"{cfg_path} already references plugin.ts")
+    already = plugin_path in plugins
     plugins = [p for p in plugins if p != plugin_path]
     plugins.append(plugin_path)
     cfg["plugin"] = plugins
     cfg_path.write_text(json.dumps(cfg, indent=2) + "\n")
-    return ("installed", f"{cfg_path} (plugin entry added)")
+
+    agents_src = root / "AGENTS.md"
+    agents_dest = cfg_path.parent / "AGENTS.md"
+    if agents_src.exists():
+        _upsert_agents_md(agents_dest, agents_src.read_text())
+
+    if already and not force:
+        return ("skipped", f"{cfg_path} already references plugin.ts + {agents_dest}")
+    return ("installed", f"{cfg_path} (plugin entry added) + {agents_dest}")
 
 
 _INSTALLERS = {

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -1,10 +1,8 @@
 # Stash Plugin
 
-You are connected to Stash, a collaborative workspace platform for AI agents and humans.
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
 
-## Activity Streaming
-
-Your activity is being streamed to an Stash history store. Other agents and humans in your workspace can see what tools you use and what you work on.
+Your activity in this repo is also streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
 ## Stash CLI
 

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -1,0 +1,11 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -22,6 +22,9 @@ envsubst < hooks.json > ~/.codex/hooks.json
 
 # Merge the config.toml snippet (enables hooks + registers notify fallback)
 envsubst < config.toml.snippet >> ~/.codex/config.toml
+
+# Agent context — tells Codex it has the stash CLI available
+cat AGENTS.md >> ~/.codex/AGENTS.md
 ```
 
 ## Commands

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -18,8 +18,11 @@ cd path/to/stash/plugins/cursor-plugin
 
 # Symlink hooks.json into Cursor with PLUGIN_ROOT baked in.
 export PLUGIN_ROOT=$(pwd)
-mkdir -p ~/.cursor
+mkdir -p ~/.cursor ~/.cursor/rules
 envsubst < hooks.json > ~/.cursor/hooks.json
+
+# Agent context — tells Cursor it has the stash CLI available
+cp stash.mdc ~/.cursor/rules/stash.mdc
 ```
 
 Or, for per-project use, drop `hooks.json` into `<project>/.cursor/hooks.json`

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -1,0 +1,16 @@
+---
+description: Stash CLI and workspace context
+alwaysApply: true
+---
+
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/plugins/gemini-plugin/GEMINI.md
+++ b/plugins/gemini-plugin/GEMINI.md
@@ -1,0 +1,11 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/plugins/gemini-plugin/README.md
+++ b/plugins/gemini-plugin/README.md
@@ -19,6 +19,9 @@ export PLUGIN_ROOT=$(pwd)
 # If ~/.gemini/settings.json doesn't exist yet:
 mkdir -p ~/.gemini
 envsubst < settings.snippet.json > ~/.gemini/settings.json
+
+# Agent context — tells Gemini it has the stash CLI available
+cat GEMINI.md >> ~/.gemini/GEMINI.md
 ```
 
 If you already have a `~/.gemini/settings.json`, merge the `hooks` block by

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -1,0 +1,11 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -22,6 +22,13 @@ Point your opencode config at `plugin.ts`. The config key is `plugin` (singular)
 
 Or drop the plugin into your project's `.opencode/plugin/` directory (note: singular `plugin/`, not `plugins/`).
 
+Also drop `AGENTS.md` beside your opencode config so the agent knows the
+`stash` CLI is available:
+
+```bash
+cat AGENTS.md >> ~/.config/opencode/AGENTS.md
+```
+
 Restart opencode.
 
 ## How it works

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -1,0 +1,11 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -22,6 +22,9 @@ envsubst < hooks.json > ~/.codex/hooks.json
 
 # Merge the config.toml snippet (enables hooks + registers notify fallback)
 envsubst < config.toml.snippet >> ~/.codex/config.toml
+
+# Agent context — tells Codex it has the stash CLI available
+cat AGENTS.md >> ~/.codex/AGENTS.md
 ```
 
 ## Commands

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -18,8 +18,11 @@ cd path/to/stash/plugins/cursor-plugin
 
 # Symlink hooks.json into Cursor with PLUGIN_ROOT baked in.
 export PLUGIN_ROOT=$(pwd)
-mkdir -p ~/.cursor
+mkdir -p ~/.cursor ~/.cursor/rules
 envsubst < hooks.json > ~/.cursor/hooks.json
+
+# Agent context — tells Cursor it has the stash CLI available
+cp stash.mdc ~/.cursor/rules/stash.mdc
 ```
 
 Or, for per-project use, drop `hooks.json` into `<project>/.cursor/hooks.json`

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -1,0 +1,16 @@
+---
+description: Stash CLI and workspace context
+alwaysApply: true
+---
+
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -1,0 +1,11 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
+
+Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
+
+Common reads (all support `--json`):
+- `stash history search "<query>"` — full-text search across transcripts
+- `stash history query --limit 20` — recent events
+- `stash history agents` — who's been active
+- `stash notebooks list --all` — shared notebooks

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -22,6 +22,13 @@ Point your opencode config at `plugin.ts`. The config key is `plugin` (singular)
 
 Or drop the plugin into your project's `.opencode/plugin/` directory (note: singular `plugin/`, not `plugins/`).
 
+Also drop `AGENTS.md` beside your opencode config so the agent knows the
+`stash` CLI is available:
+
+```bash
+cat AGENTS.md >> ~/.config/opencode/AGENTS.md
+```
+
 Restart opencode.
 
 ## How it works


### PR DESCRIPTION
## Summary

- Every plugin now ships an agent-instructions file (CLAUDE.md / AGENTS.md / GEMINI.md / stash.mdc) whose opener leads with the concrete capability: *"You have the `stash` CLI on your PATH."*
- Previously, agents had to discover the CLI on their own — fresh post-install sessions often missed it entirely. (e.g. a new Claude Code session in `~/projects/scheduler` answering "do you have access to stash?" with a Render workspace + skill name, not "yes, I can shell out to `stash`.")
- Installers upsert a stash-owned block between `<!-- stash-plugin:begin/end -->` markers, so re-runs replace in place and any user-authored content in those files is preserved.

### Per-plugin
- **claude-plugin**: rewrote CLAUDE.md opener
- **codex-plugin**: new `AGENTS.md` → `~/.codex/AGENTS.md`
- **cursor-plugin**: new `stash.mdc` (`alwaysApply: true`) → `~/.cursor/rules/stash.mdc`
- **gemini-plugin**: new `GEMINI.md` (manual install — gemini isn't in `_INSTALLERS` yet)
- **opencode-plugin**: new `AGENTS.md` → `~/.config/opencode/AGENTS.md`
- **openclaw-plugin**: no change — routes to a downstream coding agent whose own plugin handles injection

## Test plan

- [x] `plugins/tests/` all pass (57 tests, including `test_assets_in_sync` byte-for-byte parity)
- [x] Fresh-install smoke test: ran `_install_codex` / `_install_cursor` / `_install_opencode` against a temp `$HOME`, verified expected files land
- [x] Idempotency: second install replaces the stash block in place, no duplication
- [x] User-content preservation: pre-seeded `~/.codex/AGENTS.md` with user rules; stash block appended without clobbering
- [ ] Manual: run `stash connect` end-to-end against a real codex/cursor/opencode setup
- [ ] Manual: confirm cursor picks up `~/.cursor/rules/stash.mdc` as a global rule (if it doesn't, paste into Settings → Rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)