### PR TITLE
Refactor: manifest presence is the only streaming opt-in

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2704,9 +2704,11 @@ STASH_OCTOPUS = r'''
 
 
 def _pushed_scope_phrase() -> str:
-    """Streaming is gated on `.stash/stash.json` presence — repo manifest
-    for a single repo, or `~/.stash/stash.json` for a global install."""
-    return "Coding agent sessions from any repo where stash is installed."
+    """Human phrase for what gets pushed, based on manifest location."""
+    global_manifest = Path.home() / ".stash" / "stash.json"
+    if global_manifest.exists():
+        return "All coding agent transcripts from this machine."
+    return "Coding agent transcripts from this repo."
 
 
 def _current_invite() -> tuple[str, str]:

--- a/cli/main.py
+++ b/cli/main.py
@@ -526,6 +526,31 @@ def _plugin_installed(agent: str) -> bool:
     return False
 
 
+def _install_global_manifest(force: bool) -> tuple[str, str]:
+    """Write `~/.stash/stash.json` so every cwd under `$HOME` without a
+    closer manifest still streams. This is the 'global install' — the
+    opt-in for system-wide streaming."""
+    dest = Path.home() / ".stash" / "stash.json"
+    if dest.exists() and not force:
+        return ("skipped", f"{dest} already exists")
+
+    cfg = load_config()
+    workspace_id = cfg.get("default_workspace") or ""
+    if not workspace_id:
+        return ("failed", "no default workspace — run `stash connect` first")
+    base_url = (cfg.get("base_url") or "").rstrip("/")
+
+    manifest = {
+        "version": 1,
+        "workspace_id": str(workspace_id),
+        "base_url": base_url,
+        "streaming_default": True,
+    }
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(manifest, indent=2) + "\n")
+    return ("installed", str(dest))
+
+
 @app.command("install")
 def install_cmd(
     agents: list[str] = typer.Argument(
@@ -536,11 +561,20 @@ def install_cmd(
         "", "--skip", help="Comma-separated agents to exclude (e.g. --skip codex,opencode)."
     ),
     force: bool = typer.Option(False, "--force", help="Overwrite existing hook files."),
+    global_install: bool = typer.Option(
+        False, "--global",
+        help="Also write ~/.stash/stash.json so sessions in any repo under $HOME "
+             "stream (per-repo manifests still override for routing).",
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Install Stash hook plugins for every supported coding agent on `$PATH`.
 
     Idempotent — re-running is a no-op unless `--force`.
+
+    By default, streaming is gated per-repo: only sessions in a repo with a
+    committed `.stash/stash.json` manifest push events. Pass `--global` to
+    also stream from repos without a manifest (under `$HOME`).
     """
     skip_set = {s.strip() for s in skip.split(",") if s.strip()}
 
@@ -555,7 +589,7 @@ def install_cmd(
 
     targets = [a for a in targets if a not in skip_set]
 
-    if not targets:
+    if not targets and not global_install:
         console.print(
             "[yellow]No supported coding agents detected on PATH.[/yellow] "
             "Install claude / cursor-agent / codex / opencode, then re-run."
@@ -569,6 +603,13 @@ def install_cmd(
         except Exception as e:
             status_, detail = ("failed", f"{type(e).__name__}: {e}")
         results[agent] = {"status": status_, "detail": detail}
+
+    if global_install:
+        try:
+            status_, detail = _install_global_manifest(force)
+        except Exception as e:
+            status_, detail = ("failed", f"{type(e).__name__}: {e}")
+        results["global"] = {"status": status_, "detail": detail}
 
     if _use_json(as_json):
         output_json(results)
@@ -2663,13 +2704,9 @@ STASH_OCTOPUS = r'''
 
 
 def _pushed_scope_phrase() -> str:
-    """Human phrase for 'what gets pushed', varying by the user's scope choice
-    at setup. `repo` (default) pushes only from the install repo; `workspace`
-    and `all` both push from anywhere on this machine."""
-    scope = (_read_central_config().get("scope") or "repo").strip().lower()
-    if scope == "repo":
-        return "Coding agent transcripts from this repo."
-    return "All coding agent transcripts from this machine."
+    """Streaming is gated on `.stash/stash.json` presence — repo manifest
+    for a single repo, or `~/.stash/stash.json` for a global install."""
+    return "Coding agent sessions from any repo where stash is installed."
 
 
 def _current_invite() -> tuple[str, str]:
