### PR TITLE
fix: disambiguate stash CLI in plugin context injection

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -12,7 +12,8 @@ from typing import TypedDict
 USER_CONFIG_DIR = Path.home() / ".stash"
 USER_CONFIG_FILE = USER_CONFIG_DIR / "config.json"
 
-MANIFEST_FILE = ".stash"
+MANIFEST_DIR = ".stash"
+MANIFEST_FILE = ".stash/stash.json"
 
 PRODUCTION_BASE_URL = "https://api.joinstash.ai"
 
@@ -30,7 +31,7 @@ DEFAULT_CONFIG = {
 
 
 def find_project_manifest(start: Path | None = None) -> Path | None:
-    """Walk up from cwd looking for a .stash file (not directory) at a repo root."""
+    """Walk up from cwd looking for a .stash file at a repo root."""
     cur = (start or Path.cwd()).resolve()
     for parent in [cur, *cur.parents]:
         candidate = parent / MANIFEST_FILE

--- a/cli/config.py
+++ b/cli/config.py
@@ -12,8 +12,7 @@ from typing import TypedDict
 USER_CONFIG_DIR = Path.home() / ".stash"
 USER_CONFIG_FILE = USER_CONFIG_DIR / "config.json"
 
-MANIFEST_DIR = ".stash"
-MANIFEST_FILE = ".stash/stash.json"
+MANIFEST_FILE = ".stash"
 
 PRODUCTION_BASE_URL = "https://api.joinstash.ai"
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1905,7 +1905,6 @@ def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
     if base_url != PRODUCTION_BASE_URL:
         manifest["base_url"] = base_url
 
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     console.print(f"  Wrote [cyan]{MANIFEST_FILE}[/cyan]")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1905,6 +1905,7 @@ def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
     if base_url != PRODUCTION_BASE_URL:
         manifest["base_url"] = base_url
 
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     console.print(f"  Wrote [cyan]{MANIFEST_FILE}[/cyan]")
 

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -1,6 +1,6 @@
 # Stash Plugin
 
-IMPORTANT: You have the `stash` CLI on your PATH. When the user mentions "Stash", their workspace, team activity, or transcripts, always use this CLI — not Render, MCP tools, or any other service. Run `stash --help` to see all available commands.
+IMPORTANT: You have the `stash` CLI on your PATH. When the user mentions "Stash", their workspace, team activity, or transcripts, always use this CLI. Run `stash --help` to see all available commands.
 
 ## Stash CLI
 

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -1,8 +1,6 @@
 # Stash Plugin
 
-You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, notebooks, and history from your team's shared Stash workspace.
-
-Your activity in this repo is also streamed to that workspace, so teammates' agents and humans can see what you're working on.
+IMPORTANT: You have the `stash` CLI on your PATH. When the user mentions "Stash", their workspace, team activity, or transcripts, always use this CLI — not Render, MCP tools, or any other service. Run `stash --help` to see all available commands.
 
 ## Stash CLI
 

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -54,6 +54,6 @@ stash workspaces members <workspace_id>     # List workspace members
 ```
 
 ### Tips
-- Workspace is determined from the `.stash/stash.json` manifest in the repo
+- Workspace is determined from the `.stash` manifest in the repo
 - Use `--json` flag on any command for JSON output
 - The CLI reads config from `~/.stash/config.json`

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -123,7 +123,7 @@ stash notebooks list --all                                       # List all note
 stash workspaces list --mine                                     # List your workspaces
 ```
 
-Workspace is determined from the `.stash/stash.json` manifest in the repo.
+Workspace is determined from the `.stash` manifest in the repo.
 
 ---
 

--- a/plugins/claude-plugin/commands/curate.md
+++ b/plugins/claude-plugin/commands/curate.md
@@ -42,7 +42,7 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Steps
 
-1. **Determine workspace.** Workspace ID comes from the `.stash/stash.json`
+1. **Determine workspace.** Workspace ID comes from the `.stash`
    manifest in the repo (or an ancestor). If no manifest exists, run
    `stash workspaces list --mine --json` and pick the matching workspace.
 

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -34,7 +34,7 @@ def _build_context() -> str:
 
     parts = [
         "IMPORTANT: You have the `stash` CLI installed at your disposal. "
-        "When the user asks about Stash, their workspace, team activity, or transcripts. ",
+        "When the user asks about Stash, their workspace, team activity, or transcripts, you can use this CLI. ",
     ]
 
     if api_url:

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -33,10 +33,8 @@ def _build_context() -> str:
     workspace_id = cfg.get("workspace_id", "") or _load_cli_config().get("default_workspace", "")
 
     parts = [
-        "You have the `stash` CLI on your PATH. Run `stash --help` to see commands. "
-        "Use it to read transcripts, notebooks, and history from your team's shared "
-        "Stash workspace. Your activity in this repo is streamed to that workspace, "
-        "so teammates' agents and humans can see what you're working on.",
+        "IMPORTANT: You have the `stash` CLI installed at your disposal. "
+        "When the user asks about Stash, their workspace, team activity, or transcripts. ",
     ]
 
     if api_url:
@@ -49,11 +47,12 @@ def _build_context() -> str:
             parts.append(f"The Stash web dashboard is at {web_url} .")
 
     parts.append(
-        "Common reads (all support `--json`): "
-        "`stash history search \"<query>\"`, "
-        "`stash history query --limit 20`, "
-        "`stash history agents`, "
-        "`stash notebooks list --all`."
+        "Key commands (all support `--json`): "
+        "`stash history search \"<query>\"` (full-text search), "
+        "`stash history query --limit 20` (recent events), "
+        "`stash notebooks list --all` (shared notebooks), "
+        "`stash tables list` (workspace tables), "
+        "`stash files list` (workspace files)."
     )
 
     return " ".join(parts)

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -6,7 +6,7 @@ system with a stable `notify` fallback for older builds.
 ## Prerequisites
 
 - `stash` CLI installed and logged in
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ and `httpx`
 - Codex CLI with `features.codex_hooks = true` enabled for hook-based streaming
 

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -7,7 +7,7 @@ point).
 ## Prerequisites
 
 - `stash` CLI installed and logged in (`pip install stashai && stash login`)
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)
 

