### PR TITLE
feat(codex): add [profiles.stash] for frictionless stash CLI under Codex

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -425,12 +425,22 @@ def _install_codex(force: bool) -> tuple[str, str]:
         PLUGIN_ROOT=str(root)
     )
     existing = cfg_path.read_text() if cfg_path.exists() else ""
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
     if _CODEX_MARKER not in existing:
-        cfg_path.parent.mkdir(parents=True, exist_ok=True)
         with cfg_path.open("a") as f:
             if existing and not existing.endswith("\n"):
                 f.write("\n")
             f.write(f"\n{_CODEX_MARKER}\n{snippet}\n")
+    elif "[profiles.stash]" not in existing:
+        # Upgrade path: features block is already there from an older install,
+        # but the stash profile was added later. Append just the profile
+        # portion so `codex --profile stash` works without a full reinstall.
+        profile_start = snippet.find("[profiles.stash]")
+        if profile_start != -1:
+            with cfg_path.open("a") as f:
+                if not existing.endswith("\n"):
+                    f.write("\n")
+                f.write(f"\n{_CODEX_MARKER}:profile\n{snippet[profile_start:]}")
 
     agents_src = root / "AGENTS.md"
     agents_dest = Path.home() / ".codex" / "AGENTS.md"

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -1,0 +1,75 @@
+"""Tests for `_install_codex` — focused on the config.toml append behavior.
+
+The risk this test guards against: an existing user has the old stash-plugin
+block (features only) in ~/.codex/config.toml. On the next `stash connect`
+they should get the new `[profiles.stash]` block appended so `codex --profile
+stash` works, without duplicating the whole snippet.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from cli.main import _install_codex
+
+
+def _run_install(monkeypatch, tmp_path: Path) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    _install_codex(False)
+    return tmp_path / ".codex" / "config.toml"
+
+
+def test_fresh_install_writes_profile_block(monkeypatch, tmp_path: Path) -> None:
+    cfg = _run_install(monkeypatch, tmp_path)
+    body = cfg.read_text()
+    assert "[profiles.stash]" in body
+    # TOML must still parse cleanly after our append.
+    with cfg.open("rb") as f:
+        parsed = tomllib.load(f)
+    assert parsed["profiles"]["stash"]["approval_policy"] == "on-failure"
+    assert parsed["profiles"]["stash"]["sandbox_mode"] == "workspace-write"
+    assert parsed["profiles"]["stash"]["sandbox_workspace_write"]["network_access"] is True
+
+
+def test_upgrade_from_old_install_appends_profile_only(monkeypatch, tmp_path: Path) -> None:
+    # Simulate a user who installed before the profile block existed.
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    cfg = codex_dir / "config.toml"
+    cfg.write_text(
+        "# stash-plugin\n"
+        "[features]\n"
+        "codex_hooks = true\n"
+        "suppress_unstable_features_warning = true\n"
+    )
+
+    cfg = _run_install(monkeypatch, tmp_path)
+    body = cfg.read_text()
+
+    # Features block preserved (not duplicated), profile block appended.
+    assert body.count("[features]") == 1
+    assert "[profiles.stash]" in body
+    with cfg.open("rb") as f:
+        tomllib.load(f)
+
+    # Second run is a no-op.
+    before = cfg.read_text()
+    _install_codex(False)
+    assert cfg.read_text() == before
+
+
+def test_install_preserves_unrelated_user_config(monkeypatch, tmp_path: Path) -> None:
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    cfg = codex_dir / "config.toml"
+    cfg.write_text('[model]\nname = "something-custom"\n')
+
+    cfg = _run_install(monkeypatch, tmp_path)
+    body = cfg.read_text()
+
+    assert 'name = "something-custom"' in body
+    assert "[profiles.stash]" in body
+    with cfg.open("rb") as f:
+        tomllib.load(f)

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -40,6 +40,22 @@ Everything is a plain `stash` CLI subcommand — no slash commands or skills:
 At session end (Codex `Stop`) the plugin spawns `codex exec …` headless with
 a shared curation prompt. Toggle with `auto_curate` in `~/.stash/config.json`.
 
+## Launching: use the `stash` profile
+
+`config.toml.snippet` registers a `[profiles.stash]` block. Launch Codex with
+it so stash CLI reads don't hit the sandbox's network block or per-command
+approval prompts:
+
+```bash
+codex --profile stash
+```
+
+The profile sets `sandbox_mode = "workspace-write"` with `network_access =
+true` (so `stash history …` can reach `api.stash.ac`) and
+`approval_policy = "on-failure"` (so successful reads don't prompt; failures
+still do). Run plain `codex` — without the flag — if you want Codex's default
+approval behavior.
+
 ## ⚠️ Known gaps
 
 1. **Bash-only tool hooks.** Codex's `PostToolUse` today only fires for Bash.

--- a/plugins/codex-plugin/config.toml.snippet
+++ b/plugins/codex-plugin/config.toml.snippet
@@ -11,3 +11,14 @@ suppress_unstable_features_warning = true
 # Variant B (fallback) — only if your Codex build lacks features.codex_hooks.
 # Comment out Variant A above, then uncomment this line:
 # notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]
+
+# Stash profile — launch with `codex --profile stash` so the stash CLI can
+# reach api.stash.ac through the sandbox and doesn't prompt for approval on
+# every read. approval_policy = "on-failure" still asks if a command errors,
+# so this is scoped-loosening, not a blanket allow-everything.
+[profiles.stash]
+approval_policy = "on-failure"
+sandbox_mode = "workspace-write"
+
+[profiles.stash.sandbox_workspace_write]
+network_access = true

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -40,6 +40,22 @@ Everything is a plain `stash` CLI subcommand — no slash commands or skills:
 At session end (Codex `Stop`) the plugin spawns `codex exec …` headless with
 a shared curation prompt. Toggle with `auto_curate` in `~/.stash/config.json`.
 
+## Launching: use the `stash` profile
+
+`config.toml.snippet` registers a `[profiles.stash]` block. Launch Codex with
+it so stash CLI reads don't hit the sandbox's network block or per-command
+approval prompts:
+
+```bash
+codex --profile stash
+```
+
+The profile sets `sandbox_mode = "workspace-write"` with `network_access =
+true` (so `stash history …` can reach `api.stash.ac`) and
+`approval_policy = "on-failure"` (so successful reads don't prompt; failures
+still do). Run plain `codex` — without the flag — if you want Codex's default
+approval behavior.
+
 ## ⚠️ Known gaps
 
 1. **Bash-only tool hooks.** Codex's `PostToolUse` today only fires for Bash.

--- a/stashai/plugin/assets/codex/config.toml.snippet
+++ b/stashai/plugin/assets/codex/config.toml.snippet
@@ -11,3 +11,14 @@ suppress_unstable_features_warning = true
 # Variant B (fallback) — only if your Codex build lacks features.codex_hooks.
 # Comment out Variant A above, then uncomment this line:
 # notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]
+
+# Stash profile — launch with `codex --profile stash` so the stash CLI can
+# reach api.stash.ac through the sandbox and doesn't prompt for approval on
+# every read. approval_policy = "on-failure" still asks if a command errors,
+# so this is scoped-loosening, not a blanket allow-everything.
+[profiles.stash]
+approval_policy = "on-failure"
+sandbox_mode = "workspace-write"
+
+[profiles.stash.sandbox_workspace_write]
+network_access = true


### PR DESCRIPTION
## Summary

- Codex sandboxes block outbound network by default and prompt per bash call — makes the stash CLI (history/notebooks/search reads to `api.stash.ac`) hostile to use inside Codex without approving every call.
- `stash install` now writes a `[profiles.stash]` block into `~/.codex/config.toml` alongside the existing features block: `approval_policy = "on-failure"`, `sandbox_mode = "workspace-write"`, `network_access = true`.
- Users opt in with `codex --profile stash`. Default `codex` behavior is untouched — this is scoped-loosening, not a blanket allow-everything.

## Upgrade path

Existing installs already have the `# stash-plugin` marker and the features block. On next `stash connect` we detect `[profiles.stash]` missing and append just the profile block behind a `# stash-plugin:profile` marker, so the upgrade reaches existing users without a `--force` reinstall and without duplicating the snippet.

## Test plan

- [x] `pytest cli/ plugins/` — 63 passed, including 3 new tests covering fresh install, upgrade-from-old-install, and preserving unrelated user config
- [x] Manual: fresh install writes full snippet, resulting TOML parses
- [x] Manual: upgrade from pre-profile install appends only the profile block, is idempotent on re-run
- [ ] Reviewer: sanity-check the approval/sandbox keys against a current Codex build (schema has drifted before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)