### PR TITLE
fix: show helpful usage hints for bare `stash history`

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -952,8 +952,26 @@ def nb_edit_page(
 # History (was memory stores)
 # ===========================================================================
 
-hist_app = typer.Typer(help="History — structured agent event logs.")
+hist_app = typer.Typer(help="History — structured agent event logs.", invoke_without_command=True)
 app.add_typer(hist_app, name="history")
+
+
+@hist_app.callback()
+def hist_default(ctx: typer.Context):
+    """History — structured agent event logs."""
+    if ctx.invoked_subcommand is not None:
+        return
+    console.print(
+        "\n"
+        "  [bold]stash history[/bold] — browse your workspace's agent event log.\n"
+        "\n"
+        "  [#1e3a8a]stash history query --limit 20[/#1e3a8a]      recent events\n"
+        '  [#1e3a8a]stash history search "deploy"[/#1e3a8a]       full-text search\n'
+        "  [#1e3a8a]stash history agents[/#1e3a8a]                who's been active\n"
+        "  [#1e3a8a]stash history transcript <id>[/#1e3a8a]       fetch a full session transcript\n"
+        "\n"
+        "  Run [dim]stash history --help[/dim] for all commands.\n"
+    )
 
 
 @hist_app.command("agents")


### PR DESCRIPTION
## Summary
- Running `stash history` without a subcommand now shows a quick-reference of the most common commands instead of the generic "Missing command." error
- Uses the same `invoke_without_command` + callback pattern already used by the `invite` command group

## Test plan
- [ ] Run `stash history` — should show usage hints
- [ ] Run `stash history --help` — should still show full help
- [ ] Run `stash history query`, `stash history agents`, etc. — subcommands should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)