### PR TITLE
feat: import historical conversations from coding agents

### DIFF
--- a/backend/migrations/versions/0020_unique_transcript_session.py
+++ b/backend/migrations/versions/0020_unique_transcript_session.py
@@ -1,0 +1,32 @@
+"""Add unique constraint on session_transcripts(workspace_id, session_id).
+
+Prevents duplicate imports of the same conversation.
+
+Revision ID: 0020
+Revises: 0019
+"""
+
+from alembic import op
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS idx_transcripts_ws_session"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX idx_transcripts_ws_session "
+        "ON session_transcripts(workspace_id, session_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_transcripts_ws_session")
+    op.execute(
+        "CREATE INDEX idx_transcripts_ws_session "
+        "ON session_transcripts(workspace_id, session_id)"
+    )

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -50,6 +50,7 @@ async def upload_transcript(
         "INSERT INTO session_transcripts "
         "(workspace_id, session_id, agent_name, storage_key, size_bytes, cwd, uploaded_by) "
         "VALUES ($1, $2, $3, $4, $5, $6, $7) "
+        "ON CONFLICT (workspace_id, session_id) DO NOTHING "
         "RETURNING id, workspace_id, session_id, agent_name, size_bytes, cwd, uploaded_by, uploaded_at",
         workspace_id,
         session_id,
@@ -59,6 +60,8 @@ async def upload_transcript(
         cwd,
         current_user["id"],
     )
+    if not row:
+        raise HTTPException(status_code=409, detail="Transcript already exists for this session")
     return SessionTranscriptResponse(**dict(row), download_url=None)
 
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -260,6 +260,7 @@ class StashClient:
         tool_name: str | None = None,
         metadata: dict | None = None,
         attachments: list[dict] | None = None,
+        created_at: str | None = None,
     ) -> dict:
         body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
         if session_id:
@@ -270,6 +271,8 @@ class StashClient:
             body["metadata"] = metadata
         if attachments:
             body["attachments"] = attachments
+        if created_at:
+            body["created_at"] = created_at
         return self._post(f"/api/v1/workspaces/{workspace_id}/memory/events", json=body)
 
     def query_events(
@@ -306,6 +309,37 @@ class StashClient:
         if event_type:
             params["event_type"] = event_type
         return self._list("/api/v1/me/history-events", "events", **params)
+
+    def push_events_batch(self, workspace_id: str, events: list[dict]) -> list:
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/memory/events/batch",
+            json={"events": events},
+        )
+
+    def upload_transcript(
+        self,
+        workspace_id: str,
+        session_id: str,
+        transcript_path: str,
+        agent_name: str,
+        cwd: str = "",
+    ) -> dict:
+        import gzip as _gzip
+
+        with open(transcript_path, "rb") as f:
+            raw = f.read()
+        body = _gzip.compress(raw)
+        name = os.path.basename(transcript_path)
+        if not name.endswith(".gz"):
+            name += ".gz"
+        resp = self._request(
+            "POST",
+            f"/api/v1/workspaces/{workspace_id}/transcripts",
+            data={"session_id": session_id, "agent_name": agent_name, "cwd": cwd},
+            files={"file": (name, body, "application/gzip")},
+            timeout=120,
+        )
+        return resp.json()
 
     # --- Files ---
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import mimetypes
 import os
+from pathlib import Path
 
 import httpx
 
@@ -320,7 +321,7 @@ class StashClient:
         self,
         workspace_id: str,
         session_id: str,
