### PR TITLE
docs: fix stale documentation across all pages

### DIFF
--- a/frontend/src/app/docs/api/page.tsx
+++ b/frontend/src/app/docs/api/page.tsx
@@ -12,12 +12,11 @@ export default function APIPage() {
       <Callout type="info">
         <strong>Authentication</strong> — include{" "}
         <code className="font-mono text-[13px]">Authorization: Bearer {"<api_key>"}</code> on every request.
-        Get your API key from the settings page or via <Code>POST /auth/login</Code>.
+        Get your API key from the settings page or via <Code>POST /users/login</Code>.
         <br /><br />
         <strong>OpenAPI spec</strong> — the full interactive spec is available at{" "}
-        <Code>/docs</Code> on your backend instance (or{" "}
-        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">stash.ac/docs</a>
-        ).
+        <Code>/docs</Code> on your backend instance (e.g.{" "}
+        <Code>http://localhost:3456/docs</Code>).
       </Callout>
 
       <H3>Auth</H3>
@@ -27,12 +26,16 @@ GET    /users/me            Current user profile
 PATCH  /users/me            Update profile (name, avatar, etc.)`}</CodeBlock>
 
       <H3>Workspaces</H3>
-      <CodeBlock>{`POST   /workspaces              Create a new workspace
-GET    /workspaces              List all public workspaces
-GET    /workspaces/mine         List workspaces you're a member of
-POST   /workspaces/{ws}/join    Join by invite code
-GET    /workspaces/{ws}         Workspace details and metadata
-GET    /workspaces/{ws}/members List workspace members with roles`}</CodeBlock>
+      <CodeBlock>{`POST   /workspaces                          Create a new workspace
+GET    /workspaces                          List all public workspaces
+GET    /workspaces/mine                     List workspaces you're a member of
+POST   /workspaces/join/{invite_code}       Join by invite code
+GET    /workspaces/{ws}                     Workspace details and metadata
+PATCH  /workspaces/{ws}                     Update workspace
+DELETE /workspaces/{ws}                     Delete workspace
+GET    /workspaces/{ws}/members             List workspace members with roles
+POST   /workspaces/{ws}/members             Add a member
+POST   /workspaces/{ws}/leave               Leave workspace`}</CodeBlock>
 
       <H3>Notebooks & pages</H3>
       <CodeBlock>{`POST   /workspaces/{ws}/notebooks                          Create notebook
@@ -48,27 +51,26 @@ GET    /workspaces/{ws}/notebooks/{nb}/graph               Page link graph (node
 
 GET    /workspaces/{ws}/notebooks/{nb}/pages/semantic-search?q=   Semantic search`}</CodeBlock>
 
-      <H3>History stores</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/memory                              Create store
-POST   /workspaces/{ws}/memory/{store}/events               Push a single event
-POST   /workspaces/{ws}/memory/{store}/events/batch         Push a batch of events
-GET    /workspaces/{ws}/memory/{store}/events               Query events (filter, paginate)
-GET    /workspaces/{ws}/memory/{store}/events/search?q=     Full-text search
-POST   /workspaces/{ws}/memory/{store}/query                LLM synthesis over events`}</CodeBlock>
-
-      <H3>Universal search</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/search      Workspace-scoped search across all resources
-POST   /me/search                   Personal search (outside any workspace)`}</CodeBlock>
-      <P>
-        Both accept a <Code>{"{ query, types, limit }"}</Code> body. Set{" "}
-        <Code>types</Code> to filter by resource (e.g. <Code>{`"history,notebook,table"`}</Code>).
-      </P>
+      <H3>History</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/memory/events               Push a single event
+POST   /workspaces/{ws}/memory/events/batch         Push a batch of events
+GET    /workspaces/{ws}/memory/events               Query events (filter, paginate)
+GET    /workspaces/{ws}/memory/events/search?q=     Full-text search
+GET    /workspaces/{ws}/memory/events/{id}          Get a specific event
+GET    /workspaces/{ws}/memory/agent-names           List distinct agent names
+DELETE /workspaces/{ws}/memory/agents/{agent_name}  Delete all events for an agent`}</CodeBlock>
 
       <H3>Files</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/files          Upload a file (multipart/form-data)
-GET    /workspaces/{ws}/files          List files
-GET    /workspaces/{ws}/files/{id}     Get file metadata + presigned download URL
-DELETE /workspaces/{ws}/files/{id}     Delete a file`}</CodeBlock>
+      <CodeBlock>{`POST   /workspaces/{ws}/files                Upload a file (multipart/form-data)
+GET    /workspaces/{ws}/files                List files
+GET    /workspaces/{ws}/files/{id}           Get file metadata
+GET    /workspaces/{ws}/files/{id}/download  Download file (redirects to signed URL)
+GET    /workspaces/{ws}/files/{id}/text      Get extracted text (PDF, OCR, plain text)
+DELETE /workspaces/{ws}/files/{id}           Delete a file`}</CodeBlock>
+
+      <H3>Transcripts</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/transcripts                Upload a session transcript
+GET    /workspaces/{ws}/transcripts/{session_id}   Get transcript`}</CodeBlock>
 
       <H3>Tables & rows</H3>
       <CodeBlock>{`POST   /workspaces/{ws}/tables                               Create table
@@ -85,11 +87,18 @@ POST   /workspaces/{ws}/tables/{tbl}/embedding/backfill      Backfill embeddings
 
       <H3>Permissions</H3>
       <P>
-        Every workspace resource has a visibility setting. Set it with a{" "}
-        <Code>PATCH</Code> on the resource or via the dedicated visibility endpoint:
+        Notebooks and tables have per-resource visibility and sharing. Use the
+        permissions endpoints on each resource type:
       </P>
-      <CodeBlock>{`PUT /workspaces/{ws}/{resource_type}/{id}/visibility
-body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
+      <CodeBlock>{`GET    /workspaces/{ws}/notebooks/{id}/permissions            Get visibility + shares
+PATCH  /workspaces/{ws}/notebooks/{id}/permissions            Set visibility
+POST   /workspaces/{ws}/notebooks/{id}/permissions/share      Share with a user
+DELETE /workspaces/{ws}/notebooks/{id}/permissions/share/{uid} Remove share
+
+GET    /workspaces/{ws}/tables/{id}/permissions               Get visibility + shares
+PATCH  /workspaces/{ws}/tables/{id}/permissions               Set visibility
+POST   /workspaces/{ws}/tables/{id}/permissions/share         Share with a user
+DELETE /workspaces/{ws}/tables/{id}/permissions/share/{uid}   Remove share`}</CodeBlock>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
           { v: "inherit", desc: "Default. All workspace members have access (read + write based on role)." },
@@ -106,9 +115,11 @@ body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
       <H3>Rate limits</H3>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
-          { endpoint: "REST reads", limit: "60 requests / minute" },
-          { endpoint: "File upload", limit: "10 requests / minute" },
-          { endpoint: "Auth endpoints", limit: "20 requests / minute" },
+          { endpoint: "Register", limit: "5 requests / minute" },
+          { endpoint: "Login", limit: "10 requests / minute" },
+          { endpoint: "Create API key", limit: "10 requests / minute" },
+          { endpoint: "CLI auth sessions", limit: "10 requests / minute" },
+          { endpoint: "CLI auth poll", limit: "60 requests / minute" },
         ].map((r) => (
           <div key={r.endpoint} className="flex gap-5 px-5 py-4">
             <span className="text-[13px] font-semibold text-foreground w-56 flex-shrink-0">{r.endpoint}</span>
@@ -117,18 +128,13 @@ body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
         ))}
       </div>
 
