### PR TITLE
fix: auto-update plugin cache on session start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ htmlcov/
 .turbo/
 coverage/
 .vercel
+.claude/
+.global-agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Write extremely easy to consume code. Optimize for readability: skimmable, no cl
 We are a startup. Therefore, code simplicity is our most important concern. Please NEVER
  - Attempt to preserve backwards compatibility when making an edit.
  - Use fallbacks to save the UX when a primary path doesn't work (we'd rather fail fast, and this helps us to maintain as few codepaths as possible)
- - Add dual-write or dual-read shims to support old and new formats side by side. If a format changes, change it everywhere in one shot. The plugin auto-updates on session start so stale code is not an excuse to maintain two codepaths.
+ - Support old formats. If a format changes, change it everywhere in one shot.
  
 Here are some common code patterns that we need you to avoid:
  - Excessive try/catch: only use try/catch when there's a reasonable expectation that the code within might fail during normal usage. Every try/catch that we add adds another codepath that we need to maintain (the catch) and balloons complexity. In general, we follow the concept of "parse, don't validate" from TDD whenever possible. That is, we validate inputs at module boundaries, and within a module, we don't randomly add try/catch everywhere.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@ Write extremely easy to consume code. Optimize for readability: skimmable, no cl
 ### Write simple code
 We are a startup. Therefore, code simplicity is our most important concern. Please NEVER
  - Attempt to preserve backwards compatibility when making an edit.
- - Use fallbacks when to save the UX when a primary path doesn't work (we'd rather fail fast, and this helps us to maintain as few codepaths as possible)
+ - Use fallbacks to save the UX when a primary path doesn't work (we'd rather fail fast, and this helps us to maintain as few codepaths as possible)
+ - Add dual-write or dual-read shims to support old and new formats side by side. If a format changes, change it everywhere in one shot. The plugin auto-updates on session start so stale code is not an excuse to maintain two codepaths.
  
 Here are some common code patterns that we need you to avoid:
  - Excessive try/catch: only use try/catch when there's a reasonable expectation that the code within might fail during normal usage. Every try/catch that we add adds another codepath that we need to maintain (the catch) and balloons complexity. In general, we follow the concept of "parse, don't validate" from TDD whenever possible. That is, we validate inputs at module boundaries, and within a module, we don't randomly add try/catch everywhere.

--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -13,6 +13,12 @@ SCRIPT="$1"
 shift
 TARGET="$(dirname "$0")/$SCRIPT.py"
 
+# On session start, pull the latest plugin code in the background so the
+# plugin cache never drifts from the source repo.
+if [ "$SCRIPT" = "on_session_start" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  git -C "$CLAUDE_PLUGIN_ROOT" pull --ff-only origin main >/dev/null 2>&1 &
+fi
+
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

- Plugin cache (`~/.claude/plugins/marketplaces/`) is a git clone that Claude Code never refreshes. The `streaming` → `stopped_streaming` refactor broke streaming for any user with a stale cache — hooks silently dropped every event because `_is_stopped` checked the wrong config field.
- Added a background `git pull --ff-only` in `_run.sh` on `SessionStart` so the plugin cache stays current automatically.
- Gitignore `.claude/` and `.global-agents/`.
- CLAUDE.md: added rule against dual-write/dual-read shims — the auto-update makes stale code a non-issue.

## Test plan

- [ ] Start a new Claude Code session in a stash-connected repo, verify `_run.sh` pulls latest plugin code
- [ ] Verify streaming events land in the correct workspace after the update
- [ ] Confirm no latency impact from the background git pull on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)