### PR TITLE
[codex] fix history pagination cursors

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -1,5 +1,6 @@
 """Aggregate router: cross-workspace views for the authenticated user."""
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -23,8 +24,8 @@ async def list_all_pages(current_user: dict = Depends(get_current_user)):
 async def list_all_history_events(
     agent_name: str | None = Query(None),
     event_type: str | None = Query(None),
-    after: str | None = Query(None),
-    before: str | None = Query(None),
+    after: datetime | None = Query(None),
+    before: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: dict = Depends(get_current_user),

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -4,6 +4,7 @@ Events belong directly to workspaces. No intermediate "store" abstraction.
 Hierarchy: Workspace → Agent → Session → Events
 """
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -72,8 +73,8 @@ async def query_ws_events(
     agent_name: str | None = Query(None),
     session_id: str | None = Query(None),
     event_type: str | None = Query(None),
-    after: str | None = Query(None),
-    before: str | None = Query(None),
+    after: datetime | None = Query(None),
+    before: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: dict = Depends(get_current_user),

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -25,6 +25,12 @@ def _text_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+def _normalize_ts(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
 # Dedup map for in-flight event embeds, keyed by event_id.
 _embed_tasks: dict[UUID, asyncio.Task] = {}
 
@@ -99,10 +105,8 @@ async def push_event(
     meta = metadata or {}
     if created_at is None:
         ts = datetime.now(UTC)
-    elif created_at.tzinfo is None:
-        ts = created_at.replace(tzinfo=UTC)
     else:
-        ts = created_at
+        ts = _normalize_ts(created_at)
     row = await pool.fetchrow(
         "INSERT INTO history_events "
         "(workspace_id, created_by, agent_name, event_type, content, session_id, tool_name, metadata, attachments, created_at) "
@@ -198,8 +202,8 @@ def _build_event_filters(
     agent_name: str | None,
     session_id: str | None,
     event_type: str | None,
-    after: str | None,
-    before: str | None,
+    after: datetime | None,
+    before: datetime | None,
 ) -> tuple[str, list, int]:
     """Append optional filters to a base scope condition. Returns (where, args, next_idx)."""
     conditions = [base_condition]
@@ -220,11 +224,11 @@ def _build_event_filters(
         idx += 1
     if after:
         conditions.append(f"created_at > ${idx}")
-        args.append(after)
+        args.append(_normalize_ts(after))
         idx += 1
     if before:
         conditions.append(f"created_at < ${idx}")
-        args.append(before)
+        args.append(_normalize_ts(before))
         idx += 1
 
     return " AND ".join(conditions), args, idx
@@ -259,8 +263,8 @@ async def query_workspace_events(
     agent_name: str | None = None,
     session_id: str | None = None,
     event_type: str | None = None,
-    after: str | None = None,
-    before: str | None = None,
+    after: datetime | None = None,
+    before: datetime | None = None,
     limit: int = 50,
     order: str = "desc",
 ) -> tuple[list[dict], bool]:
@@ -283,8 +287,8 @@ async def query_personal_events(
     agent_name: str | None = None,
     session_id: str | None = None,
     event_type: str | None = None,
-    after: str | None = None,
-    before: str | None = None,
+    after: datetime | None = None,
+    before: datetime | None = None,
     limit: int = 50,
     order: str = "desc",
 ) -> tuple[list[dict], bool]:
@@ -398,8 +402,8 @@ async def query_all_user_events(
     user_id: UUID,
     agent_name: str | None = None,
     event_type: str | None = None,
-    after: str | None = None,
-    before: str | None = None,
+    after: datetime | None = None,
+    before: datetime | None = None,
     limit: int = 50,
     order: str = "desc",
 ) -> tuple[list[dict], bool]:
@@ -425,11 +429,11 @@ async def query_all_user_events(
         idx += 1
     if after:
         conditions.append(f"he.created_at > ${idx}")
-        args.append(after)
+        args.append(_normalize_ts(after))
         idx += 1
     if before:
         conditions.append(f"he.created_at < ${idx}")
-        args.append(before)
+        args.append(_normalize_ts(before))
         idx += 1
 
     where = " AND ".join(conditions)

--- a/backend/tests/test_history_pagination.py
+++ b/backend/tests/test_history_pagination.py
@@ -1,0 +1,119 @@
+"""Tests for history event cursor pagination."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("hist"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+async def _workspace(client: AsyncClient, api_key: str) -> dict:
+    resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "History pagination"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def _seed_events(client: AsyncClient, api_key: str, workspace_id: str) -> None:
+    headers = _auth(api_key)
+    for day in range(1, 4):
+        resp = await client.post(
+            f"/api/v1/workspaces/{workspace_id}/memory/events",
+            json={
+                "agent_name": "tester",
+                "event_type": "note",
+                "content": f"event-{day}",
+                "session_id": "pagination-session",
+                "created_at": f"2026-01-0{day}T00:00:00Z",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_workspace_history_before_and_after_cursors(client: AsyncClient):
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    headers = _auth(api_key)
+    await _seed_events(client, api_key, ws["id"])
+
+    first = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/memory/events",
+        params={"limit": 2},
+        headers=headers,
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert [e["content"] for e in first_body["events"]] == ["event-3", "event-2"]
+    assert first_body["has_more"] is True
+
+    older = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/memory/events",
+        params={"limit": 2, "before": first_body["events"][-1]["created_at"]},
+        headers=headers,
+    )
+    assert older.status_code == 200
+    older_body = older.json()
+    assert [e["content"] for e in older_body["events"]] == ["event-1"]
+    assert older_body["has_more"] is False
+
+    asc = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/memory/events",
+        params={"limit": 2, "order": "asc"},
+        headers=headers,
+    )
+    assert asc.status_code == 200
+    asc_body = asc.json()
+    assert [e["content"] for e in asc_body["events"]] == ["event-1", "event-2"]
+
+    newer = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/memory/events",
+        params={"limit": 2, "order": "asc", "after": asc_body["events"][-1]["created_at"]},
+        headers=headers,
+    )
+    assert newer.status_code == 200
+    assert [e["content"] for e in newer.json()["events"]] == ["event-3"]
+
+
+@pytest.mark.asyncio
+async def test_all_history_events_before_cursor(client: AsyncClient):
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    headers = _auth(api_key)
+    await _seed_events(client, api_key, ws["id"])
+
+    first = await client.get(
+        "/api/v1/me/history-events",
+        params={"limit": 2},
+        headers=headers,
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert [e["content"] for e in first_body["events"]] == ["event-3", "event-2"]
+    assert first_body["has_more"] is True
+
+    older = await client.get(
+        "/api/v1/me/history-events",
+        params={"limit": 2, "before": first_body["events"][-1]["created_at"]},
+        headers=headers,
+    )
+    assert older.status_code == 200
+    older_body = older.json()
+    assert [e["content"] for e in older_body["events"]] == ["event-1"]
+    assert older_body["has_more"] is False

--- a/cli/client.py
+++ b/cli/client.py
@@ -377,13 +377,23 @@ class StashClient:
         )
 
     def all_events(
-        self, agent_name: str | None = None, event_type: str | None = None, limit: int = 50
+        self,
+        agent_name: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "desc",
     ) -> list:
