### PR TITLE
feat: make share a first-class action in the UI

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Instrument_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { BreadcrumbProvider } from "../components/BreadcrumbContext";
+import { ShareTargetProvider } from "../components/share/ShareTargetContext";
 
 const instrumentSans = Instrument_Sans({
   variable: "--font-instrument-sans",
@@ -34,7 +35,9 @@ export default function RootLayout({
       <body
         className={`${instrumentSans.variable} ${jetbrainsMono.variable} antialiased min-h-screen`}
       >
-        <BreadcrumbProvider>{children}</BreadcrumbProvider>
+        <BreadcrumbProvider>
+          <ShareTargetProvider>{children}</ShareTargetProvider>
+        </BreadcrumbProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -4,7 +4,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "../../../components/AppShell";
 import AddToCollect from "../../../components/share/AddToCollect";
-import ShareSheet from "../../../components/share/ShareSheet";
+import { useSetShareTarget } from "../../../components/share/ShareTargetContext";
 import { useAuth } from "../../../hooks/useAuth";
 import {
   getTable, updateTable,
@@ -118,6 +118,11 @@ function TableEditorPageInner() {
   const sortedColumns = table?.columns ? [...table.columns].sort((a, b) => a.order - b.order) : [];
   const visibleColumns = sortedColumns.filter((c) => !hiddenCols.has(c.id));
   const hasMore = offset < totalCount;
+
+  useSetShareTarget(
+    table ? { objectType: "table", objectId: table.id, label: table.name } : null,
+    `table:${table?.id ?? ""}:${table?.name ?? ""}`
+  );
 
   // --- Data Loading ---
   const loadTable = useCallback(async () => {
@@ -535,7 +540,6 @@ function TableEditorPageInner() {
                 label={table.name}
               />
             )}
-            {table && <TableShareButton tableId={table.id} tableName={table.name} />}
             <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>
           </>}
         </div>
@@ -797,24 +801,3 @@ function TableEditorPageInner() {
   );
 }
 
-function TableShareButton({ tableId, tableName }: { tableId: string; tableName: string }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="rounded border border-border bg-raised px-2 py-1 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground"
-      >
-        Share
-      </button>
-      {open && (
-        <ShareSheet
-          objectType="table"
-          objectId={tableId}
-          objectLabel={tableName}
-          onClose={() => setOpen(false)}
-        />
-      )}
-    </div>
-  );
-}

--- a/frontend/src/app/wiki/page.tsx
+++ b/frontend/src/app/wiki/page.tsx
@@ -8,7 +8,7 @@ import FileTreeComponent from "../../components/workspace/FileTree";
 import MarkdownEditor, { SaveStatus } from "../../components/workspace/MarkdownEditor";
 import HtmlPageEditor from "../../components/workspace/HtmlPageEditor";
 import AddToCollect from "../../components/share/AddToCollect";
-import ShareSheet from "../../components/share/ShareSheet";
+import { useSetShareTarget } from "../../components/share/ShareTargetContext";
 import { useAuth } from "../../hooks/useAuth";
 import {
   createFolder,
@@ -427,6 +427,13 @@ function WikiPageInner() {
   const depKey = `${activeWorkspace?.id ?? ""}:${folderPath.join("/")}:${selectedPage?.id ?? ""}:${selectedPage?.name ?? ""}`;
   useBreadcrumbs(crumbs, depKey);
 
+  useSetShareTarget(
+    selectedPage
+      ? { objectType: "page", objectId: selectedPage.id, label: selectedPage.name }
+      : null,
+    `page:${selectedPage?.id ?? ""}:${selectedPage?.name ?? ""}`
+  );
+
   if (loading)
     return (
       <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>
@@ -560,7 +567,6 @@ function WikiPageInner() {
                     workspaceId={wsId}
                     label={selectedPage.name}
                   />
-                  <PageShareButton pageId={selectedPage.id} pageName={selectedPage.name} />
                 </div>
               )}
 
@@ -628,24 +634,3 @@ function WikiPageInner() {
   );
 }
 
-function PageShareButton({ pageId, pageName }: { pageId: string; pageName: string }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="rounded border border-border bg-raised px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-foreground hover:border-foreground"
-      >
-        Share
-      </button>
-      {open && (
-        <ShareSheet
-          objectType="page"
-          objectId={pageId}
-          objectLabel={pageName}
-          onClose={() => setOpen(false)}
-        />
-      )}
-    </div>
-  );
-}

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import AppShell from "../../../components/AppShell";
+import { useSetShareTarget } from "../../../components/share/ShareTargetContext";
 import WorkspaceSidebar from "../../../components/workspace/WorkspaceSidebar";
 import { useAuth } from "../../../hooks/useAuth";
 import {
@@ -104,6 +105,11 @@ export default function WorkspacePage() {
   const loadWorkspace = useCallback(async () => {
     try { setWorkspace(await getWorkspace(workspaceId)); } catch { setError("Workspace not found"); }
   }, [workspaceId]);
+
+  useSetShareTarget(
+    workspace ? { objectType: "workspace", objectId: workspace.id, label: workspace.name } : null,
+    `workspace:${workspace?.id ?? ""}:${workspace?.name ?? ""}`
+  );
 
   const loadData = useCallback(async () => {
     try {

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -6,6 +6,8 @@ import { usePathname, useSearchParams } from "next/navigation";
 import type { Workspace } from "../lib/types";
 import { listMyWorkspaces } from "../lib/api";
 import { useBreadcrumbsValue, type Crumb } from "./BreadcrumbContext";
+import ShareButton from "./share/ShareButton";
+import { useShareTargetValue } from "./share/ShareTargetContext";
 
 const WS_STORAGE_KEY = "stash_selected_workspace";
 
@@ -29,6 +31,7 @@ export default function TopBar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const pageCrumbs = useBreadcrumbsValue();
+  const shareTarget = useShareTargetValue();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWsId, setSelectedWsId] = useState<string | null>(null);
 
@@ -92,7 +95,7 @@ export default function TopBar() {
   }, [pageCrumbs, pathname, selectedWsId, workspaces]);
 
   return (
-    <div className="sticky top-0 z-10 flex h-12 items-center border-b border-border bg-base px-6">
+    <div className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-border bg-base px-6">
       <nav className="flex min-w-0 items-center gap-2 text-[12px] text-muted">
         {crumbs.map((c, i) => {
           const isLast = i === crumbs.length - 1;
@@ -119,6 +122,16 @@ export default function TopBar() {
           );
         })}
       </nav>
+      {shareTarget && (
+        <div className="ml-4 shrink-0">
+          <ShareButton
+            objectType={shareTarget.objectType}
+            objectId={shareTarget.objectId}
+            label={shareTarget.label}
+            variant="prominent"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/share/ShareButton.tsx
+++ b/frontend/src/components/share/ShareButton.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  getObjectPermissions,
+  ObjectVisibility,
+  ShareableObjectType,
+} from "../../lib/api";
+import ShareSheet from "./ShareSheet";
+
+interface Props {
+  objectType: ShareableObjectType;
+  objectId: string;
+  label: string;
+  variant?: "compact" | "prominent";
+}
+
+const VIS_DISPLAY: Record<ObjectVisibility, { icon: string; word: string }> = {
+  inherit: { icon: "🔒", word: "Private" },
+  private: { icon: "🔒", word: "Private" },
+  link: { icon: "🔗", word: "Link" },
+  public: { icon: "🌐", word: "Public" },
+};
+
+export default function ShareButton({
+  objectType,
+  objectId,
+  label,
+  variant = "compact",
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [vis, setVis] = useState<ObjectVisibility | null>(null);
+
+  // Re-read after the sheet closes so the trigger reflects edits made in the sheet.
+  useEffect(() => {
+    let cancelled = false;
+    getObjectPermissions(objectType, objectId)
+      .then((p) => {
+        if (!cancelled) setVis(p.visibility);
+      })
+      .catch(() => {
+        if (!cancelled) setVis(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [objectType, objectId, open]);
+
+  const display = vis ? VIS_DISPLAY[vis] : null;
+
+  if (variant === "prominent") {
+    return (
+      <div className="relative">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-raised px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-foreground"
+        >
+          {display && <span aria-hidden>{display.icon}</span>}
+          <span>Share</span>
+          {display && (
+            <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted">
+              {display.word}
+            </span>
+          )}
+        </button>
+        {open && (
+          <ShareSheet
+            objectType={objectType}
+            objectId={objectId}
+            objectLabel={label}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 rounded border border-border bg-raised px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-foreground transition-colors hover:border-foreground"
+      >
+        {display && <span aria-hidden>{display.icon}</span>}
+        <span>Share</span>
+      </button>
+      {open && (
+        <ShareSheet
+          objectType={objectType}
+          objectId={objectId}
+          objectLabel={label}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/share/ShareSheet.tsx
+++ b/frontend/src/components/share/ShareSheet.tsx
@@ -27,6 +27,10 @@ interface Props {
   objectId: string;
   objectLabel: string;
   onClose: () => void;
+  // When provided, the sheet renders fixed-positioned at the given viewport
+  // coords (used by the wiki tree right-click flow). Otherwise it anchors
+  // inline relative to its `relative` parent.
+  anchorAt?: { x: number; y: number } | null;
 }
 
 const VISIBILITY_OPTIONS: { value: ObjectVisibility; label: string; hint: string }[] = [
@@ -35,7 +39,17 @@ const VISIBILITY_OPTIONS: { value: ObjectVisibility; label: string; hint: string
   { value: "public", label: "Public on the web", hint: "Discoverable in /discover" },
 ];
 
-export default function ShareSheet({ objectType, objectId, objectLabel, onClose }: Props) {
+const TYPE_CHIPS: Partial<Record<ShareableObjectType, string>> = {
+  page: "Page",
+  folder: "Folder",
+  table: "Table",
+  workspace: "Workspace",
+  file: "File",
+  history: "Session",
+  view: "View",
+};
+
+export default function ShareSheet({ objectType, objectId, objectLabel, onClose, anchorAt }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [perms, setPerms] = useState<ObjectPermissions | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -129,13 +143,25 @@ export default function ShareSheet({ objectType, objectId, objectLabel, onClose 
     }
   };
 
+  const containerClass = anchorAt
+    ? "fixed z-30 w-[360px] rounded-lg border border-border bg-surface shadow-xl"
+    : "absolute right-0 top-9 z-30 w-[360px] rounded-lg border border-border bg-surface shadow-xl";
+  const containerStyle = anchorAt
+    ? { left: Math.min(anchorAt.x, window.innerWidth - 376), top: anchorAt.y + 4 }
+    : undefined;
+  const typeChip = TYPE_CHIPS[objectType];
+
   return (
-    <div
-      ref={containerRef}
-      className="absolute right-0 top-9 z-30 w-[360px] rounded-lg border border-border bg-surface shadow-xl"
-    >
+    <div ref={containerRef} className={containerClass} style={containerStyle}>
       <div className="border-b border-border-subtle px-4 py-3">
-        <div className="text-[13px] font-medium text-foreground">Share</div>
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-medium text-foreground">Share</span>
+          {typeChip && (
+            <span className="rounded border border-border-subtle bg-raised px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted">
+              {typeChip}
+            </span>
+          )}
+        </div>
         <div className="truncate text-[12px] text-muted">{objectLabel}</div>
       </div>
 

--- a/frontend/src/components/share/ShareTargetContext.tsx
+++ b/frontend/src/components/share/ShareTargetContext.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import type { ShareableObjectType } from "../../lib/api";
+
+export interface ShareTarget {
+  objectType: ShareableObjectType;
+  objectId: string;
+  label: string;
+}
+
+interface Ctx {
+  target: ShareTarget | null;
+  setTarget: (t: ShareTarget | null) => void;
+}
+
+const ShareTargetContext = createContext<Ctx>({
+  target: null,
+  setTarget: () => {},
+});
+
+export function ShareTargetProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<ShareTarget | null>(null);
+  return (
+    <ShareTargetContext.Provider value={{ target, setTarget }}>
+      {children}
+    </ShareTargetContext.Provider>
+  );
+}
+
+export function useShareTargetValue() {
+  return useContext(ShareTargetContext).target;
+}
+
+export function useSetShareTarget(target: ShareTarget | null, depKey: string) {
+  const { setTarget } = useContext(ShareTargetContext);
+  const ref = useRef(target);
+
+  useEffect(() => {
+    ref.current = target;
+  }, [target]);
+
+  useEffect(() => {
+    setTarget(ref.current);
+    return () => setTarget(null);
+  }, [depKey, setTarget]);
+}

--- a/frontend/src/components/workspace/FileTree.tsx
+++ b/frontend/src/components/workspace/FileTree.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import ShareSheet from "../share/ShareSheet";
+import type { ShareableObjectType } from "../../lib/api";
 import {
   FolderTreeNode,
   PageSummary,
@@ -59,6 +61,13 @@ export default function FileTreeComponent({
 }: FileTreeProps) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
+  const [shareSheet, setShareSheet] = useState<{
+    x: number;
+    y: number;
+    objectType: ShareableObjectType;
+    objectId: string;
+    label: string;
+  } | null>(null);
 
   const toggle = (folderId: string) => {
     setCollapsed((prev) => {
@@ -268,6 +277,30 @@ export default function FileTreeComponent({
           <div className="my-1 h-px bg-border-subtle" />
           <button
             onClick={() => {
+              const target = contextMenu.target;
+              setShareSheet({
+                x: contextMenu.x,
+                y: contextMenu.y,
+                objectType: target.type === "page" ? "page" : "folder",
+                objectId: target.id,
+                label: target.name,
+              });
+              closeContextMenu();
+            }}
+            className="block w-full px-3 py-1.5 text-left text-[13px] text-foreground transition-colors hover:bg-raised"
+          >
+            {contextMenu.target.type === "folder" ? (
+              <>
+                <span>Share folder…</span>
+                <span className="ml-1 font-mono text-[10px] text-muted">applies to pages inside</span>
+              </>
+            ) : (
+              "Share page…"
+            )}
+          </button>
+          <div className="my-1 h-px bg-border-subtle" />
+          <button
+            onClick={() => {
               if (contextMenu.target.type === "page") {
                 onDeletePage(contextMenu.target.id);
               } else {
@@ -280,6 +313,16 @@ export default function FileTreeComponent({
             Delete
           </button>
         </div>
+      )}
+
+      {shareSheet && (
+        <ShareSheet
+          objectType={shareSheet.objectType}
+          objectId={shareSheet.objectId}
+          objectLabel={shareSheet.label}
+          onClose={() => setShareSheet(null)}
+          anchorAt={{ x: shareSheet.x, y: shareSheet.y }}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/workspace/WorkspaceSidebar.tsx
+++ b/frontend/src/components/workspace/WorkspaceSidebar.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from "react";
 
 import { Workspace, WorkspaceMember } from "../../lib/types";
 import { rotateWorkspaceInvite } from "../../lib/api";
-import ShareSheet from "../share/ShareSheet";
+import ShareButton from "../share/ShareButton";
 
 interface UserResult { id: string; name: string; display_name: string }
 
@@ -146,7 +146,6 @@ export default function WorkspaceSidebar({
   const [copied, setCopied] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
-  const [shareOpen, setShareOpen] = useState(false);
 
   const toggleVisibility = async () => {
     if (updatingVisibility) return;
@@ -318,22 +317,11 @@ export default function WorkspaceSidebar({
               </button>
             )}
             {isOwner && (
-              <div className="relative">
-                <button
-                  onClick={() => setShareOpen((v) => !v)}
-                  className="rounded border border-border bg-raised px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-foreground hover:border-foreground"
-                >
-                  Share
-                </button>
-                {shareOpen && (
-                  <ShareSheet
-                    objectType="workspace"
-                    objectId={workspace.id}
-                    objectLabel={workspace.name}
-                    onClose={() => setShareOpen(false)}
-                  />
-                )}
-              </div>
+              <ShareButton
+                objectType="workspace"
+                objectId={workspace.id}
+                label={workspace.name}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Sharing was buried — to share a page you scanned past nine toolbar buttons; to share a folder there was no path at all; the workspace share was hidden in the right sidebar under members. The `Share` button was visually indistinguishable from `Delete` / `Export` / `Columns` (all 10px mono uppercase border buttons), so it didn't read as a primary action.
- Promotes Share to a global, sticky control in the `TopBar` with a visibility indicator (🔒 Private / 🔗 Link / 🌐 Public) so users can see sharing status at a glance without opening the sheet.
- Adds Share to the wiki tree right-click context menu for both pages (`Share page…`) and folders (`Share folder… applies to pages inside`), closing the gap of "I want to share this without opening it first."
- Collapses four near-duplicate inline share-button copies (`PageShareButton`, `TableShareButton`, history's inline button, `WorkspaceSidebar`'s inline button) into one reusable `<ShareButton>` with `compact` and `prominent` variants.
- `ShareSheet` now accepts an `anchorAt` prop for fixed-position rendering near right-click coords, and shows a small type chip (`PAGE` / `FOLDER` / `TABLE` / `WORKSPACE`) next to the `Share` header so scope is unambiguous.

History sessions still use their existing per-row inline share (sessions need materialization before they have a shareable id, so the unified component doesn't fit). Once a session materializes into a wiki page, the new TopBar Share covers it for free.

## Files
- New: `frontend/src/components/share/ShareButton.tsx`, `frontend/src/components/share/ShareTargetContext.tsx`
- Modified: `TopBar.tsx`, `AppShell` layout (provider wiring), wiki/tables/workspace page registrations, `WorkspaceSidebar.tsx`, `FileTree.tsx`, `ShareSheet.tsx`

## Test plan
- [x] Wiki page → TopBar shows `🔒 Share PRIVATE`; toggle dropdown to "Anyone with link" → close → TopBar reads `🔗 Share LINK`
- [x] Wiki page floating Share button is gone (only save status + Collect remain)
- [x] Tables page → TopBar Share works; old toolbar Share is gone
- [x] Wiki tree right-click on a folder → `Share folder…` entry → ShareSheet anchored at click with `FOLDER` chip
- [x] Wiki tree right-click on a page (without opening it first) → `Share page…` works; ShareSheet shows `PAGE` chip
- [x] Workspace detail page (`/workspaces/[id]`) → TopBar `🔒 Share PRIVATE` (was missing in initial commit, fixed by `36e7c8e`)
- [x] Workspace sidebar → unified ShareButton; sheet shows `WORKSPACE` chip
- [x] Settings / Docs / Memory pages → TopBar Share hidden (no target registered)
- [x] `npx tsc --noEmit` clean

QA report: `.gstack/qa-reports/qa-report-localhost-3000-2026-05-08.md`. QA found one out-of-scope pre-existing bug (`POST /api/v1/tables → 404` from the bare `/tables` list — frontend hits unscoped endpoint) — flagged but not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)