### PR TITLE
fix(install): suppress noisy uv output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,14 +26,14 @@ elif command -v uv >/dev/null 2>&1; then
   INSTALL_CMD=(uv tool install "$PACKAGE" --force)
 else
   printf '→ Installing uv (manages Python for you)…\n'
-  curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null
+  curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
   export PATH="$HOME/.local/bin:$PATH"
   INSTALLER="uv"
   INSTALL_CMD=(uv tool install "$PACKAGE" --force)
 fi
 
 printf '→ Installing %s via %s…\n' "$PACKAGE" "$INSTALLER"
-"${INSTALL_CMD[@]}" >/dev/null
+"${INSTALL_CMD[@]}" >/dev/null 2>&1
 
 # pipx + uv put binaries in ~/.local/bin; pip --user puts them somewhere
 # similar. If the shell hasn't picked up PATH yet, surface the fix instead


### PR DESCRIPTION
## Summary
- uv self-installer prints to stdout ("installing to...", "everything's installed!")
- `uv tool install` prints all 19 package lines to stderr
- Neither was suppressed — now both redirect to `/dev/null` so users only see our progress lines

## Test plan
- [ ] `env PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash -c "$(curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/onboarding-not-work/install.sh)"` — should only show `→ Installing uv...` and `→ Installing stashai via uv...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)