### PR TITLE
feat: welcome email on Auth0 signup; move email service to Postmark

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -54,8 +54,8 @@ class Settings:
     AUTH0_DOMAIN: str | None = os.getenv("AUTH0_DOMAIN")
     AUTH0_AUDIENCE: str | None = os.getenv("AUTH0_AUDIENCE")
 
-    # --- Email (Resend) ---
-    RESEND_API_KEY: str | None = os.getenv("RESEND_API_KEY")
+    # --- Email (Postmark) ---
+    POSTMARK_SERVER_TOKEN: str | None = os.getenv("POSTMARK_SERVER_TOKEN")
 
 
 settings = Settings()

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -1,8 +1,7 @@
 """Provision / rotate users from Auth0 identities."""
 
-import re
-
 import logging
+import re
 
 from backend.auth import create_api_key
 from backend.database import get_pool

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -2,9 +2,14 @@
 
 import re
 
+import logging
+
 from backend.auth import create_api_key
 from backend.database import get_pool
 from backend.services import workspace_service
+from backend.services.email_service import send_welcome_email
+
+logger = logging.getLogger(__name__)
 
 _NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
@@ -80,4 +85,12 @@ async def get_or_create_user_from_auth0(
         creator_id=user["id"],
         is_public=False,
     )
+
+    if email:
+        try:
+            first_name = (name or "").split()[0] if name else None
+            send_welcome_email(email, first_name=first_name)
+        except Exception:
+            logger.exception("Failed to send welcome email to %s", email)
+
     return user, api_key

