### PR TITLE
Ask before opening codex sandbox for network access

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -458,10 +458,7 @@ def _install_codex(force: bool) -> tuple[str, str]:
         PLUGIN_ROOT=str(root)
     )
 
-    # Ask about network_access only if the block isn't already in the config.
-    # User's "no" strips the top-level block from what we write; the profile
-    # block stays so `codex --profile stash` still works as an escape hatch.
-    if "[sandbox_workspace_write]" not in existing:
+    if _CODEX_MARKER not in existing:
         if not _ask_codex_network_access():
             snippet = _strip_top_level_sandbox(snippet)
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -411,10 +411,7 @@ def _upsert_agents_md(path: Path, body: str) -> None:
 
 def _ask_codex_network_access() -> bool:
     """Prompt the user to enable top-level `network_access` for codex's
-    workspace-write sandbox. Defaults to yes on non-TTY so batch installs
-    don't hang."""
-    if not sys.stdin.isatty():
-        return True
+    workspace-write sandbox."""
     console.print(
         "For stash to work on codex specifically, we need to let bash ",
         "commands make network requests so that we can upload chat ",

--- a/cli/main.py
+++ b/cli/main.py
@@ -419,20 +419,17 @@ def _ask_codex_network_access() -> bool:
         "For stash to work, we need to let bash commands make network requests",
         "So that we can upload chat transcripts to the remote server."
         )
-    try:
-        answer = questionary.confirm(
-            "Allow codex bash commands to make outbound network requests?",
-            default=True,
-        ).ask()
-    except Exception:
-        return True
+    answer = questionary.confirm(
+        "Allow codex bash commands to make outbound network requests?",
+        default=True,
+    ).ask()
     return True if answer is None else bool(answer)
 
 
 def _strip_top_level_sandbox(snippet: str) -> str:
-    """Remove the `[sandbox_workspace_write]` top-level block (and its
-    explanatory comment) from the snippet, leaving `[profiles.stash]`
-    and everything else intact."""
+    """Call this when the user opts not to grant outbound network
+    request access. It removes the toml that grants codex outbound
+    network request access."""
     start = snippet.find("[sandbox_workspace_write]")
     if start == -1:
         return snippet
@@ -476,33 +473,6 @@ def _install_codex(force: bool) -> tuple[str, str]:
             if existing and not existing.endswith("\n"):
                 f.write("\n")
             f.write(f"\n{_CODEX_MARKER}\n{snippet}\n")
-    else:
-        # Upgrade paths: append any later-added sub-blocks the user is missing.
-        # Each block is matched on its TOML header so a user who manually
-        # edited one in doesn't get a duplicate.
-        appended = ""
-
-        if "[sandbox_workspace_write]" not in existing and "[sandbox_workspace_write]" in snippet:
-            # Slice out the top-level sandbox block from the snippet: from its
-            # preceding comment to just before the `[profiles.stash]` header.
-            sb_header = snippet.find("[sandbox_workspace_write]")
-            profile_header = snippet.find("[profiles.stash]")
-            if sb_header != -1 and profile_header != -1:
-                prev_blank = snippet.rfind("\n\n", 0, sb_header)
-                block_start = prev_blank + 2 if prev_blank != -1 else sb_header
-                block = snippet[block_start:profile_header].rstrip() + "\n"
-                appended += f"\n{_CODEX_MARKER}:sandbox\n{block}"
-
-        if "[profiles.stash]" not in existing:
-            profile_start = snippet.find("[profiles.stash]")
-            if profile_start != -1:
-                appended += f"\n{_CODEX_MARKER}:profile\n{snippet[profile_start:]}"
-
-        if appended:
-            with cfg_path.open("a") as f:
-                if not existing.endswith("\n"):
-                    f.write("\n")
-                f.write(appended)
 
     agents_src = root / "AGENTS.md"
     agents_dest = Path.home() / ".codex" / "AGENTS.md"

--- a/cli/main.py
+++ b/cli/main.py
@@ -409,6 +409,47 @@ def _upsert_agents_md(path: Path, body: str) -> None:
     path.write_text(new)
 
 
+def _ask_codex_network_access() -> bool:
+    """Prompt the user to enable top-level `network_access` for codex's
+    workspace-write sandbox. Defaults to yes on non-TTY so batch installs
+    don't hang."""
+    if not sys.stdin.isatty():
+        return True
+    console.print(
+        "\n[bold]Codex sandbox network access[/bold]\n"
+        "Codex's default sandbox blocks outbound network from bash commands.\n"
+        "Stash hooks use bash to POST session events to api.stash.ac, so they\n"
+        "need network to upload. Enabling this lets plain `codex` stream.\n"
+        "You can opt out now and use `codex --profile stash` when streaming,\n"
+        "or edit ~/.codex/config.toml later to change your mind."
+    )
+    try:
+        answer = questionary.confirm(
+            "Allow codex bash commands to make outbound network requests?",
+            default=True,
+        ).ask()
+    except Exception:
+        return True
+    return True if answer is None else bool(answer)
+
+
+def _strip_top_level_sandbox(snippet: str) -> str:
+    """Remove the `[sandbox_workspace_write]` top-level block (and its
+    explanatory comment) from the snippet, leaving `[profiles.stash]`
+    and everything else intact."""
+    start = snippet.find("[sandbox_workspace_write]")
+    if start == -1:
+        return snippet
+    prev_blank = snippet.rfind("\n\n", 0, start)
+    block_start = prev_blank + 2 if prev_blank != -1 else start
+    end = snippet.find("[profiles.stash]", start)
+    if end == -1:
+        return snippet[:block_start].rstrip() + "\n"
+    prev_blank_end = snippet.rfind("\n\n", start, end)
+    block_end = prev_blank_end + 2 if prev_blank_end != -1 else end
+    return snippet[:block_start] + snippet[block_end:]
+
+
 def _install_codex(force: bool) -> tuple[str, str]:
     from stashai.plugin.assets import assets_dir
 