-        params: dict = {"limit": limit}
+        params: dict = {"limit": limit, "order": order}
         if agent_name:
             params["agent_name"] = agent_name
         if event_type:
             params["event_type"] = event_type
+        if after:
+            params["after"] = after
+        if before:
+            params["before"] = before
         return self._list("/api/v1/me/history-events", "events", **params)
 
     def push_events_batch(self, workspace_id: str, events: list[dict]) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1699,7 +1699,14 @@ def hist_query(
     with _client() as c:
         try:
             if all_:
-                data = c.all_events(agent_name=agent_name, event_type=event_type, limit=limit)
+                data = c.all_events(
+                    agent_name=agent_name,
+                    event_type=event_type,
+                    limit=limit,
+                    before=before,
+                    after=after,
+                    order=order,
+                )
             else:
                 ws = workspace_id or _resolve_workspace()
                 data = c.query_events(ws, agent_name=agent_name, event_type=event_type, limit=limit, before=before, after=after, order=order)

--- a/cli/tests/test_history_pagination.py
+++ b/cli/tests/test_history_pagination.py
@@ -1,0 +1,80 @@
+"""Tests for history pagination plumbing in the CLI."""
+
+from cli import main as cli_main
+from cli.client import StashClient
+
+
+class RecordingClient(StashClient):
+    def __init__(self) -> None:
+        self.calls = []
+
+    def _list(self, path: str, key: str, **params):
+        self.calls.append((path, key, params))
+        return []
+
+
+def test_all_events_client_sends_cursor_params() -> None:
+    client = RecordingClient()
+
+    client.all_events(
+        agent_name="agent",
+        event_type="note",
+        limit=7,
+        before="2026-01-02T00:00:00Z",
+        after="2026-01-01T00:00:00Z",
+        order="asc",
+    )
+
+    assert client.calls == [
+        (
+            "/api/v1/me/history-events",
+            "events",
+            {
+                "limit": 7,
+                "order": "asc",
+                "agent_name": "agent",
+                "event_type": "note",
+                "after": "2026-01-01T00:00:00Z",
+                "before": "2026-01-02T00:00:00Z",
+            },
+        )
+    ]
+
+
+def test_hist_query_all_forwards_cursor_params(monkeypatch) -> None:
+    captured = {}
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def all_events(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(cli_main, "_client", lambda: FakeClient())
+    monkeypatch.setattr(cli_main, "output_json", lambda data: None)
+
+    cli_main.hist_query(
+        workspace_id=None,
+        agent_name="agent",
+        event_type="note",
+        limit=7,
+        before="2026-01-02T00:00:00Z",
+        after="2026-01-01T00:00:00Z",
+        order="asc",
+        all_=True,
+        as_json=True,
+    )
+
+    assert captured == {
+        "agent_name": "agent",
+        "event_type": "note",
+        "limit": 7,
+        "before": "2026-01-02T00:00:00Z",
+        "after": "2026-01-01T00:00:00Z",
+        "order": "asc",
+    }


### PR DESCRIPTION
## Summary

- Parse history pagination cursors as datetimes on the workspace and aggregate APIs.
- Normalize cursor timestamps before using them in `created_at` comparisons.
- Forward `--before`, `--after`, and `--order` through `stash history query --all`.
- Add focused backend and CLI tests for history pagination.

## Root Cause

History queries intentionally cap each page at 200 events, but cursor pagination was broken. The API accepted `before` and `after` as strings, then passed those raw values into timestamp comparisons, causing cursor requests to fail instead of returning the next page. The CLI `--all` path also exposed cursor flags but did not pass them to the client.

## Validation

- `ruff check backend/routers/aggregate.py backend/routers/memory.py backend/services/memory_service.py backend/tests/test_history_pagination.py cli/client.py cli/main.py cli/tests/test_history_pagination.py`
- `pytest --no-cov cli/tests/test_history_pagination.py`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_history_pagination pytest --no-cov backend/tests/test_history_pagination.py`

Note: the default local `stash_test` database was stamped with the separate Discover branch's `0029` Alembic revision, so I verified the backend tests against a fresh local test database for this branch.