--- a/backend/migrations/versions/0020_unique_transcript_session.py
+++ b/backend/migrations/versions/0020_unique_transcript_session.py
@@ -15,9 +15,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "DROP INDEX IF EXISTS idx_transcripts_ws_session"
-    )
+    op.execute("DROP INDEX IF EXISTS idx_transcripts_ws_session")
     op.execute(
         "CREATE UNIQUE INDEX idx_transcripts_ws_session "
         "ON session_transcripts(workspace_id, session_id)"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,4 +13,3 @@ sqlalchemy[asyncio]>=2.0.0
 umap-learn>=0.5.0
 python-jose[cryptography]>=3.3.0
 pypdf>=4.0
-resend>=2.0.0

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -1,23 +1,40 @@
-"""Email notifications via Resend."""
+"""Email notifications via Postmark.
+
+The www app uses the same provider for contact-sales submissions, so we
+standardize on Postmark across the product.
+"""
 
 import logging
+
+import httpx
 
 from ..config import settings
 
 logger = logging.getLogger(__name__)
 
+POSTMARK_URL = "https://api.postmarkapp.com/email"
+DEFAULT_FROM = "Stash <notifications@joinstash.ai>"
+FOUNDER_FROM = "Sam at Stash <sam@joinstash.ai>"
 
-def _get_resend():
-    if not settings.RESEND_API_KEY:
-        return None
-    try:
-        import resend
-    except ImportError:
-        logger.warning("resend package not installed, skipping email")
-        return None
 
-    resend.api_key = settings.RESEND_API_KEY
-    return resend
+def _send(payload: dict) -> None:
+    if not settings.POSTMARK_SERVER_TOKEN:
+        logger.info("Skipping email (POSTMARK_SERVER_TOKEN not set): %s", payload.get("Subject"))
+        return
+
+    payload.setdefault("MessageStream", "outbound")
+    res = httpx.post(
+        POSTMARK_URL,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Postmark-Server-Token": settings.POSTMARK_SERVER_TOKEN,
+        },
+        json=payload,
+        timeout=10.0,
+    )
+    if res.status_code >= 300:
+        logger.error("Postmark send failed (%s): %s", res.status_code, res.text)
 
 
 def send_join_request_email(
@@ -26,44 +43,98 @@ def send_join_request_email(
     workspace_name: str,
     workspace_id: str,
 ) -> None:
-    resend = _get_resend()
-    if not resend or not admin_emails:
-        logger.info("Skipping join request email (no Resend key or no admin emails)")
+    if not admin_emails:
         return
 
     review_url = f"{settings.PUBLIC_URL}/workspaces/{workspace_id}/requests"
+    html = (
+        f"<p><strong>{requester_name}</strong> requested to join "
+        f"<strong>{workspace_name}</strong> on Stash.</p>"
+        f'<p><a href="{review_url}">Review request</a></p>'
+    )
 
-    resend.Emails.send(
+    for admin in admin_emails:
+        _send(
+            {
+                "From": DEFAULT_FROM,
+                "To": admin,
+                "Subject": f"{requester_name} wants to join {workspace_name}",
+                "HtmlBody": html,
+            }
+        )
+
+
+def send_join_approved_email(user_email: str, workspace_name: str) -> None:
+    if not user_email:
+        return
+
+    _send(
         {
-            "from": "Stash <notifications@joinstash.ai>",
-            "to": admin_emails,
-            "subject": f"{requester_name} wants to join {workspace_name}",
-            "html": (
-                f"<p><strong>{requester_name}</strong> requested to join "
-                f"<strong>{workspace_name}</strong> on Stash.</p>"
-                f'<p><a href="{review_url}">Review request</a></p>'
+            "From": DEFAULT_FROM,
+            "To": user_email,
+            "Subject": f"You're in! Welcome to {workspace_name}",
+            "HtmlBody": (
+                f"<p>Your request to join <strong>{workspace_name}</strong> has been approved.</p>"
+                "<p>Next time you run a stash command in the repo, streaming will start automatically.</p>"
             ),
         }
     )
 
 
-def send_join_approved_email(
-    user_email: str,
-    workspace_name: str,
-) -> None:
-    resend = _get_resend()
-    if not resend or not user_email:
-        logger.info("Skipping approval email (no Resend key or no user email)")
+def send_welcome_email(user_email: str, first_name: str | None = None) -> None:
+    if not user_email:
         return
 
-    resend.Emails.send(
+    base = settings.PUBLIC_URL.rstrip("/")
+    install_url = f"{base}/docs/quickstart"
+    repo_install_url = f"{base}/docs/cli"
+    workspaces_url = f"{base}/workspaces"
+
+    greeting = f"Hey {first_name}," if first_name else "Hey,"
+
+    html = f"""
+<p>{greeting}</p>
+
+<p>Thanks for signing up for Stash. You just joined a workspace where every Claude Code, Cursor, and Codex session your team runs becomes shared, queryable context.</p>
+
+<p><strong>Get to your first "aha" in ~2 minutes:</strong></p>
+
+<ol>
+  <li><a href="{install_url}"><strong>Install Stash</strong></a> on the machine where you run your coding agent. One line in your terminal.</li>
+  <li><strong>During install, we'll offer to import your existing Claude Code and Cursor history.</strong> Say yes. It means your workspace is useful from day one instead of starting empty.</li>
+  <li><strong>Run a coding agent like you normally would.</strong> Stash captures the session in the background.</li>
+  <li><strong>Ask the agent something only Stash would know.</strong></li>
+</ol>
+
+<p><strong>What teams use Stash for:</strong></p>
+
+<ul>
+  <li>Live docs for an engineering team, kept in sync with a GitHub repo.</li>
+  <li>A shared repository of papers and blog posts, so the team stays up to date without re-sending links.</li>
+  <li>A knowledge base for marketing, sales, and content. Every brief, draft, and customer quote in one place.</li>
+  <li>Onboarding context for new hires: the decisions, dead-ends, and "why we did X" that never made it into the README.</li>
+  <li>Customer research and call notes pooled across PM, design, and GTM.</li>
+  <li>On-call runbooks and incident retros, queryable by the next person paged.</li>
+</ul>
+
+<p><strong>Bring your team in.</strong> One person using Stash is a personal log. A team using Stash is a shared brain.</p>
+
+<ul>
+  <li><a href="{repo_install_url}"><strong>Connect Stash to a GitHub repo</strong></a>. Adds a <code>stash.json</code> manifest and a Stash block to <code>CLAUDE.md</code>. Anyone running a coding agent in that repo is auto-connected, and the <code>CLAUDE.md</code> block is a live doc their agent reads to learn how to query the workspace.</li>
+  <li><a href="{workspaces_url}"><strong>Invite a teammate by email</strong></a>.</li>
+</ul>
+
+<p>Hit reply if anything's broken or confusing. It lands in my inbox directly.</p>
+
+<p>Sam<br>CEO, Stash</p>
+""".strip()
+
+    _send(
         {
-            "from": "Stash <notifications@joinstash.ai>",
-            "to": [user_email],
-            "subject": f"You're in! Welcome to {workspace_name}",
-            "html": (
-                f"<p>Your request to join <strong>{workspace_name}</strong> has been approved.</p>"
-                "<p>Next time you run a stash command in the repo, streaming will start automatically.</p>"
-            ),
+            "From": FOUNDER_FROM,
+            "To": user_email,
+            "ReplyTo": "sam@joinstash.ai",
+            "Subject": "Welcome to Stash, let's get your first session captured",
+            "HtmlBody": html,
         }
     )

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -36,6 +36,7 @@ class ConversationInfo:
 # Subsequent lines have {type, timestamp, cwd, sessionId}.
 # ---------------------------------------------------------------------------
 
+
 def _discover_claude() -> list[ConversationInfo]:
     if not CLAUDE_PROJECTS_DIR.is_dir():
         return []
@@ -102,6 +103,7 @@ def _parse_claude_meta(path: Path) -> ConversationInfo | None:
 # Lines are {role: "user"/"assistant", message: {content: [...]}}
 # ---------------------------------------------------------------------------
 
+
 def _discover_cursor() -> list[ConversationInfo]:
     if not CURSOR_PROJECTS_DIR.is_dir():
         return []
@@ -161,6 +163,7 @@ def _parse_cursor_meta(path: Path, project_dir_name: str) -> ConversationInfo | 
 # Codex: ~/.codex/sessions/<year>/<month>/<day>/<name>.jsonl
 # First line is {type: "session_meta", payload: {id, cwd, timestamp, ...}}
 # ---------------------------------------------------------------------------
+
 
 def _discover_codex() -> list[ConversationInfo]:
     if not CODEX_SESSIONS_DIR.is_dir():

--- a/cli/main.py
+++ b/cli/main.py
@@ -1181,7 +1181,9 @@ def hist_import(
     else:
         console.print(f"\n[green]Imported {imported} conversations.[/green]")
         if errors:
-            console.print(f"[yellow]{errors} failed (likely already imported or too large).[/yellow]")
+            console.print(
+                f"[yellow]{errors} failed (likely already imported or too large).[/yellow]"
+            )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Adds a welcome email fired from `get_or_create_user_from_auth0` on the new-user branch (covers joinstash.ai email+password signups).
- Migrates the email service off Resend and onto Postmark, the same provider the www contact-sales flow already uses. Existing `send_join_request_email` and `send_join_approved_email` are ported over.
- Drops the `resend` dependency and `RESEND_API_KEY` config.

Welcome email sender: `Sam at Stash <sam@joinstash.ai>`, ReplyTo `sam@joinstash.ai`.
Subject: "Welcome to Stash, let's get your first session captured".
Body: install link → import-existing-history note → "what teams use Stash for" use cases → repo connect + invite-by-email CTAs.

Self-hosted password signups (`/api/v1/users/register`) don't collect email today, so no welcome email there. Out of scope for this PR.

## Deploy
Set `POSTMARK_SERVER_TOKEN` on the backend (same token the www app uses). Once set, all three email sends (welcome, join-request, join-approved) start flowing through Postmark.

## Test plan
- [ ] Set `POSTMARK_SERVER_TOKEN` in staging
- [ ] Sign up a fresh Auth0 account; confirm welcome email lands and links resolve
- [ ] Sign in as a returning Auth0 user; confirm no duplicate welcome email
- [ ] Trigger a workspace join request; confirm admin notification still works on Postmark
- [ ] Approve a join request; confirm approval email still works on Postmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)