### PR TITLE
Speed up session and wiki CRUD views

### DIFF
--- a/backend/migrations/versions/0037_session_browse_indexes.py
+++ b/backend/migrations/versions/0037_session_browse_indexes.py
@@ -1,0 +1,25 @@
+"""Add session browse indexes.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-11 19:20:00.000000
+"""
+
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_events_workspace_session_created "
+        "ON history_events(workspace_id, session_id, created_at) "
+        "WHERE session_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_history_events_workspace_session_created")

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -240,31 +240,26 @@ async def _spine_wiki(stash_id: UUID) -> dict:
             stash_id,
         ),
         pool.fetch(
-            "SELECT id, name, folder_id, size_bytes, content_type, storage_key, "
+            "SELECT id, name, folder_id, size_bytes, content_type, "
             "       created_at, linked_table_id "
             "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC",
             stash_id,
         ),
     )
 
-    file_payload = []
-    for f in file_rows:
-        try:
-            url = await storage_service.get_file_url(f["storage_key"])
-        except Exception:
-            url = None
-        file_payload.append(
-            {
-                "id": str(f["id"]),
-                "name": f["name"],
-                "folder_id": str(f["folder_id"]) if f["folder_id"] else None,
-                "size_bytes": f["size_bytes"],
-                "content_type": f["content_type"],
-                "url": url,
-                "created_at": f["created_at"],
-                "linked_table_id": str(f["linked_table_id"]) if f["linked_table_id"] else None,
-            }
-        )
+    file_payload = [
+        {
+            "id": str(f["id"]),
+            "name": f["name"],
+            "folder_id": str(f["folder_id"]) if f["folder_id"] else None,
+            "size_bytes": f["size_bytes"],
+            "content_type": f["content_type"],
+            "url": None,
+            "created_at": f["created_at"],
+            "linked_table_id": str(f["linked_table_id"]) if f["linked_table_id"] else None,
+        }
+        for f in file_rows
+    ]
 
     return {
         "folders": [

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -104,6 +104,7 @@ def _events_to_viewer_shape(events: list[dict]) -> list[dict]:
             {
                 "id": str(ev["id"]),
                 "role": role,
+                "agent_name": ev.get("agent_name") or "",
                 "content": ev.get("content") or "",
                 "tool_name": ev.get("tool_name"),
                 "created_at": ev["created_at"].isoformat() if ev.get("created_at") else None,

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -27,7 +27,7 @@ from ..models import (
     WorkspacePageListResponse,
     WorkspaceTreeResponse,
 )
-from ..services import permission_service, storage_service, wiki_service, workspace_service
+from ..services import permission_service, wiki_service, workspace_service
 from ..services.wiki_service import (
     DuplicateFolderName,
     DuplicatePageName,
@@ -171,28 +171,23 @@ async def get_folder_contents(
         folder_id,
     )
     files = await pool.fetch(
-        "SELECT id, name, size_bytes, content_type, storage_key, created_at, linked_table_id "
+        "SELECT id, name, size_bytes, content_type, created_at, linked_table_id "
         "FROM files WHERE folder_id = $1 ORDER BY created_at DESC",
         folder_id,
     )
 
-    file_payload = []
-    for f in files:
-        try:
-            url = await storage_service.get_file_url(f["storage_key"])
-        except Exception:
-            url = None
-        file_payload.append(
-            {
-                "id": str(f["id"]),
-                "name": f["name"],
-                "size_bytes": f["size_bytes"],
-                "content_type": f["content_type"],
-                "url": url,
-                "created_at": f["created_at"],
-                "linked_table_id": str(f["linked_table_id"]) if f["linked_table_id"] else None,
-            }
-        )
+    file_payload = [
+        {
+            "id": str(f["id"]),
+            "name": f["name"],
+            "size_bytes": f["size_bytes"],
+            "content_type": f["content_type"],
+            "url": None,
+            "created_at": f["created_at"],
+            "linked_table_id": str(f["linked_table_id"]) if f["linked_table_id"] else None,
+        }
+        for f in files
+    ]
 
     return {
         "folder": {

--- a/frontend/src/app/stashes/[stashId]/folders/[folderId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/folders/[folderId]/page.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import AppShell from "../../../../../components/AppShell";
 import {
   FileIcon,
@@ -19,7 +26,7 @@ import {
   uploadFile,
   type FolderContents,
 } from "../../../../../lib/api";
-import type { Workspace } from "../../../../../lib/types";
+import type { FileInfo, Folder, Workspace } from "../../../../../lib/types";
 
 export default function FolderDetailPage() {
   const params = useParams();
@@ -35,8 +42,12 @@ export default function FolderDetailPage() {
 
   const load = useCallback(async () => {
     try {
-      setStash(await getWorkspace(stashId));
-      setContents(await getFolderContents(stashId, folderId));
+      const [workspace, folderContents] = await Promise.all([
+        getWorkspace(stashId),
+        getFolderContents(stashId, folderId),
+      ]);
+      setStash(workspace);
+      setContents(folderContents);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load folder");
     }
@@ -108,8 +119,8 @@ export default function FolderDetailPage() {
                 const file = e.target.files?.[0];
                 if (!file) return;
                 try {
-                  await uploadFile(stashId, file, folderId);
-                  await load();
+                  const uploaded = await uploadFile(stashId, file, folderId);
+                  addFileToContents(uploaded, setContents);
                 } catch {
                   /* */
                 }
@@ -140,8 +151,8 @@ export default function FolderDetailPage() {
                 const name = window.prompt("Folder name?");
                 if (!name?.trim()) return;
                 try {
-                  await createFolder(stashId, name.trim(), folderId);
-                  await load();
+                  const folder = await createFolder(stashId, name.trim(), folderId);
+                  addSubfolderToContents(folder, setContents);
                 } catch {
                   /* */
                 }
@@ -257,4 +268,39 @@ function formatBytes(b: number): string {
   if (b < 1024) return `${b} B`;
   if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
   return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function addSubfolderToContents(
+  folder: Folder,
+  setContents: Dispatch<SetStateAction<FolderContents | null>>
+) {
+  setContents((current) => {
+    if (!current) return current;
+    const subfolders = [
+      ...current.subfolders,
+      { id: folder.id, name: folder.name, page_count: 0, file_count: 0 },
+    ].sort((a, b) => a.name.localeCompare(b.name));
+
+    return { ...current, subfolders };
+  });
+}
+
+function addFileToContents(
+  file: FileInfo,
+  setContents: Dispatch<SetStateAction<FolderContents | null>>
+) {
+  setContents((current) => {
+    if (!current) return current;
+    const nextFile = {
+      id: file.id,
+      name: file.name,
+      size_bytes: file.size_bytes,
+      content_type: file.content_type,
+      url: file.url,
+      created_at: file.created_at,
+      linked_table_id: file.linked_table_id ?? null,
+    };
+
+    return { ...current, files: [nextFile, ...current.files] };
+  });
 }

--- a/frontend/src/app/stashes/[stashId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/p/[pageId]/page.tsx
@@ -42,8 +42,11 @@ export default function StashPageView() {
 
   const load = useCallback(async () => {
     try {
-      setStash(await getWorkspace(stashId));
-      const p = await getPage(stashId, pageId);
+      const [workspace, p] = await Promise.all([
+        getWorkspace(stashId),
+        getPage(stashId, pageId),
+      ]);
+      setStash(workspace);
       setPage(p);
       if (p.folder_id) {
         const contents = await getFolderContents(stashId, p.folder_id);

--- a/frontend/src/app/stashes/[stashId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/page.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import AppShell from "../../../components/AppShell";
 import MembersModal from "../../../components/MembersModal";
 import StashQuickAdd from "../../../components/StashQuickAdd";
@@ -25,8 +32,9 @@ import {
   joinWorkspace,
   uploadFile,
   type StashSpine,
+  type WikiFile,
 } from "../../../lib/api";
-import type { Workspace, WorkspaceMember } from "../../../lib/types";
+import type { FileInfo, Folder, Workspace, WorkspaceMember } from "../../../lib/types";
 
 interface CardItem {
   href: string;
@@ -98,16 +106,28 @@ export default function StashHomePage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
-    try {
-      setStash(await getWorkspace(stashId));
-    } catch {
+    const [stashResult, membersResult, spineResult] = await Promise.allSettled([
+      getWorkspace(stashId),
+      getWorkspaceMembers(stashId),
+      getStashSpine(stashId),
+    ]);
+
+    if (stashResult.status === "fulfilled") {
+      setStash(stashResult.value);
+    } else {
       setError("Stash not found");
     }
-    try {
-      setMembers(await getWorkspaceMembers(stashId));
-    } catch {
-      /* not a member yet */
+
+    if (membersResult.status === "fulfilled") {
+      setMembers(membersResult.value);
     }
+
+    if (spineResult.status === "fulfilled") {
+      setSpine(spineResult.value);
+    }
+  }, [stashId]);
+
+  const refreshSpine = useCallback(async () => {
     try {
       setSpine(await getStashSpine(stashId));
     } catch {
@@ -240,7 +260,7 @@ export default function StashHomePage() {
 
           {isMember && (
             <div className="mt-6">
-              <StashQuickAdd stashId={stashId} user={user} onAdded={load} />
+              <StashQuickAdd stashId={stashId} user={user} onAdded={refreshSpine} />
             </div>
           )}
 
@@ -290,8 +310,8 @@ export default function StashHomePage() {
                 const file = e.target.files?.[0];
                 if (!file) return;
                 try {
-                  await uploadFile(stashId, file);
-                  await load();
+                  const uploaded = await uploadFile(stashId, file);
+                  addFileToSpine(uploaded, setSpine);
                 } catch { /* */ }
                 if (fileInputRef.current) fileInputRef.current.value = "";
               }} />
@@ -317,8 +337,8 @@ export default function StashHomePage() {
                   const name = window.prompt("Folder name?");
                   if (!name?.trim()) return;
                   try {
-                    await createFolder(stashId, name.trim());
-                    await load();
+                    const folder = await createFolder(stashId, name.trim());
+                    addFolderToSpine(folder, setSpine);
                   } catch { /* */ }
                 }}
                 className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-foreground hover:bg-raised"
@@ -449,4 +469,53 @@ function formatBytes(b: number): string {
   if (b < 1024) return `${b} B`;
   if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
   return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function addFolderToSpine(
+  folder: Folder,
+  setSpine: Dispatch<SetStateAction<StashSpine | null>>
+) {
+  setSpine((current) => {
+    if (!current) return current;
+    const folders = [
+      ...current.wiki.folders,
+      {
+        id: folder.id,
+        name: folder.name,
+        parent_folder_id: folder.parent_folder_id,
+        page_count: 0,
+        file_count: 0,
+        has_skill: false,
+      },
+    ].sort((a, b) => a.name.localeCompare(b.name));
+
+    return { ...current, wiki: { ...current.wiki, folders } };
+  });
+}
+
+function addFileToSpine(
+  file: FileInfo,
+  setSpine: Dispatch<SetStateAction<StashSpine | null>>
+) {
+  setSpine((current) => {
+    if (!current) return current;
+    const nextFile: WikiFile = {
+      id: file.id,
+      name: file.name,
+      folder_id: file.folder_id ?? null,
+      size_bytes: file.size_bytes,
+      content_type: file.content_type,
+      url: file.url,
+      created_at: file.created_at,
+      linked_table_id: file.linked_table_id ?? null,
+    };
+
+    return {
+      ...current,
+      wiki: {
+        ...current.wiki,
+        files: [nextFile, ...current.wiki.files],
+      },
+    };
+  });
 }

--- a/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/sessions/[sessionId]/page.tsx
@@ -7,10 +7,8 @@ import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
   getSessionEvents,
-  getStashTranscript,
   getWorkspace,
   type SessionEvent,
-  type SessionTranscript,
 } from "../../../../../lib/api";
 import type { Workspace } from "../../../../../lib/types";
 
@@ -93,7 +91,7 @@ export default function SessionViewerPage() {
   const { user, loading, logout } = useAuth();
 
   const [stash, setStash] = useState<Workspace | null>(null);
-  const [transcript, setTranscript] = useState<SessionTranscript | null>(null);
+  const [agentName, setAgentName] = useState("");
   const [turns, setTurns] = useState<MessageTurn[]>([]);
   const [error, setError] = useState("");
 
@@ -104,10 +102,12 @@ export default function SessionViewerPage() {
 
   const load = useCallback(async () => {
     try {
-      setStash(await getWorkspace(stashId));
-      const tx = await getStashTranscript(stashId, sessionId);
-      setTranscript(tx);
-      const events = await getSessionEvents(stashId, sessionId);
+      const [workspace, events] = await Promise.all([
+        getWorkspace(stashId),
+        getSessionEvents(stashId, sessionId),
+      ]);
+      setStash(workspace);
+      setAgentName(events.find((event) => event.agent_name)?.agent_name ?? "");
       setTurns(events.map(eventToTurn));
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load session");
@@ -138,7 +138,7 @@ export default function SessionViewerPage() {
               <h1 className="font-display text-[24px] font-bold tracking-tight text-foreground">
                 #{sessionId.replace(/^acme-/, "")}
               </h1>
-              {transcript && (
+              {turns.length > 0 && (
                 <p className="mt-1.5 text-[11.5px] text-muted">
                   {turns.length} messages
                   {sessionDate ? (
@@ -151,9 +151,9 @@ export default function SessionViewerPage() {
                 </p>
               )}
             </div>
-            {transcript?.agent_name && (
+            {agentName && (
               <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-base px-2 py-1 text-[11px] text-foreground">
-                <span className="font-mono">⌘</span> {transcript.agent_name}
+                <span className="font-mono">⌘</span> {agentName}
               </span>
             )}
           </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1259,6 +1259,7 @@ export async function getStashTranscript(
 export interface SessionEvent {
   id: string;
   role: "user" | "assistant";
+  agent_name: string;
   content: string;
   tool_name: string | null;
   created_at: string | null;


### PR DESCRIPTION
## Summary
- Skip unused signed file URL generation in stash spine and folder contents list APIs.
- Update stash/folder wiki create and upload actions locally instead of refetching the whole stash view.
- Load stash, wiki, page, and session data in parallel where possible.
- Avoid the extra session metadata request by returning `agent_name` with session events.
- Add an index for session browsing queries on `history_events(workspace_id, session_id, created_at)`.

## Verification
- `python3 -m compileall backend/routers backend/services backend/migrations/versions/0037_session_browse_indexes.py`
- `python3 -m ruff check backend/routers/stashes.py backend/routers/wiki.py backend/routers/transcripts.py backend/migrations/versions/0037_session_browse_indexes.py`
- `npm exec tsc -- --noEmit` in `frontend/`
- `npm run test -- AppSidebar.test.tsx` in `frontend/`
- `npm run lint` in `frontend/` passes with existing warnings

## Not Run
- `python3 -m pytest backend/tests/test_history_pagination.py backend/tests/test_transcripts.py` could not run locally because the configured `stash_test` Postgres credentials reject `stash/stash`.

## Screenshots
No visual layout changes; this PR changes fetch/update behavior only.