-        transcript_path: str,
+        transcript_path: str | Path,
         agent_name: str,
         cwd: str = "",
     ) -> dict:

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -1,0 +1,281 @@
+"""Discover and import historical conversations from coding agents.
+
+Supports Claude Code, Cursor, and Codex. Each agent stores conversations as
+.jsonl files in predictable locations under ~/.<agent>/. We discover them,
+extract lightweight metadata (session_id, cwd, timestamp, size), and upload
+them as transcript blobs + summary events.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+CURSOR_PROJECTS_DIR = Path.home() / ".cursor" / "projects"
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+
+
+@dataclass
+class ConversationInfo:
+    agent: str
+    session_id: str
+    path: Path
+    cwd: str
+    timestamp: datetime
+    size_bytes: int
+    user_messages: int = 0
+    extras: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Claude Code: ~/.claude/projects/<project-dir>/<uuid>.jsonl
+# First line is {type: "permission-mode", sessionId: "..."}.
+# Subsequent lines have {type, timestamp, cwd, sessionId}.
+# ---------------------------------------------------------------------------
+
+def _discover_claude() -> list[ConversationInfo]:
+    if not CLAUDE_PROJECTS_DIR.is_dir():
+        return []
+
+    results = []
+    for project_dir in CLAUDE_PROJECTS_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for jsonl in project_dir.glob("*.jsonl"):
+            info = _parse_claude_meta(jsonl)
+            if info:
+                results.append(info)
+    return results
+
+
+def _parse_claude_meta(path: Path) -> ConversationInfo | None:
+    size = path.stat().st_size
+    if size < 10:
+        return None
+
+    session_id = ""
+    cwd = ""
+    timestamp = None
+    user_count = 0
+
+    with open(path) as f:
+        for i, raw in enumerate(f):
+            if i > 50:
+                break
+            line = json.loads(raw)
+            if not session_id:
+                session_id = line.get("sessionId", "")
+            if not cwd and line.get("cwd"):
+                cwd = line["cwd"]
+            if not timestamp and line.get("timestamp"):
+                timestamp = _parse_iso(line["timestamp"])
+            if line.get("type") == "user":
+                user_count += 1
+                if user_count >= 3:
+                    break
+
+    if not session_id:
+        session_id = path.stem
+
+    if not timestamp:
+        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+    return ConversationInfo(
+        agent="claude",
+        session_id=session_id,
+        path=path,
+        cwd=cwd,
+        timestamp=timestamp,
+        size_bytes=size,
+        user_messages=user_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cursor: ~/.cursor/projects/<project-dir>/agent-transcripts/<id>/<id>.jsonl
+# Lines are {role: "user"/"assistant", message: {content: [...]}}
+# ---------------------------------------------------------------------------
+
+def _discover_cursor() -> list[ConversationInfo]:
+    if not CURSOR_PROJECTS_DIR.is_dir():
+        return []
+
+    results = []
+    for project_dir in CURSOR_PROJECTS_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        transcripts_dir = project_dir / "agent-transcripts"
+        if not transcripts_dir.is_dir():
+            continue
+        for session_dir in transcripts_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            for jsonl in session_dir.glob("*.jsonl"):
+                info = _parse_cursor_meta(jsonl, project_dir.name)
+                if info:
+                    results.append(info)
+    return results
+
+
+def _parse_cursor_meta(path: Path, project_dir_name: str) -> ConversationInfo | None:
+    size = path.stat().st_size
+    if size < 10:
+        return None
+
+    session_id = path.stem
+    cwd = project_dir_name.replace("-", "/")
+    if not cwd.startswith("/"):
+        cwd = "/" + cwd
+    timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    user_count = 0
+
+    with open(path) as f:
+        for i, raw in enumerate(f):
+            if i > 30:
+                break
+            line = json.loads(raw)
+            if line.get("role") == "user":
+                user_count += 1
+
+    return ConversationInfo(
+        agent="cursor",
+        session_id=session_id,
+        path=path,
+        cwd=cwd,
+        timestamp=timestamp,
+        size_bytes=size,
+        user_messages=user_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Codex: ~/.codex/sessions/<year>/<month>/<day>/<name>.jsonl
+# First line is {type: "session_meta", payload: {id, cwd, timestamp, ...}}
+# ---------------------------------------------------------------------------
+
+def _discover_codex() -> list[ConversationInfo]:
+    if not CODEX_SESSIONS_DIR.is_dir():
+        return []
+
+    results = []
+    for jsonl in CODEX_SESSIONS_DIR.rglob("*.jsonl"):
+        info = _parse_codex_meta(jsonl)
+        if info:
+            results.append(info)
+    return results
+
+
+def _parse_codex_meta(path: Path) -> ConversationInfo | None:
+    size = path.stat().st_size
+    if size < 10:
+        return None
+
+    session_id = ""
+    cwd = ""
+    timestamp = None
+
+    with open(path) as f:
+        raw = f.readline()
+        if not raw.strip():
+            return None
+        line = json.loads(raw)
+        if line.get("type") == "session_meta":
+            payload = line.get("payload", {})
+            session_id = payload.get("id", "")
+            cwd = payload.get("cwd", "")
+            ts_str = payload.get("timestamp") or line.get("timestamp")
+            if ts_str:
+                timestamp = _parse_iso(ts_str)
+
+    if not session_id:
+        session_id = path.stem
+
+    if not timestamp:
+        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+    return ConversationInfo(
+        agent="codex",
+        session_id=session_id,
+        path=path,
+        cwd=cwd,
+        timestamp=timestamp,
+        size_bytes=size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_AGENT_DISCOVERERS = {
+    "claude": _discover_claude,
+    "cursor": _discover_cursor,
+    "codex": _discover_codex,
+}
+
+
+def discover_conversations(agents: list[str] | None = None) -> list[ConversationInfo]:
+    """Find all historical conversations from the specified agents (default: all)."""
+    targets = agents or list(_AGENT_DISCOVERERS.keys())
+    results: list[ConversationInfo] = []
+    for agent in targets:
+        fn = _AGENT_DISCOVERERS.get(agent)
+        if fn:
+            results.extend(fn())
+    results.sort(key=lambda c: c.timestamp, reverse=True)
+    return results
+
+
+def summarize_discovery(conversations: list[ConversationInfo]) -> dict[str, dict]:
+    """Return {agent: {count, total_size_bytes}} for display."""
+    summary: dict[str, dict] = {}
+    for c in conversations:
+        if c.agent not in summary:
+            summary[c.agent] = {"count": 0, "total_size_bytes": 0}
+        summary[c.agent]["count"] += 1
+        summary[c.agent]["total_size_bytes"] += c.size_bytes
+    return summary
+
+
+def upload_conversation(client, workspace_id: str, conv: ConversationInfo) -> dict:
+    """Upload a single conversation transcript + push a summary event."""
+    result = client.upload_transcript(
+        workspace_id=workspace_id,
+        session_id=conv.session_id,
+        transcript_path=conv.path,
+        agent_name=conv.agent,
+        cwd=conv.cwd,
+    )
+
+    client.push_event(
+        workspace_id=workspace_id,
+        agent_name=conv.agent,
+        event_type="session_end",
+        content=f"Imported historical session ({_fmt_size(conv.size_bytes)})",
+        session_id=conv.session_id,
+        metadata={
+            "cwd": conv.cwd,
+            "imported": True,
+            "source": "history_import",
+        },
+        created_at=conv.timestamp.isoformat(),
+    )
+    return result
+
+
+def _parse_iso(s: str) -> datetime:
+    s = s.replace("Z", "+00:00")
+    return datetime.fromisoformat(s)
+
+
+def _fmt_size(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n // 1024} KB"
+    return f"{n // 1024 // 1024} MB"

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -8,11 +8,9 @@ them as transcript blobs + summary events.
 
 from __future__ import annotations
 
-import gzip
 import json
-import os
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
@@ -67,7 +65,10 @@ def _parse_claude_meta(path: Path) -> ConversationInfo | None:
         for i, raw in enumerate(f):
             if i > 50:
                 break
-            line = json.loads(raw)
+            try:
+                line = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
             if not session_id:
                 session_id = line.get("sessionId", "")
             if not cwd and line.get("cwd"):
@@ -83,7 +84,7 @@ def _parse_claude_meta(path: Path) -> ConversationInfo | None:
         session_id = path.stem
 
     if not timestamp:
-        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 
     return ConversationInfo(
         agent="claude",
@@ -131,14 +132,17 @@ def _parse_cursor_meta(path: Path, project_dir_name: str) -> ConversationInfo | 
     cwd = project_dir_name.replace("-", "/")
     if not cwd.startswith("/"):
         cwd = "/" + cwd
-    timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
     user_count = 0
 
     with open(path) as f:
         for i, raw in enumerate(f):
             if i > 30:
                 break
-            line = json.loads(raw)
+            try:
+                line = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
             if line.get("role") == "user":
                 user_count += 1
 
@@ -183,7 +187,10 @@ def _parse_codex_meta(path: Path) -> ConversationInfo | None:
         raw = f.readline()
         if not raw.strip():
             return None
-        line = json.loads(raw)
+        try:
+            line = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
         if line.get("type") == "session_meta":
             payload = line.get("payload", {})
             session_id = payload.get("id", "")
@@ -196,7 +203,7 @@ def _parse_codex_meta(path: Path) -> ConversationInfo | None:
         session_id = path.stem
 
     if not timestamp:
-        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 
     return ConversationInfo(
         agent="codex",

--- a/cli/main.py
+++ b/cli/main.py
@@ -2474,7 +2474,7 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
             try:
                 upload_conversation(c, ws, conv)
                 imported += 1
-            except Exception:
+            except StashError:
                 pass
             progress.advance(task)
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1112,6 +1112,78 @@ def hist_transcript(
     sys.stdout.write(body)
 
 
+@hist_app.command("import")
+def hist_import(
+    workspace_id: str = typer.Option(None, "--ws"),
+    agent_name: str = typer.Option(None, "--agent", help="Only import from this agent."),
+    limit: int = typer.Option(0, "-n", "--limit", help="Max conversations to import (0 = all)."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Import historical conversations from coding agents on this machine.
+
+    Discovers conversations from Claude Code, Cursor, and Codex, then uploads
+    them as transcripts to the workspace.
+    """
+    from .import_history import discover_conversations, summarize_discovery, upload_conversation
+
+    _require_auth()
+
+    agents = [agent_name] if agent_name else None
+    conversations = discover_conversations(agents)
+
+    if not conversations:
+        console.print("[dim]No historical conversations found.[/dim]")
+        raise typer.Exit(0)
+
+    summary = summarize_discovery(conversations)
+
+    if _use_json(as_json) and not yes:
+        output_json({"discovered": summary, "total": len(conversations)})
+        raise typer.Exit(0)
+
+    if not as_json:
+        console.print("\n[bold]Discovered conversations:[/bold]\n")
+        for ag, info in sorted(summary.items()):
+            sz = info["total_size_bytes"]
+            label = f"{sz // 1024 // 1024} MB" if sz > 1024 * 1024 else f"{sz // 1024} KB"
+            console.print(f"  {ag:<12} {info['count']:>4} conversations   ({label})")
+        console.print(f"\n  [bold]Total: {len(conversations)} conversations[/bold]")
+
+    if limit > 0:
+        conversations = conversations[:limit]
+
+    if not yes:
+        ok = questionary.confirm(
+            f"Import {len(conversations)} conversations into workspace?", default=True
+        ).ask()
+        if not ok:
+            raise typer.Exit(0)
+
+    ws = workspace_id or _resolve_workspace()
+
+    from rich.progress import Progress
+
+    imported = 0
+    errors = 0
+    with _client() as c, Progress(console=console) as progress:
+        task = progress.add_task("Importing…", total=len(conversations))
+        for conv in conversations:
+            try:
+                upload_conversation(c, ws, conv)
+                imported += 1
+            except StashError:
+                errors += 1
+            progress.advance(task)
+
+    if _use_json(as_json):
+        output_json({"imported": imported, "errors": errors})
+    else:
+        console.print(f"\n[green]Imported {imported} conversations.[/green]")
+        if errors:
+            console.print(f"[yellow]{errors} failed (likely already imported or too large).[/yellow]")
+
+
 # ===========================================================================
 # Tables
 # ===========================================================================
