### PR TITLE
feat: HTML notebook pages (iframe-sandboxed)

### DIFF
--- a/backend/migrations/versions/0023_html_pages.py
+++ b/backend/migrations/versions/0023_html_pages.py
@@ -1,0 +1,33 @@
+"""Add HTML page support to notebook_pages.
+
+Pages are markdown by default. An HTML page stores its content in
+content_html and is rendered in a sandboxed iframe by the frontend, so
+even AI-generated HTML with <script> tags is safe to display.
+
+Revision ID: 0023
+Revises: 0022
+"""
+
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE notebook_pages ADD COLUMN IF NOT EXISTS content_type "
+        "VARCHAR(16) NOT NULL DEFAULT 'markdown' "
+        "CHECK (content_type IN ('markdown', 'html'))"
+    )
+    op.execute(
+        "ALTER TABLE notebook_pages ADD COLUMN IF NOT EXISTS content_html "
+        "TEXT NOT NULL DEFAULT ''"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE notebook_pages DROP COLUMN IF EXISTS content_html")
+    op.execute("ALTER TABLE notebook_pages DROP COLUMN IF EXISTS content_type")

--- a/backend/models.py
+++ b/backend/models.py
@@ -336,12 +336,16 @@ class PageCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     folder_id: UUID | None = None
     content: str = ""
+    content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
+    content_html: str = ""
 
 
 class PageUpdateRequest(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=255)
     folder_id: UUID | None = None
     content: str | None = None
+    content_type: str | None = Field(None, pattern=r"^(markdown|html)$")
+    content_html: str | None = None
     move_to_root: bool = False
 
 
@@ -351,6 +355,8 @@ class PageResponse(BaseModel):
     folder_id: UUID | None
     name: str
     content_markdown: str
+    content_type: str = "markdown"
+    content_html: str = ""
     content_hash: str | None = None
     metadata: dict = {}
     created_by: UUID

--- a/backend/routers/notebooks.py
+++ b/backend/routers/notebooks.py
@@ -145,6 +145,8 @@ async def create_ws_page(
             current_user["id"],
             folder_id=req.folder_id,
             content=req.content,
+            content_type=req.content_type,
+            content_html=req.content_html,
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))
@@ -206,6 +208,8 @@ async def update_ws_page(
             name=req.name,
             folder_id=req.folder_id,
             content=req.content,
+            content_type=req.content_type,
+            content_html=req.content_html,
             move_to_root=req.move_to_root,
         )
     except DuplicatePageName as e:

--- a/backend/services/notebook_service.py
+++ b/backend/services/notebook_service.py
@@ -30,6 +30,24 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
 
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(html: str) -> str:
+    """Strip tags so HTML pages can be embedded/searched as plain text."""
+    return _HTML_TAG_RE.sub(" ", html)
+
+
+def _active_content(content_type: str, content_markdown: str, content_html: str) -> str:
+    """Return the canonical text representation for hashing/embedding.
+
+    HTML pages are stripped to plain text so embeddings stay meaningful.
+    """
+    if content_type == "html":
+        return _strip_html(content_html)
+    return content_markdown
+
+
 # Dedup map for in-flight embed tasks: only one embed per page at a time.
 # Keyed by page_id; newer calls cancel the pending task.
 _embed_tasks: dict[UUID, asyncio.Task] = {}
@@ -170,21 +188,28 @@ async def create_page(
     folder_id: UUID | None = None,
     content: str = "",
     metadata: dict | None = None,
+    content_type: str = "markdown",
+    content_html: str = "",
 ) -> dict:
     pool = get_pool()