-      <H3>Aggregate endpoints</H3>
-      <P>
-        <Code>/api/v1/me/notebooks</Code>, <Code>/me/tables</Code>, and{" "}
-        <Code>/me/history-events</Code> return resources from every workspace
-        the current user has access to, useful for cross-workspace views. Every
-        resource itself still belongs to exactly one workspace — there is no
-        personal (no-workspace) scope. Full schema in the{" "}
-        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">
-          OpenAPI spec
-        </a>
-        .
-      </P>
+      <H3>Personal / aggregate endpoints</H3>
+      <CodeBlock>{`GET    /me/notebooks              List all your notebooks (cross-workspace)
+GET    /me/history-events          List all your history events (cross-workspace)
+GET    /me/tables                  List all your tables (cross-workspace)
+GET    /me/activity-timeline       Activity timeline for dashboard
+GET    /me/knowledge-density       Knowledge density heatmap data
+GET    /me/embedding-projection    2D embedding projection for space explorer`}</CodeBlock>
     </>
   );
 }

--- a/frontend/src/app/docs/cli/page.tsx
+++ b/frontend/src/app/docs/cli/page.tsx
@@ -15,8 +15,8 @@ export default function CLIPage() {
       <H3>First-time setup</H3>
       <P>
         Run the interactive setup wizard. It configures the API endpoint, authenticates you
-        (login or register), creates a workspace, and creates a default history store — all in
-        one shot. No manual config editing required.
+        (login or register), and creates a workspace — all in one shot. No manual config
+        editing required.
       </P>
       <CodeBlock>{`stash connect`}</CodeBlock>
       <P>
@@ -25,9 +25,12 @@ export default function CLIPage() {
       </P>
 
       <H3>Auth commands</H3>
-      <CodeBlock>{`stash login                             # Password login
-stash auth <url> --api-key <key>        # Authenticate using an existing API key
+      <CodeBlock>{`stash login <name> --password <pw>       # Password login
+stash signin                            # Sign in through the browser
+stash register <name>                   # Create a new account
+stash auth <url> --api-key <key>        # Store existing credentials
 stash whoami                            # Show the current logged-in user
+stash disconnect                        # Sign out and clear config
 stash config [key] [value]              # View or update any config value`}</CodeBlock>
 
       <Callout>
@@ -37,33 +40,47 @@ stash config [key] [value]              # View or update any config value`}</Cod
         CI and scripts.
       </Callout>
 
-      <H3>Search</H3>
-      <CodeBlock>{`# Universal search across all data types
-stash search <query>
-  --ws <workspace_id>          Scope to a workspace
-  --types history,notebook,table   Filter by resource type`}</CodeBlock>
-
       <H3>Notebooks</H3>
       <CodeBlock>{`stash notebooks list [--ws ID] [--all]
-stash notebooks create <name> [--ws ID]
+stash notebooks create <name> [--ws ID] [--personal]
 stash notebooks pages <notebook_id> [--ws ID]
-stash notebooks add-page <nb_id> <name> [--content "..."] [--attach path]
+stash notebooks add-page <nb_id> <name> [--content "..."]
 stash notebooks read-page <nb_id> <page_id>
-stash notebooks edit-page <nb_id> <page_id> --content "..." [--attach path]`}</CodeBlock>
+stash notebooks edit-page <nb_id> <page_id> --content "..."`}</CodeBlock>
 
-      <H3>History stores</H3>
-      <CodeBlock>{`stash history list [--ws ID] [--all]
-stash history create <name> [--ws ID]
-stash history push <content> [--store ID] [--agent cli] [--type message]
-stash history query [--store ID] [--agent X] [--type Y] [-n 50]
-stash history search <query> [--store ID]`}</CodeBlock>
+      <H3>History</H3>
+      <CodeBlock>{`stash history push <content> [--ws ID] [--agent cli] [--type message]
+stash history query [--ws ID] [--agent X] [--type Y] [-n 50] [--all]
+stash history search <query> [--ws ID] [-n 50]
+stash history agents [--ws ID]
+stash history transcript <session_id> [--ws ID]`}</CodeBlock>
 
       <H3>Tables</H3>
+      <CodeBlock>{`stash tables list [--ws ID] [--all] [--personal]
+stash tables create <name> [--ws ID] [--columns JSON]
+stash tables rows <table_id> [--sort COL] [--filter COL]
+stash tables insert <table_id> <data_json>
+stash tables import <table_id> <file> [--format csv|json]
+stash tables export <table_id>
+stash tables count <table_id>
+stash tables update-row <table_id> <row_id> <data_json>
+stash tables delete-row <table_id> <row_id>`}</CodeBlock>
+
+      <H3>Files</H3>
+      <CodeBlock>{`stash files upload <path> [--ws ID]
+stash files list [--ws ID]
+stash files rm <file_id>
+stash files text <file_id>`}</CodeBlock>
+
+      <H3>Streaming & hooks</H3>
       <P>
-        Full CRUD for tables is available. Run{" "}
-        <Code>stash --help</Code> for the complete command tree, or{" "}
-        <Code>stash &lt;command&gt; --help</Code> for options on any subcommand.
+        Install Stash hooks for all supported coding agents on your <Code>$PATH</Code>,
+        then enable or disable streaming per repo:
       </P>
+      <CodeBlock>{`stash install                           # Install hook plugins
+stash enable                            # Enable streaming for this repo
+stash disable                           # Disable streaming for this repo
+stash settings                          # Interactive settings page`}</CodeBlock>
     </>
   );
 }

--- a/frontend/src/app/docs/concepts/page.tsx
+++ b/frontend/src/app/docs/concepts/page.tsx
@@ -5,13 +5,13 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Workspace",
     badge: "Container",
     badgeColor: "bg-blue-500/10 text-blue-500",
-    desc: "Top-level permissioned container. Members share all resources — notebooks, history stores, tables, files. Invite others with a short code. Set visibility to public or private.",
+    desc: "Top-level permissioned container. Members share all resources — notebooks, history, tables, files. Invite others with a short code. Set visibility to public or private.",
   },
   {
-    name: "History Store",
-    badge: "History",
+    name: "History",
+    badge: "Events",
     badgeColor: "bg-brand/10 text-brand",
-    desc: "Append-only event log. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text and semantic search.",
+    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text search.",
   },
   {
     name: "Notebook",
@@ -47,7 +47,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Curation",
     badge: "Tool",
     badgeColor: "bg-amber-500/10 text-amber-600",
-    desc: "CLI command that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Run it whenever you want your knowledge base tidied up.",
+    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in Claude Code.",
   },
 ];
 