@@ -2124,6 +2196,9 @@ def login_cmd():
             except StashError as e:
                 console.print(f"[red]Could not connect repo: {e.detail}[/red]")
 
+    # --- Step 6: Import historical conversations ---
+    _onboarding_import_history(detected)
+
     _show_setup_complete_splash()
 
 
@@ -2364,6 +2439,46 @@ def _install_claude_plugin() -> bool:
         if last:
             console.print(f"  [green]✓[/green] {last[-1]}")
     return True
+
+
+def _onboarding_import_history(detected_agents: list[str]) -> None:
+    """Offer to import historical conversations during onboarding."""
+    from .import_history import discover_conversations, summarize_discovery, upload_conversation
+
+    agents = detected_agents or None
+    conversations = discover_conversations(agents)
+    if not conversations:
+        return
+
+    summary = summarize_discovery(conversations)
+    console.print("\n[bold]Historical conversations found:[/bold]\n")
+    for ag, info in sorted(summary.items()):
+        sz = info["total_size_bytes"]
+        label = f"{sz // 1024 // 1024} MB" if sz > 1024 * 1024 else f"{sz // 1024} KB"
+        console.print(f"  {ag:<12} {info['count']:>4} conversations   ({label})")
+
+    _reserve_bottom_padding(4)
+    ok = questionary.confirm(
+        f"Import {len(conversations)} historical conversations?", default=True
+    ).ask()
+    if not ok:
+        return
+
+    ws = _resolve_workspace()
+    from rich.progress import Progress
+
+    imported = 0
+    with _client() as c, Progress(console=console) as progress:
+        task = progress.add_task("Importing…", total=len(conversations))
+        for conv in conversations:
+            try:
+                upload_conversation(c, ws, conv)
+                imported += 1
+            except Exception:
+                pass
+            progress.advance(task)
+
+    console.print(f"  [green]��[/green] Imported {imported} conversations")
 
 
 def _show_setup_complete_splash() -> None:


### PR DESCRIPTION
## Summary
- Adds `stash history import` CLI command that discovers past conversations from Claude Code (`~/.claude/projects/`), Cursor (`~/.cursor/projects/`), and Codex (`~/.codex/sessions/`) and uploads them as transcript blobs + summary events
- Integrates into `stash login` onboarding — after repo connection, shows what was found and offers a one-click import
- Adds `upload_transcript` and `push_events_batch` methods to the CLI client

## Test plan
- [x] `stash history import --help` shows correct options
- [x] `stash history import --json` returns discovery summary without uploading
- [x] `stash history import --json --agent claude` filters to single agent
- [x] Discovery finds conversations from all three agents (tested: 529 Claude, 555 Codex, 50 Cursor on dev machine in 210ms)
- [x] Existing CLI tests pass
- [ ] Run `stash history import -n 3 --ws <id>` to verify actual upload against a live workspace
- [ ] Run `stash login` fresh to verify onboarding step appears after repo connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)