### PR TITLE
fix(www): redirect www.joinstash.ai to apex to fix CORS

### DIFF
--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.joinstash.ai" }],
+        destination: "https://joinstash.ai/:path*",
+        permanent: true,
+      },
+      {
         source: "/install",
         destination:
           "https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh",


### PR DESCRIPTION
## Summary
- Sophia hit "Failed to fetch" on the CLI authorize page because her browser was on `www.joinstash.ai`, which isn't in the backend's CORS allowlist
- Adds a permanent redirect from `www.joinstash.ai` → `joinstash.ai` so all traffic uses the canonical apex origin
- **Also needed:** add `https://www.joinstash.ai` to `CORS_ORIGINS` on Render as an immediate fix until this redirect deploys

## Test plan
- [ ] Verify `curl -sI https://www.joinstash.ai/install` returns a 308 to `https://joinstash.ai/install` after deploy
- [ ] Verify connect-token flow works end-to-end from a fresh browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)