### PR TITLE
[codex] Show session dates in transcript viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ If you are about to ask the user to do something for you, think about whether yo
 Previous Claude coding sessions are stored as `.jsonl` files in your ~/.claude file. Read these to understand prior decisions, debugging sessions, and context that isn't in git history.
 
 When you create or update a PR, share the GitHub link with the user at the end of your session.
-When you make local changes for a task, commit them, push the branch, and open a PR before finishing unless the user explicitly says not to.
+When you make local changes for a task, commit them, push the branch, and open a ready-for-review PR before finishing unless the user explicitly says not to. Do not open draft PRs unless the user explicitly asks for a draft.
 When making local changes for a task that already has a PR, commit and push those changes to the PR branch before finishing so the remote branch stays up to date.
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ If you are about to ask the user to do something for you, think about whether yo
 Previous Claude coding sessions are stored as `.jsonl` files in your ~/.claude file. Read these to understand prior decisions, debugging sessions, and context that isn't in git history.
 
 When you create or update a PR, share the GitHub link with the user at the end of your session.
+When you make local changes for a task, commit them, push the branch, and open a PR before finishing unless the user explicitly says not to.
 When making local changes for a task that already has a PR, commit and push those changes to the PR branch before finishing so the remote branch stays up to date.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ If you are about to ask the user to do something for you, think about whether yo
 Previous Claude coding sessions are stored as `.jsonl` files in your ~/.claude file. Read these to understand prior decisions, debugging sessions, and context that isn't in git history.
 
 When you create or update a PR, share the GitHub link with the user at the end of your session.
-When you make local changes for a task, commit them, push the branch, and open a PR before finishing unless the user explicitly says not to.
+When you make local changes for a task, commit them, push the branch, and open a ready-for-review PR before finishing unless the user explicitly says not to. Do not open draft PRs unless the user explicitly asks for a draft.
 When making local changes for a task that already has a PR, commit and push those changes to the PR branch before finishing so the remote branch stays up to date.
 
 ### PR hygiene

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ If you are about to ask the user to do something for you, think about whether yo
 Previous Claude coding sessions are stored as `.jsonl` files in your ~/.claude file. Read these to understand prior decisions, debugging sessions, and context that isn't in git history.
 
 When you create or update a PR, share the GitHub link with the user at the end of your session.
+When you make local changes for a task, commit them, push the branch, and open a PR before finishing unless the user explicitly says not to.
 When making local changes for a task that already has a PR, commit and push those changes to the PR branch before finishing so the remote branch stays up to date.
 
 ### PR hygiene

--- a/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
@@ -19,21 +19,42 @@ interface MessageTurn {
   who: "user" | "assistant";
   name: string;
   time?: string;
+  dateKey?: string;
+  dateLabel?: string;
   content: string;
   toolName?: string | null;
 }
 
+function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatSessionDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 function eventToTurn(ev: SessionEvent): MessageTurn {
+  const createdAt = ev.created_at ? new Date(ev.created_at) : null;
+
   return {
     kind: "message",
     who: ev.role,
     name: ev.role === "assistant" ? "agent" : "user",
-    time: ev.created_at
-      ? new Date(ev.created_at).toLocaleTimeString(undefined, {
+    time: createdAt
+      ? createdAt.toLocaleTimeString(undefined, {
           hour: "numeric",
           minute: "2-digit",
         })
       : undefined,
+    dateKey: createdAt ? formatDateKey(createdAt) : undefined,
+    dateLabel: createdAt ? formatSessionDate(createdAt) : undefined,
     content: ev.content,
     toolName: ev.tool_name,
   };
@@ -105,6 +126,8 @@ export default function SessionViewerPage() {
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user) return null;
 
+  const sessionDate = turns.find((turn) => turn.dateLabel)?.dateLabel;
+
   return (
     <AppShell user={user} onLogout={logout}>
       <div className="scroll-thin flex-1 overflow-y-auto">
@@ -118,6 +141,12 @@ export default function SessionViewerPage() {
               {transcript && (
                 <p className="mt-1.5 text-[11.5px] text-muted">
                   {turns.length} messages
+                  {sessionDate ? (
+                    <>
+                      {" · "}
+                      <span className="text-foreground">{sessionDate}</span>
+                    </>
+                  ) : null}
                   {stash ? <span> · in <span className="text-foreground">{stash.name}</span></span> : null}
                 </p>
               )}
@@ -136,9 +165,20 @@ export default function SessionViewerPage() {
           )}
 
           <div className="flex flex-col">
-            {turns.map((turn, i) => (
-              <MessageRow key={i} turn={turn} />
-            ))}
+            {turns.map((turn, i) => {
+              const previousTurn = turns[i - 1];
+              const dateDividerLabel =
+                turn.dateLabel && turn.dateKey !== previousTurn?.dateKey
+                  ? turn.dateLabel
+                  : null;
+
+              return (
+                <div key={i}>
+                  {dateDividerLabel ? <DateDivider label={dateDividerLabel} /> : null}
+                  <MessageRow turn={turn} />
+                </div>
+              );
+            })}
             {!error && turns.length === 0 && (
               <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
                 Loading transcript…
@@ -148,6 +188,16 @@ export default function SessionViewerPage() {
         </div>
       </div>
     </AppShell>
+  );
+}
+
+function DateDivider({ label }: { label: string }) {
+  return (
+    <div className="my-4 flex items-center gap-3 text-[11px] font-medium text-muted">
+      <span className="h-px flex-1 bg-border" />
+      <span>{label}</span>
+      <span className="h-px flex-1 bg-border" />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Show the session date in the transcript header so users can tell which calendar day a session occurred.
- Add date dividers inside the transcript when events span multiple days while keeping per-message timestamps compact.
- Update `CLAUDE.md` and `AGENTS.md` to require committing, pushing, and opening a ready-for-review PR whenever local changes are made unless the user explicitly opts out. Draft PRs are only allowed when the user explicitly asks for one.

## Screenshot
![Session date shown in transcript viewer](https://gist.githubusercontent.com/henry-dowling/3d69765572f2909317325e7be940a6f6/raw/466d932119232e8229d494f074ca831cb31db72a/stash-session-date-pr.svg)

## Validation
- `npm run lint -- --quiet`
- `npm run build`
- `npm run test`
- `git diff --check`
- Playwright smoke test with mocked session data and screenshot capture