@@ -2791,46 +2828,6 @@ Run `stash --help` to see everything.
 """
 
 
-def _capture_install_repo() -> None:
-    """At connect time, remember the git common-dir of this repo so the
-    plugins can scope uploads to it (and its worktrees). If cwd isn't in a
-    git repo, prompt the user to pick scope=all or skip uploads entirely."""
-    import subprocess as _sp
-
-    common = ""
-    for args in (
-        ["git", "-C", str(Path.cwd()), "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        ["git", "-C", str(Path.cwd()), "rev-parse", "--git-common-dir"],
-    ):
-        try:
-            out = _sp.run(args, capture_output=True, text=True, timeout=2)
-        except Exception:
-            continue
-        if out.returncode == 0 and out.stdout.strip():
-            common = out.stdout.strip()
-            if not Path(common).is_absolute():
-                common = str(Path.cwd() / common)
-            break
-
-    central = _read_central_config()
-    if common:
-        updates = {"install_repo_common_dir": common}
-        if "scope" not in central:
-            updates["scope"] = "repo"
-        _write_central_config(updates)
-        return
-    if central.get("install_repo_common_dir"):
-        return
-    console.print(
-        "\n[yellow]Not inside a git repo.[/yellow] Uploads are scoped to the install "
-        "repo by default; with none captured, nothing will upload."
-    )
-    if typer.confirm("Upload from everywhere? (scope=all)", default=False):
-        _write_central_config({"scope": "all"})
-    else:
-        _write_central_config({"scope": "repo"})
-
-
 def _install_claude_plugin() -> bool:
     """Install the stash plugin for Claude Code via the official marketplace.
 
@@ -2872,7 +2869,6 @@ def _show_setup_complete_splash(
     joined_via_manifest: bool = False,
 ) -> None:
     """Clear the onboarding transcript and show a clean success splash."""
-    _capture_install_repo()
     console.clear()
     octopus = textwrap.dedent(STASH_OCTOPUS.strip("\n"))
     logo = textwrap.dedent(STASH_LOGO.strip("\n"))
@@ -3020,12 +3016,6 @@ PLUGIN_DATA_DIRS = {
 }
 
 
