### PR TITLE
feat: workspace join requests with email notifications

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -52,5 +52,8 @@ class Settings:
     AUTH0_DOMAIN: str | None = os.getenv("AUTH0_DOMAIN")
     AUTH0_AUDIENCE: str | None = os.getenv("AUTH0_AUDIENCE")
 
+    # --- Email (Resend) ---
+    RESEND_API_KEY: str | None = os.getenv("RESEND_API_KEY")
+
 
 settings = Settings()

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -45,7 +45,14 @@ async def get_or_create_user_from_auth0(
         auth0_sub,
     )
     if row:
-        await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
+        if email:
+            await pool.execute(
+                "UPDATE users SET last_seen = now(), email = $2 WHERE id = $1",
+                row["id"],
+                email,
+            )
+        else:
+            await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
         api_key = await create_api_key(row["id"], name=key_name)
         return dict(row), api_key
 
@@ -54,12 +61,13 @@ async def get_or_create_user_from_auth0(
     display_name = name or username
 
     row = await pool.fetchrow(
-        "INSERT INTO users (name, display_name, auth0_sub, description) "
-        "VALUES ($1, $2, $3, '') "
+        "INSERT INTO users (name, display_name, auth0_sub, description, email) "
+        "VALUES ($1, $2, $3, '', $4) "
         "RETURNING id, name, display_name, description, created_at, last_seen",
         username,
         display_name,
         auth0_sub,
+        email,
     )
     user = dict(row)
     api_key = await create_api_key(user["id"], name=key_name)

--- a/backend/migrations/versions/0019_join_requests.py
+++ b/backend/migrations/versions/0019_join_requests.py
@@ -1,0 +1,44 @@
+"""Add email column to users and workspace_join_requests table.
+
+Revision ID: 0019
+Revises: 0018
+"""
+
+from alembic import op
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS email VARCHAR(255)")
+
+    op.execute("""
+CREATE TABLE IF NOT EXISTS workspace_join_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status VARCHAR(8) NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'approved', 'denied')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ,
+    resolved_by UUID REFERENCES users(id)
+)
+""")
+
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS join_requests_pending_unique "
+        "ON workspace_join_requests (workspace_id, user_id) "
+        "WHERE status = 'pending'"
+    )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS join_requests_workspace_status "
+        "ON workspace_join_requests (workspace_id, status)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS workspace_join_requests")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS email")

--- a/backend/models.py
+++ b/backend/models.py
@@ -487,3 +487,28 @@ class SessionTranscriptResponse(BaseModel):
     download_url: str | None
     uploaded_by: UUID
     uploaded_at: datetime
+
+
+# --- Join Requests ---
+
+
+class JoinRequestResponse(BaseModel):
+    id: UUID
+    workspace_id: UUID
+    user_id: UUID
+    status: str
+    created_at: datetime
+    resolved_at: datetime | None = None
+    resolved_by: UUID | None = None
+    user_name: str | None = None
+    user_display_name: str | None = None
+
+
+class JoinRequestListResponse(BaseModel):
+    requests: list[JoinRequestResponse]
+
+
+class WorkspacePublicInfo(BaseModel):
+    id: UUID
+    name: str
+    member_count: int

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ sqlalchemy[asyncio]>=2.0.0
 umap-learn>=0.5.0
 python-jose[cryptography]>=3.3.0
 pypdf>=4.0
+resend>=2.0.0

--- a/backend/routers/workspaces.py
+++ b/backend/routers/workspaces.py
@@ -10,14 +10,18 @@ from ..models import (
     InviteTokenCreateResponse,
     InviteTokenListResponse,
     InviteTokenSummary,
+    JoinRequestListResponse,
+    JoinRequestResponse,
     RedeemInviteAuthedRequest,
     WorkspaceCreateRequest,
     WorkspaceListResponse,
     WorkspaceMember,
+    WorkspacePublicInfo,
     WorkspaceResponse,
     WorkspaceUpdateRequest,
 )