@@ -421,26 +462,51 @@ def _install_codex(force: bool) -> tuple[str, str]:
     from string import Template
 
     cfg_path = Path.home() / ".codex" / "config.toml"
+    existing = cfg_path.read_text() if cfg_path.exists() else ""
     snippet = Template((root / "config.toml.snippet").read_text()).safe_substitute(
         PLUGIN_ROOT=str(root)
     )
-    existing = cfg_path.read_text() if cfg_path.exists() else ""
+
+    # Ask about network_access only if the block isn't already in the config.
+    # User's "no" strips the top-level block from what we write; the profile
+    # block stays so `codex --profile stash` still works as an escape hatch.
+    if "[sandbox_workspace_write]" not in existing:
+        if not _ask_codex_network_access():
+            snippet = _strip_top_level_sandbox(snippet)
+
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     if _CODEX_MARKER not in existing:
         with cfg_path.open("a") as f:
             if existing and not existing.endswith("\n"):
                 f.write("\n")
             f.write(f"\n{_CODEX_MARKER}\n{snippet}\n")
-    elif "[profiles.stash]" not in existing:
-        # Upgrade path: features block is already there from an older install,
-        # but the stash profile was added later. Append just the profile
-        # portion so `codex --profile stash` works without a full reinstall.
-        profile_start = snippet.find("[profiles.stash]")
-        if profile_start != -1:
+    else:
+        # Upgrade paths: append any later-added sub-blocks the user is missing.
+        # Each block is matched on its TOML header so a user who manually
+        # edited one in doesn't get a duplicate.
+        appended = ""
+
+        if "[sandbox_workspace_write]" not in existing and "[sandbox_workspace_write]" in snippet:
+            # Slice out the top-level sandbox block from the snippet: from its
+            # preceding comment to just before the `[profiles.stash]` header.
+            sb_header = snippet.find("[sandbox_workspace_write]")
+            profile_header = snippet.find("[profiles.stash]")
+            if sb_header != -1 and profile_header != -1:
+                prev_blank = snippet.rfind("\n\n", 0, sb_header)
+                block_start = prev_blank + 2 if prev_blank != -1 else sb_header
+                block = snippet[block_start:profile_header].rstrip() + "\n"
+                appended += f"\n{_CODEX_MARKER}:sandbox\n{block}"
+
+        if "[profiles.stash]" not in existing:
+            profile_start = snippet.find("[profiles.stash]")
+            if profile_start != -1:
+                appended += f"\n{_CODEX_MARKER}:profile\n{snippet[profile_start:]}"
+
+        if appended:
             with cfg_path.open("a") as f:
                 if not existing.endswith("\n"):
                     f.write("\n")