-SCOPE_CHOICES = [
-    ("repo", "only sessions in the install repo"),
-    ("workspace", "any session tagged with this workspace"),
-    ("all", "every session on this machine"),
-]
-
 OUTPUT_FORMAT_CHOICES = [
     ("human", "colored, human-readable"),
     ("json", "machine-readable JSON"),
@@ -3066,9 +3056,11 @@ def _render_settings_header(cfg: dict, central: dict) -> None:
     plugins_seen = [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()]
     row(f"{'Plugins:':<14}", ", ".join(plugins_seen) or "(none detected)")
 
-    install_repo = central.get("install_repo_common_dir") or ""
-    if install_repo:
-        row(f"{'Install repo:':<14}", install_repo)
+    global_manifest = Path.home() / ".stash" / "stash.json"
+    if global_manifest.exists():
+        row(f"{'Install:':<14}", "global (~/.stash/stash.json)")
+    else:
+        row(f"{'Install:':<14}", "per-repo (via .stash/stash.json manifests)")
     console.print()
 
 
@@ -3083,6 +3075,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
         display_cfg["api_key"] = display_cfg["api_key"][:10] + "..."
 
     if as_json or cfg.get("output_format") == "json":
+        global_manifest = Path.home() / ".stash" / "stash.json"
         output_json(
             {
                 "config": display_cfg,
@@ -3092,8 +3085,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
                 "plugins_installed": [
                     name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()
                 ],
-                "scope": (central.get("scope") or "repo").strip().lower(),
-                "install_repo_common_dir": central.get("install_repo_common_dir") or "",
+                "global_install": global_manifest.exists(),
             }
         )
         return
@@ -3105,14 +3097,12 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
 
         streaming_enabled = bool(central.get("streaming_enabled", True))
         auto_curate = bool(central.get("auto_curate", True))
-        scope = (central.get("scope") or "repo").strip().lower()
         output_format = cfg.get("output_format", "human")
         base_url = cfg.get("base_url", "")
 
         rows = [
             ("Streaming", "on" if streaming_enabled else "off", "streaming"),
             ("Auto-curate", "on" if auto_curate else "off", "auto_curate"),
-            ("Scope", scope, "scope"),
             ("Output format", output_format, "output_format"),
             ("Endpoint", base_url, "base_url"),
         ]
@@ -3136,20 +3126,6 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             _write_central_config({"streaming_enabled": not streaming_enabled})
         elif picked == "auto_curate":
             _write_central_config({"auto_curate": not auto_curate})
-        elif picked == "scope":
-            label_w2 = max(len(v) for v, _ in SCOPE_CHOICES)
-            scope_choices = [
-                questionary.Choice(f"{v:<{label_w2}}   {desc}", value=v)
-                for v, desc in SCOPE_CHOICES
-            ]
-            new_scope = questionary.select(
-                "Upload scope — which sessions push to the shared store?",
-                choices=scope_choices,
-                default=next((ch for ch in scope_choices if ch.value == scope), None),
-                use_shortcuts=True,
-            ).ask()
-            if new_scope:
-                _write_central_config({"scope": new_scope})
         elif picked == "output_format":
             label_w2 = max(len(v) for v, _ in OUTPUT_FORMAT_CHOICES)
             fmt_choices = [
@@ -3271,13 +3247,6 @@ def config_cmd(
     from .config import USER_CONFIG_FILE, find_project_config
 
     if key and value:
-        if key == "scope":
-            if value not in {"repo", "workspace", "all"}:
-                console.print("[red]Invalid scope. Must be: repo | workspace | all[/red]")
-                raise typer.Exit(1)
-            _write_central_config({"scope": value})
-            console.print(f"[green]scope = {value}[/green]")
-            return
         write_scope = "project" if project else "user"
         allowed = {
             "base_url",

--- a/plugins/tests/conftest.py
+++ b/plugins/tests/conftest.py
@@ -1,5 +1,5 @@
-"""Default the scope gate to wide-open for pre-existing tests that don't
-set up install_repo_common_dir. Per-test scope tests re-patch this."""
+"""Default the scope gate to wide-open for tests that don't set up a
+manifest. Per-test scope tests re-patch this."""
 
 from __future__ import annotations
 
@@ -11,4 +11,4 @@ def _scope_wide_open(monkeypatch):
     # Only patch the binding that hooks.py uses. Tests that import
     # scope.cwd_in_scope directly (scope.py's own tests) get the real thing.
     from stashai.plugin import hooks
-    monkeypatch.setattr(hooks, "cwd_in_scope", lambda cwd, cfg: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda cwd: True)

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -22,7 +22,7 @@ from stashai.plugin.event import HookEvent
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    scope_mod._has_manifest.cache_clear()
+    scope_mod.cwd_in_scope.cache_clear()
     scope_mod.repo_stash_disabled.cache_clear()
 
 

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -14,16 +14,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from stashai.plugin import scope as scope_mod
 from stashai.plugin.event import HookEvent
 
 
-@pytest.fixture(autouse=True)
-def _clear_cache():
-    scope_mod.cwd_in_scope.cache_clear()
-    scope_mod.repo_stash_disabled.cache_clear()
 
 
 def test_manifest_in_cwd_is_in_scope(tmp_path):

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -1,11 +1,17 @@
-"""Scope gate — the shape that actually matters: worktree match, sibling
-reject, scope=all bypass. Plus the regression test: scope=repo must block
-live events when cwd is out of scope (and scope=all must preserve old
-behavior if a user opts out)."""
+"""Scope gate — manifest presence is the only opt-in signal.
+
+The gate checks for `.stash/stash.json` walking up from cwd:
+- Repo-level manifest in cwd or ancestor → in scope.
+- Global manifest at `~/.stash/stash.json` → in scope (implicitly covered
+  by the walk-up if `$HOME` is above cwd; the mechanism is the same).
+- Nothing → out of scope.
+
+Regression test: out-of-scope sessions must short-circuit before any event
+reaches the transport.
+"""
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -14,48 +20,59 @@ from stashai.plugin import scope as scope_mod
 from stashai.plugin.event import HookEvent
 
 
-def _init_repo(path: Path) -> None:
-    subprocess.run(["git", "init", "-q", str(path)], check=True)
-
-
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    scope_mod._common_dir.cache_clear()
+    scope_mod._has_manifest.cache_clear()
+    scope_mod.repo_stash_disabled.cache_clear()
 
 
-def test_worktree_shares_install_scope(tmp_path):
-    main = tmp_path / "main"
-    main.mkdir()
-    _init_repo(main)
-    (main / "f.txt").write_text("x")
-    subprocess.run(["git", "-C", str(main), "add", "."], check=True, capture_output=True)
-    subprocess.run(
-        ["git", "-C", str(main), "-c", "user.email=t@t", "-c", "user.name=t",
-         "commit", "-q", "-m", "init"],
-        check=True, capture_output=True,
-    )
-    wt = tmp_path / "wt"
-    subprocess.run(
-        ["git", "-C", str(main), "worktree", "add", "-q", "--detach", str(wt)],
-        check=True, capture_output=True,
-    )
-    install = scope_mod._common_dir(str(main))
-    assert scope_mod.cwd_in_scope(str(wt), {"scope": "repo", "install_repo_common_dir": install})
+def test_manifest_in_cwd_is_in_scope(tmp_path):
+    (tmp_path / ".stash").mkdir()
+    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1}')
+    assert scope_mod.cwd_in_scope(str(tmp_path))
 
 
-def test_sibling_repo_rejected(tmp_path):
-    main = tmp_path / "main"
-    sib = tmp_path / "sib"
-    main.mkdir(); sib.mkdir()
-    _init_repo(main); _init_repo(sib)
-    install = scope_mod._common_dir(str(main))
-    assert not scope_mod.cwd_in_scope(str(sib), {"scope": "repo", "install_repo_common_dir": install})
+def test_manifest_in_ancestor_is_in_scope(tmp_path):
+    (tmp_path / ".stash").mkdir()
+    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1}')
+    sub = tmp_path / "packages" / "foo"
+    sub.mkdir(parents=True)
+    assert scope_mod.cwd_in_scope(str(sub))
 
 
-def test_scope_all_bypasses_check(tmp_path):
-    outside = tmp_path / "notrepo"
-    outside.mkdir()
-    assert scope_mod.cwd_in_scope(str(outside), {"scope": "all", "install_repo_common_dir": ""})
+def test_no_manifest_rejected(tmp_path):
+    assert not scope_mod.cwd_in_scope(str(tmp_path))
+
+
+def test_empty_cwd_rejected():
+    assert not scope_mod.cwd_in_scope("")
+    assert not scope_mod.cwd_in_scope(None)
+
+
+def test_repo_manifest_wins_over_shallower_one(tmp_path):
+    # A repo-level manifest under an ancestor with its own manifest should
+    # still be in scope — the walk-up finds the nearest first.
+    (tmp_path / ".stash").mkdir()
+    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "A"}')
+
+    repo = tmp_path / "projects" / "repo"
+    (repo / ".stash").mkdir(parents=True)
+    (repo / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "B"}')
+
+    # Both cwds resolve to in-scope; routing (which workspace) is read by the
+    # plugin separately via get_config(), not the scope gate.
+    assert scope_mod.cwd_in_scope(str(repo))
+    assert scope_mod.cwd_in_scope(str(tmp_path))
+
+
+def test_repo_stash_disabled_marker(tmp_path):
+    (tmp_path / ".stash").mkdir()
+    (tmp_path / ".stash" / "config.json").write_text('{"stash_disabled_here": true}')
+    assert scope_mod.repo_stash_disabled(str(tmp_path))
+
+
+def test_repo_stash_disabled_missing_file(tmp_path):
+    assert not scope_mod.repo_stash_disabled(str(tmp_path))
 
 
 # --- Regression: the gate must short-circuit live events -------------------
@@ -69,11 +86,11 @@ class _RecordingClient:
         return {"ok": True}
 
 
-def test_scope_repo_blocks_live_events_out_of_scope(monkeypatch):
+def test_out_of_scope_blocks_live_events(monkeypatch):
     from stashai.plugin import hooks, scope as s
     from stashai.plugin.hooks import stream_user_message
-    monkeypatch.setattr(s, "cwd_in_scope", lambda cwd, cfg: False)
-    monkeypatch.setattr(hooks, "cwd_in_scope", lambda cwd, cfg: False)
+    monkeypatch.setattr(s, "cwd_in_scope", lambda cwd: False)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda cwd: False)
 
     c = _RecordingClient()
     stream_user_message(c, {"workspace_id": "ws1", "agent_name": "a"}, {"session_id": "s"},
@@ -81,10 +98,10 @@ def test_scope_repo_blocks_live_events_out_of_scope(monkeypatch):
     assert c.calls == []
 
 
-def test_scope_all_preserves_old_behavior(monkeypatch):
+def test_in_scope_allows_live_events(monkeypatch):
     from stashai.plugin.hooks import stream_user_message
-    c = _RecordingClient()
     # Autouse fixture in conftest already patches cwd_in_scope → True.
+    c = _RecordingClient()
     stream_user_message(c, {"workspace_id": "ws1", "agent_name": "a"}, {"session_id": "s"},
                         "hello", HookEvent(kind="prompt", cwd="/anywhere"))
     assert len(c.calls) == 1

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from stashai.plugin.event import HookEvent
 from stashai.plugin.scope import cwd_in_scope, repo_stash_disabled
 from stashai.plugin.stash_client import StashClient
-from stashai.plugin.state import get_scope_config, read_stats, record_tool_use
+from stashai.plugin.state import read_stats, record_tool_use
 from stashai.plugin.summarize import summarize_tool_use
 
 
@@ -28,7 +28,7 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> bool:
     cwd = getattr(event, "cwd", None) if event is not None else None
     if repo_stash_disabled(cwd):
         return True
-    return not cwd_in_scope(cwd, get_scope_config())
+    return not cwd_in_scope(cwd)
 
 
 # --- Prompt streaming ---

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -1,15 +1,5 @@
-"""Stream gate — plugin hooks only push events when a `.stash/stash.json`
+"""Plugin hooks only push events when a `.stash/stash.json`
 manifest is discoverable from cwd (in the current directory or any ancestor).
-
-The manifest's location encodes scope:
-- `<repo>/.stash/stash.json` — per-repo install. Events stream when cwd is
-  anywhere inside that tree, routed to that manifest's `workspace_id`.
-- `~/.stash/stash.json` — global install. Acts as a catch-all: anything
-  under `$HOME` without a closer manifest still streams.
-
-Closest-ancestor wins, so a repo-level manifest always overrides the global
-one for routing. There is no separate "scope" config — the manifest's
-presence is the opt-in, and its location encodes the breadth.
 """
 
 from __future__ import annotations

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -17,10 +17,7 @@ def _has_manifest(cwd: str | None) -> bool:
     """True if `.stash/stash.json` exists in cwd or any ancestor."""
     if not cwd:
         return False
-    try:
-        cur = Path(cwd).resolve()
-    except Exception:
-        return False
+    cur = Path(cwd).resolve()
     for parent in [cur, *cur.parents]:
         if (parent / ".stash" / _MANIFEST_FILENAME).exists():
             return True
@@ -44,10 +41,7 @@ def repo_stash_disabled(cwd: str | None) -> bool:
     treated as 'not disabled'."""
     if not cwd:
         return False
-    try:
-        cur = Path(cwd).resolve()
-    except Exception:
-        return False
+    cur = Path(cwd).resolve()
     for parent in [cur, *cur.parents]:
         candidate = parent / ".stash" / _CONFIG_FILENAME
         if not candidate.exists():

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -5,14 +5,12 @@ manifest is discoverable from cwd (in the current directory or any ancestor).
 from __future__ import annotations
 
 import json
-from functools import lru_cache
 from pathlib import Path
 
 _MANIFEST_FILENAME = "stash.json"
 _CONFIG_FILENAME = "config.json"
 
 
-@lru_cache(maxsize=64)
 def cwd_in_scope(cwd: str | None) -> bool:
     """True if `.stash/stash.json` exists in cwd or any ancestor."""
     if not cwd:
@@ -24,7 +22,6 @@ def cwd_in_scope(cwd: str | None) -> bool:
     return False
 
 
-@lru_cache(maxsize=64)
 def repo_stash_disabled(cwd: str | None) -> bool:
     """True if the repo containing `cwd` has opted out of stash streaming
     via `stash_disabled_here=true` in .stash/config.json. Walks up from cwd

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -1,51 +1,49 @@
-"""Repo-scope gate. With `scope=repo` (default), plugins only push events
-and transcripts for sessions run in the repo captured at `stash connect`
-time — or any of its worktrees (they share the git common-dir).
+"""Stream gate — plugin hooks only push events when a `.stash/stash.json`
+manifest is discoverable from cwd (in the current directory or any ancestor).
+
+The manifest's location encodes scope:
+- `<repo>/.stash/stash.json` — per-repo install. Events stream when cwd is
+  anywhere inside that tree, routed to that manifest's `workspace_id`.
+- `~/.stash/stash.json` — global install. Acts as a catch-all: anything
+  under `$HOME` without a closer manifest still streams.
+
+Closest-ancestor wins, so a repo-level manifest always overrides the global
+one for routing. There is no separate "scope" config — the manifest's
+presence is the opt-in, and its location encodes the breadth.
 """
 
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from functools import lru_cache
 from pathlib import Path
 
+_MANIFEST_FILENAME = "stash.json"
+_CONFIG_FILENAME = "config.json"
+
 
 @lru_cache(maxsize=64)
-def _common_dir(cwd: str) -> str | None:
+def _has_manifest(cwd: str | None) -> bool:
+    """True if `.stash/stash.json` exists in cwd or any ancestor."""
     if not cwd:
-        return None
-    try:
-        proc = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            capture_output=True, text=True, timeout=2,
-        )
-        if proc.returncode == 0 and proc.stdout.strip():
-            return proc.stdout.strip()
-    except Exception:
-        pass
-    try:
-        proc = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=2,
-        )
-        if proc.returncode == 0 and proc.stdout.strip():
-            return os.path.abspath(os.path.join(cwd, proc.stdout.strip()))
-    except Exception:
-        pass
-    return None
-
-
-def cwd_in_scope(cwd: str | None, cfg: dict) -> bool:
-    scope = (cfg.get("scope") or "repo").strip().lower()
-    if scope in ("all", "workspace"):
-        return True
-    install = cfg.get("install_repo_common_dir") or ""
-    if not install or not cwd:
         return False
