### PR TITLE
fix: make plugin discoverability changes actually reach users

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "productivity",
       "homepage": "https://stash.ac",
       "author": {

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Connect Claude Code to Stash — stream activity to history and collaborate in workspaces.",
   "author": {
     "name": "Fergana Labs"

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -1,10 +1,26 @@
 #!/usr/bin/env python3
-"""SessionStart: save session_id for downstream streaming."""
+"""SessionStart: save session_id for downstream streaming, and inject a
+context message so the agent knows the stash CLI is on its PATH."""
+
+import json
+import sys
 
 from config import DATA_DIR, get_stdin_data, is_configured
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 from adapt import adapt_session_start
+
+CONTEXT = (
+    "You have the `stash` CLI on your PATH. Run `stash --help` to see commands. "
+    "Use it to read transcripts, notebooks, and history from your team's shared "
+    "Stash workspace. Your activity in this repo is streamed to that workspace, "
+    "so teammates' agents and humans can see what you're working on. "
+    "Common reads (all support `--json`): "
+    "`stash history search \"<query>\"`, "
+    "`stash history query --limit 20`, "
+    "`stash history agents`, "
+    "`stash notebooks list --all`."
+)
 
 
 def main():
@@ -17,6 +33,16 @@ def main():
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)
     reset_stats(DATA_DIR)
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": CONTEXT,
+            }
+        },
+        sys.stdout,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two structural fixes so the discoverability work from #167 actually reaches users:

1. **SessionStart hook injects context for Claude Code.** Plugin `CLAUDE.md` is *not* auto-loaded by Claude Code — the opener rewrite from #167 never reached the agent's context. Fix emits `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}` from the SessionStart hook so Claude Code injects "you have the `stash` CLI on your PATH" into every session. Bumps Claude plugin to `0.1.4`.

2. **`stash connect` re-applies installers on every run.** Previously, once `_plugin_installed("codex")` returned True, we'd skip the installer forever — meaning #167's new `~/.codex/AGENTS.md` write never reached any existing user. Now every detected agent re-runs its installer (each is idempotent via marker upserts and PLUGIN_ROOT-scoped hook merging). Existing users see a silent upgrade; if anything actually changed, we print `upgraded`.

3. **Bump stashai 0.1.9 → 0.1.10** so the publish workflow ships #167's `_install_codex` AGENTS.md write to PyPI.

## Verified

- [x] Smoke tested SessionStart hook output — valid JSON envelope on stdout
- [x] All 57 plugin tests pass
- [x] Manually ran `_install_codex(force=True)` against my home dir, confirmed `~/.codex/AGENTS.md` written with stash-owned block; Codex picks it up (it auto-loads global AGENTS.md per OpenAI docs)
- [ ] After merge: confirm publish workflow tags v0.1.10 and pushes to PyPI
- [ ] After merge: re-run `stash connect` on a machine that already has codex installed — verify the silent upgrade writes AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)