### PR TITLE
fix(www): auto-redirect to login when access token is stale

### DIFF
--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -25,7 +25,10 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
     setState({ kind: "submitting" });
     try {
       const tokenRes = await fetch("/auth/access-token");
-      if (!tokenRes.ok) throw new Error("Auth0 session expired — reload this page.");
+      if (!tokenRes.ok) {
+        window.location.href = `/auth/login?returnTo=${encodeURIComponent(window.location.href)}`;
+        return;
+      }
       const { token } = await tokenRes.json();
 
       const exchangeUrl = new URL(`${apiUrl}/api/v1/auth0/exchange`);


### PR DESCRIPTION
## Summary
- When clicking "Authorize CLI" with a stale access token, the page showed a dead-end "Auth0 session expired — reload this page" error
- Now it silently redirects to `/auth/login?returnTo=...` which gets a fresh session and bounces the user right back to the authorize page

## Test plan
- [ ] With a stale session, click "Authorize CLI" — should redirect to Auth0 login and return to the authorize page automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)