### PR TITLE
fix: ship #167's AGENTS.md write to existing users + PyPI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2044,11 +2044,34 @@ def connect(
         }
         missing = [a for a in detected if not _plugin_installed(a)]
         already = [a for a in detected if a not in missing]
-        if already:
+
+        # Re-apply already-installed agents so plugin upgrades (new hook
+        # entries, new instructions files, …) reach existing users on
+        # `stash connect` re-runs. Each installer is idempotent and
+        # returns 'skipped' when nothing changed.
+        upgraded: list[str] = []
+        for agent in already:
+            try:
+                status_, detail = _INSTALLERS[agent](False)
+            except Exception as e:
+                status_, detail = ("failed", f"{type(e).__name__}: {e}")
+            if status_ == "installed":
+                upgraded.append(agent)
+                console.print(
+                    f"  [green]upgraded[/green] {agent:8} {detail}"
+                )
+            elif status_ == "failed":
+                console.print(
+                    f"  [red]failed[/red] {agent:8} {detail}"
+                )
+
+        unchanged = [a for a in already if a not in upgraded]
+        if unchanged:
             console.print(
                 f"  [green]✓[/green] Stash plugin already installed for "
-                f"[bold]{', '.join(agent_label[a] for a in already)}[/bold]"
+                f"[bold]{', '.join(agent_label[a] for a in unchanged)}[/bold]"
             )
+
         for agent in missing:
             _reserve_bottom_padding(4)
             install_plugin = questionary.confirm(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.9"
+version = "0.1.10"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Two pieces from PR #168's branch did not survive the squash-merge — main only got the SessionStart hook fix. This PR ships them on their own:

1. **`stash connect` re-applies installers for already-installed agents.** Without this, the new `~/.codex/AGENTS.md` write from #167 never reaches any user who installed Codex before #167. Each installer is already idempotent (hook merge keys on PLUGIN_ROOT; AGENTS.md upserts a marker-bounded block), so it's safe to run on every connect.

2. **Bumps stashai 0.1.9 → 0.1.10** so the publish workflow (which fired on #167 and #168 but no-op'd because the version hadn't moved) actually ships #167's `_install_codex` change to PyPI.

After merge: `pip install --upgrade stashai && stash connect` will write `~/.codex/AGENTS.md` for any user, new or existing.

## Verified

- [x] Syntax check passes
- [x] All 57 plugin tests pass
- [x] Diff is byte-identical to the second commit on the merged-PR-168 branch (just rebased onto main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)