### PR TITLE
feat: add stash upload, wiki search, and fork URL parsing

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -100,13 +100,15 @@ def _events_to_viewer_shape(events: list[dict]) -> list[dict]:
         role = _event_role(ev.get("event_type"))
         if role is None:
             continue
-        out.append({
-            "id": str(ev["id"]),
-            "role": role,
-            "content": ev.get("content") or "",
-            "tool_name": ev.get("tool_name"),
-            "created_at": ev["created_at"].isoformat() if ev.get("created_at") else None,
-        })
+        out.append(
+            {
+                "id": str(ev["id"]),
+                "role": role,
+                "content": ev.get("content") or "",
+                "tool_name": ev.get("tool_name"),
+                "created_at": ev["created_at"].isoformat() if ev.get("created_at") else None,
+            }
+        )
     return out
 
 
@@ -116,7 +118,7 @@ async def get_transcript_metadata(
     session_id: str,
     current_user: dict = Depends(get_current_user),
 ):
-    """Metadata-only response. The frontend follows up with /download for
+    """Metadata-only response. The frontend follows up with /events for
     the bytes."""
     await _check_member(workspace_id, current_user["id"])
     events = await memory_service.read_session_events(workspace_id, session_id)

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -7,7 +7,7 @@ inside a folder.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..auth import get_current_user
 from ..models import (
@@ -202,6 +202,18 @@ async def semantic_search_pages(
     if query_embedding is None:
         raise HTTPException(status_code=500, detail="Failed to embed query")
     pages = await wiki_service.search_pages_vector(workspace_id, query_embedding, limit)
+    return {"pages": pages}
+
+
+@router.get("/pages/search")
+async def search_pages(
+    workspace_id: UUID,
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_ws_access(workspace_id, current_user["id"])
+    pages = await wiki_service.search_pages_fts(workspace_id, q, limit)
     return {"pages": pages}
 
 

--- a/backend/services/discover_service.py
+++ b/backend/services/discover_service.py
@@ -105,8 +105,7 @@ async def get_featured() -> list[dict]:
 async def get_public_detail(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     ws_row = await pool.fetchrow(
-        f"{_CATALOG_SELECT} WHERE w.id = $1 AND w.is_public = true "
-        "AND w.discoverable = true",
+        f"{_CATALOG_SELECT} WHERE w.id = $1 AND w.is_public = true " "AND w.discoverable = true",
         workspace_id,
     )
     if not ws_row:

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -1,8 +1,8 @@
 """Backend coverage for the rows-only transcript path.
 
 Upload now parses JSONL into history_events rows; no R2 blob. The
