### PR TITLE
fix(www): fetch access token server-side to fix stale session auth

### DIFF
--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -7,13 +7,14 @@ type Props = {
   sessionId: string;
   device?: string;
   userName: string;
+  accessToken: string;
 };
 
 // Client-side "Authorize CLI" confirmation. Explicit click triggers the Auth0
 // → backend token exchange + CLI approve. Without this gate, the CLI would
 // silently receive a token any time a user with an active Auth0 session loaded
 // this URL.
-export default function ConnectTokenClient({ apiUrl, sessionId, device, userName }: Props) {
+export default function ConnectTokenClient({ apiUrl, sessionId, device, userName, accessToken }: Props) {
   const [state, setState] = useState<
     | { kind: "idle" }
     | { kind: "submitting" }
@@ -24,19 +25,11 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
   async function authorize() {
     setState({ kind: "submitting" });
     try {
-      const tokenRes = await fetch("/auth/access-token");
-      if (!tokenRes.ok) {
-        const returnTo = `${window.location.pathname}${window.location.search}`;
-        window.location.href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
-        return;
-      }
-      const { token } = await tokenRes.json();
-
       const exchangeUrl = new URL(`${apiUrl}/api/v1/auth0/exchange`);
       if (device) exchangeUrl.searchParams.set("device", device);
       const exchangeRes = await fetch(exchangeUrl.toString(), {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (!exchangeRes.ok) {
         const detail = await exchangeRes.text().catch(() => "");

--- a/www/app/connect-token/page.tsx
+++ b/www/app/connect-token/page.tsx
@@ -49,11 +49,20 @@ export default async function ConnectTokenPage({
   }
 
   const { auth0 } = await import("@managed/auth0/client");
+  const qs = new URLSearchParams({ session: sessionId });
+  if (device) qs.set("device", device);
+  const returnTo = `/connect-token?${qs.toString()}`;
+
   const session = await auth0.getSession();
   if (!session) {
-    const qs = new URLSearchParams({ session: sessionId });
-    if (device) qs.set("device", device);
-    const returnTo = `/connect-token?${qs.toString()}`;
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  let accessToken: string;
+  try {
+    const tokenResponse = await auth0.getAccessToken();
+    accessToken = tokenResponse.token;
+  } catch {
     redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
   }
 
@@ -77,6 +86,7 @@ export default async function ConnectTokenPage({
         sessionId={sessionId}
         device={device}
         userName={userName}
+        accessToken={accessToken}
       />
       <Link href="/auth/logout" className="mt-6 inline-block text-[14px] text-brand hover:underline">
         Use a different account


### PR DESCRIPTION
## Summary
- The client-side `/auth/access-token` fetch was fundamentally broken for stale sessions: 401 errors, CORS failures on Auth0 logout, infinite redirect loops
- Moved the access token fetch to the server component using `auth0.getAccessToken()`
- If the token is stale, the server redirects to `/auth/login` before the page even renders — user logs in and returns to the authorize page seamlessly
- The client component receives a guaranteed-valid token as a prop and never touches `/auth/access-token`

## Test plan
- [ ] Fresh session: click "Authorize CLI" — should work immediately
- [ ] Stale session: visit the page — should redirect to Auth0 login and return with a working session
- [ ] After login, "Authorize CLI" should succeed on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)