### PR TITLE
fix(www): show Sign in button instead of silent redirect on stale token

### DIFF
--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -18,6 +18,7 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
     | { kind: "idle" }
     | { kind: "submitting" }
     | { kind: "done" }
+    | { kind: "reauth"; loginUrl: string }
     | { kind: "error"; message: string; detail?: string }
   >({ kind: "idle" });
 
@@ -26,7 +27,10 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
     try {
       const tokenRes = await fetch("/auth/access-token");
       if (!tokenRes.ok) {
-        window.location.href = `/auth/login?returnTo=${encodeURIComponent(window.location.href)}`;
+        setState({
+          kind: "reauth",
+          loginUrl: `/auth/login?returnTo=${encodeURIComponent(window.location.href)}`,
+        });
         return;
       }
       const { token } = await tokenRes.json();
@@ -66,6 +70,22 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
       const detail = (err as { detail?: string })?.detail;
       setState({ kind: "error", message, detail });
     }
+  }
+
+  if (state.kind === "reauth") {
+    return (
+      <div className="mt-6">
+        <p className="text-[16px] leading-[1.6] text-dim">
+          Your session has expired. Sign in again to authorize the CLI.
+        </p>
+        <a
+          href={state.loginUrl}
+          className="mt-4 inline-flex rounded-xl bg-brand px-5 py-2.5 text-[14px] font-semibold text-white transition-all hover:bg-brand-hover"
+        >
+          Sign in
+        </a>
+      </div>
+    );
   }
 
   if (state.kind === "done") {


### PR DESCRIPTION
## Summary
- The silent redirect from PR 199 was jarring — user clicked "Authorize CLI" and got dumped to a login page with no context
- Now shows "Your session has expired. Sign in again to authorize the CLI." with a **Sign in** button
- Button takes them through Auth0 login and returns them to the authorize page

## Test plan
- [ ] With a stale session, click "Authorize CLI" — should show the message and Sign in button
- [ ] Click Sign in — should go through Auth0 and return to the authorize page with a working session

🤖 Generated with [Claude Code](https://claude.com/claude-code)