### PR TITLE
Remove redundant streaming_enabled kill switch

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2955,7 +2955,6 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
         output_json(
             {
                 "config": display_cfg,
-                "streaming_enabled": bool(central.get("streaming_enabled", True)),
                 "auto_curate": bool(central.get("auto_curate", True)),
                 "last_curate_at": central.get("last_curate_at"),
                 "plugins_installed": [
@@ -2971,12 +2970,10 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
         central = _read_central_config()
         _render_settings_header(cfg, central)
 
-        streaming_enabled = bool(central.get("streaming_enabled", True))
         auto_curate = bool(central.get("auto_curate", True))
         base_url = cfg.get("base_url", "")
 
         rows = [
-            ("Streaming", "on" if streaming_enabled else "off", "streaming"),
             ("Auto-curate", "on" if auto_curate else "off", "auto_curate"),
             ("Endpoint", base_url, "base_url"),
         ]
@@ -2996,9 +2993,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
         if picked in (None, "exit"):
             return
 
-        if picked == "streaming":
-            _write_central_config({"streaming_enabled": not streaming_enabled})
-        elif picked == "auto_curate":
+        if picked == "auto_curate":
             _write_central_config({"auto_curate": not auto_curate})
         elif picked == "base_url":
             new_url = questionary.text("Endpoint base URL", default=base_url).ask()

--- a/plugins/claude-plugin/scripts/on_session_end.py
+++ b/plugins/claude-plugin/scripts/on_session_end.py
@@ -22,7 +22,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_stop(get_stdin_data())
         try:
             with get_client() as client:

--- a/plugins/claude-plugin/scripts/on_stop.py
+++ b/plugins/claude-plugin/scripts/on_stop.py
@@ -18,8 +18,6 @@ def main():
         return
 
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
 
     event = adapt_stop(get_stdin_data())
     cfg = get_config()

--- a/plugins/claude-plugin/scripts/on_tool_use.py
+++ b/plugins/claude-plugin/scripts/on_tool_use.py
@@ -13,8 +13,6 @@ def main():
         return
 
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
 
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:

--- a/plugins/codex-plugin/scripts/on_notify.py
+++ b/plugins/codex-plugin/scripts/on_notify.py
@@ -42,8 +42,6 @@ def main():
     if codex_hooks_recently_active():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
 
     data = _parse_argv()
     if data.get("type") != "agent-turn-complete":

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -24,8 +24,6 @@ def main():
     # codex_hooks and notify are wired up.
     mark_codex_hooks_active()
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
     try:

--- a/plugins/codex-plugin/scripts/on_tool_use.py
+++ b/plugins/codex-plugin/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/plugins/cursor-plugin/scripts/on_agent_response.py
+++ b/plugins/cursor-plugin/scripts/on_agent_response.py
@@ -18,8 +18,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_agent_response(get_stdin_data())
     if not event.last_assistant_message:
         return

--- a/plugins/cursor-plugin/scripts/on_session_end.py
+++ b/plugins/cursor-plugin/scripts/on_session_end.py
@@ -22,7 +22,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/plugins/cursor-plugin/scripts/on_tool_use.py
+++ b/plugins/cursor-plugin/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/plugins/gemini-plugin/scripts/on_session_end.py
+++ b/plugins/gemini-plugin/scripts/on_session_end.py
@@ -19,7 +19,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/plugins/gemini-plugin/scripts/on_stop.py
+++ b/plugins/gemini-plugin/scripts/on_stop.py
@@ -16,8 +16,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
     try:

--- a/plugins/gemini-plugin/scripts/on_tool_use.py
+++ b/plugins/gemini-plugin/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/plugins/openclaw-plugin/scripts/on_prompt.py
+++ b/plugins/openclaw-plugin/scripts/on_prompt.py
@@ -21,8 +21,6 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    if not state.get("streaming_enabled", True):
-        return
 
     try:
         with get_client() as client:

--- a/plugins/openclaw-plugin/scripts/on_session_end.py
+++ b/plugins/openclaw-plugin/scripts/on_session_end.py
@@ -21,7 +21,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/plugins/openclaw-plugin/scripts/on_stop.py
+++ b/plugins/openclaw-plugin/scripts/on_stop.py
@@ -18,8 +18,6 @@ def main():
         return
 
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
 
     event = adapt_stop(get_stdin_data())
     cfg = get_config()

--- a/plugins/opencode-plugin/scripts/on_session_end.py
+++ b/plugins/opencode-plugin/scripts/on_session_end.py
@@ -19,7 +19,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/plugins/opencode-plugin/scripts/on_session_start.py
+++ b/plugins/opencode-plugin/scripts/on_session_start.py
@@ -19,7 +19,7 @@ from stashai.plugin.curate_spawn import spawn_curation
 
 def _flush_stale_session(prior_sid: str, state: dict) -> None:
     cfg = get_config()
-    if not (state.get("streaming_enabled", True) and cfg.get("workspace_id")):
+    if not cfg.get("workspace_id"):
         return
     stale_state = {**state, "session_id": prior_sid}
     stale_event = HookEvent(kind="session_end", session_id=prior_sid, cwd="")

--- a/plugins/opencode-plugin/scripts/on_tool_use.py
+++ b/plugins/opencode-plugin/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/plugins/tests/test_central_state.py
+++ b/plugins/tests/test_central_state.py
@@ -1,7 +1,7 @@
 """Central config + curate spawn gating tests.
 
-The shared `state.py` helpers read `auto_curate`, `streaming_enabled`, and
-`last_curate_at` from `~/.stash/config.json` so every installed plugin
+The shared `state.py` helpers read `auto_curate` and `last_curate_at`
+from `~/.stash/config.json` so every installed plugin
 shares one toggle surface. These tests patch `CENTRAL_CONFIG_PATH` to a
 tempdir and verify the read/write/gating logic.
 """
@@ -37,17 +37,6 @@ def test_auto_curate_toggle_round_trip(central):
     assert '"auto_curate": false' in path.read_text()
     state_mod.set_auto_curate(True)
     assert state_mod.auto_curate_enabled() is True
-
-
-def test_streaming_enabled_overlayed_into_load_state(central, tmp_path):
-    state_mod, _ = central
-    data_dir = tmp_path / "plugin-data"
-    state_mod.save_state(data_dir, {"streaming_enabled": True, "session_id": "x"})
-
-    state_mod.set_streaming_enabled(False)
-    loaded = state_mod.load_state(data_dir)
-    assert loaded["streaming_enabled"] is False
-    assert loaded["session_id"] == "x"
 
 
 def test_curate_cooldown_blocks_within_window(central):

--- a/stashai/plugin/assets/codex/scripts/on_notify.py
+++ b/stashai/plugin/assets/codex/scripts/on_notify.py
@@ -42,8 +42,6 @@ def main():
     if codex_hooks_recently_active():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
 
     data = _parse_argv()
     if data.get("type") != "agent-turn-complete":

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -24,8 +24,6 @@ def main():
     # codex_hooks and notify are wired up.
     mark_codex_hooks_active()
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
     try:

--- a/stashai/plugin/assets/codex/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/codex/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/stashai/plugin/assets/cursor/scripts/on_agent_response.py
+++ b/stashai/plugin/assets/cursor/scripts/on_agent_response.py
@@ -18,8 +18,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_agent_response(get_stdin_data())
     if not event.last_assistant_message:
         return

--- a/stashai/plugin/assets/cursor/scripts/on_session_end.py
+++ b/stashai/plugin/assets/cursor/scripts/on_session_end.py
@@ -22,7 +22,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/stashai/plugin/assets/cursor/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/cursor/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/stashai/plugin/assets/opencode/scripts/on_session_end.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_end.py
@@ -19,7 +19,7 @@ def main():
     state = load_state(DATA_DIR)
     cfg = get_config()
 
-    if state.get("streaming_enabled", True) and cfg.get("workspace_id"):
+    if cfg.get("workspace_id"):
         event = adapt_session_end(get_stdin_data())
         try:
             with get_client() as client:

--- a/stashai/plugin/assets/opencode/scripts/on_session_start.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_start.py
@@ -19,7 +19,7 @@ from stashai.plugin.curate_spawn import spawn_curation
 
 def _flush_stale_session(prior_sid: str, state: dict) -> None:
     cfg = get_config()
-    if not (state.get("streaming_enabled", True) and cfg.get("workspace_id")):
+    if not cfg.get("workspace_id"):
         return
     stale_state = {**state, "session_id": prior_sid}
     stale_event = HookEvent(kind="session_end", session_id=prior_sid, cwd="")

--- a/stashai/plugin/assets/opencode/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/opencode/scripts/on_tool_use.py
@@ -10,8 +10,6 @@ def main():
     if not is_configured():
         return
     state = load_state(DATA_DIR)
-    if not state.get("streaming_enabled", True):
-        return
     event = adapt_tool_use(get_stdin_data())
     if not event.tool_name:
         return

--- a/stashai/plugin/state.py
+++ b/stashai/plugin/state.py
@@ -1,9 +1,8 @@
 """Per-plugin persistent state plus shared curate-gating helpers.
 
 Per-plugin state (session_id) lives under each agent's `data_dir`.
-Auto-curate toggling, the cross-agent cooldown, and the streaming kill switch
-live in the central CLI config at `~/.stash/config.json` so one toggle
-controls every installed plugin.
+Auto-curate toggling and the cross-agent cooldown live in the central CLI
+config at `~/.stash/config.json` so one toggle controls every installed plugin.
 """
 
 from __future__ import annotations
@@ -25,7 +24,6 @@ CENTRAL_CONFIG_PATH = Path.home() / ".stash" / "config.json"
 _DEFAULT_STATS = {"tool_count": 0, "tools_used": [], "files_changed": []}
 
 DEFAULT_STATE = {
-    "streaming_enabled": True,
     "session_id": "",
     "last_sync": None,
     "stats": dict(_DEFAULT_STATS),
@@ -51,16 +49,8 @@ def _write_json(path: Path, data: dict) -> None:
 
 
 def load_state(data_dir: Path) -> dict:
-    """Return per-plugin state merged with centralized toggles.
-
-    `streaming_enabled` lives in central config (~/.stash/config.json) so one
-    toggle controls every installed plugin. Per-plugin `session_id` still lives
-    under `data_dir/state.json`.
-    """
+    """Return per-plugin state with centralized toggles overlaid."""
     state = _read_json(data_dir / "state.json", dict(DEFAULT_STATE))
-    central = _read_central()
-    if "streaming_enabled" in central:
-        state["streaming_enabled"] = bool(central["streaming_enabled"])
     return state
 
 
@@ -126,10 +116,6 @@ def _write_central(updates: dict) -> None:
     existing = _read_central()
     existing.update(updates)
     _write_json(CENTRAL_CONFIG_PATH, existing)
-
-
-def set_streaming_enabled(enabled: bool) -> None:
-    _write_central({"streaming_enabled": bool(enabled)})
 
 
 def auto_curate_enabled() -> bool:


### PR DESCRIPTION
## Summary
- Manifest presence (`cwd_in_scope`) already gates transcript uploads per-project. The global `streaming_enabled` toggle in `~/.stash/config.json` was a second, redundant gate.
- Removed `streaming_enabled` from `DEFAULT_STATE`, `load_state()` overlay, `set_streaming_enabled()`, the `stash settings` UI, all 27 plugin hook scripts, and the related test.
- 30 files changed, -81 lines, +15 lines.

## Test plan
- [x] `pytest plugins/tests/test_central_state.py` — 9/9 pass
- [ ] Verify `stash settings` no longer shows "Streaming" row
- [ ] Verify transcript upload still works when manifest is present
- [ ] Verify no upload when manifest is absent (disconnect a repo, run a session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)