### PR TITLE
[codex] Add session titles and sidebar navigation targets

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -68,6 +68,7 @@ class Settings:
     # --- LLM (Anthropic, for Ask-the-stash agent) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+    SESSION_TITLE_MODEL: str = os.getenv("SESSION_TITLE_MODEL", "claude-haiku-4-5-20251001")
     ASK_MAX_TURNS: int = int(os.getenv("ASK_MAX_TURNS", "8"))
 
 

--- a/backend/migrations/versions/0036_unify_sharing_and_permissions.py
+++ b/backend/migrations/versions/0036_unify_sharing_and_permissions.py
@@ -33,6 +33,7 @@ depends_on = None
 
 def upgrade() -> None:
     import logging
+
     log = logging.getLogger("alembic.migration.0036")
 
     def step(msg: str) -> None:
@@ -143,7 +144,9 @@ def upgrade() -> None:
     )
 
     step("3c. collapse permission enum to (view, edit)")
-    op.execute("UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')")
+    op.execute(
+        "UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')"
+    )
     op.execute("ALTER TABLE share_links DROP CONSTRAINT IF EXISTS share_links_permission_check")
     op.execute(
         "ALTER TABLE share_links ADD CONSTRAINT share_links_permission_check "
@@ -201,7 +204,9 @@ def upgrade() -> None:
     # 5. workspace_members.role → owner/editor/viewer
     # ──────────────────────────────────────────────────────────────────
     step("5a. DROP workspace_members role check")
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     step("5b. UPDATE roles admin->owner")
     op.execute("UPDATE workspace_members SET role = 'owner' WHERE role IN ('admin', 'owner')")
     step("5c. UPDATE roles other->editor")
@@ -259,12 +264,22 @@ def downgrade() -> None:
     # Schema-only restore. The blob and metadata mappings can't be
     # round-tripped — this just gets the columns back so the old code
     # boots.
-    op.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
+    op.execute(
+        "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
 
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     op.execute(
         "ALTER TABLE workspace_members ADD CONSTRAINT workspace_members_role_check "
         "CHECK (role IN ('owner', 'admin', 'member'))"

--- a/backend/migrations/versions/0037_session_titles.py
+++ b/backend/migrations/versions/0037_session_titles.py
@@ -1,0 +1,29 @@
+"""Cache AI-generated session titles.
+
+Revision ID: 0037
+Revises: 0036
+"""
+
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE session_titles (
+            workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            session_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (workspace_id, session_id)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE session_titles")

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
+
 from ..auth import get_current_user
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, TableResponse

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -40,6 +40,7 @@ from ..models import (
 from ..services import (
     ask_service,
     memory_service,
+    session_title_service,
     skill_service,
     stash_service,
     storage_service,
@@ -205,11 +206,13 @@ async def revoke_stash_invite_token(
 async def _spine_sessions(stash_id: UUID) -> list[dict]:
     """Sessions in this workspace, sourced from history_events rows."""
     sessions = await memory_service.list_workspace_sessions(stash_id)
+    titles = await session_title_service.ensure_session_titles(stash_id, sessions)
     return [
         {
             "session_id": s["session_id"],
-            "title": s["session_id"],
+            "title": titles[s["session_id"]],
             "agent_name": s["agent_name"] or "",
+            "event_count": int(s["event_count"] or 0),
             "size_bytes": int(s["size_bytes"] or 0),
             "last_at": s["last_at"],
             "updated_at": s["last_at"],

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -212,10 +212,7 @@ async def get_folder_contents(
             }
             for r in subfolders
         ],
-        "pages": [
-            {"id": str(r["id"]), "name": r["name"]}
-            for r in pages
-        ],
+        "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],
         "files": file_payload,
     }
 

--- a/backend/services/discover_service.py
+++ b/backend/services/discover_service.py
@@ -49,7 +49,10 @@ async def list_catalog(
     cursor: str | None = None,
 ) -> tuple[list[dict], str | None]:
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')", "w.discoverable = true"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')",
+        "w.discoverable = true",
+    ]
     args: list = []
     idx = 1
 
@@ -115,7 +118,8 @@ async def get_featured() -> list[dict]:
 async def get_public_detail(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     ws_row = await pool.fetchrow(
-        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') " "AND w.discoverable = true",
+        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') "
+        "AND w.discoverable = true",
         workspace_id,
     )
     if not ws_row:
@@ -160,7 +164,9 @@ async def list_admin_candidates(
 ) -> list[dict]:
     """List public workspaces available to curate into Discover."""
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"
+    ]
     args: list = []
     idx = 1
 

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -214,16 +214,25 @@ async def list_workspace_sessions(workspace_id: UUID) -> list[dict]:
     list — replaces a SELECT against session_transcripts."""
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT session_id, "
-        "       MAX(agent_name) AS agent_name, "
-        "       COUNT(*)::INT AS event_count, "
-        "       SUM(LENGTH(content))::BIGINT AS size_bytes, "
-        "       MIN(created_at) AS started_at, "
-        "       MAX(created_at) AS last_at "
-        "FROM history_events "
-        "WHERE workspace_id = $1 AND session_id IS NOT NULL "
-        "GROUP BY session_id "
-        "ORDER BY last_at DESC",
+        "WITH history_sessions AS ("
+        "  SELECT session_id, "
+        "         MAX(agent_name) AS agent_name, "
+        "         COUNT(*)::INT AS event_count, "
+        "         SUM(LENGTH(content))::BIGINT AS size_bytes, "
+        "         MIN(created_at) AS started_at, "
+        "         MAX(created_at) AS last_at "
+        "  FROM history_events "
+        "  WHERE workspace_id = $1 AND session_id IS NOT NULL "
+        "  GROUP BY session_id"
+        ") "
+        "SELECT history_sessions.*, session_meta.summary AS stash_summary "
+        "FROM history_sessions "
+        "LEFT JOIN sessions session_meta "
+        "  ON session_meta.workspace_id = $1 "
+        "  AND session_meta.session_id = history_sessions.session_id "
+        "  AND session_meta.summary IS NOT NULL "
+        "  AND session_meta.summary <> '' "
+        "ORDER BY history_sessions.last_at DESC",
         workspace_id,
     )
     return [dict(r) for r in rows]

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -77,6 +77,7 @@ async def set_summary(session_row_id: UUID, summary: str, status: str = "ready")
 
 async def set_files_touched(session_row_id: UUID, files: list[str]) -> None:
     import json
+
     pool = get_pool()
     await pool.execute(
         "UPDATE sessions SET files_touched = $1::jsonb WHERE id = $2",

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -1,0 +1,156 @@
+"""AI-generated labels for agent sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from uuid import UUID
+
+from ..config import settings
+from ..database import get_pool
+
+MAX_BATCH_SIZE = 10
+MAX_SOURCE_CHARS = 1_400
+
+
+def _source_hash(session: dict) -> str:
+    summary = session.get("stash_summary") or ""
+    last_at = session.get("last_at")
+    if hasattr(last_at, "isoformat"):
+        last_at = last_at.isoformat()
+    raw = f"{session['session_id']}|{session.get('event_count')}|{last_at}|{summary}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _clean_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _json_text(text: str) -> str:
+    text = text.strip()
+    if not text.startswith("```"):
+        return text
+
+    lines = text.splitlines()
+    if len(lines) < 3 or not lines[-1].startswith("```"):
+        return text
+    return "\n".join(lines[1:-1]).strip()
+
+
+async def ensure_session_titles(workspace_id: UUID, sessions: list[dict]) -> dict[str, str]:
+    if not sessions:
+        return {}
+
+    pool = get_pool()
+    session_ids = [s["session_id"] for s in sessions]
+    cache_rows = await pool.fetch(
+        "SELECT session_id, title, source_hash FROM session_titles "
+        "WHERE workspace_id = $1 AND session_id = ANY($2::text[])",
+        workspace_id,
+        session_ids,
+    )
+    cached = {r["session_id"]: dict(r) for r in cache_rows}
+
+    stale = []
+    for session in sessions:
+        source_hash = _source_hash(session)
+        cached_row = cached.get(session["session_id"])
+        if not cached_row or cached_row["source_hash"] != source_hash:
+            stale.append({**session, "source_hash": source_hash})
+
+    for i in range(0, len(stale), MAX_BATCH_SIZE):
+        batch = stale[i : i + MAX_BATCH_SIZE]
+        candidates = await _build_candidates(workspace_id, batch)
+        titles = await _generate_titles(candidates)
+        rows = [
+            (workspace_id, c["session_id"], titles[c["session_id"]], c["source_hash"])
+            for c in candidates
+        ]
+        await pool.executemany(
+            "INSERT INTO session_titles (workspace_id, session_id, title, source_hash) "
+            "VALUES ($1, $2, $3, $4) "
+            "ON CONFLICT (workspace_id, session_id) DO UPDATE SET "
+            "title = EXCLUDED.title, source_hash = EXCLUDED.source_hash, updated_at = now()",
+            rows,
+        )
+        for workspace_id_value, session_id, title, source_hash in rows:
+            cached[session_id] = {
+                "workspace_id": workspace_id_value,
+                "session_id": session_id,
+                "title": title,
+                "source_hash": source_hash,
+            }
+
+    return {session_id: cached[session_id]["title"] for session_id in session_ids}
+
+
+async def _build_candidates(workspace_id: UUID, sessions: list[dict]) -> list[dict]:
+    return [
+        {
+            "session_id": session["session_id"],
+            "source_hash": session["source_hash"],
+            "source": await _session_source(workspace_id, session),
+        }
+        for session in sessions
+    ]
+
+
+async def _session_source(workspace_id: UUID, session: dict) -> str:
+    summary = _clean_text(session.get("stash_summary") or "")
+    if summary:
+        return summary[:MAX_SOURCE_CHARS]
+
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT event_type, tool_name, content FROM history_events "
+        "WHERE workspace_id = $1 AND session_id = $2 AND content <> '' "
+        "ORDER BY created_at ASC, id ASC LIMIT 14",
+        workspace_id,
+        session["session_id"],
+    )
+    parts = []
+    for row in rows:
+        label = row["event_type"] or "event"
+        if row["tool_name"]:
+            label = f"{label}:{row['tool_name']}"
+        content = _clean_text(row["content"] or "")
+        if content:
+            parts.append(f"{label}: {content[:500]}")
+    return "\n".join(parts)[:MAX_SOURCE_CHARS]
+
+
+async def _generate_titles(candidates: list[dict]) -> dict[str, str]:
+    if not settings.ANTHROPIC_API_KEY:
+        raise RuntimeError("ANTHROPIC_API_KEY is required to generate session titles")
+
+    from anthropic import AsyncAnthropic
+
+    client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+    payload = [{"session_id": c["session_id"], "source": c["source"]} for c in candidates]
+    response = await client.messages.create(
+        model=settings.SESSION_TITLE_MODEL,
+        max_tokens=900,
+        system=(
+            "Write concise labels for coding agent sessions. Each label should be "
+            "specific, 3 to 8 words, and must not include session IDs, agent IDs, "
+            "hashes, or the word 'session'. Return raw JSON only, with no markdown."
+        ),
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Return a JSON array of objects shaped like "
+                    '{"session_id": "...", "title": "..."}. Sessions:\n' + json.dumps(payload)
+                ),
+            }
+        ],
+    )
+    text = "\n".join(
+        block.text for block in response.content if getattr(block, "type", "") == "text"
+    )
+    parsed = json.loads(_json_text(text))
+    titles = {item["session_id"]: _clean_text(item["title"]) for item in parsed}
+    missing = [c["session_id"] for c in candidates if c["session_id"] not in titles]
+    if missing:
+        raise ValueError(f"Missing generated titles for sessions: {', '.join(missing)}")
+    return titles

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -51,11 +51,16 @@ async def ensure_session_titles(workspace_id: UUID, sessions: list[dict]) -> dic
     )
     cached = {r["session_id"]: dict(r) for r in cache_rows}
 