--- a/plugins/gemini-plugin/README.md
+++ b/plugins/gemini-plugin/README.md
@@ -5,7 +5,7 @@ Streams Gemini CLI sessions to an Stash workspace.
 ## Prerequisites
 
 - `stash` CLI installed and logged in
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ and `httpx` (`pip install httpx`)
 - Gemini CLI ≥ the version that shipped `hooks` in `settings.json`
 

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -36,7 +36,7 @@ Python script. The Python side imports from `stashai.plugin` (shipped via
 # Prereqs (one-time)
 pip install stashai httpx
 stash connect
-# Ensure .stash/stash.json manifest exists in your repo
+# Ensure .stash manifest exists in your repo
 
 # Install the extension
 openclaw plugins install github:Fergana-Labs/stash#plugins/openclaw-plugin

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -5,7 +5,7 @@ Streams opencode sessions to an Stash workspace.
 ## Prerequisites
 
 - `stash` CLI installed and logged in
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ and `httpx`
 - opencode installed (Bun-based runtime — opencode transpiles TS directly, no build step needed)
 

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -1,9 +1,7 @@
 """Scope gate — manifest presence is the only opt-in signal.
 
-The gate checks for `.stash/stash.json` walking up from cwd:
-- Repo-level manifest in cwd or ancestor → in scope.
-- Global manifest at `~/.stash/stash.json` → in scope (implicitly covered
-  by the walk-up if `$HOME` is above cwd; the mechanism is the same).
+The gate checks for a flat `.stash` file walking up from cwd:
+- Repo-level `.stash` in cwd or ancestor → in scope.
 - Nothing → out of scope.
 
 Regression test: out-of-scope sessions must short-circuit before any event
@@ -21,14 +19,12 @@ from stashai.plugin.event import HookEvent
 
 
 def test_manifest_in_cwd_is_in_scope(tmp_path):
-    (tmp_path / ".stash").mkdir()
-    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1}')
+    (tmp_path / ".stash").write_text('{"workspace_id": "test"}')
     assert scope_mod.cwd_in_scope(str(tmp_path))
 
 
 def test_manifest_in_ancestor_is_in_scope(tmp_path):
-    (tmp_path / ".stash").mkdir()
-    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1}')
+    (tmp_path / ".stash").write_text('{"workspace_id": "test"}')
     sub = tmp_path / "packages" / "foo"
     sub.mkdir(parents=True)
     assert scope_mod.cwd_in_scope(str(sub))
@@ -44,17 +40,12 @@ def test_empty_cwd_rejected():
 
 
 def test_repo_manifest_wins_over_shallower_one(tmp_path):
-    # A repo-level manifest under an ancestor with its own manifest should
-    # still be in scope — the walk-up finds the nearest first.
-    (tmp_path / ".stash").mkdir()
-    (tmp_path / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "A"}')
+    (tmp_path / ".stash").write_text('{"workspace_id": "A"}')
 
     repo = tmp_path / "projects" / "repo"
-    (repo / ".stash").mkdir(parents=True)
-    (repo / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "B"}')
+    repo.mkdir(parents=True)
+    (repo / ".stash").write_text('{"workspace_id": "B"}')
 
-    # Both cwds resolve to in-scope; routing (which workspace) is read by the
-    # plugin separately via get_config(), not the scope gate.
     assert scope_mod.cwd_in_scope(str(repo))
     assert scope_mod.cwd_in_scope(str(tmp_path))
 
@@ -63,8 +54,7 @@ def test_worktree_resolves_to_main_repo_manifest(tmp_path, monkeypatch):
     """A git worktree without its own manifest should find the main repo's manifest."""
     main_repo = tmp_path / "main-repo"
     main_repo.mkdir()
-    (main_repo / ".stash").mkdir()
-    (main_repo / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "W"}')
+    (main_repo / ".stash").write_text('{"workspace_id": "W"}')
 
     worktree = tmp_path / "worktree-checkout"
     worktree.mkdir()
@@ -79,16 +69,12 @@ def test_worktree_resolves_to_main_repo_manifest(tmp_path, monkeypatch):
 
 
 def test_worktree_manifest_beats_global(tmp_path, monkeypatch):
-    """Main repo manifest takes precedence over a global ~/.stash/ manifest."""
+    """Main repo manifest takes precedence over an ancestor's .stash file."""
     main_repo = tmp_path / "main-repo"
     main_repo.mkdir()
-    (main_repo / ".stash").mkdir()
-    (main_repo / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "company"}')
+    (main_repo / ".stash").write_text('{"workspace_id": "company"}')
 
-    # Simulate a global manifest in an ancestor of the worktree
-    global_stash = tmp_path / ".stash"
-    global_stash.mkdir()
-    (global_stash / "stash.json").write_text('{"version": 1, "workspace_id": "personal"}')
+    (tmp_path / ".stash").write_text('{"workspace_id": "personal"}')
 
     worktree = tmp_path / "worktrees" / "feature"
     worktree.mkdir(parents=True)
@@ -106,13 +92,11 @@ def test_main_repo_manifest_beats_worktree_local(tmp_path, monkeypatch):
     """Main repo manifest wins even if the worktree has its own."""
     main_repo = tmp_path / "main-repo"
     main_repo.mkdir()
-    (main_repo / ".stash").mkdir()
-    (main_repo / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "main"}')
+    (main_repo / ".stash").write_text('{"workspace_id": "main"}')
 
     worktree = tmp_path / "worktree-checkout"
     worktree.mkdir()
-    (worktree / ".stash").mkdir()
-    (worktree / ".stash" / "stash.json").write_text('{"version": 1, "workspace_id": "local"}')
+    (worktree / ".stash").write_text('{"workspace_id": "local"}')
 
     monkeypatch.setattr(
         scope_mod, "_git_repo_info", lambda cwd: (worktree, main_repo)

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -6,7 +6,7 @@ system with a stable `notify` fallback for older builds.
 ## Prerequisites
 
 - `stash` CLI installed and logged in
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ and `httpx`
 - Codex CLI with `features.codex_hooks = true` enabled for hook-based streaming
 

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -7,7 +7,7 @@ point).
 ## Prerequisites
 
 - `stash` CLI installed and logged in (`pip install stashai && stash login`)
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)
 

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -5,7 +5,7 @@ Streams opencode sessions to an Stash workspace.
 ## Prerequisites
 
 - `stash` CLI installed and logged in