-    ch = _content_hash(content)
+    active = _active_content(content_type, content, content_html)
+    ch = _content_hash(active)
     meta = metadata or {}
     try:
         row = await pool.fetchrow(
             "INSERT INTO notebook_pages "
-            "(notebook_id, folder_id, name, content_markdown, content_hash, metadata, created_by, updated_by) "
-            "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $7) "
-            "RETURNING id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
-            "created_by, updated_by, created_at, updated_at",
+            "(notebook_id, folder_id, name, content_markdown, content_html, content_type, "
+            "content_hash, metadata, created_by, updated_by) "
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $9) "
+            "RETURNING id, notebook_id, folder_id, name, content_markdown, content_html, "
+            "content_type, content_hash, metadata, created_by, updated_by, "
+            "created_at, updated_at",
             notebook_id,
             folder_id,
             name,
             content,
+            content_html,
+            content_type,
             ch,
             meta,
             created_by,
@@ -192,9 +217,11 @@ async def create_page(
     except asyncpg.UniqueViolationError as e:
         raise DuplicatePageName(notebook_id, folder_id, name) from e
     page = dict(row)
-    # Fire-and-forget: embed page + extract wiki links
-    if content:
-        _schedule_embed(page["id"], content)
+    # Fire-and-forget: embed page + extract wiki links. Wiki links are a
+    # markdown-only concept ([[page]] syntax), so HTML pages skip extraction.
+    if active:
+        _schedule_embed(page["id"], active)
+    if content_type == "markdown" and content:
         asyncio.create_task(_update_page_links(page["id"], notebook_id, content))
     # Re-resolve dangling links from other pages that might reference this new page
     asyncio.create_task(_resolve_dangling_links(notebook_id, name, page["id"]))
@@ -204,7 +231,8 @@ async def create_page(
 async def get_page(page_id: UUID, notebook_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
+        "SELECT id, notebook_id, folder_id, name, content_markdown, content_html, "
+        "content_type, content_hash, metadata, "
         "created_by, updated_by, created_at, updated_at "
         "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
         page_id,
@@ -244,6 +272,8 @@ async def update_page(
     name: str | None = None,
     folder_id: UUID | None = None,
     content: str | None = None,
+    content_type: str | None = None,
+    content_html: str | None = None,
     move_to_root: bool = False,
     metadata: dict | None = None,
     on_conflict: Callable[[dict], Awaitable[str]] | None = None,
@@ -261,18 +291,22 @@ async def update_page(
     Bounded to MAX_UPDATE_RETRIES attempts.
     """
     pool = get_pool()
+    content_changed = content is not None or content_type is not None or content_html is not None
 
     for attempt in range(MAX_UPDATE_RETRIES):
         expected_hash: str | None = None
-        if content is not None:
+        current_type: str | None = None
+        if content_changed:
             current = await pool.fetchrow(
-                "SELECT content_hash FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
+                "SELECT content_hash, content_type, content_markdown, content_html "
+                "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
                 page_id,
                 notebook_id,
             )
             if current is None:
                 return None
             expected_hash = current["content_hash"]
+            current_type = current["content_type"]
 
         sets = ["updated_at = now()", "updated_by = $1"]
         args: list = [updated_by]
@@ -292,8 +326,22 @@ async def update_page(
             sets.append(f"content_markdown = ${idx}")
             args.append(content)
             idx += 1
+        if content_html is not None:
+            sets.append(f"content_html = ${idx}")
+            args.append(content_html)
+            idx += 1
+        if content_type is not None:
+            sets.append(f"content_type = ${idx}")
+            args.append(content_type)
+            idx += 1
+        if content_changed:
+            # Hash over the active content for the post-update state.
+            new_type = content_type or current_type or "markdown"
+            new_md = content if content is not None else (current["content_markdown"] if current else "")
+            new_html = content_html if content_html is not None else (current["content_html"] if current else "")
+            new_active = _active_content(new_type, new_md, new_html)
             sets.append(f"content_hash = ${idx}")
-            args.append(_content_hash(content))
+            args.append(_content_hash(new_active))
             idx += 1
         if metadata is not None:
             sets.append(f"metadata = ${idx}::jsonb")
@@ -310,7 +358,8 @@ async def update_page(
         try:
             row = await pool.fetchrow(
                 f"UPDATE notebook_pages SET {', '.join(sets)} WHERE {where} "
-                "RETURNING id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
+                "RETURNING id, notebook_id, folder_id, name, content_markdown, content_html, "
+                "content_type, content_hash, metadata, "
                 "created_by, updated_by, created_at, updated_at",
                 *args,
             )
@@ -320,19 +369,23 @@ async def update_page(
             raise DuplicatePageName(notebook_id, folder_id, name or "") from e
         if row:
             page = dict(row)
-            if content is not None:
-                # Skip the embed if content hash didn't change — saves an OpenAI call
-                # on pure rename/folder-move/metadata updates that still pass content.
-                if page["content_hash"] != expected_hash:
-                    _schedule_embed(page["id"], content)
-                asyncio.create_task(_update_page_links(page["id"], notebook_id, content))
+            if content_changed and page["content_hash"] != expected_hash:
+                active = _active_content(
+                    page["content_type"], page["content_markdown"], page["content_html"]
+                )
+                _schedule_embed(page["id"], active)
+                if page["content_type"] == "markdown":
+                    asyncio.create_task(
+                        _update_page_links(page["id"], notebook_id, page["content_markdown"])
+                    )
             return page
 
         if expected_hash is None:
             return None
 
         fresh = await pool.fetchrow(
-            "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash, metadata, "
+            "SELECT id, notebook_id, folder_id, name, content_markdown, content_html, "
+            "content_type, content_hash, metadata, "
             "created_by, updated_by, created_at, updated_at "
             "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
             page_id,
@@ -355,7 +408,8 @@ async def update_page(
 
     logger.warning("update_page exhausted retries for page %s", page_id)
     fresh = await pool.fetchrow(
-        "SELECT id, notebook_id, folder_id, name, content_markdown, content_hash "
+        "SELECT id, notebook_id, folder_id, name, content_markdown, content_html, "
+        "content_type, content_hash "
         "FROM notebook_pages WHERE id = $1 AND notebook_id = $2",
         page_id,
         notebook_id,

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -179,7 +179,8 @@ async def inline_items(view: dict) -> list[dict]:
             if nb:
                 label = label or nb["name"]
                 pages = await pool.fetch(
-                    "SELECT id, name, content_markdown, updated_at FROM notebook_pages "
+                    "SELECT id, name, content_markdown, content_html, content_type, "
+                    "updated_at FROM notebook_pages "
                     "WHERE notebook_id = $1 ORDER BY name",
                     obj_id,
                 )
@@ -189,7 +190,9 @@ async def inline_items(view: dict) -> list[dict]:
                         {
                             "id": str(p["id"]),
                             "name": p["name"],
+                            "content_type": p["content_type"],
                             "content_markdown": p["content_markdown"],
+                            "content_html": p["content_html"],
                             "updated_at": p["updated_at"].isoformat(),
                         }
                         for p in pages
@@ -333,20 +336,23 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                         )
                         folder_id_map[f["id"]] = new_f
                     pages = await conn.fetch(
-                        "SELECT folder_id, name, content_markdown, content_hash, metadata "
+                        "SELECT folder_id, name, content_markdown, content_html, "
+                        "content_type, content_hash, metadata "
                         "FROM notebook_pages WHERE notebook_id = $1",
                         src_id,
                     )
                     for p in pages:
                         await conn.execute(
                             "INSERT INTO notebook_pages "
-                            "(notebook_id, folder_id, name, content_markdown, "
-                            "content_hash, metadata, created_by) "
-                            "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                            "(notebook_id, folder_id, name, content_markdown, content_html, "
+                            "content_type, content_hash, metadata, created_by) "
+                            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                             new_nb_id,
                             folder_id_map.get(p["folder_id"]) if p["folder_id"] else None,
                             p["name"],
                             p["content_markdown"] or "",
+                            p["content_html"] or "",
+                            p["content_type"],
                             p["content_hash"],
                             p["metadata"] or {},
                             forker_id,

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -319,20 +319,23 @@ async def fork_workspace(
                     folder_id_map[f["id"]] = new_folder_id
 
                 pages = await conn.fetch(
-                    "SELECT id, folder_id, name, content_markdown, content_hash, metadata "
+                    "SELECT id, folder_id, name, content_markdown, content_html, "
+                    "content_type, content_hash, metadata "
                     "FROM notebook_pages WHERE notebook_id = $1",
                     nb["id"],
                 )
                 for p in pages:
                     new_page_id = await conn.fetchval(
                         "INSERT INTO notebook_pages "
-                        "(notebook_id, folder_id, name, content_markdown, content_hash, "
-                        "metadata, created_by) "
-                        "VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+                        "(notebook_id, folder_id, name, content_markdown, content_html, "
+                        "content_type, content_hash, metadata, created_by) "
+                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id",
                         new_nb_id,
                         folder_id_map.get(p["folder_id"]) if p["folder_id"] else None,
                         p["name"],
                         p["content_markdown"] or "",
+                        p["content_html"] or "",
+                        p["content_type"],
                         p["content_hash"],
                         p["metadata"] or {},
                         forker_id,

--- a/cli/client.py
+++ b/cli/client.py
@@ -280,8 +280,15 @@ class StashClient:
         name: str,
         content: str = "",
         folder_id: str | None = None,
+        content_type: str = "markdown",
+        content_html: str = "",
     ) -> dict:
-        body: dict = {"name": name, "content": content}
+        body: dict = {
+            "name": name,
+            "content": content,
+            "content_type": content_type,
+            "content_html": content_html,
+        }
         if folder_id:
             body["folder_id"] = folder_id
         return self._post(

--- a/cli/main.py
+++ b/cli/main.py
@@ -1121,12 +1121,33 @@ def nb_add_page(
     name: str = typer.Argument(...),
     workspace_id: str = typer.Option(None, "--ws"),
     content: str = typer.Option(""),
+    page_type: str = typer.Option(
+        "markdown", "--type", help="Page type: markdown (default) or html.", case_sensitive=False
+    ),
+    html_file: str = typer.Option(
+        None, "--html-file", help="Local HTML file to load as content for an html page."
+    ),
     attach: list[str] = typer.Option(
         None, "--attach", help="Local file path to upload and embed (repeatable)."
     ),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Add a page to a notebook."""
+    """Add a page to a notebook. Use --type html and --html-file for AI-generated slides."""
+    page_type = page_type.lower()
+    if page_type not in ("markdown", "html"):
+        console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
+        raise typer.Exit(1)
+    if page_type == "html" and html_file:
+        if not Path(html_file).is_file():
+            console.print(f"[red]Not a file: {html_file}[/red]")
+            raise typer.Exit(1)
+        html_body = Path(html_file).read_text()
+    elif page_type == "html":
+        html_body = content  # caller can pass --content with raw HTML
+        content = ""
+    else:
+        html_body = ""
+
     with _client() as c:
         try:
             ws = workspace_id or _resolve_workspace()
@@ -1134,14 +1155,29 @@ def nb_add_page(
                 if not Path(p).is_file():
                     console.print(f"[red]Not a file: {p}[/red]")
                     raise typer.Exit(1)
-            body = _prepend_attachments(c, ws, content, attach)
-            data = c.create_page(ws, notebook_id, name, content=body)
+            if page_type == "markdown":
+                body = _prepend_attachments(c, ws, content, attach)
+            else:
+                body = ""
+                if attach:
+                    console.print("[yellow]--attach is ignored for html pages[/yellow]")
+            data = c.create_page(
+                ws,
+                notebook_id,
+                name,
+                content=body,
+                content_type=page_type,
+                content_html=html_body,
+            )
         except StashError as e:
             _err(e)
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]Page '{data['name']}' created.[/green]  ID: {data['id']}")
+        console.print(
+            f"[green]Page '{data['name']}' created.[/green]  ID: {data['id']}  "
+            f"Type: {data.get('content_type', 'markdown')}"
+        )
 
 
 @nb_app.command("read-page")
@@ -1162,7 +1198,10 @@ def nb_read_page(
         output_json(data)
     else:
         console.print(f"[bold]{data['name']}[/bold]\n")
-        console.print(data.get("content_markdown", ""))
+        if data.get("content_type") == "html":
+            console.print(data.get("content_html", ""))
+        else:
+            console.print(data.get("content_markdown", ""))
 
 
 @nb_app.command("edit-page")
@@ -1172,14 +1211,43 @@ def nb_edit_page(
     content: str = typer.Option(None, "--content"),
     name: str = typer.Option(None, "--name"),
     workspace_id: str = typer.Option(None, "--ws"),
+    page_type: str = typer.Option(
+        None, "--type", help="Switch the page to this type: markdown or html.", case_sensitive=False
+    ),
+    html_file: str = typer.Option(
+        None, "--html-file", help="Local HTML file to load as content_html."
+    ),
     attach: list[str] = typer.Option(
         None, "--attach", help="Local file path to upload and prepend (repeatable)."
     ),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Update a page. Reads from stdin if --content not given."""
+    """Update a page. Reads from stdin if --content not given.
+
+    For html pages: pass --html-file to replace content_html, or pipe HTML on
+    stdin and pass --type html.
+    """
+    html_body: str | None = None
+    if html_file:
+        if not Path(html_file).is_file():
+            console.print(f"[red]Not a file: {html_file}[/red]")
+            raise typer.Exit(1)
+        html_body = Path(html_file).read_text()
     if content is None and not sys.stdin.isatty():
         content = sys.stdin.read()
+    if page_type:
+        page_type = page_type.lower()
+        if page_type not in ("markdown", "html"):
+            console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
+            raise typer.Exit(1)
+    # If --html-file is set without --type, infer html.
+    if html_body is not None and page_type is None:
+        page_type = "html"
+    # If --type html and only --content (no --html-file), treat content as HTML.
+    if page_type == "html" and html_body is None and content is not None:
+        html_body = content
+        content = None
+
     with _client() as c:
         try:
             ws = workspace_id or _resolve_workspace()
@@ -1187,18 +1255,24 @@ def nb_edit_page(
                 if not Path(p).is_file():
                     console.print(f"[red]Not a file: {p}[/red]")
                     raise typer.Exit(1)
-            if attach:
+            if attach and page_type != "html":
                 base = (
                     content
                     if content is not None
                     else c.get_page(ws, notebook_id, page_id).get("content_markdown", "")
                 )
                 content = _prepend_attachments(c, ws, base, attach)
+            elif attach:
+                console.print("[yellow]--attach is ignored for html pages[/yellow]")
             kwargs = {}
             if content is not None:
                 kwargs["content"] = content
             if name is not None:
                 kwargs["name"] = name
+            if page_type is not None:
+                kwargs["content_type"] = page_type
+            if html_body is not None:
+                kwargs["content_html"] = html_body
             data = c.update_page(ws, notebook_id, page_id, **kwargs)
         except StashError as e:
             _err(e)

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -7,6 +7,7 @@ import AppShell from "../../components/AppShell";
 import { useBreadcrumbs, type Crumb } from "../../components/BreadcrumbContext";
 import NotebookTreeComponent from "../../components/workspace/FileTree";
 import MarkdownEditor, { SaveStatus } from "../../components/workspace/MarkdownEditor";
+import HtmlPageEditor from "../../components/workspace/HtmlPageEditor";
 import { useAuth } from "../../hooks/useAuth";
 import {
   listAllNotebooks,
@@ -323,8 +324,17 @@ function WikiPageInner() {
     if (!selectedNotebook) return;
     const name = prompt("Page name:");
     if (!name) return;
+    const typeRaw = (prompt("Page type — 'markdown' or 'html':", "markdown") || "markdown").trim().toLowerCase();
+    const content_type: "markdown" | "html" = typeRaw === "html" ? "html" : "markdown";
     try {
-      const p = await createPage(selectedNotebook.workspace_id, selectedNotebook.id, name, folderId || undefined);
+      const p = await createPage(
+        selectedNotebook.workspace_id,
+        selectedNotebook.id,
+        name,
+        folderId || undefined,
+        undefined,
+        { content_type },
+      );
       await loadTree(selectedNotebook);
       await loadWorkspacePages();
       setSelectedPageId(p.id);
@@ -405,6 +415,18 @@ function WikiPageInner() {
     if (!selectedNotebook || !selectedPageId) return;
     try {
       await updatePage(selectedNotebook.workspace_id, selectedNotebook.id, selectedPageId, { content });
+    } catch (err) { setError(err instanceof Error ? err.message : "Failed to save"); }
+  }, [selectedNotebook, selectedPageId]);
+
+  const handleSaveHtmlPage = useCallback(async (content_html: string) => {
+    if (!selectedNotebook || !selectedPageId) return;
+    try {
+      await updatePage(
+        selectedNotebook.workspace_id,
+        selectedNotebook.id,
+        selectedPageId,
+        { content_html, content_type: "html" },
+      );
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to save"); }
   }, [selectedNotebook, selectedPageId]);
 
@@ -595,6 +617,16 @@ function WikiPageInner() {
               {selectedPage ? (
                 <div className="flex-1 flex flex-col overflow-hidden">
                   <div className="flex-1 overflow-y-auto">
+                    {selectedPage.content_type === "html" ? (
+                      <div className="mx-auto w-full max-w-[1200px] px-6 py-4">
+                        <HtmlPageEditor
+                          key={selectedPage.id}
+                          file={selectedPage}
+                          onSave={handleSaveHtmlPage}
+                          onSaveStatusChange={setSaveStatus}
+                        />
+                      </div>
+                    ) : (
                     <MarkdownEditor
                       key={selectedPage.id}
                       notebookId={selectedNotebook.id}
@@ -606,6 +638,7 @@ function WikiPageInner() {
                       pageIndex={workspacePages}
                       onNavigateInternal={handleNavigateInternal}
                     />
+                    )}
 
                     {/* Backlinks */}
                     {backlinks.length > 0 && (

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import HtmlPageView from "../../../components/workspace/HtmlPageView";
 import ViewForkButton from "./ViewForkButton";
 
 const BACKEND_ORIGIN =
@@ -130,7 +131,16 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
   }
 
   if (item.object_type === "notebook") {
-    const inline = item.inline as { description?: string; pages?: { id: string; name: string; content_markdown: string }[] };
+    const inline = item.inline as {
+      description?: string;
+      pages?: {
+        id: string;
+        name: string;
+        content_type?: "markdown" | "html";
+        content_markdown: string;
+        content_html?: string;
+      }[];
+    };
     return (
       <div>
         {inline.description ? (
@@ -139,9 +149,15 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
         {(inline.pages ?? []).map((p) => (
           <div key={p.id} className="mb-6 last:mb-0">
             <h3 className="font-display text-[16px] font-bold text-ink">{p.name}</h3>
-            <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-background p-3 font-mono text-[12px] leading-[1.5] text-foreground">
-              {p.content_markdown || "(empty)"}
-            </pre>
+            {p.content_type === "html" ? (
+              <div className="mt-2">
+                <HtmlPageView html={p.content_html || ""} title={p.name} />
+              </div>
+            ) : (
+              <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-background p-3 font-mono text-[12px] leading-[1.5] text-foreground">
+                {p.content_markdown || "(empty)"}
+              </pre>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/components/workspace/HtmlPageEditor.tsx
+++ b/frontend/src/components/workspace/HtmlPageEditor.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import HtmlPageView from "./HtmlPageView";
+import { NotebookPage } from "../../lib/types";
+import type { SaveStatus } from "./MarkdownEditor";
+
+const AUTOSAVE_DEBOUNCE_MS = 1500;
+
+interface HtmlPageEditorProps {
+  file: NotebookPage;
+  onSave: (html: string) => void;
+  onSaveStatusChange?: (status: SaveStatus) => void;
+}
+
+// Split textarea + sandboxed iframe preview. Same 1500ms debounced autosave
+// as MarkdownEditor. The preview reuses HtmlPageView so the live preview
+// and the read-only renderer share an isolation boundary — what you see
+// here is exactly what readers will see.
+export default function HtmlPageEditor({
+  file,
+  onSave,
+  onSaveStatusChange,
+}: HtmlPageEditorProps) {
+  const [value, setValue] = useState(file.content_html);
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSaved = useRef(file.content_html);
+
+  // Pull in fresh content when the parent swaps to a different page.
+  useEffect(() => {
+    setValue(file.content_html);
+    lastSaved.current = file.content_html;
+    setDirty(false);
+  }, [file.id, file.content_html]);
+
+  useEffect(() => {
+    onSaveStatusChange?.(saving ? "saving" : dirty ? "dirty" : "saved");
+  }, [saving, dirty, onSaveStatusChange]);
+
+  function onChange(next: string) {
+    setValue(next);
+    setDirty(next !== lastSaved.current);
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      if (next === lastSaved.current) return;
+      setSaving(true);
+      try {
+        onSave(next);
+        lastSaved.current = next;
+        setDirty(false);
+      } finally {
+        setSaving(false);
+      }
+    }, AUTOSAVE_DEBOUNCE_MS);
+  }
+
+  return (
+    <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-2">
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        className="min-h-[60vh] w-full rounded-md border border-border-subtle bg-background p-3 font-mono text-[13px] leading-[1.5] text-foreground"
+        placeholder="<!doctype html>&#10;<html>&#10;  <body>&#10;    <h1>Hello</h1>&#10;  </body>&#10;</html>"
+      />
+      <div className="min-h-[60vh] overflow-hidden rounded-md border border-border-subtle bg-raised/30">
+        <HtmlPageView html={value} title={file.name} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+type Props = {
+  html: string;
+  title: string;
+};
+
+// HTML page renderer. The iframe sandbox is the entire defense — content
+// gets a unique opaque origin, can't read parent cookies/storage, can't
+// navigate the top frame. Scripts run, but in a vacuum, which is what
+// makes AI-generated HTML safe to display.
+export default function HtmlPageView({ html, title }: Props) {
+  return (
+    <iframe
+      srcDoc={html}
+      sandbox="allow-scripts"
+      title={title}
+      style={{
+        width: "100%",
+        aspectRatio: "16 / 9",
+        border: 0,
+        display: "block",
+      }}
+    />
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -356,11 +356,18 @@ export async function createPage(
   notebookId: string,
   name: string,
   folderId?: string,
-  content?: string
+  content?: string,
+  options?: { content_type?: "markdown" | "html"; content_html?: string }
 ): Promise<NotebookPage> {
   return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages`, {
     method: "POST",
-    body: JSON.stringify({ name, folder_id: folderId || null, content: content || "" }),
+    body: JSON.stringify({
+      name,
+      folder_id: folderId || null,
+      content: content || "",
+      content_type: options?.content_type ?? "markdown",
+      content_html: options?.content_html ?? "",
+    }),
   });
 }
 
@@ -376,7 +383,14 @@ export async function updatePage(
   workspaceId: string | null,
   notebookId: string,
   pageId: string,
-  data: { name?: string; folder_id?: string; content?: string; move_to_root?: boolean }
+  data: {
+    name?: string;
+    folder_id?: string;
+    content?: string;
+    content_type?: "markdown" | "html";
+    content_html?: string;
+    move_to_root?: boolean;
+  }
 ): Promise<NotebookPage> {
   return apiFetch(`${scope(workspaceId)}/notebooks/${notebookId}/pages/${pageId}`, {
     method: "PATCH",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -48,12 +48,16 @@ export interface Notebook {
   updated_at: string;
 }
 
+export type PageContentType = "markdown" | "html";
+
 export interface NotebookPage {
   id: string;
   notebook_id: string;
   folder_id: string | null;
   name: string;
+  content_type: PageContentType;
   content_markdown: string;
+  content_html: string;
   created_by: string;
   updated_by: string | null;
   created_at: string;


### PR DESCRIPTION
**Stacked on PR #219** — review #219 first; the View renderer changes here build on it.

## Summary
Adds an `html` page type alongside markdown so AI-generated slides, charts, dashboards, or any self-contained HTML document can live in a notebook. The renderer puts the content inside a sandboxed iframe (`sandbox="allow-scripts"`, no `allow-same-origin`), so even untrusted HTML with `<script>` tags can't reach the parent DOM, cookies, or storage.

## Architectural principle
The backend stores and renders, it does not generate. Agents (Claude Code, Cursor, the CLI, scripts) produce HTML locally and push it through the existing page endpoint. **No `/generate` endpoint, no model SDK in the backend, now or later.** This matches how the rest of Stash works.

## What's in the diff
- `0023` migration: `notebook_pages.content_type` (`'markdown'|'html'`) + `content_html`. Existing rows backfill to `'markdown'`.
- Backend service: writes both columns; `content_hash` computed over the active content (markdown or stripped-HTML); embeddings strip tags so semantic search keeps working on HTML; wiki-link extraction is a no-op for HTML pages.
- View inliner + workspace fork + view fork: clone `content_type` and `content_html` alongside `content_markdown`.
- Frontend `HtmlPageView`: the iframe sandbox itself. Used by both the live preview in the editor and the read-only renderer in `/v/[slug]` so what the author sees matches what readers see.
- Frontend `HtmlPageEditor`: textarea + live preview side-by-side, same 1500ms debounced autosave as `MarkdownEditor`.
- Notebook editor switches between Markdown and HTML editors based on `page.content_type`; page creation prompts for type.
- CLI: `stash notebooks add-page --type html --html-file slide.html` and same flags on `edit-page`.

## Security
- `sandbox="allow-scripts"` is the entire defense — opaque origin, no parent cookie/storage access, no top-frame navigation. `<script>` runs but in a vacuum.
- **Never** add `allow-same-origin`; that single token defeats the isolation.
- No HTML sanitization on the way in. The whole point is that we don't have to.
- The iframe can `fetch` external CDNs (fonts, charting libs) — accepted for now; lock down with a CSP `<meta>` later if needed.

## Suggested agent workflow
1. Agent generates a single self-contained HTML document locally.
2. Agent writes it to `/tmp/slide.html`.
3. Agent runs `stash notebooks add-page <nb-id> "Q4 retro" --type html --html-file /tmp/slide.html`.
4. Page is live in the workspace, and in any published View that includes it at `/v/<slug>`.

## Test plan
- [ ] `alembic upgrade head` runs cleanly through 0023; existing pages still readable; `SELECT content_type FROM notebook_pages LIMIT 1` returns `'markdown'`
- [ ] Existing markdown pages: editor and CLI behavior unchanged
- [ ] Create HTML page via CLI: `stash notebooks add-page <nb-id> "test" --type html --html-file /tmp/test.html`
- [ ] Sandbox check: include `<script>parent.document.title='pwned'</script>`; after save the parent title is **unchanged** (this is the test that matters)
- [ ] Add the HTML page to a View, publish, visit `/v/<slug>` in a private window — iframe renders, same isolation
- [ ] Semantic search returns HTML pages by their text content (proves tag-stripping)
- [ ] Frontend `tsc --noEmit` passes (verified locally)

## Out of scope
- A backend `/generate-html` endpoint — explicitly **not a goal** (see Architectural principle above)
- CodeMirror / syntax highlighting in the HTML editor — `<textarea>` is fine for v1
- Per-page configurable aspect ratio — defaults to 16:9
- Wiki-link semantics inside HTML pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)