### PR TITLE
feat: session transcript viewer with Auth0 JWT auth

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -117,6 +117,7 @@ async def _get_user_from_jwt(token: str) -> dict:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
 
     user = dict(row)
+    user["key_id"] = None
     uid = str(user["id"])
     now = time.monotonic()
     if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -77,14 +77,7 @@ def verify_password(password: str, password_hash: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-) -> dict:
-    token: str = credentials.credentials
-
-    if not token.startswith("mc_"):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-
+async def _get_user_from_api_key(token: str) -> dict:
     key_hash = hash_api_key(token)
     pool = get_pool()
     row = await pool.fetchrow(
@@ -107,6 +100,45 @@ async def get_current_user(
             "UPDATE user_api_keys SET last_used_at = now() WHERE id = $1", user["key_id"]
         )
     return user
+
+
+async def _get_user_from_jwt(token: str) -> dict:
+    from .config import settings
+    from .managed.auth0.jwt import validate_auth0_token
+
+    claims = await validate_auth0_token(token)
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, name, display_name, description, created_at, last_seen "
+        "FROM users WHERE auth0_sub = $1",
+        claims["sub"],
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
+
+    user = dict(row)
+    uid = str(user["id"])
+    now = time.monotonic()
+    if now - _last_seen_written.get(uid) > _LAST_SEEN_DEBOUNCE_SECONDS:
+        _last_seen_written.set(uid, now)
+        await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", user["id"])
+    return user
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict:
+    token: str = credentials.credentials
+
+    if token.startswith("mc_"):
+        return await _get_user_from_api_key(token)
+
+    from .config import settings
+
+    if settings.AUTH0_ENABLED:
+        return await _get_user_from_jwt(token)
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
 
 async def get_current_user_optional(

--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ class Settings:
     PUBLIC_URL: str = os.getenv("PUBLIC_URL", "http://localhost:3457")
     CORS_ORIGINS: list[str] = [
         o.strip()
-        for o in os.getenv("CORS_ORIGINS", "http://localhost:3457,http://localhost:3456").split(",")
+        for o in os.getenv("CORS_ORIGINS", "http://localhost:3457,http://localhost:3456,http://localhost:3000").split(",")
         if o.strip()
     ]
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -95,12 +95,16 @@ async def logout(current_user: dict = Depends(get_current_user)):
     """Revoke the API key that authenticated this request. The caller must
     also drop the key client-side — this just ensures the key can't be reused
     if it was captured elsewhere."""
+    key_id = current_user.get("key_id")
+    if not key_id:
+        return None
+
     from ..database import get_pool
 
     pool = get_pool()
     await pool.execute(
         "UPDATE user_api_keys SET revoked_at = now() " "WHERE id = $1 AND revoked_at IS NULL",
-        current_user["key_id"],
+        key_id,
     )
     return None
 
@@ -114,7 +118,7 @@ async def update_me(req: UserUpdateRequest, current_user: dict = Depends(get_cur
             description=req.description,
             password=req.password,
             current_password=req.current_password,
-            current_key_id=current_user["key_id"],
+            current_key_id=current_user.get("key_id"),
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -107,14 +107,19 @@ async def update_user(
     )
 
     if password is not None:
-        # Revoke every other active key. The caller's key stays valid so the
-        # user doesn't get kicked out of the tab that just changed the password.
-        await pool.execute(
-            "UPDATE user_api_keys SET revoked_at = now() "
-            "WHERE user_id = $1 AND revoked_at IS NULL AND id <> $2",
-            user_id,
-            current_key_id,
-        )
+        if current_key_id is not None:
+            await pool.execute(
+                "UPDATE user_api_keys SET revoked_at = now() "
+                "WHERE user_id = $1 AND revoked_at IS NULL AND id <> $2",
+                user_id,
+                current_key_id,
+            )
+        else:
+            await pool.execute(
+                "UPDATE user_api_keys SET revoked_at = now() "
+                "WHERE user_id = $1 AND revoked_at IS NULL",
+                user_id,
+            )
     return dict(row)
 
 

--- a/www/app/history/[workspaceId]/[sessionId]/TranscriptViewer.tsx
+++ b/www/app/history/[workspaceId]/[sessionId]/TranscriptViewer.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import pako from "pako";
+
+type Props = {
+  apiUrl: string;
+  workspaceId: string;
+  sessionId: string;
+  accessToken: string;
+};
+
+type ContentBlock = {
+  type: string;
+  text?: string;
+  name?: string;
+};
+
+type TranscriptLine = {
+  type: string;
+  message?: { content?: string | ContentBlock[] };
+};
+
+type Message = {
+  role: "user" | "assistant";
+  text: string;
+  tools: string[];
+};
+
+function extractText(content: string | ContentBlock[] | undefined): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  return content
+    .filter((b) => b.type === "text" && b.text)
+    .map((b) => b.text!)
+    .join("\n");
+}
+
+function extractToolNames(content: string | ContentBlock[] | undefined): string[] {
+  if (!content || typeof content === "string") return [];
+  return content.filter((b) => b.type === "tool_use" && b.name).map((b) => b.name!);
+}
+
+export default function TranscriptViewer({ apiUrl, workspaceId, sessionId, accessToken }: Props) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [meta, setMeta] = useState<{ agent_name?: string; cwd?: string; uploaded_at?: string }>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const metaRes = await fetch(
+        `${apiUrl}/api/v1/workspaces/${workspaceId}/transcripts/${sessionId}`,
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+      if (!metaRes.ok) {
+        const detail = await metaRes.json().catch(() => ({}));
+        setError(detail.detail || `HTTP ${metaRes.status}`);
+        setLoading(false);
+        return;
+      }
+      const metaData = await metaRes.json();
+      setMeta(metaData);
+
+      if (!metaData.download_url) {
+        setError("No transcript content available");
+        setLoading(false);
+        return;
+      }
+
+      const contentRes = await fetch(metaData.download_url);
+      const buf = new Uint8Array(await contentRes.arrayBuffer());
+      let text: string;
+      if (buf[0] === 0x1f && buf[1] === 0x8b) {
+        text = new TextDecoder().decode(pako.ungzip(buf));
+      } else {
+        text = new TextDecoder().decode(buf);
+      }
+
+      const msgs: Message[] = [];
+      for (const line of text.split("\n")) {
+        if (!line.trim()) continue;
+        const obj: TranscriptLine = JSON.parse(line);
+        if (obj.type !== "user" && obj.type !== "assistant") continue;
+        const t = extractText(obj.message?.content);
+        const tools = extractToolNames(obj.message?.content);
+        if (!t && tools.length === 0) continue;
+        msgs.push({ role: obj.type as "user" | "assistant", text: t, tools });
+      }
+      setMessages(msgs);
+      setLoading(false);
+    })();
+  }, [apiUrl, workspaceId, sessionId, accessToken]);
+
+  if (error) {
+    return (
+      <div className="py-20 text-center">
+        <h2 className="font-display text-[24px] font-bold text-ink">Transcript not found</h2>
+        <p className="mt-2 text-dim">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {!loading && (
+        <div className="mb-6 flex items-center gap-2 font-mono text-[12px] text-muted">
+          {meta.agent_name && <span className="text-ink">{meta.agent_name}</span>}
+          {meta.cwd && (
+            <>
+              <span>&middot;</span>
+              <span>{meta.cwd}</span>
+            </>
+          )}
+          {meta.uploaded_at && (
+            <>
+              <span>&middot;</span>
+              <span>{new Date(meta.uploaded_at).toLocaleDateString()}</span>
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-3 pb-16">
+        {loading &&
+          Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className={`h-14 animate-pulse rounded-xl bg-raised ${i % 2 === 0 ? "ml-auto w-2/3" : "w-3/4"}`}
+            />
+          ))}
+
+        {messages.map((msg, i) => (
+          <div key={i}>
+            {msg.tools.length > 0 && (
+              <div className={`mb-1 flex gap-1 ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+                {msg.tools.map((name, j) => (
+                  <span
+                    key={j}
+                    className="rounded-md bg-agent-soft px-2 py-0.5 font-mono text-[11px] text-agent"
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+            )}
+            {msg.text && (
+              <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+                <div
+                  className={`max-w-[80%] rounded-xl px-4 py-3 text-[14px] leading-[1.6] whitespace-pre-wrap ${
+                    msg.role === "user"
+                      ? "bg-inverted text-on-inverted"
+                      : "bg-raised text-ink"
+                  }`}
+                >
+                  {msg.text}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/www/app/history/[workspaceId]/[sessionId]/page.tsx
+++ b/www/app/history/[workspaceId]/[sessionId]/page.tsx
@@ -1,0 +1,68 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import TranscriptViewer from "./TranscriptViewer";
+
+export const dynamic = "force-dynamic";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
+
+export default async function HistorySessionPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; sessionId: string }>;
+}) {
+  const { workspaceId, sessionId } = await params;
+
+  if (!AUTH0_ENABLED) {
+    return (
+      <Shell>
+        <p className="text-dim">Sign-in is not configured on this deployment.</p>
+      </Shell>
+    );
+  }
+
+  const { auth0 } = await import("@managed/auth0/client");
+  const returnTo = `/history/${workspaceId}/${sessionId}`;
+
+  const session = await auth0.getSession();
+  if (!session) {
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  let accessToken: string;
+  try {
+    const tokenResponse = await auth0.getAccessToken();
+    accessToken = tokenResponse.token;
+  } catch {
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  return (
+    <Shell>
+      <div className="mb-4 flex items-center justify-between">
+        <Link href="/" className="font-display text-[16px] font-bold text-ink hover:text-brand">
+          stash
+        </Link>
+        <span className="font-mono text-[11px] text-muted">
+          {(session.user?.email as string) || ""}
+        </span>
+      </div>
+      <TranscriptViewer
+        apiUrl={API_URL}
+        workspaceId={workspaceId}
+        sessionId={sessionId}
+        accessToken={accessToken}
+      />
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-[720px] px-6 pb-24 pt-12">{children}</div>
+    </main>
+  );
+}

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.17.0",
         "next": "16.1.6",
+        "pako": "^2.1.0",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pako": "^2.0.4",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
@@ -1022,6 +1024,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1537,6 +1546,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/www/package.json
+++ b/www/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.17.0",
     "next": "16.1.6",
+    "pako": "^2.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pako": "^2.0.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",


### PR DESCRIPTION
## Summary
- Adds Auth0 JWT support to `get_current_user()` — the core API now accepts Auth0 JWTs alongside `mc_` API keys when `AUTH0_ENABLED=true`
- Adds `/history/[workspaceId]/[sessionId]` page to `www/` that renders session transcripts in a chat bubble UI
- Page uses Auth0 server-side session to get an access token, calls the core API transcript endpoint directly

## How it works
1. User visits `joinstash.ai/history/{workspaceId}/{sessionId}`
2. Auth0 middleware checks session, redirects to login if needed
3. Server component gets Auth0 access token, passes to client component
4. Client fetches transcript metadata from core API (with JWT auth)
5. Client downloads gzipped JSONL from signed S3 URL, decompresses with pako
6. Renders user/assistant messages using existing design tokens

## Deploy checklist
- [ ] Add `https://joinstash.ai` to `CORS_ORIGINS` env var on Render (core API)

## Test plan
- [ ] Verify existing `mc_` API key auth still works (CLI, desktop app)
- [ ] Visit `/history/{workspaceId}/{sessionId}` while logged in — transcript loads
- [ ] Visit while logged out — redirects to Auth0 login, then back to transcript
- [ ] Visit with invalid session ID — shows "Transcript not found" error
- [ ] Verify `stash history share` CLI command generates correct URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)