### PR TITLE
fix: strip whitespace from CORS_ORIGINS env var entries

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -23,9 +23,13 @@ class Settings:
 
     # --- URLs & CORS ---
     PUBLIC_URL: str = os.getenv("PUBLIC_URL", "http://localhost:3457")
-    CORS_ORIGINS: list[str] = os.getenv(
-        "CORS_ORIGINS", "http://localhost:3457,http://localhost:3456"
-    ).split(",")
+    CORS_ORIGINS: list[str] = [
+        o.strip()
+        for o in os.getenv(
+            "CORS_ORIGINS", "http://localhost:3457,http://localhost:3456"
+        ).split(",")
+        if o.strip()
+    ]
 
     # --- Embeddings ---
     # Provider: "openai", "huggingface", "local", or "auto" (default).


### PR DESCRIPTION
## Summary
- Sophia's "Failed to fetch" on the CLI authorize page was caused by a newline in the Render env var textarea getting baked into the parsed origin string
- `.split(",")` without `.strip()` turned `https://www.joinstash.ai` into `\nhttps://www.joinstash.ai`, which silently failed the CORS match
- Strips whitespace and filters empty entries from each origin after splitting

## Test plan
- [ ] Deploy and verify `curl -X OPTIONS https://api.joinstash.ai/api/v1/auth0/exchange -H "Origin: https://www.joinstash.ai" -H "Access-Control-Request-Method: POST"` returns 200 with `access-control-allow-origin`
- [ ] Have Sophia retry `stash connect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)