### PR TITLE
fix: query events newest-first with pagination

### DIFF
--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -242,7 +242,7 @@ async def _query_events(
         f"SELECT id, workspace_id, created_by, agent_name, event_type, session_id, "
         f"tool_name, content, metadata, attachments, created_at "
         f"FROM history_events WHERE {where} "
-        f"ORDER BY created_at ASC LIMIT ${limit_idx}",
+        f"ORDER BY created_at DESC LIMIT ${limit_idx}",
         *args,
     )
     events = [dict(r) for r in rows]

--- a/cli/client.py
+++ b/cli/client.py
@@ -354,6 +354,7 @@ class StashClient:
         event_type: str | None = None,
         limit: int = 50,
         after: str | None = None,
+        before: str | None = None,
     ) -> list:
         params: dict = {"limit": limit}
         if agent_name:
@@ -362,6 +363,8 @@ class StashClient:
             params["event_type"] = event_type
         if after:
             params["after"] = after
+        if before:
+            params["before"] = before
         return self._list(f"/api/v1/workspaces/{workspace_id}/memory/events", "events", **params)
 
     def search_events(self, workspace_id: str, query: str, limit: int = 50) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1689,17 +1689,19 @@ def hist_query(
     agent_name: str = typer.Option(None, "--agent"),
     event_type: str = typer.Option(None, "--type"),
     limit: int = typer.Option(50, "-n", "--limit"),
+    before: str = typer.Option(None, "--before", help="Cursor: ISO timestamp or event ID for previous page"),
+    after: str = typer.Option(None, "--after", help="Cursor: ISO timestamp or event ID for next page"),
     all_: bool = typer.Option(False, "--all"),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Query events. --all for cross-workspace."""
+    """Query events (newest first). --all for cross-workspace."""
     with _client() as c:
         try:
             if all_:
                 data = c.all_events(agent_name=agent_name, event_type=event_type, limit=limit)
             else:
                 ws = workspace_id or _resolve_workspace()
-                data = c.query_events(ws, agent_name=agent_name, event_type=event_type, limit=limit)
+                data = c.query_events(ws, agent_name=agent_name, event_type=event_type, limit=limit, before=before, after=after)
         except StashError as e:
             _err(e)
     if _use_json(as_json):


### PR DESCRIPTION
## Summary

- `stash history query` now returns newest events first (was oldest-first, which meant recent activity was buried past the 200-event limit)
- Backend: `ORDER BY created_at ASC` → `DESC` in `_query_events`
- CLI: added `--before` and `--after` cursor flags for pagination (backend already supported these params)

## Test plan

- [ ] `stash history query --limit 5` returns the 5 most recent events
- [ ] `--before <timestamp>` paginates backward through older events
- [ ] `--json` output is also newest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)