### PR TITLE
feat: stash share + markdown views + text API

### DIFF
--- a/backend/routers/views.py
+++ b/backend/routers/views.py
@@ -2,7 +2,8 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import PlainTextResponse
 
 from ..auth import get_current_user
 from ..models import (
@@ -85,12 +86,22 @@ async def delete_view(
         raise HTTPException(status_code=404, detail="View not found")
 
 
-@public_router.get("/{slug}", response_model=ViewPublicResponse)
-async def get_public_view(slug: str):
+@public_router.get("/{slug}")
+async def get_public_view(
+    slug: str,
+    format: str = Query(None, alias="format"),
+):
     view = await view_service.get_public_view(slug)
     if not view:
         raise HTTPException(status_code=404, detail="View not found")
     items = await view_service.inline_items(view)
+
+    if format == "text":
+        return PlainTextResponse(
+            view_service.items_to_text(view["title"], items),
+            media_type="text/markdown",
+        )
+
     workspace_name = view.pop("_workspace_name", "")
     workspace_is_public = view.pop("_workspace_is_public", False)
     return ViewPublicResponse(

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -256,6 +256,44 @@ async def inline_items(view: dict) -> list[dict]:
     return out
 
 
+def items_to_text(title: str, items: list[dict]) -> str:
+    """Flatten a View's inlined items into readable markdown text."""
+    parts = [f"# {title}\n"]
+    for item in items:
+        obj_type = item["object_type"]
+        label = item.get("label", "")
+        inline = item.get("inline", {})
+        if not inline:
+            continue
+
+        if obj_type == "notebook":
+            for page in inline.get("pages", []):
+                if page.get("content_markdown"):
+                    parts.append(page["content_markdown"])
+        elif obj_type == "table":
+            cols = inline.get("columns", [])
+            rows = inline.get("rows", [])
+            if cols:
+                parts.append(f"## {label}\n")
+                header = " | ".join(c["name"] for c in cols)
+                sep = " | ".join("---" for _ in cols)
+                parts.append(f"| {header} |")
+                parts.append(f"| {sep} |")
+                for r in rows[:100]:
+                    vals = " | ".join(str(r["data"].get(c["name"], "")) for c in cols)
+                    parts.append(f"| {vals} |")
+                parts.append("")
+        elif obj_type == "file":
+            parts.append(f"*Attached file: {label} ({inline.get('content_type', 'unknown')})*\n")
+        elif obj_type == "history":
+            parts.append(f"**{inline.get('agent_name', '')}** ({inline.get('event_type', '')})")
+            if inline.get("content"):
+                parts.append(inline["content"])
+            parts.append("")
+
+    return "\n\n".join(parts)
+
+
 async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict | None:
     """Create a new private workspace containing only the items in the view.
 

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -274,15 +274,13 @@ def items_to_text(title: str, items: list[dict]) -> str:
             cols = inline.get("columns", [])
             rows = inline.get("rows", [])
             if cols:
-                parts.append(f"## {label}\n")
                 header = " | ".join(c["name"] for c in cols)
                 sep = " | ".join("---" for _ in cols)
-                parts.append(f"| {header} |")
-                parts.append(f"| {sep} |")
+                table_lines = [f"## {label}", "", f"| {header} |", f"| {sep} |"]
                 for r in rows[:100]:
                     vals = " | ".join(str(r["data"].get(c["name"], "")) for c in cols)
-                    parts.append(f"| {vals} |")
-                parts.append("")
+                    table_lines.append(f"| {vals} |")
+                parts.append("\n".join(table_lines))
         elif obj_type == "file":
             parts.append(f"*Attached file: {label} ({inline.get('content_type', 'unknown')})*\n")
         elif obj_type == "history":

--- a/cli/main.py
+++ b/cli/main.py
@@ -1658,7 +1658,10 @@ def _transcript_to_markdown(raw_jsonl: str) -> str:
         raw_line = raw_line.strip()
         if not raw_line:
             continue
-        obj = json.loads(raw_line)
+        try:
+            obj = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            continue
 
         msg = obj.get("message")
         if not msg:

--- a/cli/main.py
+++ b/cli/main.py
@@ -795,6 +795,183 @@ def fork(
 
 
 # ===========================================================================
+# Share — publish a session artifact as a public View
+# ===========================================================================
+
+
+def _find_session_jsonl(session_id: str) -> Path | None:
+    """Locate the .jsonl file for a given session ID under ~/.claude/projects/."""
+    projects = Path.home() / ".claude" / "projects"
+    if not projects.is_dir():
+        return None
+    for project_dir in projects.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for jsonl in project_dir.glob("*.jsonl"):
+            with open(jsonl) as f:
+                for i, raw in enumerate(f):
+                    if i > 5:
+                        break
+                    try:
+                        line = json.loads(raw)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if line.get("sessionId") == session_id:
+                        return jsonl
+    return None
+
+
+def _current_session_id() -> str | None:
+    """Read the active session ID from the Stash plugin state file."""
+    state_file = Path.home() / ".claude" / "plugins" / "data" / "stash" / "state.json"
+    if not state_file.exists():
+        return None
+    try:
+        data = json.loads(state_file.read_text())
+        return data.get("session_id") or None
+    except Exception:
+        return None
+
+
+def _extract_artifact(raw_jsonl: str) -> tuple[str, str, str]:
+    """Extract (title, first_user_prompt, last_assistant_message) from a transcript.
+
+    Returns the bookends of the conversation: the question that kicked it off
+    and the final answer — which is usually the investigation summary.
+    """
+    first_user = ""
+    last_assistant = ""
+    title = ""
+
+    for raw_line in raw_jsonl.splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            obj = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        if obj.get("type") == "ai-title":
+            title = obj.get("aiTitle") or obj.get("title") or ""
+            continue
+
+        msg = obj.get("message")
+        if not msg:
+            continue
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if not content:
+            continue
+
+        blocks = content if isinstance(content, list) else [{"type": "text", "text": content}]
+        text_parts = []
+        for block in blocks:
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text", "").strip():
+                text_parts.append(block["text"].strip())
+
+        if not text_parts:
+            continue
+        combined = "\n\n".join(text_parts)
+
+        if role == "user" and not first_user:
+            first_user = combined
+        elif role == "assistant":
+            last_assistant = combined
+
+    return title, first_user, last_assistant
+
+
+@app.command("share")
+def share_session(
+    title: str = typer.Option("", "--title", "-t", help="Title for the shared artifact."),
+    session_id: str = typer.Option("", "--session", "-s", help="Session ID. Auto-detected if omitted."),
+    files: list[str] = typer.Option([], "--file", "-f", help="Files to attach (repeatable)."),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Share a session as a public artifact with a shareable link.
+
+    Publishes a curated summary (the question + finding), the full conversation
+    transcript, and any attached files as a single public View.
+    """
+    _require_auth()
+    ws = workspace_id or _resolve_workspace()
+
+    # Resolve session ID
+    sid = session_id or _current_session_id()
+    if not sid:
+        console.print("[red]Could not detect session. Pass --session <id> explicitly.[/red]")
+        raise typer.Exit(1)
+
+    # Find and read the JSONL transcript
+    jsonl_path = _find_session_jsonl(sid)
+    if not jsonl_path:
+        console.print(f"[red]Transcript file not found for session {sid[:8]}…[/red]")
+        raise typer.Exit(1)
+
+    raw_jsonl = jsonl_path.read_text(errors="replace")
+    ai_title, first_user, last_assistant = _extract_artifact(raw_jsonl)
+
+    if not last_assistant:
+        console.print("[red]No assistant messages found in this session.[/red]")
+        raise typer.Exit(1)
+
+    page_title = title or ai_title or f"Session {sid[:8]}"
+
+    # Build the summary page
+    summary_parts = []
+    if first_user:
+        summary_parts.append(f"## Question\n\n{first_user}")
+    summary_parts.append(f"## Finding\n\n{last_assistant}")
+    summary_md = "\n\n---\n\n".join(summary_parts)
+
+    # Build the full transcript page
+    full_md = _transcript_to_markdown(raw_jsonl)
+
+    console.print(f"[dim]Sharing session {sid[:8]}…[/dim]")
+
+    with _client() as c:
+        # Create notebook with two pages: Summary + Full Transcript
+        nb = c.create_notebook(ws, page_title, description="Shared session artifact")
+        c.create_page(ws, nb["id"], "Summary", content=summary_md)
+        c.create_page(ws, nb["id"], "Full Transcript", content=full_md)
+
+        view_items: list[dict] = [
+            {"object_type": "notebook", "object_id": nb["id"], "position": 0},
+        ]
+
+        # Upload attached files
+        for fp in files:
+            p = Path(fp)
+            if not p.exists():
+                console.print(f"[yellow]Skipping {fp} (not found)[/yellow]")
+                continue
+            uploaded = c.upload_ws_file(ws, str(p))
+            view_items.append({
+                "object_type": "file",
+                "object_id": uploaded["id"],
+                "position": len(view_items),
+                "label_override": p.name,
+            })
+            console.print(f"  [dim]Attached {p.name}[/dim]")
+
+        # Upload the full transcript blob
+        c.upload_transcript(ws, sid, str(jsonl_path), agent_name="claude", cwd=str(jsonl_path.parent))
+
+        # Create the public View
+        view = c.create_view(
+            ws,
+            title=page_title,
+            description="Shared session artifact",
+            is_public=True,
+            items=view_items,
+        )
+
+    public_url = f"{_web_app_url()}/v/{view['slug']}"
+    console.print(f"\n[green bold]Shared![/green bold]  {public_url}")
+
+
+# ===========================================================================
 # Views (curated subsets of a workspace, publishable as their own URL)
 # ===========================================================================
 

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import HtmlPageView from "../../../components/workspace/HtmlPageView";
 import ViewForkButton from "./ViewForkButton";
@@ -154,9 +156,11 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
                 <HtmlPageView html={p.content_html || ""} title={p.name} />
               </div>
             ) : (
-              <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-background p-3 font-mono text-[12px] leading-[1.5] text-foreground">
-                {p.content_markdown || "(empty)"}
-              </pre>
+              <div className="mt-2 markdown-content">
+                <Markdown remarkPlugins={[remarkGfm]}>
+                  {p.content_markdown || "(empty)"}
+                </Markdown>
+              </div>
             )}
           </div>
         ))}

