### PR TITLE
Simplify enable/disable: manifest presence is the opt-in

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -17,6 +17,8 @@ from rich.text import Text
 
 from .client import StashClient, StashError
 from .config import (
+    MANIFEST_FILENAME,
+    PROJECT_DIRNAME,
     PROJECT_FILENAME,
     Manifest,
     find_project_config,
@@ -29,6 +31,17 @@ from .config import (
 from .formatting import console, output_json, print_members, print_rooms, print_user
 
 app = typer.Typer(name="stash", help="Stash CLI — workspaces, notebooks, tables, history.")
+
+_DISABLED_MANIFEST = "stash.json.disabled"
+
+
+def _find_disabled_manifest(start: Path | None = None) -> Path | None:
+    cur = (start or Path.cwd()).resolve()
+    for parent in [cur, *cur.parents]:
+        candidate = parent / PROJECT_DIRNAME / _DISABLED_MANIFEST
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _client() -> StashClient:
@@ -2122,22 +2135,9 @@ def connect(
                     raise typer.Exit(1)
 
                 if not go:
-                    # Record an opt-out for this repo (next to the manifest).
                     manifest_path = find_project_manifest()
-                    project_path = (
-                        manifest_path.parent / PROJECT_FILENAME
-                        if manifest_path
-                        else find_project_config() or (Path.cwd() / ".stash" / PROJECT_FILENAME)
-                    )
-                    existing = {}
-                    if project_path.exists():
-                        try:
-                            existing = json.loads(project_path.read_text())
-                        except Exception:
-                            existing = {}
-                    existing["transcript_upload_hook"] = False
-                    project_path.parent.mkdir(parents=True, exist_ok=True)
-                    project_path.write_text(json.dumps(existing, indent=2) + "\n")
+                    if manifest_path:
+                        manifest_path.rename(manifest_path.with_name(_DISABLED_MANIFEST))
                     console.print(
                         "[yellow]Skipped.[/yellow] Hooks in this repo will stay inert. "
                         "Run [cyan]stash enable[/cyan] later to change your mind."
@@ -2350,10 +2350,11 @@ def _update_gitignore_for_manifest(repo_root: Path) -> str:
     Returns a short status string for display ('created', 'updated', 'already-set')."""
     gi = repo_root / ".gitignore"
     config_entry = ".stash/config.json"
+    disabled_entry = ".stash/stash.json.disabled"
     manifest_entry = "!.stash/stash.json"
 
     if not gi.exists():
-        gi.write_text(f"{config_entry}\n")
+        gi.write_text(f"{config_entry}\n{disabled_entry}\n")
         return "created"
 
     lines = gi.read_text().splitlines()
@@ -2361,9 +2362,10 @@ def _update_gitignore_for_manifest(repo_root: Path) -> str:
 
     has_wholesale = any(s in (".stash/", ".stash") for s in stripped)
     has_config_entry = any(s == config_entry for s in stripped)
+    has_disabled_entry = any(s == disabled_entry for s in stripped)
     has_manifest_negation = any(s == manifest_entry for s in stripped)
 
-    if has_config_entry and (not has_wholesale or has_manifest_negation):
+    if has_config_entry and has_disabled_entry and (not has_wholesale or has_manifest_negation):
         return "already-set"
 
     new_lines = list(lines)
@@ -2371,6 +2373,8 @@ def _update_gitignore_for_manifest(repo_root: Path) -> str:
         new_lines.append(manifest_entry)
     if not has_config_entry:
         new_lines.append(config_entry)
+    if not has_disabled_entry:
+        new_lines.append(disabled_entry)
     gi.write_text("\n".join(new_lines) + "\n")
     return "updated"
 
@@ -2520,7 +2524,12 @@ def _offer_repo_init(client: "StashClient | None" = None) -> None:
 def enable_cmd():
     """Re-enable Stash streaming for this repo (undoes `stash disable`)."""
     manifest_path = find_project_manifest()
-    if manifest_path is None:
+    if manifest_path is not None:
+        console.print("[green]Stash streaming is already enabled.[/green]")
+        return
+
+    disabled_path = _find_disabled_manifest()
+    if disabled_path is None:
         console.print(
             "[yellow]No .stash/stash.json found in this repo.[/yellow]  "
             "Ask a maintainer to run [cyan]stash connect[/cyan] here and accept the "
@@ -2528,25 +2537,14 @@ def enable_cmd():
         )
         raise typer.Exit(1)
 
-    # Pin the config to the manifest's directory. find_project_config() walks up
-    # and could resolve to a parent repo's .stash/config.json in nested setups,
-    # which would enable/disable the wrong repo.
-    project_path = manifest_path.parent / PROJECT_FILENAME
-    existing = {}
-    if project_path.exists():
-        try:
-            existing = json.loads(project_path.read_text())
-        except Exception:
-            existing = {}
-    existing.pop("transcript_upload_hook", None)
-    project_path.parent.mkdir(parents=True, exist_ok=True)
-    project_path.write_text(json.dumps(existing, indent=2) + "\n")
-    console.print(f"[green]Stash streaming enabled for this repo.[/green]  ({project_path})")
+    enabled_path = disabled_path.with_name(MANIFEST_FILENAME)
+    disabled_path.rename(enabled_path)
+    console.print(f"[green]Stash streaming enabled for this repo.[/green]  ({enabled_path})")
 
 
 @app.command("disable")
 def disable_cmd():
-    """Stop streaming for this repo without touching the committed manifest."""
+    """Stop streaming for this repo by renaming the manifest."""
     manifest_path = find_project_manifest()
     if manifest_path is None:
         console.print(
@@ -2555,19 +2553,10 @@ def disable_cmd():
         )
         raise typer.Exit(1)
 
-    # See enable_cmd: pin to manifest dir so we don't disable a parent repo.
-    project_path = manifest_path.parent / PROJECT_FILENAME
-    existing = {}
-    if project_path.exists():
-        try:
-            existing = json.loads(project_path.read_text())
-        except Exception:
-            existing = {}
-    existing["transcript_upload_hook"] = False
-    project_path.parent.mkdir(parents=True, exist_ok=True)
-    project_path.write_text(json.dumps(existing, indent=2) + "\n")
+    disabled_path = manifest_path.with_name(_DISABLED_MANIFEST)
+    manifest_path.rename(disabled_path)
     console.print(
-        f"[yellow]Stash streaming disabled for this repo.[/yellow]  ({project_path})\n"
+        f"[yellow]Stash streaming disabled for this repo.[/yellow]  ({disabled_path})\n"
         "Run [cyan]stash enable[/cyan] to turn it back on."
     )
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2135,7 +2135,7 @@ def connect(
                             existing = json.loads(project_path.read_text())
                         except Exception:
                             existing = {}
-                    existing["stash_disabled_here"] = True
+                    existing["transcript_upload_hook"] = False
                     project_path.parent.mkdir(parents=True, exist_ok=True)
                     project_path.write_text(json.dumps(existing, indent=2) + "\n")
                     console.print(
@@ -2538,7 +2538,7 @@ def enable_cmd():
             existing = json.loads(project_path.read_text())
         except Exception:
             existing = {}
-    existing.pop("stash_disabled_here", None)
+    existing.pop("transcript_upload_hook", None)
     project_path.parent.mkdir(parents=True, exist_ok=True)
     project_path.write_text(json.dumps(existing, indent=2) + "\n")
     console.print(f"[green]Stash streaming enabled for this repo.[/green]  ({project_path})")
@@ -2563,7 +2563,7 @@ def disable_cmd():
             existing = json.loads(project_path.read_text())
         except Exception:
             existing = {}
-    existing["stash_disabled_here"] = True
+    existing["transcript_upload_hook"] = False
     project_path.parent.mkdir(parents=True, exist_ok=True)
     project_path.write_text(json.dumps(existing, indent=2) + "\n")
     console.print(

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -123,32 +123,6 @@ def test_main_repo_manifest_beats_worktree_local(tmp_path, monkeypatch):
     assert manifest["workspace_id"] == "main"
 
 
-def test_worktree_disabled_checks_main_repo(tmp_path, monkeypatch):
-    """repo_transcript_hook_enabled should check the main worktree root."""
-    main_repo = tmp_path / "main-repo"
-    main_repo.mkdir()
-    (main_repo / ".stash").mkdir()
-    (main_repo / ".stash" / "config.json").write_text('{"transcript_upload_hook": false}')
-
-    worktree = tmp_path / "worktree-checkout"
-    worktree.mkdir()
-
-    monkeypatch.setattr(
-        scope_mod, "_git_repo_info", lambda cwd: (worktree, main_repo)
-    )
-
-    assert not scope_mod.repo_transcript_hook_enabled(str(worktree))
-
-
-def test_repo_transcript_hook_disabled(tmp_path):
-    (tmp_path / ".stash").mkdir()
-    (tmp_path / ".stash" / "config.json").write_text('{"transcript_upload_hook": false}')
-    assert not scope_mod.repo_transcript_hook_enabled(str(tmp_path))
-
-
-def test_repo_transcript_hook_enabled_missing_file(tmp_path):
-    assert scope_mod.repo_transcript_hook_enabled(str(tmp_path))
-
 
 # --- Regression: the gate must short-circuit live events -------------------
 

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -124,11 +124,11 @@ def test_main_repo_manifest_beats_worktree_local(tmp_path, monkeypatch):
 
 
 def test_worktree_disabled_checks_main_repo(tmp_path, monkeypatch):
-    """repo_stash_disabled should check the main worktree root."""
+    """repo_transcript_hook_enabled should check the main worktree root."""
     main_repo = tmp_path / "main-repo"
     main_repo.mkdir()
     (main_repo / ".stash").mkdir()
-    (main_repo / ".stash" / "config.json").write_text('{"stash_disabled_here": true}')
+    (main_repo / ".stash" / "config.json").write_text('{"transcript_upload_hook": false}')
 
     worktree = tmp_path / "worktree-checkout"
     worktree.mkdir()
@@ -137,17 +137,17 @@ def test_worktree_disabled_checks_main_repo(tmp_path, monkeypatch):
         scope_mod, "_git_repo_info", lambda cwd: (worktree, main_repo)
     )
 
-    assert scope_mod.repo_stash_disabled(str(worktree))
+    assert not scope_mod.repo_transcript_hook_enabled(str(worktree))
 
 
-def test_repo_stash_disabled_marker(tmp_path):
+def test_repo_transcript_hook_disabled(tmp_path):
     (tmp_path / ".stash").mkdir()
-    (tmp_path / ".stash" / "config.json").write_text('{"stash_disabled_here": true}')
-    assert scope_mod.repo_stash_disabled(str(tmp_path))
+    (tmp_path / ".stash" / "config.json").write_text('{"transcript_upload_hook": false}')
+    assert not scope_mod.repo_transcript_hook_enabled(str(tmp_path))
 
 
-def test_repo_stash_disabled_missing_file(tmp_path):
-    assert not scope_mod.repo_stash_disabled(str(tmp_path))
+def test_repo_transcript_hook_enabled_missing_file(tmp_path):
+    assert scope_mod.repo_transcript_hook_enabled(str(tmp_path))
 
 
 # --- Regression: the gate must short-circuit live events -------------------

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from stashai.plugin.event import HookEvent
-from stashai.plugin.scope import cwd_in_scope, repo_transcript_hook_enabled
+from stashai.plugin.scope import cwd_in_scope
 from stashai.plugin.stash_client import StashClient
 from stashai.plugin.state import read_stats, record_tool_use
 from stashai.plugin.summarize import summarize_tool_use
@@ -26,8 +26,6 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> bool:
     if not cfg.get("workspace_id"):
         return True
     cwd = getattr(event, "cwd", None) if event is not None else None
-    if not repo_transcript_hook_enabled(cwd):
-        return True
     return not cwd_in_scope(cwd)
 
 

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from stashai.plugin.event import HookEvent
-from stashai.plugin.scope import cwd_in_scope, repo_stash_disabled
+from stashai.plugin.scope import cwd_in_scope, repo_transcript_hook_enabled
 from stashai.plugin.stash_client import StashClient
 from stashai.plugin.state import read_stats, record_tool_use
 from stashai.plugin.summarize import summarize_tool_use
@@ -26,7 +26,7 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> bool:
     if not cfg.get("workspace_id"):
         return True
     cwd = getattr(event, "cwd", None) if event is not None else None
-    if repo_stash_disabled(cwd):
+    if not repo_transcript_hook_enabled(cwd):
         return True
     return not cwd_in_scope(cwd)
 

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -76,14 +76,14 @@ def cwd_in_scope(cwd: str | None) -> bool:
     return find_manifest(cwd) is not None
 
 
-def repo_stash_disabled(cwd: str | None) -> bool:
-    """True if the repo containing `cwd` has opted out of stash streaming
-    via `stash_disabled_here=true` in .stash/config.json.
+def repo_transcript_hook_enabled(cwd: str | None) -> bool:
+    """True unless the repo has opted out via `transcript_upload_hook: false`
+    in .stash/config.json.
 
     Same precedence as find_manifest: main repo wins over worktree-local.
-    Never raises — a missing / malformed file is treated as 'not disabled'."""
+    Never raises — a missing / malformed file is treated as enabled."""
     if not cwd:
-        return False
+        return True
     cur = Path(cwd).resolve()
 
     _toplevel, main_root = _git_repo_info(cur)
@@ -93,8 +93,8 @@ def repo_stash_disabled(cwd: str | None) -> bool:
             try:
                 data = json.loads(candidate.read_text())
             except Exception:
-                return False
-            return bool(data.get("stash_disabled_here", False))
+                return True
+            return bool(data.get("transcript_upload_hook", True))
 
     for parent in [cur, *cur.parents]:
         candidate = parent / ".stash" / _CONFIG_FILENAME
@@ -103,6 +103,6 @@ def repo_stash_disabled(cwd: str | None) -> bool:
         try:
             data = json.loads(candidate.read_text())
         except Exception:
-            return False
-        return bool(data.get("stash_disabled_here", False))
-    return False
+            return True
+        return bool(data.get("transcript_upload_hook", True))
+    return True

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -10,7 +10,6 @@ import subprocess
 from pathlib import Path
 
 _MANIFEST_FILENAME = "stash.json"
-_CONFIG_FILENAME = "config.json"
 
 
 def _git_repo_info(cwd: Path) -> tuple[Path | None, Path | None]:
@@ -76,33 +75,3 @@ def cwd_in_scope(cwd: str | None) -> bool:
     return find_manifest(cwd) is not None
 
 
-def repo_transcript_hook_enabled(cwd: str | None) -> bool:
-    """True unless the repo has opted out via `transcript_upload_hook: false`
-    in .stash/config.json.
-
-    Same precedence as find_manifest: main repo wins over worktree-local.
-    Never raises — a missing / malformed file is treated as enabled."""
-    if not cwd:
-        return True
-    cur = Path(cwd).resolve()
-
-    _toplevel, main_root = _git_repo_info(cur)
-    if main_root:
-        candidate = main_root / ".stash" / _CONFIG_FILENAME
-        if candidate.exists():
-            try:
-                data = json.loads(candidate.read_text())
-            except Exception:
-                return True
-            return bool(data.get("transcript_upload_hook", True))
-
-    for parent in [cur, *cur.parents]:
-        candidate = parent / ".stash" / _CONFIG_FILENAME
-        if not candidate.exists():
-            continue
-        try:
-            data = json.loads(candidate.read_text())
-        except Exception:
-            return True
-        return bool(data.get("transcript_upload_hook", True))
-    return True


### PR DESCRIPTION
## Summary
- Removes the `stash_disabled_here` / `transcript_upload_hook` config.json flag entirely
- Manifest presence (`stash.json`) is now the sole gate for auto-uploads — no separate config key to reason about
- `stash disable` renames the manifest to `stash.json.disabled`, `stash enable` renames it back
- CLI read commands (`stash history`, etc.) still work via user auth regardless of manifest state
- `stash.json.disabled` is added to `.gitignore` (local opt-out shouldn't be committed)

## Test plan
- [x] All 10 scope tests pass
- [x] No remaining references to old flag names

🤖 Generated with [Claude Code](https://claude.com/claude-code)