### PR TITLE
Rename agent_name → tag_name

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,7 @@ workspaces ─┬── workspace_members ──── users
                   object_shares
 ```
 
-`history_events` lives directly under a workspace (no intermediate "store" abstraction). Grouping in the UI is by `agent_name` + `session_id` on the event row.
+`history_events` lives directly under a workspace (no intermediate "store" abstraction). Grouping in the UI is by `tag_name` + `session_id` on the event row.
 
 ### Workspace scoping
 

--- a/backend/migrations/versions/0024_rename_agent_to_tag.py
+++ b/backend/migrations/versions/0024_rename_agent_to_tag.py
@@ -1,0 +1,24 @@
+"""Rename agent_name → tag_name in history_events and session_transcripts.
+
+Revision ID: 0024
+Revises: 0023
+"""
+
+from alembic import op
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE history_events RENAME COLUMN agent_name TO tag_name")
+    op.execute("ALTER TABLE session_transcripts RENAME COLUMN agent_name TO tag_name")
+    op.execute("ALTER INDEX IF EXISTS idx_history_events_agent_session RENAME TO idx_history_events_tag_session")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE history_events RENAME COLUMN tag_name TO agent_name")
+    op.execute("ALTER TABLE session_transcripts RENAME COLUMN tag_name TO agent_name")
+    op.execute("ALTER INDEX IF EXISTS idx_history_events_tag_session RENAME TO idx_history_events_agent_session")

--- a/backend/models.py
+++ b/backend/models.py
@@ -540,7 +540,7 @@ class Attachment(BaseModel):
 
 
 class HistoryEventCreateRequest(BaseModel):
-    agent_name: str = Field(..., min_length=1, max_length=64)
+    tag_name: str = Field(..., min_length=1, max_length=64)
     event_type: str = Field(..., min_length=1, max_length=64)
     content: str = Field(..., min_length=1)
     session_id: str | None = Field(None, max_length=64)
@@ -561,7 +561,7 @@ class HistoryEventResponse(BaseModel):
     workspace_id: UUID | None = None
     created_by: UUID | None = None
     created_by_name: str | None = None
-    agent_name: str
+    tag_name: str
     event_type: str
     session_id: str | None
     tool_name: str | None
@@ -636,7 +636,7 @@ class SessionTranscriptResponse(BaseModel):
     id: UUID
     workspace_id: UUID
     session_id: str
-    agent_name: str
+    tag_name: str
     size_bytes: int
     cwd: str | None
     download_url: str | None

--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -19,7 +19,7 @@ async def list_all_notebooks(current_user: dict = Depends(get_current_user)):
 
 @router.get("/history-events")
 async def list_all_history_events(
-    agent_name: str | None = Query(None),
+    tag_name: str | None = Query(None),
     event_type: str | None = Query(None),
     after: str | None = Query(None),
     before: str | None = Query(None),
@@ -29,7 +29,7 @@ async def list_all_history_events(
     """Events across all accessible workspaces + personal, with filters."""
     events, has_more = await memory_service.query_all_user_events(
         current_user["id"],
-        agent_name=agent_name,
+        tag_name=tag_name,
         event_type=event_type,
         after=after,
         before=before,
@@ -63,7 +63,7 @@ async def activity_timeline(
     workspace_id: UUID | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
-    """Agent activity bucketed by time for the dashboard timeline."""
+    """Tag activity bucketed by time for the dashboard timeline."""
     if workspace_id is not None:
         await _verify_workspace_access(workspace_id, current_user["id"])
     return await analytics_service.get_activity_timeline(

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -1,7 +1,7 @@
-"""History router: workspace and personal agent event storage.
+"""History router: workspace and personal event storage.
 
 Events belong directly to workspaces. No intermediate "store" abstraction.
-Hierarchy: Workspace → Agent → Session → Events
+Hierarchy: Workspace → Tag → Session → Events
 """
 
 from uuid import UUID
@@ -41,7 +41,7 @@ async def push_ws_event(
     attachments = [a.model_dump(mode="json") for a in req.attachments] if req.attachments else None
     event = await memory_service.push_event(
         workspace_id,
-        agent_name=req.agent_name,
+        tag_name=req.tag_name,
         event_type=req.event_type,
         content=req.content,
         created_by=current_user["id"],
@@ -69,7 +69,7 @@ async def push_ws_events_batch(
 @ws_router.get("/events", response_model=HistoryEventListResponse)
 async def query_ws_events(
     workspace_id: UUID,
-    agent_name: str | None = Query(None),
+    tag_name: str | None = Query(None),
     session_id: str | None = Query(None),
     event_type: str | None = Query(None),
     after: str | None = Query(None),
@@ -80,7 +80,7 @@ async def query_ws_events(
     await _check_member(workspace_id, current_user["id"])
     events, has_more = await memory_service.query_workspace_events(
         workspace_id,
-        agent_name=agent_name,
+        tag_name=tag_name,
         session_id=session_id,
         event_type=event_type,
         after=after,
@@ -121,30 +121,30 @@ async def get_ws_event(
     return HistoryEventResponse(**event)
 
 
-@ws_router.delete("/agents/{agent_name}", status_code=204)
-async def delete_ws_agent(
+@ws_router.delete("/tags/{tag_name}", status_code=204)
+async def delete_ws_tag(
     workspace_id: UUID,
-    agent_name: str,
+    tag_name: str,
     current_user: dict = Depends(get_current_user),
 ):
-    """Delete all events for an agent in this workspace."""
+    """Delete all events for a tag in this workspace."""
     await _check_member(workspace_id, current_user["id"])
-    await memory_service.delete_workspace_agent_events(agent_name, workspace_id)
+    await memory_service.delete_workspace_tag_events(tag_name, workspace_id)
 
 
-@ws_router.get("/agent-names")
-async def list_ws_agent_names(
+@ws_router.get("/tag-names")
+async def list_ws_tag_names(
     workspace_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
-    """List distinct agent names in this workspace."""
+    """List distinct tag names in this workspace."""
     await _check_member(workspace_id, current_user["id"])
     from ..database import get_pool
 
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT DISTINCT agent_name FROM history_events "
-        "WHERE workspace_id = $1 ORDER BY agent_name",
+        "SELECT DISTINCT tag_name FROM history_events "
+        "WHERE workspace_id = $1 ORDER BY tag_name",
         workspace_id,
     )
-    return {"agent_names": [r["agent_name"] for r in rows]}
+    return {"tag_names": [r["tag_name"] for r in rows]}

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -24,7 +24,7 @@ async def upload_transcript(
     workspace_id: UUID,
     file: UploadFile,
     session_id: str = Form(...),
-    agent_name: str = Form(...),
+    tag_name: str = Form(...),
     cwd: str | None = Form(None),
     current_user: dict = Depends(get_current_user),
 ):
@@ -48,13 +48,13 @@ async def upload_transcript(
     pool = get_pool()
     row = await pool.fetchrow(
         "INSERT INTO session_transcripts "
-        "(workspace_id, session_id, agent_name, storage_key, size_bytes, cwd, uploaded_by) "
+        "(workspace_id, session_id, tag_name, storage_key, size_bytes, cwd, uploaded_by) "
         "VALUES ($1, $2, $3, $4, $5, $6, $7) "
         "ON CONFLICT (workspace_id, session_id) DO NOTHING "
-        "RETURNING id, workspace_id, session_id, agent_name, size_bytes, cwd, uploaded_by, uploaded_at",
+        "RETURNING id, workspace_id, session_id, tag_name, size_bytes, cwd, uploaded_by, uploaded_at",
         workspace_id,
         session_id,
-        agent_name,
+        tag_name,
         storage_key,
         len(content),
         cwd,
@@ -74,7 +74,7 @@ async def get_transcript(
     await _check_member(workspace_id, current_user["id"])
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, workspace_id, session_id, agent_name, storage_key, size_bytes, cwd, "
+        "SELECT id, workspace_id, session_id, tag_name, storage_key, size_bytes, cwd, "
         "uploaded_by, uploaded_at FROM session_transcripts "
         "WHERE workspace_id = $1 AND session_id = $2 "
         "ORDER BY uploaded_at DESC LIMIT 1",

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -89,7 +89,7 @@ async def get_activity_timeline(
     bucket: str = "day",
     workspace_id: UUID | None = None,
 ) -> dict:
-    """Agent activity bucketed by time for the timeline visualization."""
+    """Tag activity bucketed by time for the timeline visualization."""
     pool = get_pool()
     days = min(days, 90)
     if bucket not in ("hour", "day", "week"):
@@ -107,13 +107,13 @@ async def get_activity_timeline(
         _accessible_events_cte(ws_idx=ws_idx) + """
         SELECT
             DATE_TRUNC($2, me.created_at) AS bucket_date,
-            me.agent_name,
+            me.tag_name,
             me.event_type,
             COUNT(*) AS cnt
         FROM history_events me
         JOIN accessible_events a ON a.event_id = me.id
         WHERE me.created_at >= $3
-        GROUP BY bucket_date, me.agent_name, me.event_type
+        GROUP BY bucket_date, me.tag_name, me.event_type
         ORDER BY bucket_date
         """,
         scope_arg,
@@ -122,29 +122,29 @@ async def get_activity_timeline(
     )
 
     # Build response shape
-    agents_set: set[str] = set()
+    tags_set: set[str] = set()
     buckets_map: dict[str, dict] = {}
 
     for row in rows:
         date_str = row["bucket_date"].isoformat()
-        agent = row["agent_name"] or "unknown"
+        tag = row["tag_name"] or "unknown"
         etype = row["event_type"] or "other"
         cnt = row["cnt"]
 
-        agents_set.add(agent)
+        tags_set.add(tag)
 
         if date_str not in buckets_map:
-            buckets_map[date_str] = {"date": date_str, "agents": {}}
+            buckets_map[date_str] = {"date": date_str, "tags": {}}
 
         b = buckets_map[date_str]
-        if agent not in b["agents"]:
-            b["agents"][agent] = {"total": 0, "by_type": {}}
+        if tag not in b["tags"]:
+            b["tags"][tag] = {"total": 0, "by_type": {}}
 
-        b["agents"][agent]["total"] += cnt
-        b["agents"][agent]["by_type"][etype] = b["agents"][agent]["by_type"].get(etype, 0) + cnt
+        b["tags"][tag]["total"] += cnt
+        b["tags"][tag]["by_type"][etype] = b["tags"][tag]["by_type"].get(etype, 0) + cnt
 
     return {
-        "agents": sorted(agents_set),
+        "tags": sorted(tags_set),
         "buckets": list(buckets_map.values()),
     }
 
@@ -653,7 +653,7 @@ async def get_embedding_projection(
     if source is None or source == "history_events":
         rows = await pool.fetch(
             _accessible_events_cte(ws_idx=ws_idx) + """
-            SELECT me.id, me.agent_name, me.event_type, me.embedding, me.created_at
+            SELECT me.id, me.tag_name, me.event_type, me.embedding, me.created_at
             FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
             WHERE me.embedding IS NOT NULL
@@ -667,7 +667,7 @@ async def get_embedding_projection(
             all_items.append(
                 {
                     "id": str(r["id"]),
-                    "label": f"{r['agent_name'] or 'agent'}: {r['event_type'] or 'event'}",
+                    "label": f"{r['tag_name'] or 'unknown'}: {r['event_type'] or 'event'}",
                     "source": "history_events",
                     "created_at": r["created_at"].isoformat() if r["created_at"] else None,
                     "embedding": np.array(r["embedding"]),

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -1,7 +1,7 @@
-"""History service: structured agent event storage with FTS, vector search, and batch insert.
+"""History service: structured event storage with FTS, vector search, and batch insert.
 
 Events belong directly to a workspace (or are personal with workspace_id=NULL).
-Grouped by agent_name → session_id for display.
+Grouped by tag_name → session_id for display.
 """
 
 import asyncio
@@ -84,7 +84,7 @@ async def _embed_events_batch(event_ids: list[UUID], contents: list[str]) -> Non
 
 async def push_event(
     workspace_id: UUID | None,
-    agent_name: str,
+    tag_name: str,
     event_type: str,
     content: str,
     created_by: UUID,
@@ -105,13 +105,13 @@ async def push_event(
         ts = created_at
     row = await pool.fetchrow(
         "INSERT INTO history_events "
-        "(workspace_id, created_by, agent_name, event_type, content, session_id, tool_name, metadata, attachments, created_at) "
+        "(workspace_id, created_by, tag_name, event_type, content, session_id, tool_name, metadata, attachments, created_at) "
         "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10) "
-        "RETURNING id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "RETURNING id, workspace_id, created_by, tag_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at",
         workspace_id,
         created_by,
-        agent_name,
+        tag_name,
         event_type,
         content,
         session_id,
@@ -147,14 +147,14 @@ async def push_events_batch(
                     ts = raw_ts
                 row = await conn.fetchrow(
                     "INSERT INTO history_events "
-                    "(workspace_id, created_by, agent_name, event_type, content, "
+                    "(workspace_id, created_by, tag_name, event_type, content, "
                     "session_id, tool_name, metadata, attachments, created_at) "
                     "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10) "
-                    "RETURNING id, workspace_id, created_by, agent_name, event_type, "
+                    "RETURNING id, workspace_id, created_by, tag_name, event_type, "
                     "session_id, tool_name, content, metadata, attachments, created_at",
                     workspace_id,
                     created_by,
-                    evt["agent_name"],
+                    evt["tag_name"],
                     evt["event_type"],
                     evt["content"],
                     evt.get("session_id"),
@@ -195,7 +195,7 @@ async def get_personal_event(event_id: UUID, user_id: UUID) -> dict | None:
 def _build_event_filters(
     base_condition: str,
     base_args: list,
-    agent_name: str | None,
+    tag_name: str | None,
     session_id: str | None,
     event_type: str | None,
     after: str | None,
@@ -206,9 +206,9 @@ def _build_event_filters(
     args = list(base_args)
     idx = len(args) + 1
 
-    if agent_name:
-        conditions.append(f"agent_name = ${idx}")
-        args.append(agent_name)
+    if tag_name:
+        conditions.append(f"tag_name = ${idx}")
+        args.append(tag_name)
         idx += 1
     if session_id:
         conditions.append(f"session_id = ${idx}")
@@ -239,7 +239,7 @@ async def _query_events(
     pool = get_pool()
     args = [*args, limit + 1]
     rows = await pool.fetch(
-        f"SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        f"SELECT id, workspace_id, created_by, tag_name, event_type, session_id, "
         f"tool_name, content, metadata, attachments, created_at "
         f"FROM history_events WHERE {where} "
         f"ORDER BY created_at ASC LIMIT ${limit_idx}",
@@ -254,7 +254,7 @@ async def _query_events(
 
 async def query_workspace_events(
     workspace_id: UUID,
-    agent_name: str | None = None,
+    tag_name: str | None = None,
     session_id: str | None = None,
     event_type: str | None = None,
     after: str | None = None,
@@ -266,7 +266,7 @@ async def query_workspace_events(
     where, args, next_idx = _build_event_filters(
         "workspace_id = $1",
         [workspace_id],
-        agent_name,
+        tag_name,
         session_id,
         event_type,
         after,
@@ -277,7 +277,7 @@ async def query_workspace_events(
 
 async def query_personal_events(
     user_id: UUID,
-    agent_name: str | None = None,
+    tag_name: str | None = None,
     session_id: str | None = None,
     event_type: str | None = None,
     after: str | None = None,
@@ -289,7 +289,7 @@ async def query_personal_events(
     where, args, next_idx = _build_event_filters(
         "workspace_id IS NULL AND created_by = $1",
         [user_id],
-        agent_name,
+        tag_name,
         session_id,
         event_type,
         after,
@@ -307,7 +307,7 @@ async def search_workspace_events(
     pool = get_pool()
     limit = min(limit, 200)
     rows = await pool.fetch(
-        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "SELECT id, workspace_id, created_by, tag_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at, "
         "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
         "FROM history_events "
@@ -329,7 +329,7 @@ async def search_personal_events(
     pool = get_pool()
     limit = min(limit, 200)
     rows = await pool.fetch(
-        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "SELECT id, workspace_id, created_by, tag_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at, "
         "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
         "FROM history_events "
@@ -352,7 +352,7 @@ async def search_workspace_events_vector(
     pool = get_pool()
     limit = min(limit, 200)
     rows = await pool.fetch(
-        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "SELECT id, workspace_id, created_by, tag_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at, "
         "1 - (embedding <=> $2) AS similarity "
         "FROM history_events "
@@ -374,7 +374,7 @@ async def search_personal_events_vector(
     pool = get_pool()
     limit = min(limit, 200)
     rows = await pool.fetch(
-        "SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
+        "SELECT id, workspace_id, created_by, tag_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at, "
         "1 - (embedding <=> $2) AS similarity "
         "FROM history_events "
@@ -392,7 +392,7 @@ async def search_personal_events_vector(
 
 async def query_all_user_events(
     user_id: UUID,
-    agent_name: str | None = None,
+    tag_name: str | None = None,
     event_type: str | None = None,
     after: str | None = None,
     before: str | None = None,
@@ -409,9 +409,9 @@ async def query_all_user_events(
     args: list = [user_id]
     idx = 2
 
-    if agent_name:
-        conditions.append(f"he.agent_name = ${idx}")
-        args.append(agent_name)
+    if tag_name:
+        conditions.append(f"he.tag_name = ${idx}")
+        args.append(tag_name)
         idx += 1
     if event_type:
         conditions.append(f"he.event_type = ${idx}")
@@ -430,7 +430,7 @@ async def query_all_user_events(
     args.append(limit + 1)
 
     rows = await pool.fetch(
-        f"SELECT he.id, he.workspace_id, he.created_by, he.agent_name, he.event_type, "
+        f"SELECT he.id, he.workspace_id, he.created_by, he.tag_name, he.event_type, "
         f"he.session_id, he.tool_name, he.content, he.metadata, he.created_at, "
         f"w.name AS workspace_name, "
         f"COALESCE(u.display_name, u.name) AS created_by_name "
@@ -449,23 +449,23 @@ async def query_all_user_events(
     return events, has_more
 
 
-async def delete_workspace_agent_events(agent_name: str, workspace_id: UUID) -> int:
-    """Delete all workspace events for a given agent. Returns count deleted."""
+async def delete_workspace_tag_events(tag_name: str, workspace_id: UUID) -> int:
+    """Delete all workspace events for a given tag. Returns count deleted."""
     pool = get_pool()
     result = await pool.execute(
-        "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id = $2",
-        agent_name,
+        "DELETE FROM history_events WHERE tag_name = $1 AND workspace_id = $2",
+        tag_name,
         workspace_id,
     )
     return int(result.split()[-1]) if result else 0
 
 
-async def delete_personal_agent_events(agent_name: str, user_id: UUID) -> int:
-    """Delete all personal events for a given agent. Returns count deleted."""
+async def delete_personal_tag_events(tag_name: str, user_id: UUID) -> int:
+    """Delete all personal events for a given tag. Returns count deleted."""
     pool = get_pool()
     result = await pool.execute(
-        "DELETE FROM history_events WHERE agent_name = $1 AND workspace_id IS NULL AND created_by = $2",
-        agent_name,
+        "DELETE FROM history_events WHERE tag_name = $1 AND workspace_id IS NULL AND created_by = $2",
+        tag_name,
         user_id,
     )
     return int(result.split()[-1]) if result else 0

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -228,14 +228,14 @@ async def inline_items(view: dict) -> list[dict]:
                 }
         elif obj_type == "history":
             ev = await pool.fetchrow(
-                "SELECT agent_name, event_type, content, created_at "
+                "SELECT tag_name, event_type, content, created_at "
                 "FROM history_events WHERE id = $1",
                 obj_id,
             )
             if ev:
-                label = label or f"{ev['agent_name']} · {ev['event_type']}"
+                label = label or f"{ev['tag_name']} · {ev['event_type']}"
                 inline = {
-                    "agent_name": ev["agent_name"],
+                    "tag_name": ev["tag_name"],
                     "event_type": ev["event_type"],
                     "content": ev["content"],
                     "created_at": ev["created_at"].isoformat(),
@@ -284,7 +284,7 @@ def items_to_text(title: str, items: list[dict]) -> str:
         elif obj_type == "file":
             parts.append(f"*Attached file: {label} ({inline.get('content_type', 'unknown')})*\n")
         elif obj_type == "history":
-            parts.append(f"**{inline.get('agent_name', '')}** ({inline.get('event_type', '')})")
+            parts.append(f"**{inline.get('tag_name', '')}** ({inline.get('event_type', '')})")
             if inline.get("content"):
                 parts.append(inline["content"])
             parts.append("")
@@ -421,7 +421,7 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
 
                 elif t == "history":
                     src = await conn.fetchrow(
-                        "SELECT created_by, agent_name, event_type, session_id, tool_name, "
+                        "SELECT created_by, tag_name, event_type, session_id, tool_name, "
                         "content, metadata, attachments, created_at "
                         "FROM history_events WHERE id = $1",
                         src_id,
@@ -429,10 +429,10 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                     if not src:
                         continue
                     await conn.execute(
-                        "INSERT INTO history_events (workspace_id, created_by, agent_name, "
+                        "INSERT INTO history_events (workspace_id, created_by, tag_name, "
                         "event_type, session_id, tool_name, content, metadata, attachments, "
                         "created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
-                        new_ws_id, src["created_by"], src["agent_name"],
+                        new_ws_id, src["created_by"], src["tag_name"],
                         src["event_type"], src["session_id"], src["tool_name"],
                         src["content"], src["metadata"], src["attachments"],
                         src["created_at"],

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -394,14 +394,14 @@ async def fork_workspace(
                         forker_id,
                     )
 
-            # History events: preserve original author, agent_name, content,
+            # History events: preserve original author, tag_name, content,
             # event_type, session_id, tool_name, metadata, attachments, created_at.
             # Embeddings are not copied.
             await conn.execute(
-                "INSERT INTO history_events (workspace_id, created_by, agent_name, "
+                "INSERT INTO history_events (workspace_id, created_by, tag_name, "
                 "event_type, session_id, tool_name, content, metadata, attachments, "
                 "created_at) "
-                "SELECT $1, created_by, agent_name, event_type, session_id, tool_name, "
+                "SELECT $1, created_by, tag_name, event_type, session_id, tool_name, "
                 "content, metadata, attachments, created_at "
                 "FROM history_events WHERE workspace_id = $2",
                 new_ws_id,

--- a/backend/static/SKILL.md
+++ b/backend/static/SKILL.md
@@ -48,7 +48,7 @@ curl -X POST {{BASE_URL}}/api/v1/workspaces \
 curl -X POST {{BASE_URL}}/api/v1/workspaces/$WS/memory/events \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"agent_name":"cli","event_type":"note","content":"Hello"}'
+  -d '{"tag_name":"cli","event_type":"note","content":"Hello"}'
 ```
 
 ### 4. Create a Notebook Page