-    current = _common_dir(cwd)
-    return bool(current) and os.path.normpath(current) == os.path.normpath(install)
+    try:
+        cur = Path(cwd).resolve()
+    except Exception:
+        return False
+    for parent in [cur, *cur.parents]:
+        if (parent / ".stash" / _MANIFEST_FILENAME).exists():
+            return True
+    return False
+
+
+def cwd_in_scope(cwd: str | None) -> bool:
+    """True when cwd is within a stash-installed tree.
+
+    Callers used to pass a scope config dict here; the concept has been
+    folded into the manifest's location so that's no longer needed.
+    """
+    return _has_manifest(cwd)
 
 
 @lru_cache(maxsize=64)
@@ -61,7 +59,7 @@ def repo_stash_disabled(cwd: str | None) -> bool:
     except Exception:
         return False
     for parent in [cur, *cur.parents]:
-        candidate = parent / ".stash" / "config.json"
+        candidate = parent / ".stash" / _CONFIG_FILENAME
         if not candidate.exists():
             continue
         try:

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -13,7 +13,7 @@ _CONFIG_FILENAME = "config.json"
 
 
 @lru_cache(maxsize=64)
-def _has_manifest(cwd: str | None) -> bool:
+def cwd_in_scope(cwd: str | None) -> bool:
     """True if `.stash/stash.json` exists in cwd or any ancestor."""
     if not cwd:
         return False
