### PR TITLE
feat(www): add joinstash.ai/install vanity redirect

### DIFF
--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: "/install",
+        destination:
+          "https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh",
+        permanent: false,
+      },
+      {
         source: "/join/:code",
         destination: `${MANAGED_APP_URL}/join/:code`,
         permanent: false,


### PR DESCRIPTION
## Summary
- Adds a 302 redirect from `joinstash.ai/install` → the raw GitHub `install.sh` on main
- Enables `curl -fsSL https://joinstash.ai/install | bash` as a clean install oneliner
- Single source of truth — no duplicate script to maintain

## Test plan
- [ ] Deploy to Vercel preview and verify `curl -fsSL <preview-url>/install` returns the install script
- [ ] Confirm existing `/join/:code` and `/login` redirects still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)