--- a/plans/sharing-demo.md
+++ b/plans/sharing-demo.md
@@ -1,0 +1,123 @@
+# Sharing Demo — Script & Build Plan
+
+## The Story
+
+Henry investigates something in Claude Code. He shares his **finding** to Stash — not a raw transcript, but a packaged artifact: a curated summary on top, the full conversation and any generated files underneath. He gets a link. Sam pastes that link into his own Claude Code and asks questions about it.
+
+---
+
+## Demo Script
+
+### Scene 1: The Investigation (Henry's terminal, ~60s)
+
+Henry is in Claude Code, working in the Stash repo.
+
+> **Henry:** "There's been a spike in 401s on the transcript upload endpoint. Can you investigate?"
+
+Claude digs in — reads logs, checks the auth middleware, traces the token validation path, finds the root cause (a clock-skew issue in JWT expiry validation).
+
+Claude produces a natural summary at the end:
+> "The 401 spike is caused by a 30-second clock skew between the auth service and the API server. Tokens minted in the last 30s of their TTL are rejected because the API server's clock is ahead. The fix is to add a `leeway` parameter to the JWT decode call."
+
+### Scene 2: The Share (Henry's terminal, ~15s)
+
+> **Henry:** "Share that with Sam."
+
+Claude runs:
+```
+stash share --title "Auth 401 spike — clock skew in JWT validation"
+```
+
+Output:
+```
+Sharing session a3f2c8d1…
+  Attached error_log.csv
+Shared!  https://app.joinstash.ai/v/auth-401-spike-clock-skew-a8f2k1
+```
+
+What happened behind the scenes:
+1. Auto-detected the current Claude Code session ID
+2. Extracted the artifact: first user prompt ("Question") + last assistant message ("Finding")
+3. Converted the full conversation to readable markdown
+4. Created a notebook with two pages: **Summary** and **Full Transcript**
+5. Uploaded any generated files (CSVs, images, etc.)
+6. Uploaded the raw JSONL transcript blob for future reference
+7. Bundled everything into a public View and printed the URL
+
+### Scene 3: The Web View (browser, ~10s)
+
+Cut to the browser showing the View at `/v/auth-401-spike-clock-skew-a8f2k1`:
+- Clean title and workspace attribution
+- **Summary** page: the question and finding, rendered as proper markdown
+- **Full Transcript** page: the complete conversation, expandable
+- Attached files listed below
+- Fork button to pull the artifact into your own workspace
+
+### Scene 4: The Consumption (Sam's terminal, ~30s)
+
+Sam is in his own Claude Code session.
+
+> **Sam:** "Henry shared this with me: https://app.joinstash.ai/v/auth-401-spike-clock-skew-a8f2k1 — can you read it and tell me what he found? Is it something we should fix before the release?"
+
+Claude fetches the URL with `?format=text`, gets clean markdown back, and responds conversationally — it knows the finding, the root cause, the proposed fix, and which files were touched. Sam can ask follow-up questions as if Claude had done the investigation itself.
+
+---
+
+## What We Built
+
+### `stash share` CLI command (cli/main.py)
+
+New top-level command:
+```
+stash share [--title "..."] [--session <id>] [--file path ...] [--ws <id>]
+```
+
+- **Auto-detects session ID** from `~/.claude/plugins/data/stash/state.json`
+- **Extracts artifact** from the JSONL: first user prompt + last assistant message (the bookends of the conversation — the question and the answer)
+- **Creates a notebook** with two pages:
+  - "Summary" — the curated Question + Finding
+  - "Full Transcript" — the complete conversation as markdown
+- **Uploads attached files** via `--file` flag (repeatable)
+- **Uploads the raw transcript** blob for full fidelity
+- **Creates a public View** bundling notebook + files
+- **Prints the shareable URL**
+
+### Markdown rendering on `/v/[slug]` (frontend)
+
+Notebook pages now render with `react-markdown` + `remark-gfm` instead of a `<pre>` tag. Uses the existing `.markdown-content` CSS class. The artifact looks like a real document, not raw markdown source.
+
+### `?format=text` on the public view API (backend)
+
+`GET /api/v1/views/{slug}?format=text` returns plain markdown text (Content-Type: `text/markdown`). This is how another agent consumes the artifact — WebFetch the URL, get clean content, no HTML parsing needed.
+
+---
+
+## How Each Piece Connects
+
+```
+Henry's Claude Code session
+    │
+    ├── hooks stream events to Stash (already existed)
+    │
+    └── `stash share` (NEW)
+         │
+         ├── reads JSONL from ~/.claude/projects/
+         ├── extracts artifact (question + finding)
+         ├── creates notebook (Summary + Full Transcript)
+         ├��─ uploads files
+         └── publishes public View
+              │
+              ├── Web: /v/{slug} renders with markdown (UPDATED)
+              │
+              └── API: /api/v1/views/{slug}?format=text (NEW)
+                   │
+                   └── Sam's Claude Code fetches this
+```
+
+## Demo Prep Checklist
+
+- [ ] Install the updated CLI from this branch (`pip install -e .` or copy to main repo)
+- [ ] Pick a good investigation to do live (or pre-record Scene 1)
+- [ ] Verify the View renders correctly on the production frontend
+- [ ] Test the `?format=text` consumption path from a second Claude Code session
+- [ ] Have Sam's workspace ready (or use the same workspace)


