### PR TITLE
chore: bump plugin to 0.1.5, update welcome, add auto-bump CI

### DIFF
--- a/.github/workflows/bump-plugin-version.yml
+++ b/.github/workflows/bump-plugin-version.yml
@@ -1,0 +1,46 @@
+name: Bump Claude plugin version
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump patch version in plugin.json
+        run: |
+          FILE="plugins/claude-plugin/.claude-plugin/plugin.json"
+          CUR=$(python3 -c "import json; print(json.load(open('$FILE'))['version'])")
+          MAJOR=$(echo "$CUR" | cut -d. -f1)
+          MINOR=$(echo "$CUR" | cut -d. -f2)
+          PATCH=$(echo "$CUR" | cut -d. -f3)
+          NEW="$MAJOR.$MINOR.$((PATCH + 1))"
+          python3 -c "
+          import json, pathlib
+          p = pathlib.Path('$FILE')
+          d = json.loads(p.read_text())
+          d['version'] = '$NEW'
+          p.write_text(json.dumps(d, indent=2) + '\n')
+          "
+          echo "Bumped plugin version $CUR → $NEW"
+
+      - name: Commit and push
+        run: |
+          # Skip if the triggering commit was already a plugin bump (avoid infinite loop)
+          if git log -1 --pretty=%s | grep -q "^chore: bump claude plugin"; then
+            echo "Last commit was a plugin bump — skipping"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugins/claude-plugin/.claude-plugin/plugin.json
+          git diff --cached --quiet && echo "No change" && exit 0
+          git commit -m "chore: bump claude plugin to $(python3 -c "import json; print(json.load(open('plugins/claude-plugin/.claude-plugin/plugin.json'))['version'])")"
+          git push

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Connect Claude Code to Stash — stream activity to history and collaborate in workspaces.",
   "author": {
     "name": "Fergana Labs"

--- a/plugins/claude-plugin/commands/welcome.md
+++ b/plugins/claude-plugin/commands/welcome.md
@@ -8,24 +8,21 @@ Render the markdown block below to the user verbatim. Do not summarize, paraphra
 
 ## What just happened
 
-Your coding agent now has the `stash` CLI on its PATH. It can read the transcripts your teammates' coding agents push to this workspace — so it knows what the rest of your team is working on.
+Your coding agent now has the `stash` CLI on its PATH. It can read transcripts, notebooks, tables, and files that your teammates' coding agents push to this workspace — so it knows what the rest of your team is working on.
 
 ## See your workspace
 
 Open [app.joinstash.ai](https://app.joinstash.ai) to browse your workspace's transcripts and team activity.
 
-## Examples of questions your agent might want answered
-
-- "Why did Sam bump the rate limit from 100 to 500?"
-- "Has anyone already tried fixing the memory leak in our backend?"
-- "Is anyone else currently working on our api gateway?"
-
-You can read a blog post about it here: [Agent velocity for coding teams](https://henrydowling.com/agent-velocity.html)
-
 ## Commands your agent can now use
 
-- `stash history search "<query>"` — full-text search across transcripts
-- `stash history query --agent <name>` — pull a specific agent's events
+```
+stash history search "<query>"          # full-text search across transcripts
+stash history query --agent <name>      # pull a specific agent's events
+stash notebooks list --all              # browse shared notebooks
+stash tables list --ws <workspace_id>   # list workspace tables
+stash files list --ws <workspace_id>    # list workspace files
+```
 
 Run `stash --help` to see everything.
 
@@ -35,10 +32,10 @@ Run `stash --help` to see everything.
 **A:** No.
 
 **Q:** What gets pushed to the shared store?
-**A:** For sessions in this repo (and its worktrees): prompts, assistant replies, summarized tool activity, and the full session transcript (.jsonl) at session end. Other repos push nothing unless you widen scope. Transcripts are stored verbatim — no secret scrubbing yet.
+**A:** For sessions in this repo (and its worktrees): prompts, assistant replies, summarized tool activity, and the full session transcript at session end. Other repos push nothing unless you widen scope.
 
 **Q:** Where can I see my conversation transcripts?
-**A:** Open your workspace in the browser: [app.joinstash.ai](https://app.joinstash.ai). (If you self-host, browse to your own frontend instead.)
+**A:** Open your workspace in the browser: [app.joinstash.ai](https://app.joinstash.ai).
 
 **Q:** How do I share my workspace with my team?
-**A:** Share the invite code (`stash workspaces info <id>` prints it). Teammates run `stash connect` if needed, then `stash workspaces join <invite_code>`.
+**A:** `stash invite create --ws <workspace_id>` generates a magic-link invite. Teammates click the link or run `stash connect` and paste the code.


### PR DESCRIPTION
## Summary
- Bump Claude plugin version `0.1.4` → `0.1.5` so installs pick up the latest changes
- Rewrite `welcome.md` — uses `joinstash.ai` domain, shows notebooks/tables/files/invite commands, removes stale content
- Add `bump-plugin-version.yml` GitHub Action that auto-increments the plugin patch version on every push to main (no more manual bumps)

## Test plan
- [ ] Merge and verify the auto-bump workflow creates a follow-up commit incrementing to `0.1.6`
- [ ] Update the stash plugin in a Claude Code session and confirm `/stash:welcome` renders the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)