### PR TITLE
feat: include subagent transcripts in shared stashes

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -961,6 +961,21 @@ def share_session(
     # Build the full transcript page
     full_md = _transcript_to_markdown(raw_jsonl)
 
+    # Discover subagent transcripts
+    subagents_dir = jsonl_path.parent / jsonl_path.stem / "subagents"
+    subagent_entries: list[tuple[str, str, str]] = []  # (label, raw_jsonl, jsonl_path)
+    if subagents_dir.is_dir():
+        for sa_jsonl in sorted(subagents_dir.glob("agent-*.jsonl")):
+            meta_path = sa_jsonl.with_suffix("").with_suffix(".meta.json")
+            label = sa_jsonl.stem
+            if meta_path.exists():
+                meta = json.loads(meta_path.read_text())
+                desc = meta.get("description", "")
+                name = meta.get("name", "")
+                label = desc or name or label
+            sa_raw = sa_jsonl.read_text(errors="replace")
+            subagent_entries.append((label, sa_raw, str(sa_jsonl)))
+
     console.print(f"[dim]Sharing session {sid[:8]}…[/dim]")
 
     with _client() as c:
@@ -968,6 +983,11 @@ def share_session(
         nb = c.create_notebook(ws, page_title, description="Shared session artifact")
         c.create_page(ws, nb["id"], "Summary", content=summary_md)
         c.create_page(ws, nb["id"], "Full Transcript", content=full_md)
+
+        for sa_label, sa_raw, _sa_path in subagent_entries:
+            sa_md = _transcript_to_markdown(sa_raw)
+            c.create_page(ws, nb["id"], f"Subagent: {sa_label}", content=sa_md)
+            console.print(f"  [dim]Included subagent: {sa_label}[/dim]")
 
         view_items: list[dict] = [
             {"object_type": "notebook", "object_id": nb["id"], "position": 0},
@@ -994,6 +1014,14 @@ def share_session(
         except StashError as e:
             if e.status_code != 409:
                 raise
+
+        for sa_label, _sa_raw, sa_path in subagent_entries:
+            sa_session_id = Path(sa_path).stem
+            try:
+                c.upload_transcript(ws, sa_session_id, sa_path, agent_name="claude-subagent", cwd=str(jsonl_path.parent))
+            except StashError as e:
+                if e.status_code != 409:
+                    raise
 
         # Create the public View
         view = c.create_view(

--- a/stashai/plugin/_do_upload.py
+++ b/stashai/plugin/_do_upload.py
@@ -15,14 +15,29 @@ from stashai.plugin.stash_client import StashClient
 def main() -> None:
     _, transcript_path, session_id, workspace_id, agent_name, cwd, base_url, api_key = sys.argv
 
+    path = Path(transcript_path)
     with StashClient(base_url=base_url, api_key=api_key) as client:
         client.upload_transcript(
             workspace_id=workspace_id,
             session_id=session_id,
-            transcript_path=Path(transcript_path),
+            transcript_path=path,
             agent_name=agent_name,
             cwd=cwd,
         )
+
+        subagents_dir = path.parent / path.stem / "subagents"
+        if subagents_dir.is_dir():
+            for sa_jsonl in subagents_dir.glob("agent-*.jsonl"):
+                try:
+                    client.upload_transcript(
+                        workspace_id=workspace_id,
+                        session_id=sa_jsonl.stem,
+                        transcript_path=sa_jsonl,
+                        agent_name="claude-subagent",
+                        cwd=cwd,
+                    )
+                except Exception:
+                    pass
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -236,3 +236,17 @@ def stream_session_end(
         )
     except Exception:
         pass
+
+    subagents_dir = path.parent / path.stem / "subagents"
+    if subagents_dir.is_dir():
+        for sa_jsonl in subagents_dir.glob("agent-*.jsonl"):
+            try:
+                client.upload_transcript(
+                    workspace_id=workspace_id,
+                    session_id=sa_jsonl.stem,
+                    transcript_path=sa_jsonl,
+                    agent_name="claude-subagent",
+                    cwd=event.cwd,
+                )
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- **`stash share`** now discovers subagent transcripts in `<session>/subagents/`, converts each to markdown, and adds them as notebook pages (e.g. "Subagent: Reddit batch 1 analysis"). Also uploads each subagent transcript blob to the server.
- **Session-end hooks** (`hooks.py`) now upload subagent transcripts alongside the parent transcript automatically.
- **Background uploader** (`_do_upload.py`) does the same for agents without session-end hooks (e.g. Codex).

## Test plan
- [x] Verified `stash share` includes all 10 subagent transcripts from a real session: https://app.joinstash.ai/v/reddit-analysis-with-subagents-d6c24a
- [ ] Verify `stash share` still works for sessions with no subagents (no-op, no errors)
- [ ] Verify session-end hook uploads subagent transcripts to server

🤖 Generated with [Claude Code](https://claude.com/claude-code)