### PR DESCRIPTION
## Summary

- **`stash share` CLI command** — packages a Claude Code session into a shareable artifact. Auto-detects the current session, extracts a curated summary (question + finding), includes the full transcript, uploads attached files, and publishes a public View with a shareable URL.
- **Markdown rendering on `/v/[slug]`** — notebook pages now render with `react-markdown` + `remark-gfm` (already installed, previously unused) instead of raw `<pre>` text. Uses existing `.markdown-content` CSS.
- **`?format=text` on public view API** — `GET /api/v1/views/{slug}?format=text` returns plain markdown (`text/markdown`), so another coding agent can fetch and consume a shared artifact cleanly.

## How it works

```
stash share --title "Auth 401 spike investigation" --file error_log.csv
```

1. Reads session ID from `~/.claude/plugins/data/stash/state.json`
2. Finds the JSONL transcript in `~/.claude/projects/`
3. Extracts artifact: first user prompt → "Question", last assistant message → "Finding"
4. Creates a notebook with two pages: Summary + Full Transcript
5. Uploads any `--file` attachments
6. Uploads the raw transcript blob
7. Bundles everything into a public View
8. Prints the shareable URL

## Test plan

- [ ] Run `stash share --session <known-id> --title "test"` and verify View is created with summary + transcript pages
- [ ] Open the `/v/` URL and verify markdown renders properly (headings, code blocks, bold)
- [ ] Fetch the URL with `?format=text` and verify clean markdown is returned
- [ ] Test `--file` flag with a CSV to verify file attachment
- [ ] Test auto-detection of session ID (requires active Stash plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)