### PR TITLE
remove dead manifest keys: streaming_default, require_approval

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -31,8 +31,6 @@ class Manifest(TypedDict, total=False):
     workspace_name: str
     invite_code: str
     base_url: str
-    streaming_default: bool
-    require_approval: bool
 
 DEFAULT_CONFIG = {
     "base_url": "http://localhost:3456",

--- a/cli/main.py
+++ b/cli/main.py
@@ -559,7 +559,6 @@ def _install_global_manifest(workspace_id: str, force: bool = False) -> tuple[st
         "version": 1,
         "workspace_id": str(workspace_id),
         "base_url": base_url,
-        "streaming_default": True,
     }
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(manifest, indent=2) + "\n")
@@ -2474,7 +2473,6 @@ def _offer_repo_init(client: "StashClient | None" = None) -> None:
         "workspace_name": chosen_ws["name"],
         "invite_code": invite_code,
         "base_url": base_url,
-        "streaming_default": True,
     }
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")


### PR DESCRIPTION
## Summary
- Remove `streaming_default` from manifest — written during onboarding but never read at runtime
- Remove `require_approval` from Manifest TypedDict — also never referenced anywhere
- Streaming is controlled solely by `stash_disabled_here` in `.stash/config.json`

## Test plan
- [x] `streaming_default` has zero reads in `stashai/` (the plugin runtime)
- [x] `require_approval` only existed in the TypedDict definition
- [x] Scope tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)