+    titles = {}
     stale = []
     for session in sessions:
         source_hash = _source_hash(session)
         cached_row = cached.get(session["session_id"])
-        if not cached_row or cached_row["source_hash"] != source_hash:
+
+        titles[session["session_id"]] = cached_row["title"] if cached_row else session["session_id"]
+        if cached_row and cached_row["source_hash"] == source_hash:
+            continue
+        if settings.ANTHROPIC_API_KEY:
             stale.append({**session, "source_hash": source_hash})
 
     for i in range(0, len(stale), MAX_BATCH_SIZE):
@@ -80,8 +85,9 @@ async def ensure_session_titles(workspace_id: UUID, sessions: list[dict]) -> dic
                 "title": title,
                 "source_hash": source_hash,
             }
+            titles[session_id] = title
 
-    return {session_id: cached[session_id]["title"] for session_id in session_ids}
+    return {session_id: titles[session_id] for session_id in session_ids}
 
 
 async def _build_candidates(workspace_id: UUID, sessions: list[dict]) -> list[dict]:

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -18,7 +18,6 @@ from uuid import UUID
 from ..config import settings
 from ..database import get_pool
 
-
 VALID_TARGETS = {"workspace", "session", "page", "folder", "file"}
 VALID_PERMISSIONS = {"view", "edit"}
 