-- `.stash/stash.json` manifest present in repo (or ancestor)
+- `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ and `httpx`
 - opencode installed (Bun-based runtime — opencode transpiles TS directly, no build step needed)
 

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -1,6 +1,6 @@
-"""Plugin hooks only push events when a `.stash` file is discoverable from cwd
-(in the current directory or any ancestor), or from the main worktree when cwd
-is inside a git worktree.
+"""Plugin hooks only push events when a `.stash/stash.json` manifest is
+discoverable from cwd (in the current directory or any ancestor), or from the
+main worktree when cwd is inside a git worktree.
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ import json
 import subprocess
 from pathlib import Path
 
-_MANIFEST_FILE = ".stash"
+_MANIFEST_FILE = ".stash/stash.json"
 
 
 def _git_repo_info(cwd: Path) -> tuple[Path | None, Path | None]:
@@ -41,7 +41,7 @@ def _git_repo_info(cwd: Path) -> tuple[Path | None, Path | None]:
 
 
 def find_manifest(cwd: str | None) -> dict | None:
-    """Return the parsed `.stash` manifest for cwd.
+    """Return the parsed `.stash/stash.json` manifest for cwd.
 
     If inside a git repo, checks the main worktree root (works for both
     regular checkouts and linked worktrees). Falls back to walking up
@@ -71,5 +71,5 @@ def find_manifest(cwd: str | None) -> dict | None:
 
 
 def cwd_in_scope(cwd: str | None) -> bool:
-    """True if a `.stash` manifest file exists in cwd or any ancestor."""
+    """True if a `.stash/stash.json` manifest exists in cwd or any ancestor."""
     return find_manifest(cwd) is not None

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -1,6 +1,6 @@
-"""Plugin hooks only push events when a `.stash/stash.json` manifest is
-discoverable from cwd (in the current directory or any ancestor), or from the
-main worktree when cwd is inside a git worktree.
+"""Plugin hooks only push events when a `.stash` manifest file is discoverable
+from cwd (in the current directory or any ancestor), or from the main worktree
+when cwd is inside a git worktree.
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ import json
 import subprocess
 from pathlib import Path
 
-_MANIFEST_FILE = ".stash/stash.json"
+_MANIFEST_FILE = ".stash"
 
 
 def _git_repo_info(cwd: Path) -> tuple[Path | None, Path | None]:
@@ -41,7 +41,7 @@ def _git_repo_info(cwd: Path) -> tuple[Path | None, Path | None]:
 
 
 def find_manifest(cwd: str | None) -> dict | None:
-    """Return the parsed `.stash/stash.json` manifest for cwd.
+    """Return the parsed `.stash` manifest for cwd.
 
     If inside a git repo, checks the main worktree root (works for both
     regular checkouts and linked worktrees). Falls back to walking up
@@ -71,5 +71,5 @@ def find_manifest(cwd: str | None) -> dict | None:
 
 
 def cwd_in_scope(cwd: str | None) -> bool:
-    """True if a `.stash/stash.json` manifest exists in cwd or any ancestor."""
+    """True if a `.stash` manifest file exists in cwd or any ancestor."""
     return find_manifest(cwd) is not None

--- a/stashai/plugin/sleep_prompt.py
+++ b/stashai/plugin/sleep_prompt.py
@@ -48,7 +48,7 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Steps
 
-1. **Determine workspace.** Workspace ID comes from the `.stash/stash.json`
+1. **Determine workspace.** Workspace ID comes from the `.stash`
    manifest in the repo (or an ancestor). If no manifest exists, run
    `stash workspaces list --mine --json` and pick the matching workspace.
 


### PR DESCRIPTION
## Summary
- Prefix SessionStart `additionalContext` with `IMPORTANT:` and explicitly tell the model to use the stash CLI, not Render/MCP tools
- Strengthen CLAUDE.md with the same disambiguation
- Model was consistently reaching for Render MCP when users asked about "Stash workspace" despite having the CLI on PATH

## Test plan
- [ ] Merge, update plugin, start a new session, ask "Do you have access to Stash?" — should mention the CLI immediately
- [ ] Ask "What can you see in our Stash workspace?" — should run `stash` commands, not call Render

🤖 Generated with [Claude Code](https://claude.com/claude-code)