### PR TITLE
fix(www): auto-redirect to Auth0 login on stale token

### DIFF
--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -18,7 +18,6 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
     | { kind: "idle" }
     | { kind: "submitting" }
     | { kind: "done" }
-    | { kind: "reauth"; loginUrl: string }
     | { kind: "error"; message: string; detail?: string }
   >({ kind: "idle" });
 
@@ -27,10 +26,8 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
     try {
       const tokenRes = await fetch("/auth/access-token");
       if (!tokenRes.ok) {
-        setState({
-          kind: "reauth",
-          loginUrl: `/auth/login?returnTo=${encodeURIComponent(window.location.href)}`,
-        });
+        const returnTo = `${window.location.pathname}${window.location.search}`;
+        window.location.href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
         return;
       }
       const { token } = await tokenRes.json();
@@ -70,22 +67,6 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
       const detail = (err as { detail?: string })?.detail;
       setState({ kind: "error", message, detail });
     }
-  }
-
-  if (state.kind === "reauth") {
-    return (
-      <div className="mt-6">
-        <p className="text-[16px] leading-[1.6] text-dim">
-          Your session has expired. Sign in again to authorize the CLI.
-        </p>
-        <a
-          href={state.loginUrl}
-          className="mt-4 inline-flex rounded-xl bg-brand px-5 py-2.5 text-[14px] font-semibold text-white transition-all hover:bg-brand-hover"
-        >
-          Sign in
-        </a>
-      </div>
-    );
   }
 
   if (state.kind === "done") {


### PR DESCRIPTION
## Summary
- When "Authorize CLI" fails due to stale token, auto-redirect to `/auth/login` with a relative `returnTo` path
- Previous attempts used `window.location.href` (full URL) which Auth0 rejected, dumping the user on the landing page
- Now uses `pathname + search` (relative path), matching the server-side redirect pattern on line 57 of page.tsx

## Test plan
- [ ] With a stale session, click "Authorize CLI" — should redirect to Auth0 login and return to the authorize page

🤖 Generated with [Claude Code](https://claude.com/claude-code)