### PR TITLE
feat: accept Auth0 JWTs as alternative to API keys

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -117,6 +117,7 @@ async def _get_user_from_jwt(token: str) -> dict:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
 
     user = dict(row)
+    user["key_id"] = None
     uid = str(user["id"])
     now = time.monotonic()
     if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -77,14 +77,7 @@ def verify_password(password: str, password_hash: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-) -> dict:
-    token: str = credentials.credentials
-
-    if not token.startswith("mc_"):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-
+async def _get_user_from_api_key(token: str) -> dict:
     key_hash = hash_api_key(token)
     pool = get_pool()
     row = await pool.fetchrow(
@@ -107,6 +100,45 @@ async def get_current_user(
             "UPDATE user_api_keys SET last_used_at = now() WHERE id = $1", user["key_id"]
         )
     return user
+
+
+async def _get_user_from_jwt(token: str) -> dict:
+    from .config import settings
+    from .managed.auth0.jwt import validate_auth0_token
+
+    claims = await validate_auth0_token(token)
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, name, display_name, description, created_at, last_seen "
+        "FROM users WHERE auth0_sub = $1",
+        claims["sub"],
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
+
+    user = dict(row)
+    uid = str(user["id"])
+    now = time.monotonic()
+    if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:
+        _last_seen_written.set(uid, now)
+        await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", user["id"])
+    return user
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict:
+    token: str = credentials.credentials
+
+    if token.startswith("mc_"):
+        return await _get_user_from_api_key(token)
+
+    from .config import settings
+
+    if settings.AUTH0_ENABLED:
+        return await _get_user_from_jwt(token)
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
 
 async def get_current_user_optional(

--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ class Settings:
     PUBLIC_URL: str = os.getenv("PUBLIC_URL", "http://localhost:3457")
     CORS_ORIGINS: list[str] = [
         o.strip()
-        for o in os.getenv("CORS_ORIGINS", "http://localhost:3457,http://localhost:3456").split(",")
+        for o in os.getenv("CORS_ORIGINS", "http://localhost:3457,http://localhost:3456,http://localhost:3000").split(",")
         if o.strip()
     ]
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -95,12 +95,16 @@ async def logout(current_user: dict = Depends(get_current_user)):
     """Revoke the API key that authenticated this request. The caller must
     also drop the key client-side — this just ensures the key can't be reused
     if it was captured elsewhere."""
+    key_id = current_user.get("key_id")
+    if not key_id:
+        return None
+
     from ..database import get_pool
 
     pool = get_pool()
     await pool.execute(
         "UPDATE user_api_keys SET revoked_at = now() " "WHERE id = $1 AND revoked_at IS NULL",
-        current_user["key_id"],
+        key_id,
     )
     return None
 
@@ -114,7 +118,7 @@ async def update_me(req: UserUpdateRequest, current_user: dict = Depends(get_cur
             description=req.description,
             password=req.password,
             current_password=req.current_password,
-            current_key_id=current_user["key_id"],
+            current_key_id=current_user.get("key_id"),
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -107,14 +107,19 @@ async def update_user(
     )
 
     if password is not None:
-        # Revoke every other active key. The caller's key stays valid so the
-        # user doesn't get kicked out of the tab that just changed the password.
-        await pool.execute(
-            "UPDATE user_api_keys SET revoked_at = now() "
-            "WHERE user_id = $1 AND revoked_at IS NULL AND id <> $2",
-            user_id,
-            current_key_id,
-        )
+        if current_key_id is not None:
+            await pool.execute(
+                "UPDATE user_api_keys SET revoked_at = now() "
+                "WHERE user_id = $1 AND revoked_at IS NULL AND id <> $2",
+                user_id,
+                current_key_id,
+            )
+        else:
+            await pool.execute(
+                "UPDATE user_api_keys SET revoked_at = now() "
+                "WHERE user_id = $1 AND revoked_at IS NULL",
+                user_id,
+            )
     return dict(row)
 
 


### PR DESCRIPTION
## Summary
- Modifies `get_current_user()` to accept Auth0 JWTs alongside `mc_` API keys when `AUTH0_ENABLED=true`
- Looks up users by `auth0_sub` claim from the JWT, reusing the existing managed Auth0 JWT validation
- Adds `localhost:3000` to default CORS origins for local dev with stash_web

## Context
The web app (stash_web) uses Auth0 for authentication. Previously, calling core API endpoints from the web frontend required proxying through stash_web's backend or exchanging the JWT for an API key. This change lets the web app send its Auth0 JWT directly to the core API, enabling features like the session transcript viewer.

## Deploy checklist
- [ ] Add `https://app.joinstash.ai` to `CORS_ORIGINS` env var on Render

## Test plan
- [ ] Verify existing `mc_` API key auth still works (CLI, desktop app)
- [ ] Verify Auth0 JWT auth works from the web app
- [ ] Verify unauthenticated requests are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)