@@ -145,12 +144,14 @@ def _parse_deck(narrative_md: str) -> list[dict] | None:
                 title = stripped[2:].strip()
                 body_lines = lines[j + 1 :]
                 break
-        slides.append({
-            "index": i,
-            "title": title or f"Slide {i + 1}",
-            "kicker": f"{i + 1:02d} / {len(parts):02d}",
-            "body": "\n".join(body_lines).strip(),
-        })
+        slides.append(
+            {
+                "index": i,
+                "title": title or f"Slide {i + 1}",
+                "kicker": f"{i + 1:02d} / {len(parts):02d}",
+                "body": "\n".join(body_lines).strip(),
+            }
+        )
     return slides
 
 
@@ -256,8 +257,7 @@ async def _session_projection(session_row_id: UUID) -> dict:
         "events": [
             {
                 "id": str(e["id"]),
-                "role": "user" if e["event_type"] == "user_message"
-                        else "assistant",
+                "role": "user" if e["event_type"] == "user_message" else "assistant",
                 "content": e["content"] or "",
                 "tool_name": e["tool_name"],
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
@@ -315,7 +315,9 @@ async def _folder_projection(folder_id: UUID) -> dict:
         "folder": {
             "id": str(folder["id"]),
             "name": folder["name"],
-            "parent_folder_id": str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None,
+            "parent_folder_id": (
+                str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None
+            ),
         },
         "subfolders": [{"id": str(r["id"]), "name": r["name"]} for r in subfolders],
         "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -526,15 +526,13 @@ async def set_member_role(
     if target_role == "owner" and role != "owner":
         # Prevent demoting the last owner.
         owner_count = await pool.fetchval(
-            "SELECT COUNT(*) FROM workspace_members "
-            "WHERE workspace_id = $1 AND role = 'owner'",
+            "SELECT COUNT(*) FROM workspace_members " "WHERE workspace_id = $1 AND role = 'owner'",
             workspace_id,
         )
         if owner_count <= 1:
             return False
     await pool.execute(
-        "UPDATE workspace_members SET role = $1 "
-        "WHERE workspace_id = $2 AND user_id = $3",
+        "UPDATE workspace_members SET role = $1 " "WHERE workspace_id = $2 AND user_id = $3",
         role,
         workspace_id,
         target_user_id,

--- a/backend/tests/test_stash_spine_sessions.py
+++ b/backend/tests/test_stash_spine_sessions.py
@@ -14,6 +14,42 @@ def test_session_title_json_text_accepts_fenced_json():
 
 
 @pytest.mark.asyncio
+async def test_session_titles_use_session_ids_when_generation_is_not_configured(monkeypatch):
+    workspace_id = uuid4()
+    last_at = datetime(2026, 5, 11, tzinfo=UTC)
+
+    class Pool:
+        async def fetch(self, *args):
+            return []
+
+        async def executemany(self, *args):
+            raise AssertionError("placeholder titles should not be cached")
+
+    async def generate_titles(candidates):
+        raise AssertionError("generation should not run without an Anthropic key")
+
+    monkeypatch.setattr(session_title_service, "get_pool", lambda: Pool())
+    monkeypatch.setattr(session_title_service.settings, "ANTHROPIC_API_KEY", None)
+    monkeypatch.setattr(session_title_service, "_generate_titles", generate_titles)
+
+    titles = await session_title_service.ensure_session_titles(
+        workspace_id,
+        [
+            {
+                "session_id": "agent-123",
+                "agent_name": "codex",
+                "event_count": 9,
+                "size_bytes": 2048,
+                "last_at": last_at,
+                "stash_summary": "",
+            }
+        ],
+    )
+
+    assert titles == {"agent-123": "agent-123"}
+
+
+@pytest.mark.asyncio
 async def test_spine_sessions_use_generated_titles(monkeypatch):
     workspace_id = uuid4()
 

--- a/backend/tests/test_stash_spine_sessions.py
+++ b/backend/tests/test_stash_spine_sessions.py
@@ -1,0 +1,46 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from backend.routers import stashes
+from backend.services import session_title_service
+
+
+def test_session_title_json_text_accepts_fenced_json():
+    text = '```json\n[{"session_id": "s1", "title": "Fix Auth"}]\n```'
+
+    assert session_title_service._json_text(text) == '[{"session_id": "s1", "title": "Fix Auth"}]'
+
+
+@pytest.mark.asyncio
+async def test_spine_sessions_use_generated_titles(monkeypatch):
+    workspace_id = uuid4()
+
+    async def list_workspace_sessions(stash_id):
+        assert stash_id == workspace_id
+        return [
+            {
+                "session_id": "agent-123",
+                "agent_name": "codex",
+                "event_count": 9,
+                "size_bytes": 2048,
+                "last_at": datetime(2026, 5, 11, tzinfo=UTC),
+            }
+        ]
+
+    async def ensure_session_titles(stash_id, sessions):
+        assert stash_id == workspace_id
+        assert sessions[0]["session_id"] == "agent-123"
+        return {"agent-123": "Add scrollable session list"}
+
+    monkeypatch.setattr(stashes.memory_service, "list_workspace_sessions", list_workspace_sessions)
+    monkeypatch.setattr(
+        stashes.session_title_service, "ensure_session_titles", ensure_session_titles
+    )
+
+    sessions = await stashes._spine_sessions(workspace_id)
+
+    assert sessions[0]["title"] == "Add scrollable session list"
+    assert sessions[0]["event_count"] == 9
+    assert sessions[0]["session_id"] == "agent-123"

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,7 +6,7 @@ import Header from "../../components/Header";
 import { useAuth } from "../../hooks/useAuth";
 import { getToken, setToken, listMyWorkspaces } from "../../lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+const API_BASE = "";
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
 // FastAPI returns `detail` as either a string or an array of validation errors
@@ -91,7 +91,7 @@ function LoginPageInner() {
       const body = mode === "login"
         ? { name, password }
         : { name, display_name: name, description: "", password };
-      const res = await fetch(`${API_URL}/api/v1/users/${endpoint}`, {
+      const res = await fetch(`${API_BASE}/api/v1/users/${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -107,7 +107,7 @@ function LoginPageInner() {
 
       if (cliSession) {
         const approveRes = await fetch(
-          `${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
+          `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
           {
             method: "POST",
             headers: { Authorization: `Bearer ${data.api_key}` },
@@ -229,7 +229,7 @@ function AuthorizeCliPanel({
       const token = getToken();
       if (!token) throw new Error("Not signed in");
       const res = await fetch(
-        `${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
+        `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
         {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/app/stashes/[stashId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/page.tsx
@@ -142,8 +142,8 @@ export default function StashHomePage() {
   const sessions: CardItem[] = (spine?.sessions ?? []).slice(0, 6).map((s) => ({
     href: `/stashes/${stashId}/sessions/${encodeURIComponent(s.session_id)}`,
     icon: <SessionsIcon />,
-    title: `#${s.session_id.length > 28 ? s.session_id.slice(0, 28) + "…" : s.session_id}`,
-    subtitle: `${s.agent_name} · ${formatBytes(s.size_bytes)}`,
+    title: s.title,
+    subtitle: `${s.agent_name} · ${s.event_count} events · ${formatBytes(s.size_bytes)}`,
   }));
 
   // Root-level wiki contents only. Nested folders/pages/files surface

--- a/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
@@ -7,6 +7,7 @@ import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
   getSessionEvents,
+  getStashSpine,
   getStashTranscript,
   getWorkspace,
   type SessionEvent,
@@ -94,19 +95,30 @@ export default function SessionViewerPage() {
 
   const [stash, setStash] = useState<Workspace | null>(null);
   const [transcript, setTranscript] = useState<SessionTranscript | null>(null);
+  const [sessionTitle, setSessionTitle] = useState("");
   const [turns, setTurns] = useState<MessageTurn[]>([]);
   const [error, setError] = useState("");
 
   useBreadcrumbs(
-    [{ label: "Sessions" }, { label: `#${sessionId}` }],
-    `${stashId}/session/${sessionId}`
+    [
+      { label: "Sessions", href: `/stashes/${stashId}/sessions` },
+      { label: sessionTitle || "Session" },
+    ],
+    `${stashId}/session/${sessionId}/${sessionTitle}`
   );
 
   const load = useCallback(async () => {
     try {
-      setStash(await getWorkspace(stashId));
-      const tx = await getStashTranscript(stashId, sessionId);
+      const [workspace, tx, spine] = await Promise.all([
+        getWorkspace(stashId),
+        getStashTranscript(stashId, sessionId),
+        getStashSpine(stashId),
+      ]);
+      setStash(workspace);
       setTranscript(tx);
+      setSessionTitle(
+        spine.sessions.find((session) => session.session_id === sessionId)?.title ?? ""
+      );
       const events = await getSessionEvents(stashId, sessionId);
       setTurns(events.map(eventToTurn));
     } catch (e) {
@@ -136,7 +148,7 @@ export default function SessionViewerPage() {
           <div className="mb-5 flex items-start justify-between gap-4 border-b border-border pb-4">
             <div className="min-w-0">
               <h1 className="font-display text-[24px] font-bold tracking-tight text-foreground">
-                #{sessionId.replace(/^acme-/, "")}
+                {sessionTitle || "Session"}
               </h1>
               {transcript && (
                 <p className="mt-1.5 text-[11.5px] text-muted">

--- a/frontend/src/app/stashes/[stashId]/sessions/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/sessions/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import AppShell from "../../../../components/AppShell";
+import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
+import { useAuth } from "../../../../hooks/useAuth";
+import { getStashSpine, getWorkspace, type StashSpine } from "../../../../lib/api";
+import type { Workspace } from "../../../../lib/types";
+
+export default function SessionsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const stashId = params.stashId as string;
+  const { user, loading, logout } = useAuth();
+
+  const [stash, setStash] = useState<Workspace | null>(null);
+  const [spine, setSpine] = useState<StashSpine | null>(null);
+  const [error, setError] = useState("");
+
+  useBreadcrumbs([{ label: "Sessions" }], `${stashId}/sessions`);
+
+  const load = useCallback(async () => {
+    try {
+      const [workspace, nextSpine] = await Promise.all([
+        getWorkspace(stashId),
+        getStashSpine(stashId),
+      ]);
+      setStash(workspace);
+      setSpine(nextSpine);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load sessions");
+    }
+  }, [stashId]);
+
+  useEffect(() => {
+    if (user) load();
+  }, [user, load]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  if (loading)
+    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (!user) return null;
+
+  const sessions = spine?.sessions ?? [];
+
+  return (
+    <AppShell user={user} onLogout={logout}>
+      <div className="scroll-thin flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-4xl px-10 py-8">
+          <div className="mb-5 border-b border-border pb-4">
+            <h1 className="font-display text-[24px] font-bold tracking-tight text-foreground">
+              Sessions
+            </h1>
+            <p className="mt-1.5 text-[12px] text-muted">
+              {sessions.length} transcript{sessions.length === 1 ? "" : "s"}
+              {stash ? <span> · in <span className="text-foreground">{stash.name}</span></span> : null}
+            </p>
+          </div>
+
+          {error && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {sessions.length > 0 ? (
+            <div className="overflow-hidden rounded-lg border border-border bg-base">
+              {sessions.map((session) => (
+                <Link
+                  key={session.session_id}
+                  href={`/stashes/${stashId}/sessions/${encodeURIComponent(session.session_id)}`}
+                  className="flex items-start gap-3 border-b border-border px-4 py-3 transition-colors last:border-b-0 hover:bg-raised"
+                >
+                  <span className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-[var(--color-brand-50)] text-[15px] text-[var(--color-brand-700)]">
+                    💬
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[14px] font-semibold text-foreground">
+                      {session.title}
+                    </span>
+                    <span className="mt-1 block truncate text-[11.5px] text-muted">
+                      {[
+                        session.agent_name,
+                        `${session.event_count} events`,
+                        relativeTime(session.last_at),
+                        formatBytes(session.size_bytes),
+                      ]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-md border border-dashed border-border px-4 py-8 text-center text-sm text-muted">
+              No sessions yet.
+            </div>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function formatBytes(b: number): string {
+  if (!b) return "0 B";
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppSidebar from "./AppSidebar";
@@ -78,12 +78,6 @@ const emptySpine = {
   },
 };
 
-function detailsFor(label: string): HTMLDetailsElement {
-  const details = screen.getByText(label).closest("details");
-  if (!details) throw new Error(`No details element for ${label}`);
-  return details as HTMLDetailsElement;
-}
-
 describe("AppSidebar tree expansion", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -104,9 +98,9 @@ describe("AppSidebar tree expansion", () => {
 
     await screen.findByText("Demo Stash");
 
-    expect(detailsFor("Demo Stash")).not.toHaveAttribute("open");
-    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
-    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    expect(screen.getByLabelText("Expand stash")).toBeInTheDocument();
+    expect(screen.queryByText("Sessions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Wiki")).not.toBeInTheDocument();
     expect(getStashSpine).not.toHaveBeenCalled();
   });
 
@@ -142,10 +136,61 @@ describe("AppSidebar tree expansion", () => {
 
     await screen.findByText("Demo Stash");
 
-    await waitFor(() => expect(detailsFor("Demo Stash")).toHaveAttribute("open"));
-    expect(detailsFor("Sessions")).toHaveAttribute("open");
-    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    await waitFor(() => expect(screen.getByLabelText("Collapse stash")).toBeInTheDocument());
+    expect(screen.getByLabelText("Collapse sessions")).toBeInTheDocument();
+    expect(screen.getByLabelText("Expand wiki")).toBeInTheDocument();
     expect(getStashSpine).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("gives section rows separate navigation and disclosure targets", async () => {
+    localStorage.setItem("stash_sidebar_open_stashes", "ws-1");
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+    const sessionsLink = await screen.findByRole("link", { name: /Sessions/ });
+    expect(sessionsLink).toHaveAttribute("href", "/stashes/ws-1/sessions");
+
+    fireEvent.click(screen.getByLabelText("Expand sessions"));
+
+    expect(screen.getByLabelText("Collapse sessions")).toBeInTheDocument();
+    expect(sessionsLink).toHaveAttribute("href", "/stashes/ws-1/sessions");
+  });
+
+  it("shows generated session titles with compact timestamps", async () => {
+    const lastAt = "2026-05-11T18:24:00Z";
+    const timestamp = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(lastAt));
+    vi.mocked(getStashSpine).mockResolvedValue({
+      ...emptySpine,
+      sessions: [
+        {
+          session_id: "agent-1",
+          title: "Refine Sidebar Session Titles",
+          agent_name: "codex",
+          event_count: 12,
+          size_bytes: 1024,
+          last_at: lastAt,
+          updated_at: lastAt,
+        },
+      ],
+    });
+    localStorage.setItem("stash_sidebar_open_stashes", "ws-1");
+    localStorage.setItem("stash_sidebar_open_sections", "ws-1:sessions");
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    const sessionLink = await screen.findByRole("link", {
+      name: /Refine Sidebar Session Titles/,
+    });
+
+    expect(sessionLink).toHaveAttribute("href", "/stashes/ws-1/sessions/agent-1");
+    expect(sessionLink).toHaveAttribute("title", `Refine Sidebar Session Titles - ${timestamp}`);
+    expect(screen.getByText(timestamp)).toBeInTheDocument();
   });
 
   it("keeps the stash landing route collapsed without saved state", async () => {
@@ -155,9 +200,9 @@ describe("AppSidebar tree expansion", () => {
 
     await screen.findByText("Demo Stash");
 
-    expect(detailsFor("Demo Stash")).not.toHaveAttribute("open");
-    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
-    expect(detailsFor("Wiki")).not.toHaveAttribute("open");
+    expect(screen.getByLabelText("Expand stash")).toBeInTheDocument();
+    expect(screen.queryByText("Sessions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Wiki")).not.toBeInTheDocument();
     expect(getStashSpine).not.toHaveBeenCalled();
   });
 
@@ -168,9 +213,9 @@ describe("AppSidebar tree expansion", () => {
 
     await screen.findByText("Demo Stash");
 
-    await waitFor(() => expect(detailsFor("Demo Stash")).toHaveAttribute("open"));
-    expect(detailsFor("Sessions")).not.toHaveAttribute("open");
-    expect(detailsFor("Wiki")).toHaveAttribute("open");
+    await waitFor(() => expect(screen.getByLabelText("Collapse stash")).toBeInTheDocument());
+    expect(screen.getByLabelText("Expand sessions")).toBeInTheDocument();
+    expect(screen.getByLabelText("Collapse wiki")).toBeInTheDocument();
     expect(localStorage.getItem("stash_sidebar_open_stashes")).toBeNull();
     expect(localStorage.getItem("stash_sidebar_open_sections")).toBeNull();
   });

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -68,6 +68,15 @@ function sectionKey(stashId: string, section: SidebarSection): string {
   return `${stashId}:${section}`;
 }
 
+function formatSessionTimestamp(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
 function Chevron() {
   return (
     <svg
@@ -88,29 +97,134 @@ function NavRow({
   href,
   icon,
   label,
+  title,
   active,
   trailing,
 }: {
   href: string;
   icon: React.ReactNode;
   label: string;
+  title?: string;
   active?: boolean;
   trailing?: React.ReactNode;
 }) {
   return (
     <Link
       href={href}
+      title={title ?? label}
       className={
-        "page-row flex items-center gap-2 rounded-md px-2 py-1 text-[13px] transition-colors " +
+        "page-row flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-[13px] transition-colors " +
         (active
           ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
           : "text-dim hover:bg-raised hover:text-foreground")
       }
     >
-      <span className="flex h-4 w-4 items-center justify-center text-[14px]">{icon}</span>
-      <span className="flex-1 truncate">{label}</span>
+      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-[14px]">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
       {trailing}
     </Link>
+  );
+}
+
+function ChevronButton({
+  open,
+  onClick,
+  label,
+}: {
+  open: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        "flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-base " +
+        (open ? "rotate-90" : "")
+      }
+      aria-label={label}
+    >
+      <Chevron />
+    </button>
+  );
+}
+
+function SessionsBlock({
+  stash,
+  spine,
+  open,
+  onOpenChange,
+  pathname,
+}: {
+  stash: StashNode;
+  spine: StashSpine | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pathname: string;
+}) {
+  const href = `/stashes/${stash.id}/sessions`;
+  const active = pathname === href;
+
+  return (
+    <div className="text-[13px]">
+      <div
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-1 transition-colors " +
+          (active
+            ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
+            : "hover:bg-raised")
+        }
+      >
+        <ChevronButton
+          open={open}
+          onClick={() => onOpenChange(!open)}
+          label={open ? "Collapse sessions" : "Expand sessions"}
+        />
+        <Link href={href} className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
+            <SessionsIcon />
+          </span>
+          <span
+            className={
+              "flex-1 truncate font-medium " +
+              (active ? "text-[var(--color-brand-800)]" : "text-foreground")
+            }
+          >
+            Sessions
+          </span>
+          <span className="text-[10.5px] text-muted">{spine?.sessions.length ?? 0}</span>
+        </Link>
+      </div>
+      {open && (
+        <div className="ml-3 space-y-0.5 border-l border-border pl-2">
+          {spine?.sessions.map((s) => {
+            const sessionHref = `/stashes/${stash.id}/sessions/${encodeURIComponent(s.session_id)}`;
+            const sessionTimestamp = formatSessionTimestamp(s.last_at);
+            return (
+              <NavRow
+                key={s.session_id}
+                href={sessionHref}
+                icon={<SessionsIcon className="text-muted" />}
+                label={s.title}
+                title={`${s.title} - ${sessionTimestamp}`}
+                trailing={
+                  <span className="flex-shrink-0 text-[10.5px] text-muted">
+                    {sessionTimestamp}
+                  </span>
+                }
+                active={pathname === sessionHref}
+              />
+            );
+          })}
+          {(!spine || spine.sessions.length === 0) && (
+            <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -134,63 +248,51 @@ function StashTree({
   const isActive = pathname === `/stashes/${stash.id}`;
 
   return (
-    <details
-      open={open}
-      onToggle={(e) => onOpenChange(e.currentTarget.open)}
-      className="group/stash"
-    >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 text-[13px] hover:bg-raised">
-        <Chevron />
-        <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
-          <StashIcon />
-        </span>
+    <div className="group/stash">
+      <div
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-1 text-[13px] transition-colors " +
+          (isActive ? "bg-[var(--color-brand-50)]" : "hover:bg-raised")
+        }
+      >
+        <ChevronButton
+          open={open}
+          onClick={() => onOpenChange(!open)}
+          label={open ? "Collapse stash" : "Expand stash"}
+        />
         <Link
           href={`/stashes/${stash.id}`}
           className={
-            "flex-1 truncate font-medium " +
+            "flex min-w-0 flex-1 items-center gap-1.5 truncate font-medium " +
             (isActive ? "text-[var(--color-brand-800)]" : "text-foreground")
           }
         >
-          {stash.name}
+          <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
+            <StashIcon />
+          </span>
+          <span className="truncate">{stash.name}</span>
         </Link>
-      </summary>
-      <div className="ml-3 space-y-0.5 border-l border-border pl-2">
-        <details
-          open={openSections.sessions}
-          onToggle={(e) => onSectionOpenChange("sessions", e.currentTarget.open)}
-          className="text-[13px]"
-        >
-          <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
-            <Chevron />
-            <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
-              <SessionsIcon />
-            </span>
-            <span className="flex-1 truncate font-medium text-foreground">Sessions</span>
-            <span className="text-[10.5px] text-muted">{spine?.sessions.length ?? 0}</span>
-          </summary>
-          <div className="ml-3 space-y-0.5 border-l border-border pl-2">
-            {spine?.sessions.slice(0, 8).map((s) => (
-              <NavRow
-                key={s.session_id}
-                href={`/stashes/${stash.id}/sessions/${encodeURIComponent(s.session_id)}`}
-                icon={<span className="text-muted">#</span>}
-                label={s.session_id.length > 22 ? s.session_id.slice(0, 22) + "…" : s.session_id}
-              />
-            ))}
-            {(!spine || spine.sessions.length === 0) && (
-              <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
-            )}
-          </div>
-        </details>
-
-        <WikiBlock
-          stash={stash}
-          spine={spine}
-          open={openSections.wiki}
-          onOpenChange={(nextOpen) => onSectionOpenChange("wiki", nextOpen)}
-        />
       </div>
-    </details>
+      {open && (
+        <div className="ml-3 space-y-0.5 border-l border-border pl-2">
+          <SessionsBlock
+            stash={stash}
+            spine={spine}
+            open={openSections.sessions}
+            onOpenChange={(nextOpen) => onSectionOpenChange("sessions", nextOpen)}
+            pathname={pathname}
+          />
+
+          <WikiBlock
+            stash={stash}
+            spine={spine}
+            open={openSections.wiki}
+            onOpenChange={(nextOpen) => onSectionOpenChange("wiki", nextOpen)}
+            pathname={pathname}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -230,74 +332,90 @@ function FolderTreeNode({
   stashId,
   folderId,
   name,
+  pathname,
 }: {
   stashId: string;
   folderId: string;
   name: string;
+  pathname: string;
 }) {
   const [contents, setContents] = useState<FolderContents | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [open, setOpen] = useState(false);
+  const href = `/stashes/${stashId}/folders/${folderId}`;
+  const active = pathname === href;
+
+  function toggleOpen() {
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    if (!nextOpen || loaded) return;
+    setLoaded(true);
+    getFolderContents(stashId, folderId).then(setContents);
+  }
+
   return (
-    <details
-      className="text-[12.5px]"
-      onToggle={(e) => {
-        if ((e.target as HTMLDetailsElement).open && !loaded) {
-          setLoaded(true);
-          getFolderContents(stashId, folderId)
-            .then(setContents)
-            .catch(() => setContents({
-              folder: { id: folderId, name, parent_folder_id: null },
-              breadcrumbs: [],
-              subfolders: [],
-              pages: [],
-              files: [],
-            }));
+    <div className="text-[12.5px]">
+      <div
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-0.5 transition-colors " +
+          (active
+            ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
+            : "hover:bg-raised")
         }
-      }}
-    >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised">
-        <Chevron />
-        <span className="flex h-4 w-4 items-center justify-center text-muted">
-          <FolderIcon />
-        </span>
+      >
+        <ChevronButton
+          open={open}
+          onClick={toggleOpen}
+          label={open ? "Collapse folder" : "Expand folder"}
+        />
         <Link
-          href={`/stashes/${stashId}/folders/${folderId}`}
-          className="flex-1 truncate text-left text-foreground hover:text-[var(--color-brand-700)]"
+          href={href}
+          className={
+            "flex min-w-0 flex-1 items-center gap-1.5 text-left hover:text-[var(--color-brand-700)] " +
+            (active ? "text-[var(--color-brand-800)]" : "text-foreground")
+          }
         >
-          {name}
+          <span className="flex h-4 w-4 items-center justify-center text-muted">
+            <FolderIcon />
+          </span>
+          <span className="truncate">{name}</span>
         </Link>
-      </summary>
-      <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
-        {contents === null && loaded && (
-          <div className="px-2 py-1 text-[11px] italic text-muted">loading…</div>
-        )}
-        {contents?.subfolders.map((sub) => (
-          <FolderTreeNode
-            key={sub.id}
-            stashId={stashId}
-            folderId={sub.id}
-            name={sub.name}
-          />
-        ))}
-        {contents?.pages.map((p) => (
-          <NavRow
-            key={p.id}
-            href={`/stashes/${stashId}/p/${p.id}`}
-            icon={<PageIcon className="text-muted" />}
-            label={p.name}
-          />
-        ))}
-        {contents?.files.map((f) => (
-          <FileNavRow key={f.id} stashId={stashId} file={f} />
-        ))}
-        {contents &&
-          contents.subfolders.length === 0 &&
-          contents.pages.length === 0 &&
-          contents.files.length === 0 && (
-            <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
-          )}
       </div>
-    </details>
+      {open && (
+        <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
+          {contents === null && loaded && (
+            <div className="px-2 py-1 text-[11px] italic text-muted">loading…</div>
+          )}
+          {contents?.subfolders.map((sub) => (
+            <FolderTreeNode
+              key={sub.id}
+              stashId={stashId}
+              folderId={sub.id}
+              name={sub.name}
+              pathname={pathname}
+            />
+          ))}
+          {contents?.pages.map((p) => (
+            <NavRow
+              key={p.id}
+              href={`/stashes/${stashId}/p/${p.id}`}
+              icon={<PageIcon className="text-muted" />}
+              label={p.name}
+              active={pathname === `/stashes/${stashId}/p/${p.id}`}
+            />
+          ))}
+          {contents?.files.map((f) => (
+            <FileNavRow key={f.id} stashId={stashId} file={f} />
+          ))}
+          {contents &&
+            contents.subfolders.length === 0 &&
+            contents.pages.length === 0 &&
+            contents.files.length === 0 && (
+              <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
+            )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -306,11 +424,13 @@ function WikiBlock({
   spine,
   open,
   onOpenChange,
+  pathname,
 }: {
   stash: StashNode;
   spine: StashSpine | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  pathname: string;
 }) {
   const folders = spine?.wiki.folders ?? [];
   const pages = spine?.wiki.pages ?? [];
@@ -320,44 +440,51 @@ function WikiBlock({
   const rootFiles = files.filter((f) => !f.folder_id);
   const total = folders.length + pages.length + files.length;
   return (
-    <details
-      open={open}
-      onToggle={(e) => onOpenChange(e.currentTarget.open)}
-      className="text-[13px]"
-    >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
-        <Chevron />
+    <div className="text-[13px]">
+      <div className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
+        <ChevronButton
+          open={open}
+          onClick={() => onOpenChange(!open)}
+          label={open ? "Collapse wiki" : "Expand wiki"}
+        />
         <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
           <WikiIcon />
         </span>
         <span className="flex-1 truncate font-medium text-foreground">Wiki</span>
         <span className="text-[10.5px] text-muted">{total}</span>
-      </summary>
-      <div className="ml-3 space-y-0.5 border-l border-border pl-2">
-        {rootFolders.map((f) => (
-          <FolderTreeNode
-            key={f.id}
-            stashId={stash.id}
-            folderId={f.id}
-            name={f.name}
-          />
-        ))}
-        {rootPages.slice(0, 10).map((p) => (
-          <NavRow
-            key={p.id}
-            href={`/stashes/${stash.id}/p/${p.id}`}
-            icon={<PageIcon className="text-muted" />}
-            label={p.name}
-          />
-        ))}
-        {rootFiles.slice(0, 12).map((f) => (
-          <FileNavRow key={f.id} stashId={stash.id} file={f} />
-        ))}
-        {!spine || total === 0 ? (
-          <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
-        ) : null}
       </div>
-    </details>
+      {open && (
+        <div className="ml-3 space-y-0.5 border-l border-border pl-2">
+          {rootFolders.map((f) => (
+            <FolderTreeNode
+              key={f.id}
+              stashId={stash.id}
+              folderId={f.id}
+              name={f.name}
+              pathname={pathname}
+            />
+          ))}
+          {rootPages.slice(0, 10).map((p) => {
+            const href = `/stashes/${stash.id}/p/${p.id}`;
+            return (
+              <NavRow
+                key={p.id}
+                href={href}
+                icon={<PageIcon className="text-muted" />}
+                label={p.name}
+                active={pathname === href}
+              />
+            );
+          })}
+          {rootFiles.slice(0, 12).map((f) => (
+            <FileNavRow key={f.id} stashId={stash.id} file={f} />
+          ))}
+          {!spine || total === 0 ? (
+            <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -61,12 +61,12 @@ export default function CommandPalette({ open, onClose, stashId }: CommandPalett
           });
       });
       spine.sessions.forEach((s) => {
-        if (s.session_id.toLowerCase().includes(q))
+        if (`${s.title} ${s.session_id}`.toLowerCase().includes(q))
           local.push({
             kind: "session",
-            label: `#${s.session_id}`,
+            label: s.title,
             href: `/stashes/${stashId}/sessions/${encodeURIComponent(s.session_id)}`,
-            detail: s.agent_name,
+            detail: `${s.agent_name} · ${s.event_count} events`,
           });
       });
       spine.wiki.folders.forEach((f) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1280,6 +1280,7 @@ export interface StashSpineSession {
   session_id: string;
   title: string;
   agent_name: string;
+  event_count: number;
   size_bytes: number;
   last_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

This PR makes the Stash sidebar easier to navigate and makes agent sessions readable.

- Adds cached AI-generated titles for workspace sessions, backed by a new `session_titles` table.
- Adds a full `/stashes/:stashId/sessions` page so clicking the Sessions row shows every session in a scrollable list.
- Replaces session IDs in sidebar/search/session pages with generated titles while preserving links by `session_id`.
- Shows each sidebar session row as a truncated generated title with a compact right-aligned datetime.
- Splits sidebar rows into explicit disclosure chevrons and separate row-body navigation targets, matching the Notion-style interaction.
- Uses same-origin login/register API calls in local development so the Next proxy path works instead of hitting browser fetch/CORS failures.
- Rebases on current `main` and includes formatter cleanup needed for backend lint on the touched migration/service files.

## Screenshots

![stash-sidebar-session-datetime.png](https://github.com/user-attachments/assets/dc3b2b6e-1ebd-4dbf-ac85-d6f4d27b5b4d)

![stash-sidebar-targets-after.png](https://github.com/user-attachments/assets/713efceb-401c-470b-ba3e-ab32d723291d)

## Validation

- `ruff check backend/ cli/`
- `black --check backend/ cli/`
- `pytest --no-cov backend/tests/test_stash_spine_sessions.py`
- `npm run build` from `frontend/`
- `npm run test` from `frontend/`
- `npm run lint` from `frontend/` (0 errors, existing warnings remain)
- `git diff --check`
- Playwright browser check: session row shows the generated title on the left and compact datetime on the right
- Playwright browser check: folder row body navigates to the folder page, and folder chevron expands child pages

## Stash Coordination

Checked Stash activity before opening this. Recent `sam-claude-code` activity did not show up for this repo/task; search only surfaced older April notes around memory/sidebar work.