--- a/frontend/src/app/docs/consume/page.tsx
+++ b/frontend/src/app/docs/consume/page.tsx
@@ -8,9 +8,9 @@ export default function ConsumePage() {
         Getting data into Stash. Push events via the CLI or REST API.
       </Subtitle>
 
-      <H3>History stores</H3>
+      <H3>History</H3>
       <P>
-        History stores are append-only event logs. Events are grouped by{" "}
+        Each workspace has an append-only event log. Events are grouped by{" "}
         <code className="text-brand font-mono text-[13px]">agent_name</code> and{" "}
         <code className="text-brand font-mono text-[13px]">session_id</code>, giving you a
         conversation-like view of each agent session. Push events via the CLI or REST API.
@@ -23,7 +23,7 @@ export default function ConsumePage() {
         },
         {
           label: "curl",
-          code: `curl -X POST https://stash.ac/api/v1/workspaces/{ws}/memory/{store}/events \\
+          code: `curl -X POST https://stash.ac/api/v1/workspaces/{ws}/memory/events \\
   -H "Authorization: Bearer $API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{"agent_name":"my-agent","event_type":"tool_use","content":"..."}'`,

--- a/frontend/src/app/docs/curate/page.tsx
+++ b/frontend/src/app/docs/curate/page.tsx
@@ -25,8 +25,9 @@ export default function CuratePage() {
 
       <H3>Curation tool</H3>
       <P>
-        Run <Code>stash curate</Code> to organize your workspace data into wiki pages.
-        It reads history stores, notebooks, and tables, then calls Claude to create structured content:
+        Curation runs automatically after agent sessions end (with a 24-hour cooldown), or on
+        demand via the <Code>/curate</Code> slash command in Claude Code.
+        It reads history, notebooks, and tables, then calls Claude to create structured content:
       </P>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
@@ -47,8 +48,8 @@ export default function CuratePage() {
       </div>
 
       <Callout type="tip">
-        Run curation whenever you want your knowledge base tidied up. The tool processes
-        new data since the last run and writes organized wiki pages into the target notebook.
+        Curation processes new data since the last run and writes organized wiki pages into
+        the target notebook. Toggle auto-curation on or off in <Code>stash settings</Code>.
       </Callout>
 
       <H3>Linking between pages</H3>

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -33,7 +33,7 @@ const PILLARS = [
 
 const QUICK_LINKS = [
   { href: "/docs/quickstart", label: "Quickstart", desc: "Connect Claude Code and start in 5 minutes." },
-  { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history stores are." },
+  { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history are." },
   { href: "/docs/api", label: "REST API", desc: "Full HTTP reference for all resources." },
   { href: "/docs/cli", label: "CLI", desc: "Push events and manage resources from the terminal." },
   { href: "/docs/webhooks", label: "Webhooks", desc: "Subscribe to workspace events with HMAC delivery." },

--- a/frontend/src/app/docs/quickstart/page.tsx
+++ b/frontend/src/app/docs/quickstart/page.tsx
@@ -24,7 +24,7 @@ export default function QuickstartPage() {
         <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
         <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
         <code className="text-brand font-mono text-[13px]">pip install stashai</code>. The
-        interactive wizard covers account creation, workspace creation, and history store setup
+        interactive wizard covers account creation and workspace creation
         in one shot — then come back to step 2.
       </P>
 
@@ -50,13 +50,15 @@ stash login`}</CodeBlock>
 
       <H3>4. Curate your knowledge base</H3>
       <P>
-        Use the <code className="text-brand font-mono text-[13px]">stash curate</code> CLI command to organize
+        Curation runs automatically after agent sessions (with a 24-hour cooldown), organizing
         ingested data into a categorized wiki with <code className="text-brand font-mono text-[13px]">[[backlinks]]</code>,
-        folders, and summaries.
+        folders, and summaries. You can also trigger it manually with
+        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in Claude Code.
       </P>
       <Callout type="tip">
         The more data you push, the richer the wiki gets. The curation tool merges
         duplicates, creates category pages, and links related content automatically.
+        Toggle auto-curation in <code className="text-brand font-mono text-[13px]">stash settings</code>.
       </Callout>
     </>
   );

--- a/frontend/src/app/docs/workspaces/page.tsx
+++ b/frontend/src/app/docs/workspaces/page.tsx
@@ -10,7 +10,7 @@ export default function WorkspacesPage() {
 
       <P>
         Create a workspace, invite team members, and everything you
-        build — notebooks, chats, history stores, tables, files, pages — is shared and scoped
+        build — notebooks, history, tables, files, pages — is shared and scoped
         to that workspace. Workspaces are isolated: no resource leaks between them.
       </P>
 

--- a/www/app/docs/api/page.tsx
+++ b/www/app/docs/api/page.tsx
@@ -12,12 +12,11 @@ export default function APIPage() {
       <Callout type="info">
         <strong>Authentication</strong> — include{" "}
         <code className="font-mono text-[13px]">Authorization: Bearer {"<api_key>"}</code> on every request.
-        Get your API key from the settings page or via <Code>POST /auth/login</Code>.
+        Get your API key from the settings page or via <Code>POST /users/login</Code>.
         <br /><br />
         <strong>OpenAPI spec</strong> — the full interactive spec is available at{" "}
-        <Code>/docs</Code> on your backend instance (or{" "}
-        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">stash.ac/docs</a>
-        ).
+        <Code>/docs</Code> on your backend instance (e.g.{" "}
+        <Code>http://localhost:3456/docs</Code>).
       </Callout>
 
       <H3>Auth</H3>
@@ -27,12 +26,16 @@ GET    /users/me            Current user profile
 PATCH  /users/me            Update profile (name, avatar, etc.)`}</CodeBlock>
 
       <H3>Workspaces</H3>
-      <CodeBlock>{`POST   /workspaces              Create a new workspace
-GET    /workspaces              List all public workspaces
-GET    /workspaces/mine         List workspaces you're a member of
-POST   /workspaces/{ws}/join    Join by invite code
-GET    /workspaces/{ws}         Workspace details and metadata
-GET    /workspaces/{ws}/members List workspace members with roles`}</CodeBlock>
+      <CodeBlock>{`POST   /workspaces                          Create a new workspace
+GET    /workspaces                          List all public workspaces
+GET    /workspaces/mine                     List workspaces you're a member of
+POST   /workspaces/join/{invite_code}       Join by invite code
+GET    /workspaces/{ws}                     Workspace details and metadata
+PATCH  /workspaces/{ws}                     Update workspace
+DELETE /workspaces/{ws}                     Delete workspace
+GET    /workspaces/{ws}/members             List workspace members with roles
+POST   /workspaces/{ws}/members             Add a member
+POST   /workspaces/{ws}/leave               Leave workspace`}</CodeBlock>
 
       <H3>Notebooks & pages</H3>
       <CodeBlock>{`POST   /workspaces/{ws}/notebooks                          Create notebook
@@ -48,27 +51,26 @@ GET    /workspaces/{ws}/notebooks/{nb}/graph               Page link graph (node
 
 GET    /workspaces/{ws}/notebooks/{nb}/pages/semantic-search?q=   Semantic search`}</CodeBlock>
 
-      <H3>History stores</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/memory                              Create store
-POST   /workspaces/{ws}/memory/{store}/events               Push a single event
-POST   /workspaces/{ws}/memory/{store}/events/batch         Push a batch of events
-GET    /workspaces/{ws}/memory/{store}/events               Query events (filter, paginate)
-GET    /workspaces/{ws}/memory/{store}/events/search?q=     Full-text search
-POST   /workspaces/{ws}/memory/{store}/query                LLM synthesis over events`}</CodeBlock>
-
-      <H3>Universal search</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/search      Workspace-scoped search across all resources
-POST   /me/search                   Personal search (outside any workspace)`}</CodeBlock>
-      <P>
-        Both accept a <Code>{"{ query, types, limit }"}</Code> body. Set{" "}
-        <Code>types</Code> to filter by resource (e.g. <Code>{`"history,notebook,table"`}</Code>).
-      </P>
+      <H3>History</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/memory/events               Push a single event
+POST   /workspaces/{ws}/memory/events/batch         Push a batch of events
+GET    /workspaces/{ws}/memory/events               Query events (filter, paginate)
+GET    /workspaces/{ws}/memory/events/search?q=     Full-text search
+GET    /workspaces/{ws}/memory/events/{id}          Get a specific event
+GET    /workspaces/{ws}/memory/agent-names           List distinct agent names
+DELETE /workspaces/{ws}/memory/agents/{agent_name}  Delete all events for an agent`}</CodeBlock>
 
       <H3>Files</H3>
-      <CodeBlock>{`POST   /workspaces/{ws}/files          Upload a file (multipart/form-data)
-GET    /workspaces/{ws}/files          List files
-GET    /workspaces/{ws}/files/{id}     Get file metadata + presigned download URL
-DELETE /workspaces/{ws}/files/{id}     Delete a file`}</CodeBlock>
+      <CodeBlock>{`POST   /workspaces/{ws}/files                Upload a file (multipart/form-data)
+GET    /workspaces/{ws}/files                List files
+GET    /workspaces/{ws}/files/{id}           Get file metadata
+GET    /workspaces/{ws}/files/{id}/download  Download file (redirects to signed URL)
+GET    /workspaces/{ws}/files/{id}/text      Get extracted text (PDF, OCR, plain text)
+DELETE /workspaces/{ws}/files/{id}           Delete a file`}</CodeBlock>
+
+      <H3>Transcripts</H3>
+      <CodeBlock>{`POST   /workspaces/{ws}/transcripts                Upload a session transcript
+GET    /workspaces/{ws}/transcripts/{session_id}   Get transcript`}</CodeBlock>
 
       <H3>Tables & rows</H3>
       <CodeBlock>{`POST   /workspaces/{ws}/tables                               Create table
@@ -85,11 +87,18 @@ POST   /workspaces/{ws}/tables/{tbl}/embedding/backfill      Backfill embeddings
 
       <H3>Permissions</H3>
       <P>
-        Every workspace resource has a visibility setting. Set it with a{" "}
-        <Code>PATCH</Code> on the resource or via the dedicated visibility endpoint:
+        Notebooks and tables have per-resource visibility and sharing. Use the
+        permissions endpoints on each resource type:
       </P>
-      <CodeBlock>{`PUT /workspaces/{ws}/{resource_type}/{id}/visibility
-body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
+      <CodeBlock>{`GET    /workspaces/{ws}/notebooks/{id}/permissions            Get visibility + shares
+PATCH  /workspaces/{ws}/notebooks/{id}/permissions            Set visibility
+POST   /workspaces/{ws}/notebooks/{id}/permissions/share      Share with a user
+DELETE /workspaces/{ws}/notebooks/{id}/permissions/share/{uid} Remove share
+
+GET    /workspaces/{ws}/tables/{id}/permissions               Get visibility + shares
+PATCH  /workspaces/{ws}/tables/{id}/permissions               Set visibility
+POST   /workspaces/{ws}/tables/{id}/permissions/share         Share with a user
+DELETE /workspaces/{ws}/tables/{id}/permissions/share/{uid}   Remove share`}</CodeBlock>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
           { v: "inherit", desc: "Default. All workspace members have access (read + write based on role)." },
@@ -106,9 +115,11 @@ body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
       <H3>Rate limits</H3>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
-          { endpoint: "REST reads", limit: "60 requests / minute" },
-          { endpoint: "File upload", limit: "10 requests / minute" },
-          { endpoint: "Auth endpoints", limit: "20 requests / minute" },
+          { endpoint: "Register", limit: "5 requests / minute" },
+          { endpoint: "Login", limit: "10 requests / minute" },
+          { endpoint: "Create API key", limit: "10 requests / minute" },
+          { endpoint: "CLI auth sessions", limit: "10 requests / minute" },
+          { endpoint: "CLI auth poll", limit: "60 requests / minute" },
         ].map((r) => (
           <div key={r.endpoint} className="flex gap-5 px-5 py-4">
             <span className="text-[13px] font-semibold text-foreground w-56 flex-shrink-0">{r.endpoint}</span>
@@ -117,16 +128,13 @@ body: { "visibility": "inherit" | "private" | "public" }`}</CodeBlock>
         ))}
       </div>
 
-      <H3>Personal endpoints</H3>
-      <P>
-        Most workspace-scoped endpoints have a personal variant. For notebooks, for example:{" "}
-        <Code>/me/notebooks</Code>. Personal endpoints return resources not tied to any workspace.
-        Full list available in the{" "}
-        <a href="https://stash.ac/docs" className="text-brand underline underline-offset-2">
-          OpenAPI spec
-        </a>
-        .
-      </P>
+      <H3>Personal / aggregate endpoints</H3>
+      <CodeBlock>{`GET    /me/notebooks              List all your notebooks (cross-workspace)
+GET    /me/history-events          List all your history events (cross-workspace)
+GET    /me/tables                  List all your tables (cross-workspace)
+GET    /me/activity-timeline       Activity timeline for dashboard
+GET    /me/knowledge-density       Knowledge density heatmap data
+GET    /me/embedding-projection    2D embedding projection for space explorer`}</CodeBlock>
     </>
   );
 }

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -15,8 +15,8 @@ export default function CLIPage() {
       <H3>First-time setup</H3>
       <P>
         Run the interactive setup wizard. It configures the API endpoint, authenticates you
-        (login or register), creates a workspace, and creates a default history store — all in
-        one shot. No manual config editing required.
+        (login or register), and creates a workspace — all in one shot. No manual config
+        editing required.
       </P>
       <CodeBlock>{`stash connect`}</CodeBlock>
       <P>
@@ -25,9 +25,12 @@ export default function CLIPage() {
       </P>
 
       <H3>Auth commands</H3>
-      <CodeBlock>{`stash login                             # Password login
-stash auth <url> --api-key <key>        # Authenticate using an existing API key
+      <CodeBlock>{`stash login <name> --password <pw>       # Password login
+stash signin                            # Sign in through the browser
+stash register <name>                   # Create a new account
+stash auth <url> --api-key <key>        # Store existing credentials
 stash whoami                            # Show the current logged-in user
+stash disconnect                        # Sign out and clear config
 stash config [key] [value]              # View or update any config value`}</CodeBlock>
 
       <Callout>
@@ -37,12 +40,6 @@ stash config [key] [value]              # View or update any config value`}</Cod
         CI and scripts.
       </Callout>
 
-      <H3>Search</H3>
-      <CodeBlock>{`# Universal search across all data types
-stash search <query>
-  --ws <workspace_id>          Scope to a workspace
-  --types history,notebook,table   Filter by resource type`}</CodeBlock>
-
       <H3>Notebooks</H3>
       <CodeBlock>{`stash notebooks list [--ws ID] [--all]
 stash notebooks create <name> [--ws ID] [--personal]
@@ -51,19 +48,39 @@ stash notebooks add-page <nb_id> <name> [--content "..."]
 stash notebooks read-page <nb_id> <page_id>
 stash notebooks edit-page <nb_id> <page_id> --content "..."`}</CodeBlock>
 
-      <H3>History stores</H3>
-      <CodeBlock>{`stash history list [--ws ID] [--all]
-stash history create <name> [--ws ID]
-stash history push <content> [--store ID] [--agent cli] [--type message]
-stash history query [--store ID] [--agent X] [--type Y] [-n 50]
-stash history search <query> [--store ID]`}</CodeBlock>
+      <H3>History</H3>
+      <CodeBlock>{`stash history push <content> [--ws ID] [--agent cli] [--type message]
+stash history query [--ws ID] [--agent X] [--type Y] [-n 50] [--all]
+stash history search <query> [--ws ID] [-n 50]
+stash history agents [--ws ID]
+stash history transcript <session_id> [--ws ID]`}</CodeBlock>
 
       <H3>Tables</H3>
+      <CodeBlock>{`stash tables list [--ws ID] [--all] [--personal]
+stash tables create <name> [--ws ID] [--columns JSON]
+stash tables rows <table_id> [--sort COL] [--filter COL]
+stash tables insert <table_id> <data_json>
+stash tables import <table_id> <file> [--format csv|json]
+stash tables export <table_id>
+stash tables count <table_id>
+stash tables update-row <table_id> <row_id> <data_json>
+stash tables delete-row <table_id> <row_id>`}</CodeBlock>
+
+      <H3>Files</H3>
+      <CodeBlock>{`stash files upload <path> [--ws ID]
+stash files list [--ws ID]
+stash files rm <file_id>
+stash files text <file_id>`}</CodeBlock>
+
+      <H3>Streaming & hooks</H3>
       <P>
-        Full CRUD for tables is available. Run{" "}
-        <Code>stash --help</Code> for the complete command tree, or{" "}
-        <Code>stash &lt;command&gt; --help</Code> for options on any subcommand.
+        Install Stash hooks for all supported coding agents on your <Code>$PATH</Code>,
+        then enable or disable streaming per repo:
       </P>
+      <CodeBlock>{`stash install                           # Install hook plugins
+stash enable                            # Enable streaming for this repo
+stash disable                           # Disable streaming for this repo
+stash settings                          # Interactive settings page`}</CodeBlock>
     </>
   );
 }

--- a/www/app/docs/concepts/page.tsx
+++ b/www/app/docs/concepts/page.tsx
@@ -5,13 +5,13 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Workspace",
     badge: "Container",
     badgeColor: "bg-blue-500/10 text-blue-500",
-    desc: "Top-level permissioned container. Members share all resources — notebooks, history stores, tables, files. Invite others with a short code. Set visibility to public or private.",
+    desc: "Top-level permissioned container. Members share all resources — notebooks, history, tables, files. Invite others with a short code. Set visibility to public or private.",
   },
   {
-    name: "History Store",
-    badge: "History",
+    name: "History",
+    badge: "Events",
     badgeColor: "bg-brand/10 text-brand",
-    desc: "Append-only event log. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text and semantic search.",
+    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text search.",
   },
   {
     name: "Notebook",
@@ -47,7 +47,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Curation",
     badge: "Tool",
     badgeColor: "bg-amber-500/10 text-amber-600",
-    desc: "CLI command that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Run it whenever you want your knowledge base tidied up.",
+    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in Claude Code.",
   },
 ];
 

--- a/www/app/docs/consume/page.tsx
+++ b/www/app/docs/consume/page.tsx
@@ -8,9 +8,9 @@ export default function ConsumePage() {
         Getting data into Stash. Push events via the CLI or REST API.
       </Subtitle>
 
-      <H3>History stores</H3>
+      <H3>History</H3>
       <P>
-        History stores are append-only event logs. Events are grouped by{" "}
+        Each workspace has an append-only event log. Events are grouped by{" "}
         <code className="text-brand font-mono text-[13px]">agent_name</code> and{" "}
         <code className="text-brand font-mono text-[13px]">session_id</code>, giving you a
         conversation-like view of each agent session. Push events via the CLI or REST API.
@@ -23,7 +23,7 @@ export default function ConsumePage() {
         },
         {
           label: "curl",
-          code: `curl -X POST https://stash.ac/api/v1/workspaces/{ws}/memory/{store}/events \\
+          code: `curl -X POST https://stash.ac/api/v1/workspaces/{ws}/memory/events \\
   -H "Authorization: Bearer $API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{"agent_name":"my-agent","event_type":"tool_use","content":"..."}'`,

--- a/www/app/docs/curate/page.tsx
+++ b/www/app/docs/curate/page.tsx
@@ -25,8 +25,9 @@ export default function CuratePage() {
 
       <H3>Curation tool</H3>
       <P>
-        Run <Code>stash curate</Code> to organize your workspace data into wiki pages.
-        It reads history stores, notebooks, and tables, then calls Claude to create structured content:
+        Curation runs automatically after agent sessions end (with a 24-hour cooldown), or on
+        demand via the <Code>/curate</Code> slash command in Claude Code.
+        It reads history, notebooks, and tables, then calls Claude to create structured content:
       </P>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">
         {[
@@ -47,8 +48,8 @@ export default function CuratePage() {
       </div>
 
       <Callout type="tip">
-        Run curation whenever you want your knowledge base tidied up. The tool processes
-        new data since the last run and writes organized wiki pages into the target notebook.
+        Curation processes new data since the last run and writes organized wiki pages into
+        the target notebook. Toggle auto-curation on or off in <Code>stash settings</Code>.
       </Callout>
 
       <H3>Wiki features</H3>

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -33,7 +33,7 @@ const PILLARS = [
 
 const QUICK_LINKS = [
   { href: "/docs/quickstart", label: "Quickstart", desc: "Connect Claude Code and start in 5 minutes." },
-  { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history stores are." },
+  { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history are." },
   { href: "/docs/api", label: "REST API", desc: "Full HTTP reference for all resources." },
   { href: "/docs/cli", label: "CLI", desc: "Push events and manage resources from the terminal." },
   { href: "/docs/self-hosting", label: "Self-Hosting", desc: "Run stash on your own infra with Postgres + pgvector." },

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -24,7 +24,7 @@ export default function QuickstartPage() {
         <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
         <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
         <code className="text-brand font-mono text-[13px]">pip install stashai</code>. The
-        interactive wizard covers account creation, workspace creation, and history store setup
+        interactive wizard covers account creation and workspace creation
         in one shot — then come back to step 2.
       </P>
 
@@ -50,13 +50,15 @@ stash login`}</CodeBlock>
 
       <H3>4. Curate your knowledge base</H3>
       <P>
-        Use the <code className="text-brand font-mono text-[13px]">stash curate</code> CLI command to organize
+        Curation runs automatically after agent sessions (with a 24-hour cooldown), organizing
         ingested data into a categorized wiki with <code className="text-brand font-mono text-[13px]">[[backlinks]]</code>,
-        folders, and summaries.
+        folders, and summaries. You can also trigger it manually with
+        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in Claude Code.
       </P>
       <Callout type="tip">
         The more data you push, the richer the wiki gets. The curation tool merges
         duplicates, creates category pages, and links related content automatically.
+        Toggle auto-curation in <code className="text-brand font-mono text-[13px]">stash settings</code>.
       </Callout>
     </>
   );

--- a/www/app/docs/workspaces/page.tsx
+++ b/www/app/docs/workspaces/page.tsx
@@ -10,7 +10,7 @@ export default function WorkspacesPage() {
 
       <P>
         Create a workspace, invite team members, and everything you
-        build — notebooks, chats, history stores, tables, files, pages — is shared and scoped
+        build — notebooks, history, tables, files, pages — is shared and scoped
         to that workspace. Workspaces are isolated: no resource leaks between them.
       </P>
 
@@ -46,17 +46,12 @@ export default function WorkspacesPage() {
         ))}
       </div>
 
-      <Callout type="tip">
-        The curation tool uses <strong>object-level permissions</strong> — it writes
-        to a <em>personal</em> notebook (private by default) and only publishes summaries
-        to shared workspace notebooks when configured to do so.
-      </Callout>
-
       <H3>Personal resources</H3>
       <P>
-        Notebooks, tables, history stores, and files can also exist outside any workspace as
-        personal resources. The curation tool writes to the user&apos;s personal notebook by default.
-        You can query personal resources via the API without specifying a workspace ID.
+        Notebooks, tables, and files can also exist outside any workspace as
+        personal resources. You can query personal resources via the API
+        using the <code className="text-brand font-mono text-[13px]">/me/</code> endpoints
+        without specifying a workspace ID.
       </P>
     </>
   );


### PR DESCRIPTION
## Summary
- **History store model removed**: events are workspace-scoped now — removed all `{store}` path params, `history list`/`create` commands, and "History Store" as a named concept
- **CLI reference rewritten**: fixed `login` syntax, removed nonexistent `search`/`history list`/`history create`, added full tables/files/streaming sections with actual flags
- **API reference corrected**: fixed workspace join path, memory event routes, permissions endpoints, rate limits, auth callout, OpenAPI link; removed phantom universal search endpoints; added transcripts + aggregate endpoints
- **Curation docs updated**: replaced `stash curate` (doesn't exist) with actual behavior — auto-runs after sessions with 24h cooldown, `/curate` slash command, `stash settings` toggle
- **Both www/ and frontend/ synced**

## Test plan
- [ ] Verify www docs render correctly at stash.ac/docs
- [ ] Spot-check CLI commands mentioned in docs against `stash --help`
- [ ] Spot-check API routes mentioned in docs against `/docs` OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)