### PR TITLE
First-class sharing: universal Share sheet, page-level Views, agent enablement

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,8 @@ from .routers import (
     files,
     memory,
     notebooks,
+    permissions,
+    public,
     skill,
     tables,
     transcripts,
@@ -95,6 +97,8 @@ app.include_router(transcripts.router)
 app.include_router(aggregate.router)
 app.include_router(skill.router)
 app.include_router(admin.router)
+app.include_router(permissions.router)
+app.include_router(public.router)
 
 if settings.AUTH0_ENABLED:
     from backend.managed.auth0 import router as auth0_router

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,8 @@ from .routers import (
     notebooks,
     permissions,
     public,
+    publish,
+    sessions,
     skill,
     tables,
     transcripts,
@@ -99,6 +101,9 @@ app.include_router(skill.router)
 app.include_router(admin.router)
 app.include_router(permissions.router)
 app.include_router(public.router)
+app.include_router(public.llms_router)
+app.include_router(sessions.router)
+app.include_router(publish.router)
 
 if settings.AUTH0_ENABLED:
     from backend.managed.auth0 import router as auth0_router

--- a/backend/migrations/versions/0025_share_primitives.py
+++ b/backend/migrations/versions/0025_share_primitives.py
@@ -1,0 +1,96 @@
+"""Sharing primitives: extend object_permissions to cover every shareable
+unit and add a 'link' visibility state.
+
+The pre-existing object_type enum only covered chat/notebook/history/deck/table.
+First-class sharing also needs workspace, page, file, and view (the View itself
+gets shares so collaborators can edit its curation). The visibility enum gains
+'link' — readable by anyone with the URL but not listed in Discover.
+
+Revision ID: 0025
+Revises: 0024
+"""
+
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+_NEW_OBJECT_TYPES = "('workspace', 'chat', 'notebook', 'page', 'history', 'deck', 'table', 'file', 'view')"
+_NEW_VISIBILITY = "('inherit', 'private', 'link', 'public')"
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE object_permissions DROP CONSTRAINT IF EXISTS object_permissions_object_type_check")
+    op.execute("ALTER TABLE object_permissions DROP CONSTRAINT IF EXISTS object_permissions_visibility_check")
+    op.execute(
+        f"ALTER TABLE object_permissions ADD CONSTRAINT object_permissions_object_type_check "
+        f"CHECK (object_type IN {_NEW_OBJECT_TYPES})"
+    )
+    op.execute(
+        f"ALTER TABLE object_permissions ADD CONSTRAINT object_permissions_visibility_check "
+        f"CHECK (visibility IN {_NEW_VISIBILITY})"
+    )
+
+    op.execute("ALTER TABLE object_shares DROP CONSTRAINT IF EXISTS object_shares_object_type_check")
+    op.execute(
+        f"ALTER TABLE object_shares ADD CONSTRAINT object_shares_object_type_check "
+        f"CHECK (object_type IN {_NEW_OBJECT_TYPES})"
+    )
+
+    # view_items can now point at individual pages, not just whole notebooks.
+    op.execute("ALTER TABLE view_items DROP CONSTRAINT IF EXISTS view_items_object_type_check")
+    op.execute(
+        "ALTER TABLE view_items ADD CONSTRAINT view_items_object_type_check "
+        "CHECK (object_type IN ('notebook', 'page', 'table', 'file', 'history'))"
+    )
+
+    # Backfill: every workspaces.is_public=true becomes object_permissions(workspace, id, 'public')
+    op.execute(
+        "INSERT INTO object_permissions (object_type, object_id, visibility) "
+        "SELECT 'workspace', id, 'public' FROM workspaces WHERE is_public = true "
+        "ON CONFLICT (object_type, object_id) DO UPDATE SET visibility = 'public'"
+    )
+
+    # Backfill: every views.is_public=true becomes object_permissions(view, id, 'public')
+    # This lets the new permission-derived access logic produce the same answer
+    # the old is_public boolean did, until the View ACL is fully removed in Phase 4.
+    op.execute(
+        "INSERT INTO object_permissions (object_type, object_id, visibility) "
+        "SELECT 'view', id, 'public' FROM views WHERE is_public = true "
+        "ON CONFLICT (object_type, object_id) DO UPDATE SET visibility = 'public'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM object_permissions WHERE object_type IN ('workspace', 'page', 'file', 'view') "
+        "OR visibility = 'link'"
+    )
+    op.execute("DELETE FROM object_shares WHERE object_type IN ('workspace', 'page', 'file', 'view')")
+
+    op.execute("ALTER TABLE object_permissions DROP CONSTRAINT IF EXISTS object_permissions_object_type_check")
+    op.execute("ALTER TABLE object_permissions DROP CONSTRAINT IF EXISTS object_permissions_visibility_check")
+    op.execute(
+        "ALTER TABLE object_permissions ADD CONSTRAINT object_permissions_object_type_check "
+        "CHECK (object_type IN ('chat', 'notebook', 'history', 'deck', 'table'))"
+    )
+    op.execute(
+        "ALTER TABLE object_permissions ADD CONSTRAINT object_permissions_visibility_check "
+        "CHECK (visibility IN ('inherit', 'private', 'public'))"
+    )
+
+    op.execute("ALTER TABLE object_shares DROP CONSTRAINT IF EXISTS object_shares_object_type_check")
+    op.execute(
+        "ALTER TABLE object_shares ADD CONSTRAINT object_shares_object_type_check "
+        "CHECK (object_type IN ('chat', 'notebook', 'history', 'deck', 'table'))"
+    )
+
+    op.execute("DELETE FROM view_items WHERE object_type = 'page'")
+    op.execute("ALTER TABLE view_items DROP CONSTRAINT IF EXISTS view_items_object_type_check")
+    op.execute(
+        "ALTER TABLE view_items ADD CONSTRAINT view_items_object_type_check "
+        "CHECK (object_type IN ('notebook', 'table', 'file', 'history'))"
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -176,11 +176,11 @@ class WorkspacePublicDetail(BaseModel):
 
 # --- Views (curated subsets of a workspace) ---
 
-ViewObjectType = str  # 'notebook' | 'table' | 'file' | 'history'
+ViewObjectType = str  # 'notebook' | 'page' | 'table' | 'file' | 'history'
 
 
 class ViewItem(BaseModel):
-    object_type: ViewObjectType = Field(..., pattern=r"^(notebook|table|file|history)$")
+    object_type: ViewObjectType = Field(..., pattern=r"^(notebook|page|table|file|history)$")
     object_id: UUID
     position: int = 0
     label_override: str | None = Field(None, max_length=160)
@@ -593,12 +593,12 @@ class HistoryQueryResponse(BaseModel):
 class PermissionResponse(BaseModel):
     object_type: str
     object_id: UUID
-    visibility: str  # inherit, private, public
+    visibility: str  # inherit, private, link, public
     shares: list["ShareResponse"] = []
 
 
 class SetVisibilityRequest(BaseModel):
-    visibility: str = Field(..., pattern=r"^(inherit|private|public)$")
+    visibility: str = Field(..., pattern=r"^(inherit|private|link|public)$")
 
 
 class ShareRequest(BaseModel):
@@ -612,6 +612,17 @@ class ShareResponse(BaseModel):
     permission: str
     granted_by: UUID
     created_at: datetime
+
+
+class ShareLinkResponse(BaseModel):
+    """URL the share sheet copies to clipboard. For workspaces this points at
+    /s/{slug-or-uuid}; for everything else it points at the auto-created
+    one-item View at /v/{slug}."""
+
+    url: str
+    kind: str  # 'workspace' | 'view'
+    view_id: UUID | None = None
+    view_slug: str | None = None
 
 
 # --- Files ---

--- a/backend/models.py
+++ b/backend/models.py
@@ -625,6 +625,30 @@ class ShareLinkResponse(BaseModel):
     view_slug: str | None = None
 
 
+class PublishRequest(BaseModel):
+    """Single-call publish: create a page from supplied content and return a
+    share URL for it. Designed for AI agents — collapses 4-5 round trips into
+    one. Notebook is optional; defaults to a workspace's "AI Drafts" notebook
+    that's auto-created on first use."""
+
+    workspace_id: UUID
+    title: str = Field(..., min_length=1, max_length=255)
+    content: str = ""
+    content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
+    audience: str = Field("link", pattern=r"^(link|public)$")
+    notebook_id: UUID | None = None
+
+
+class PublishResponse(BaseModel):
+    page_id: UUID
+    notebook_id: UUID
+    workspace_id: UUID
+    visibility: str
+    url: str
+    view_id: UUID | None = None
+    view_slug: str | None = None
+
+
 # --- Files ---
 
 

--- a/backend/routers/discover.py
+++ b/backend/routers/discover.py
@@ -12,7 +12,7 @@ from ..models import (
     WorkspacePublicNotebookSummary,
     WorkspacePublicTableSummary,
 )
-from ..services import discover_service
+from ..services import discover_service, view_service
 
 router = APIRouter(prefix="/api/v1/discover", tags=["discover"])
 
@@ -51,3 +51,14 @@ async def public_workspace(workspace_id: UUID):
         tables=[WorkspacePublicTableSummary(**t) for t in detail["tables"]],
         files=[WorkspacePublicFileSummary(**f) for f in detail["files"]],
     )
+
+
+@router.get("/views")
+async def list_public_views(
+    q: str | None = Query(None, max_length=128),
+    sort: str = Query("trending", pattern="^(trending|newest|popular)$"),
+    limit: int = Query(48, ge=1, le=100),
+):
+    """All Views whose every item is publicly readable."""
+    items = await view_service.list_public_views(query=q, sort=sort, limit=limit)
+    return {"views": items}

--- a/backend/routers/permissions.py
+++ b/backend/routers/permissions.py
@@ -41,6 +41,11 @@ async def _require_admin(object_type: str, object_id: UUID, user_id: UUID) -> No
     if workspace_id is None:
         raise HTTPException(status_code=404, detail="Object not found")
 
+    if object_type == "view":
+        if await view_service.user_can_manage(object_id, user_id):
+            return
+        raise HTTPException(status_code=403, detail="Not allowed to manage this view")
+
     if object_type == "workspace":
         # Sharing the workspace itself: must be a workspace owner/admin.
         role = await workspace_service.get_member_role(workspace_id, user_id)
@@ -139,7 +144,7 @@ async def create_share_link(
     immediately 404s for anonymous viewers — easy to forget, hard to debug."""
     await _require_admin(object_type, object_id, current_user["id"])
 
-    if ensure:
+    if ensure and object_type != "view":
         current_vis = await permission_service.get_visibility(object_type, object_id)
         if _VISIBILITY_RANK.get(current_vis, 0) < _VISIBILITY_RANK[ensure]:
             await permission_service.set_visibility(object_type, object_id, ensure)
@@ -155,6 +160,17 @@ async def create_share_link(
         view = await view_service.get_view(object_id)
         if not view:
             raise HTTPException(status_code=404, detail="View not found")
+        if ensure:
+            for item in view["items"]:
+                await _require_admin(item["object_type"], item["object_id"], current_user["id"])
+            for item in view["items"]:
+                current_vis = await permission_service.get_visibility(
+                    item["object_type"], item["object_id"]
+                )
+                if _VISIBILITY_RANK.get(current_vis, 0) < _VISIBILITY_RANK[ensure]:
+                    await permission_service.set_visibility(
+                        item["object_type"], item["object_id"], ensure
+                    )
         return ShareLinkResponse(
             url=f"{base}/v/{view['slug']}",
             kind="view",

--- a/backend/routers/permissions.py
+++ b/backend/routers/permissions.py
@@ -1,0 +1,153 @@
+"""Unified permissions router: one endpoint surface for every shareable object.
+
+Sits at /api/v1/objects/{object_type}/{object_id} and gives the share sheet a
+single API to talk to regardless of whether it's sharing a workspace, a
+notebook, a single page, a table, a file, a history event, or a View itself.
+
+The legacy notebook-scoped endpoints under /api/v1/workspaces/.../notebooks/...
+keep working — this is additive.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user
+from ..config import settings
+from ..database import get_pool
+from ..models import (
+    PermissionResponse,
+    SetVisibilityRequest,
+    ShareLinkResponse,
+    ShareRequest,
+    ShareResponse,
+)
+from ..services import permission_service, view_service, workspace_service
+
+router = APIRouter(prefix="/api/v1/objects", tags=["permissions"])
+
+
+# Object types the share sheet can operate on. 'view' is included so that a
+# View's curation can be co-edited via object_shares.
+_SHAREABLE = {"workspace", "notebook", "page", "table", "file", "history", "view"}
+
+
+async def _require_admin(object_type: str, object_id: UUID, user_id: UUID) -> None:
+    """Caller must be workspace owner/admin (or, for personal items, the creator)."""
+    if object_type not in _SHAREABLE:
+        raise HTTPException(status_code=400, detail=f"Unsupported object_type: {object_type}")
+
+    workspace_id = await permission_service.resolve_workspace_id(object_type, object_id)
+    if workspace_id is None:
+        raise HTTPException(status_code=404, detail="Object not found")
+
+    if object_type == "workspace":
+        # Sharing the workspace itself: must be a workspace owner/admin.
+        role = await workspace_service.get_member_role(workspace_id, user_id)
+        if role not in ("owner", "admin"):
+            raise HTTPException(status_code=403, detail="Only workspace owner/admin can share")
+        return
+
+    role = await workspace_service.get_member_role(workspace_id, user_id)
+    if role in ("owner", "admin"):
+        return
+
+    # Members can manage shares on objects they have write access to (Drive-style).
+    can_write = await permission_service.check_access(
+        object_type, object_id, user_id, workspace_id=workspace_id, require_write=True
+    )
+    if not can_write:
+        raise HTTPException(status_code=403, detail="Not allowed to manage permissions for this object")
+
+
+@router.get("/{object_type}/{object_id}/permissions", response_model=PermissionResponse)
+async def get_permissions(
+    object_type: str,
+    object_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_admin(object_type, object_id, current_user["id"])
+    perms = await permission_service.get_permissions(object_type, object_id)
+    return PermissionResponse(**perms)
+
+
+@router.patch("/{object_type}/{object_id}/permissions")
+async def set_visibility(
+    object_type: str,
+    object_id: UUID,
+    req: SetVisibilityRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_admin(object_type, object_id, current_user["id"])
+    await permission_service.set_visibility(object_type, object_id, req.visibility)
+    return {"status": "ok", "visibility": req.visibility}
+
+
+@router.post("/{object_type}/{object_id}/shares", response_model=ShareResponse)
+async def add_share(
+    object_type: str,
+    object_id: UUID,
+    req: ShareRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_admin(object_type, object_id, current_user["id"])
+    share = await permission_service.add_share(
+        object_type, object_id, req.user_id, req.permission, current_user["id"]
+    )
+    pool = get_pool()
+    user = await pool.fetchrow("SELECT name FROM users WHERE id = $1", req.user_id)
+    return ShareResponse(
+        user_id=share["user_id"],
+        user_name=user["name"] if user else "",
+        permission=share["permission"],
+        granted_by=share["granted_by"],
+        created_at=share["created_at"],
+    )
+
+
+@router.delete("/{object_type}/{object_id}/shares/{user_id}", status_code=204)
+async def remove_share(
+    object_type: str,
+    object_id: UUID,
+    user_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_admin(object_type, object_id, current_user["id"])
+    await permission_service.remove_share(object_type, object_id, user_id)
+
+
+@router.post("/{object_type}/{object_id}/share-link", response_model=ShareLinkResponse)
+async def create_share_link(
+    object_type: str,
+    object_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Idempotently mint the URL for the share sheet's "Copy link" button.
+
+    For a workspace the URL is /s/{id}. For every other shareable object we
+    auto-create (or reuse) a one-item View pointing at it and return /v/{slug}.
+    The View is just the slugged shell — access is governed by the object's
+    own permissions, not by the View."""
+    await _require_admin(object_type, object_id, current_user["id"])
+
+    base = settings.PUBLIC_URL.rstrip("/")
+
+    if object_type == "workspace":
+        return ShareLinkResponse(url=f"{base}/s/{object_id}", kind="workspace")
+
+    workspace_id = await permission_service.resolve_workspace_id(object_type, object_id)
+    if workspace_id is None:
+        raise HTTPException(status_code=404, detail="Object not found")
+
+    view = await view_service.find_or_create_share_link_view(
+        workspace_id=workspace_id,
+        owner_id=current_user["id"],
+        object_type=object_type,
+        object_id=object_id,
+    )
+    return ShareLinkResponse(
+        url=f"{base}/v/{view['slug']}",
+        kind="view",
+        view_id=view["id"],
+        view_slug=view["slug"],
+    )

--- a/backend/routers/permissions.py
+++ b/backend/routers/permissions.py
@@ -10,7 +10,7 @@ keep working — this is additive.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..auth import get_current_user
 from ..config import settings
@@ -116,10 +116,14 @@ async def remove_share(
     await permission_service.remove_share(object_type, object_id, user_id)
 
 
+_VISIBILITY_RANK = {"private": 0, "inherit": 0, "link": 1, "public": 2}
+
+
 @router.post("/{object_type}/{object_id}/share-link", response_model=ShareLinkResponse)
 async def create_share_link(
     object_type: str,
     object_id: UUID,
+    ensure: str | None = Query(None, pattern=r"^(link|public)$"),
     current_user: dict = Depends(get_current_user),
 ):
     """Idempotently mint the URL for the share sheet's "Copy link" button.
@@ -127,13 +131,36 @@ async def create_share_link(
     For a workspace the URL is /s/{id}. For every other shareable object we
     auto-create (or reuse) a one-item View pointing at it and return /v/{slug}.
     The View is just the slugged shell — access is governed by the object's
-    own permissions, not by the View."""
+    own permissions, not by the View.
+
+    `ensure=link|public`: raise the underlying object's visibility to at
+    least the requested level before returning the URL. Without this, an
+    agent that calls share-link on an `inherit` object gets back a URL that
+    immediately 404s for anonymous viewers — easy to forget, hard to debug."""
     await _require_admin(object_type, object_id, current_user["id"])
+
+    if ensure:
+        current_vis = await permission_service.get_visibility(object_type, object_id)
+        if _VISIBILITY_RANK.get(current_vis, 0) < _VISIBILITY_RANK[ensure]:
+            await permission_service.set_visibility(object_type, object_id, ensure)
 
     base = settings.PUBLIC_URL.rstrip("/")
 
     if object_type == "workspace":
         return ShareLinkResponse(url=f"{base}/s/{object_id}", kind="workspace")
+
+    if object_type == "view":
+        # Views already have their own /v/{slug} URL — return it directly
+        # rather than wrapping a View around a View.
+        view = await view_service.get_view(object_id)
+        if not view:
+            raise HTTPException(status_code=404, detail="View not found")
+        return ShareLinkResponse(
+            url=f"{base}/v/{view['slug']}",
+            kind="view",
+            view_id=view["id"],
+            view_slug=view["slug"],
+        )
 
     workspace_id = await permission_service.resolve_workspace_id(object_type, object_id)
     if workspace_id is None:

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -23,6 +23,36 @@ def _viewer(current_user: dict | None) -> UUID | None:
     return current_user["id"] if current_user else None
 
 
+async def _readable_rows(
+    object_type: str,
+    rows,
+    viewer: UUID | None,
+    *,
+    workspace_id: UUID | None = None,
+) -> list[dict]:
+    out: list[dict] = []
+    for row in rows:
+        obj = dict(row)
+        if await permission_service.check_access(
+            object_type,
+            obj["id"],
+            viewer,
+            workspace_id=workspace_id or obj.get("workspace_id"),
+        ):
+            out.append(obj)
+    return out
+
+
+async def _readable_notebook_pages(notebook_id: UUID, viewer: UUID | None) -> list[dict]:
+    pool = get_pool()
+    pages = await pool.fetch(
+        "SELECT id, name, content_type, content_markdown, content_html, updated_at "
+        "FROM notebook_pages WHERE notebook_id = $1 ORDER BY created_at, name",
+        notebook_id,
+    )
+    return await _readable_rows("page", pages, viewer)
+
+
 _LLMS_TXT = """# Stash
 
 Stash is a shared memory system for AI coding agents. Workspaces contain
@@ -84,28 +114,33 @@ async def public_workspace(
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    notebooks = await pool.fetch(
+    notebook_rows = await pool.fetch(
         "SELECT nb.id, nb.name, nb.description, nb.updated_at, "
         "(SELECT COUNT(*) FROM notebook_pages p WHERE p.notebook_id = nb.id) AS page_count "
         "FROM notebooks nb WHERE nb.workspace_id = $1 ORDER BY nb.updated_at DESC",
         workspace_id,
     )
-    tables = await pool.fetch(
+    table_rows = await pool.fetch(
         "SELECT t.id, t.name, t.updated_at, "
         "(SELECT COUNT(*) FROM table_rows tr WHERE tr.table_id = t.id) AS row_count "
         "FROM tables t WHERE t.workspace_id = $1 ORDER BY t.updated_at DESC",
         workspace_id,
     )
-    files = await pool.fetch(
+    file_rows = await pool.fetch(
         "SELECT id, name, content_type, COALESCE(size_bytes, 0) AS size_bytes, created_at "
         "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 200",
         workspace_id,
     )
+    notebooks = await _readable_rows("notebook", notebook_rows, viewer, workspace_id=workspace_id)
+    for nb in notebooks:
+        nb["page_count"] = len(await _readable_notebook_pages(nb["id"], viewer))
+    tables = await _readable_rows("table", table_rows, viewer, workspace_id=workspace_id)
+    files = await _readable_rows("file", file_rows, viewer, workspace_id=workspace_id)
     payload = {
         "workspace": dict(ws),
-        "notebooks": [dict(n) for n in notebooks],
-        "tables": [dict(t) for t in tables],
-        "files": [dict(f) for f in files],
+        "notebooks": notebooks,
+        "tables": tables,
+        "files": files,
     }
     if format == "text":
         ws_d = payload["workspace"]
@@ -151,11 +186,7 @@ async def public_notebook(
     if not nb:
         raise HTTPException(status_code=404, detail="Notebook not found")
 
-    pages = await pool.fetch(
-        "SELECT id, name, content_type, content_markdown, content_html, updated_at FROM notebook_pages "
-        "WHERE notebook_id = $1 ORDER BY created_at, name",
-        notebook_id,
-    )
+    pages = await _readable_notebook_pages(notebook_id, viewer)
     if format == "text":
         lines = [f"# {nb['name']}", ""]
         if nb.get("description"):

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -7,7 +7,8 @@ routes under /s/[workspaceId]/n/[nb]/p/[page] etc consume these.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import PlainTextResponse
 
 from ..auth import get_current_user_optional
 from ..database import get_pool
@@ -15,14 +16,51 @@ from ..services import permission_service
 
 router = APIRouter(prefix="/api/v1/public", tags=["public"])
 
+llms_router = APIRouter(tags=["public"])
+
 
 def _viewer(current_user: dict | None) -> UUID | None:
     return current_user["id"] if current_user else None
 
 
+_LLMS_TXT = """# Stash
+
+Stash is a shared memory system for AI coding agents. Workspaces contain
+notebooks (collections of pages), tables, files, and history (agent
+sessions). Pages can be shared as Views with slugged URLs.
+
+## For browsing agents
+
+Any /v/{slug} or /s/{ws}/n/{nb}/p/{page} URL returns HTML by default.
+Append ?format=text to the corresponding API endpoint to get clean
+markdown:
+
+- View: GET /api/v1/views/{slug}?format=text
+- Page: GET /api/v1/public/pages/{page_id}?format=text
+- Notebook (all pages): GET /api/v1/public/notebooks/{notebook_id}?format=text
+- Workspace overview: GET /api/v1/public/workspaces/{workspace_id}?format=text
+
+All public endpoints are anonymous-readable when the underlying object's
+visibility is `link` or `public`. No auth headers needed.
+
+## Privacy
+
+Items marked `private` or `inherit` (workspace-only) are never returned by
+any public endpoint, regardless of how the URL is shaped.
+"""
+
+
+@llms_router.get("/llms.txt", include_in_schema=False)
+async def llms_txt():
+    from fastapi.responses import PlainTextResponse
+
+    return PlainTextResponse(_LLMS_TXT, media_type="text/plain")
+
+
 @router.get("/workspaces/{workspace_id}")
 async def public_workspace(
     workspace_id: UUID,
+    format: str | None = Query(None),
     current_user: dict | None = Depends(get_current_user_optional),
 ):
     pool = get_pool()
@@ -63,17 +101,42 @@ async def public_workspace(
         "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 200",
         workspace_id,
     )
-    return {
+    payload = {
         "workspace": dict(ws),
         "notebooks": [dict(n) for n in notebooks],
         "tables": [dict(t) for t in tables],
         "files": [dict(f) for f in files],
     }
+    if format == "text":
+        ws_d = payload["workspace"]
+        lines = [f"# {ws_d['name']}", ""]
+        if ws_d.get("summary"):
+            lines += [ws_d["summary"], ""]
+        if ws_d.get("description"):
+            lines += [ws_d["description"], ""]
+        if payload["notebooks"]:
+            lines.append("## Notebooks")
+            for n in payload["notebooks"]:
+                lines.append(f"- {n['name']} ({n['page_count']} pages)")
+            lines.append("")
+        if payload["tables"]:
+            lines.append("## Tables")
+            for t in payload["tables"]:
+                lines.append(f"- {t['name']} ({t['row_count']} rows)")
+            lines.append("")
+        if payload["files"]:
+            lines.append("## Files")
+            for f in payload["files"]:
+                lines.append(f"- {f['name']}")
+            lines.append("")
+        return PlainTextResponse("\n".join(lines), media_type="text/markdown")
+    return payload
 
 
 @router.get("/notebooks/{notebook_id}")
 async def public_notebook(
     notebook_id: UUID,
+    format: str | None = Query(None),
     current_user: dict | None = Depends(get_current_user_optional),
 ):
     pool = get_pool()
@@ -89,16 +152,43 @@ async def public_notebook(
         raise HTTPException(status_code=404, detail="Notebook not found")
 
     pages = await pool.fetch(
-        "SELECT id, name, content_type, updated_at FROM notebook_pages "
+        "SELECT id, name, content_type, content_markdown, content_html, updated_at FROM notebook_pages "
         "WHERE notebook_id = $1 ORDER BY created_at, name",
         notebook_id,
     )
-    return {"notebook": dict(nb), "pages": [dict(p) for p in pages]}
+    if format == "text":
+        lines = [f"# {nb['name']}", ""]
+        if nb.get("description"):
+            lines += [nb["description"], ""]
+        for p in pages:
+            lines.append(f"## {p['name']}")
+            if p["content_type"] == "html":
+                lines.append("_(HTML content omitted in text format)_")
+            else:
+                lines.append((p["content_markdown"] or "").rstrip())
+            lines.append("")
+        return PlainTextResponse("\n".join(lines), media_type="text/markdown")
+
+    # JSON form drops the heavy content_markdown/content_html unless a caller
+    # specifically asked for full pages — keeps the index endpoint cheap.
+    return {
+        "notebook": dict(nb),
+        "pages": [
+            {
+                "id": str(p["id"]),
+                "name": p["name"],
+                "content_type": p["content_type"],
+                "updated_at": p["updated_at"].isoformat(),
+            }
+            for p in pages
+        ],
+    }
 
 
 @router.get("/pages/{page_id}")
 async def public_page(
     page_id: UUID,
+    format: str | None = Query(None),
     current_user: dict | None = Depends(get_current_user_optional),
 ):
     pool = get_pool()
@@ -114,6 +204,18 @@ async def public_page(
     )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    if format == "text":
+        if page["content_type"] == "html":
+            # HTML pages don't have a clean text projection — return a hint
+            # plus the raw HTML so the agent can decide what to do.
+            return PlainTextResponse(
+                f"# {page['name']}\n\n_(HTML page — raw markup follows)_\n\n{page['content_html']}",
+                media_type="text/markdown",
+            )
+        return PlainTextResponse(
+            f"# {page['name']}\n\n{page['content_markdown'] or ''}",
+            media_type="text/markdown",
+        )
     return dict(page)
 
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -1,0 +1,163 @@
+"""Anonymous read endpoints for the /s/{workspace} browse surface.
+
+Every endpoint runs the same Drive-style ACL check the authenticated routes
+do, but with an optional viewer (None = anonymous). The frontend nested
+routes under /s/[workspaceId]/n/[nb]/p/[page] etc consume these.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user_optional
+from ..database import get_pool
+from ..services import permission_service
+
+router = APIRouter(prefix="/api/v1/public", tags=["public"])
+
+
+def _viewer(current_user: dict | None) -> UUID | None:
+    return current_user["id"] if current_user else None
+
+
+@router.get("/workspaces/{workspace_id}")
+async def public_workspace(
+    workspace_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    pool = get_pool()
+    viewer = _viewer(current_user)
+    if not await permission_service.check_access("workspace", workspace_id, viewer):
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    ws = await pool.fetchrow(
+        "SELECT w.id, w.name, w.summary, w.description, w.cover_image_url, w.is_public, "
+        "w.creator_id, u.name AS creator_name, u.display_name AS creator_display_name, "
+        "w.tags, w.category, w.featured, w.fork_count, w.forked_from_workspace_id, "
+        "w.created_at, w.updated_at, "
+        "(SELECT COUNT(*) FROM workspace_members wm WHERE wm.workspace_id = w.id) AS member_count, "
+        "(SELECT COUNT(*) FROM notebooks nb WHERE nb.workspace_id = w.id) AS notebook_count, "
+        "(SELECT COUNT(*) FROM tables t WHERE t.workspace_id = w.id) AS table_count, "
+        "(SELECT COUNT(*) FROM files f WHERE f.workspace_id = w.id) AS file_count, "
+        "(SELECT COUNT(*) FROM history_events he WHERE he.workspace_id = w.id) AS history_event_count "
+        "FROM workspaces w JOIN users u ON u.id = w.creator_id WHERE w.id = $1",
+        workspace_id,
+    )
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    notebooks = await pool.fetch(
+        "SELECT nb.id, nb.name, nb.description, nb.updated_at, "
+        "(SELECT COUNT(*) FROM notebook_pages p WHERE p.notebook_id = nb.id) AS page_count "
+        "FROM notebooks nb WHERE nb.workspace_id = $1 ORDER BY nb.updated_at DESC",
+        workspace_id,
+    )
+    tables = await pool.fetch(
+        "SELECT t.id, t.name, t.updated_at, "
+        "(SELECT COUNT(*) FROM table_rows tr WHERE tr.table_id = t.id) AS row_count "
+        "FROM tables t WHERE t.workspace_id = $1 ORDER BY t.updated_at DESC",
+        workspace_id,
+    )
+    files = await pool.fetch(
+        "SELECT id, name, content_type, COALESCE(size_bytes, 0) AS size_bytes, created_at "
+        "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 200",
+        workspace_id,
+    )
+    return {
+        "workspace": dict(ws),
+        "notebooks": [dict(n) for n in notebooks],
+        "tables": [dict(t) for t in tables],
+        "files": [dict(f) for f in files],
+    }
+
+
+@router.get("/notebooks/{notebook_id}")
+async def public_notebook(
+    notebook_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    pool = get_pool()
+    viewer = _viewer(current_user)
+    if not await permission_service.check_access("notebook", notebook_id, viewer):
+        raise HTTPException(status_code=404, detail="Notebook not found")
+
+    nb = await pool.fetchrow(
+        "SELECT id, name, description, workspace_id, updated_at FROM notebooks WHERE id = $1",
+        notebook_id,
+    )
+    if not nb:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+
+    pages = await pool.fetch(
+        "SELECT id, name, content_type, updated_at FROM notebook_pages "
+        "WHERE notebook_id = $1 ORDER BY created_at, name",
+        notebook_id,
+    )
+    return {"notebook": dict(nb), "pages": [dict(p) for p in pages]}
+
+
+@router.get("/pages/{page_id}")
+async def public_page(
+    page_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    pool = get_pool()
+    viewer = _viewer(current_user)
+    if not await permission_service.check_access("page", page_id, viewer):
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    page = await pool.fetchrow(
+        "SELECT p.id, p.name, p.content_type, p.content_markdown, p.content_html, "
+        "p.notebook_id, p.updated_at, n.workspace_id, n.name AS notebook_name "
+        "FROM notebook_pages p JOIN notebooks n ON n.id = p.notebook_id WHERE p.id = $1",
+        page_id,
+    )
+    if not page:
+        raise HTTPException(status_code=404, detail="Page not found")
+    return dict(page)
+
+
+@router.get("/tables/{table_id}")
+async def public_table(
+    table_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    pool = get_pool()
+    viewer = _viewer(current_user)
+    if not await permission_service.check_access("table", table_id, viewer):
+        raise HTTPException(status_code=404, detail="Table not found")
+
+    t = await pool.fetchrow(
+        "SELECT id, name, description, columns, workspace_id, updated_at FROM tables WHERE id = $1",
+        table_id,
+    )
+    if not t:
+        raise HTTPException(status_code=404, detail="Table not found")
+    rows = await pool.fetch(
+        "SELECT data, row_order FROM table_rows WHERE table_id = $1 "
+        "ORDER BY row_order LIMIT 500",
+        table_id,
+    )
+    return {
+        "table": dict(t),
+        "rows": [{"data": r["data"], "row_order": r["row_order"]} for r in rows],
+    }
+
+
+@router.get("/files/{file_id}")
+async def public_file(
+    file_id: UUID,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    pool = get_pool()
+    viewer = _viewer(current_user)
+    if not await permission_service.check_access("file", file_id, viewer):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    f = await pool.fetchrow(
+        "SELECT id, name, content_type, size_bytes, workspace_id, created_at FROM files WHERE id = $1",
+        file_id,
+    )
+    if not f:
+        raise HTTPException(status_code=404, detail="File not found")
+    return dict(f)

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -1,0 +1,82 @@
+"""One-call publish endpoint for AI agents.
+
+Collapses the create-page → set-visibility → mint-share-link sequence into a
+single POST. Optionally find-or-creates an "AI Drafts" notebook so the agent
+doesn't need to know the workspace's folder structure.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user
+from ..config import settings
+from ..database import get_pool
+from ..models import PublishRequest, PublishResponse
+from ..services import notebook_service, permission_service, view_service, workspace_service
+
+router = APIRouter(prefix="/api/v1", tags=["publish"])
+
+AI_DRAFTS_NOTEBOOK_NAME = "AI Drafts"
+
+
+async def _find_or_create_drafts_notebook(workspace_id, user_id) -> dict:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, name, description, created_by, created_at, updated_at "
+        "FROM notebooks WHERE workspace_id = $1 AND name = $2 LIMIT 1",
+        workspace_id,
+        AI_DRAFTS_NOTEBOOK_NAME,
+    )
+    if row:
+        return dict(row)
+    return await notebook_service.create_notebook(
+        workspace_id=workspace_id,
+        name=AI_DRAFTS_NOTEBOOK_NAME,
+        description="Pages published by agents via the /publish endpoint. Auto-created.",
+        created_by=user_id,
+    )
+
+
+@router.post("/publish", response_model=PublishResponse)
+async def publish(
+    req: PublishRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    if not await workspace_service.is_member(req.workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+    notebook = (
+        await notebook_service.get_notebook(req.notebook_id)
+        if req.notebook_id
+        else await _find_or_create_drafts_notebook(req.workspace_id, current_user["id"])
+    )
+    if not notebook or notebook.get("workspace_id") != req.workspace_id:
+        raise HTTPException(status_code=404, detail="Notebook not found in this workspace")
+
+    page = await notebook_service.create_page(
+        notebook_id=notebook["id"],
+        name=req.title,
+        created_by=current_user["id"],
+        content=req.content if req.content_type == "markdown" else "",
+        content_type=req.content_type,
+        content_html=req.content if req.content_type == "html" else "",
+    )
+
+    await permission_service.set_visibility("page", page["id"], req.audience)
+
+    view = await view_service.find_or_create_share_link_view(
+        workspace_id=req.workspace_id,
+        owner_id=current_user["id"],
+        object_type="page",
+        object_id=page["id"],
+    )
+
+    base = settings.PUBLIC_URL.rstrip("/")
+    return PublishResponse(
+        page_id=page["id"],
+        notebook_id=notebook["id"],
+        workspace_id=req.workspace_id,
+        visibility=req.audience,
+        url=f"{base}/v/{view['slug']}",
+        view_id=view["id"],
+        view_slug=view["slug"],
+    )

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -52,9 +52,12 @@ async def list_my_sessions(
           MIN(he.created_at) AS started_at,
           MAX(he.created_at) AS last_event_at,
           (
-            SELECT LEFT(content, 240) FROM history_events
-            WHERE session_id = he.session_id AND event_type IN ('user_prompt', 'prompt', 'message')
-            ORDER BY created_at LIMIT 1
+            SELECT LEFT(he2.content, 240) FROM history_events he2
+            WHERE he2.session_id = he.session_id
+              AND he2.workspace_id IS NOT DISTINCT FROM he.workspace_id
+              AND (he2.workspace_id IS NOT NULL OR he2.created_by = $1)
+              AND he2.event_type IN ('user_prompt', 'prompt', 'message')
+            ORDER BY he2.created_at LIMIT 1
           ) AS first_prompt_preview
         FROM history_events he
         LEFT JOIN workspaces w ON w.id = he.workspace_id

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1,0 +1,158 @@
+"""Sessions router: GUI-friendly endpoints for browsing and sharing sessions.
+
+A "session" in Stash is a sequence of `history_events` rows tied by
+session_id. The CLI's `stash share` materializes a session into a notebook
+page from a local .jsonl file. This router provides the same materialize
+step server-side, sourced from the events the workspace already has, so the
+frontend /history page can ship a Share button without involving the CLI.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..auth import get_current_user
+from ..database import get_pool
+from ..services import notebook_service, workspace_service
+
+router = APIRouter(prefix="/api/v1", tags=["sessions"])
+
+# Stable name for the auto-created notebook that holds materialized sessions.
+SESSIONS_NOTEBOOK_NAME = "Sessions"
+
+
+@router.get("/me/sessions")
+async def list_my_sessions(
+    workspace_id: UUID | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: dict = Depends(get_current_user),
+):
+    """Recent sessions across the user's accessible workspaces, grouped by
+    session_id. Each row carries the agent name, event count, first & last
+    timestamps, and a preview of the first prompt."""
+    pool = get_pool()
+    args: list = [current_user["id"]]
+    where = [
+        "he.session_id IS NOT NULL",
+        "(he.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1) "
+        "OR he.created_by = $1)",
+    ]
+    if workspace_id is not None:
+        args.append(workspace_id)
+        where.append(f"he.workspace_id = ${len(args)}")
+
+    rows = await pool.fetch(
+        f"""
+        SELECT
+          he.session_id,
+          he.workspace_id,
+          w.name AS workspace_name,
+          MAX(he.agent_name) AS agent_name,
+          COUNT(*)::INT AS event_count,
+          MIN(he.created_at) AS started_at,
+          MAX(he.created_at) AS last_event_at,
+          (
+            SELECT LEFT(content, 240) FROM history_events
+            WHERE session_id = he.session_id AND event_type IN ('user_prompt', 'prompt', 'message')
+            ORDER BY created_at LIMIT 1
+          ) AS first_prompt_preview
+        FROM history_events he
+        LEFT JOIN workspaces w ON w.id = he.workspace_id
+        WHERE {' AND '.join(where)}
+        GROUP BY he.session_id, he.workspace_id, w.name
+        ORDER BY last_event_at DESC
+        LIMIT {int(limit)}
+        """,
+        *args,
+    )
+    return {"sessions": [dict(r) for r in rows]}
+
+
+async def _find_or_create_sessions_notebook(workspace_id: UUID, user_id: UUID) -> dict:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, name, description, created_by, created_at, updated_at "
+        "FROM notebooks WHERE workspace_id = $1 AND name = $2 LIMIT 1",
+        workspace_id,
+        SESSIONS_NOTEBOOK_NAME,
+    )
+    if row:
+        return dict(row)
+    return await notebook_service.create_notebook(
+        workspace_id=workspace_id,
+        name=SESSIONS_NOTEBOOK_NAME,
+        description="Materialized agent sessions, auto-created when you share a session.",
+        created_by=user_id,
+    )
+
+
+def _format_session_markdown(events: list[dict]) -> str:
+    if not events:
+        return "_No events in this session._"
+    parts: list[str] = []
+    started_at = events[0]["created_at"]
+    parts.append(f"_Started {started_at.isoformat()} · {len(events)} events_\n")
+    for ev in events:
+        agent = ev["agent_name"] or "agent"
+        etype = ev["event_type"] or "event"
+        tool = ev["tool_name"]
+        header = f"### {agent} · {etype}"
+        if tool:
+            header += f" · `{tool}`"
+        parts.append(header)
+        content = (ev["content"] or "").strip()
+        if content:
+            parts.append(content)
+        parts.append("")
+    return "\n".join(parts)
+
+
+@router.post("/workspaces/{workspace_id}/sessions/{session_id}/materialize")
+async def materialize_session(
+    workspace_id: UUID,
+    session_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Idempotent: turn a session_id into a notebook page in the workspace's
+    Sessions notebook, returning the page so the frontend can open ShareSheet
+    on it. Re-materializing the same session updates the existing page rather
+    than spawning duplicates."""
+    if not await workspace_service.is_member(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+    pool = get_pool()
+    events = await pool.fetch(
+        "SELECT agent_name, event_type, tool_name, content, created_at "
+        "FROM history_events WHERE session_id = $1 AND workspace_id = $2 "
+        "ORDER BY created_at",
+        session_id,
+        workspace_id,
+    )
+    if not events:
+        raise HTTPException(status_code=404, detail="No events for that session in this workspace")
+
+    notebook = await _find_or_create_sessions_notebook(workspace_id, current_user["id"])
+    short = session_id[:8]
+    page_name = f"Session {short}"
+    content = _format_session_markdown([dict(e) for e in events])
+
+    existing = await pool.fetchrow(
+        "SELECT id FROM notebook_pages WHERE notebook_id = $1 AND name = $2 LIMIT 1",
+        notebook["id"],
+        page_name,
+    )
+    if existing:
+        page = await notebook_service.update_page(
+            existing["id"],
+            notebook["id"],
+            current_user["id"],
+            content=content,
+        )
+    else:
+        page = await notebook_service.create_page(
+            notebook_id=notebook["id"],
+            name=page_name,
+            content=content,
+            created_by=current_user["id"],
+        )
+    return {"page": page, "notebook_id": str(notebook["id"])}

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -132,14 +132,25 @@ async def materialize_session(
         raise HTTPException(status_code=404, detail="No events for that session in this workspace")
 
     notebook = await _find_or_create_sessions_notebook(workspace_id, current_user["id"])
-    short = session_id[:8]
-    page_name = f"Session {short}"
+
+    # Title format: "{agent} · {date} · {short_id}". Naive prefix-truncation
+    # produced ugly names like "Session session-" for non-UUID session_ids;
+    # combining agent + date + short_id reads naturally and avoids collisions
+    # within an agent in the same minute.
+    agent = (events[0]["agent_name"] or "agent").strip() or "agent"
+    started = events[0]["created_at"]
+    date_str = started.strftime("%Y-%m-%d %H:%M")
+    short_id = session_id.removeprefix("session-").removeprefix("session_")[:6] or session_id[:6]
+    page_name = f"{agent} · {date_str} · {short_id}"
     content = _format_session_markdown([dict(e) for e in events])
 
+    # Idempotency by metadata.session_id, not by name — that way we can change
+    # the display name format without orphaning previously-materialized pages.
     existing = await pool.fetchrow(
-        "SELECT id FROM notebook_pages WHERE notebook_id = $1 AND name = $2 LIMIT 1",
+        "SELECT id FROM notebook_pages "
+        "WHERE notebook_id = $1 AND metadata->>'session_id' = $2 LIMIT 1",
         notebook["id"],
-        page_name,
+        session_id,
     )
     if existing:
         page = await notebook_service.update_page(
@@ -154,5 +165,6 @@ async def materialize_session(
             name=page_name,
             content=content,
             created_by=current_user["id"],
+            metadata={"session_id": session_id, "materialized": True},
         )
     return {"page": page, "notebook_id": str(notebook["id"])}

--- a/backend/routers/views.py
+++ b/backend/routers/views.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse
 
-from ..auth import get_current_user
+from ..auth import get_current_user, get_current_user_optional
 from ..models import (
     ViewCreateRequest,
     ViewForkRequest,
@@ -90,8 +90,10 @@ async def delete_view(
 async def get_public_view(
     slug: str,
     format: str = Query(None, alias="format"),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    view = await view_service.get_public_view(slug)
+    viewer_id = current_user["id"] if current_user else None
+    view = await view_service.get_public_view(slug, viewer_id=viewer_id)
     if not view:
         raise HTTPException(status_code=404, detail="View not found")
     items = await view_service.inline_items(view)

--- a/backend/routers/views.py
+++ b/backend/routers/views.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse
 
 from ..auth import get_current_user, get_current_user_optional
+from ..config import settings
 from ..models import (
     ViewCreateRequest,
     ViewForkRequest,
@@ -15,10 +16,34 @@ from ..models import (
     ViewUpdateRequest,
     WorkspaceResponse,
 )
-from ..services import view_service, workspace_service
+from ..services import permission_service, view_service, workspace_service
 
 ws_router = APIRouter(prefix="/api/v1/workspaces", tags=["views"])
 public_router = APIRouter(prefix="/api/v1/views", tags=["views"])
+
+_VISIBILITY_RANK = {"private": 0, "inherit": 0, "link": 1, "public": 2}
+
+
+async def _require_can_share_item(workspace_id: UUID, item, user_id: UUID) -> None:
+    item_workspace_id = await permission_service.resolve_workspace_id(
+        item.object_type, item.object_id
+    )
+    if item_workspace_id != workspace_id:
+        raise HTTPException(status_code=400, detail="View items must be in the workspace")
+
+    role = await workspace_service.get_member_role(workspace_id, user_id)
+    if role in ("owner", "admin"):
+        return
+
+    can_write = await permission_service.check_access(
+        item.object_type,
+        item.object_id,
+        user_id,
+        workspace_id=workspace_id,
+        require_write=True,
+    )
+    if not can_write:
+        raise HTTPException(status_code=403, detail="Not allowed to share one or more items")
 
 
 @ws_router.post("/{workspace_id}/views", response_model=ViewResponse, status_code=201)
@@ -39,6 +64,49 @@ async def create_view(
         items=req.items,
     )
     return ViewResponse(**view)
+
+
+@ws_router.post("/{workspace_id}/views/share-bundle", status_code=201)
+async def create_shared_view(
+    workspace_id: UUID,
+    req: ViewCreateRequest,
+    ensure: str = Query("link", pattern=r"^(link|public)$"),
+    current_user: dict = Depends(get_current_user),
+):
+    """Create a View and make every underlying item readable at the requested level.
+
+    Views are presentation-only for reader access, so bundle sharing must
+    mutate the underlying items rather than the View object's ACL.
+    """
+    if not await workspace_service.is_member(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    if not req.items:
+        raise HTTPException(status_code=400, detail="A shared bundle needs at least one item")
+
+    for item in req.items:
+        await _require_can_share_item(workspace_id, item, current_user["id"])
+
+    for item in req.items:
+        current_vis = await permission_service.get_visibility(item.object_type, item.object_id)
+        if _VISIBILITY_RANK.get(current_vis, 0) < _VISIBILITY_RANK[ensure]:
+            await permission_service.set_visibility(item.object_type, item.object_id, ensure)
+
+    view = await view_service.create_view(
+        workspace_id=workspace_id,
+        owner_id=current_user["id"],
+        title=req.title,
+        description=req.description,
+        is_public=ensure == "public",
+        cover_image_url=req.cover_image_url,
+        items=req.items,
+    )
+    base = settings.PUBLIC_URL.rstrip("/")
+    return {
+        "view": ViewResponse(**view),
+        "url": f"{base}/v/{view['slug']}",
+        "view_id": view["id"],
+        "view_slug": view["slug"],
+    }
 
 
 @ws_router.get("/{workspace_id}/views", response_model=ViewListResponse)
@@ -96,7 +164,7 @@ async def get_public_view(
     view = await view_service.get_public_view(slug, viewer_id=viewer_id)
     if not view:
         raise HTTPException(status_code=404, detail="View not found")
-    items = await view_service.inline_items(view)
+    items = await view_service.inline_items(view, viewer_id=viewer_id)
 
     if format == "text":
         return PlainTextResponse(

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -20,7 +20,7 @@ _WORKSPACE_LOOKUP = {
     "notebook": ("notebooks", "workspace_id"),
     "table": ("tables", "workspace_id"),
     "file": ("files", "workspace_id"),
-    "history": ("histories", "workspace_id"),
+    "history": ("history_events", "workspace_id"),
     "view": ("views", "workspace_id"),
 }
 
@@ -45,11 +45,30 @@ async def resolve_workspace_id(object_type: str, object_id: UUID) -> UUID | None
 async def _effective_read_visibility(
     object_type: str, object_id: UUID, workspace_id: UUID | None
 ) -> str:
-    """Resolve `inherit` to the parent workspace's visibility so anonymous
-    viewers can read items inside a public/link workspace by default."""
+    """Resolve read inheritance for anonymous/link readers.
+
+    Pages inherit from their notebook first, then the workspace. Other
+    workspace objects inherit directly from the workspace. Explicit object
+    visibility always wins, including `private` children inside a public parent.
+    """
     vis = await get_visibility(object_type, object_id)
     if vis != "inherit":
         return vis
+
+    if object_type == "page":
+        pool = get_pool()
+        row = await pool.fetchrow(
+            "SELECT p.notebook_id, n.workspace_id FROM notebook_pages p "
+            "JOIN notebooks n ON n.id = p.notebook_id WHERE p.id = $1",
+            object_id,
+        )
+        if not row:
+            return "inherit"
+        notebook_vis = await get_visibility("notebook", row["notebook_id"])
+        if notebook_vis != "inherit":
+            return notebook_vis
+        return await get_visibility("workspace", row["workspace_id"])
+
     if object_type == "workspace" or workspace_id is None:
         return "inherit"
     parent_vis = await get_visibility("workspace", workspace_id)
@@ -103,13 +122,12 @@ async def check_access(
     if role in ("owner", "admin"):
         return True
 
-    # 'public' and 'link' grant anonymous read; write still requires a share entry.
-    if vis in ("public", "link") and not require_write:
+    # 'public' and 'link' grant read to any viewer; write still requires a
+    # share entry. Use effective visibility so logged-in non-members can read
+    # inherited pages from a link/public notebook, matching anonymous behavior.
+    effective = await _effective_read_visibility(object_type, object_id, workspace_id)
+    if effective in ("public", "link") and not require_write:
         return True
-
-    if vis == "inherit" and workspace_id and role is not None:
-        if not require_write:
-            return True
 
     share = await pool.fetchrow(
         "SELECT permission FROM object_shares "
@@ -122,6 +140,25 @@ async def check_access(
         if not require_write:
             return True
         return share["permission"] in ("write", "admin")
+
+    if object_type == "page" and vis == "inherit":
+        row = await pool.fetchrow(
+            "SELECT notebook_id FROM notebook_pages WHERE id = $1",
+            object_id,
+        )
+        if not row:
+            return False
+        return await check_access(
+            "notebook",
+            row["notebook_id"],
+            user_id,
+            workspace_id=workspace_id,
+            require_write=require_write,
+        )
+
+    if vis == "inherit" and workspace_id and role is not None:
+        if not require_write:
+            return True
 
     return False
 

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -1,10 +1,11 @@
 """Permission service: Google Drive-like access checks for all object types.
 
 Access logic:
-1. Workspace owner/admin always has access (bypass all checks).
-2. visibility='public' → anyone can read. Write requires share entry.
-3. visibility='private' → only users in object_shares.
-4. visibility='inherit' (default) → workspace members + object_shares.
+1. Anonymous viewer (user_id=None) gets read iff visibility is 'link' or 'public'.
+2. Workspace owner/admin always has access (bypass all checks).
+3. visibility='public'/'link' → anyone can read. Write requires share entry.
+4. visibility='private' → only users in object_shares.
+5. visibility='inherit' (default) → workspace members + object_shares.
 """
 
 from uuid import UUID
@@ -12,15 +13,71 @@ from uuid import UUID
 from ..database import get_pool
 
 
+# Object types that live inside a workspace and don't have their own workspace_id
+# column. resolve_workspace_id maps object_id → parent workspace via a join.
+_WORKSPACE_LOOKUP = {
+    "workspace": ("workspaces", "id"),
+    "notebook": ("notebooks", "workspace_id"),
+    "table": ("tables", "workspace_id"),
+    "file": ("files", "workspace_id"),
+    "history": ("histories", "workspace_id"),
+    "view": ("views", "workspace_id"),
+}
+
+
+async def resolve_workspace_id(object_type: str, object_id: UUID) -> UUID | None:
+    """Look up the workspace_id for an object. Pages walk through their notebook."""
+    pool = get_pool()
+    if object_type == "page":
+        row = await pool.fetchrow(
+            "SELECT n.workspace_id FROM notebook_pages p "
+            "JOIN notebooks n ON n.id = p.notebook_id WHERE p.id = $1",
+            object_id,
+        )
+        return row["workspace_id"] if row else None
+    if object_type in _WORKSPACE_LOOKUP:
+        table, col = _WORKSPACE_LOOKUP[object_type]
+        row = await pool.fetchrow(f"SELECT {col} AS ws FROM {table} WHERE id = $1", object_id)
+        return row["ws"] if row else None
+    return None
+
+
+async def _effective_read_visibility(
+    object_type: str, object_id: UUID, workspace_id: UUID | None
+) -> str:
+    """Resolve `inherit` to the parent workspace's visibility so anonymous
+    viewers can read items inside a public/link workspace by default."""
+    vis = await get_visibility(object_type, object_id)
+    if vis != "inherit":
+        return vis
+    if object_type == "workspace" or workspace_id is None:
+        return "inherit"
+    parent_vis = await get_visibility("workspace", workspace_id)
+    return parent_vis
+
+
 async def check_access(
     object_type: str,
     object_id: UUID,
-    user_id: UUID,
+    user_id: UUID | None,
     workspace_id: UUID | None = None,
     require_write: bool = False,
 ) -> bool:
-    """Check if a user can access an object. Returns True if allowed."""
+    """Check if a user can access an object. user_id=None means anonymous viewer."""
     pool = get_pool()
+
+    if workspace_id is None:
+        workspace_id = await resolve_workspace_id(object_type, object_id)
+
+    vis = await get_visibility(object_type, object_id)
+
+    # Anonymous viewers only get read, and only when the effective visibility
+    # (own row or — if 'inherit' — the parent workspace's row) is link or public.
+    if user_id is None:
+        if require_write:
+            return False
+        effective = await _effective_read_visibility(object_type, object_id, workspace_id)
+        return effective in ("public", "link")
 
     # Owner of personal (workspace-less) items always has full access
     if workspace_id is None:
@@ -41,24 +98,19 @@ async def check_access(
             if row:
                 return True
 
-    # Fetch workspace role and visibility once, reuse below
     role = await get_workspace_role(workspace_id, user_id) if workspace_id else None
-    vis = await get_visibility(object_type, object_id)
 
-    # Workspace owner/admin always has access
     if role in ("owner", "admin"):
         return True
 
-    # Public objects are readable by anyone
-    if vis == "public" and not require_write:
+    # 'public' and 'link' grant anonymous read; write still requires a share entry.
+    if vis in ("public", "link") and not require_write:
         return True
 
-    # 'inherit' grants workspace members read access; write requires explicit share
     if vis == "inherit" and workspace_id and role is not None:
         if not require_write:
             return True
 
-    # Check object_shares
     share = await pool.fetchrow(
         "SELECT permission FROM object_shares "
         "WHERE object_type = $1 AND object_id = $2 AND user_id = $3",
@@ -101,10 +153,9 @@ async def get_visibility(object_type: str, object_id: UUID) -> str:
 
 
 async def set_visibility(object_type: str, object_id: UUID, visibility: str) -> None:
-    """Set object visibility (inherit/private/public)."""
+    """Set object visibility (inherit/private/link/public)."""
     pool = get_pool()
     if visibility == "inherit":
-        # Remove the row (inherit is default)
         await pool.execute(
             "DELETE FROM object_permissions WHERE object_type = $1 AND object_id = $2",
             object_type,
@@ -118,6 +169,16 @@ async def set_visibility(object_type: str, object_id: UUID, visibility: str) -> 
             object_type,
             object_id,
             visibility,
+        )
+
+    # Workspaces have a legacy is_public column that the Discover catalog still
+    # queries. Mirror visibility=public into it so /discover finds workspaces
+    # shared via the new sheet, and clear it on demote.
+    if object_type == "workspace":
+        await pool.execute(
+            "UPDATE workspaces SET is_public = $1 WHERE id = $2",
+            visibility == "public",
+            object_id,
         )
 
 

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -323,9 +323,11 @@ async def get_public_view(slug: str, viewer_id: UUID | None = None) -> dict | No
     return view
 
 
-async def inline_items(view: dict) -> list[dict]:
+async def inline_items(view: dict, viewer_id: UUID | None = None) -> list[dict]:
     """Resolve each view_item into a dict with {object_type, object_id, position,
     label, inline} where inline is a type-specific payload."""
+    from . import permission_service
+
     pool = get_pool()
     out: list[dict] = []
     for item in view["items"]:
@@ -345,6 +347,12 @@ async def inline_items(view: dict) -> list[dict]:
                     "WHERE notebook_id = $1 ORDER BY created_at, name",
                     obj_id,
                 )
+                visible_pages = []
+                for p in pages:
+                    if await permission_service.check_access(
+                        "page", p["id"], viewer_id, workspace_id=view["workspace_id"]
+                    ):
+                        visible_pages.append(p)
                 inline = {
                     "description": nb["description"],
                     "pages": [
@@ -356,7 +364,7 @@ async def inline_items(view: dict) -> list[dict]:
                             "content_html": p["content_html"],
                             "updated_at": p["updated_at"].isoformat(),
                         }
-                        for p in pages
+                        for p in visible_pages
                     ],
                 }
         elif obj_type == "page":
@@ -482,12 +490,18 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
     view's items, not the whole source workspace.
     """
     pool = get_pool()
-    view_row = await pool.fetchrow(
-        f"{_VIEW_SELECT} WHERE slug = $1 AND is_public = true", slug
-    )
+    view_row = await pool.fetchrow(f"{_VIEW_SELECT} WHERE slug = $1", slug)
     if not view_row:
         return None
     view = await _attach_items(dict(view_row))
+
+    from . import permission_service
+
+    for item in view["items"]:
+        if not await permission_service.check_access(
+            item["object_type"], item["object_id"], None, workspace_id=view["workspace_id"]
+        ):
+            return None
 
     source_ws = await pool.fetchrow(
         "SELECT id, name FROM workspaces WHERE id = $1", view["workspace_id"]
@@ -528,6 +542,7 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                 forker_id,
             )
 
+            page_nb_id: UUID | None = None
             for item in view["items"]:
                 t = item["object_type"]
                 src_id = item["object_id"]
@@ -541,26 +556,46 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                     new_nb_id = await conn.fetchval(
                         "INSERT INTO notebooks (workspace_id, name, description, created_by) "
                         "VALUES ($1, $2, $3, $4) RETURNING id",
-                        new_ws_id, nb["name"], nb["description"] or "", forker_id,
+                        new_ws_id,
+                        nb["name"],
+                        nb["description"] or "",
+                        forker_id,
                     )
-                    folders = await conn.fetch(
-                        "SELECT id, name FROM notebook_folders WHERE notebook_id = $1", src_id
+                    pages = await conn.fetch(
+                        "SELECT id, folder_id, name, content_markdown, content_html, "
+                        "content_type, content_hash, metadata "
+                        "FROM notebook_pages WHERE notebook_id = $1",
+                        src_id,
+                    )
+                    visible_pages = []
+                    for p in pages:
+                        if await permission_service.check_access(
+                            "page", p["id"], None, workspace_id=view["workspace_id"]
+                        ):
+                            visible_pages.append(p)
+
+                    folder_ids = [p["folder_id"] for p in visible_pages if p["folder_id"]]
+                    folders = (
+                        await conn.fetch(
+                            "SELECT id, name FROM notebook_folders "
+                            "WHERE notebook_id = $1 AND id = ANY($2::uuid[])",
+                            src_id,
+                            folder_ids,
+                        )
+                        if folder_ids
+                        else []
                     )
                     folder_id_map: dict = {}
                     for f in folders:
                         new_f = await conn.fetchval(
                             "INSERT INTO notebook_folders (notebook_id, name, created_by) "
                             "VALUES ($1, $2, $3) RETURNING id",
-                            new_nb_id, f["name"], forker_id,
+                            new_nb_id,
+                            f["name"],
+                            forker_id,
                         )
                         folder_id_map[f["id"]] = new_f
-                    pages = await conn.fetch(
-                        "SELECT folder_id, name, content_markdown, content_html, "
-                        "content_type, content_hash, metadata "
-                        "FROM notebook_pages WHERE notebook_id = $1",
-                        src_id,
-                    )
-                    for p in pages:
+                    for p in visible_pages:
                         await conn.execute(
                             "INSERT INTO notebook_pages "
                             "(notebook_id, folder_id, name, content_markdown, content_html, "
@@ -577,6 +612,38 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                             forker_id,
                         )
 
+                elif t == "page":
+                    src = await conn.fetchrow(
+                        "SELECT name, content_markdown, content_html, content_type, "
+                        "content_hash, metadata FROM notebook_pages WHERE id = $1",
+                        src_id,
+                    )
+                    if not src:
+                        continue
+                    if page_nb_id is None:
+                        page_nb_id = await conn.fetchval(
+                            "INSERT INTO notebooks (workspace_id, name, description, created_by) "
+                            "VALUES ($1, $2, $3, $4) RETURNING id",
+                            new_ws_id,
+                            "Pages",
+                            f"Pages forked from {view['title']}.",
+                            forker_id,
+                        )
+                    await conn.execute(
+                        "INSERT INTO notebook_pages "
+                        "(notebook_id, name, content_markdown, content_html, "
+                        "content_type, content_hash, metadata, created_by) "
+                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                        page_nb_id,
+                        src["name"],
+                        src["content_markdown"] or "",
+                        src["content_html"] or "",
+                        src["content_type"],
+                        src["content_hash"],
+                        src["metadata"] or {},
+                        forker_id,
+                    )
+
                 elif t == "table":
                     src = await conn.fetchrow(
                         "SELECT name, description, columns, views FROM tables WHERE id = $1",
@@ -587,8 +654,12 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                     new_t_id = await conn.fetchval(
                         "INSERT INTO tables (workspace_id, name, description, columns, views, created_by) "
                         "VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
-                        new_ws_id, src["name"], src["description"] or "",
-                        src["columns"], src["views"], forker_id,
+                        new_ws_id,
+                        src["name"],
+                        src["description"] or "",
+                        src["columns"],
+                        src["views"],
+                        forker_id,
                     )
                     rows = await conn.fetch(
                         "SELECT data, row_order FROM table_rows WHERE table_id = $1 "
@@ -599,7 +670,10 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                         await conn.execute(
                             "INSERT INTO table_rows (table_id, data, row_order, created_by) "
                             "VALUES ($1, $2, $3, $4)",
-                            new_t_id, r["data"], r["row_order"], forker_id,
+                            new_t_id,
+                            r["data"],
+                            r["row_order"],
+                            forker_id,
                         )
 
                 elif t == "history":
@@ -615,9 +689,15 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                         "INSERT INTO history_events (workspace_id, created_by, agent_name, "
                         "event_type, session_id, tool_name, content, metadata, attachments, "
                         "created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
-                        new_ws_id, src["created_by"], src["agent_name"],
-                        src["event_type"], src["session_id"], src["tool_name"],
-                        src["content"], src["metadata"], src["attachments"],
+                        new_ws_id,
+                        src["created_by"],
+                        src["agent_name"],
+                        src["event_type"],
+                        src["session_id"],
+                        src["tool_name"],
+                        src["content"],
+                        src["metadata"],
+                        src["attachments"],
                         src["created_at"],
                     )
                 # files are intentionally skipped (S3 copy out of scope).

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -77,6 +77,78 @@ async def create_view(
     return await _attach_items(dict(row))
 
 
+async def _object_title(object_type: str, object_id: UUID) -> str:
+    """Best-effort human label for an underlying object — used as the default
+    View title when minting a share-link View."""
+    pool = get_pool()
+    if object_type == "notebook":
+        row = await pool.fetchrow("SELECT name FROM notebooks WHERE id = $1", object_id)
+    elif object_type == "page":
+        row = await pool.fetchrow("SELECT name FROM notebook_pages WHERE id = $1", object_id)
+    elif object_type == "table":
+        row = await pool.fetchrow("SELECT name FROM tables WHERE id = $1", object_id)
+    elif object_type == "file":
+        row = await pool.fetchrow("SELECT name FROM files WHERE id = $1", object_id)
+    elif object_type == "history":
+        row = await pool.fetchrow(
+            "SELECT agent_name AS name FROM history_events WHERE id = $1", object_id
+        )
+    else:
+        row = None
+    return (row["name"] if row else "Shared item")
+
+
+async def find_or_create_share_link_view(
+    workspace_id: UUID,
+    owner_id: UUID,
+    object_type: str,
+    object_id: UUID,
+) -> dict:
+    """Reuse-or-create the one-item View that backs the Copy Link button.
+
+    Idempotent on (owner, object_type, object_id): clicking Copy Link a second
+    time on the same object returns the same /v/{slug} URL."""
+    pool = get_pool()
+    existing = await pool.fetchrow(
+        "SELECT v.id, v.workspace_id, v.slug, v.title, v.description, v.owner_id, "
+        "v.is_public, v.cover_image_url, v.view_count, v.created_at, v.updated_at "
+        "FROM views v "
+        "WHERE v.owner_id = $1 "
+        "AND (SELECT COUNT(*) FROM view_items WHERE view_id = v.id) = 1 "
+        "AND EXISTS (SELECT 1 FROM view_items "
+        "            WHERE view_id = v.id AND object_type = $2 AND object_id = $3) "
+        "ORDER BY v.created_at LIMIT 1",
+        owner_id,
+        object_type,
+        object_id,
+    )
+    if existing:
+        return await _attach_items(dict(existing))
+
+    title = await _object_title(object_type, object_id)
+    slug = _slugify(title)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "INSERT INTO views (workspace_id, slug, title, description, owner_id, "
+                "is_public, cover_image_url) VALUES ($1, $2, $3, $4, $5, true, NULL) "
+                f"RETURNING {', '.join(['id','workspace_id','slug','title','description','owner_id','is_public','cover_image_url','view_count','created_at','updated_at'])}",
+                workspace_id,
+                slug,
+                title,
+                "",
+                owner_id,
+            )
+            await conn.execute(
+                "INSERT INTO view_items (view_id, object_type, object_id, position, label_override) "
+                "VALUES ($1, $2, $3, 0, NULL)",
+                row["id"],
+                object_type,
+                object_id,
+            )
+    return await _attach_items(dict(row))
+
+
 async def update_view(
     view_id: UUID,
     user_id: UUID,
@@ -130,6 +202,74 @@ async def delete_view(view_id: UUID, user_id: UUID) -> bool:
     return result == "DELETE 1"
 
 
+async def list_public_views(
+    *,
+    query: str | None = None,
+    sort: str = "trending",
+    limit: int = 48,
+) -> list[dict]:
+    """Catalog of Views whose every underlying item is anonymously readable."""
+    from . import permission_service
+
+    pool = get_pool()
+    where = ["1=1"]
+    args: list = []
+    idx = 1
+    if query:
+        where.append(f"(v.title ILIKE ${idx} OR v.description ILIKE ${idx})")
+        args.append(f"%{query}%")
+        idx += 1
+
+    if sort == "newest":
+        order = "v.created_at DESC, v.id DESC"
+    elif sort == "popular":
+        order = "v.view_count DESC, v.updated_at DESC, v.id DESC"
+    else:
+        order = "v.updated_at DESC, v.id DESC"
+
+    rows = await pool.fetch(
+        f"SELECT v.id, v.workspace_id, v.slug, v.title, v.description, v.owner_id, "
+        f"v.cover_image_url, v.view_count, v.created_at, v.updated_at, "
+        f"u.name AS owner_name, u.display_name AS owner_display_name, "
+        f"w.name AS workspace_name "
+        f"FROM views v JOIN users u ON u.id = v.owner_id "
+        f"JOIN workspaces w ON w.id = v.workspace_id "
+        f"WHERE {' AND '.join(where)} ORDER BY {order} LIMIT {int(limit) * 2}",
+        *args,
+    )
+
+    out: list[dict] = []
+    for r in rows:
+        view = await _attach_items(dict(r))
+        readable = True
+        for item in view["items"]:
+            ok = await permission_service.check_access(
+                item["object_type"], item["object_id"], None, workspace_id=view["workspace_id"]
+            )
+            if not ok:
+                readable = False
+                break
+        if readable:
+            out.append({
+                "id": str(view["id"]),
+                "slug": view["slug"],
+                "title": view["title"],
+                "description": view["description"],
+                "cover_image_url": view["cover_image_url"],
+                "view_count": view["view_count"],
+                "owner_name": view.get("owner_name"),
+                "owner_display_name": view.get("owner_display_name"),
+                "workspace_id": str(view["workspace_id"]),
+                "workspace_name": view.get("workspace_name"),
+                "item_count": len(view["items"]),
+                "created_at": view["created_at"].isoformat(),
+                "updated_at": view["updated_at"].isoformat(),
+            })
+            if len(out) >= limit:
+                break
+    return out
+
+
 async def list_workspace_views(workspace_id: UUID) -> list[dict]:
     pool = get_pool()
     rows = await pool.fetch(
@@ -145,15 +285,39 @@ async def get_view(view_id: UUID) -> dict | None:
     return await _attach_items(dict(row)) if row else None
 
 
-async def get_public_view(slug: str) -> dict | None:
+async def get_public_view(slug: str, viewer_id: UUID | None = None) -> dict | None:
+    """Resolve a View by slug for the given viewer (None = anonymous).
+
+    Strict access: the View renders iff the viewer can read every one of its
+    items via the object-level permission service. There's no separate View
+    ACL — we derive it from the items, which avoids the orphan-View bug
+    (a public View over a now-private item would silently leak today).
+    """
+    from . import permission_service
+
     pool = get_pool()
-    row = await pool.fetchrow(
-        f"{_VIEW_SELECT} WHERE slug = $1 AND is_public = true", slug
-    )
+    row = await pool.fetchrow(f"{_VIEW_SELECT} WHERE slug = $1", slug)
     if not row:
         return None
-    await pool.execute("UPDATE views SET view_count = view_count + 1 WHERE id = $1", row["id"])
     view = await _attach_items(dict(row))
+
+    # The View itself can also be ACLd via object_permissions on object_type='view'
+    # (e.g. a viewer was explicitly shared on the curation). If the viewer can't
+    # see the View object directly AND can't see at least one item, treat as 404.
+    can_see_view = await permission_service.check_access(
+        "view", view["id"], viewer_id, workspace_id=view["workspace_id"]
+    )
+
+    for item in view["items"]:
+        item_workspace = view["workspace_id"]
+        ok = await permission_service.check_access(
+            item["object_type"], item["object_id"], viewer_id, workspace_id=item_workspace
+        )
+        if not ok and not can_see_view:
+            return None
+
+    await pool.execute("UPDATE views SET view_count = view_count + 1 WHERE id = $1", view["id"])
+
     ws = await pool.fetchrow(
         "SELECT name, is_public FROM workspaces WHERE id = $1", view["workspace_id"]
     )
@@ -197,6 +361,24 @@ async def inline_items(view: dict) -> list[dict]:
                         }
                         for p in pages
                     ],
+                }
+        elif obj_type == "page":
+            p = await pool.fetchrow(
+                "SELECT id, name, content_markdown, content_html, content_type, updated_at "
+                "FROM notebook_pages WHERE id = $1",
+                obj_id,
+            )
+            if p:
+                label = label or p["name"]
+                inline = {
+                    "page": {
+                        "id": str(p["id"]),
+                        "name": p["name"],
+                        "content_type": p["content_type"],
+                        "content_markdown": p["content_markdown"],
+                        "content_html": p["content_html"],
+                        "updated_at": p["updated_at"].isoformat(),
+                    }
                 }
         elif obj_type == "table":
             t = await pool.fetchrow(
@@ -270,6 +452,10 @@ def items_to_text(title: str, items: list[dict]) -> str:
             for page in inline.get("pages", []):
                 if page.get("content_markdown"):
                     parts.append(page["content_markdown"])
+        elif obj_type == "page":
+            page = inline.get("page", {})
+            if page.get("content_markdown"):
+                parts.append(page["content_markdown"])
         elif obj_type == "table":
             cols = inline.get("columns", [])
             rows = inline.get("rows", [])

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -301,19 +301,16 @@ async def get_public_view(slug: str, viewer_id: UUID | None = None) -> dict | No
         return None
     view = await _attach_items(dict(row))
 
-    # The View itself can also be ACLd via object_permissions on object_type='view'
-    # (e.g. a viewer was explicitly shared on the curation). If the viewer can't
-    # see the View object directly AND can't see at least one item, treat as 404.
-    can_see_view = await permission_service.check_access(
-        "view", view["id"], viewer_id, workspace_id=view["workspace_id"]
-    )
-
+    # Strict mode: the View renders iff every underlying item is readable to
+    # the viewer. There's no separate View ACL — Views are pure presentation,
+    # so an item being privately overridden hides the whole publication, even
+    # for the workspace owner browsing the public URL. Owners can always
+    # navigate via the workspace UI.
     for item in view["items"]:
-        item_workspace = view["workspace_id"]
         ok = await permission_service.check_access(
-            item["object_type"], item["object_id"], viewer_id, workspace_id=item_workspace
+            item["object_type"], item["object_id"], viewer_id, workspace_id=view["workspace_id"]
         )
-        if not ok and not can_see_view:
+        if not ok:
             return None
 
     await pool.execute("UPDATE views SET view_count = view_count + 1 WHERE id = $1", view["id"])

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -124,6 +124,15 @@ async def update_workspace(
         "(SELECT COUNT(*) FROM workspace_members wm WHERE wm.workspace_id = id) AS member_count",
         *args,
     )
+    if row and is_public is not None:
+        # Mirror the legacy is_public toggle into the unified ACL so the
+        # public reader (which checks object_permissions) stays in sync with
+        # the discover catalog (which still queries workspaces.is_public).
+        from . import permission_service
+
+        await permission_service.set_visibility(
+            "workspace", workspace_id, "public" if is_public else "inherit"
+        )
     return dict(row) if row else None
 
 

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -49,6 +49,17 @@ async def _make_notebook(pool, workspace_id, created_by):
     return row["id"]
 
 
+async def _make_page(pool, notebook_id, created_by, name="page"):
+    row = await pool.fetchrow(
+        "INSERT INTO notebook_pages (notebook_id, name, content_markdown, created_by) "
+        "VALUES ($1, $2, 'content', $3) RETURNING id",
+        notebook_id,
+        name,
+        created_by,
+    )
+    return row["id"]
+
+
 @pytest.mark.asyncio
 async def test_owner_has_access(pool):
     user_id = await _make_user(pool)
@@ -155,3 +166,64 @@ async def test_private_visibility_denies_member(pool):
     assert not await permission_service.check_access(
         "notebook", nb_id, member_id, workspace_id=ws_id
     )
+
+
+@pytest.mark.asyncio
+async def test_page_inherits_notebook_visibility_for_link_readers(pool):
+    owner_id = await _make_user(pool)
+    ws_id = await _make_workspace(pool, owner_id)
+    nb_id = await _make_notebook(pool, ws_id, owner_id)
+    inherited_page_id = await _make_page(pool, nb_id, owner_id, "inherited")
+    private_page_id = await _make_page(pool, nb_id, owner_id, "private")
+
+    await permission_service.set_visibility("notebook", nb_id, "link")
+    await permission_service.set_visibility("page", private_page_id, "private")
+
+    assert await permission_service.check_access("page", inherited_page_id, None)
+    assert not await permission_service.check_access("page", private_page_id, None)
+
+
+@pytest.mark.asyncio
+async def test_page_inherits_notebook_shares_for_authenticated_readers(pool):
+    owner_id = await _make_user(pool)
+    reader_id = await _make_user(pool)
+    ws_id = await _make_workspace(pool, owner_id)
+    nb_id = await _make_notebook(pool, ws_id, owner_id)
+    page_id = await _make_page(pool, nb_id, owner_id)
+
+    await permission_service.set_visibility("notebook", nb_id, "private")
+    await permission_service.add_share("notebook", nb_id, reader_id, "read", owner_id)
+
+    assert await permission_service.check_access("page", page_id, reader_id)
+
+
+@pytest.mark.asyncio
+async def test_private_notebook_hides_inherited_pages_from_workspace_members(pool):
+    owner_id = await _make_user(pool)
+    member_id = await _make_user(pool)
+    ws_id = await _make_workspace(pool, owner_id)
+    await pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'member')",
+        ws_id,
+        member_id,
+    )
+    nb_id = await _make_notebook(pool, ws_id, owner_id)
+    page_id = await _make_page(pool, nb_id, owner_id)
+
+    await permission_service.set_visibility("notebook", nb_id, "private")
+
+    assert not await permission_service.check_access("page", page_id, member_id)
+
+
+@pytest.mark.asyncio
+async def test_history_resolves_to_history_events_workspace(pool):
+    owner_id = await _make_user(pool)
+    ws_id = await _make_workspace(pool, owner_id)
+    event_id = await pool.fetchval(
+        "INSERT INTO history_events (workspace_id, created_by, agent_name, event_type, content) "
+        "VALUES ($1, $2, 'agent', 'message', 'hello') RETURNING id",
+        ws_id,
+        owner_id,
+    )
+
+    assert await permission_service.resolve_workspace_id("history", event_id) == ws_id

--- a/cli/client.py
+++ b/cli/client.py
@@ -577,3 +577,53 @@ class StashClient:
     def delete_table_column(self, workspace_id: str | None, table_id: str, column_id: str) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables" if workspace_id else "/api/v1/tables"
         return self._request("DELETE", f"{base}/{table_id}/columns/{column_id}").json()
+
+    # ── Unified sharing API (object_type: workspace|notebook|page|table|file|history|view) ──
+
+    def get_object_permissions(self, object_type: str, object_id: str) -> dict:
+        return self._get(f"/api/v1/objects/{object_type}/{object_id}/permissions")
+
+    def set_object_visibility(self, object_type: str, object_id: str, visibility: str) -> dict:
+        return self._patch(
+            f"/api/v1/objects/{object_type}/{object_id}/permissions",
+            json={"visibility": visibility},
+        )
+
+    def add_object_share(
+        self, object_type: str, object_id: str, user_id: str, permission: str = "read"
+    ) -> dict:
+        return self._post(
+            f"/api/v1/objects/{object_type}/{object_id}/shares",
+            json={"user_id": user_id, "permission": permission},
+        )
+
+    def remove_object_share(self, object_type: str, object_id: str, user_id: str) -> None:
+        self._delete(f"/api/v1/objects/{object_type}/{object_id}/shares/{user_id}")
+
+    def share_link(
+        self, object_type: str, object_id: str, ensure: str | None = None
+    ) -> dict:
+        path = f"/api/v1/objects/{object_type}/{object_id}/share-link"
+        if ensure:
+            path += f"?ensure={ensure}"
+        return self._post(path)
+
+    def publish(
+        self,
+        workspace_id: str,
+        title: str,
+        content: str,
+        content_type: str = "markdown",
+        audience: str = "link",
+        notebook_id: str | None = None,
+    ) -> dict:
+        body: dict = {
+            "workspace_id": workspace_id,
+            "title": title,
+            "content": content,
+            "content_type": content_type,
+            "audience": audience,
+        }
+        if notebook_id:
+            body["notebook_id"] = notebook_id
+        return self._post("/api/v1/publish", json=body)

--- a/cli/main.py
+++ b/cli/main.py
@@ -3541,5 +3541,65 @@ def config_cmd(
     console.print(json.dumps(display, indent=2, default=str))
 
 
+@app.command("share-object")
+def share_object_cmd(
+    object_type: str = typer.Argument(..., help="workspace|notebook|page|table|file|history|view"),
+    object_id: str = typer.Argument(..., help="UUID of the object"),
+    ensure: str = typer.Option("link", "--ensure", help="Raise visibility to at least this level: ''|'link'|'public'"),
+):
+    """Mint a share URL for any object. Idempotent."""
+    cfg = load_config()
+    c = StashClient(cfg["base_url"], cfg.get("api_key", ""))
+    result = c.share_link(object_type, object_id, ensure or None)
+    console.print(result["url"])
+
+
+@app.command("visibility")
+def visibility_cmd(
+    object_type: str = typer.Argument(..., help="workspace|notebook|page|table|file|history|view"),
+    object_id: str = typer.Argument(..., help="UUID of the object"),
+    level: str = typer.Argument(..., help="inherit|private|link|public"),
+):
+    """Set visibility on any object."""
+    cfg = load_config()
+    c = StashClient(cfg["base_url"], cfg.get("api_key", ""))
+    c.set_object_visibility(object_type, object_id, level)
+    console.print(f"[green]✓[/green] {object_type} {object_id[:8]}… → {level}")
+
+
+@app.command("publish")
+def publish_cmd(
+    file_path: str = typer.Argument(..., help="Path to .html or .md file to publish"),
+    title: str = typer.Option(None, "--title", "-t", help="Page title (defaults to filename)"),
+    workspace_id: str = typer.Option(None, "--workspace", "-w"),
+    notebook_id: str = typer.Option(None, "--notebook", "-n", help="Defaults to auto-created 'AI Drafts'"),
+    audience: str = typer.Option("link", "--audience", help="link | public"),
+):
+    """Publish a local file as a Stash page and print the share URL.
+
+    Single call: creates the page, sets visibility, mints the share-link.
+    Mirrors what an agent does via the MCP `stash_publish_html` tool."""
+    p = Path(file_path)
+    if not p.exists():
+        console.print(f"[red]File not found: {file_path}[/red]")
+        raise typer.Exit(1)
+    content_type = "html" if p.suffix.lower() in (".html", ".htm") else "markdown"
+    cfg = load_config()
+    c = StashClient(cfg["base_url"], cfg.get("api_key", ""))
+    ws = workspace_id or (load_manifest() or {}).get("workspace_id")
+    if not ws:
+        console.print("[red]No workspace. Pass --workspace or run `stash connect`.[/red]")
+        raise typer.Exit(1)
+    result = c.publish(
+        workspace_id=ws,
+        title=title or p.stem,
+        content=p.read_text(),
+        content_type=content_type,
+        audience=audience,
+        notebook_id=notebook_id,
+    )
+    console.print(result["url"])
+
+
 if __name__ == "__main__":
     app()

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -514,6 +514,103 @@ def stash_whoami() -> str:
     return _json(client.whoami())
 
 
+# ── Sharing (unified ACL + share-link + publish) ──────────────────
+
+
+@mcp.tool()
+def stash_get_permissions(object_type: str, object_id: str) -> str:
+    """Get visibility + shares for any object (workspace|notebook|page|table|file|history|view)."""
+    client, _ = _client()
+    return _json(client.get_object_permissions(object_type, object_id))
+
+
+@mcp.tool()
+def stash_set_visibility(object_type: str, object_id: str, visibility: str) -> str:
+    """Set visibility on an object. Allowed: inherit | private | link | public."""
+    client, _ = _client()
+    return _json(client.set_object_visibility(object_type, object_id, visibility))
+
+
+@mcp.tool()
+def stash_add_share(
+    object_type: str, object_id: str, user_id: str, permission: str = "read"
+) -> str:
+    """Grant a specific user access to an object. permission: read | write | admin."""
+    client, _ = _client()
+    return _json(client.add_object_share(object_type, object_id, user_id, permission))
+
+
+@mcp.tool()
+def stash_remove_share(object_type: str, object_id: str, user_id: str) -> str:
+    """Revoke a specific user's access to an object."""
+    client, _ = _client()
+    client.remove_object_share(object_type, object_id, user_id)
+    return _json({"removed": user_id})
+
+
+@mcp.tool()
+def stash_share(object_type: str, object_id: str, ensure: str = "link") -> str:
+    """Mint or fetch a share URL for any object. ensure: '' | 'link' | 'public'.
+
+    With ensure='link' (default), the underlying object's visibility is raised
+    to at least 'link' if it isn't already, so the returned URL is guaranteed
+    to be readable to anyone with it. Pass ensure='' to skip the visibility
+    bump (use when you want the URL but plan to set permissions separately)."""
+    client, _ = _client()
+    return _json(client.share_link(object_type, object_id, ensure or None))
+
+
+@mcp.tool()
+def stash_publish_html(
+    title: str,
+    html: str,
+    workspace_id: str = "",
+    audience: str = "link",
+    notebook_id: str = "",
+) -> str:
+    """Single-call publish: create an HTML page and return a share URL.
+
+    If notebook_id is omitted, the page lands in the workspace's auto-created
+    'AI Drafts' notebook. audience: 'link' (anyone with URL) or 'public'
+    (also listed in /discover)."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(
+        client.publish(
+            workspace_id=ws,
+            title=title,
+            content=html,
+            content_type="html",
+            audience=audience,
+            notebook_id=notebook_id or None,
+        )
+    )
+
+
+@mcp.tool()
+def stash_publish_markdown(
+    title: str,
+    markdown: str,
+    workspace_id: str = "",
+    audience: str = "link",
+    notebook_id: str = "",
+) -> str:
+    """Single-call publish: create a markdown page and return a share URL.
+    Same flow as stash_publish_html but for markdown content."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(
+        client.publish(
+            workspace_id=ws,
+            title=title,
+            content=markdown,
+            content_type="markdown",
+            audience=audience,
+            notebook_id=notebook_id or None,
+        )
+    )
+
+
 # ── Entry point ───────────────────────────────────────────────────
 
 def main():

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -21,6 +21,17 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        // /v/{slug}/embed must be iframe-able from anywhere.
+        source: "/v/:slug/embed",
+        headers: [
+          { key: "Content-Security-Policy", value: "frame-ancestors *" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -19,6 +19,10 @@ const nextConfig: NextConfig = {
         source: "/health",
         destination: `${backend}/health`,
       },
+      {
+        source: "/llms.txt",
+        destination: `${backend}/llms.txt`,
+      },
     ];
   },
   async headers() {

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -7,19 +7,50 @@ const BACKEND_ORIGIN =
 
 type SearchParams = {
   q?: string;
-  sort?: "trending" | "newest" | "forks";
+  sort?: string;
   category?: string;
   tag?: string;
+  tab?: "workspaces" | "views";
 };
+
+interface PublicViewCard {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  cover_image_url: string | null;
+  view_count: number;
+  owner_name: string | null;
+  owner_display_name: string | null;
+  workspace_id: string;
+  workspace_name: string | null;
+  item_count: number;
+  created_at: string;
+  updated_at: string;
+}
 
 async function fetchCatalog(params: SearchParams): Promise<{ workspaces: CatalogCard[] }> {
   const qs = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) if (v) qs.set(k, v);
+  for (const [k, v] of Object.entries({ q: params.q, sort: params.sort, category: params.category, tag: params.tag })) {
+    if (v) qs.set(k, v);
+  }
   const res = await fetch(
     `${BACKEND_ORIGIN}/api/v1/discover/workspaces${qs.size ? `?${qs}` : ""}`,
     { next: { revalidate: 60 } }
   );
   if (!res.ok) return { workspaces: [] };
+  return res.json();
+}
+
+async function fetchViews(params: SearchParams): Promise<{ views: PublicViewCard[] }> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set("q", params.q);
+  if (params.sort) qs.set("sort", params.sort);
+  const res = await fetch(
+    `${BACKEND_ORIGIN}/api/v1/discover/views${qs.size ? `?${qs}` : ""}`,
+    { next: { revalidate: 30 } }
+  );
+  if (!res.ok) return { views: [] };
   return res.json();
 }
 
@@ -29,46 +60,102 @@ export default async function DiscoverPage({
   searchParams: Promise<SearchParams>;
 }) {
   const params = await searchParams;
-  const sort = params.sort ?? "trending";
-  const { workspaces } = await fetchCatalog({ ...params, sort });
+  const tab = params.tab ?? "workspaces";
+  const isViews = tab === "views";
+
+  const sortOptions = isViews
+    ? (["trending", "newest", "popular"] as const)
+    : (["trending", "newest", "forks"] as const);
+  const sort = (sortOptions as readonly string[]).includes(params.sort ?? "")
+    ? (params.sort as string)
+    : sortOptions[0];
+
+  const data = isViews
+    ? await fetchViews({ ...params, sort })
+    : await fetchCatalog({ ...params, sort });
 
   return (
     <main className="mx-auto max-w-[1200px] px-7 py-12">
       <h1 className="font-display text-[36px] font-black tracking-[-0.03em] text-ink">
-        Discover Stashes
+        Discover
       </h1>
       <p className="mt-2 text-[15px] text-dim">
-        Public Stashes you can read, fork, or join.
+        {isViews
+          ? "Curated Views — published bundles you can read or fork."
+          : "Public Stashes you can read, fork, or join."}
       </p>
 
-      <div className="mt-6 flex flex-wrap gap-2 border-b border-border-subtle pb-2">
-        {(["trending", "newest", "forks"] as const).map((key) => (
+      <div className="mt-6 flex items-center gap-4 border-b border-border-subtle">
+        {(["workspaces", "views"] as const).map((t) => (
           <Link
-            key={key}
-            href={`/discover?sort=${key}${params.q ? `&q=${encodeURIComponent(params.q)}` : ""}`}
-            className={`rounded-md px-3 py-2 text-[14px] transition ${
-              sort === key ? "bg-raised text-ink" : "text-dim hover:bg-raised hover:text-ink"
-            }`}
+            key={t}
+            href={`/discover?tab=${t}${params.q ? `&q=${encodeURIComponent(params.q)}` : ""}`}
+            className={
+              "border-b-2 px-2 pb-2 text-[14px] transition " +
+              (tab === t
+                ? "border-ink text-ink"
+                : "border-transparent text-muted hover:text-ink")
+            }
           >
-            {key === "forks" ? "Most forked" : key.charAt(0).toUpperCase() + key.slice(1)}
+            {t === "workspaces" ? "Stashes" : "Views"}
           </Link>
         ))}
       </div>
 
-      {workspaces.length === 0 ? (
-        <p className="mt-12 text-center text-[14px] text-muted">No public Stashes yet.</p>
+      <div className="mt-4 flex flex-wrap gap-2 pb-2">
+        {sortOptions.map((key) => (
+          <Link
+            key={key}
+            href={`/discover?tab=${tab}&sort=${key}${params.q ? `&q=${encodeURIComponent(params.q)}` : ""}`}
+            className={`rounded-md px-3 py-1.5 text-[13px] transition ${
+              sort === key ? "bg-raised text-ink" : "text-dim hover:bg-raised hover:text-ink"
+            }`}
+          >
+            {key === "forks"
+              ? "Most forked"
+              : key === "popular"
+              ? "Most viewed"
+              : key.charAt(0).toUpperCase() + key.slice(1)}
+          </Link>
+        ))}
+      </div>
+
+      {isViews ? (
+        <ViewsGrid views={(data as { views: PublicViewCard[] }).views} />
       ) : (
-        <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {workspaces.map((w) => (
-            <Card key={w.id} ws={w} />
-          ))}
-        </div>
+        <WorkspacesGrid workspaces={(data as { workspaces: CatalogCard[] }).workspaces} />
       )}
     </main>
   );
 }
 
-function Card({ ws }: { ws: CatalogCard }) {
+function WorkspacesGrid({ workspaces }: { workspaces: CatalogCard[] }) {
+  if (workspaces.length === 0) {
+    return <p className="mt-12 text-center text-[14px] text-muted">No public Stashes yet.</p>;
+  }
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {workspaces.map((w) => (
+        <WorkspaceCard key={w.id} ws={w} />
+      ))}
+    </div>
+  );
+}
+
+function ViewsGrid({ views }: { views: PublicViewCard[] }) {
+  if (views.length === 0) {
+    return <p className="mt-12 text-center text-[14px] text-muted">No public Views yet.</p>;
+  }
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {views.map((v) => (
+        <ViewCard key={v.id} view={v} />
+      ))}
+    </div>
+  );
+}
+
+function WorkspaceCard({ ws }: { ws: CatalogCard }) {
   const owner = ws.creator_display_name || ws.creator_name;
   return (
     <Link
@@ -94,6 +181,30 @@ function Card({ ws }: { ws: CatalogCard }) {
       <div className="mt-auto flex items-center justify-between pt-4 text-[12px] text-dim">
         <span>by {owner}</span>
         <span>★ {ws.fork_count}</span>
+      </div>
+    </Link>
+  );
+}
+
+function ViewCard({ view }: { view: PublicViewCard }) {
+  const owner = view.owner_display_name || view.owner_name || "—";
+  return (
+    <Link
+      href={`/v/${view.slug}`}
+      className="group flex flex-col rounded-xl border border-border-subtle bg-raised/30 p-5 transition hover:border-ink"
+    >
+      <h3 className="font-display text-[18px] font-bold text-ink group-hover:text-brand">
+        {view.title}
+      </h3>
+      {view.description ? (
+        <p className="mt-2 line-clamp-2 text-[14px] text-dim">{view.description}</p>
+      ) : null}
+      <p className="mt-3 font-mono text-[11px] uppercase tracking-wider text-muted">
+        {view.item_count} item{view.item_count === 1 ? "" : "s"} · from {view.workspace_name ?? "—"}
+      </p>
+      <div className="mt-auto flex items-center justify-between pt-4 text-[12px] text-dim">
+        <span>by {owner}</span>
+        <span>{view.view_count} view{view.view_count === 1 ? "" : "s"}</span>
       </div>
     </Link>
   );

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import AppShell from "../../components/AppShell";
+import AddToCollect from "../../components/share/AddToCollect";
+import ShareSheet from "../../components/share/ShareSheet";
+import { useAuth } from "../../hooks/useAuth";
+import {
+  listMySessions,
+  materializeSession,
+  type SessionSummary,
+} from "../../lib/api";
+
+export default function HistoryPage() {
+  const { user, loading, logout } = useAuth();
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    listMySessions()
+      .then(setSessions)
+      .catch((err) => setLoadError(err instanceof Error ? err.message : "Failed to load"))
+      .finally(() => setLoadingSessions(false));
+  }, [user]);
+
+  if (loading) {
+    return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
+  }
+  if (!user) return null;
+
+  return (
+    <AppShell user={user} onLogout={logout}>
+      <main className="mx-auto max-w-[1100px] px-7 py-12">
+        <h1 className="font-display text-[32px] font-bold tracking-[-0.02em] text-foreground">
+          History
+        </h1>
+        <p className="mt-2 text-[14px] text-dim">
+          Recent agent sessions across your workspaces. Share any session to send a colleague a link.
+        </p>
+
+        {loadError && <p className="mt-6 text-[13px] text-red-500">{loadError}</p>}
+        {loadingSessions && !loadError && (
+          <p className="mt-6 text-[13px] text-muted">Loading sessions…</p>
+        )}
+
+        {!loadingSessions && sessions.length === 0 && !loadError && (
+          <p className="mt-12 text-center text-[14px] text-muted">
+            No sessions yet. Run an agent against this workspace and they'll appear here.
+          </p>
+        )}
+
+        <ul className="mt-6 divide-y divide-border-subtle border-y border-border-subtle">
+          {sessions.map((s) => (
+            <SessionRow key={s.session_id} session={s} />
+          ))}
+        </ul>
+      </main>
+    </AppShell>
+  );
+}
+
+function SessionRow({ session }: { session: SessionSummary }) {
+  return (
+    <li className="flex items-start justify-between gap-4 py-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[11px] uppercase tracking-wider text-muted">
+            {session.agent_name || "agent"}
+          </span>
+          <span className="text-[12px] text-dim">{session.event_count} events</span>
+          <span className="text-[12px] text-dim">{relativeTime(session.last_event_at)}</span>
+          {session.workspace_name && (
+            <span className="text-[12px] text-dim">in {session.workspace_name}</span>
+          )}
+        </div>
+        {session.first_prompt_preview && (
+          <p className="mt-1 line-clamp-2 text-[14px] text-foreground">
+            {session.first_prompt_preview}
+          </p>
+        )}
+        <p className="mt-1 font-mono text-[10px] text-muted">{session.session_id.slice(0, 12)}…</p>
+      </div>
+      <SessionActions session={session} />
+    </li>
+  );
+}
+
+function SessionActions({ session }: { session: SessionSummary }) {
+  const [open, setOpen] = useState(false);
+  const [materialized, setMaterialized] = useState<{ id: string; notebookId: string } | null>(null);
+  const [working, setWorking] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onShare = async () => {
+    if (!session.workspace_id) {
+      setErr("Session is missing a workspace");
+      return;
+    }
+    setWorking(true);
+    setErr(null);
+    try {
+      const result = await materializeSession(session.workspace_id, session.session_id);
+      setMaterialized({ id: result.page.id, notebookId: result.notebook_id });
+      setOpen(true);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to share");
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      {session.workspace_id && materialized && (
+        <AddToCollect
+          objectType="page"
+          objectId={materialized.id}
+          workspaceId={session.workspace_id}
+          label={`Session ${session.session_id.slice(0, 8)}`}
+        />
+      )}
+      <div className="relative">
+        <button
+          onClick={onShare}
+          disabled={working}
+          className="rounded border border-border bg-raised px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground disabled:opacity-50"
+        >
+          {working ? "Preparing…" : "Share"}
+        </button>
+        {open && materialized && (
+          <ShareSheet
+            objectType="page"
+            objectId={materialized.id}
+            objectLabel={`Session ${session.session_id.slice(0, 8)}`}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </div>
+      {err && <span className="text-[11px] text-red-500">{err}</span>}
+    </div>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.round(diff / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return `${Math.round(d / 30)}mo ago`;
+}

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -47,7 +47,7 @@ export default function HistoryPage() {
 
         {!loadingSessions && sessions.length === 0 && !loadError && (
           <p className="mt-12 text-center text-[14px] text-muted">
-            No sessions yet. Run an agent against this workspace and they'll appear here.
+            No sessions yet. Run an agent against this workspace and they&apos;ll appear here.
           </p>
         )}
 

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -8,6 +8,7 @@ import { useBreadcrumbs, type Crumb } from "../../components/BreadcrumbContext";
 import NotebookTreeComponent from "../../components/workspace/FileTree";
 import MarkdownEditor, { SaveStatus } from "../../components/workspace/MarkdownEditor";
 import HtmlPageEditor from "../../components/workspace/HtmlPageEditor";
+import ShareSheet from "../../components/share/ShareSheet";
 import { useAuth } from "../../hooks/useAuth";
 import {
   listAllNotebooks,
@@ -599,18 +600,21 @@ function WikiPageInner() {
               )}
 
               {selectedPage && (
-                <div className="pointer-events-none absolute right-5 top-3 z-10 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted">
-                  <span
-                    className={
-                      "h-1.5 w-1.5 rounded-full " +
-                      (saveStatus === "saved" ? "bg-[#22C55E]" : "bg-[#EAB308]")
-                    }
-                  />
-                  {saveStatus === "saving"
-                    ? "saving"
-                    : saveStatus === "dirty"
-                    ? "unsaved"
-                    : "saved"}
+                <div className="absolute right-5 top-3 z-20 flex items-center gap-3">
+                  <div className="pointer-events-none flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted">
+                    <span
+                      className={
+                        "h-1.5 w-1.5 rounded-full " +
+                        (saveStatus === "saved" ? "bg-[#22C55E]" : "bg-[#EAB308]")
+                      }
+                    />
+                    {saveStatus === "saving"
+                      ? "saving"
+                      : saveStatus === "dirty"
+                      ? "unsaved"
+                      : "saved"}
+                  </div>
+                  <PageShareButton pageId={selectedPage.id} pageName={selectedPage.name} />
                 </div>
               )}
 
@@ -679,5 +683,27 @@ function WikiPageInner() {
 
       </div>
     </AppShell>
+  );
+}
+
+function PageShareButton({ pageId, pageName }: { pageId: string; pageName: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded border border-border bg-raised px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-foreground hover:border-foreground"
+      >
+        Share
+      </button>
+      {open && (
+        <ShareSheet
+          objectType="page"
+          objectId={pageId}
+          objectLabel={pageName}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
   );
 }

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -8,6 +8,7 @@ import { useBreadcrumbs, type Crumb } from "../../components/BreadcrumbContext";
 import NotebookTreeComponent from "../../components/workspace/FileTree";
 import MarkdownEditor, { SaveStatus } from "../../components/workspace/MarkdownEditor";
 import HtmlPageEditor from "../../components/workspace/HtmlPageEditor";
+import AddToCollect from "../../components/share/AddToCollect";
 import ShareSheet from "../../components/share/ShareSheet";
 import { useAuth } from "../../hooks/useAuth";
 import {
@@ -525,6 +526,23 @@ function WikiPageInner() {
             {/* Sidebar: file tree */}
             <div className="flex w-[260px] flex-shrink-0 flex-col overflow-hidden border-r border-border bg-surface">
               {selectedNotebook.workspace_id && (
+                <div className="flex items-center justify-between gap-2 border-b border-border-subtle px-3 py-2.5">
+                  <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">
+                    {selectedNotebook.name}
+                  </span>
+                  <AddToCollect
+                    objectType="notebook"
+                    objectId={selectedNotebook.id}
+                    workspaceId={selectedNotebook.workspace_id}
+                    label={selectedNotebook.name}
+                  />
+                  <NotebookShareButton
+                    notebookId={selectedNotebook.id}
+                    notebookName={selectedNotebook.name}
+                  />
+                </div>
+              )}
+              {selectedNotebook.workspace_id && (
                 <div className="border-b border-border-subtle px-3 py-3">
                   <input
                     type="text"
@@ -614,6 +632,14 @@ function WikiPageInner() {
                       ? "unsaved"
                       : "saved"}
                   </div>
+                  {selectedNotebook?.workspace_id && (
+                    <AddToCollect
+                      objectType="page"
+                      objectId={selectedPage.id}
+                      workspaceId={selectedNotebook.workspace_id}
+                      label={selectedPage.name}
+                    />
+                  )}
                   <PageShareButton pageId={selectedPage.id} pageName={selectedPage.name} />
                 </div>
               )}
@@ -683,6 +709,28 @@ function WikiPageInner() {
 
       </div>
     </AppShell>
+  );
+}
+
+function NotebookShareButton({ notebookId, notebookName }: { notebookId: string; notebookName: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded border border-border bg-raised px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground"
+      >
+        Share
+      </button>
+      {open && (
+        <ShareSheet
+          objectType="notebook"
+          objectId={notebookId}
+          objectLabel={notebookName}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/app/s/[workspaceId]/n/[notebookId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/n/[notebookId]/p/[pageId]/page.tsx
@@ -40,7 +40,7 @@ interface PublicPage {
 
 async function loadPage(pageId: string): Promise<PublicPage | null> {
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/pages/${pageId}`, {
-    next: { revalidate: 30 },
+    cache: "no-store",
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`page fetch failed: ${res.status}`);

--- a/frontend/src/app/s/[workspaceId]/n/[notebookId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/n/[notebookId]/p/[pageId]/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import HtmlPageView from "../../../../../../../components/workspace/HtmlPageView";
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ pageId: string }>;
+}): Promise<Metadata> {
+  const { pageId } = await params;
+  const page = await loadPage(pageId);
+  if (!page) return { title: "Page not found · Stash" };
+  const title = `${page.name} · ${page.notebook_name}`;
+  const description = `A page in ${page.notebook_name}.`;
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "article", siteName: "Stash" },
+    twitter: { card: "summary", title, description },
+  };
+}
+
+interface PublicPage {
+  id: string;
+  name: string;
+  content_type: "markdown" | "html";
+  content_markdown: string;
+  content_html: string;
+  notebook_id: string;
+  notebook_name: string;
+  workspace_id: string;
+  updated_at: string;
+}
+
+async function loadPage(pageId: string): Promise<PublicPage | null> {
+  const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/pages/${pageId}`, {
+    next: { revalidate: 30 },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`page fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export default async function PublicPageReader({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; notebookId: string; pageId: string }>;
+}) {
+  const { workspaceId, notebookId, pageId } = await params;
+  const page = await loadPage(pageId);
+  if (!page) notFound();
+
+  return (
+    <main className="mx-auto max-w-[860px] px-7 py-12">
+      <nav className="font-mono text-[11px] uppercase tracking-wider text-muted">
+        <Link href={`/s/${workspaceId}`} className="hover:text-ink">
+          Workspace
+        </Link>{" "}
+        ›{" "}
+        <Link href={`/s/${workspaceId}/n/${notebookId}`} className="hover:text-ink">
+          {page.notebook_name}
+        </Link>
+      </nav>
+
+      <header className="mt-4 border-b border-border-subtle pb-6">
+        <h1 className="font-display text-[clamp(28px,3vw,40px)] font-black leading-[1.1] tracking-[-0.02em] text-ink">
+          {page.name}
+        </h1>
+      </header>
+
+      <article className="mt-8">
+        {page.content_type === "html" ? (
+          <HtmlPageView html={page.content_html || ""} title={page.name} />
+        ) : (
+          <div className="markdown-content">
+            <Markdown remarkPlugins={[remarkGfm]}>{page.content_markdown || "(empty)"}</Markdown>
+          </div>
+        )}
+      </article>
+    </main>
+  );
+}

--- a/frontend/src/app/s/[workspaceId]/n/[notebookId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/n/[notebookId]/page.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+interface NotebookDetail {
+  notebook: {
+    id: string;
+    name: string;
+    description: string;
+    workspace_id: string;
+    updated_at: string;
+  };
+  pages: {
+    id: string;
+    name: string;
+    content_type: "markdown" | "html";
+    updated_at: string;
+  }[];
+}
+
+async function loadNotebook(notebookId: string): Promise<NotebookDetail | null> {
+  const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/notebooks/${notebookId}`, {
+    next: { revalidate: 30 },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`notebook fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export default async function PublicNotebookPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; notebookId: string }>;
+}) {
+  const { workspaceId, notebookId } = await params;
+  const detail = await loadNotebook(notebookId);
+  if (!detail) notFound();
+  const { notebook, pages } = detail;
+
+  return (
+    <main className="mx-auto max-w-[900px] px-7 py-12">
+      <Link
+        href={`/s/${workspaceId}`}
+        className="font-mono text-[12px] uppercase tracking-wider text-muted hover:text-ink"
+      >
+        ← Workspace
+      </Link>
+
+      <header className="mt-6 border-b border-border-subtle pb-6">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-muted">Notebook</p>
+        <h1 className="mt-2 font-display text-[clamp(28px,3vw,40px)] font-black leading-[1.1] tracking-[-0.02em] text-ink">
+          {notebook.name}
+        </h1>
+        {notebook.description ? (
+          <p className="mt-3 max-w-[680px] text-[14px] text-foreground">{notebook.description}</p>
+        ) : null}
+        <p className="mt-3 font-mono text-[11px] uppercase tracking-wider text-muted">
+          {pages.length} page{pages.length === 1 ? "" : "s"}
+        </p>
+      </header>
+
+      <ul className="mt-6 divide-y divide-border-subtle border-y border-border-subtle">
+        {pages.length === 0 ? (
+          <li className="py-4 text-[13px] text-muted">No pages.</li>
+        ) : (
+          pages.map((p) => (
+            <li key={p.id}>
+              <Link
+                href={`/s/${workspaceId}/n/${notebookId}/p/${p.id}`}
+                className="flex items-center justify-between gap-4 py-3 transition hover:bg-raised/40"
+              >
+                <span className="truncate text-[15px] text-ink">{p.name}</span>
+                <span className="shrink-0 font-mono text-[11px] uppercase tracking-wider text-muted">
+                  {p.content_type}
+                </span>
+              </Link>
+            </li>
+          ))
+        )}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/app/s/[workspaceId]/n/[notebookId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/n/[notebookId]/page.tsx
@@ -21,7 +21,7 @@ interface NotebookDetail {
 
 async function loadNotebook(notebookId: string): Promise<NotebookDetail | null> {
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/notebooks/${notebookId}`, {
-    next: { revalidate: 30 },
+    cache: "no-store",
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`notebook fetch failed: ${res.status}`);

--- a/frontend/src/app/s/[workspaceId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -7,13 +8,35 @@ import ForkButton from "./ForkButton";
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}): Promise<Metadata> {
+  const { workspaceId } = await params;
+  const detail = await loadDetail(workspaceId);
+  if (!detail) return { title: "Workspace not found · Stash" };
+  const ws = detail.workspace;
+  const title = `${ws.name} · Stash`;
+  const description = ws.summary || ws.description || `A workspace by ${ws.creator_display_name || ws.creator_name}.`;
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website", url: `/s/${workspaceId}`, siteName: "Stash" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
 async function loadDetail(workspaceId: string): Promise<PublicWorkspaceDetail | null> {
+  // /api/v1/public/* is permission-aware and works for both `link` and `public`
+  // workspaces. /api/v1/discover/* only returns is_public=true catalog cards
+  // (used by the Discover index, not by the share-URL reader).
   const res = await fetch(
-    `${BACKEND_ORIGIN}/api/v1/discover/workspaces/${workspaceId}`,
-    { next: { revalidate: 60 } }
+    `${BACKEND_ORIGIN}/api/v1/public/workspaces/${workspaceId}`,
+    { next: { revalidate: 30 } }
   );
   if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`discover fetch failed: ${res.status}`);
+  if (!res.ok) throw new Error(`public fetch failed: ${res.status}`);
   return res.json();
 }
 

--- a/frontend/src/app/s/[workspaceId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/page.tsx
@@ -33,7 +33,7 @@ async function loadDetail(workspaceId: string): Promise<PublicWorkspaceDetail | 
   // (used by the Discover index, not by the share-URL reader).
   const res = await fetch(
     `${BACKEND_ORIGIN}/api/v1/public/workspaces/${workspaceId}`,
-    { next: { revalidate: 30 } }
+    { cache: "no-store" }
   );
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`public fetch failed: ${res.status}`);

--- a/frontend/src/app/s/[workspaceId]/t/[tableId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/t/[tableId]/page.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+interface PublicTable {
+  table: {
+    id: string;
+    name: string;
+    description: string;
+    columns: { name: string; type: string }[];
+    workspace_id: string;
+    updated_at: string;
+  };
+  rows: { data: Record<string, unknown>; row_order: number }[];
+}
+
+async function loadTable(tableId: string): Promise<PublicTable | null> {
+  const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/tables/${tableId}`, {
+    next: { revalidate: 30 },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`table fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export default async function PublicTablePage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; tableId: string }>;
+}) {
+  const { workspaceId, tableId } = await params;
+  const data = await loadTable(tableId);
+  if (!data) notFound();
+  const { table, rows } = data;
+
+  return (
+    <main className="mx-auto max-w-[1100px] px-7 py-12">
+      <Link
+        href={`/s/${workspaceId}`}
+        className="font-mono text-[12px] uppercase tracking-wider text-muted hover:text-ink"
+      >
+        ← Workspace
+      </Link>
+
+      <header className="mt-4 border-b border-border-subtle pb-6">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-muted">Table</p>
+        <h1 className="mt-2 font-display text-[clamp(28px,3vw,40px)] font-black leading-[1.1] tracking-[-0.02em] text-ink">
+          {table.name}
+        </h1>
+        {table.description ? (
+          <p className="mt-3 max-w-[680px] text-[14px] text-foreground">{table.description}</p>
+        ) : null}
+        <p className="mt-3 font-mono text-[11px] uppercase tracking-wider text-muted">
+          {rows.length} row{rows.length === 1 ? "" : "s"} (capped at 500)
+        </p>
+      </header>
+
+      <div className="mt-6 overflow-x-auto rounded border border-border-subtle">
+        <table className="min-w-full text-[13px]">
+          <thead className="bg-raised/40">
+            <tr>
+              {table.columns.map((c) => (
+                <th
+                  key={c.name}
+                  className="border-b border-border-subtle px-3 py-2 text-left font-mono text-[10px] uppercase text-muted"
+                >
+                  {c.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} className="border-b border-border-subtle/60">
+                {table.columns.map((c) => (
+                  <td key={c.name} className="px-3 py-2 text-foreground">
+                    {String(r.data[c.name] ?? "")}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/s/[workspaceId]/t/[tableId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/t/[tableId]/page.tsx
@@ -17,7 +17,7 @@ interface PublicTable {
 
 async function loadTable(tableId: string): Promise<PublicTable | null> {
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/public/tables/${tableId}`, {
-    next: { revalidate: 30 },
+    cache: "no-store",
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`table fetch failed: ${res.status}`);

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -3,6 +3,8 @@
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "../../../components/AppShell";
+import AddToCollect from "../../../components/share/AddToCollect";
+import ShareSheet from "../../../components/share/ShareSheet";
 import { useAuth } from "../../../hooks/useAuth";
 import {
   getTable, updateTable,
@@ -525,6 +527,15 @@ function TableEditorPageInner() {
             <button onClick={() => fileInputRef.current?.click()} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>
             <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleCsvImport(e.target.files[0]); e.target.value = ""; }} />
             {selectedRows.size > 0 && <button onClick={handleBulkDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}
+            {wsId && table && (
+              <AddToCollect
+                objectType="table"
+                objectId={table.id}
+                workspaceId={wsId}
+                label={table.name}
+              />
+            )}
+            {table && <TableShareButton tableId={table.id} tableName={table.name} />}
             <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>
           </>}
         </div>
@@ -783,5 +794,27 @@ function TableEditorPageInner() {
         )}
       </div>
     </AppShell>
+  );
+}
+
+function TableShareButton({ tableId, tableName }: { tableId: string; tableName: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded border border-border bg-raised px-2 py-1 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground"
+      >
+        Share
+      </button>
+      {open && (
+        <ShareSheet
+          objectType="table"
+          objectId={tableId}
+          objectLabel={tableName}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
   );
 }

--- a/frontend/src/app/v/[slug]/embed/page.tsx
+++ b/frontend/src/app/v/[slug]/embed/page.tsx
@@ -21,7 +21,7 @@ type ViewPublic = {
 
 async function loadView(slug: string): Promise<ViewPublic | null> {
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/views/${slug}`, {
-    next: { revalidate: 30 },
+    cache: "no-store",
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`view fetch failed: ${res.status}`);

--- a/frontend/src/app/v/[slug]/embed/page.tsx
+++ b/frontend/src/app/v/[slug]/embed/page.tsx
@@ -1,0 +1,93 @@
+import { notFound } from "next/navigation";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import HtmlPageView from "../../../../components/workspace/HtmlPageView";
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+type ViewItemInlined = {
+  object_type: "notebook" | "page" | "table" | "file" | "history";
+  object_id: string;
+  position: number;
+  label: string;
+  inline: Record<string, unknown>;
+};
+
+type ViewPublic = {
+  view: { id: string; slug: string; title: string };
+  items: ViewItemInlined[];
+};
+
+async function loadView(slug: string): Promise<ViewPublic | null> {
+  const res = await fetch(`${BACKEND_ORIGIN}/api/v1/views/${slug}`, {
+    next: { revalidate: 30 },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`view fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export default async function EmbedView({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const data = await loadView(slug);
+  if (!data) notFound();
+  return (
+    <main className="px-4 py-4">
+      <h1 className="mb-3 font-display text-[18px] font-bold text-ink">{data.view.title}</h1>
+      <div className="space-y-6">
+        {data.items.map((it, i) => (
+          <ItemBody key={`${it.object_type}-${it.object_id}-${i}`} item={it} />
+        ))}
+      </div>
+      <p className="mt-4 text-right font-mono text-[10px] uppercase tracking-wider text-muted">
+        <a href={`/v/${slug}`} target="_blank" rel="noreferrer" className="hover:text-ink">
+          on Stash ↗
+        </a>
+      </p>
+    </main>
+  );
+}
+
+function ItemBody({ item }: { item: ViewItemInlined }) {
+  if (Object.keys(item.inline).length === 0) {
+    return <p className="text-[12px] italic text-muted">Item unavailable.</p>;
+  }
+  if (item.object_type === "page") {
+    const p = (item.inline as { page?: { content_type?: string; content_markdown?: string; content_html?: string; name?: string } }).page;
+    if (!p) return null;
+    return p.content_type === "html" ? (
+      <HtmlPageView html={p.content_html || ""} title={p.name || item.label} />
+    ) : (
+      <div className="markdown-content">
+        <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>
+      </div>
+    );
+  }
+  if (item.object_type === "notebook") {
+    const inline = item.inline as {
+      pages?: { id: string; name: string; content_type?: string; content_markdown?: string; content_html?: string }[];
+    };
+    return (
+      <div className="space-y-4">
+        {(inline.pages ?? []).map((p) => (
+          <div key={p.id}>
+            <h2 className="mb-2 font-display text-[15px] font-bold text-ink">{p.name}</h2>
+            {p.content_type === "html" ? (
+              <HtmlPageView html={p.content_html || ""} title={p.name} />
+            ) : (
+              <div className="markdown-content">
+                <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <p className="text-[12px] text-muted">{item.label}</p>;
+}

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -62,8 +62,11 @@ type ViewPublic = {
 };
 
 async function loadView(slug: string): Promise<ViewPublic | null> {
+  // Permissions changes (revoke a share, flip an item to private) MUST take
+  // effect immediately — caching the SSR response would let stale public
+  // pages keep rendering after the publisher pulled access.
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/views/${slug}`, {
-    next: { revalidate: 30 },
+    cache: "no-store",
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`view fetch failed: ${res.status}`);

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Markdown from "react-markdown";
@@ -9,8 +10,34 @@ import ViewForkButton from "./ViewForkButton";
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const data = await loadView(slug);
+  if (!data) return { title: "View not found · Stash" };
+  const title = `${data.view.title} · Stash`;
+  const description =
+    data.view.description ||
+    `A View of ${data.items.length} item${data.items.length === 1 ? "" : "s"} from ${data.workspace_name}.`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      url: `/v/${slug}`,
+      siteName: "Stash",
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
 type ViewItemInlined = {
-  object_type: "notebook" | "table" | "file" | "history";
+  object_type: "notebook" | "page" | "table" | "file" | "history";
   object_id: string;
   position: number;
   label: string;
@@ -164,6 +191,29 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
             )}
           </div>
         ))}
+      </div>
+    );
+  }
+
+  if (item.object_type === "page") {
+    const inline = item.inline as {
+      page?: {
+        id: string;
+        name: string;
+        content_type?: "markdown" | "html";
+        content_markdown: string;
+        content_html?: string;
+      };
+    };
+    const p = inline.page;
+    if (!p) return <p className="text-[13px] italic text-muted">This page is no longer available.</p>;
+    return p.content_type === "html" ? (
+      <HtmlPageView html={p.content_html || ""} title={p.name} />
+    ) : (
+      <div className="markdown-content">
+        <Markdown remarkPlugins={[remarkGfm]}>
+          {p.content_markdown || "(empty)"}
+        </Markdown>
       </div>
     );
   }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { User } from "../lib/types";
 import AppSidebar from "./AppSidebar";
+import CollectTray from "./share/CollectTray";
 import TopBar from "./TopBar";
 
 interface AppShellProps {
@@ -19,6 +20,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         <TopBar />
         <div className="flex-1 overflow-y-auto">{children}</div>
       </main>
+      <CollectTray />
     </div>
   );
 }

--- a/frontend/src/components/share/AddToCollect.tsx
+++ b/frontend/src/components/share/AddToCollect.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { CollectableObjectType } from "../../lib/api";
+import { useCollectTray } from "../../lib/collectTray";
+
+interface Props {
+  objectType: CollectableObjectType;
+  objectId: string;
+  workspaceId: string;
+  label: string;
+}
+
+/**
+ * Small "+" button that adds the given object to the Collect tray. Renders
+ * "✓ in tray" when the item is already collected so the user can see status
+ * at a glance and remove it without opening the tray.
+ */
+export default function AddToCollect({ objectType, objectId, workspaceId, label }: Props) {
+  const { add, remove, has } = useCollectTray();
+  const inTray = has(objectType, objectId);
+
+  return (
+    <button
+      onClick={() =>
+        inTray
+          ? remove(objectType, objectId)
+          : add({ object_type: objectType, object_id: objectId, workspace_id: workspaceId, label })
+      }
+      title={inTray ? "Remove from Collect tray" : "Add to Collect tray"}
+      className={
+        "rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider transition " +
+        (inTray
+          ? "border-brand/40 bg-brand/15 text-brand hover:border-brand/60"
+          : "border-border bg-raised text-foreground hover:border-foreground")
+      }
+    >
+      {inTray ? "✓ In tray" : "+ Collect"}
+    </button>
+  );
+}

--- a/frontend/src/components/share/CollectTray.tsx
+++ b/frontend/src/components/share/CollectTray.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 
-import { createView } from "../../lib/api";
+import { createSharedView } from "../../lib/api";
 import { useCollectTray } from "../../lib/collectTray";
-import ShareSheet from "./ShareSheet";
 
 /**
  * Persistent tray for bundling items across the app into a single shareable
@@ -17,7 +16,8 @@ export default function CollectTray() {
   const [title, setTitle] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [sharedView, setSharedView] = useState<{ id: string; title: string } | null>(null);
+  const [sharedBundle, setSharedBundle] = useState<{ url: string; title: string } | null>(null);
+  const [copied, setCopied] = useState(false);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
 
   const onShare = async () => {
@@ -26,7 +26,7 @@ export default function CollectTray() {
     setCreateError(null);
     try {
       const ws = items[0].workspace_id;
-      const view = await createView(
+      const result = await createSharedView(
         ws,
         title.trim() || `Bundle of ${items.length} item${items.length === 1 ? "" : "s"}`,
         items.map((it, i) => ({
@@ -35,7 +35,7 @@ export default function CollectTray() {
           position: i,
         }))
       );
-      setSharedView({ id: view.id, title: view.title });
+      setSharedBundle({ url: result.url, title: result.view.title });
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Failed to create view");
     } finally {
@@ -43,12 +43,22 @@ export default function CollectTray() {
     }
   };
 
-  const onShareSheetClose = () => {
-    // Once the user dismisses the share sheet, clear the tray and reset.
-    // The View is created and they have the link.
-    setSharedView(null);
+  const onBundleDone = () => {
+    setSharedBundle(null);
     setTitle("");
+    setCopied(false);
     clear();
+  };
+
+  const onCopyBundleLink = async () => {
+    if (!sharedBundle) return;
+    try {
+      await navigator.clipboard.writeText(sharedBundle.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore — link is visible for manual copy */
+    }
   };
 
   if (items.length === 0 && !open) return null;
@@ -146,14 +156,27 @@ export default function CollectTray() {
         </button>
       )}
 
-      {sharedView && (
-        <div className="absolute bottom-0 right-0">
-          <ShareSheet
-            objectType="view"
-            objectId={sharedView.id}
-            objectLabel={sharedView.title}
-            onClose={onShareSheetClose}
-          />
+      {sharedBundle && (
+        <div className="absolute bottom-0 right-0 w-[360px] rounded-lg border border-border bg-surface p-4 shadow-xl">
+          <div className="text-[13px] font-medium text-foreground">Bundle shared</div>
+          <div className="mt-1 truncate text-[12px] text-muted">{sharedBundle.title}</div>
+          <div className="mt-3 rounded border border-border-subtle bg-raised px-2 py-1.5 text-[12px] text-dim">
+            {sharedBundle.url}
+          </div>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              onClick={onBundleDone}
+              className="rounded border border-border bg-raised px-3 py-1 text-[12px] text-foreground hover:border-foreground"
+            >
+              Done
+            </button>
+            <button
+              onClick={onCopyBundleLink}
+              className="rounded border border-brand bg-brand/15 px-3 py-1 text-[12px] text-brand hover:bg-brand/25"
+            >
+              {copied ? "Copied!" : "Copy link"}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/share/CollectTray.tsx
+++ b/frontend/src/components/share/CollectTray.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+
+import { createView } from "../../lib/api";
+import { useCollectTray } from "../../lib/collectTray";
+import ShareSheet from "./ShareSheet";
+
+/**
+ * Persistent tray for bundling items across the app into a single shareable
+ * View. Mounted globally in AppShell. Collapses to a small badge when empty
+ * or hidden; expands to a list with reorder/remove + Share.
+ */
+export default function CollectTray() {
+  const { items, remove, reorder, clear } = useCollectTray();
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [sharedView, setSharedView] = useState<{ id: string; title: string } | null>(null);
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+
+  const onShare = async () => {
+    if (items.length === 0) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const ws = items[0].workspace_id;
+      const view = await createView(
+        ws,
+        title.trim() || `Bundle of ${items.length} item${items.length === 1 ? "" : "s"}`,
+        items.map((it, i) => ({
+          object_type: it.object_type,
+          object_id: it.object_id,
+          position: i,
+        }))
+      );
+      setSharedView({ id: view.id, title: view.title });
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Failed to create view");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const onShareSheetClose = () => {
+    // Once the user dismisses the share sheet, clear the tray and reset.
+    // The View is created and they have the link.
+    setSharedView(null);
+    setTitle("");
+    clear();
+  };
+
+  if (items.length === 0 && !open) return null;
+
+  return (
+    <div className="fixed bottom-5 right-5 z-40">
+      {open ? (
+        <div className="w-[340px] rounded-lg border border-border bg-surface shadow-2xl">
+          <div className="flex items-center justify-between border-b border-border-subtle px-4 py-2.5">
+            <div className="font-mono text-[11px] uppercase tracking-wider text-muted">
+              Collect tray · {items.length}
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-[14px] text-muted hover:text-foreground"
+            >
+              ×
+            </button>
+          </div>
+
+          {items.length === 0 ? (
+            <p className="px-4 py-6 text-center text-[13px] text-muted">
+              Empty. Click <span className="font-mono">+ Collect</span> on any page, table, notebook, or session to start a bundle.
+            </p>
+          ) : (
+            <>
+              <ul className="max-h-[320px] overflow-y-auto px-2 py-2">
+                {items.map((it, i) => (
+                  <li
+                    key={`${it.object_type}-${it.object_id}`}
+                    draggable
+                    onDragStart={() => setDragIdx(i)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => {
+                      if (dragIdx !== null && dragIdx !== i) reorder(dragIdx, i);
+                      setDragIdx(null);
+                    }}
+                    className="group flex items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-raised"
+                  >
+                    <span className="cursor-grab text-muted">⋮⋮</span>
+                    <span className="font-mono text-[10px] uppercase text-muted">{it.object_type}</span>
+                    <span className="min-w-0 flex-1 truncate text-foreground">{it.label}</span>
+                    <button
+                      onClick={() => remove(it.object_type, it.object_id)}
+                      className="text-muted opacity-0 transition group-hover:opacity-100 hover:text-red-500"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="border-t border-border-subtle px-4 py-3">
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={`Bundle title (default: "Bundle of ${items.length}")`}
+                  className="mb-2 w-full rounded border border-border bg-raised px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted"
+                />
+                {createError && (
+                  <div className="mb-2 text-[11px] text-red-500">{createError}</div>
+                )}
+                <div className="flex items-center justify-between gap-2">
+                  <button
+                    onClick={() => clear()}
+                    disabled={creating}
+                    className="text-[11px] text-muted hover:text-foreground disabled:opacity-50"
+                  >
+                    Clear all
+                  </button>
+                  <button
+                    onClick={onShare}
+                    disabled={creating || items.length === 0}
+                    className="rounded border border-brand bg-brand/15 px-3 py-1 text-[12px] text-brand hover:bg-brand/25 disabled:opacity-50"
+                  >
+                    {creating ? "Creating…" : "Share bundle"}
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          className="flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 shadow-lg hover:border-foreground"
+        >
+          <span className="font-mono text-[11px] uppercase tracking-wider text-foreground">
+            Collect
+          </span>
+          <span className="rounded-full bg-brand/20 px-1.5 text-[11px] font-medium text-brand">
+            {items.length}
+          </span>
+        </button>
+      )}
+
+      {sharedView && (
+        <div className="absolute bottom-0 right-0">
+          <ShareSheet
+            objectType="view"
+            objectId={sharedView.id}
+            objectLabel={sharedView.title}
+            onClose={onShareSheetClose}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/share/ShareSheet.tsx
+++ b/frontend/src/components/share/ShareSheet.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  ObjectPermissions,
+  ObjectShare,
+  ObjectVisibility,
+  ShareableObjectType,
+  addObjectShare,
+  createShareLink,
+  getObjectPermissions,
+  removeObjectShare,
+  setObjectVisibility,
+} from "../../lib/api";
+
+interface UserResult {
+  id: string;
+  name: string;
+  display_name: string;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+interface Props {
+  objectType: ShareableObjectType;
+  objectId: string;
+  objectLabel: string;
+  onClose: () => void;
+}
+
+const VISIBILITY_OPTIONS: { value: ObjectVisibility; label: string; hint: string }[] = [
+  { value: "private", label: "Restricted", hint: "Only people you've added can open" },
+  { value: "link", label: "Anyone with the link", hint: "Anyone with the URL can read" },
+  { value: "public", label: "Public on the web", hint: "Discoverable in /discover" },
+];
+
+export default function ShareSheet({ objectType, objectId, objectLabel, onClose }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [perms, setPerms] = useState<ObjectPermissions | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [updatingVis, setUpdatingVis] = useState(false);
+  const [linkUrl, setLinkUrl] = useState<string | null>(null);
+  const [embedSlug, setEmbedSlug] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [embedCopied, setEmbedCopied] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      const p = await getObjectPermissions(objectType, objectId);
+      setPerms(p);
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to load permissions");
+    }
+  }, [objectType, objectId]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const currentVisibility: ObjectVisibility = perms?.visibility ?? "inherit";
+  // 'inherit' isn't user-facing in this dropdown — display it as Restricted because
+  // workspace members can already see it via their membership.
+  const dropdownValue: ObjectVisibility = currentVisibility === "inherit" ? "private" : currentVisibility;
+
+  const onChangeVisibility = async (next: ObjectVisibility) => {
+    if (next === dropdownValue) return;
+    setUpdatingVis(true);
+    try {
+      await setObjectVisibility(objectType, objectId, next);
+      await reload();
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to update visibility");
+    } finally {
+      setUpdatingVis(false);
+    }
+  };
+
+  const onCopyLink = async () => {
+    try {
+      const result = await createShareLink(objectType, objectId);
+      setLinkUrl(result.url);
+      setEmbedSlug(result.kind === "view" ? result.view_slug ?? null : null);
+      await navigator.clipboard.writeText(result.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to create link");
+    }
+  };
+
+  const onCopyEmbed = async () => {
+    if (!embedSlug) return;
+    const origin = window.location.origin;
+    const snippet = `<iframe src="${origin}/v/${embedSlug}/embed" width="100%" height="600" frameborder="0"></iframe>`;
+    await navigator.clipboard.writeText(snippet);
+    setEmbedCopied(true);
+    setTimeout(() => setEmbedCopied(false), 1500);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute right-0 top-9 z-30 w-[360px] rounded-lg border border-border bg-surface shadow-xl"
+    >
+      <div className="border-b border-border-subtle px-4 py-3">
+        <div className="text-[13px] font-medium text-foreground">Share</div>
+        <div className="truncate text-[12px] text-muted">{objectLabel}</div>
+      </div>
+
+      {loadError && (
+        <div className="border-b border-border-subtle bg-red-500/5 px-4 py-2 text-[12px] text-red-500">
+          {loadError}
+        </div>
+      )}
+
+      {perms && (
+        <>
+          <PeopleSection
+            objectType={objectType}
+            objectId={objectId}
+            shares={perms.shares}
+            onChange={reload}
+          />
+
+          <div className="border-t border-border-subtle px-4 py-3">
+            <div className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted">
+              General access
+            </div>
+            <select
+              value={dropdownValue}
+              onChange={(e) => onChangeVisibility(e.target.value as ObjectVisibility)}
+              disabled={updatingVis}
+              className="w-full rounded border border-border bg-raised px-2 py-1.5 text-[13px] text-foreground"
+            >
+              {VISIBILITY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <div className="mt-1.5 text-[11px] text-muted">
+              {VISIBILITY_OPTIONS.find((o) => o.value === dropdownValue)?.hint}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-2 border-t border-border-subtle px-4 py-3">
+            <div className="min-w-0 flex-1 truncate text-[12px] text-dim">
+              {linkUrl ?? "Get a shareable link"}
+            </div>
+            <button
+              onClick={onCopyLink}
+              className={
+                "shrink-0 rounded border px-3 py-1 text-[12px] " +
+                (copied
+                  ? "border-brand/40 bg-brand/15 text-brand"
+                  : "border-border bg-raised text-foreground hover:border-foreground")
+              }
+            >
+              {copied ? "Copied!" : "Copy link"}
+            </button>
+          </div>
+
+          {embedSlug && (
+            <div className="flex items-center justify-between gap-2 border-t border-border-subtle px-4 py-3">
+              <div className="min-w-0 flex-1 truncate font-mono text-[11px] text-dim">
+                &lt;iframe src=&quot;…/v/{embedSlug}/embed&quot;&gt;
+              </div>
+              <button
+                onClick={onCopyEmbed}
+                className={
+                  "shrink-0 rounded border px-3 py-1 text-[12px] " +
+                  (embedCopied
+                    ? "border-brand/40 bg-brand/15 text-brand"
+                    : "border-border bg-raised text-foreground hover:border-foreground")
+                }
+              >
+                {embedCopied ? "Copied!" : "Copy embed"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function PeopleSection({
+  objectType,
+  objectId,
+  shares,
+  onChange,
+}: {
+  objectType: ShareableObjectType;
+  objectId: string;
+  shares: ObjectShare[];
+  onChange: () => void | Promise<void>;
+}) {
+  return (
+    <div className="px-4 py-3">
+      <div className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted">
+        People with access
+      </div>
+      <div className="space-y-1.5">
+        {shares.length === 0 && (
+          <div className="text-[12px] text-muted">No one shared yet — workspace members already have access.</div>
+        )}
+        {shares.map((s) => (
+          <ShareRow
+            key={s.user_id}
+            share={s}
+            onRemove={async () => {
+              await removeObjectShare(objectType, objectId, s.user_id);
+              await onChange();
+            }}
+          />
+        ))}
+      </div>
+      <AddPersonInput
+        onAdd={async (userId, permission) => {
+          await addObjectShare(objectType, objectId, userId, permission);
+          await onChange();
+        }}
+        excludeUserIds={shares.map((s) => s.user_id)}
+      />
+    </div>
+  );
+}
+
+function ShareRow({ share, onRemove }: { share: ObjectShare; onRemove: () => Promise<void> }) {
+  const [removing, setRemoving] = useState(false);
+  return (
+    <div className="flex items-center justify-between gap-2 rounded bg-raised px-2 py-1.5 text-[12px]">
+      <span className="truncate text-foreground">{share.user_name || share.user_id.slice(0, 8)}</span>
+      <span className="font-mono text-[10px] uppercase tracking-wider text-muted">{share.permission}</span>
+      <button
+        onClick={async () => {
+          setRemoving(true);
+          try {
+            await onRemove();
+          } finally {
+            setRemoving(false);
+          }
+        }}
+        disabled={removing}
+        className="text-[11px] text-muted hover:text-red-500 disabled:opacity-50"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+function AddPersonInput({
+  onAdd,
+  excludeUserIds,
+}: {
+  onAdd: (userId: string, permission: "read" | "write") => Promise<void>;
+  excludeUserIds: string[];
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserResult[]>([]);
+  const [permission, setPermission] = useState<"read" | "write">("read");
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const exclude = useMemo(() => new Set(excludeUserIds), [excludeUserIds]);
+
+  const search = useCallback(
+    async (q: string) => {
+      if (q.length < 1) {
+        setResults([]);
+        return;
+      }
+      try {
+        const token = localStorage.getItem("stash_token") || "";
+        const res = await fetch(`${API_BASE}/api/v1/users/search?q=${encodeURIComponent(q)}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data: UserResult[] = await res.json();
+          setResults(data.filter((u) => !exclude.has(u.id)));
+        }
+      } catch {
+        // search failures are non-fatal
+      }
+    },
+    [exclude]
+  );
+
+  const handleInput = (v: string) => {
+    setQuery(v);
+    setError(null);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(v), 200);
+  };
+
+  const handlePick = async (u: UserResult) => {
+    setAdding(true);
+    setError(null);
+    try {
+      await onAdd(u.id, permission);
+      setQuery("");
+      setResults([]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return (
+    <div className="mt-2">
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => handleInput(e.target.value)}
+          placeholder="Add person by username"
+          disabled={adding}
+          className="min-w-0 flex-1 rounded border border-border bg-raised px-2 py-1 text-[12px] text-foreground placeholder:text-muted"
+        />
+        <select
+          value={permission}
+          onChange={(e) => setPermission(e.target.value as "read" | "write")}
+          className="shrink-0 rounded border border-border bg-raised px-1.5 py-1 text-[11px] text-foreground"
+        >
+          <option value="read">Viewer</option>
+          <option value="write">Editor</option>
+        </select>
+      </div>
+      {error && <div className="mt-1 text-[11px] text-red-500">{error}</div>}
+      {results.length > 0 && (
+        <div className="mt-1 max-h-40 overflow-y-auto rounded border border-border-subtle bg-surface">
+          {results.map((u) => (
+            <button
+              key={u.id}
+              onClick={() => handlePick(u)}
+              disabled={adding}
+              className="flex w-full items-center justify-between gap-2 px-2 py-1.5 text-left text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+            >
+              <span className="truncate">{u.display_name || u.name}</span>
+              <span className="text-[11px] text-muted">@{u.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/share/ShareSheet.tsx
+++ b/frontend/src/components/share/ShareSheet.tsx
@@ -94,15 +94,24 @@ export default function ShareSheet({ objectType, objectId, objectLabel, onClose 
   };
 
   const onCopyLink = async () => {
+    let result;
     try {
-      const result = await createShareLink(objectType, objectId);
-      setLinkUrl(result.url);
-      setEmbedSlug(result.kind === "view" ? result.view_slug ?? null : null);
+      result = await createShareLink(objectType, objectId);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to create link");
+      return;
+    }
+    setLinkUrl(result.url);
+    setEmbedSlug(result.kind === "view" ? result.view_slug ?? null : null);
+    // Clipboard is best-effort — some browsers (headless, sandboxed iframes,
+    // permission denied) reject writeText. The URL is still shown above so
+    // the user can select-and-copy by hand.
+    try {
       await navigator.clipboard.writeText(result.url);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch (err) {
-      setLoadError(err instanceof Error ? err.message : "Failed to create link");
+    } catch {
+      /* ignore — link is rendered for manual copy */
     }
   };
 
@@ -110,9 +119,13 @@ export default function ShareSheet({ objectType, objectId, objectLabel, onClose 
     if (!embedSlug) return;
     const origin = window.location.origin;
     const snippet = `<iframe src="${origin}/v/${embedSlug}/embed" width="100%" height="600" frameborder="0"></iframe>`;
-    await navigator.clipboard.writeText(snippet);
-    setEmbedCopied(true);
-    setTimeout(() => setEmbedCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setEmbedCopied(true);
+      setTimeout(() => setEmbedCopied(false), 1500);
+    } catch {
+      /* ignore — snippet is rendered for manual copy */
+    }
   };
 
   return (

--- a/frontend/src/components/share/ShareSheet.tsx
+++ b/frontend/src/components/share/ShareSheet.tsx
@@ -96,13 +96,14 @@ export default function ShareSheet({ objectType, objectId, objectLabel, onClose 
   const onCopyLink = async () => {
     let result;
     try {
-      result = await createShareLink(objectType, objectId);
+      result = await createShareLink(objectType, objectId, "link");
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : "Failed to create link");
       return;
     }
     setLinkUrl(result.url);
     setEmbedSlug(result.kind === "view" ? result.view_slug ?? null : null);
+    await reload();
     // Clipboard is best-effort — some browsers (headless, sandboxed iframes,
     // permission denied) reject writeText. The URL is still shown above so
     // the user can select-and-copy by hand.

--- a/frontend/src/components/workspace/WorkspaceSidebar.tsx
+++ b/frontend/src/components/workspace/WorkspaceSidebar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 
 import { Workspace, WorkspaceMember } from "../../lib/types";
 import { rotateWorkspaceInvite } from "../../lib/api";
+import ShareSheet from "../share/ShareSheet";
 
 interface UserResult { id: string; name: string; display_name: string }
 
@@ -145,6 +146,7 @@ export default function WorkspaceSidebar({
   const [copied, setCopied] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   const toggleVisibility = async () => {
     if (updatingVisibility) return;
@@ -305,15 +307,35 @@ export default function WorkspaceSidebar({
               {workspace.is_public ? "Public" : "Private"}
             </span>
           </span>
-          {isOwner && (
-            <button
-              onClick={toggleVisibility}
-              disabled={updatingVisibility}
-              className="text-[10px] text-muted hover:text-foreground underline underline-offset-2 disabled:opacity-50"
-            >
-              {updatingVisibility ? "saving..." : workspace.is_public ? "make private" : "make public"}
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {isOwner && (
+              <button
+                onClick={toggleVisibility}
+                disabled={updatingVisibility}
+                className="text-[10px] text-muted hover:text-foreground underline underline-offset-2 disabled:opacity-50"
+              >
+                {updatingVisibility ? "saving..." : workspace.is_public ? "make private" : "make public"}
+              </button>
+            )}
+            {isOwner && (
+              <div className="relative">
+                <button
+                  onClick={() => setShareOpen((v) => !v)}
+                  className="rounded border border-border bg-raised px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground"
+                >
+                  Share
+                </button>
+                {shareOpen && (
+                  <ShareSheet
+                    objectType="workspace"
+                    objectId={workspace.id}
+                    objectLabel={workspace.name}
+                    onClose={() => setShareOpen(false)}
+                  />
+                )}
+              </div>
+            )}
+          </div>
         </div>
         <div className="mt-3 flex flex-col gap-2">
           <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -836,6 +836,90 @@ export async function removeShare(
   );
 }
 
+// --- Universal share API (works on any shareable object_type) ---
+
+export type ShareableObjectType =
+  | "workspace"
+  | "notebook"
+  | "page"
+  | "table"
+  | "file"
+  | "history"
+  | "view";
+
+export type ObjectVisibility = "inherit" | "private" | "link" | "public";
+
+export interface ObjectShare {
+  user_id: string;
+  user_name: string;
+  permission: "read" | "write" | "admin";
+  granted_by: string;
+  created_at: string;
+}
+
+export interface ObjectPermissions {
+  object_type: string;
+  object_id: string;
+  visibility: ObjectVisibility;
+  shares: ObjectShare[];
+}
+
+export interface ShareLinkResult {
+  url: string;
+  kind: "workspace" | "view";
+  view_id?: string | null;
+  view_slug?: string | null;
+}
+
+export async function getObjectPermissions(
+  objectType: ShareableObjectType,
+  objectId: string
+): Promise<ObjectPermissions> {
+  return apiFetch(`/api/v1/objects/${objectType}/${objectId}/permissions`);
+}
+
+export async function setObjectVisibility(
+  objectType: ShareableObjectType,
+  objectId: string,
+  visibility: ObjectVisibility
+): Promise<void> {
+  await apiFetch(`/api/v1/objects/${objectType}/${objectId}/permissions`, {
+    method: "PATCH",
+    body: JSON.stringify({ visibility }),
+  });
+}
+
+export async function addObjectShare(
+  objectType: ShareableObjectType,
+  objectId: string,
+  userId: string,
+  permission: "read" | "write" | "admin"
+): Promise<ObjectShare> {
+  return apiFetch(`/api/v1/objects/${objectType}/${objectId}/shares`, {
+    method: "POST",
+    body: JSON.stringify({ user_id: userId, permission }),
+  });
+}
+
+export async function removeObjectShare(
+  objectType: ShareableObjectType,
+  objectId: string,
+  userId: string
+): Promise<void> {
+  await apiFetch(`/api/v1/objects/${objectType}/${objectId}/shares/${userId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function createShareLink(
+  objectType: ShareableObjectType,
+  objectId: string
+): Promise<ShareLinkResult> {
+  return apiFetch(`/api/v1/objects/${objectType}/${objectId}/share-link`, {
+    method: "POST",
+  });
+}
+
 // --- Files ---
 
 export async function uploadFile(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -913,9 +913,11 @@ export async function removeObjectShare(
 
 export async function createShareLink(
   objectType: ShareableObjectType,
-  objectId: string
+  objectId: string,
+  ensure?: "link" | "public"
 ): Promise<ShareLinkResult> {
-  return apiFetch(`/api/v1/objects/${objectType}/${objectId}/share-link`, {
+  const qs = ensure ? `?ensure=${ensure}` : "";
+  return apiFetch(`/api/v1/objects/${objectType}/${objectId}/share-link${qs}`, {
     method: "POST",
   });
 }
@@ -1014,6 +1016,13 @@ export interface CreatedView {
   updated_at: string;
 }
 
+export interface SharedViewResult {
+  view: CreatedView;
+  url: string;
+  view_id: string;
+  view_slug: string;
+}
+
 export async function createView(
   workspaceId: string,
   title: string,
@@ -1026,6 +1035,30 @@ export async function createView(
       title,
       description: opts.description ?? "",
       is_public: opts.is_public ?? false,
+      cover_image_url: null,
+      items: items.map((it, i) => ({
+        object_type: it.object_type,
+        object_id: it.object_id,
+        position: it.position ?? i,
+        label_override: it.label_override ?? null,
+      })),
+    }),
+  });
+}
+
+export async function createSharedView(
+  workspaceId: string,
+  title: string,
+  items: ViewItemSpec[],
+  opts: { description?: string; ensure?: "link" | "public" } = {}
+): Promise<SharedViewResult> {
+  const ensure = opts.ensure ?? "link";
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/views/share-bundle?ensure=${ensure}`, {
+    method: "POST",
+    body: JSON.stringify({
+      title,
+      description: opts.description ?? "",
+      is_public: ensure === "public",
       cover_image_url: null,
       items: items.map((it, i) => ({
         object_type: it.object_type,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -953,6 +953,90 @@ export async function deleteFile(workspaceId: string, fileId: string): Promise<v
   await apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}`, { method: "DELETE" });
 }
 
+// --- Sessions (history events grouped by session_id) ---
+
+export interface SessionSummary {
+  session_id: string;
+  workspace_id: string | null;
+  workspace_name: string | null;
+  agent_name: string | null;
+  event_count: number;
+  started_at: string;
+  last_event_at: string;
+  first_prompt_preview: string | null;
+}
+
+export async function listMySessions(workspaceId?: string, limit = 50): Promise<SessionSummary[]> {
+  const qs = new URLSearchParams();
+  if (workspaceId) qs.set("workspace_id", workspaceId);
+  qs.set("limit", String(limit));
+  const data = await apiFetch<{ sessions: SessionSummary[] }>(
+    `/api/v1/me/sessions?${qs.toString()}`
+  );
+  return data.sessions;
+}
+
+export interface MaterializedSession {
+  page: { id: string; notebook_id: string; name: string };
+  notebook_id: string;
+}
+
+export async function materializeSession(
+  workspaceId: string,
+  sessionId: string
+): Promise<MaterializedSession> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/sessions/${sessionId}/materialize`, {
+    method: "POST",
+  });
+}
+
+// --- Views (curated bundles of items shareable as /v/{slug}) ---
+
+export type CollectableObjectType = "notebook" | "page" | "table" | "file" | "history";
+
+export interface ViewItemSpec {
+  object_type: CollectableObjectType;
+  object_id: string;
+  position?: number;
+  label_override?: string | null;
+}
+
+export interface CreatedView {
+  id: string;
+  workspace_id: string;
+  slug: string;
+  title: string;
+  description: string;
+  owner_id: string;
+  view_count: number;
+  items: ViewItemSpec[];
+  created_at: string;
+  updated_at: string;
+}
+
+export async function createView(
+  workspaceId: string,
+  title: string,
+  items: ViewItemSpec[],
+  opts: { description?: string; is_public?: boolean } = {}
+): Promise<CreatedView> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/views`, {
+    method: "POST",
+    body: JSON.stringify({
+      title,
+      description: opts.description ?? "",
+      is_public: opts.is_public ?? false,
+      cover_image_url: null,
+      items: items.map((it, i) => ({
+        object_type: it.object_type,
+        object_id: it.object_id,
+        position: it.position ?? i,
+        label_override: it.label_override ?? null,
+      })),
+    }),
+  });
+}
+
 // --- Cross-notebook page index ---
 
 export interface WorkspacePageEntry {

--- a/frontend/src/lib/collectTray.ts
+++ b/frontend/src/lib/collectTray.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { CollectableObjectType } from "./api";
+
+export interface CollectedItem {
+  object_type: CollectableObjectType;
+  object_id: string;
+  workspace_id: string;
+  label: string;
+  added_at: number;
+}
+
+const STORAGE_KEY = "stash_collect_tray_v1";
+const EVT = "stash:collect-tray-changed";
+
+function readStorage(): CollectedItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(items: CollectedItem[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  // Same-tab notification — the storage event only fires across tabs, so we
+  // dispatch a custom event for components mounted in the current document.
+  window.dispatchEvent(new Event(EVT));
+}
+
+export function useCollectTray() {
+  const [items, setItems] = useState<CollectedItem[]>([]);
+
+  useEffect(() => {
+    setItems(readStorage());
+    const sync = () => setItems(readStorage());
+    window.addEventListener("storage", sync);
+    window.addEventListener(EVT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(EVT, sync);
+    };
+  }, []);
+
+  const add = useCallback((item: Omit<CollectedItem, "added_at">) => {
+    const current = readStorage();
+    const exists = current.some(
+      (c) => c.object_type === item.object_type && c.object_id === item.object_id
+    );
+    if (exists) return;
+    // The tray is workspace-scoped — a View can only contain items from one
+    // workspace. If the user adds across workspaces, replace the whole tray
+    // rather than mixing (which the backend would reject anyway).
+    const fromOtherWs = current.length > 0 && current[0].workspace_id !== item.workspace_id;
+    const next = fromOtherWs ? [{ ...item, added_at: Date.now() }] : [...current, { ...item, added_at: Date.now() }];
+    writeStorage(next);
+  }, []);
+
+  const remove = useCallback((object_type: CollectableObjectType, object_id: string) => {
+    const next = readStorage().filter(
+      (c) => !(c.object_type === object_type && c.object_id === object_id)
+    );
+    writeStorage(next);
+  }, []);
+
+  const reorder = useCallback((from: number, to: number) => {
+    const next = readStorage();
+    if (from < 0 || to < 0 || from >= next.length || to >= next.length) return;
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    writeStorage(next);
+  }, []);
+
+  const clear = useCallback(() => writeStorage([]), []);
+
+  const has = useCallback(
+    (object_type: CollectableObjectType, object_id: string) =>
+      items.some((c) => c.object_type === object_type && c.object_id === object_id),
+    [items]
+  );
+
+  return { items, add, remove, reorder, clear, has };
+}


### PR DESCRIPTION
## Summary

Makes sharing first-class across workspaces, notebooks, pages (markdown + HTML), tables, and history sessions. One ACL plane (`object_permissions` + `object_shares`) governs access; Views are pure presentation that derive their audience from item permissions. New `/v/{slug}` orphan-proof reader, `/s/{ws}/n/{nb}/p/{page}` browse path, `/discover?tab=views`, `/v/{slug}/embed`, MCP + CLI parity, and an agent-friendly `/api/v1/publish` one-call endpoint.

- **Universal `<ShareSheet>`** — Notion-style people + general-access dropdown wired into page editor, notebook header, table page header, workspace sidebar, and per-session row in `/history`.
- **Multi-item bundling** — `<CollectTray>` persistent tray + `+ Collect` button on every shareable surface. Atomic `POST /workspaces/{ws}/views/share-bundle?ensure=link` creates the View AND raises every item to the requested visibility in one call.
- **One-call publish** — `POST /api/v1/publish` creates a page in an auto-created "AI Drafts" notebook, sets visibility, mints share link, returns URL.
- **Agent reader path** — `?format=text` on `/api/v1/public/{pages,notebooks,workspaces}/{id}` plus `/llms.txt` so browsing agents get clean markdown without scraping HTML.
- **MCP + CLI parity** — `cli/mcp_server.py` gains `stash_share`, `stash_set_visibility`, `stash_publish_html`, etc. CLI gains `stash share-object`, `stash visibility`, `stash publish`.
- **Strict-mode ACL fixes** — Pages cascade `inherit` through their notebook then workspace; logged-in non-members can read via inherited shares; `object_type='history'` resolves through `history_events` (latent bug fixed).

## Test plan

- [x] Backend: `pytest backend/tests/` — 56/56 pass, including 11 new permission tests (page→notebook inheritance, link readers, `history_events` resolver)
- [x] Frontend: `tsc --noEmit` clean
- [x] Manual end-to-end via curl + headless browser:
  - [x] Click Share on a markdown page → "Anyone with the link" → open URL in incognito → renders + OG card
  - [x] Click Share on an HTML page → URL renders sandboxed iframe + OG card
  - [x] Make workspace public → /s/{slug} catalog opens → click into a notebook → click into a page → reads anonymously
  - [x] Override one page to Restricted → that page 404s, rest still browseable
  - [x] CollectTray: add 2 pages from different notebooks → Share bundle → /v/{slug} renders both items anonymously
  - [x] /history: click Share on a session → materializes (idempotent) → ShareSheet opens → URL renders session content
  - [x] /api/v1/publish with HTML → URL works in same response cycle
  - [x] /v/{slug}/embed serves with `Content-Security-Policy: frame-ancestors *`
  - [x] Page→private flips revoke /v/ access immediately (no 30s SSR cache)
  - [x] Multi-item View where one item is private → 404 (strict mode)

## QA reports

- `.gstack/qa-reports/qa-report-sharing-2026-05-06.md` — initial sharing build (3 bugs found, 3 fixed)
- `.gstack/qa-reports/qa-report-sharing-postlaunch-2026-05-06.md` — post-launch UX flows (0 bugs, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)