-                f.write(f"\n{_CODEX_MARKER}:profile\n{snippet[profile_start:]}")
+                f.write(appended)
 
     agents_src = root / "AGENTS.md"
     agents_dest = Path.home() / ".codex" / "AGENTS.md"

--- a/cli/main.py
+++ b/cli/main.py
@@ -416,8 +416,9 @@ def _ask_codex_network_access() -> bool:
     if not sys.stdin.isatty():
         return True
     console.print(
-        "For stash to work, we need to let bash commands make network requests",
-        "So that we can upload chat transcripts to the remote server."
+        "For stash to work on codex specifically, we need to let bash ",
+        "commands make network requests so that we can upload chat ",
+        "transcripts to the remote server."
         )
     answer = questionary.confirm(
         "Allow codex bash commands to make outbound network requests?",

--- a/cli/main.py
+++ b/cli/main.py
@@ -416,13 +416,9 @@ def _ask_codex_network_access() -> bool:
     if not sys.stdin.isatty():
         return True
     console.print(
-        "\n[bold]Codex sandbox network access[/bold]\n"
-        "Codex's default sandbox blocks outbound network from bash commands.\n"
-        "Stash hooks use bash to POST session events to api.stash.ac, so they\n"
-        "need network to upload. Enabling this lets plain `codex` stream.\n"
-        "You can opt out now and use `codex --profile stash` when streaming,\n"
-        "or edit ~/.codex/config.toml later to change your mind."
-    )
+        "For stash to work, we need to let bash commands make network requests",
+        "So that we can upload chat transcripts to the remote server."
+        )
     try:
         answer = questionary.confirm(
             "Allow codex bash commands to make outbound network requests?",

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -25,16 +25,19 @@ def test_fresh_install_writes_profile_block(monkeypatch, tmp_path: Path) -> None
     cfg = _run_install(monkeypatch, tmp_path)
     body = cfg.read_text()
     assert "[profiles.stash]" in body
+    assert "[sandbox_workspace_write]" in body
     # TOML must still parse cleanly after our append.
     with cfg.open("rb") as f:
         parsed = tomllib.load(f)
     assert parsed["profiles"]["stash"]["approval_policy"] == "on-failure"
     assert parsed["profiles"]["stash"]["sandbox_mode"] == "workspace-write"
     assert parsed["profiles"]["stash"]["sandbox_workspace_write"]["network_access"] is True
+    # Top-level network grant — what lets plain `codex` stream without --profile.
+    assert parsed["sandbox_workspace_write"]["network_access"] is True
 
 
-def test_upgrade_from_old_install_appends_profile_only(monkeypatch, tmp_path: Path) -> None:
-    # Simulate a user who installed before the profile block existed.
+def test_upgrade_from_old_install_appends_missing_blocks(monkeypatch, tmp_path: Path) -> None:
+    # Simulate a user who installed before the profile + sandbox blocks existed.
     codex_dir = tmp_path / ".codex"
     codex_dir.mkdir()
     cfg = codex_dir / "config.toml"
@@ -48,16 +51,49 @@ def test_upgrade_from_old_install_appends_profile_only(monkeypatch, tmp_path: Pa
     cfg = _run_install(monkeypatch, tmp_path)
     body = cfg.read_text()
 
-    # Features block preserved (not duplicated), profile block appended.
+    # Features block preserved (not duplicated); both new blocks appended.
     assert body.count("[features]") == 1
     assert "[profiles.stash]" in body
+    assert "[sandbox_workspace_write]" in body
     with cfg.open("rb") as f:
-        tomllib.load(f)
+        parsed = tomllib.load(f)
+    assert parsed["sandbox_workspace_write"]["network_access"] is True
+    assert parsed["profiles"]["stash"]["sandbox_workspace_write"]["network_access"] is True
 
     # Second run is a no-op.
     before = cfg.read_text()
     _install_codex(False)
     assert cfg.read_text() == before
+
+
+def test_upgrade_appends_only_missing_block(monkeypatch, tmp_path: Path) -> None:
+    # Simulate a user who already has the profile block (older upgrade path)
+    # but is missing the newer top-level sandbox block.
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    cfg = codex_dir / "config.toml"
+    cfg.write_text(
+        "# stash-plugin\n"
+        "[features]\n"
+        "codex_hooks = true\n"
+        "\n"
+        "[profiles.stash]\n"
+        'approval_policy = "on-failure"\n'
+        'sandbox_mode = "workspace-write"\n'
+        "\n"
+        "[profiles.stash.sandbox_workspace_write]\n"
+        "network_access = true\n"
+    )
+
+    cfg = _run_install(monkeypatch, tmp_path)
+    body = cfg.read_text()
+
+    # Exactly one of each header — no duplicate profile.
+    assert body.count("[profiles.stash]") == 1
+    assert body.count("[sandbox_workspace_write]") == 1
+    with cfg.open("rb") as f:
+        parsed = tomllib.load(f)
+    assert parsed["sandbox_workspace_write"]["network_access"] is True
 
 
 def test_install_preserves_unrelated_user_config(monkeypatch, tmp_path: Path) -> None:

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -1,10 +1,4 @@
-"""Tests for `_install_codex` — focused on the config.toml append behavior.
-
-The risk this test guards against: an existing user has the old stash-plugin
-block (features only) in ~/.codex/config.toml. On the next `stash connect`
-they should get the new `[profiles.stash]` block appended so `codex --profile
-stash` works, without duplicating the whole snippet.
-"""
+"""Tests for `_install_codex` — focused on the config.toml append behavior."""
 
 from __future__ import annotations
 
@@ -36,64 +30,11 @@ def test_fresh_install_writes_profile_block(monkeypatch, tmp_path: Path) -> None
     assert parsed["sandbox_workspace_write"]["network_access"] is True
 
 
-def test_upgrade_from_old_install_appends_missing_blocks(monkeypatch, tmp_path: Path) -> None:
-    # Simulate a user who installed before the profile + sandbox blocks existed.
-    codex_dir = tmp_path / ".codex"
-    codex_dir.mkdir()
-    cfg = codex_dir / "config.toml"
-    cfg.write_text(
-        "# stash-plugin\n"
-        "[features]\n"
-        "codex_hooks = true\n"
-        "suppress_unstable_features_warning = true\n"
-    )
-
+def test_second_run_is_noop(monkeypatch, tmp_path: Path) -> None:
     cfg = _run_install(monkeypatch, tmp_path)
-    body = cfg.read_text()
-
-    # Features block preserved (not duplicated); both new blocks appended.
-    assert body.count("[features]") == 1
-    assert "[profiles.stash]" in body
-    assert "[sandbox_workspace_write]" in body
-    with cfg.open("rb") as f:
-        parsed = tomllib.load(f)
-    assert parsed["sandbox_workspace_write"]["network_access"] is True
-    assert parsed["profiles"]["stash"]["sandbox_workspace_write"]["network_access"] is True
-
-    # Second run is a no-op.
     before = cfg.read_text()
     _install_codex(False)
     assert cfg.read_text() == before
-
-
-def test_upgrade_appends_only_missing_block(monkeypatch, tmp_path: Path) -> None:
-    # Simulate a user who already has the profile block (older upgrade path)
-    # but is missing the newer top-level sandbox block.
-    codex_dir = tmp_path / ".codex"
-    codex_dir.mkdir()
-    cfg = codex_dir / "config.toml"
-    cfg.write_text(
-        "# stash-plugin\n"
-        "[features]\n"
-        "codex_hooks = true\n"
-        "\n"
-        "[profiles.stash]\n"
-        'approval_policy = "on-failure"\n'
-        'sandbox_mode = "workspace-write"\n'
-        "\n"
-        "[profiles.stash.sandbox_workspace_write]\n"
-        "network_access = true\n"
-    )
-
-    cfg = _run_install(monkeypatch, tmp_path)
-    body = cfg.read_text()
-
-    # Exactly one of each header — no duplicate profile.
-    assert body.count("[profiles.stash]") == 1
-    assert body.count("[sandbox_workspace_write]") == 1
-    with cfg.open("rb") as f:
-        parsed = tomllib.load(f)
-    assert parsed["sandbox_workspace_write"]["network_access"] is True
 
 
 def test_install_preserves_unrelated_user_config(monkeypatch, tmp_path: Path) -> None:

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from cli.main import _install_codex
 
 
-def _run_install(monkeypatch, tmp_path: Path) -> Path:
+def _run_install(monkeypatch, tmp_path: Path, allow_network: bool = True) -> Path:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr("cli.main._ask_codex_network_access", lambda: allow_network)
     _install_codex(False)
     return tmp_path / ".codex" / "config.toml"
 

--- a/plugins/codex-plugin/config.toml.snippet
+++ b/plugins/codex-plugin/config.toml.snippet
@@ -12,10 +12,18 @@ suppress_unstable_features_warning = true
 # Comment out Variant A above, then uncomment this line:
 # notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]
 
-# Stash profile — launch with `codex --profile stash` so the stash CLI can
-# reach api.stash.ac through the sandbox and doesn't prompt for approval on
-# every read. approval_policy = "on-failure" still asks if a command errors,
-# so this is scoped-loosening, not a blanket allow-everything.
+# Codex's default workspace-write sandbox blocks outbound network, which
+# silently kills stash hook POSTs to api.stash.ac. Lifting the block at the
+# top level lets plain `codex` stream. The plugin still gates streaming
+# per-repo on `.stash/stash.json` presence, so this is a capability grant,
+# not a trust grant. Remove this block if you want network only under
+# `codex --profile stash`.
+[sandbox_workspace_write]
+network_access = true
+
+# Stash profile — equivalent for users who prefer keeping the default
+# sandbox tight and only lifting it with `codex --profile stash`.
+# approval_policy = "on-failure" still asks when a command errors.
 [profiles.stash]
 approval_policy = "on-failure"
 sandbox_mode = "workspace-write"

--- a/stashai/plugin/assets/codex/config.toml.snippet
+++ b/stashai/plugin/assets/codex/config.toml.snippet
@@ -12,10 +12,18 @@ suppress_unstable_features_warning = true
 # Comment out Variant A above, then uncomment this line:
 # notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]
 
-# Stash profile — launch with `codex --profile stash` so the stash CLI can
-# reach api.stash.ac through the sandbox and doesn't prompt for approval on
-# every read. approval_policy = "on-failure" still asks if a command errors,
-# so this is scoped-loosening, not a blanket allow-everything.
+# Codex's default workspace-write sandbox blocks outbound network, which
+# silently kills stash hook POSTs to api.stash.ac. Lifting the block at the
+# top level lets plain `codex` stream. The plugin still gates streaming
+# per-repo on `.stash/stash.json` presence, so this is a capability grant,
+# not a trust grant. Remove this block if you want network only under
+# `codex --profile stash`.
+[sandbox_workspace_write]
+network_access = true
+
+# Stash profile — equivalent for users who prefer keeping the default
+# sandbox tight and only lifting it with `codex --profile stash`.
+# approval_policy = "on-failure" still asks when a command errors.
 [profiles.stash]
 approval_policy = "on-failure"
 sandbox_mode = "workspace-write"


### PR DESCRIPTION
Codex streaming wasn't working because it blocks network access from bash commands (and codex hooks are really just bash command)

Now, we ask the user during onboarding "Do you want to allow network outbound for codex bash commands (this is required for stash to work)"? If they hit yes, then chat transcript uploads will work for codex.

