### PR TITLE
feat(codex): upload transcripts from Stop hook

### DIFF
--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -81,8 +81,8 @@ The `config.toml.snippet` has two mutually-exclusive variants.
 | `SessionStart` | — (warms cache) | — |
 | `UserPromptSubmit` | `user_message` | — |
 | `PostToolUse` | `tool_use` | **Bash only today** — Codex hardcodes `tool_name="Bash"` for every shell call |
-| `Stop` | `assistant_message` + `session_end` | — |
-| `notify` (fallback) | `assistant_message` + `session_end` | Dedups with Stop — pick one |
+| `Stop` | `assistant_message` + transcript upload | Transcript uploaded in background with 60s cooldown |
+| `notify` (fallback) | `assistant_message` | Dedups with Stop — pick one |
 
 ## Retrieval
 

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stop: stream the assistant's final message for this turn, then try curation.
+"""Stop: stream the assistant's final message, upload transcript, then try curation.
 
 Codex's Stop hook fires per-turn. We push assistant_message (not session_end)
 and deliberately do NOT clear session_id — subsequent turns in the same
@@ -7,11 +7,15 @@ session need it for correlation. Curation is attempted on every Stop but
 `spawn_curation` enforces the central 30-min cooldown, so it only actually
 fires once per half-hour. Codex has no SessionEnd hook today, so this is the
 only curation trigger.
+
+Transcript upload is spawned as a detached background process (so it doesn't
+block the hook timeout) with a 60s cooldown between uploads per session.
 """
 
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 from stashai.plugin.hooks import stream_assistant_message
 from stashai.plugin.state import load_state, mark_codex_hooks_active
+from stashai.plugin.transcript_upload import spawn_transcript_upload
 
 from adapt import adapt_stop
 from stashai.plugin.curate_spawn import spawn_curation
@@ -20,8 +24,6 @@ from stashai.plugin.curate_spawn import spawn_curation
 def main():
     if not is_configured():
         return
-    # Heartbeat so the notify-array fallback can self-suppress when both
-    # codex_hooks and notify are wired up.
     mark_codex_hooks_active()
     state = load_state(DATA_DIR)
     event = adapt_stop(get_stdin_data())
@@ -31,6 +33,18 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+
+    spawn_transcript_upload(
+        data_dir=DATA_DIR,
+        transcript_path=event.transcript_path,
+        session_id=state.get("session_id", ""),
+        workspace_id=cfg["workspace_id"],
+        agent_name=cfg["agent_name"],
+        cwd=event.cwd,
+        base_url=cfg["api_endpoint"],
+        api_key=cfg["api_key"],
+    )
+
     spawn_curation("codex", ["exec"])
 
 