-from ..services import invite_token_service, workspace_service
+from ..services import invite_token_service, join_request_service, workspace_service
+from ..services.email_service import send_join_approved_email, send_join_request_email
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
@@ -196,6 +200,100 @@ async def kick_member(
     kicked = await workspace_service.kick_member(workspace_id, user_id, current_user["id"])
     if not kicked:
         raise HTTPException(status_code=403, detail="Cannot kick this member")
+
+
+# ---------------------------------------------------------------------------
+# Join requests
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{workspace_id}/public-info", response_model=WorkspacePublicInfo)
+async def get_workspace_public_info(workspace_id: UUID):
+    info = await join_request_service.get_workspace_public_info(workspace_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return WorkspacePublicInfo(**info)
+
+
+@router.post("/{workspace_id}/join-requests", response_model=JoinRequestResponse, status_code=201)
+async def create_join_request(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    ws = await workspace_service.get_workspace(workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    try:
+        req = await join_request_service.create_request(workspace_id, current_user["id"])
+    except ValueError as e:
+        if str(e) == "already_member":
+            raise HTTPException(status_code=409, detail="Already a workspace member")
+        raise HTTPException(status_code=400, detail="Could not create join request")
+
+    requester_name = current_user.get("display_name") or current_user["name"]
+    admin_emails = await join_request_service.get_admin_emails(workspace_id)
+    send_join_request_email(admin_emails, requester_name, ws["name"], str(workspace_id))
+
+    return JoinRequestResponse(**req)
+
+
+@router.get("/{workspace_id}/join-requests", response_model=JoinRequestListResponse)
+async def list_join_requests(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    role = await workspace_service.get_member_role(workspace_id, current_user["id"])
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Only owner/admin can view join requests")
+    pending = await join_request_service.list_pending(workspace_id)
+    return JoinRequestListResponse(requests=[JoinRequestResponse(**r) for r in pending])
+
+
+@router.post("/{workspace_id}/join-requests/{request_id}/approve", response_model=JoinRequestResponse)
+async def approve_join_request(
+    workspace_id: UUID,
+    request_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    role = await workspace_service.get_member_role(workspace_id, current_user["id"])
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Only owner/admin can approve join requests")
+    result = await join_request_service.approve_request(request_id, current_user["id"])
+    if not result:
+        raise HTTPException(status_code=404, detail="Join request not found or already resolved")
+
+    ws = await workspace_service.get_workspace(workspace_id)
+    user_email = await join_request_service.get_user_email(result["user_id"])
+    if user_email and ws:
+        send_join_approved_email(user_email, ws["name"])
+
+    return JoinRequestResponse(**result)
+
+
+@router.post("/{workspace_id}/join-requests/{request_id}/deny", response_model=JoinRequestResponse)
+async def deny_join_request(
+    workspace_id: UUID,
+    request_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    role = await workspace_service.get_member_role(workspace_id, current_user["id"])
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Only owner/admin can deny join requests")
+    result = await join_request_service.deny_request(request_id, current_user["id"])
+    if not result:
+        raise HTTPException(status_code=404, detail="Join request not found or already resolved")
+    return JoinRequestResponse(**result)
+
+
+@router.get("/{workspace_id}/join-requests/mine", response_model=JoinRequestResponse)
+async def get_my_join_request(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    req = await join_request_service.get_user_request_status(workspace_id, current_user["id"])
+    if not req:
+        raise HTTPException(status_code=404, detail="No join request found")
+    return JoinRequestResponse(**req)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -1,0 +1,69 @@
+"""Email notifications via Resend."""
+
+import logging
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _get_resend():
+    if not settings.RESEND_API_KEY:
+        return None
+    try:
+        import resend
+    except ImportError:
+        logger.warning("resend package not installed, skipping email")
+        return None
+
+    resend.api_key = settings.RESEND_API_KEY
+    return resend
+
+
+def send_join_request_email(
+    admin_emails: list[str],
+    requester_name: str,
+    workspace_name: str,
+    workspace_id: str,
+) -> None:
+    resend = _get_resend()
+    if not resend or not admin_emails:
+        logger.info("Skipping join request email (no Resend key or no admin emails)")
+        return
+
+    review_url = f"{settings.PUBLIC_URL}/workspaces/{workspace_id}/requests"
+
+    resend.Emails.send(
+        {
+            "from": "Stash <notifications@joinstash.ai>",
+            "to": admin_emails,
+            "subject": f"{requester_name} wants to join {workspace_name}",
+            "html": (
+                f"<p><strong>{requester_name}</strong> requested to join "
+                f"<strong>{workspace_name}</strong> on Stash.</p>"
+                f'<p><a href="{review_url}">Review request</a></p>'
+            ),
+        }
+    )
+
+
+def send_join_approved_email(
+    user_email: str,
+    workspace_name: str,
+) -> None:
+    resend = _get_resend()
+    if not resend or not user_email:
+        logger.info("Skipping approval email (no Resend key or no user email)")
+        return
+
+    resend.Emails.send(
+        {
+            "from": "Stash <notifications@joinstash.ai>",
+            "to": [user_email],
+            "subject": f"You're in! Welcome to {workspace_name}",
+            "html": (
+                f"<p>Your request to join <strong>{workspace_name}</strong> has been approved.</p>"
+                "<p>Next time you run a stash command in the repo, streaming will start automatically.</p>"
+            ),
+        }
+    )

--- a/backend/services/join_request_service.py
+++ b/backend/services/join_request_service.py
@@ -1,0 +1,129 @@
+"""Workspace join requests: create, list, approve, deny."""
+
+from uuid import UUID
+
+from ..database import get_pool
+from . import workspace_service
+
+
+async def get_workspace_public_info(workspace_id: UUID) -> dict | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT w.id, w.name, "
+        "(SELECT COUNT(*) FROM workspace_members wm WHERE wm.workspace_id = w.id) AS member_count "
+        "FROM workspaces w WHERE w.id = $1",
+        workspace_id,
+    )
+    return dict(row) if row else None
+
+
+async def create_request(workspace_id: UUID, user_id: UUID) -> dict:
+    pool = get_pool()
+
+    already_member = await workspace_service.is_member(workspace_id, user_id)
+    if already_member:
+        raise ValueError("already_member")
+
+    row = await pool.fetchrow(
+        "INSERT INTO workspace_join_requests (workspace_id, user_id) "
+        "VALUES ($1, $2) "
+        "ON CONFLICT (workspace_id, user_id) WHERE status = 'pending' DO NOTHING "
+        "RETURNING id, workspace_id, user_id, status, created_at, resolved_at, resolved_by",
+        workspace_id,
+        user_id,
+    )
+    if not row:
+        existing = await pool.fetchrow(
+            "SELECT id, workspace_id, user_id, status, created_at, resolved_at, resolved_by "
+            "FROM workspace_join_requests "
+            "WHERE workspace_id = $1 AND user_id = $2 AND status = 'pending'",
+            workspace_id,
+            user_id,
+        )
+        if existing:
+            return dict(existing)
+        raise ValueError("request_failed")
+    return dict(row)
+
+
+async def list_pending(workspace_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT jr.id, jr.workspace_id, jr.user_id, jr.status, jr.created_at, "
+        "u.name AS user_name, u.display_name AS user_display_name "
+        "FROM workspace_join_requests jr "
+        "JOIN users u ON u.id = jr.user_id "
+        "WHERE jr.workspace_id = $1 AND jr.status = 'pending' "
+        "ORDER BY jr.created_at",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def approve_request(request_id: UUID, approver_id: UUID) -> dict | None:
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "UPDATE workspace_join_requests "
+                "SET status = 'approved', resolved_at = now(), resolved_by = $2 "
+                "WHERE id = $1 AND status = 'pending' "
+                "RETURNING id, workspace_id, user_id, status, created_at, resolved_at, resolved_by",
+                request_id,
+                approver_id,
+            )
+            if not row:
+                return None
+            await conn.execute(
+                "INSERT INTO workspace_members (workspace_id, user_id, role) "
+                "VALUES ($1, $2, 'member') "
+                "ON CONFLICT (workspace_id, user_id) DO NOTHING",
+                row["workspace_id"],
+                row["user_id"],
+            )
+    return dict(row)
+
+
+async def deny_request(request_id: UUID, denier_id: UUID) -> dict | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "UPDATE workspace_join_requests "
+        "SET status = 'denied', resolved_at = now(), resolved_by = $2 "
+        "WHERE id = $1 AND status = 'pending' "
+        "RETURNING id, workspace_id, user_id, status, created_at, resolved_at, resolved_by",
+        request_id,
+        denier_id,
+    )
+    return dict(row) if row else None
+
+
+async def get_user_request_status(workspace_id: UUID, user_id: UUID) -> dict | None:
+    """Get the most recent join request for a user in a workspace."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, user_id, status, created_at, resolved_at, resolved_by "
+        "FROM workspace_join_requests "
+        "WHERE workspace_id = $1 AND user_id = $2 "
+        "ORDER BY created_at DESC LIMIT 1",
+        workspace_id,
+        user_id,
+    )
+    return dict(row) if row else None
+
+
+async def get_admin_emails(workspace_id: UUID) -> list[str]:
+    """Get email addresses of workspace owners and admins."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT u.email FROM users u "
+        "JOIN workspace_members wm ON wm.user_id = u.id "
+        "WHERE wm.workspace_id = $1 AND wm.role IN ('owner', 'admin') "
+        "AND u.email IS NOT NULL",
+        workspace_id,
+    )
+    return [r["email"] for r in rows]
+
+
+async def get_user_email(user_id: UUID) -> str | None:
+    pool = get_pool()
+    return await pool.fetchval("SELECT email FROM users WHERE id = $1", user_id)

--- a/cli/client.py
+++ b/cli/client.py
@@ -128,6 +128,20 @@ class StashClient:
     def workspace_members(self, workspace_id: str) -> list:
         return self._get(f"/api/v1/workspaces/{workspace_id}/members")
 
+    def workspace_public_info(self, workspace_id: str) -> dict:
+        return self._get(f"/api/v1/workspaces/{workspace_id}/public-info")
+
+    def create_join_request(self, workspace_id: str) -> dict:
+        return self._post(f"/api/v1/workspaces/{workspace_id}/join-requests")
+
+    def get_my_join_request(self, workspace_id: str) -> dict | None:
+        try:
+            return self._get(f"/api/v1/workspaces/{workspace_id}/join-requests/mine")
+        except StashError as e:
+            if e.status_code == 404:
+                return None
+            raise
+
     # --- Magic-link invite tokens ---
 
     def create_invite_token(self, workspace_id: str, max_uses: int = 1, ttl_days: int = 7) -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -2149,9 +2149,9 @@ def connect_cmd():
         _connect_repo(repo_root, c)
 
 
-@app.command("request")
-def request_cmd():
-    """Request to join this repo's workspace (use after a previous denial)."""
+@app.command("join")
+def join_cmd():
+    """Request to join this repo's workspace."""
     cfg = _require_auth()
 
     repo_root = _git_toplevel()
@@ -2169,6 +2169,38 @@ def request_cmd():
 
     with StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"]) as c:
         _handle_not_member(ws_id, c)
+
+
+@app.command("leave")
+def leave_cmd():
+    """Leave this repo's workspace."""
+    cfg = _require_auth()
+
+    repo_root = _git_toplevel()
+    if not repo_root:
+        console.print("[red]Not inside a git repo.[/red]")
+        raise typer.Exit(1)
+
+    manifest_path = repo_root / MANIFEST_FILE
+    if not manifest_path.is_file():
+        console.print("[yellow]No .stash file found. Nothing to leave.[/yellow]")
+        raise typer.Exit(1)
+
+    manifest = json.loads(manifest_path.read_text())
+    ws_id = manifest.get("workspace_id", "")
+
+    with StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"]) as c:
+        try:
+            c.leave_workspace(ws_id)
+        except StashError as e:
+            if "owner" in str(e.detail).lower():
+                console.print("  [red]Owners cannot leave their own workspace.[/red]")
+                return
+            console.print(f"  [red]{e.detail}[/red]")
+            return
+
+    clear_streaming(ws_id)
+    console.print(f"  [green]✓[/green] Left workspace {ws_id[:8]}…")
 
 
 @app.command("start")
@@ -2205,7 +2237,7 @@ def start_cmd():
                 else:
                     console.print(
                         "  [yellow]You're not a member of this workspace.[/yellow] "
-                        "Run [cyan]stash request[/cyan] to request access."
+                        "Run [cyan]stash join[/cyan] to request access."
                     )
                     return
             else:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1832,16 +1832,68 @@ def _require_auth() -> dict:
     return cfg
 
 
+def _handle_not_member(ws_id: str, client: StashClient) -> None:
+    """Handle the case where .stash exists but the user isn't a member."""
+    try:
+        info = client.workspace_public_info(ws_id)
+        ws_name = info["name"]
+        member_count = info["member_count"]
+    except StashError:
+        ws_name = ws_id[:8] + "…"
+        member_count = "?"
+
+    console.print(
+        f"\n  This repo belongs to workspace [bold]{ws_name}[/bold] "
+        f"({member_count} member{'s' if member_count != 1 else ''})."
+    )
+    console.print("  You're not a member yet.\n")
+
+    existing = client.get_my_join_request(ws_id)
+    if existing and existing.get("status") == "pending":
+        console.print(
+            "  [yellow]You already have a pending request.[/yellow] "
+            "The workspace owner has been notified."
+        )
+        return
+    if existing and existing.get("status") == "approved":
+        console.print(
+            "  [green]✓[/green] Your request was approved! "
+            "Run [cyan]stash start[/cyan] to begin streaming."
+        )
+        return
+
+    try:
+        client.create_join_request(ws_id)
+        console.print(
+            "  [green]✓[/green] Request sent! The workspace owner will be notified by email.\n"
+            "  You'll be able to stream once your request is approved."
+        )
+    except StashError as e:
+        if e.status_code == 409:
+            console.print("  [green]✓[/green] You're already a member of this workspace!")
+        else:
+            console.print(f"  [red]Could not send join request: {e.detail}[/red]")
+
+
 def _connect_repo(repo_root: Path, client: StashClient) -> None:
     """Shared logic for connecting a repo to a workspace. Creates .stash file and appends to CLAUDE.md."""
     manifest_path = repo_root / MANIFEST_FILE
     if manifest_path.is_file():
         manifest = json.loads(manifest_path.read_text())
-        console.print(
-            f"  [green]✓[/green] This repo is already connected to workspace "
-            f"[bold]{manifest.get('workspace_id', '?')[:8]}…[/bold]"
-        )
-        return
+        ws_id = manifest.get("workspace_id", "")
+
+        try:
+            client.get_workspace(ws_id)
+            console.print(
+                f"  [green]✓[/green] This repo is already connected to workspace "
+                f"[bold]{ws_id[:8]}…[/bold]"
+            )
+            return
+        except StashError as e:
+            if e.status_code in (403, 404):
+                _handle_not_member(ws_id, client)
+                return
+            raise
 
     my_workspaces = client.list_workspaces(mine=True)
 
@@ -2097,10 +2149,32 @@ def connect_cmd():
         _connect_repo(repo_root, c)
 
 
+@app.command("request")
+def request_cmd():
+    """Request to join this repo's workspace (use after a previous denial)."""
+    cfg = _require_auth()
+
+    repo_root = _git_toplevel()
+    if not repo_root:
+        console.print("[red]Not inside a git repo.[/red]")
+        raise typer.Exit(1)
+
+    manifest_path = repo_root / MANIFEST_FILE
+    if not manifest_path.is_file():
+        console.print("[yellow]No .stash file found. Run `stash connect` first.[/yellow]")
+        raise typer.Exit(1)
+
+    manifest = json.loads(manifest_path.read_text())
+    ws_id = manifest.get("workspace_id", "")
+
+    with StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"]) as c:
+        _handle_not_member(ws_id, c)
+
+
 @app.command("start")
 def start_cmd():
     """Start streaming transcripts to this repo's workspace."""
-    _require_auth()
+    cfg = _require_auth()
 
     manifest = load_manifest()
     if not manifest:
@@ -2111,6 +2185,31 @@ def start_cmd():
     if not workspace_id:
         console.print("[red].stash file is missing workspace_id.[/red]")
         raise typer.Exit(1)
+
+    with StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"]) as c:
+        try:
+            c.get_workspace(workspace_id)
+        except StashError as e:
+            if e.status_code in (403, 404):
+                req = c.get_my_join_request(workspace_id)
+                if req and req.get("status") == "approved":
+                    console.print(
+                        f"  [green]✓[/green] Your request to join was approved!"
+                    )
+                elif req and req.get("status") == "pending":
+                    console.print(
+                        "  [yellow]Your join request is still pending.[/yellow] "
+                        "You'll be able to stream once approved."
+                    )
+                    return
+                else:
+                    console.print(
+                        "  [yellow]You're not a member of this workspace.[/yellow] "
+                        "Run [cyan]stash request[/cyan] to request access."
+                    )
+                    return
+            else:
+                raise
 
     set_streaming(workspace_id)
     console.print(f"  [green]✓[/green] Streaming enabled for workspace {workspace_id[:8]}…")

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -25,6 +25,7 @@ import {
   getKnowledgeDensity,
   getEmbeddingProjection,
   getPageGraph,
+  listJoinRequests,
 } from "../../../lib/api";
 import {
   ActivityTimeline,
@@ -101,6 +102,7 @@ export default function WorkspacePage() {
   const [pageGraph, setPageGraph] = useState<PageGraph | null>(null);
   const [graphNotebookId, setGraphNotebookId] = useState<string | null>(null);
   const [graphAutoLoaded, setGraphAutoLoaded] = useState(false);
+  const [pendingRequestCount, setPendingRequestCount] = useState(0);
 
   const loadWorkspace = useCallback(async () => {
     try { setWorkspace(await getWorkspace(workspaceId)); } catch { setError("Workspace not found"); }
@@ -184,6 +186,14 @@ export default function WorkspacePage() {
   };
 
   const isOwner = members.some(m => m.user_id === user?.id && m.role === "owner");
+  const isAdmin = members.some(m => m.user_id === user?.id && (m.role === "owner" || m.role === "admin"));
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    listJoinRequests(workspaceId)
+      .then((jr) => setPendingRequestCount(jr.requests.length))
+      .catch(() => {});
+  }, [isAdmin, workspaceId]);
 
   useEffect(() => { if (!loading && !user) router.push("/login"); }, [user, loading, router]);
   if (loading) return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
@@ -409,6 +419,7 @@ export default function WorkspacePage() {
                 members={members}
                 currentUserId={user.id}
                 isOwner={isOwner}
+                pendingRequestCount={pendingRequestCount}
                 onLeave={async () => { await leaveWorkspace(workspaceId); router.push("/rooms"); }}
                 onDelete={async () => { await deleteWorkspace(workspaceId); router.push("/rooms"); }}
                 onKickMember={async (uid) => { await kickWorkspaceMember(workspaceId, uid); await loadData(); }}

--- a/frontend/src/app/workspaces/[workspaceId]/requests/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/requests/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import AppShell from "../../../../components/AppShell";
+import { useAuth } from "../../../../hooks/useAuth";
+import {
+  approveJoinRequest,
+  denyJoinRequest,
+  getWorkspace,
+  listJoinRequests,
+} from "../../../../lib/api";
+import { JoinRequest, Workspace } from "../../../../lib/types";
+
+export default function JoinRequestsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+  const { user, loading, logout } = useAuth();
+
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [requests, setRequests] = useState<JoinRequest[]>([]);
+  const [error, setError] = useState("");
+  const [processing, setProcessing] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const [ws, jr] = await Promise.all([
+        getWorkspace(workspaceId),
+        listJoinRequests(workspaceId),
+      ]);
+      setWorkspace(ws);
+      setRequests(jr.requests);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (user) loadData();
+  }, [user, loadData]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  const handleApprove = async (requestId: string) => {
+    setProcessing(requestId);
+    try {
+      await approveJoinRequest(workspaceId, requestId);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to approve");
+    }
+    setProcessing(null);
+  };
+
+  const handleDeny = async (requestId: string) => {
+    setProcessing(requestId);
+    try {
+      await denyJoinRequest(workspaceId, requestId);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to deny");
+    }
+    setProcessing(null);
+  };
+
+  if (loading)
+    return (
+      <div className="min-h-screen flex items-center justify-center text-muted">
+        Loading...
+      </div>
+    );
+  if (!user) return null;
+
+  return (
+    <AppShell user={user} onLogout={logout}>
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <button
+              onClick={() => router.push(`/workspaces/${workspaceId}`)}
+              className="text-xs text-brand hover:text-brand-hover mb-1 inline-block"
+            >
+              &larr; Back to workspace
+            </button>
+            <h1 className="text-lg font-semibold text-foreground">
+              Join Requests
+            </h1>
+            {workspace && (
+              <p className="text-sm text-dim">{workspace.name}</p>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-800 text-red-400 text-sm px-4 py-2 rounded mb-4">
+            {error}
+            <button
+              onClick={() => setError("")}
+              className="ml-2 text-red-500 hover:text-red-300"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
+        {requests.length === 0 ? (
+          <div className="bg-surface border border-border rounded-xl px-6 py-10 text-center">
+            <p className="text-dim">No pending join requests.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {requests.map((req) => (
+              <div
+                key={req.id}
+                className="bg-surface border border-border rounded-xl px-5 py-4 flex items-center justify-between"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-human-muted text-human flex items-center justify-center text-sm font-bold">
+                    {(
+                      req.user_display_name ||
+                      req.user_name ||
+                      "?"
+                    )
+                      .charAt(0)
+                      .toUpperCase()}
+                  </div>
+                  <div>
+                    <div className="text-sm text-foreground font-medium">
+                      {req.user_display_name || req.user_name}
+                    </div>
+                    {req.user_name && (
+                      <div className="text-xs text-muted">
+                        @{req.user_name}
+                      </div>
+                    )}
+                    <div className="text-xs text-muted">
+                      Requested{" "}
+                      {new Date(req.created_at).toLocaleDateString()}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => handleApprove(req.id)}
+                    disabled={processing === req.id}
+                    className="text-xs bg-brand hover:bg-brand-hover text-foreground px-4 py-1.5 rounded disabled:opacity-50"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => handleDeny(req.id)}
+                    disabled={processing === req.id}
+                    className="text-xs text-red-400 hover:text-red-300 border border-border hover:border-red-800 px-4 py-1.5 rounded disabled:opacity-50"
+                  >
+                    Deny
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/src/components/workspace/WorkspaceSidebar.tsx
+++ b/frontend/src/components/workspace/WorkspaceSidebar.tsx
@@ -99,6 +99,7 @@ interface WorkspaceSidebarProps {
   members: WorkspaceMember[];
   currentUserId: string;
   isOwner: boolean;
+  pendingRequestCount?: number;
   onLeave: () => void;
   onDelete: () => void;
   onKickMember: (userId: string) => void;
@@ -124,6 +125,7 @@ export default function WorkspaceSidebar({
   onKickMember,
   onUpdateWorkspace,
   onAddMember,
+  pendingRequestCount,
   onAddToAccessList,
   onRemoveFromAccessList,
   onGetAccessList,
@@ -312,6 +314,19 @@ export default function WorkspaceSidebar({
       </div>
 
       <div className="flex-1 overflow-y-auto p-4">
+        {isOwner && pendingRequestCount !== undefined && pendingRequestCount > 0 && (
+          <a
+            href={`/workspaces/${workspace.id}/requests`}
+            className="flex items-center justify-between px-3 py-2 mb-3 rounded-lg bg-brand/10 border border-brand/30 hover:bg-brand/15 transition-colors"
+          >
+            <span className="text-xs text-brand font-medium">
+              Pending join requests
+            </span>
+            <span className="text-xs bg-brand text-foreground rounded-full w-5 h-5 flex items-center justify-center font-bold">
+              {pendingRequestCount}
+            </span>
+          </a>
+        )}
         <h3 className="text-xs uppercase tracking-wider text-muted mb-2">
           Members ({members.length})
         </h3>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import {
   HistoryEventWithContext,
   History,
   HistoryWithWorkspace,
+  JoinRequest,
   Notebook,
   NotebookFolder,
   NotebookPage,
@@ -20,6 +21,7 @@ import {
   TableWithWorkspace,
   Workspace,
   WorkspaceMember,
+  WorkspacePublicInfo,
   ActivityTimeline,
   KnowledgeDensity,
   EmbeddingProjection,
@@ -231,6 +233,32 @@ export async function deleteWorkspace(workspaceId: string): Promise<void> {
 
 export async function kickWorkspaceMember(workspaceId: string, userId: string): Promise<void> {
   await apiFetch(`/api/v1/workspaces/${workspaceId}/kick/${userId}`, { method: "POST" });
+}
+
+// --- Join Requests ---
+
+export async function getWorkspacePublicInfo(workspaceId: string): Promise<WorkspacePublicInfo> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/public-info`);
+}
+
+export async function createJoinRequest(workspaceId: string): Promise<JoinRequest> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/join-requests`, { method: "POST" });
+}
+
+export async function listJoinRequests(workspaceId: string): Promise<{ requests: JoinRequest[] }> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/join-requests`);
+}
+
+export async function approveJoinRequest(workspaceId: string, requestId: string): Promise<JoinRequest> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/join-requests/${requestId}/approve`, { method: "POST" });
+}
+
+export async function denyJoinRequest(workspaceId: string, requestId: string): Promise<JoinRequest> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/join-requests/${requestId}/deny`, { method: "POST" });
+}
+
+export async function getMyJoinRequest(workspaceId: string): Promise<JoinRequest> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/join-requests/mine`);
 }
 
 // --- Notebooks ---

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -264,6 +264,26 @@ export interface EmbeddingProjection {
   cached: boolean;
 }
 
+// --- Join Requests ---
+
+export interface JoinRequest {
+  id: string;
+  workspace_id: string;
+  user_id: string;
+  status: "pending" | "approved" | "denied";
+  created_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  user_name: string | null;
+  user_display_name: string | null;
+}
+
+export interface WorkspacePublicInfo {
+  id: string;
+  name: string;
+  member_count: number;
+}
+
 // --- Search ---
 
 export interface UserSearchResult {


### PR DESCRIPTION
## Summary
- Adds a **join request flow** for when users clone a repo with `.stash` and aren't workspace members — they request access, owners/admins approve via a web page, and both sides get email notifications via Resend
- **CLI**: `stash connect` auto-sends a join request when `.stash` exists but user isn't a member; new `stash request` command for re-requesting after denial; `stash start` checks membership first
- **Backend**: 6 new API endpoints, `join_request_service`, `email_service` (Resend), migration 0019 (email column on users + `workspace_join_requests` table), Auth0 now stores user email
- **Frontend**: new `/workspaces/{id}/requests` approve/deny page + pending request badge in workspace sidebar

## Design decisions
- Three join paths: **join requests** (primary, requires approval), **invite links** (growth hack, instant), **direct add** (admin action)
- Pending users are fully blocked — no reads, no streaming (prevents misinformation in the memory store)
- Denied users can manually re-request via `stash request` but it won't auto-fire on every CLI command
- Email degrades gracefully — skips silently if `RESEND_API_KEY` not set or `resend` package not installed

## Deploy notes
- Set `RESEND_API_KEY` env var on Render to enable email notifications
- Configure a verified sender domain in Resend for `notifications@joinstash.ai`

## Test plan
- [ ] Clone a repo with `.stash`, run `stash connect` as non-member → verify join request is created
- [ ] Check owner gets email with link to `/workspaces/{id}/requests`
- [ ] Approve request on web page → verify requester gets "you're in" email
- [ ] Run `stash start` as newly-approved member → verify streaming enables
- [ ] Deny a request, then run `stash request` → verify new request is created
- [ ] Verify `stash start` blocks with message when request is still pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)