### PR TITLE
feat: agent session context includes workspace URL

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -2310,15 +2310,19 @@ STASH_OCTOPUS = r"""
 
 
 def _frontend_base_url() -> str:
-    """Return the frontend root for the currently configured backend. Managed
-    backend → app.joinstash.ai (the marketing site at joinstash.ai has no /workspaces
-    redirect); localhost backend → :3457; any other self-host → whatever the
-    configured base_url is."""
+    """Return the frontend root for the currently configured backend.
+
+    api.stash.ac → stash.ac, api.joinstash.ai → joinstash.ai,
+    localhost backend → :3457."""
     base_url = (load_config().get("base_url") or "").rstrip("/")
     if "localhost" in base_url or "127.0.0.1" in base_url:
         return base_url.replace(":3456", ":3457")
-    if base_url == "https://api.joinstash.ai":
-        return "https://app.joinstash.ai"
+    from urllib.parse import urlparse as _urlparse
+
+    parsed = _urlparse(base_url)
+    host = parsed.hostname or ""
+    if host.startswith("api."):
+        return f"{parsed.scheme}://{host[4:]}"
     return base_url
 
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2312,8 +2312,7 @@ STASH_OCTOPUS = r"""
 def _frontend_base_url() -> str:
     """Return the frontend root for the currently configured backend.
 
-    api.stash.ac → stash.ac, api.joinstash.ai → joinstash.ai,
-    localhost backend → :3457."""
+    api.joinstash.ai → app.joinstash.ai, localhost backend → :3457."""
     base_url = (load_config().get("base_url") or "").rstrip("/")
     if "localhost" in base_url or "127.0.0.1" in base_url:
         return base_url.replace(":3456", ":3457")
@@ -2322,7 +2321,7 @@ def _frontend_base_url() -> str:
     parsed = _urlparse(base_url)
     host = parsed.hostname or ""
     if host.startswith("api."):
-        return f"{parsed.scheme}://{host[4:]}"
+        return f"{parsed.scheme}://app.{host[4:]}"
     return base_url
 
 

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -15,12 +15,12 @@ from adapt import adapt_session_start
 def _frontend_url(api_url: str) -> str:
     """Derive the web dashboard URL from the API base URL.
 
-    api.stash.ac → stash.ac, api.joinstash.ai → joinstash.ai, etc.
+    api.joinstash.ai → app.joinstash.ai, etc.
     """
     parsed = urlparse(api_url)
     host = parsed.hostname or ""
     if host.startswith("api."):
-        host = host[4:]
+        host = f"app.{host[4:]}"
     if "localhost" in host or "127.0.0.1" in host:
         port = parsed.port + 1 if parsed.port else 3457
         return f"{parsed.scheme}://{host}:{port}"

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -4,23 +4,59 @@ context message so the agent knows the stash CLI is on its PATH."""
 
 import json
 import sys
+from urllib.parse import urlparse
 
-from config import DATA_DIR, get_stdin_data, is_configured
+from config import DATA_DIR, _load_cli_config, get_config, get_stdin_data, is_configured
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 from adapt import adapt_session_start
 
-CONTEXT = (
-    "You have the `stash` CLI on your PATH. Run `stash --help` to see commands. "
-    "Use it to read transcripts, notebooks, and history from your team's shared "
-    "Stash workspace. Your activity in this repo is streamed to that workspace, "
-    "so teammates' agents and humans can see what you're working on. "
-    "Common reads (all support `--json`): "
-    "`stash history search \"<query>\"`, "
-    "`stash history query --limit 20`, "
-    "`stash history agents`, "
-    "`stash notebooks list --all`."
-)
+
+def _frontend_url(api_url: str) -> str:
+    """Derive the web dashboard URL from the API base URL.
+
+    api.stash.ac → stash.ac, api.joinstash.ai → joinstash.ai, etc.
+    """
+    parsed = urlparse(api_url)
+    host = parsed.hostname or ""
+    if host.startswith("api."):
+        host = host[4:]
+    if "localhost" in host or "127.0.0.1" in host:
+        port = parsed.port + 1 if parsed.port else 3457
+        return f"{parsed.scheme}://{host}:{port}"
+    return f"{parsed.scheme}://{host}"
+
+
+def _build_context() -> str:
+    cfg = get_config()
+    api_url = cfg.get("api_endpoint", "")
+    workspace_id = cfg.get("workspace_id", "") or _load_cli_config().get("default_workspace", "")
+
+    parts = [
+        "You have the `stash` CLI on your PATH. Run `stash --help` to see commands. "
+        "Use it to read transcripts, notebooks, and history from your team's shared "
+        "Stash workspace. Your activity in this repo is streamed to that workspace, "
+        "so teammates' agents and humans can see what you're working on.",
+    ]
+
+    if api_url:
+        web_url = _frontend_url(api_url)
+        if workspace_id:
+            parts.append(
+                f"The web dashboard for this workspace is at {web_url}/workspaces/{workspace_id} ."
+            )
+        else:
+            parts.append(f"The Stash web dashboard is at {web_url} .")
+
+    parts.append(
+        "Common reads (all support `--json`): "
+        "`stash history search \"<query>\"`, "
+        "`stash history query --limit 20`, "
+        "`stash history agents`, "
+        "`stash notebooks list --all`."
+    )
+
+    return " ".join(parts)
 
 
 def main():
@@ -38,7 +74,7 @@ def main():
         {
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",
-                "additionalContext": CONTEXT,
+                "additionalContext": _build_context(),
             }
         },
         sys.stdout,


### PR DESCRIPTION
## Summary
- The SessionStart hook now dynamically builds the context message with the actual web dashboard URL (e.g. `https://stash.ac/workspaces/<id>`) so agents can answer "where is my workspace?" directly
- Workspace ID is resolved from the `.stash` manifest, falling back to `default_workspace` in CLI config
- `_frontend_base_url()` in the CLI now generically strips `api.` prefixes instead of hardcoding `api.joinstash.ai`

## Test plan
- [ ] Start a new Claude Code session in a repo with Stash configured — verify the system-reminder includes the workspace URL
- [ ] Confirm `api.stash.ac` → `stash.ac`, `api.joinstash.ai` → `joinstash.ai`, `localhost:3456` → `localhost:3457`
- [ ] Ask the agent "where can I see my workspace?" and confirm it gives a concrete URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)