### PR TITLE
fix: scope transcript import to current repo directory

### DIFF
--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -229,14 +229,22 @@ _AGENT_DISCOVERERS = {
 }
 
 
-def discover_conversations(agents: list[str] | None = None) -> list[ConversationInfo]:
-    """Find all historical conversations from the specified agents (default: all)."""
+def discover_conversations(
+    agents: list[str] | None = None,
+    repo_dir: str | Path | None = None,
+) -> list[ConversationInfo]:
+    """Find historical conversations, optionally scoped to a repo directory."""
     targets = agents or list(_AGENT_DISCOVERERS.keys())
     results: list[ConversationInfo] = []
     for agent in targets:
         fn = _AGENT_DISCOVERERS.get(agent)
         if fn:
             results.extend(fn())
+
+    if repo_dir is not None:
+        prefix = str(Path(repo_dir).resolve())
+        results = [c for c in results if c.cwd and c.cwd.startswith(prefix)]
+
     results.sort(key=lambda c: c.timestamp, reverse=True)
     return results
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1492,7 +1492,7 @@ def hist_import(
     _require_auth()
 
     agents = [agent_name] if agent_name else None
-    conversations = discover_conversations(agents)
+    conversations = discover_conversations(agents, repo_dir=Path.cwd())
 
     if not conversations:
         console.print("[dim]No historical conversations found.[/dim]")


### PR DESCRIPTION
## Summary
- `stash history import` was discovering **all** conversations across every project on the machine (1133 on mine), instead of just the ones for the current repo
- Now filters by matching conversation `cwd` against `Path.cwd()`, so only conversations from the current repo are imported
- Also fixes the onboarding import flow which had the same bug

## Test plan
- [x] Run `stash history import --limit 5` from a specific repo — should only show conversations for that repo
- [ ] Run from a repo with no history — should show "No historical conversations found"
- [ ] Verify onboarding import also scopes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)