### PR TITLE
fix(www): lower docs sidebar breakpoint for zoom tolerance

### DIFF
--- a/www/app/docs/layout.tsx
+++ b/www/app/docs/layout.tsx
@@ -86,7 +86,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 border-b border-border-subtle bg-background/95 backdrop-blur">
-        <div className="h-16 max-w-[1440px] mx-auto px-6 lg:px-8 flex items-center justify-between">
+        <div className="h-16 max-w-[1440px] mx-auto px-6 md:px-8 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Link href="/" className="font-display text-[22px] font-bold tracking-tight text-brand">
               stash
@@ -106,9 +106,9 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
         </div>
       </header>
 
-      <div className="max-w-[1440px] mx-auto px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] gap-8 lg:gap-10">
-          <aside className="hidden lg:block">
+      <div className="max-w-[1440px] mx-auto px-6 md:px-8 py-8">
+        <div className="grid grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] gap-8 md:gap-8 lg:gap-10">
+          <aside className="hidden md:block">
             <div className="sticky top-24 rounded-2xl border border-border bg-surface p-4">
               {NAV.map((section) => (
                 <div key={section.title} className="mb-5 last:mb-0">


### PR DESCRIPTION
## Summary
- Lowers the docs sidebar visibility breakpoint from `lg` (1024px) to `md` (768px) so browser zoom at ~1100px window width no longer drops to single-column mobile layout
- Sidebar starts at 200px wide at `md`, expanding to 240px at `lg` for a comfortable fit at narrower viewports

## Context
Michael saw mobile layout at 1101px — most likely caused by browser zoom pushing CSS viewport below the `lg` 1024px threshold. This fix keeps the sidebar visible even at 130% zoom on an 1100px window.

## Test plan
- [ ] Resize browser to ~1100px at 110% zoom — sidebar should remain visible
- [ ] Check 768px–1024px range — sidebar shows at 200px width
- [ ] Check 1280px+ — right-side TOC still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)