### PR TITLE
fix(install): sweep stale stash hook entries across plugin roots

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -296,9 +296,11 @@ def _entry_references(obj: object, needle: str) -> bool:
 def _merge_json_hooks(dest: Path, template: str, plugin_root: Path) -> str:
     """Merge stash hook entries into a JSON hooks file under each event array.
 
-    Stash-owned entries are identified by the PLUGIN_ROOT path embedded in their
-    command strings — so re-runs replace our entries in place and never touch
-    user-added entries. Returns 'installed', 'skipped', or 'failed'.
+    Stash-owned entries are identified by the shared `stashai/plugin/assets/<agent>`
+    suffix embedded in their command strings — so re-runs sweep out every
+    stash-owned entry (including stale ones left by old dev checkouts or prior
+    pipx versions) and leave user-added entries untouched. Returns 'installed',
+    'skipped', or 'failed'.
     """
     from string import Template
 
@@ -319,6 +321,7 @@ def _merge_json_hooks(dest: Path, template: str, plugin_root: Path) -> str:
     except json.JSONDecodeError:
         return "failed"
 
+    stash_marker = f"stashai/plugin/assets/{plugin_root.name}"
     tmpl_hooks = tmpl_data.get("hooks", {})
     existing_hooks = existing.setdefault("hooks", {})
     changed = False
@@ -328,7 +331,7 @@ def _merge_json_hooks(dest: Path, template: str, plugin_root: Path) -> str:
         cur = existing_hooks.get(event) or []
         if not isinstance(cur, list):
             cur = []
-        user_entries = [e for e in cur if not _entry_references(e, root_str)]
+        user_entries = [e for e in cur if not _entry_references(e, stash_marker)]
         merged = user_entries + tmpl_entries
         if merged != cur:
             changed = True

--- a/cli/tests/test_install_hooks.py
+++ b/cli/tests/test_install_hooks.py
@@ -1,0 +1,95 @@
+"""Tests for `_merge_json_hooks` — the idempotent hooks.json merger used by
+`stash install` / `stash connect` to wire agent hook files.
+
+Covers the multi-root stale-entry case: a user who has run `stash install`
+from several different PLUGIN_ROOTs (old dev checkouts, prior pipx versions)
+should end up with a single stash-owned entry per event after the next install,
+regardless of which root they install from.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cli.main import _merge_json_hooks
+
+CURSOR_TEMPLATE = json.dumps(
+    {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {
+                    "command": "bash ${PLUGIN_ROOT}/scripts/_run.sh on_session_start",
+                    "timeout": 5,
+                }
+            ],
+        },
+    }
+)
+
+
+def _stash_entry(plugin_root: str) -> dict:
+    return {
+        "command": f"bash {plugin_root}/scripts/_run.sh on_session_start",
+        "timeout": 5,
+    }
+
+
+def _write_hooks(dest: Path, entries: list[dict]) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps({"version": 1, "hooks": {"sessionStart": entries}}))
+
+
+def test_merge_sweeps_stale_entries_from_other_roots(tmp_path: Path) -> None:
+    # Simulate a user who installed from two different dev checkouts plus pipx,
+    # plus a user-added entry that must be preserved.
+    dest = tmp_path / "cursor" / "hooks.json"
+    octopus_root = "/fake/projects/octopus-cli/stashai/plugin/assets/cursor"
+    disco_root = "/fake/projects/stash-discoverability-2/stashai/plugin/assets/cursor"
+    pipx_root = tmp_path / "pipx/stashai/plugin/assets/cursor"
+    user_entry = {"command": "echo user-hook", "timeout": 1}
+
+    _write_hooks(
+        dest,
+        [
+            _stash_entry(octopus_root),
+            _stash_entry(disco_root),
+            user_entry,
+        ],
+    )
+
+    status = _merge_json_hooks(dest, CURSOR_TEMPLATE, pipx_root)
+
+    assert status == "installed"
+    result = json.loads(dest.read_text())
+    entries = result["hooks"]["sessionStart"]
+
+    # User entry preserved, all stash entries replaced by the single pipx one.
+    assert user_entry in entries
+    stash_entries = [e for e in entries if "stashai/plugin/assets/cursor" in e["command"]]
+    assert len(stash_entries) == 1
+    assert str(pipx_root) in stash_entries[0]["command"]
+
+
+def test_merge_is_idempotent_from_same_root(tmp_path: Path) -> None:
+    dest = tmp_path / "cursor" / "hooks.json"
+    pipx_root = tmp_path / "pipx/stashai/plugin/assets/cursor"
+
+    first = _merge_json_hooks(dest, CURSOR_TEMPLATE, pipx_root)
+    second = _merge_json_hooks(dest, CURSOR_TEMPLATE, pipx_root)
+
+    assert first == "installed"
+    assert second == "skipped"
+
+
+def test_merge_preserves_user_entries(tmp_path: Path) -> None:
+    dest = tmp_path / "cursor" / "hooks.json"
+    pipx_root = tmp_path / "pipx/stashai/plugin/assets/cursor"
+    user_entry = {"command": "echo my-own-hook", "timeout": 2}
+
+    _write_hooks(dest, [user_entry])
+    _merge_json_hooks(dest, CURSOR_TEMPLATE, pipx_root)
+
+    entries = json.loads(dest.read_text())["hooks"]["sessionStart"]
+    assert user_entry in entries


### PR DESCRIPTION
## Summary
- \`_merge_json_hooks\` only dedupes entries matching the *current* install's \`PLUGIN_ROOT\`. Users who've run \`stash install\` from multiple locations (old dev checkouts, prior pipx versions) end up with stale stash-owned entries that each fire on every hook event.
- Match on the shared \`stashai/plugin/assets/<agent>\` suffix so any stash-owned entry — regardless of where it was installed from — is swept on re-run. User-added entries still untouched.

## Repro
I had triple-installed cursor + codex hooks (octopus-cli dev checkout + stash-discoverability-2 dev checkout + pipx venv), so every Cursor/Codex session was double/triple-posting events. Re-running \`stash install\` from pipx didn't clean up the dev-checkout entries because their PLUGIN_ROOT didn't match.

With this change, a single \`stash install\` from the canonical location cleans up stale entries automatically.

## Test plan
- [x] \`python -m pytest cli/tests/test_install_hooks.py -v --no-cov\` — 3/3 pass
- [x] Covers: multi-root stale sweep, idempotence from same root, user-entry preservation
- [x] Ruff + black clean on changed files (pre-existing errors in the rest of \`main.py\` left alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)