--- a/stashai/plugin/_do_upload.py
+++ b/stashai/plugin/_do_upload.py
@@ -1,0 +1,29 @@
+"""Detached child process that uploads a transcript file.
+
+Invoked by transcript_upload.spawn_transcript_upload(). Runs outside the
+hook timeout so large files don't block the agent.
+
+argv: script.py <transcript_path> <session_id> <workspace_id> <agent_name> <cwd> <base_url> <api_key>
+"""
+
+import sys
+from pathlib import Path
+
+from stashai.plugin.stash_client import StashClient
+
+
+def main() -> None:
+    _, transcript_path, session_id, workspace_id, agent_name, cwd, base_url, api_key = sys.argv
+
+    with StashClient(base_url=base_url, api_key=api_key) as client:
+        client.upload_transcript(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            transcript_path=Path(transcript_path),
+            agent_name=agent_name,
+            cwd=cwd,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stop: stream the assistant's final message for this turn, then try curation.
+"""Stop: stream the assistant's final message, upload transcript, then try curation.
 
 Codex's Stop hook fires per-turn. We push assistant_message (not session_end)
 and deliberately do NOT clear session_id — subsequent turns in the same
@@ -7,11 +7,15 @@ session need it for correlation. Curation is attempted on every Stop but
 `spawn_curation` enforces the central 30-min cooldown, so it only actually
 fires once per half-hour. Codex has no SessionEnd hook today, so this is the
 only curation trigger.
+
+Transcript upload is spawned as a detached background process (so it doesn't
+block the hook timeout) with a 60s cooldown between uploads per session.
 """
 
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 from stashai.plugin.hooks import stream_assistant_message
 from stashai.plugin.state import load_state, mark_codex_hooks_active
+from stashai.plugin.transcript_upload import spawn_transcript_upload
 
 from adapt import adapt_stop
 from stashai.plugin.curate_spawn import spawn_curation
@@ -20,8 +24,6 @@ from stashai.plugin.curate_spawn import spawn_curation
 def main():
     if not is_configured():
         return
-    # Heartbeat so the notify-array fallback can self-suppress when both
-    # codex_hooks and notify are wired up.
     mark_codex_hooks_active()
     state = load_state(DATA_DIR)
     event = adapt_stop(get_stdin_data())
@@ -31,6 +33,18 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+
+    spawn_transcript_upload(
+        data_dir=DATA_DIR,
+        transcript_path=event.transcript_path,
+        session_id=state.get("session_id", ""),
+        workspace_id=cfg["workspace_id"],
+        agent_name=cfg["agent_name"],
+        cwd=event.cwd,
+        base_url=cfg["api_endpoint"],
+        api_key=cfg["api_key"],
+    )
+
     spawn_curation("codex", ["exec"])
 
 

--- a/stashai/plugin/transcript_upload.py
+++ b/stashai/plugin/transcript_upload.py
@@ -1,0 +1,83 @@
+"""Background transcript upload for agents without a SessionEnd hook.
+
+Codex fires Stop on every turn but has no session-end lifecycle event.
+This module spawns a detached Python process that uploads the transcript
+file, with a per-session cooldown so we don't POST on every single turn.
+
+The backend stores each upload as a new row keyed by session_id and
+returns the latest on read, so repeated uploads are safe — they just
+replace the previous snapshot.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+UPLOAD_COOLDOWN_SECONDS = 60
+
+
+def _last_upload_path(data_dir: Path) -> Path:
+    return data_dir / "last_transcript_upload"
+
+
+def _cooldown_active(data_dir: Path) -> bool:
+    p = _last_upload_path(data_dir)
+    if not p.exists():
+        return False
+    try:
+        return (time.time() - float(p.read_text().strip())) < UPLOAD_COOLDOWN_SECONDS
+    except Exception:
+        return False
+
+
+def _record_upload(data_dir: Path) -> None:
+    p = _last_upload_path(data_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(time.time()))
+
+
+def spawn_transcript_upload(
+    data_dir: Path,
+    transcript_path: str,
+    session_id: str,
+    workspace_id: str,
+    agent_name: str,
+    cwd: str,
+    base_url: str,
+    api_key: str,
+) -> bool:
+    """Spawn a detached process to upload the transcript. Returns True on spawn."""
+    if not transcript_path or not session_id.strip():
+        return False
+    path = Path(transcript_path)
+    if not path.is_file():
+        return False
+    if _cooldown_active(data_dir):
+        return False
+
+    _record_upload(data_dir)
+
+    script = Path(__file__).parent / "_do_upload.py"
+    env = os.environ.copy()
+
+    try:
+        subprocess.Popen(
+            [
+                sys.executable, str(script),
+                str(path), session_id, workspace_id, agent_name, cwd, base_url, api_key,
+            ],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception:
+        return False
+
+    return True


### PR DESCRIPTION
## Summary
- Codex has no `SessionEnd` hook, so full `.jsonl` transcript uploads never happened — only per-turn text snippets were streamed via `assistant_message` events
- Adds `transcript_upload.py` which spawns a detached background process from the `Stop` hook to upload the transcript outside the 10s hook timeout, with a 60s cooldown between uploads
- The background worker (`_do_upload.py`) calls the existing `client.upload_transcript()` with the 60s request timeout
- Fixes the README which incorrectly claimed Stop emitted `session_end`

## Test plan
- [ ] Run a Codex session in a stash-connected repo and verify transcript appears in `stash history transcript <session_id>`
- [ ] Verify the 60s cooldown prevents uploads on every turn in a multi-turn session
- [ ] Verify the background process doesn't block or slow down the Codex Stop hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)