@@ -22,15 +22,6 @@ def _has_manifest(cwd: str | None) -> bool:
         if (parent / ".stash" / _MANIFEST_FILENAME).exists():
             return True
     return False
-
-
-def cwd_in_scope(cwd: str | None) -> bool:
-    """True when cwd is within a stash-installed tree.
-
-    Callers used to pass a scope config dict here; the concept has been
-    folded into the manifest's location so that's no longer needed.
-    """
-    return _has_manifest(cwd)
 
 
 @lru_cache(maxsize=64)

--- a/stashai/plugin/state.py
+++ b/stashai/plugin/state.py
@@ -132,14 +132,6 @@ def set_streaming_enabled(enabled: bool) -> None:
     _write_central({"streaming_enabled": bool(enabled)})
 
 
-def get_scope_config() -> dict:
-    central = _read_central()
-    return {
-        "scope": central.get("scope", "repo"),
-        "install_repo_common_dir": central.get("install_repo_common_dir", ""),
-    }
-
-
 def auto_curate_enabled() -> bool:
     """Read the central `auto_curate` flag. Defaults to True when unset."""
     raw = _read_central().get("auto_curate", True)


### PR DESCRIPTION
## Summary

We used to have three separate systems for deciding whether stash is enabled: `~/.stash/config.json[scope]`,  `~/.stash/config.json[install_repo_common_dir]`, `.stash/stash.json` manifests. This was totally redundant. Now we only use `.stash/stash.json` manifests.

### How it works now

- `cwd_in_scope(cwd)` just iteratively checks ancestors for `.stash/stash.json` in `stashai/plugin/scope.py`. Nothing else.
- Per-repo install: `stash connect` creates `<repo>/.stash/stash.json`. Everything under that tree streams to that workspace.
- Global install: `stash install --global` writes `~/.stash/stash.json`. Every cwd under `$HOME` without a closer manifest streams there.
- Closest-ancestor wins for routing. Repo manifest automatically overrides the global fallback.