### PR TITLE
docs: make docs agent-agnostic

### DIFF
--- a/frontend/src/app/docs/concepts/page.tsx
+++ b/frontend/src/app/docs/concepts/page.tsx
@@ -47,7 +47,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Curation",
     badge: "Tool",
     badgeColor: "bg-amber-500/10 text-amber-600",
-    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in Claude Code.",
+    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in supported agents.",
   },
 ];
 

--- a/frontend/src/app/docs/curate/page.tsx
+++ b/frontend/src/app/docs/curate/page.tsx
@@ -26,7 +26,7 @@ export default function CuratePage() {
       <H3>Curation tool</H3>
       <P>
         Curation runs automatically after agent sessions end (with a 24-hour cooldown), or on
-        demand via the <Code>/curate</Code> slash command in Claude Code.
+        demand via the <Code>/curate</Code> slash command in supported agents.
         It reads history, notebooks, and tables, then calls Claude to create structured content:
       </P>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -32,7 +32,7 @@ const PILLARS = [
 ];
 
 const QUICK_LINKS = [
-  { href: "/docs/quickstart", label: "Quickstart", desc: "Connect Claude Code and start in 5 minutes." },
+  { href: "/docs/quickstart", label: "Quickstart", desc: "Connect your coding agent and start in 5 minutes." },
   { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history are." },
   { href: "/docs/cli", label: "CLI", desc: "Push events and manage resources from the terminal." },
   { href: "/docs/webhooks", label: "Webhooks", desc: "Subscribe to workspace events with HMAC delivery." },
@@ -52,12 +52,12 @@ export default function DocsOverview() {
         <Link href="/docs/quickstart" className="text-brand underline underline-offset-2">
           Quickstart
         </Link>{" "}
-        — connect Claude Code and start building shared knowledge in under 5 minutes.
+        — connect your coding agent and start building shared knowledge in under 5 minutes.
       </Callout>
 
       <H3>How Stash works</H3>
       <P>
-        Stash sits between your agents and the knowledge they generate. Every Claude Code session
+        Stash sits between your coding agents and the knowledge they generate. Every agent session
         streams automatically. Every research result, file, and message lands in a shared workspace.
         The curate tool organizes it into a categorized wiki —
         with backlinks, summaries, and semantic search — so any agent on your team can find and

--- a/frontend/src/app/docs/quickstart/page.tsx
+++ b/frontend/src/app/docs/quickstart/page.tsx
@@ -10,7 +10,7 @@ export default function QuickstartPage() {
   return (
     <>
       <Title>Quickstart</Title>
-      <Subtitle>Install the CLI and start building shared knowledge in 5 minutes.</Subtitle>
+      <Subtitle>Install the CLI, connect your coding agent, and start building shared knowledge in 5 minutes.</Subtitle>
 
       <H3>1. Create an account</H3>
       <P>
@@ -53,7 +53,7 @@ stash login`}</CodeBlock>
         Curation runs automatically after agent sessions (with a 24-hour cooldown), organizing
         ingested data into a categorized wiki with <code className="text-brand font-mono text-[13px]">[[backlinks]]</code>,
         folders, and summaries. You can also trigger it manually with
-        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in Claude Code.
+        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in supported agents.
       </P>
       <Callout type="tip">
         The more data you push, the richer the wiki gets. The curation tool merges

--- a/www/app/docs/concepts/page.tsx
+++ b/www/app/docs/concepts/page.tsx
@@ -47,7 +47,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "Curation",
     badge: "Tool",
     badgeColor: "bg-amber-500/10 text-amber-600",
-    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in Claude Code.",
+    desc: "Automated process that reads workspace data (history, notebooks, tables) and calls Claude to organize it into categorized wiki pages — merging duplicates, creating backlinks, and organizing folders. Runs automatically after agent sessions (with a 24-hour cooldown) or on demand via the /curate slash command in supported agents.",
   },
 ];
 

--- a/www/app/docs/curate/page.tsx
+++ b/www/app/docs/curate/page.tsx
@@ -26,7 +26,7 @@ export default function CuratePage() {
       <H3>Curation tool</H3>
       <P>
         Curation runs automatically after agent sessions end (with a 24-hour cooldown), or on
-        demand via the <Code>/curate</Code> slash command in Claude Code.
+        demand via the <Code>/curate</Code> slash command in supported agents.
         It reads history, notebooks, and tables, then calls Claude to create structured content:
       </P>
       <div className="rounded-2xl border border-border bg-surface divide-y divide-border my-6">

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -32,7 +32,7 @@ const PILLARS = [
 ];
 
 const QUICK_LINKS = [
-  { href: "/docs/quickstart", label: "Quickstart", desc: "Connect Claude Code and start in 5 minutes." },
+  { href: "/docs/quickstart", label: "Quickstart", desc: "Connect your coding agent and start in 5 minutes." },
   { href: "/docs/concepts", label: "Concepts", desc: "What workspaces, agent names, and history are." },
   { href: "/docs/cli", label: "CLI", desc: "Push events and manage resources from the terminal." },
   { href: "/docs/self-hosting", label: "Self-Hosting", desc: "Run stash on your own infra with Postgres + pgvector." },
@@ -52,12 +52,12 @@ export default function DocsOverview() {
         <Link href="/docs/quickstart" className="text-brand underline underline-offset-2">
           Quickstart
         </Link>{" "}
-        — connect Claude Code and start building shared knowledge in under 5 minutes.
+        — connect your coding agent and start building shared knowledge in under 5 minutes.
       </Callout>
 
       <H3>How Stash works</H3>
       <P>
-        Stash sits between your agents and the knowledge they generate. Every Claude Code session
+        Stash sits between your coding agents and the knowledge they generate. Every agent session
         streams automatically. Every research result, file, and message lands in a shared workspace.
         The curate tool organizes it into a categorized wiki —
         with backlinks, summaries, and semantic search — so any agent on your team can find and

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -10,7 +10,7 @@ export default function QuickstartPage() {
   return (
     <>
       <Title>Quickstart</Title>
-      <Subtitle>Install the CLI and start building shared knowledge in 5 minutes.</Subtitle>
+      <Subtitle>Install the CLI, connect your coding agent, and start building shared knowledge in 5 minutes.</Subtitle>
 
       <H3>1. Create an account</H3>
       <P>
@@ -53,7 +53,7 @@ stash login`}</CodeBlock>
         Curation runs automatically after agent sessions (with a 24-hour cooldown), organizing
         ingested data into a categorized wiki with <code className="text-brand font-mono text-[13px]">[[backlinks]]</code>,
         folders, and summaries. You can also trigger it manually with
-        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in Claude Code.
+        the <code className="text-brand font-mono text-[13px]">/curate</code> slash command in supported agents.
       </P>
       <Callout type="tip">
         The more data you push, the richer the wiki gets. The curation tool merges

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -71,7 +71,7 @@ function Nav() {
 }
 
 function Hero() {
-  const prompt = `Set up stash in this repo so our Claude Code sessions share memory with the team. (1) Install or upgrade the CLI: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. (2) Add the Claude Code plugin: \`claude plugin marketplace add Fergana-Labs/stash\` then \`claude plugin install stash@stash-plugins\`. (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://api.stash.ac --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` and render its full output back to me as a markdown block in your reply, verbatim — don't summarize, don't add commentary, don't truncate. (Future sessions can re-read it via the \`/stash:welcome\` slash command, but you can't invoke that yourself.)`;
+  const prompt = `Set up stash in this repo so our coding agent sessions share memory with the team. (1) Install or upgrade the CLI: \`stash signin --help >/dev/null 2>&1 || pipx install stashai --force 2>/dev/null || uv tool install stashai --force\`. (2) Install the agent hooks: \`stash install\` (auto-detects supported agents on $PATH — Claude Code, Cursor, Codex, OpenCode). (3) Run \`stash signin\` to open the sign-in page in my browser, then ask me to paste the token back. Run \`stash auth https://api.stash.ac --api-key <token>\`. (4) Run \`stash workspaces list --mine --json\` — if I have multiple, ask which one and run \`stash workspaces use <id>\`. (5) Run \`stash connect --welcome\` and render its full output back to me as a markdown block in your reply, verbatim — don't summarize, don't add commentary, don't truncate.`;
   return (
     <section id="install" className="relative overflow-hidden border-b border-border-subtle">
       <div
@@ -86,7 +86,7 @@ function Hero() {
           <span className="rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-white">
             New
           </span>
-          <span>Plugin marketplace live for Claude Code</span>
+          <span>Works with Claude Code, Cursor, Codex, and more</span>
           <span className="text-muted">→</span>
         </Link>
 
@@ -153,7 +153,7 @@ function Hero() {
           <div className="mt-4 overflow-hidden rounded-xl border border-border-subtle bg-inverted shadow-[0_30px_80px_-40px_rgba(15,23,42,0.45)]">
             <div className="flex items-center justify-between border-b border-white/5 px-5 py-2.5">
               <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-on-inverted-dim">
-                claude code
+                coding agent
               </span>
               <span className="font-mono text-[11px] text-on-inverted-dim">
                 prompt
@@ -167,8 +167,8 @@ function Hero() {
             </div>
           </div>
           <p className="mt-3 text-[13px] leading-[1.5] text-dim">
-            Paste into Claude Code (or any other coding agent with shell
-            access). Same end state as the one-liner.
+            Paste into any AI coding agent with shell access (Claude Code, Cursor, Codex, etc.).
+            Same end state as the one-liner.
           </p>
         </details>
       </div>


### PR DESCRIPTION
## Summary
- Replace "Claude Code" with agent-agnostic language across all doc pages and the landing page
- Landing page banner: "Plugin marketplace live for Claude Code" → "Works with Claude Code, Cursor, Codex, and more"
- Landing page prompt: now uses `stash install` (auto-detects agents) instead of Claude Code-specific plugin commands
- Docs overview, quickstart, concepts, curate pages: "Claude Code" → "your coding agent" / "supported agents"
- Claude Code is still named alongside other agents where listing supported agents (landing page CTA, prompt)

## Test plan
- [ ] Verify no docs page mentions Claude Code as the only/default agent
- [ ] Landing page still lists supported agents in banner and prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)