### PR TITLE
[codex] fix sidebar expansion defaults

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/d3-drag": "^3.0.7",
@@ -2249,6 +2250,43 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2875,6 +2913,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3793,6 +3838,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -7232,6 +7287,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8771,6 +8836,41 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/d3-drag": "^3.0.7",

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppSidebar from "./AppSidebar";
+import {
+  getStashSpine,
+  listMyWorkspaces,
+  listPublicWorkspaces,
+} from "../lib/api";
+
+const nav = vi.hoisted(() => ({
+  pathname: "/",
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => nav.pathname,
+  useRouter: () => ({ push: nav.push }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../lib/api", () => ({
+  getFolderContents: vi.fn(),
+  getStashSpine: vi.fn(),
+  listMyWorkspaces: vi.fn(),
+  listPublicWorkspaces: vi.fn(),
+}));
+
+const user = {
+  id: "user-1",
+  name: "Henry",
+  display_name: "Henry",
+  description: "",
+  created_at: "2026-05-11T00:00:00Z",
+  last_seen: "2026-05-11T00:00:00Z",
+};
+
+const workspace = {
+  id: "ws-1",
+  name: "Demo Stash",
+  description: "",
+  creator_id: "user-1",
+  invite_code: "invite",
+  is_public: false,
+  created_at: "2026-05-11T00:00:00Z",
+  updated_at: "2026-05-11T00:00:00Z",
+  member_count: 1,
+};
+
+const emptySpine = {
+  sessions: [],
+  wiki: {
+    folders: [],
+    pages: [],
+    files: [],
+  },
+};
+
+function detailsFor(label: string): HTMLDetailsElement {
+  const details = screen.getByText(label).closest("details");
+  if (!details) throw new Error(`No details element for ${label}`);
+  return details as HTMLDetailsElement;
+}
+
+describe("AppSidebar tree expansion", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    nav.pathname = "/";
+    nav.push.mockClear();
+    vi.clearAllMocks();
+    vi.mocked(listMyWorkspaces).mockResolvedValue({ workspaces: [workspace] });
+    vi.mocked(listPublicWorkspaces).mockResolvedValue({ workspaces: [] });
+    vi.mocked(getStashSpine).mockResolvedValue(emptySpine);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("starts stashes and their top-level sections collapsed", async () => {
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+
+    expect(detailsFor("Demo Stash")).not.toHaveAttribute("open");
+    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
+    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    expect(getStashSpine).not.toHaveBeenCalled();
+  });
+
+  it("restores explicit expanded state from localStorage", async () => {
+    localStorage.setItem("stash_sidebar_open_stashes", "ws-1");
+    localStorage.setItem("stash_sidebar_open_sections", "ws-1:sessions");
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+
+    await waitFor(() => expect(detailsFor("Demo Stash")).toHaveAttribute("open"));
+    expect(detailsFor("Sessions")).toHaveAttribute("open");
+    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    expect(getStashSpine).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("keeps the stash landing route collapsed without saved state", async () => {
+    nav.pathname = "/stashes/ws-1";
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+
+    expect(detailsFor("Demo Stash")).not.toHaveAttribute("open");
+    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
+    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    expect(getStashSpine).not.toHaveBeenCalled();
+  });
+
+  it("opens the relevant tree branch for deep links only", async () => {
+    nav.pathname = "/stashes/ws-1/p/page-1";
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+
+    await waitFor(() => expect(detailsFor("Demo Stash")).toHaveAttribute("open"));
+    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
+    expect(detailsFor("Wiki")).toHaveAttribute("open");
+    expect(localStorage.getItem("stash_sidebar_open_stashes")).toBeNull();
+    expect(localStorage.getItem("stash_sidebar_open_sections")).toBeNull();
+  });
+});

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   getFolderContents,
@@ -24,6 +24,36 @@ interface AppSidebarProps {
 
 interface StashNode extends Workspace {
   shared?: boolean;
+}
+
+type SidebarSection = "sessions" | "wiki";
+
+const OPEN_STASHES_KEY = "stash_sidebar_open_stashes";
+const OPEN_SECTIONS_KEY = "stash_sidebar_open_sections";
+
+function readOpenMap(key: string): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return {};
+
+  return Object.fromEntries(
+    raw
+      .split("\n")
+      .filter(Boolean)
+      .map((id) => [id, true])
+  );
+}
+
+function writeOpenMap(key: string, value: Record<string, boolean>) {
+  if (typeof window === "undefined") return;
+
+  const openIds = Object.keys(value).filter((id) => value[id]);
+  window.localStorage.setItem(key, openIds.join("\n"));
+}
+
+function sectionKey(stashId: string, section: SidebarSection): string {
+  return `${stashId}:${section}`;
 }
 
 function Chevron() {
@@ -75,24 +105,26 @@ function NavRow({
 function StashTree({
   stash,
   spine,
-  defaultOpen,
-  onOpen,
+  open,
+  onOpenChange,
+  openSections,
+  onSectionOpenChange,
   pathname,
 }: {
   stash: StashNode;
   spine: StashSpine | null;
-  defaultOpen: boolean;
-  onOpen: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  openSections: Record<SidebarSection, boolean>;
+  onSectionOpenChange: (section: SidebarSection, open: boolean) => void;
   pathname: string;
 }) {
   const isActive = pathname === `/stashes/${stash.id}`;
 
   return (
     <details
-      open={defaultOpen}
-      onToggle={(e) => {
-        if ((e.target as HTMLDetailsElement).open) onOpen();
-      }}
+      open={open}
+      onToggle={(e) => onOpenChange(e.currentTarget.open)}
       className="group/stash"
     >
       <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 text-[13px] hover:bg-raised">
@@ -109,7 +141,11 @@ function StashTree({
         </Link>
       </summary>
       <div className="ml-3 space-y-0.5 border-l border-border pl-2">
-        <details open className="text-[13px]">
+        <details
+          open={openSections.sessions}
+          onToggle={(e) => onSectionOpenChange("sessions", e.currentTarget.open)}
+          className="text-[13px]"
+        >
           <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
             <Chevron />
             <span className="text-[14px]">💬</span>
@@ -131,7 +167,12 @@ function StashTree({
           </div>
         </details>
 
-        <WikiBlock stash={stash} spine={spine} />
+        <WikiBlock
+          stash={stash}
+          spine={spine}
+          open={openSections.wiki}
+          onOpenChange={(nextOpen) => onSectionOpenChange("wiki", nextOpen)}
+        />
       </div>
     </details>
   );
@@ -242,7 +283,17 @@ function FolderTreeNode({
   );
 }
 
-function WikiBlock({ stash, spine }: { stash: StashNode; spine: StashSpine | null }) {
+function WikiBlock({
+  stash,
+  spine,
+  open,
+  onOpenChange,
+}: {
+  stash: StashNode;
+  spine: StashSpine | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
   const folders = spine?.wiki.folders ?? [];
   const pages = spine?.wiki.pages ?? [];
   const files = spine?.wiki.files ?? [];
@@ -251,7 +302,11 @@ function WikiBlock({ stash, spine }: { stash: StashNode; spine: StashSpine | nul
   const rootFiles = files.filter((f) => !f.folder_id);
   const total = folders.length + pages.length + files.length;
   return (
-    <details open className="text-[13px]">
+    <details
+      open={open}
+      onToggle={(e) => onOpenChange(e.currentTarget.open)}
+      className="text-[13px]"
+    >
       <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
         <Chevron />
         <span className="text-[14px]">📖</span>
@@ -289,10 +344,26 @@ function WikiBlock({ stash, spine }: { stash: StashNode; spine: StashSpine | nul
 export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const userId = user?.id;
   const activeStashId = pathname.match(/^\/stashes\/([^/]+)/)?.[1] ?? null;
+  const activeTreeMatch = pathname.match(
+    /^\/stashes\/([^/]+)\/(sessions|folders|p|f|skills)(?:\/|$)/
+  );
+  const activeTreeStashId = activeTreeMatch?.[1] ?? null;
+  const activeTreeSection: SidebarSection | null =
+    activeTreeMatch?.[2] === "sessions"
+      ? "sessions"
+      : activeTreeMatch
+        ? "wiki"
+        : null;
   const [mine, setMine] = useState<Workspace[]>([]);
   const [shared, setShared] = useState<Workspace[]>([]);
-  const [openStashes, setOpenStashes] = useState<Record<string, boolean>>({});
+  const [openStashes, setOpenStashes] = useState<Record<string, boolean>>(() =>
+    readOpenMap(OPEN_STASHES_KEY)
+  );
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
+    readOpenMap(OPEN_SECTIONS_KEY)
+  );
   const [spines, setSpines] = useState<Record<string, StashSpine>>({});
 
   useEffect(() => {
@@ -301,31 +372,87 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
       .catch(() => {});
     listPublicWorkspaces()
       .then((r) => {
-        if (!user) return;
-        setShared((r.workspaces ?? []).filter((w) => w.creator_id !== user.id).slice(0, 6));
+        if (!userId) return;
+        setShared((r.workspaces ?? []).filter((w) => w.creator_id !== userId).slice(0, 6));
       })
       .catch(() => {});
-  }, [user?.id]);
+  }, [userId]);
+
+  const setOpenStash = useCallback((stashId: string, open: boolean) => {
+    setOpenStashes((current) => {
+      const next = { ...current };
+      if (open) {
+        next[stashId] = true;
+      } else {
+        delete next[stashId];
+      }
+      writeOpenMap(OPEN_STASHES_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const setOpenSection = useCallback((
+    stashId: string,
+    section: SidebarSection,
+    open: boolean
+  ) => {
+    setOpenSections((current) => {
+      const next = { ...current };
+      const key = sectionKey(stashId, section);
+      if (open) {
+        next[key] = true;
+      } else {
+        delete next[key];
+      }
+      writeOpenMap(OPEN_SECTIONS_KEY, next);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
-    const m = pathname.match(/^\/stashes\/([^/]+)/);
-    if (m?.[1]) {
-      setOpenStashes((s) => ({ ...s, [m[1]]: true }));
-      if (!spines[m[1]]) {
-        getStashSpine(m[1])
-          .then((sp) => setSpines((all) => ({ ...all, [m[1]]: sp })))
-          .catch(() => {});
-      }
-    }
-  }, [pathname, spines]);
+    const openIds = Object.keys(openStashes).filter((stashId) => openStashes[stashId]);
+    if (activeTreeStashId) openIds.push(activeTreeStashId);
 
-  function handleOpen(stashId: string) {
-    setOpenStashes((s) => ({ ...s, [stashId]: true }));
-    if (!spines[stashId]) {
-      getStashSpine(stashId)
-        .then((sp) => setSpines((all) => ({ ...all, [stashId]: sp })))
-        .catch(() => {});
-    }
+    Array.from(new Set(openIds))
+      .filter((stashId) => !spines[stashId])
+      .forEach((stashId) => {
+        getStashSpine(stashId)
+          .then((sp) => setSpines((all) => ({ ...all, [stashId]: sp })))
+          .catch(() => {});
+      });
+  }, [activeTreeStashId, openStashes, spines]);
+
+  function getOpenSections(stashId: string): Record<SidebarSection, boolean> {
+    return {
+      sessions:
+        !!openSections[sectionKey(stashId, "sessions")] ||
+        (activeTreeStashId === stashId && activeTreeSection === "sessions"),
+      wiki:
+        !!openSections[sectionKey(stashId, "wiki")] ||
+        (activeTreeStashId === stashId && activeTreeSection === "wiki"),
+    };
+  }
+
+  function isStashOpen(stashId: string): boolean {
+    return !!openStashes[stashId] || activeTreeStashId === stashId;
+  }
+
+  function handleStashOpenChange(stashId: string, open: boolean) {
+    if (open && activeTreeStashId === stashId && !openStashes[stashId]) return;
+    setOpenStash(stashId, open);
+  }
+
+  function handleSectionOpenChange(
+    stashId: string,
+    section: SidebarSection,
+    open: boolean
+  ) {
+    const isRouteOpen =
+      activeTreeStashId === stashId &&
+      activeTreeSection === section &&
+      !openSections[sectionKey(stashId, section)];
+    if (open && isRouteOpen) return;
+    setOpenSection(stashId, section, open);
   }
 
   const targetStashId = activeStashId ?? mine[0]?.id ?? null;
@@ -410,8 +537,12 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
                 key={s.id}
                 stash={{ ...s, shared: true }}
                 spine={spines[s.id] ?? null}
-                defaultOpen={!!openStashes[s.id]}
-                onOpen={() => handleOpen(s.id)}
+                open={isStashOpen(s.id)}
+                onOpenChange={(open) => handleStashOpenChange(s.id, open)}
+                openSections={getOpenSections(s.id)}
+                onSectionOpenChange={(section, open) =>
+                  handleSectionOpenChange(s.id, section, open)
+                }
                 pathname={pathname}
               />
             ))}
@@ -437,8 +568,12 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
             key={s.id}
             stash={s}
             spine={spines[s.id] ?? null}
-            defaultOpen={!!openStashes[s.id]}
-            onOpen={() => handleOpen(s.id)}
+            open={isStashOpen(s.id)}
+            onOpenChange={(open) => handleStashOpenChange(s.id, open)}
+            openSections={getOpenSections(s.id)}
+            onSectionOpenChange={(section, open) =>
+              handleSectionOpenChange(s.id, section, open)
+            }
             pathname={pathname}
           />
         ))}


### PR DESCRIPTION
## What changed

- Default stash sidebar trees to collapsed for a fresh login.
- Remember explicitly opened stashes and top-level `Sessions` / `Wiki` sections in `localStorage`.
- Keep deep links usable by opening the relevant branch for session/wiki routes without turning the stash landing page into an expanded tree by default.
- Add focused regression tests for fresh state, restored state, stash landing routes, and deep links.
- Add the missing `@testing-library/dom` peer dependency used by the React Testing Library tests.

## Why

Large workspaces were overwhelming because every stash exposed its full `Sessions` and `Wiki` structure immediately. This matches the Notion-style sidebar model more closely: nested content is available behind toggles, and the sidebar stays clean by default.

## Screenshot

![stash-sidebar-collapsed-verified.png](https://github.com/user-attachments/assets/1953b5ed-534e-4a55-8f51-0dd0b10348a5)

## Validation

- `npm run lint -- src/components/AppSidebar.tsx src/components/AppSidebar.test.tsx`
- `npm run test`
- `npm run build`
- Playwright browser smoke check with mocked API data