-roundtrip test confirms the events come back out of the /download
-endpoint shaped like JSONL the chat viewer can parse.
+roundtrip test confirms the events come back out of the /events
+endpoint in the shape the chat viewer can parse.
 """
 
 import io
@@ -46,7 +46,7 @@ async def _workspace(client, key):
 
 
 @pytest.mark.asyncio
-async def test_upload_inserts_events_and_download_roundtrips(client: AsyncClient):
+async def test_upload_inserts_events_and_events_roundtrip(client: AsyncClient):
     key = await _register(client)
     ws = await _workspace(client, key)
     headers = {"Authorization": f"Bearer {key}"}
@@ -69,15 +69,15 @@ async def test_upload_inserts_events_and_download_roundtrips(client: AsyncClient
     assert meta.status_code == 200
     assert meta.json()["event_count"] == 2
 
-    dl = await client.get(
-        f"/api/v1/workspaces/{ws}/transcripts/sess-1/download",
+    events_resp = await client.get(
+        f"/api/v1/workspaces/{ws}/transcripts/sess-1/events",
         headers=headers,
     )
-    assert dl.status_code == 200
-    lines = [json.loads(line) for line in dl.text.splitlines() if line.strip()]
-    assert [line["type"] for line in lines] == ["user", "assistant"]
-    assert lines[0]["message"]["content"] == "hi"
-    assert lines[1]["message"]["content"] == "hello"
+    assert events_resp.status_code == 200
+    events = events_resp.json()["events"]
+    assert [event["role"] for event in events] == ["user", "assistant"]
+    assert events[0]["content"] == "hi"
+    assert events[1]["content"] == "hello"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_wiki_search.py
+++ b/backend/tests/test_wiki_search.py
@@ -1,0 +1,49 @@
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+@pytest.mark.asyncio
+async def test_search_pages_finds_workspace_pages(client: AsyncClient) -> None:
+    api_key = await _register(client)
+    headers = _auth(api_key)
+    workspace = (
+        await client.post("/api/v1/workspaces", json={"name": "Searchable"}, headers=headers)
+    ).json()
+
+    alpha = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/pages/new",
+        json={"name": "Alpha", "content": "alpha result lives here"},
+        headers=headers,
+    )
+    assert alpha.status_code == 201
+    beta = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/pages/new",
+        json={"name": "Beta", "content": "nothing relevant"},
+        headers=headers,
+    )
+    assert beta.status_code == 201
+
+    resp = await client.get(
+        f"/api/v1/workspaces/{workspace['id']}/pages/search",
+        params={"q": "alpha", "limit": 10},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    pages = resp.json()["pages"]
+    assert [page["name"] for page in pages] == ["Alpha"]

--- a/cli/client.py
+++ b/cli/client.py
@@ -304,6 +304,14 @@ class StashClient:
     def list_pages(self, workspace_id: str) -> list:
         return self._list(f"/api/v1/workspaces/{workspace_id}/pages", "pages")
 
+    def search_pages(self, workspace_id: str, query: str, limit: int = 20) -> list:
+        return self._list(
+            f"/api/v1/workspaces/{workspace_id}/pages/search",
+            "pages",
+            q=query,
+            limit=limit,
+        )
+
     def get_page(self, workspace_id: str, page_id: str) -> dict:
         return self._get(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -6,6 +6,7 @@ import json
 import sys
 import textwrap
 from pathlib import Path
+from urllib.parse import urlparse
 
 import questionary
 import typer
@@ -886,13 +887,25 @@ def _do_fork(workspace_id: str, suggested_name: str = "") -> None:
         console.print(f"  Wrote [cyan]{MANIFEST_FILE}[/cyan] → {new_ws['id']}")
 
 
+def _parse_workspace_id(url_or_id: str) -> str:
+    value = url_or_id.strip().rstrip("/")
+    parsed = urlparse(value)
+    parts = [part for part in parsed.path.split("/") if part]
+    for marker in ("s", "workspaces"):
+        if marker in parts:
+            marker_index = parts.index(marker)
+            if marker_index + 1 < len(parts):
+                return parts[marker_index + 1]
+    return value
+
+
 @app.command("fork")
 def fork(
-    workspace_id: str = typer.Argument(..., help="ID of the public Stash to fork."),
+    workspace_id: str = typer.Argument(..., help="ID or URL of the public Stash to fork."),
     name: str = typer.Option("", "--name", help="Name for the new private Stash."),
 ):
     """Fork a public Stash into a new private Stash you own."""
-    _do_fork(workspace_id, suggested_name=name)
+    _do_fork(_parse_workspace_id(workspace_id), suggested_name=name)
 
 
 # ===========================================================================
@@ -1151,6 +1164,175 @@ def share_session(
 
     public_url = f"{_web_app_url()}/v/{view['slug']}"
     console.print(f"\n[green bold]Shared![/green bold]  {public_url}")
+
+
+_UPLOAD_TEXT_EXTENSIONS = {
+    ".bash",
+    ".bib",
+    ".c",
+    ".cfg",
+    ".cpp",
+    ".csv",
+    ".fish",
+    ".go",
+    ".h",
+    ".htm",
+    ".html",
+    ".ini",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".kt",
+    ".lua",
+    ".md",
+    ".mdx",
+    ".org",
+    ".pl",
+    ".py",
+    ".r",
+    ".rb",
+    ".rs",
+    ".rst",
+    ".sh",
+    ".sql",
+    ".svg",
+    ".swift",
+    ".tex",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+    ".zsh",
+}
+
+
+def _is_upload_text_file(path: Path) -> bool:
+    return path.suffix.lower() in _UPLOAD_TEXT_EXTENSIONS
+
+
+def _has_hidden_part(path: Path) -> bool:
+    return any(part.startswith(".") for part in path.parts)
+
+
+def _upload_file_list(target: Path) -> list[Path]:
+    if target.is_file():
+        return [target]
+    return sorted(
+        path
+        for path in target.rglob("*")
+        if path.is_file() and not _has_hidden_part(path.relative_to(target))
+    )
+
+
+def _upload_folder_for_file(
+    c: StashClient,
+    workspace_id: str,
+    root_folder_id: str,
+    folder_cache: dict[tuple[str, str], str],
+    relative_path: Path,
+) -> str:
+    parent_id = root_folder_id
+    for folder_name in relative_path.parts[:-1]:
+        key = (parent_id, folder_name)
+        if key not in folder_cache:
+            folder_cache[key] = c.create_folder(
+                workspace_id,
+                folder_name,
+                parent_folder_id=parent_id,
+            )["id"]
+        parent_id = folder_cache[key]
+    return parent_id
+
+
+@app.command("upload")
+def upload(
+    path: str = typer.Argument(..., help="Directory or file to upload."),
+    name: str = typer.Option("", "--name", "-n", help="Name for the uploaded folder."),
+    workspace_id: str = typer.Option(None, "--ws"),
+    public: bool = typer.Option(True, "--public/--private", help="Publish a shareable View."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Upload local files into workspace pages and publish them as a View."""
+    _require_auth()
+    target = Path(path)
+    if not target.exists():
+        console.print(f"[red]Not found: {path}[/red]")
+        raise typer.Exit(1)
+
+    files = _upload_file_list(target)
+    if not files:
+        console.print(f"[red]No files found in {path}[/red]")
+        raise typer.Exit(1)
+
+    root_name = name or (target.stem if target.is_file() else target.name)
+    ws = workspace_id or _resolve_workspace()
+    console.print(f"[dim]Uploading {len(files)} file(s) as '{root_name}'...[/dim]")
+
+    with _client() as c:
+        root_folder = c.create_folder(ws, root_name)
+        folder_cache: dict[tuple[str, str], str] = {}
+        view_items: list[dict] = [
+            {"object_type": "folder", "object_id": root_folder["id"], "position": 0},
+        ]
+
+        for file_path in files:
+            relative_path = (
+                file_path.relative_to(target) if target.is_dir() else Path(file_path.name)
+            )
+            folder_id = _upload_folder_for_file(
+                c,
+                ws,
+                root_folder["id"],
+                folder_cache,
+                relative_path,
+            )
+
+            if _is_upload_text_file(file_path):
+                content = file_path.read_text(errors="replace")
+                c.create_page(ws, file_path.name, content=content, folder_id=folder_id)
+                console.print(f"  [dim]Page: {relative_path}[/dim]")
+                continue
+
+            uploaded = c.upload_ws_file(ws, str(file_path))
+            c.create_page(
+                ws,
+                file_path.name,
+                content=_markdown_snippet(uploaded),
+                folder_id=folder_id,
+            )
+            view_items.append(
+                {
+                    "object_type": "file",
+                    "object_id": uploaded["id"],
+                    "position": len(view_items),
+                    "label_override": str(relative_path),
+                }
+            )
+            console.print(f"  [dim]File: {relative_path}[/dim]")
+
+        view = c.create_view(
+            ws,
+            title=root_name,
+            description=f"Uploaded from {target.name}",
+            is_public=public,
+            items=view_items,
+        )
+
+    result = {"folder": root_folder, "view": view}
+    if _use_json(as_json):
+        output_json(result)
+        return
+    if public:
+        public_url = f"{_web_app_url()}/v/{view['slug']}"
+        console.print(f"\n[green bold]Uploaded![/green bold]  {public_url}")
+        return
+    console.print(
+        f"\n[green bold]Uploaded![/green bold]  Folder: {root_folder['id']}  View: {view['id']}"
+    )
 
 
 def _parse_view_slug(url_or_slug: str) -> str:
