### PR TITLE
refactor: remove stash install command

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -551,8 +551,6 @@ def _install_global_manifest(force: bool) -> tuple[str, str]:
     return ("installed", str(dest))
 
 
-
-
 @app.command()
 def whoami(as_json: bool = typer.Option(False, "--json")):
     """Show profile."""
@@ -2053,8 +2051,8 @@ def connect(
             gm_status, gm_detail = _install_global_manifest(force=False)
             if gm_status == "installed":
                 console.print(f"  [green]✓[/green] Global manifest written: {gm_detail}")
-        except Exception:
-            pass
+        except Exception as e:
+            console.print(f"  [yellow]⚠[/yellow] Could not write global manifest: {e}")
 
     # --- Step 1: API endpoint ---
     cfg = load_config()

--- a/cli/main.py
+++ b/cli/main.py
@@ -551,77 +551,6 @@ def _install_global_manifest(force: bool) -> tuple[str, str]:
     return ("installed", str(dest))
 
 
-@app.command("install")
-def install_cmd(
-    agents: list[str] = typer.Argument(
-        None,
-        help="Agent(s) to install for. Defaults to every supported agent on $PATH.",
-    ),
-    skip: str = typer.Option(
-        "", "--skip", help="Comma-separated agents to exclude (e.g. --skip codex,opencode)."
-    ),
-    force: bool = typer.Option(False, "--force", help="Overwrite existing hook files."),
-    global_install: bool = typer.Option(
-        False, "--global",
-        help="Also write ~/.stash/stash.json so sessions in any repo under $HOME "
-             "stream (per-repo manifests still override for routing).",
-    ),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Install Stash hook plugins for every supported coding agent on `$PATH`.
-
-    Idempotent — re-running is a no-op unless `--force`.
-
-    By default, streaming is gated per-repo: only sessions in a repo with a
-    committed `.stash/stash.json` manifest push events. Pass `--global` to
-    also stream from repos without a manifest (under `$HOME`).
-    """
-    skip_set = {s.strip() for s in skip.split(",") if s.strip()}
-
-    if agents:
-        unknown = [a for a in agents if a not in _SUPPORTED_AGENTS]
-        if unknown:
-            console.print(f"[red]Unknown agents: {', '.join(unknown)}[/red]")
-            raise typer.Exit(1)
-        targets = agents
-    else:
-        targets = _detected_agents()
-
-    targets = [a for a in targets if a not in skip_set]
-
-    if not targets and not global_install:
-        console.print(
-            "[yellow]No supported coding agents detected on PATH.[/yellow] "
-            "Install claude / cursor-agent / codex / opencode, then re-run."
-        )
-        raise typer.Exit(1)
-
-    results: dict[str, dict] = {}
-    for agent in targets:
-        try:
-            status_, detail = _INSTALLERS[agent](force)
-        except Exception as e:
-            status_, detail = ("failed", f"{type(e).__name__}: {e}")
-        results[agent] = {"status": status_, "detail": detail}
-
-    if global_install:
-        try:
-            status_, detail = _install_global_manifest(force)
-        except Exception as e:
-            status_, detail = ("failed", f"{type(e).__name__}: {e}")
-        results["global"] = {"status": status_, "detail": detail}
-
-    if _use_json(as_json):
-        output_json(results)
-        return
-
-    for agent, r in results.items():
-        color = {"installed": "green", "skipped": "yellow", "failed": "red"}[r["status"]]
-        console.print(f"  [{color}]{r['status']:9}[/{color}] {agent:8} {r['detail']}")
-
-    any_failed = any(r["status"] == "failed" for r in results.values())
-    if any_failed:
-        raise typer.Exit(1)
 
 
 @app.command()
@@ -2118,6 +2047,14 @@ def connect(
         ).ask()
         if scope is None:
             raise typer.Exit(1)
+
+    if scope == "user":
+        try:
+            gm_status, gm_detail = _install_global_manifest(force=False)
+            if gm_status == "installed":
+                console.print(f"  [green]✓[/green] Global manifest written: {gm_detail}")
+        except Exception:
+            pass
 
     # --- Step 1: API endpoint ---
     cfg = load_config()

--- a/cli/tests/test_install_hooks.py
+++ b/cli/tests/test_install_hooks.py
@@ -1,7 +1,7 @@
 """Tests for `_merge_json_hooks` — the idempotent hooks.json merger used by
-`stash install` / `stash connect` to wire agent hook files.
+`stash connect` to wire agent hook files.
 
-Covers the multi-root stale-entry case: a user who has run `stash install`
+Covers the multi-root stale-entry case: a user who has run `stash connect`
 from several different PLUGIN_ROOTs (old dev checkouts, prior pipx versions)
 should end up with a single stash-owned entry per event after the next install,
 regardless of which root they install from.

--- a/plugins/tests/test_assets_in_sync.py
+++ b/plugins/tests/test_assets_in_sync.py
@@ -1,9 +1,9 @@
 """Assert that `stashai/plugin/assets/<agent>/` is a byte-identical copy of
 `plugins/<agent>-plugin/`.
 
-`stash install` reads from the shipped stashai assets so users don't need the
+`stash connect` reads from the shipped stashai assets so users don't need the
 repo. `plugins/<agent>-plugin/` is the canonical source contributors edit.
-Drift between the two means `stash install` would hand out stale hook files.
+Drift between the two means `stash connect` would hand out stale hook files.
 """
 
 from __future__ import annotations

--- a/stashai/plugin/assets/__init__.py
+++ b/stashai/plugin/assets/__init__.py
@@ -1,7 +1,7 @@
 """Plugin asset templates shipped with stashai.
 
 Each agent directory mirrors `plugins/<agent>-plugin/` in the source repo.
-`stash install` reads these to install hook configs into `~/.<agent>/` without
+`stash connect` reads these to install hook configs into `~/.<agent>/` without
 requiring the user to clone the stash repo.
 
 The source-of-truth is `plugins/<agent>-plugin/`; a drift test in


### PR DESCRIPTION
## Summary

- Removes the standalone `stash install` command — it duplicated what `stash connect` Step 4 already does (auto-detect agents on PATH, prompt per-agent, install hooks)
- The only unique piece (`--global` for writing `~/.stash/stash.json`) now fires automatically when the user picks "Everywhere on this machine" in `stash connect`'s scope picker
- Updates comment references from `stash install` → `stash connect`

Stacks on #176 — merge that first.

## Test plan

- [x] Existing `test_install_hooks.py` passes (tests `_merge_json_hooks` directly)
- [x] `test_assets_in_sync.py` passes
- [x] `test_scope.py` passes
- [ ] Manual: run `stash connect`, pick "Everywhere on this machine", verify `~/.stash/stash.json` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)