### PR TITLE
fix(install): auto-bootstrap uv so install works without Python

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,10 @@
 #
 #   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh)"
 #
-# Zero prerequisites: if no Python toolchain is present, the script
+# If no Python toolchain is present, the script
 # bootstraps `uv` (a single Rust binary) which downloads the right Python
-# version automatically. The user never needs to install Python themselves.
-#
+# version automatically.
+
 # Re-run safe (idempotent): if stashai is already installed, the picked
 # package manager will upgrade it to the latest version.
 set -euo pipefail

--- a/install.sh
+++ b/install.sh
@@ -8,16 +8,20 @@
 #
 #   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh)"
 #
-# `curl … | bash` works for the install part but the interactive picker
-# needs a real terminal on stdin — bash's `| bash` makes the script body
-# stdin instead. We try to detect that case and surface an actionable
-# message rather than crashing inside questionary.
+# Zero prerequisites: if no Python toolchain is present, the script
+# bootstraps `uv` (a single Rust binary) which downloads the right Python
+# version automatically. The user never needs to install Python themselves.
 #
 # Re-run safe (idempotent): if stashai is already installed, the picked
 # package manager will upgrade it to the latest version.
 set -euo pipefail
 
 PACKAGE="stashai"
+MIN_PYTHON="3.11"
+
+python_ge() {
+  python3 -c "import sys; exit(0 if sys.version_info >= (${1//./,}) else 1)" 2>/dev/null
+}
 
 if command -v pipx >/dev/null 2>&1; then
   INSTALLER="pipx"
@@ -25,19 +29,15 @@ if command -v pipx >/dev/null 2>&1; then
 elif command -v uv >/dev/null 2>&1; then
   INSTALLER="uv"
   INSTALL_CMD=(uv tool install "$PACKAGE" --force)
-elif command -v pip3 >/dev/null 2>&1; then
+elif command -v pip3 >/dev/null 2>&1 && python_ge "$MIN_PYTHON"; then
   INSTALLER="pip3"
   INSTALL_CMD=(pip3 install --user --upgrade "$PACKAGE")
 else
-  cat >&2 <<'MSG'
-stash needs a Python package manager to install. None found on PATH.
-
-Pick one and re-run:
-  brew install pipx          # macOS / Homebrew
-  python3 -m pip install pipx
-  curl -LsSf https://astral.sh/uv/install.sh | sh    # uv
-MSG
-  exit 1
+  printf '→ Installing uv (manages Python for you)…\n'
+  curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null
+  export PATH="$HOME/.local/bin:$PATH"
+  INSTALLER="uv"
+  INSTALL_CMD=(uv tool install "$PACKAGE" --force)
 fi
 
 printf '→ Installing %s via %s…\n' "$PACKAGE" "$INSTALLER"


### PR DESCRIPTION
## Summary
- On a fresh Mac (system Python 3.9), `pip3 install stashai` fails with a cryptic "no matching distribution found" because the package requires Python >=3.11
- Instead of erroring out and asking the user to install things, the script now auto-installs `uv` (a Rust binary) which downloads its own Python — zero prerequisites beyond `curl` and `bash`
- Adds a `python_ge` check so the `pip3` fallback is only used when the system Python is actually new enough

## Test plan
- [ ] Run install script on a Mac with no pipx/uv and system Python 3.9
- [ ] Verify uv is auto-installed and stashai installs successfully
- [ ] Verify `stash connect` runs after install
- [ ] Verify idempotent re-run still works on machines that already have pipx/uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)