### PR TITLE
fix(install): drop pip3 --user fallback, always prefer uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,11 +17,6 @@
 set -euo pipefail
 
 PACKAGE="stashai"
-MIN_PYTHON="3.11"
-
-python_ge() {
-  python3 -c "import sys; exit(0 if sys.version_info >= (${1//./,}) else 1)" 2>/dev/null
-}
 
 if command -v pipx >/dev/null 2>&1; then
   INSTALLER="pipx"
@@ -29,9 +24,6 @@ if command -v pipx >/dev/null 2>&1; then
 elif command -v uv >/dev/null 2>&1; then
   INSTALLER="uv"
   INSTALL_CMD=(uv tool install "$PACKAGE" --force)
-elif command -v pip3 >/dev/null 2>&1 && python_ge "$MIN_PYTHON"; then
-  INSTALLER="pip3"
-  INSTALL_CMD=(pip3 install --user --upgrade "$PACKAGE")
 else
   printf '→ Installing uv (manages Python for you)…\n'
   curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null


### PR DESCRIPTION
## Summary
- Followup to #193 — the pip3 --user fallback was still causing Michael's install to break
- `pip3 install --user` puts binaries in `~/Library/Python/X.Y/bin/` on macOS, which isn't on PATH, so `stash connect` never runs
- Removes the pip3 fallback entirely — install chain is now just pipx → uv → auto-install uv

## Test plan
- [ ] `env PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash -c "$(cat install.sh)"` — hits the auto-install-uv path
- [ ] Verify `stash connect` runs after install
- [ ] Re-run on a machine with pipx — still uses pipx

🤖 Generated with [Claude Code](https://claude.com/claude-code)