### PR TITLE
Fix skills files to match current CLI + domain rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
       "version": "0.1.4",
       "category": "productivity",
-      "homepage": "https://joinstash.ai",
+      "homepage": "https://stash.ac",
       "author": {
         "name": "Fergana Labs"
       }

--- a/backend/static/SKILL.md
+++ b/backend/static/SKILL.md
@@ -9,7 +9,6 @@ It provides:
 - tables (typed columns, rows, CSV import/export, semantic row search)
 - structured history/memory events (with file attachments)
 - file uploads (S3-backed; PDF/image text extraction when available)
-- decks (standalone — see deck endpoints)
 
 Design boundary:
 - Stash owns persistent shared state and plugin-based memory access
@@ -88,7 +87,7 @@ scope — pick or create a workspace first.
 | Files | `/api/v1/workspaces/{ws}/files` |
 | Memory / History | `/api/v1/workspaces/{ws}/memory/events` |
 | Transcripts | `/api/v1/workspaces/{ws}/transcripts` |
-| Aggregate (across the user's workspaces) | `/api/v1/me/{notebooks,tables,history-events,decks}` |
+| Aggregate (across the user's workspaces) | `/api/v1/me/{notebooks,tables,history-events}` |
 
 CRUD verbs are standard: `POST` to create, `GET` list/detail, `PATCH` update,
 `DELETE` remove. Semantic-search endpoints hang off their parent resource
@@ -114,10 +113,12 @@ The viewer renders all three with the same style; an `↗` glyph marks
 off-origin URLs. Internal `/notebooks?…` and stash absolute URLs are
 SPA-routed (same tab, no reload); externals open in a new tab.
 
-There is no `[[wiki-link]]` syntax. The TipTap editor offers an
-autocomplete triggered by typing `[[`, but what it inserts is a
-markdown link with the page's id URL — the `[[…]]` brackets never
-reach storage.
+`[[wiki-link]]` syntax is supported: `[[Page Name]]` resolves to
+another page by name within the same notebook. Use
+`[[Page Name|display text]]` for a custom label. The backend extracts
+these links for backlinking and link-graph resolution. The TipTap
+editor also offers a `[[` autocomplete that inserts standard markdown
+links — both forms work.
 
 ### Block elements
 
@@ -152,7 +153,8 @@ tags are not supported.
 When generating page content programmatically, follow these rules and
 you'll round-trip cleanly through edit mode:
 
-1. Never emit `[[…]]` — use the id-URL link form.
+1. Prefer `[[Page Name]]` for cross-page links within the same notebook —
+   the backend resolves them and builds the backlink graph automatically.
 2. Never emit relative paths like `[text](foo.md)` or `![](foo.jpg)` —
    the renderer treats them as dead and the editor strips them if a
    user saves the page.
@@ -198,6 +200,19 @@ Query/search:
   endpoint until `status` is `done` or `failed`.
 - `DELETE /files/{id}` — best-effort S3 cleanup plus DB row delete.
 
+## Transcripts
+
+Session transcripts are full `.jsonl` conversation logs uploaded at session end.
+
+- `POST /transcripts` — multipart upload. Fields: `file` (the .jsonl),
+  `session_id` (required), `agent_name` (required), `cwd` (optional).
+  50 MB cap.
+- `GET  /transcripts/{session_id}` — fetch metadata and a signed download URL
+  for a transcript by session ID.
+
+The CLI wraps this: `stash history transcript <session_id>` fetches and
+prints a transcript; `--save ./out.jsonl` writes it to a file instead.
+
 ## Rate Limits
 - Registration: 5/min
 - Login: 10/min
@@ -211,7 +226,6 @@ Query/search:
   (`done` with `text: null`).
 - Attach files to history events rather than embedding base64 — keeps event
   payloads small and allows reuse across events.
-- When authoring page content that links to other pages in the same
-  workspace, use `[[folder/page]]` / `[[notebook/folder/page]]` wiki
-  syntax. Unqualified `[[page]]` only resolves to a sibling in the same
-  folder.
+- When authoring page content that links to other pages, use
+  `[[Page Name]]` wiki syntax. Links resolve by page name within the
+  same notebook. Use `[[Page Name|display text]]` for a custom label.

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
       "title": "API Endpoint",
       "description": "Stash API base URL",
       "type": "string",
-      "default": "https://joinstash.ai",
+      "default": "https://api.stash.ac",
       "sensitive": false
     },
     "api_key": {

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -15,47 +15,97 @@ Most things are plain `stash` CLI subcommands. Always use `--json` for machine-r
 
 ### Plugin control
 ```bash
-stash connect                      # Interactive setup (auth + workspace + store)
+stash connect                      # Interactive first-time setup (auth + workspace + config)
 stash settings                     # Interactive settings page (streaming, scope, endpoint, …)
-stash disconnect                   # Pause event streaming across every plugin
-stash prompts curate               # Print the sleep-time curation prompt to stdout
-```
-
-### Workspaces, notebooks, history, tables
-
-### Notebooks
-```bash
-stash notebooks list --all                                        # List all notebooks
-stash notebooks list --ws <workspace_id>                          # List workspace notebooks
-stash notebooks create "name" --ws <workspace_id>                 # Create notebook
-stash notebooks pages <notebook_id> --ws <workspace_id>           # List pages
-stash notebooks read-page <notebook_id> <page_id> --ws <ws_id>   # Read a page
-stash notebooks add-page <notebook_id> "title" --ws <ws_id> --content "markdown content"
-stash notebooks edit-page <notebook_id> <page_id> --ws <ws_id> --content "new content"
+stash enable                       # Re-enable streaming for this repo
+stash disable                      # Pause streaming for this repo (config stays intact)
+stash disconnect                   # Sign out and clear config (next `stash connect` re-onboards)
 ```
 
 ### History (Agent Event Logs)
 ```bash
-stash history agents --ws <workspace_id>                              # List distinct agent names
-stash history push "text" --ws <ws_id> --agent <name> --type <event_type>
-stash history query --ws <ws_id> --limit 20                           # Query events
-stash history search "query" --ws <ws_id>                             # Full-text search
-stash history query --all --limit 20                                  # Cross-workspace events
+stash history agents --ws <workspace_id>                                 # List distinct agent names
+stash history push "text" --ws <ws_id> --agent <name> --type <type>      # Push an event
+stash history push "text" --attach ./file.pdf                            # Push with file attachment
+stash history query --ws <ws_id> --limit 20                              # Query events
+stash history query --all --limit 20                                     # Cross-workspace events
+stash history search "query" --ws <ws_id>                                # Full-text search
+stash history transcript <session_id> --ws <ws_id>                       # Fetch session transcript
+stash history transcript <session_id> --save ./out.jsonl                 # Save transcript to file
+```
+
+### Notebooks
+```bash
+stash notebooks list --all                                        # List all notebooks (cross-workspace)
+stash notebooks list --ws <workspace_id>                          # List workspace notebooks
+stash notebooks create "name" --ws <workspace_id>                 # Create notebook
+stash notebooks create "name" --personal                          # Create personal notebook
+stash notebooks pages <notebook_id> --ws <workspace_id>           # List pages
+stash notebooks read-page <notebook_id> <page_id> --ws <ws_id>   # Read a page
+stash notebooks add-page <notebook_id> "title" --ws <ws_id> --content "markdown"
+stash notebooks add-page <notebook_id> "title" --attach ./img.png # Add page with file attachment
+stash notebooks edit-page <notebook_id> <page_id> --ws <ws_id> --content "new content"
+stash notebooks edit-page <notebook_id> <page_id> --name "New Title" # Rename a page
 ```
 
 ### Tables
 ```bash
-stash tables list --ws <workspace_id>                            # List tables
-stash tables search <table_id> "query" --ws <workspace_id>      # Search rows
+stash tables list --ws <workspace_id>                             # List workspace tables
+stash tables list --all                                           # Cross-workspace
+stash tables list --personal                                      # Personal tables
+stash tables create "name" --ws <ws_id> --columns '[{"name":"Col","type":"text"}]'
+stash tables schema <table_id> --ws <ws_id>                       # Show column schema
+stash tables rows <table_id> --ws <ws_id> --limit 50              # Read rows
+stash tables rows <table_id> --sort "Name" --order desc           # Sort rows
+stash tables rows <table_id> --filter '[{"column_id":"Name","op":"eq","value":"Alice"}]'
+stash tables insert <table_id> '{"Name":"Alice"}' --ws <ws_id>   # Insert a row
+stash tables import <table_id> -f data.csv --ws <ws_id>           # Bulk import CSV/JSON
+stash tables update <table_id> --name "New Name" --ws <ws_id>     # Rename table
+stash tables update-row <table_id> <row_id> '{"Status":"done"}'   # Update a row
+stash tables delete-row <table_id> <row_id> --ws <ws_id>          # Delete a row
+stash tables add-column <table_id> "Col" --type text --ws <ws_id> # Add a column
+stash tables delete-column <table_id> <col_id> --ws <ws_id>       # Delete a column
+stash tables count <table_id> --ws <ws_id>                        # Count rows
+stash tables export <table_id> -f out.csv --ws <ws_id>            # Export as CSV
+stash tables delete <table_id> -y --ws <ws_id>                    # Delete table and all data
+```
+
+### Files
+```bash
+stash files upload ./report.pdf --ws <workspace_id>               # Upload to workspace
+stash files upload ./photo.png                                    # Upload to personal files
+stash files list --ws <workspace_id>                              # List workspace files
+stash files list                                                  # List personal files
+stash files text <file_id> --ws <workspace_id>                    # Get extracted text (PDF, OCR)
+stash files rm <file_id>                                          # Delete a file
 ```
 
 ### Workspaces
 ```bash
-stash workspaces list --mine                # List your workspaces
-stash workspaces members <workspace_id>     # List workspace members
+stash workspaces list --mine                                      # List your workspaces
+stash workspaces create "name"                                    # Create a workspace
+stash workspaces info <workspace_id>                              # Show workspace details
+stash workspaces members <workspace_id>                           # List members
+stash workspaces join <invite_code>                               # Join via invite code
+stash workspaces use <workspace_id_or_name>                       # Set default workspace
+stash workspaces use <name> --scope project                       # Set default for this repo only
+```
+
+### Invites
+```bash
+stash invite --ws <workspace_id>                                  # Create a magic-link invite
+stash invite --ws <ws_id> --uses 5 --days 30                      # Multi-use, 30-day TTL
+stash invite list --ws <workspace_id>                             # List active invite tokens
+stash invite revoke <token_id> --ws <workspace_id>                # Revoke an invite
+```
+
+### Keys
+```bash
+stash keys list                                                   # List your API keys
+stash keys revoke <key_id>                                        # Revoke an API key
 ```
 
 ### Tips
 - Workspace is determined from the `.stash/stash.json` manifest in the repo
 - Use `--json` flag on any command for JSON output
-- The CLI reads config from `~/.stash/config.json`
+- The CLI reads config from `~/.stash/config.json`; project overrides go in `.stash/config.json`

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -6,7 +6,7 @@ Turn any Claude Code session into an Stash agent. Every prompt, tool use, and se
 
 ### Step 1: Create an account
 
-Go to [joinstash.ai/login](https://joinstash.ai/login) and register a human account. Save your API key — it's shown only once.
+Go to [stash.ac](https://stash.ac) and register a human account. Save your API key — it's shown only once.
 
 ### Step 2: Install the plugin
 
@@ -21,7 +21,7 @@ Claude Code will prompt you for three config values:
 |--------|-------|
 | `api_key` | Your API key (from step 1) |
 | `agent_name` | A name for this agent (any string) |
-| `api_endpoint` | `https://joinstash.ai` (default, usually skip) |
+| `api_endpoint` | `https://api.stash.ac` (default, usually skip) |
 
 ### Step 3: Connect to a workspace
 
@@ -54,7 +54,7 @@ Every Claude Code session now automatically:
 To collaborate with teammates in a shared workspace:
 
 1. Each person follows Steps 1-2 above (own account, plugin installed)
-2. One person creates a workspace at [joinstash.ai/rooms](https://joinstash.ai/rooms)
+2. One person creates a workspace at [stash.ac](https://stash.ac)
 3. Share the **invite code** (shown on the workspace page) with teammates
 4. Each person runs `stash connect` and joins the workspace
 
@@ -68,7 +68,7 @@ Now everyone's activity streams to the same workspace. You can:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `api_endpoint` | `https://joinstash.ai` | Stash backend URL |
+| `api_endpoint` | `https://api.stash.ac` | Stash backend URL |
 | `api_key` | *(required)* | Your API key |
 | `agent_name` | *(required)* | Agent name (any string) |
 | `workspace_id` | *(optional)* | Set via `stash connect` |
@@ -111,7 +111,7 @@ Everything is a `stash` CLI subcommand — there are no slash commands.
 |---------|-------------|
 | `stash connect` | Onboarding wizard — pick workspace, create history store |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause activity streaming across every installed plugin |
+| `stash disconnect` | Sign out and clear config (re-run `stash connect` to re-onboard) |
 
 The plugin also gives Claude access to the rest of the `stash` CLI. Key commands:
 

--- a/plugins/claude-plugin/commands/welcome.md
+++ b/plugins/claude-plugin/commands/welcome.md
@@ -12,7 +12,7 @@ Your coding agent now has the `stash` CLI on its PATH. It can read the transcrip
 
 ## See your workspace
 
-Open [app.joinstash.ai](https://app.joinstash.ai) to browse your workspace's transcripts and team activity.
+Open [stash.ac](https://stash.ac) to browse your workspace's transcripts and team activity.
 
 ## Examples of questions your agent might want answered
 
@@ -38,7 +38,7 @@ Run `stash --help` to see everything.
 **A:** For sessions in this repo (and its worktrees): prompts, assistant replies, summarized tool activity, and the full session transcript (.jsonl) at session end. Other repos push nothing unless you widen scope. Transcripts are stored verbatim — no secret scrubbing yet.
 
 **Q:** Where can I see my conversation transcripts?
-**A:** Open your workspace in the browser: [app.joinstash.ai](https://app.joinstash.ai). (If you self-host, browse to your own frontend instead.)
+**A:** Open your workspace in the browser: [stash.ac](https://stash.ac). (If you self-host, browse to your own frontend instead.)
 
 **Q:** How do I share my workspace with my team?
-**A:** Share the invite code (`stash workspaces info <id>` prints it). Teammates run `stash connect` if needed, then `stash workspaces join <invite_code>`.
+**A:** Create an invite link with `stash invite --ws <workspace_id>`. Teammates run `stash connect` if needed, then `stash workspaces join <invite_code>`.

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -82,7 +82,7 @@ def get_config() -> dict:
         cli = _load_cli_config()
         manifest = find_manifest(os.getcwd())
         return {
-            "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+            "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
             "api_key": cli.get("api_key", ""),
             "agent_name": cli.get("username", ""),
             "workspace_id": (manifest or {}).get("workspace_id", ""),
@@ -91,7 +91,7 @@ def get_config() -> dict:
         }
 
     return {
-        "api_endpoint": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_api_endpoint", "https://joinstash.ai"),
+        "api_endpoint": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_api_endpoint", "https://api.stash.ac"),
         "api_key": api_key,
         "agent_name": agent_name,
         "workspace_id": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_workspace_id", ""),

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -35,7 +35,7 @@ Everything is a plain `stash` CLI subcommand — no slash commands or skills:
 |---------|-------------|
 | `stash connect` | Interactive setup (auth + workspace + store) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash disconnect` | Sign out and clear config (re-run `stash connect` to re-onboard) |
 
 At session end (Codex `Stop`) the plugin spawns `codex exec …` headless with
 a shared curation prompt. Toggle with `auto_curate` in `~/.stash/config.json`.
@@ -51,10 +51,11 @@ codex --profile stash
 ```
 
 The profile sets `sandbox_mode = "workspace-write"` with `network_access =
-true` (so `stash history …` can reach `api.joinstash.ai`) and
+true` (so `stash history …` can reach `api.stash.ac`) and
 `approval_policy = "on-failure"` (so successful reads don't prompt; failures
 still do). Run plain `codex` — without the flag — if you want Codex's default
 approval behavior.
+
 
 ## ⚠️ Known gaps
 
@@ -93,5 +94,5 @@ the `stash` CLI — all commands support `--json`:
 stash history query --ws <id> --limit 20 --json
 stash history search "<query>" --ws <id> --json
 stash whoami --json
-stash workspace list --mine --json
+stash workspaces list --mine --json
 ```

--- a/plugins/codex-plugin/config.toml.snippet
+++ b/plugins/codex-plugin/config.toml.snippet
@@ -13,7 +13,7 @@ suppress_unstable_features_warning = true
 # notify = ["bash", "${PLUGIN_ROOT}/scripts/_run.sh", "on_notify"]
 
 # Codex's default workspace-write sandbox blocks outbound network, which
-# silently kills stash hook POSTs to api.joinstash.ai. Lifting the block at the
+# silently kills stash hook POSTs to api.stash.ac. Lifting the block at the
 # top level lets plain `codex` stream. The plugin still gates streaming
 # per-repo on `.stash/stash.json` presence, so this is a capability grant,
 # not a trust grant. Remove this block if you want network only under

--- a/plugins/codex-plugin/scripts/config.py
+++ b/plugins/codex-plugin/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/plugins/cursor-plugin/scripts/config.py
+++ b/plugins/cursor-plugin/scripts/config.py
@@ -74,7 +74,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/plugins/gemini-plugin/scripts/config.py
+++ b/plugins/gemini-plugin/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/plugins/openclaw-plugin/index.ts
+++ b/plugins/openclaw-plugin/index.ts
@@ -157,7 +157,7 @@ async function drainQueue(base: string, apiKey: string): Promise<void> {
 async function pushEvent(body: EventBody): Promise<void> {
   const cfg = readConfig();
   const manifest = findManifest();
-  const base = cfg.base_url ?? "https://joinstash.ai";
+  const base = cfg.base_url ?? "https://api.stash.ac";
   const apiKey = cfg.api_key ?? "";
   const workspaceId = manifest?.workspace_id ?? "";
   if (!apiKey) return;

--- a/plugins/openclaw-plugin/scripts/config.py
+++ b/plugins/openclaw-plugin/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/plugins/opencode-plugin/scripts/config.py
+++ b/plugins/opencode-plugin/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -51,7 +51,7 @@ codex --profile stash
 ```
 
 The profile sets `sandbox_mode = "workspace-write"` with `network_access =
-true` (so `stash history …` can reach `api.joinstash.ai`) and
+true` (so `stash history …` can reach `api.stash.ac`) and
 `approval_policy = "on-failure"` (so successful reads don't prompt; failures
 still do). Run plain `codex` — without the flag — if you want Codex's default
 approval behavior.

--- a/stashai/plugin/assets/codex/scripts/config.py
+++ b/stashai/plugin/assets/codex/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/stashai/plugin/assets/cursor/scripts/config.py
+++ b/stashai/plugin/assets/cursor/scripts/config.py
@@ -74,7 +74,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),

--- a/stashai/plugin/assets/opencode/scripts/config.py
+++ b/stashai/plugin/assets/opencode/scripts/config.py
@@ -69,7 +69,7 @@ def get_config() -> dict:
     cli = _cli_config()
     manifest = find_manifest(os.getcwd())
     return {
-        "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
+        "api_endpoint": cli.get("base_url", "https://api.stash.ac"),
         "api_key": cli.get("api_key", ""),
         "agent_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),


### PR DESCRIPTION
## Summary

- **Rewrote `plugins/claude-plugin/CLAUDE.md`** — removed ghost commands (`stash prompts curate`, `stash tables search`), fixed `disconnect` description, added all missing CLI sections: files, keys, invites, history transcript, full tables reference (14 commands), full workspaces reference, enable/disable
- **Fixed `backend/static/SKILL.md`** — resolved wiki-link contradiction (backend supports `[[Page Name]]`), removed dead "decks" reference, corrected authoring rules and agent tips, added transcript endpoint docs
- **Updated `joinstash.ai` → `api.stash.ac`** across all 9 plugin config.py files, plugin.json, marketplace.json, openclaw index.ts, config.toml.snippet, READMEs, and welcome.md

## Test plan

- [ ] Verify `stash --help` subcommands match the CLAUDE.md reference
- [ ] Verify SKILL.md wiki-link docs match `notebook_service.py` behavior
- [ ] Confirm `api.stash.ac` is the correct default endpoint for all plugins
- [ ] Spot-check that no functional `joinstash.ai` references were broken (CLI host-matching in `cli/main.py` was intentionally left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)