@@ -161,12 +161,12 @@ you'll round-trip cleanly through edit mode:
 
 ## History / Memory Events
 
-Events are structured append-only records keyed by `(workspace, agent_name, event_type)`.
+Events are structured append-only records keyed by `(workspace, tag_name, event_type)`.
 
 ```json
 POST /api/v1/workspaces/{ws}/memory/events
 {
-  "agent_name": "cli",
+  "tag_name": "cli",
   "event_type": "note",
   "content": "text body",
   "session_id": "optional",
@@ -182,7 +182,7 @@ POST /api/v1/workspaces/{ws}/memory/events
 wrapper (`stash history push --attach ./path`) uploads and attaches in one step.
 
 Query/search:
-- `GET /events?agent_name=&event_type=&limit=&after=`
+- `GET /events?tag_name=&event_type=&limit=&after=`
 - `GET /events/search?q=&limit=`
 - `GET /events/{event_id}`
 

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -57,7 +57,7 @@ async def test_upload_and_fetch_roundtrip(client: AsyncClient, stub_storage):
     up = await client.post(
         f"/api/v1/workspaces/{ws}/transcripts",
         files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
-        data={"session_id": "sess-1", "agent_name": "claude"},
+        data={"session_id": "sess-1", "tag_name": "claude"},
         headers={"Authorization": f"Bearer {key}"},
     )
     assert up.status_code == 201, up.text
@@ -79,7 +79,7 @@ async def test_oversize_rejected(client: AsyncClient, stub_storage):
     r = await client.post(
         f"/api/v1/workspaces/{ws}/transcripts",
         files={"file": ("s.jsonl", io.BytesIO(big), "application/jsonl")},
-        data={"session_id": "sess-big", "agent_name": "claude"},
+        data={"session_id": "sess-big", "tag_name": "claude"},
         headers={"Authorization": f"Bearer {key}"},
     )
     assert r.status_code == 413
@@ -93,7 +93,7 @@ async def test_non_member_forbidden(client: AsyncClient, stub_storage):
     r = await client.post(
         f"/api/v1/workspaces/{ws}/transcripts",
         files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
-        data={"session_id": "sess", "agent_name": "claude"},
+        data={"session_id": "sess", "tag_name": "claude"},
         headers={"Authorization": f"Bearer {other}"},
     )
     assert r.status_code == 403

--- a/cli/client.py
+++ b/cli/client.py
@@ -326,14 +326,14 @@ class StashClient:
 
     # --- History (workspace events) ---
 
-    def list_agent_names(self, workspace_id: str) -> list:
-        data = self._get(f"/api/v1/workspaces/{workspace_id}/memory/agent-names")
-        return data.get("agent_names", []) if isinstance(data, dict) else data
+    def list_tag_names(self, workspace_id: str) -> list:
+        data = self._get(f"/api/v1/workspaces/{workspace_id}/memory/tag-names")
+        return data.get("tag_names", []) if isinstance(data, dict) else data
 
     def push_event(
         self,
         workspace_id: str,
-        agent_name: str,
+        tag_name: str,
         event_type: str,
         content: str,
         session_id: str | None = None,
@@ -342,7 +342,7 @@ class StashClient:
         attachments: list[dict] | None = None,
         created_at: str | None = None,
     ) -> dict:
-        body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
+        body: dict = {"tag_name": tag_name, "event_type": event_type, "content": content}
         if session_id:
             body["session_id"] = session_id
         if tool_name:
@@ -358,14 +358,14 @@ class StashClient:
     def query_events(
         self,
         workspace_id: str,
-        agent_name: str | None = None,
+        tag_name: str | None = None,
         event_type: str | None = None,
         limit: int = 50,
         after: str | None = None,
     ) -> list:
         params: dict = {"limit": limit}
-        if agent_name:
-            params["agent_name"] = agent_name
+        if tag_name:
+            params["tag_name"] = tag_name
         if event_type:
             params["event_type"] = event_type
         if after:
@@ -381,11 +381,11 @@ class StashClient:
         )
 
     def all_events(
-        self, agent_name: str | None = None, event_type: str | None = None, limit: int = 50
+        self, tag_name: str | None = None, event_type: str | None = None, limit: int = 50
     ) -> list:
         params: dict = {"limit": limit}
-        if agent_name:
-            params["agent_name"] = agent_name
+        if tag_name:
+            params["tag_name"] = tag_name
         if event_type:
             params["event_type"] = event_type
         return self._list("/api/v1/me/history-events", "events", **params)
@@ -401,7 +401,7 @@ class StashClient:
         workspace_id: str,
         session_id: str,
         transcript_path: str | Path,
-        agent_name: str,
+        tag_name: str,
         cwd: str = "",
     ) -> dict:
         import gzip as _gzip
@@ -415,7 +415,7 @@ class StashClient:
         resp = self._request(
             "POST",
             f"/api/v1/workspaces/{workspace_id}/transcripts",
-            data={"session_id": session_id, "agent_name": agent_name, "cwd": cwd},
+            data={"session_id": session_id, "tag_name": tag_name, "cwd": cwd},
             files={"file": (name, body, "application/gzip")},
             timeout=120,
         )

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -522,7 +522,7 @@ def upload_conversation(client, workspace_id: str, conv: ConversationInfo) -> di
             workspace_id=workspace_id,
             session_id=conv.session_id,
             transcript_path=transcript_path,
-            agent_name=conv.agent,
+            tag_name=conv.agent,
             cwd=conv.cwd,
         )
     finally:
@@ -531,7 +531,7 @@ def upload_conversation(client, workspace_id: str, conv: ConversationInfo) -> di
 
     client.push_event(
         workspace_id=workspace_id,
-        agent_name=conv.agent,
+        tag_name=conv.agent,
         event_type="session_end",
         content=f"Imported historical session ({_fmt_size(conv.size_bytes)})",
         session_id=conv.session_id,

--- a/cli/main.py
+++ b/cli/main.py
@@ -990,7 +990,7 @@ def share_session(
 
         # Upload the full transcript blob (may already exist via hooks — that's fine)
         try:
-            c.upload_transcript(ws, sid, str(jsonl_path), agent_name="claude", cwd=str(jsonl_path.parent))
+            c.upload_transcript(ws, sid, str(jsonl_path), tag_name="claude", cwd=str(jsonl_path.parent))
         except StashError as e:
             if e.status_code != 409:
                 raise
@@ -1519,7 +1519,7 @@ def nb_edit_page(
 # History (was memory stores)
 # ===========================================================================
 
-hist_app = typer.Typer(help="History — structured agent event logs.", invoke_without_command=True)
+hist_app = typer.Typer(help="History — structured event logs.", invoke_without_command=True)
 app.add_typer(hist_app, name="history")
 
 
@@ -1530,7 +1530,7 @@ def hist_default(
     limit: int = typer.Option(20, "-n", "--limit"),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """History — structured agent event logs."""
+    """History — structured event logs."""
     if ctx.invoked_subcommand is not None:
         return
     ws = workspace_id or _resolve_workspace()
@@ -1545,26 +1545,26 @@ def hist_default(
         for ev in data:
             tool = f" ({ev['tool_name']})" if ev.get("tool_name") else ""
             console.print(
-                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
+                f"  [{ev['created_at'][:19]}] {ev['tag_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
             )
 
 
-@hist_app.command("agents")
-def hist_agents(
+@hist_app.command("tags")
+def hist_tags(
     workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")
 ):
-    """List distinct agent names that have logged events in this workspace."""
+    """List distinct tag names that have logged events in this workspace."""
     ws = workspace_id or _resolve_workspace()
     with _client() as c:
         try:
-            data = c.list_agent_names(ws)
+            data = c.list_tag_names(ws)
         except StashError as e:
             _err(e)
     if _use_json(as_json):
         output_json(data)
     else:
         if not data:
-            console.print("[dim]No agents have logged events yet.[/dim]")
+            console.print("[dim]No tags have logged events yet.[/dim]")
         else:
             for name in data:
                 console.print(f"  {name}")
@@ -1574,7 +1574,7 @@ def hist_agents(
 def hist_push(
     content: str = typer.Argument(...),
     workspace_id: str = typer.Option(None, "--ws"),
-    agent_name: str = typer.Option("cli", "--agent"),
+    tag_name: str = typer.Option("cli", "--tag"),
     event_type: str = typer.Option("message", "--type"),
     session_id: str = typer.Option(None, "--session"),
     tool_name: str = typer.Option(None, "--tool"),
@@ -1604,7 +1604,7 @@ def hist_push(
                 )
             data = c.push_event(
                 ws,
-                agent_name=agent_name,
+                tag_name=tag_name,
                 event_type=event_type,
                 content=content,
                 session_id=session_id,
@@ -1623,7 +1623,7 @@ def hist_push(
 @hist_app.command("query")
 def hist_query(
     workspace_id: str = typer.Option(None, "--ws"),
-    agent_name: str = typer.Option(None, "--agent"),
+    tag_name: str = typer.Option(None, "--tag"),
     event_type: str = typer.Option(None, "--type"),
     limit: int = typer.Option(50, "-n", "--limit"),
     all_: bool = typer.Option(False, "--all"),
@@ -1633,10 +1633,10 @@ def hist_query(
     with _client() as c:
         try:
             if all_:
-                data = c.all_events(agent_name=agent_name, event_type=event_type, limit=limit)
+                data = c.all_events(tag_name=tag_name, event_type=event_type, limit=limit)
             else:
                 ws = workspace_id or _resolve_workspace()
-                data = c.query_events(ws, agent_name=agent_name, event_type=event_type, limit=limit)
+                data = c.query_events(ws, tag_name=tag_name, event_type=event_type, limit=limit)
         except StashError as e:
             _err(e)
     if _use_json(as_json):
@@ -1645,7 +1645,7 @@ def hist_query(
         for ev in data:
             tool = f" ({ev['tool_name']})" if ev.get("tool_name") else ""
             console.print(
-                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
+                f"  [{ev['created_at'][:19]}] {ev['tag_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
             )
 
 
@@ -1668,7 +1668,7 @@ def hist_search(
     else:
         for ev in data:
             console.print(
-                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}: {ev['content'][:200]}"
+                f"  [{ev['created_at'][:19]}] {ev['tag_name']}/{ev['event_type']}: {ev['content'][:200]}"
             )
 
 
@@ -1826,7 +1826,7 @@ def hist_share(
 @hist_app.command("import")
 def hist_import(
     workspace_id: str = typer.Option(None, "--ws"),
-    agent_name: str = typer.Option(None, "--agent", help="Only import from this agent."),
+    agent_name: str = typer.Option(None, "--agent", help="Only import from this agent binary."),
     limit: int = typer.Option(0, "-n", "--limit", help="Max conversations to import (0 = all)."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     as_json: bool = typer.Option(False, "--json"),

--- a/frontend/src/app/docs/concepts/page.tsx
+++ b/frontend/src/app/docs/concepts/page.tsx
@@ -11,7 +11,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "History",
     badge: "Events",
     badgeColor: "bg-brand/10 text-brand",
-    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text search.",
+    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, tag names, and metadata. Events are grouped by tag_name and session_id for a conversation-like view. Searchable via full-text search.",
   },
   {
     name: "Notebook",

--- a/frontend/src/app/memory/[storeId]/page.tsx
+++ b/frontend/src/app/memory/[storeId]/page.tsx
@@ -18,15 +18,15 @@ import { HistoryEvent, History, HistoryWithWorkspace } from "../../../lib/types"
 
 interface SessionGroup {
   sessionId: string;
-  agentName: string;
+  tagName: string;
   events: HistoryEvent[];
   firstContent: string;
   timeRange: string;
   lastTimestamp: number;
 }
 
-interface AgentGroup {
-  agentName: string;
+interface TagGroup {
+  tagName: string;
   sessions: SessionGroup[];
   eventCount: number;
 }
@@ -57,11 +57,11 @@ function shouldShowTimestamp(a: string, b: string): boolean {
   return Math.abs(new Date(a).getTime() - new Date(b).getTime()) > 5 * 60 * 1000;
 }
 
-function buildGroups(events: HistoryEvent[]): AgentGroup[] {
+function buildGroups(events: HistoryEvent[]): TagGroup[] {
   const agentMap = new Map<string, Map<string, HistoryEvent[]>>();
 
   for (const evt of events) {
-    const agent = evt.agent_name || "unknown";
+    const agent = evt.tag_name || "unknown";
     const session = evt.session_id || "no-session";
     if (!agentMap.has(agent)) agentMap.set(agent, new Map());
     const sessionMap = agentMap.get(agent)!;
@@ -69,9 +69,9 @@ function buildGroups(events: HistoryEvent[]): AgentGroup[] {
     sessionMap.get(session)!.push(evt);
   }
 
-  const groups: AgentGroup[] = [];
+  const groups: TagGroup[] = [];
 
-  for (const [agentName, sessionMap] of agentMap) {
+  for (const [tagName, sessionMap] of agentMap) {
     const sessions: SessionGroup[] = [];
 
     for (const [sessionId, evts] of sessionMap) {
@@ -82,7 +82,7 @@ function buildGroups(events: HistoryEvent[]): AgentGroup[] {
       const last = sorted[sorted.length - 1];
       sessions.push({
         sessionId,
-        agentName,
+        tagName,
         events: sorted,
         firstContent: truncate(first.content, 60),
         timeRange: `${formatTime(first.created_at)} — ${formatTimeShort(last.created_at)}`,
@@ -93,7 +93,7 @@ function buildGroups(events: HistoryEvent[]): AgentGroup[] {
     sessions.sort((a, b) => b.lastTimestamp - a.lastTimestamp);
 
     groups.push({
-      agentName,
+      tagName,
       sessions,
       eventCount: sessions.reduce((sum, s) => sum + s.events.length, 0),
     });
@@ -133,7 +133,7 @@ function HistoryDetailPageInner() {
   const [eventsLoading, setEventsLoading] = useState(false);
 
   /* sidebar selection */
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [selectedTag, setSelectedAgent] = useState<string | null>(null);
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
 
   const workspaceId = searchParams.get("workspaceId");
@@ -296,7 +296,7 @@ function HistoryDetailPageInner() {
                 setSelectedSession(null);
               }}
               className={`w-full text-left px-2 py-1.5 rounded text-[13px] font-medium transition-colors duration-[150ms] ${
-                !selectedSession && !selectedAgent
+                !selectedSession && !selectedTag
                   ? "bg-brand/15 text-brand"
                   : "text-foreground hover:bg-raised"
               }`}
@@ -314,23 +314,23 @@ function HistoryDetailPageInner() {
           ) : (
             <div className="px-2 py-2">
               {groups.map((ag) => (
-                <div key={ag.agentName} className="mb-2">
+                <div key={ag.tagName} className="mb-2">
                   <button
                     onClick={() => {
                       setSelectedAgent(
-                        selectedAgent === ag.agentName ? null : ag.agentName
+                        selectedTag === ag.tagName ? null : ag.tagName
                       );
                       setSelectedSession(null);
                     }}
                     className={`w-full text-left flex items-center gap-1.5 px-2 py-1 rounded transition-colors duration-[150ms] ${
-                      selectedAgent === ag.agentName && !selectedSession
+                      selectedTag === ag.tagName && !selectedSession
                         ? "bg-agent-muted"
                         : "hover:bg-raised"
                     }`}
                   >
                     <span className="w-1.5 h-1.5 rounded-full bg-agent flex-shrink-0" />
                     <span className="text-[13px] font-medium text-foreground truncate">
-                      {ag.agentName}
+                      {ag.tagName}
                     </span>
                     <span className="text-[10px] text-muted ml-auto font-mono">
                       {ag.eventCount}
@@ -342,7 +342,7 @@ function HistoryDetailPageInner() {
                       <button
                         key={sess.sessionId}
                         onClick={() => {
-                          setSelectedAgent(ag.agentName);
+                          setSelectedAgent(ag.tagName);
                           setSelectedSession(sess.sessionId);
                         }}
                         className={`w-full text-left px-2 py-1 rounded transition-colors duration-[150ms] ${
@@ -375,12 +375,12 @@ function HistoryDetailPageInner() {
               <SessionView
                 events={selectedEvents}
                 sessionId={selectedSession}
-                agentName={selectedAgent || ""}
+                tagName={selectedTag || ""}
               />
-            ) : selectedAgent ? (
-              <AgentOverview
+            ) : selectedTag ? (
+              <TagOverview
                 groups={groups}
-                agentName={selectedAgent}
+                tagName={selectedTag}
                 onSelectSession={(sid) => setSelectedSession(sid)}
               />
             ) : (
@@ -405,16 +405,16 @@ function HistoryDetailPageInner() {
 function SessionView({
   events,
   sessionId,
-  agentName,
+  tagName,
 }: {
   events: HistoryEvent[];
   sessionId: string;
-  agentName: string;
+  tagName: string;
 }) {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-xl font-bold text-foreground font-display">{agentName}</h1>
+        <h1 className="text-xl font-bold text-foreground font-display">{tagName}</h1>
         <p className="text-[11px] text-muted font-mono mt-1">
           session: {sessionId} &middot; {events.length} event
           {events.length !== 1 ? "s" : ""}
@@ -449,16 +449,16 @@ function SessionView({
 
 /* ── Agent overview ── */
 
-function AgentOverview({
+function TagOverview({
   groups,
-  agentName,
+  tagName,
   onSelectSession,
 }: {
-  groups: AgentGroup[];
-  agentName: string;
+  groups: TagGroup[];
+  tagName: string;
   onSelectSession: (sid: string) => void;
 }) {
-  const ag = groups.find((g) => g.agentName === agentName);
+  const ag = groups.find((g) => g.tagName === tagName);
   if (!ag) return <p className="text-muted text-sm">No data for this agent.</p>;
 
   return (
@@ -466,7 +466,7 @@ function AgentOverview({
       <div className="mb-6">
         <h1 className="text-xl font-bold text-foreground font-display flex items-center gap-2">
           <span className="w-2 h-2 rounded-full bg-agent" />
-          {agentName}
+          {tagName}
         </h1>
         <p className="text-[11px] text-muted mt-1">
           {ag.sessions.length} session{ag.sessions.length !== 1 ? "s" : ""} &middot;{" "}
@@ -507,7 +507,7 @@ function AllEventsView({
   eventsLoading,
   onSelectSession,
 }: {
-  groups: AgentGroup[];
+  groups: TagGroup[];
   eventsLoading: boolean;
   onSelectSession: (agent: string, sid: string) => void;
 }) {
@@ -526,11 +526,11 @@ function AllEventsView({
       </h1>
 
       {groups.map((ag) => (
-        <div key={ag.agentName} className="mb-6">
+        <div key={ag.tagName} className="mb-6">
           <div className="flex items-center gap-2 mb-2">
             <span className="w-2 h-2 rounded-full bg-agent" />
             <h2 className="text-[15px] font-semibold text-foreground">
-              {ag.agentName}
+              {ag.tagName}
             </h2>
             <span className="text-[10px] text-muted font-mono">
               {ag.eventCount} events
@@ -541,7 +541,7 @@ function AllEventsView({
             {ag.sessions.slice(0, 5).map((sess) => (
               <button
                 key={sess.sessionId}
-                onClick={() => onSelectSession(ag.agentName, sess.sessionId)}
+                onClick={() => onSelectSession(ag.tagName, sess.sessionId)}
                 className="w-full text-left bg-surface border border-border rounded-lg p-2.5 hover:bg-raised transition-colors duration-[150ms]"
               >
                 <div className="flex items-center gap-2">
@@ -580,7 +580,7 @@ function StoreEventCard({ event }: { event: HistoryEvent }) {
         {/* Header row */}
         <div className="flex items-center gap-1.5 mb-1 flex-wrap">
           <span className="text-[11px] font-medium text-agent bg-agent-muted px-1.5 py-0.5 rounded font-mono uppercase tracking-[0.05em]">
-            {event.agent_name}
+            {event.tag_name}
           </span>
           <span className="text-[11px] bg-raised text-muted px-1.5 py-0.5 rounded">
             {event.event_type}

--- a/frontend/src/app/memory/page.tsx
+++ b/frontend/src/app/memory/page.tsx
@@ -14,15 +14,15 @@ import { HistoryEventWithContext } from "../../lib/types";
 
 interface SessionGroup {
   sessionId: string;
-  agentName: string;
+  tagName: string;
   events: HistoryEventWithContext[];
   firstContent: string;
   timeRange: string;
   lastTimestamp: number;
 }
 
-interface AgentGroup {
-  agentName: string;
+interface TagGroup {
+  tagName: string;
   sessions: SessionGroup[];
   eventCount: number;
 }
@@ -53,21 +53,21 @@ function shouldShowTimestamp(a: string, b: string): boolean {
   return Math.abs(new Date(a).getTime() - new Date(b).getTime()) > 5 * 60 * 1000;
 }
 
-function buildGroups(events: HistoryEventWithContext[]): AgentGroup[] {
-  const agentMap = new Map<string, Map<string, HistoryEventWithContext[]>>();
+function buildGroups(events: HistoryEventWithContext[]): TagGroup[] {
+  const tagMap = new Map<string, Map<string, HistoryEventWithContext[]>>();
 
   for (const evt of events) {
-    const agent = evt.agent_name || "unknown";
+    const tag = evt.tag_name || "unknown";
     const session = evt.session_id || "no-session";
-    if (!agentMap.has(agent)) agentMap.set(agent, new Map());
-    const sessionMap = agentMap.get(agent)!;
+    if (!tagMap.has(tag)) tagMap.set(tag, new Map());
+    const sessionMap = tagMap.get(tag)!;
     if (!sessionMap.has(session)) sessionMap.set(session, []);
     sessionMap.get(session)!.push(evt);
   }
 
-  const groups: AgentGroup[] = [];
+  const groups: TagGroup[] = [];
 
-  for (const [agentName, sessionMap] of agentMap) {
+  for (const [tagName, sessionMap] of tagMap) {
     const sessions: SessionGroup[] = [];
 
     for (const [sessionId, evts] of sessionMap) {
@@ -78,7 +78,7 @@ function buildGroups(events: HistoryEventWithContext[]): AgentGroup[] {
       const last = sorted[sorted.length - 1];
       sessions.push({
         sessionId,
-        agentName,
+        tagName,
         events: sorted,
         firstContent: truncate(first.content, 60),
         timeRange: `${formatTime(first.created_at)} — ${formatTimeShort(last.created_at)}`,
@@ -89,7 +89,7 @@ function buildGroups(events: HistoryEventWithContext[]): AgentGroup[] {
     sessions.sort((a, b) => b.lastTimestamp - a.lastTimestamp);
 
     groups.push({
-      agentName,
+      tagName,
       sessions,
       eventCount: sessions.reduce((sum, s) => sum + s.events.length, 0),
     });
@@ -173,7 +173,7 @@ function MemoryPageInner() {
 
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [selectedTag, setSelectedAgent] = useState<string | null>(null);
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
 
   const fetchEvents = useCallback(
@@ -235,12 +235,12 @@ function MemoryPageInner() {
   }, [groups]);
 
   const selectedEvents = useMemo(() => {
-    if (!selectedSession || !selectedAgent) return null;
-    const ag = groups.find((g) => g.agentName === selectedAgent);
+    if (!selectedSession || !selectedTag) return null;
+    const ag = groups.find((g) => g.tagName === selectedTag);
     if (!ag) return null;
     const sess = ag.sessions.find((s) => s.sessionId === selectedSession);
     return sess?.events ?? null;
-  }, [groups, selectedAgent, selectedSession]);
+  }, [groups, selectedTag, selectedSession]);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
@@ -261,10 +261,10 @@ function MemoryPageInner() {
         <aside className="w-[250px] flex-shrink-0 overflow-y-auto border-r border-border bg-surface">
           <div className="border-b border-border-subtle px-4 py-4">
             <p className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted">
-              Agents
+              Tags
             </p>
             <p className="mt-1 font-display text-[15px] font-semibold text-foreground">
-              {groups.length} agent{groups.length === 1 ? "" : "s"} · {events.length} events
+              {groups.length} tag{groups.length === 1 ? "" : "s"} · {events.length} events
             </p>
           </div>
 
@@ -274,14 +274,14 @@ function MemoryPageInner() {
             <div className="px-2 py-2">
               {groups.map((ag) => (
                 <button
-                  key={ag.agentName}
+                  key={ag.tagName}
                   onClick={() => {
-                    setSelectedAgent(ag.agentName);
+                    setSelectedAgent(ag.tagName);
                     setSelectedSession(null);
                   }}
                   className={
                     "mb-0.5 flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors " +
-                    (selectedAgent === ag.agentName
+                    (selectedTag === ag.tagName
                       ? "bg-agent-muted"
                       : "hover:bg-raised")
                   }
@@ -291,7 +291,7 @@ function MemoryPageInner() {
                     style={{ background: "var(--color-agent)" }}
                   />
                   <span className="truncate text-[13px] font-medium text-foreground">
-                    {ag.agentName}
+                    {ag.tagName}
                   </span>
                   <span className="ml-auto font-mono text-[10px] text-muted">
                     {ag.eventCount}
@@ -299,7 +299,7 @@ function MemoryPageInner() {
                 </button>
               ))}
               {groups.length === 0 && !eventsLoading && (
-                <p className="px-2 py-2 text-[11px] text-muted">No agents yet.</p>
+                <p className="px-2 py-2 text-[11px] text-muted">No tags yet.</p>
               )}
             </div>
           )}
@@ -320,15 +320,15 @@ function MemoryPageInner() {
                   onClick={() => setSelectedSession(null)}
                   className="mb-5 text-[13px] text-muted transition-colors hover:text-foreground"
                 >
-                  ← {selectedAgent}
+                  ← {selectedTag}
                 </button>
                 <SessionView
                   events={selectedEvents}
                   sessionId={selectedSession}
-                  agentName={selectedAgent || ""}
+                  tagName={selectedTag || ""}
                 />
               </div>
-            ) : selectedAgent ? (
+            ) : selectedTag ? (
               <div>
                 <button
                   onClick={() => {
@@ -339,9 +339,9 @@ function MemoryPageInner() {
                 >
                   ← Recent activity
                 </button>
-                <AgentOverview
+                <TagOverview
                   groups={groups}
-                  agentName={selectedAgent}
+                  tagName={selectedTag}
                   wsId={wsId}
                   onSelectSession={(sid) => setSelectedSession(sid)}
                   onDelete={async () => {
@@ -349,8 +349,8 @@ function MemoryPageInner() {
                     try {
                       const { apiFetch } = await import("../../lib/api");
                       await apiFetch(
-                        `/api/v1/workspaces/${wsId}/memory/agents/${encodeURIComponent(
-                          selectedAgent
+                        `/api/v1/workspaces/${wsId}/memory/tags/${encodeURIComponent(
+                          selectedTag
                         )}`,
                         { method: "DELETE" }
                       );
@@ -367,7 +367,7 @@ function MemoryPageInner() {
                 hasMore={hasMore}
                 loadingMore={loadingMore}
                 onLoadMore={loadMore}
-                onSelectAgent={(agent) => {
+                onSelectTag={(agent) => {
                   setSelectedAgent(agent);
                   setSelectedSession(null);
                 }}
@@ -392,11 +392,11 @@ type SortOrder = "oldest" | "newest";
 function SessionView({
   events,
   sessionId,
-  agentName,
+  tagName,
 }: {
   events: HistoryEventWithContext[];
   sessionId: string;
-  agentName: string;
+  tagName: string;
 }) {
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [toolFilter, setToolFilter] = useState<string>("all");
@@ -424,7 +424,7 @@ function SessionView({
       result = result.filter(
         (e) =>
           e.content.toLowerCase().includes(q) ||
-          e.agent_name.toLowerCase().includes(q) ||
+          e.tag_name.toLowerCase().includes(q) ||
           (e.tool_name && e.tool_name.toLowerCase().includes(q))
       );
     }
@@ -457,10 +457,10 @@ function SessionView({
   return (
     <div>
       <header className="mb-5 flex items-center gap-3 border-b border-border-subtle pb-4">
-        <RoleAvatar role="agent" name={agentName} size={32} />
+        <RoleAvatar role="agent" name={tagName} size={32} />
         <div>
           <div className="font-display text-[16px] font-bold text-foreground">
-            {agentName}
+            {tagName}
           </div>
           <div className="mt-0.5 flex items-center gap-2 font-mono text-[11px] text-muted">
             <RoleTag role="agent" />
@@ -561,29 +561,29 @@ function SessionView({
 
 /* ── Agent overview ── */
 
-function AgentOverview({
+function TagOverview({
   groups,
-  agentName,
+  tagName,
   onSelectSession,
   onDelete,
 }: {
-  groups: AgentGroup[];
-  agentName: string;
+  groups: TagGroup[];
+  tagName: string;
   wsId: string | null;
   onSelectSession: (sid: string) => void;
   onDelete: () => void;
 }) {
-  const ag = groups.find((g) => g.agentName === agentName);
-  if (!ag) return <p className="text-[13px] text-muted">No data for this agent.</p>;
+  const ag = groups.find((g) => g.tagName === tagName);
+  if (!ag) return <p className="text-[13px] text-muted">No data for this tag.</p>;
 
   return (
     <div>
       <header className="mb-6 flex items-start justify-between gap-3 border-b border-border-subtle pb-4">
         <div className="flex items-center gap-3">
-          <RoleAvatar role="agent" name={agentName} size={32} />
+          <RoleAvatar role="agent" name={tagName} size={32} />
           <div>
             <div className="font-display text-[16px] font-bold text-foreground">
-              {agentName}
+              {tagName}
             </div>
             <div className="mt-0.5 flex items-center gap-2 font-mono text-[11px] text-muted">
               <RoleTag role="agent" />
@@ -596,13 +596,13 @@ function AgentOverview({
         </div>
         <button
           onClick={() => {
-            if (confirm(`Delete all ${ag.eventCount} events for "${agentName}"?`)) {
+            if (confirm(`Delete all ${ag.eventCount} events for "${tagName}"?`)) {
               onDelete();
             }
           }}
           className="rounded px-2 py-1 text-[12px] text-red-500 transition-colors hover:bg-red-500/10"
         >
-          Delete agent
+          Delete tag
         </button>
       </header>
 
@@ -639,7 +639,7 @@ function RecentActivityView({
   hasMore: hasMoreEvents,
   loadingMore: loadingMoreEvents,
   onLoadMore: onLoadMoreEvents,
-  onSelectAgent,
+  onSelectTag,
   onSelectSession,
 }: {
   allSessions: SessionGroup[];
@@ -647,7 +647,7 @@ function RecentActivityView({
   hasMore: boolean;
   loadingMore: boolean;
   onLoadMore: () => void;
-  onSelectAgent: (agent: string) => void;
+  onSelectTag: (agent: string) => void;
   onSelectSession: (agent: string, sid: string) => void;
 }) {
   const [visibleCount, setVisibleCount] = useState(SESSIONS_PAGE_SIZE);
@@ -685,7 +685,7 @@ function RecentActivityView({
   if (allSessions.length === 0) {
     return (
       <p className="text-[13px] text-muted">
-        No events found. Agent activity will appear here as events are logged.
+        No events found. Activity will appear here as events are logged.
       </p>
     );
   }
@@ -698,20 +698,20 @@ function RecentActivityView({
       <div className="flex flex-col gap-2">
         {visible.map((sess) => (
           <div
-            key={`${sess.agentName}-${sess.sessionId}`}
-            onClick={() => onSelectSession(sess.agentName, sess.sessionId)}
+            key={`${sess.tagName}-${sess.sessionId}`}
+            onClick={() => onSelectSession(sess.tagName, sess.sessionId)}
             className="w-full cursor-pointer rounded-lg border border-border-subtle bg-base px-4 py-3 text-left transition-colors hover:border-brand"
           >
             <div className="flex items-center gap-2">
-              <RoleAvatar role="agent" name={sess.agentName} size={22} />
+              <RoleAvatar role="agent" name={sess.tagName} size={22} />
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  onSelectAgent(sess.agentName);
+                  onSelectTag(sess.tagName);
                 }}
                 className="rounded font-mono text-[11px] font-medium tracking-[0.05em] text-foreground underline-offset-2 hover:underline"
               >
-                {sess.agentName}
+                {sess.tagName}
               </button>
               <RoleTag role="agent" />
               <span className="truncate text-[13px] text-dim">
@@ -747,7 +747,7 @@ function RecentActivityView({
 function EventRow({ event }: { event: HistoryEventWithContext }) {
   const isUser = isUserEvent(event.event_type);
   const role: Role = isUser ? "human" : "agent";
-  const displayName = isUser ? (event.created_by_name || "user") : event.agent_name;
+  const displayName = isUser ? (event.created_by_name || "user") : event.tag_name;
   return (
     <div className="flex gap-3">
       <RoleAvatar role={role} name={displayName} size={24} />
@@ -761,7 +761,7 @@ function EventRow({ event }: { event: HistoryEventWithContext }) {
           <span className="font-mono text-[11px] text-dim">{event.event_type}</span>
           {isUser && (
             <span className="text-[11px] text-muted">
-              → {event.agent_name}
+              → {event.tag_name}
             </span>
           )}
           {event.store_name && (

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -288,10 +288,10 @@ function SearchPageInner() {
                           className="inline-flex h-[22px] w-[22px] flex-shrink-0 items-center justify-center rounded-full font-display text-[10px] font-bold text-white"
                           style={{ background: "var(--color-agent)" }}
                         >
-                          {event.agent_name[0]?.toUpperCase() || "A"}
+                          {event.tag_name[0]?.toUpperCase() || "A"}
                         </span>
                         <span className="text-[14px] font-semibold text-foreground">
-                          {event.agent_name}
+                          {event.tag_name}
                         </span>
                         <span
                           className="inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em]"

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -220,7 +220,7 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
 
   if (item.object_type === "history") {
     const inline = item.inline as {
-      agent_name?: string;
+      tag_name?: string;
       event_type?: string;
       content?: string;
       created_at?: string;
@@ -228,7 +228,7 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
     return (
       <div>
         <p className="font-mono text-[11px] uppercase text-muted">
-          {inline.agent_name} · {inline.event_type} · {inline.created_at}
+          {inline.tag_name} · {inline.event_type} · {inline.created_at}
         </p>
         <pre className="mt-2 whitespace-pre-wrap break-words rounded bg-background p-3 font-mono text-[12px] leading-[1.5] text-foreground">
           {inline.content || ""}

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -39,7 +39,7 @@ import {
   WorkspaceMember,
 } from "../../../lib/types";
 import DashboardSection from "../../../components/viz/DashboardSection";
-import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
+import TagActivityTimeline from "../../../components/viz/TagActivityTimeline";
 import KnowledgeDensityMap from "../../../components/viz/KnowledgeDensityMap";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import PageGraphView from "../../../components/workspace/PageGraphView";
@@ -241,12 +241,12 @@ export default function WorkspacePage() {
               {/* Visualizations */}
               {(vizLoading || timeline?.buckets.length || density?.clusters.length || projection?.points.length) ? (
                 <div className="space-y-4">
-                  <DashboardSection title="Agent Activity" loading={vizLoading} empty={!timeline?.buckets.length} emptyMessage="No agent activity yet.">
+                  <DashboardSection title="Tag Activity" loading={vizLoading} empty={!timeline?.buckets.length} emptyMessage="No tag activity yet.">
                     {timeline && (
-                      <AgentActivityTimeline
+                      <TagActivityTimeline
                         data={timeline}
-                        onAgentClick={(agent) =>
-                          router.push(`/memory?ws=${workspaceId}&agent=${encodeURIComponent(agent)}`)
+                        onTagClick={(tag) =>
+                          router.push(`/memory?ws=${workspaceId}&tag=${encodeURIComponent(tag)}`)
                         }
                       />
                     )}

--- a/frontend/src/components/viz/TagActivityTimeline.tsx
+++ b/frontend/src/components/viz/TagActivityTimeline.tsx
@@ -5,7 +5,7 @@ import type { ActivityTimeline } from "../../lib/types";
 
 interface Props {
   data: ActivityTimeline;
-  onAgentClick?: (agent: string) => void;
+  onTagClick?: (tag: string) => void;
 }
 
 const CELL_SIZE = 14;
@@ -37,22 +37,22 @@ function getIntensity(count: number, maxCount: number): number {
 interface TooltipInfo {
   x: number;
   y: number;
-  agent: string;
+  tag: string;
   date: string;
   total: number;
   byType: Record<string, number>;
 }
 
-export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
+export default function TagActivityTimeline({ data, onTagClick }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
-  const [hoverAgent, setHoverAgent] = useState<string | null>(null);
+  const [hoverTag, setHoverTag] = useState<string | null>(null);
 
   // Compute max count for intensity scaling
   const maxCount = data.buckets.reduce((max, b) => {
-    for (const agent of Object.values(b.agents)) {
-      if (agent.total > max) max = agent.total;
+    for (const tag of Object.values(b.tags)) {
+      if (tag.total > max) max = tag.total;
     }
     return max;
   }, 0);
@@ -64,11 +64,11 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const agents = data.agents;
+    const tags = data.tags;
     const buckets = data.buckets;
 
     const totalWidth = LABEL_WIDTH + PADDING + buckets.length * (CELL_SIZE + CELL_GAP);
-    const totalHeight = PADDING + agents.length * (CELL_SIZE + CELL_GAP) + PADDING;
+    const totalHeight = PADDING + tags.length * (CELL_SIZE + CELL_GAP) + PADDING;
 
     const dpr = window.devicePixelRatio || 2;
     canvas.width = totalWidth * dpr;
@@ -79,15 +79,15 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
 
     ctx.clearRect(0, 0, totalWidth, totalHeight);
 
-    // Agent labels (violet)
+    // Tag labels (violet)
     ctx.font = "500 11px 'JetBrains Mono', monospace";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     ctx.fillStyle = "#8B5CF6";
 
-    for (let i = 0; i < agents.length; i++) {
+    for (let i = 0; i < tags.length; i++) {
       const y = PADDING + i * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2;
-      const label = agents[i].length > 10 ? agents[i].slice(0, 9) + "..." : agents[i];
+      const label = tags[i].length > 10 ? tags[i].slice(0, 9) + "..." : tags[i];
       ctx.fillText(label, LABEL_WIDTH, y);
     }
 
@@ -96,10 +96,10 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
       const bucket = buckets[bi];
       const x = LABEL_WIDTH + PADDING + bi * (CELL_SIZE + CELL_GAP);
 
-      for (let ai = 0; ai < agents.length; ai++) {
+      for (let ai = 0; ai < tags.length; ai++) {
         const y = PADDING + ai * (CELL_SIZE + CELL_GAP);
-        const agentData = bucket.agents[agents[ai]];
-        const count = agentData?.total ?? 0;
+        const tagData = bucket.tags[tags[ai]];
+        const count = tagData?.total ?? 0;
         const intensity = getIntensity(count, maxCount);
 
         // Cell background
@@ -135,21 +135,20 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
     if (!p) return;
     const { bi, ai, clientX, clientY } = p;
 
-    // Any hover over a valid row — the whole row is a click target for the agent filter
-    const agent = ai >= 0 && ai < data.agents.length ? data.agents[ai] : null;
-    setHoverAgent(agent);
+    const tag = ai >= 0 && ai < data.tags.length ? data.tags[ai] : null;
+    setHoverTag(tag);
 
-    if (bi >= 0 && bi < data.buckets.length && agent) {
+    if (bi >= 0 && bi < data.buckets.length && tag) {
       const bucket = data.buckets[bi];
-      const agentData = bucket.agents[agent];
-      if (agentData && agentData.total > 0) {
+      const tagData = bucket.tags[tag];
+      if (tagData && tagData.total > 0) {
         setTooltip({
           x: clientX,
           y: clientY,
-          agent,
+          tag,
           date: bucket.date.split("T")[0],
-          total: agentData.total,
-          byType: agentData.by_type,
+          total: tagData.total,
+          byType: tagData.by_type,
         });
         return;
       }
@@ -158,13 +157,13 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
   };
 
   const handleClick = (e: React.MouseEvent) => {
-    if (!onAgentClick) return;
+    if (!onTagClick) return;
     const p = pointToCell(e);
     if (!p) return;
-    if (p.ai >= 0 && p.ai < data.agents.length) onAgentClick(data.agents[p.ai]);
+    if (p.ai >= 0 && p.ai < data.tags.length) onTagClick(data.tags[p.ai]);
   };
 
-  const cursor = onAgentClick && hoverAgent ? "cursor-pointer" : "cursor-crosshair";
+  const cursor = onTagClick && hoverTag ? "cursor-pointer" : "cursor-crosshair";
 
   return (
     <div ref={containerRef} className="relative overflow-x-auto">
@@ -172,7 +171,7 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
         ref={canvasRef}
         className={cursor}
         onMouseMove={handleMouseMove}
-        onMouseLeave={() => { setTooltip(null); setHoverAgent(null); }}
+        onMouseLeave={() => { setTooltip(null); setHoverTag(null); }}
         onClick={handleClick}
       />
       {tooltip && (
@@ -181,7 +180,7 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
           style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
         >
           <div className="text-xs font-medium text-foreground">
-            <span className="text-violet-400">{tooltip.agent}</span>
+            <span className="text-violet-400">{tooltip.tag}</span>
             <span className="text-muted mx-1">&middot;</span>
             <span className="text-muted font-mono">{tooltip.date}</span>
           </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -476,7 +476,7 @@ export async function queryHistoryEvents(
   workspaceId: string | null,
   storeId: string,
   params?: {
-    agent_name?: string;
+    tag_name?: string;
     session_id?: string;
     event_type?: string;
     after?: string;
@@ -485,7 +485,7 @@ export async function queryHistoryEvents(
   }
 ): Promise<{ events: HistoryEvent[]; has_more: boolean }> {
   const searchParams = new URLSearchParams();
-  if (params?.agent_name) searchParams.set("agent_name", params.agent_name);
+  if (params?.tag_name) searchParams.set("tag_name", params.tag_name);
   if (params?.session_id) searchParams.set("session_id", params.session_id);
   if (params?.event_type) searchParams.set("event_type", params.event_type);
   if (params?.after) searchParams.set("after", params.after);
@@ -518,7 +518,7 @@ export async function listAllHistories(): Promise<{ stores: HistoryWithWorkspace
 
 export async function queryAllHistoryEvents(
   params?: {
-    agent_name?: string;
+    tag_name?: string;
     event_type?: string;
     after?: string;
     before?: string;
@@ -526,7 +526,7 @@ export async function queryAllHistoryEvents(
   }
 ): Promise<{ events: HistoryEventWithContext[]; has_more: boolean }> {
   const searchParams = new URLSearchParams();
-  if (params?.agent_name) searchParams.set("agent_name", params.agent_name);
+  if (params?.tag_name) searchParams.set("tag_name", params.tag_name);
   if (params?.event_type) searchParams.set("event_type", params.event_type);
   if (params?.after) searchParams.set("after", params.after);
   if (params?.before) searchParams.set("before", params.before);
@@ -538,7 +538,7 @@ export async function queryAllHistoryEvents(
 export async function queryWorkspaceHistoryEvents(
   workspaceId: string,
   params?: {
-    agent_name?: string;
+    tag_name?: string;
     session_id?: string;
     event_type?: string;
     after?: string;
@@ -547,7 +547,7 @@ export async function queryWorkspaceHistoryEvents(
   }
 ): Promise<{ events: HistoryEvent[]; has_more: boolean }> {
   const searchParams = new URLSearchParams();
-  if (params?.agent_name) searchParams.set("agent_name", params.agent_name);
+  if (params?.tag_name) searchParams.set("tag_name", params.tag_name);
   if (params?.session_id) searchParams.set("session_id", params.session_id);
   if (params?.event_type) searchParams.set("event_type", params.event_type);
   if (params?.after) searchParams.set("after", params.after);
@@ -970,11 +970,11 @@ export async function semanticSearchTableRows(
   return data.rows;
 }
 
-// --- Agent Names ---
+// --- Tag Names ---
 
-export async function listAgentNames(workspaceId: string): Promise<string[]> {
-  const data = await apiFetch<{ agent_names: string[] }>(
-    `/api/v1/workspaces/${workspaceId}/memory/agent-names`
+export async function listTagNames(workspaceId: string): Promise<string[]> {
+  const data = await apiFetch<{ tag_names: string[] }>(
+    `/api/v1/workspaces/${workspaceId}/memory/tag-names`
   );
-  return data.agent_names;
+  return data.tag_names;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -108,7 +108,7 @@ export interface History {
 export interface HistoryEvent {
   id: string;
   store_id: string;
-  agent_name: string;
+  tag_name: string;
   event_type: string;
   session_id: string | null;
   tool_name: string | null;
@@ -237,10 +237,10 @@ export interface PageGraph {
 // --- Dashboard Visualizations ---
 
 export interface ActivityTimeline {
-  agents: string[];
+  tags: string[];
   buckets: {
     date: string;
-    agents: Record<string, { total: number; by_type: Record<string, number> }>;
+    tags: Record<string, { total: number; by_type: Record<string, number> }>;
   }[];
 }
 

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -20,9 +20,9 @@
       "type": "string",
       "sensitive": true
     },
-    "agent_name": {
-      "title": "Agent Name",
-      "description": "Agent identity name in Stash",
+    "tag_name": {
+      "title": "Tag Name",
+      "description": "Tag identity name in Stash",
       "type": "string",
       "sensitive": false
     },

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -32,10 +32,10 @@ stash notebooks add-page <notebook_id> "title" --ws <ws_id> --content "markdown 
 stash notebooks edit-page <notebook_id> <page_id> --ws <ws_id> --content "new content"
 ```
 
-### History (Agent Event Logs)
+### History (Event Logs)
 ```bash
-stash history agents --ws <workspace_id>                              # List distinct agent names
-stash history push "text" --ws <ws_id> --agent <name> --type <event_type>
+stash history tags --ws <workspace_id>                                # List distinct tag names
+stash history push "text" --ws <ws_id> --tag <name> --type <event_type>
 stash history query --ws <ws_id> --limit 20                           # Query events
 stash history search "query" --ws <ws_id>                             # Full-text search
 stash history query --all --limit 20                                  # Cross-workspace events

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -20,7 +20,7 @@ Claude Code will prompt you for three config values:
 | Config | Value |
 |--------|-------|
 | `api_key` | Your API key (from step 1) |
-| `agent_name` | A name for this agent (any string) |
+| `tag_name` | A name for this tag (any string) |
 | `api_endpoint` | `https://joinstash.ai` (default, usually skip) |
 
 ### Step 3: Connect to a workspace
@@ -70,7 +70,7 @@ Now everyone's activity streams to the same workspace. You can:
 |-----|---------|-------------|
 | `api_endpoint` | `https://joinstash.ai` | Stash backend URL |
 | `api_key` | *(required)* | Your API key |
-| `agent_name` | *(required)* | Agent name (any string) |
+| `tag_name` | *(required)* | Tag name (any string) |
 | `workspace_id` | *(optional)* | Set via `stash connect` |
 | `auto_curate` | `true` | Spawn `claude -p` headless at session end to curate history into wiki pages. Stored in `~/.stash/config.json`. |
 

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -76,7 +76,7 @@ def _load_cli_config() -> dict:
 
 def get_config() -> dict:
     api_key = os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_api_key", "")
-    agent_name = os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_agent_name", "")
+    tag_name = os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_tag_name", "")
 
     if not api_key:
         cli = _load_cli_config()
@@ -84,7 +84,7 @@ def get_config() -> dict:
         return {
             "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
             "api_key": cli.get("api_key", ""),
-            "agent_name": cli.get("username", ""),
+            "tag_name": cli.get("username", ""),
             "workspace_id": (manifest or {}).get("workspace_id", ""),
             "auto_curate": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_auto_curate", "true"),
             "client": "claude_code",
@@ -93,7 +93,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_api_endpoint", "https://joinstash.ai"),
         "api_key": api_key,
-        "agent_name": agent_name,
+        "tag_name": tag_name,
         "workspace_id": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_workspace_id", ""),
         "auto_curate": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_auto_curate", "true"),
         "client": "claude_code",
@@ -107,4 +107,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/codex-plugin/scripts/config.py
+++ b/plugins/codex-plugin/scripts/config.py
@@ -71,7 +71,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
         "api_key": cli.get("api_key", ""),
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "codex_cli",
@@ -85,4 +85,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -39,7 +39,7 @@ def main():
         transcript_path=event.transcript_path,
         session_id=state.get("session_id", ""),
         workspace_id=cfg["workspace_id"],
-        agent_name=cfg["agent_name"],
+        tag_name=cfg["tag_name"],
         cwd=event.cwd,
         base_url=cfg["api_endpoint"],
         api_key=cfg["api_key"],

--- a/plugins/cursor-plugin/scripts/config.py
+++ b/plugins/cursor-plugin/scripts/config.py
@@ -76,7 +76,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
         "api_key": cli.get("api_key", ""),
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),  # off by default for Cursor
         "client": "cursor",
@@ -90,4 +90,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/gemini-plugin/scripts/config.py
+++ b/plugins/gemini-plugin/scripts/config.py
@@ -71,7 +71,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
         "api_key": cli.get("api_key", ""),
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "gemini_cli",
@@ -85,4 +85,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/openclaw-plugin/index.ts
+++ b/plugins/openclaw-plugin/index.ts
@@ -30,7 +30,7 @@ type StashManifest = {
 };
 
 type EventBody = {
-  agent_name: string;
+  tag_name: string;
   event_type: "session_start" | "user_message" | "assistant_message" | "session_end";
   content: string;
   session_id?: string;
@@ -164,7 +164,7 @@ async function pushEvent(body: EventBody): Promise<void> {
 
   const fullBody: EventBody = {
     ...body,
-    agent_name: cfg.username ?? "openclaw",
+    tag_name: cfg.username ?? "openclaw",
     metadata: { ...(body.metadata ?? {}), client: "openclaw" },
   };
   const path = eventsPath(workspaceId);
@@ -186,7 +186,7 @@ export default definePluginEntry({
   register(api) {
     api.on("session_start", (event, ctx) => {
       send({
-        agent_name: "",
+        tag_name: "",
         event_type: "session_start",
         content: "",
         session_id: event.sessionKey ?? event.sessionId ?? ctx.sessionKey,
@@ -202,7 +202,7 @@ export default definePluginEntry({
 
       if (role === "user") {
         send({
-          agent_name: "",
+          tag_name: "",
           event_type: "user_message",
           content: stripSenderWrapper(text),
           session_id: event.sessionKey ?? ctx.sessionKey,
@@ -211,7 +211,7 @@ export default definePluginEntry({
       }
       if (role === "assistant") {
         send({
-          agent_name: "",
+          tag_name: "",
           event_type: "assistant_message",
           content: text,
           session_id: event.sessionKey ?? ctx.sessionKey,
@@ -223,7 +223,7 @@ export default definePluginEntry({
 
     api.on("session_end", (event, ctx) => {
       send({
-        agent_name: "",
+        tag_name: "",
         event_type: "session_end",
         content: "",
         session_id: event.sessionKey ?? event.sessionId ?? ctx.sessionKey,

--- a/plugins/openclaw-plugin/scripts/config.py
+++ b/plugins/openclaw-plugin/scripts/config.py
@@ -71,7 +71,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
         "api_key": cli.get("api_key", ""),
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "openclaw",
@@ -85,4 +85,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/opencode-plugin/scripts/config.py
+++ b/plugins/opencode-plugin/scripts/config.py
@@ -71,7 +71,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": cli.get("base_url", "https://joinstash.ai"),
         "api_key": cli.get("api_key", ""),
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "opencode",
@@ -85,4 +85,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/plugins/tests/test_adapters.py
+++ b/plugins/tests/test_adapters.py
@@ -143,21 +143,21 @@ def test_push_event_stamps_client_into_metadata():
     c = FakeClient(base_url="http://x", api_key="k")
 
     c.push_event(
-        workspace_id="ws1", agent_name="henry", event_type="tool_use",
+        workspace_id="ws1", tag_name="henry", event_type="tool_use",
         content="...", tool_name="edit", metadata={"cwd": "/tmp"}, client="cursor",
     )
     body = calls[-1][1]["json"]
     assert body["metadata"] == {"cwd": "/tmp", "client": "cursor"}
 
     c.push_event(
-        workspace_id="ws1", agent_name="henry", event_type="user_message",
+        workspace_id="ws1", tag_name="henry", event_type="user_message",
         content="hi", client="claude_code",
     )
     body = calls[-1][1]["json"]
     assert body["metadata"] == {"client": "claude_code"}
 
     c.push_event(
-        workspace_id="ws1", agent_name="henry", event_type="user_message", content="hi",
+        workspace_id="ws1", tag_name="henry", event_type="user_message", content="hi",
     )
     body = calls[-1][1]["json"]
     assert "metadata" not in body
@@ -213,7 +213,7 @@ def test_client_facet_flows_through_stream_paths():
         calls.clear()
         cfg = {
             "workspace_id": "ws1",
-            "agent_name": "henry",
+            "tag_name": "henry",
             "client": client_name,
         }
         state = {"session_id": "s1"}
@@ -250,7 +250,7 @@ def test_stream_session_end_not_emitted_on_assistant_message():
             return {}
 
     c = FakeClient(base_url="http://x", api_key="k")
-    cfg = {"workspace_id": "ws1", "agent_name": "henry", "client": "claude_code"}
+    cfg = {"workspace_id": "ws1", "tag_name": "henry", "client": "claude_code"}
     state = {"session_id": "s1"}
     stream_assistant_message(c, cfg, state, HookEvent(
         kind="stop", last_assistant_message="turn complete.",

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -54,7 +54,7 @@ def test_failed_push_enqueues(tmp_path):
     client = _make_client(tmp_path, fail_first_n=1)
     with pytest.raises(Exception):
         client.push_event(
-            workspace_id="ws-1", agent_name="a", event_type="tool_use", content="x",
+            workspace_id="ws-1", tag_name="a", event_type="tool_use", content="x",
         )
     queued = _queue_lines(tmp_path)
     assert len(queued) == 1
@@ -68,11 +68,11 @@ def test_successful_push_drains_backlog(tmp_path):
     client = _make_client(tmp_path, fail_first_n=2)
     for i in range(2):
         with pytest.raises(Exception):
-            client.push_event(workspace_id="ws-1", agent_name="a", event_type="t", content=f"e{i}")
+            client.push_event(workspace_id="ws-1", tag_name="a", event_type="t", content=f"e{i}")
     assert len(_queue_lines(tmp_path)) == 2
 
     # Third push: succeeds + drains backlog.
-    client.push_event(workspace_id="ws-1", agent_name="a", event_type="t", content="e2")
+    client.push_event(workspace_id="ws-1", tag_name="a", event_type="t", content="e2")
 
     # Queue should be empty after drain.
     assert _queue_lines(tmp_path) == []
@@ -84,13 +84,13 @@ def test_drain_stops_on_first_failure(tmp_path):
     """If backend is still down during drain, leftover entries stay queued."""
     client = _make_client(tmp_path, fail_first_n=1)
     with pytest.raises(Exception):
-        client.push_event(workspace_id="ws-1", agent_name="a", event_type="t", content="e0")
+        client.push_event(workspace_id="ws-1", tag_name="a", event_type="t", content="e0")
     assert len(_queue_lines(tmp_path)) == 1
 
     # Force the recorder to fail the next 5 POSTs (live push + drain attempts).
     client._http.fail_first_n = len(client._http.calls) + 5
     with pytest.raises(Exception):
-        client.push_event(workspace_id="ws-1", agent_name="a", event_type="t", content="e1")
+        client.push_event(workspace_id="ws-1", tag_name="a", event_type="t", content="e1")
 
     # Both events should still be queued (live push failed; drain never ran).
     queued = _queue_lines(tmp_path)
@@ -103,5 +103,5 @@ def test_no_data_dir_no_queue(tmp_path):
     client = StashClient(base_url="https://example.test", api_key="k")
     client._http = _Recorder(fail_first_n=1)
     with pytest.raises(Exception):
-        client.push_event(workspace_id="ws-1", agent_name="a", event_type="t", content="x")
+        client.push_event(workspace_id="ws-1", tag_name="a", event_type="t", content="x")
     assert not (tmp_path / QUEUE_FILENAME).exists()

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -126,7 +126,7 @@ def test_out_of_scope_blocks_live_events(monkeypatch):
     monkeypatch.setattr(hooks, "cwd_in_scope", lambda cwd: False)
 
     c = _RecordingClient()
-    stream_user_message(c, {"workspace_id": "ws1", "agent_name": "a"}, {"session_id": "s"},
+    stream_user_message(c, {"workspace_id": "ws1", "tag_name": "a"}, {"session_id": "s"},
                         "hello", HookEvent(kind="prompt", cwd="/other"))
     assert c.calls == []
 
@@ -135,6 +135,6 @@ def test_in_scope_allows_live_events(monkeypatch):
     from stashai.plugin.hooks import stream_user_message
     # Autouse fixture in conftest already patches cwd_in_scope → True.
     c = _RecordingClient()
-    stream_user_message(c, {"workspace_id": "ws1", "agent_name": "a"}, {"session_id": "s"},
+    stream_user_message(c, {"workspace_id": "ws1", "tag_name": "a"}, {"session_id": "s"},
                         "hello", HookEvent(kind="prompt", cwd="/anywhere"))
     assert len(c.calls) == 1

--- a/plugins/tests/test_stats_counter.py
+++ b/plugins/tests/test_stats_counter.py
@@ -53,7 +53,7 @@ def test_reset_stats_clears(tmp_path):
 
 
 def test_stream_tool_use_writes_counter(tmp_path):
-    cfg = {"workspace_id": "ws", "agent_name": "h", "client": "claude_code"}
+    cfg = {"workspace_id": "ws", "tag_name": "h", "client": "claude_code"}
     state = {"session_id": "s1"}
     c = _FakeClient()
 
@@ -73,7 +73,7 @@ def test_stream_tool_use_writes_counter(tmp_path):
 
 
 def test_stream_session_end_reads_counter(tmp_path):
-    cfg = {"workspace_id": "ws", "agent_name": "h", "client": "claude_code"}
+    cfg = {"workspace_id": "ws", "tag_name": "h", "client": "claude_code"}
     state = {
         "session_id": "s1",
         "stats": {"tool_count": 7, "tools_used": ["edit", "bash"], "files_changed": ["a.py", "b.py"]},
@@ -92,7 +92,7 @@ def test_stream_session_end_reads_counter(tmp_path):
 
 
 def test_stream_session_end_with_no_prior_tool_use(tmp_path):
-    cfg = {"workspace_id": "ws", "agent_name": "h", "client": "claude_code"}
+    cfg = {"workspace_id": "ws", "tag_name": "h", "client": "claude_code"}
     state = {"session_id": "s1"}
     c = _FakeClient()
 

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -533,7 +533,7 @@ def generate_history_events(count: int = 200):
         events.append({
             "id": uuid4(),
             "workspace_id": WORKSPACE_ID if random.random() > 0.2 else None,
-            "agent_name": agent,
+            "tag_name": agent,
             "event_type": event_type,
             "session_id": f"session-{random.randint(1, 30):03d}",
             "content": content_templates[event_type],
@@ -602,9 +602,9 @@ async def main():
             events = generate_history_events(200)
             for ev in events:
                 await conn.execute(
-                    """INSERT INTO history_events (id, workspace_id, agent_name, event_type, session_id, content, metadata, created_by, created_at, embedding)
+                    """INSERT INTO history_events (id, workspace_id, tag_name, event_type, session_id, content, metadata, created_by, created_at, embedding)
                        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)""",
-                    ev["id"], ev["workspace_id"], ev["agent_name"], ev["event_type"],
+                    ev["id"], ev["workspace_id"], ev["tag_name"], ev["event_type"],
                     ev["session_id"], ev["content"], "{}", ev["created_by"],
                     ev["created_at"], ev["embedding"],
                 )

--- a/stashai/plugin/_do_upload.py
+++ b/stashai/plugin/_do_upload.py
@@ -3,7 +3,7 @@
 Invoked by transcript_upload.spawn_transcript_upload(). Runs outside the
 hook timeout so large files don't block the agent.
 
-argv: script.py <transcript_path> <session_id> <workspace_id> <agent_name> <cwd> <base_url> <api_key>
+argv: script.py <transcript_path> <session_id> <workspace_id> <tag_name> <cwd> <base_url> <api_key>
 """
 
 import sys
@@ -13,14 +13,14 @@ from stashai.plugin.stash_client import StashClient
 
 
 def main() -> None:
-    _, transcript_path, session_id, workspace_id, agent_name, cwd, base_url, api_key = sys.argv
+    _, transcript_path, session_id, workspace_id, tag_name, cwd, base_url, api_key = sys.argv
 
     with StashClient(base_url=base_url, api_key=api_key) as client:
         client.upload_transcript(
             workspace_id=workspace_id,
             session_id=session_id,
             transcript_path=Path(transcript_path),
-            agent_name=agent_name,
+            tag_name=tag_name,
             cwd=cwd,
         )
 

--- a/stashai/plugin/assets/codex/scripts/config.py
+++ b/stashai/plugin/assets/codex/scripts/config.py
@@ -49,7 +49,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": api_endpoint,
         "api_key": api_key,
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "codex_cli",
@@ -63,4 +63,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -39,7 +39,7 @@ def main():
         transcript_path=event.transcript_path,
         session_id=state.get("session_id", ""),
         workspace_id=cfg["workspace_id"],
-        agent_name=cfg["agent_name"],
+        tag_name=cfg["tag_name"],
         cwd=event.cwd,
         base_url=cfg["api_endpoint"],
         api_key=cfg["api_key"],

--- a/stashai/plugin/assets/cursor/scripts/config.py
+++ b/stashai/plugin/assets/cursor/scripts/config.py
@@ -53,7 +53,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": api_endpoint,
         "api_key": api_key,
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "cursor",
@@ -67,4 +67,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/stashai/plugin/assets/opencode/scripts/config.py
+++ b/stashai/plugin/assets/opencode/scripts/config.py
@@ -49,7 +49,7 @@ def get_config() -> dict:
     return {
         "api_endpoint": api_endpoint,
         "api_key": api_key,
-        "agent_name": cli.get("username", ""),
+        "tag_name": cli.get("username", ""),
         "workspace_id": (manifest or {}).get("workspace_id", ""),
         "auto_curate": os.environ.get("STASH_AUTO_CURATE", "false"),
         "client": "opencode",
@@ -63,4 +63,4 @@ def get_client() -> StashClient:
 
 def is_configured() -> bool:
     cfg = get_config()
-    return bool(cfg["api_key"] and cfg["agent_name"])
+    return bool(cfg["api_key"] and cfg["tag_name"])

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -104,7 +104,7 @@ def stream_user_message(
     try:
         client.push_event(
             workspace_id=workspace_id,
-            agent_name=cfg["agent_name"],
+            tag_name=cfg["tag_name"],
             event_type="user_message",
             content=prompt_text[:2000],
             session_id=state.get("session_id", ""),
@@ -137,7 +137,7 @@ def stream_tool_use(
     try:
         client.push_event(
             workspace_id=workspace_id,
-            agent_name=cfg["agent_name"],
+            tag_name=cfg["tag_name"],
             event_type="tool_use",
             content=content,
             session_id=state.get("session_id", ""),
@@ -165,7 +165,7 @@ def stream_assistant_message(
     try:
         client.push_event(
             workspace_id=workspace_id,
-            agent_name=cfg["agent_name"],
+            tag_name=cfg["tag_name"],
             event_type="assistant_message",
             content=event.last_assistant_message[:4000],
             session_id=state.get("session_id", ""),
@@ -204,7 +204,7 @@ def stream_session_end(
     try:
         client.push_event(
             workspace_id=workspace_id,
-            agent_name=cfg["agent_name"],
+            tag_name=cfg["tag_name"],
             event_type="session_end",
             content=" ".join(parts),
             session_id=state.get("session_id", ""),
@@ -231,7 +231,7 @@ def stream_session_end(
             workspace_id=workspace_id,
             session_id=sid,
             transcript_path=path,
-            agent_name=cfg["agent_name"],
+            tag_name=cfg["tag_name"],
             cwd=event.cwd,
         )
     except Exception:

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -105,11 +105,11 @@ class StashClient:
 
     def push_event(
         self, workspace_id: str | None,
-        agent_name: str, event_type: str, content: str,
+        tag_name: str, event_type: str, content: str,
         session_id: str | None = None, tool_name: str | None = None,
         metadata: dict | None = None, client: str | None = None,
     ) -> dict:
-        body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
+        body: dict = {"tag_name": tag_name, "event_type": event_type, "content": content}
         if session_id:
             body["session_id"] = session_id
         if tool_name:
@@ -210,13 +210,13 @@ class StashClient:
 
     def query_events(
         self, workspace_id: str | None,
-        agent_name: str | None = None, event_type: str | None = None,
+        tag_name: str | None = None, event_type: str | None = None,
         session_id: str | None = None,
         limit: int = 50, after: str | None = None,
     ) -> list:
         params: dict = {"limit": limit}
-        if agent_name:
-            params["agent_name"] = agent_name
+        if tag_name:
+            params["tag_name"] = tag_name
         if event_type:
             params["event_type"] = event_type
         if session_id:
@@ -237,7 +237,7 @@ class StashClient:
     # request.
     def upload_transcript(
         self, workspace_id: str, session_id: str, transcript_path: Path,
-        agent_name: str, cwd: str | None = None,
+        tag_name: str, cwd: str | None = None,
     ) -> dict:
         import gzip
 
@@ -251,7 +251,7 @@ class StashClient:
             "POST",
             f"/api/v1/workspaces/{workspace_id}/transcripts",
             headers=self._headers(),
-            data={"session_id": session_id, "agent_name": agent_name, "cwd": cwd or ""},
+            data={"session_id": session_id, "tag_name": tag_name, "cwd": cwd or ""},
             files={"file": (name, body, "application/gzip")},
             timeout=httpx.Timeout(60.0, connect=5.0),
         )
@@ -262,12 +262,12 @@ class StashClient:
     # --- Cross-workspace aggregate (optional) ---
 
     def list_all_history_events(
-        self, agent_name: str | None = None, event_type: str | None = None,
+        self, tag_name: str | None = None, event_type: str | None = None,
         limit: int = 50,
     ) -> list:
         params: dict = {"limit": limit}
-        if agent_name:
-            params["agent_name"] = agent_name
+        if tag_name:
+            params["tag_name"] = tag_name
         if event_type:
             params["event_type"] = event_type
         return self._list("/api/v1/me/history-events", "events", **params)

--- a/stashai/plugin/transcript_upload.py
+++ b/stashai/plugin/transcript_upload.py
@@ -45,7 +45,7 @@ def spawn_transcript_upload(
     transcript_path: str,
     session_id: str,
     workspace_id: str,
-    agent_name: str,
+    tag_name: str,
     cwd: str,
     base_url: str,
     api_key: str,
@@ -68,7 +68,7 @@ def spawn_transcript_upload(
         subprocess.Popen(
             [
                 sys.executable, str(script),
-                str(path), session_id, workspace_id, agent_name, cwd, base_url, api_key,
+                str(path), session_id, workspace_id, tag_name, cwd, base_url, api_key,
             ],
             env=env,
             stdin=subprocess.DEVNULL,

--- a/www/app/docs/concepts/page.tsx
+++ b/www/app/docs/concepts/page.tsx
@@ -11,7 +11,7 @@ const CONCEPTS: { name: string; badge: string; badgeColor: string; desc: React.R
     name: "History",
     badge: "Events",
     badgeColor: "bg-brand/10 text-brand",
-    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, agent names, and metadata. Events are grouped by agent_name and session_id for a conversation-like view. Searchable via full-text search.",
+    desc: "Append-only event log scoped to a workspace. Every tool call, message, and session event is recorded with timestamps, tag names, and metadata. Events are grouped by tag_name and session_id for a conversation-like view. Searchable via full-text search.",
   },
   {
     name: "Notebook",

--- a/www/app/history/[workspaceId]/[sessionId]/TranscriptViewer.tsx
+++ b/www/app/history/[workspaceId]/[sessionId]/TranscriptViewer.tsx
@@ -43,7 +43,7 @@ function extractToolNames(content: string | ContentBlock[] | undefined): string[
 
 export default function TranscriptViewer({ apiUrl, workspaceId, sessionId, accessToken }: Props) {
   const [messages, setMessages] = useState<Message[]>([]);
-  const [meta, setMeta] = useState<{ agent_name?: string; cwd?: string; uploaded_at?: string }>({});
+  const [meta, setMeta] = useState<{ tag_name?: string; cwd?: string; uploaded_at?: string }>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -105,7 +105,7 @@ export default function TranscriptViewer({ apiUrl, workspaceId, sessionId, acces
     <>
       {!loading && (
         <div className="mb-6 flex items-center gap-2 font-mono text-[12px] text-muted">
-          {meta.agent_name && <span className="text-ink">{meta.agent_name}</span>}
+          {meta.tag_name && <span className="text-ink">{meta.tag_name}</span>}
           {meta.cwd && (
             <>
               <span>&middot;</span>


### PR DESCRIPTION
## Summary
- Renames the `agent_name` field to `tag_name` across DB schema, backend models/services/routers, CLI, frontend types/API/components, all plugins, and docs
- Adds migration `0024` to rename the column in `history_events` and `session_transcripts`
- Renames API endpoints: `/memory/agent-names` → `/memory/tag-names`, `/memory/agents/{name}` → `/memory/tags/{name}`
- Renames CLI command: `stash history agents` → `stash history tags`, `--agent` flag on push → `--tag`
- Renames frontend component: `AgentActivityTimeline` → `TagActivityTimeline`

## Test plan
- [ ] Run migration `0024` against dev DB
- [ ] Verify `stash history tags` lists tag names
- [ ] Verify `stash history push --tag cli` pushes events correctly
- [ ] Verify frontend history page renders with `tag_name` field
- [ ] Verify dashboard Tag Activity timeline renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)