@@ -1502,6 +1684,33 @@ def wiki_pages(
             label = f"{path}/{p['name']}" if path else p["name"]
             ws = f" [{p.get('workspace_name', '')}]" if p.get("workspace_name") else ""
             console.print(f"  {label}{ws}  (id: {str(p['id'])[:8]})")
+
+
+@wiki_app.command("search")
+def wiki_search(
+    query: str = typer.Argument(..., help="Search query."),
+    workspace_id: str = typer.Option(None, "--ws"),
+    limit: int = typer.Option(20, "-n", "--limit"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Full-text search across wiki pages in a workspace."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            data = c.search_pages(ws, query, limit=limit)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+        return
+    if not data:
+        console.print("[dim]No matching pages.[/dim]")
+        return
+    for page in data:
+        snippet = (page.get("content_markdown") or "")[:200].replace("\n", " ")
+        console.print(f"  [bold]{page['name']}[/bold]  [dim](page: {str(page['id'])[:8]})[/dim]")
+        if snippet:
+            console.print(f"    {snippet}...")
 
 
 def _markdown_snippet(file_resp: dict) -> str:

--- a/cli/tests/test_share_and_upload_helpers.py
+++ b/cli/tests/test_share_and_upload_helpers.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from cli.main import _is_upload_text_file, _parse_workspace_id
+
+
+def test_parse_workspace_id_accepts_bare_id() -> None:
+    assert _parse_workspace_id("abc-123") == "abc-123"
+
+
+def test_parse_workspace_id_accepts_share_url() -> None:
+    assert _parse_workspace_id("https://joinstash.ai/s/abc-123?tab=wiki") == "abc-123"
+
+
+def test_parse_workspace_id_accepts_workspace_url() -> None:
+    assert _parse_workspace_id("https://joinstash.ai/workspaces/abc-123/requests") == "abc-123"
+
+
+def test_upload_text_file_detection() -> None:
+    assert _is_upload_text_file(Path("notes.md"))
+    assert _is_upload_text_file(Path("script.py"))
+    assert not _is_upload_text_file(Path("diagram.png"))


### PR DESCRIPTION
## Summary
- **`stash upload <path>`** bulk uploads a directory or file into workspace folders/pages, then creates a shareable View. Text files become inline pages; binary files are uploaded as file attachments and linked from pages.
- **`stash wiki search <query>`** full-text searches wiki pages in the current workspace through `GET /api/v1/workspaces/{ws}/pages/search`.
- **`stash fork`** accepts Stash URLs such as `https://app.joinstash.ai/s/<id>` in addition to bare workspace IDs.

This replaces the stale notebook-based PR 236 implementation with current `main` primitives. It does not restore notebook routes or services.

## CI hygiene
- Updated the stale transcript route test/doc to assert the current `/events` contract instead of removed `/download` JSONL behavior.
- Applied Black formatting needed by the current merge ref.

## Test plan
- [x] `python -m ruff check backend/ cli/`
- [x] `black --check backend/ cli/`
- [x] `pytest --no-cov cli/tests/test_share_and_upload_helpers.py`
- [x] `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_review_236_salvage4 pytest --no-cov backend/tests`