### PR TITLE
fix: default streaming to on, use deny-list for stash stop

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -129,43 +129,27 @@ def clear_config() -> None:
 # --- Streaming toggle ---
 
 
-def _streaming_set() -> set[str]:
+def _stopped_set() -> set[str]:
     if USER_CONFIG_FILE.exists():
-        val = _read_json(USER_CONFIG_FILE).get("streaming")
+        val = _read_json(USER_CONFIG_FILE).get("stopped_streaming")
         if isinstance(val, list):
             return set(val)
     return set()
 
 
 def is_streaming(workspace_id: str) -> bool:
-    return workspace_id in _streaming_set()
+    return workspace_id not in _stopped_set()
 
 
 def set_streaming(workspace_id: str) -> None:
-    ids = _streaming_set()
-    ids.add(workspace_id)
-    _write_to(USER_CONFIG_FILE, {"streaming": sorted(ids)})
+    ids = _stopped_set()
+    ids.discard(workspace_id)
+    _write_to(USER_CONFIG_FILE, {"stopped_streaming": sorted(ids)})
 
 
 def clear_streaming(workspace_id: str) -> None:
-    ids = _streaming_set()
-    ids.discard(workspace_id)
-    _write_to(USER_CONFIG_FILE, {"streaming": sorted(ids)})
-
-
-def _hints_shown_set() -> set[str]:
-    if USER_CONFIG_FILE.exists():
-        val = _read_json(USER_CONFIG_FILE).get("hints_shown")
-        if isinstance(val, list):
-            return set(val)
-    return set()
-
-
-def is_hint_shown(workspace_id: str) -> bool:
-    return workspace_id in _hints_shown_set()
-
-
-def mark_hint_shown(workspace_id: str) -> None:
-    ids = _hints_shown_set()
+    ids = _stopped_set()
     ids.add(workspace_id)
-    _write_to(USER_CONFIG_FILE, {"hints_shown": sorted(ids)})
+    _write_to(USER_CONFIG_FILE, {"stopped_streaming": sorted(ids)})
+
+

--- a/cli/main.py
+++ b/cli/main.py
@@ -1852,7 +1852,7 @@ def _handle_not_member(ws_id: str, client: StashClient) -> None:
     if existing and existing.get("status") == "approved":
         console.print(
             "  [green]✓[/green] Your request was approved! "
-            "Run [cyan]stash start[/cyan] to begin streaming."
+            "Streaming is now active."
         )
         return
 
@@ -1914,7 +1914,7 @@ def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
 
     console.print(
         f"\n  Commit [cyan]{MANIFEST_FILE}[/cyan] and [cyan]CLAUDE.md[/cyan] and push. "
-        "Teammates will see a prompt to run [cyan]stash start[/cyan]."
+        "Teammates will start streaming automatically."
     )
 
 
@@ -2205,7 +2205,7 @@ def leave_cmd():
 
 @app.command("start")
 def start_cmd():
-    """Start streaming transcripts to this repo's workspace."""
+    """Resume streaming transcripts (undoes `stash stop`)."""
     cfg = _require_auth()
 
     manifest = load_manifest()

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -13,7 +13,6 @@ Never call `stream_session_end` from a per-turn hook — you'll emit a bogus
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 from stashai.plugin.event import HookEvent
@@ -42,14 +41,6 @@ def _read_user_config() -> dict:
         return {}
 
 
-def _write_user_config(updates: dict) -> None:
-    import json
-    existing = _read_user_config()
-    existing.update(updates)
-    _CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    _CONFIG_FILE.write_text(json.dumps(existing, indent=2) + "\n")
-
-
 def _is_agent_enabled(cfg: dict) -> bool:
     data = _read_user_config()
     enabled = data.get("enabled_agents")
@@ -60,21 +51,9 @@ def _is_agent_enabled(cfg: dict) -> bool:
     return canonical in enabled
 
 
-def _is_streaming(workspace_id: str) -> bool:
-    streaming = _read_user_config().get("streaming")
-    return isinstance(streaming, list) and workspace_id in streaming
-
-
-def _is_hint_shown(workspace_id: str) -> bool:
-    hints = _read_user_config().get("hints_shown")
-    return isinstance(hints, list) and workspace_id in hints
-
-
-def _mark_hint_shown(workspace_id: str) -> None:
-    data = _read_user_config()
-    hints = set(data.get("hints_shown") or [])
-    hints.add(workspace_id)
-    _write_user_config({"hints_shown": sorted(hints)})
+def _is_stopped(workspace_id: str) -> bool:
+    stopped = _read_user_config().get("stopped_streaming")
+    return isinstance(stopped, list) and workspace_id in stopped
 
 
 def _resolve_workspace(cfg: dict, event: HookEvent | None) -> str | None:
@@ -95,8 +74,8 @@ def _resolve_workspace(cfg: dict, event: HookEvent | None) -> str | None:
 def _short_circuit(cfg: dict, event: HookEvent | None) -> tuple[bool, str | None]:
     """Return (should_skip, workspace_id).
 
-    Streams only if the user has opted in via `stash start`.
-    Shows a one-time hint for workspaces the user hasn't opted into yet.
+    Streams by default to any workspace with a manifest. Only skips if the
+    user explicitly ran `stash stop`.
     """
     if not _is_agent_enabled(cfg):
         return True, None
@@ -105,18 +84,10 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> tuple[bool, str | None
     if not workspace_id:
         return True, None
 
-    if _is_streaming(workspace_id):
-        return False, workspace_id
+    if _is_stopped(workspace_id):
+        return True, None
 
-    if not _is_hint_shown(workspace_id):
-        print(
-            f"\nThis repo streams to Stash workspace {workspace_id[:8]}…\n"
-            f"Run `stash start` to begin sharing.\n",
-            file=sys.stderr,
-        )
-        _mark_hint_shown(workspace_id)
-
-    return True, None
+    return False, workspace_id
 
 
 # --- Prompt streaming ---


### PR DESCRIPTION
## Summary
- Streaming was gated behind an allowlist (`streaming` in `~/.stash/config.json`) requiring an explicit `stash start` to opt in. Repos with a valid `.stash/stash.json` manifest silently never streamed until the user discovered the extra step.
- Flipped to a deny-list model (`stopped_streaming`): connected repos stream by default, `stash stop` adds to the deny-list, `stash start` removes from it.
- Removed the one-time hint machinery (`_is_hint_shown`, `_mark_hint_shown`) since streaming is now automatic.

## Test plan
- [x] Existing plugin tests pass (59/59)
- [ ] Verify a repo with `.stash/stash.json` streams without running `stash start`
- [ ] Verify `stash stop` adds workspace to `stopped_streaming` and halts streaming
- [ ] Verify `stash start` removes workspace from `stopped_streaming` and resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)