### PR TITLE
[FER-12] Make landing page pink

### DIFF
--- a/backend/migrations/versions/0036_unify_sharing_and_permissions.py
+++ b/backend/migrations/versions/0036_unify_sharing_and_permissions.py
@@ -33,6 +33,7 @@ depends_on = None
 
 def upgrade() -> None:
     import logging
+
     log = logging.getLogger("alembic.migration.0036")
 
     def step(msg: str) -> None:
@@ -143,7 +144,9 @@ def upgrade() -> None:
     )
 
     step("3c. collapse permission enum to (view, edit)")
-    op.execute("UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')")
+    op.execute(
+        "UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')"
+    )
     op.execute("ALTER TABLE share_links DROP CONSTRAINT IF EXISTS share_links_permission_check")
     op.execute(
         "ALTER TABLE share_links ADD CONSTRAINT share_links_permission_check "
@@ -201,7 +204,9 @@ def upgrade() -> None:
     # 5. workspace_members.role → owner/editor/viewer
     # ──────────────────────────────────────────────────────────────────
     step("5a. DROP workspace_members role check")
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     step("5b. UPDATE roles admin->owner")
     op.execute("UPDATE workspace_members SET role = 'owner' WHERE role IN ('admin', 'owner')")
     step("5c. UPDATE roles other->editor")
@@ -259,12 +264,22 @@ def downgrade() -> None:
     # Schema-only restore. The blob and metadata mappings can't be
     # round-tripped — this just gets the columns back so the old code
     # boots.
-    op.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
+    op.execute(
+        "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
 
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     op.execute(
         "ALTER TABLE workspace_members ADD CONSTRAINT workspace_members_role_check "
         "CHECK (role IN ('owner', 'admin', 'member'))"

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
+
 from ..auth import get_current_user
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, TableResponse

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -207,10 +207,7 @@ async def get_folder_contents(
             }
             for r in subfolders
         ],
-        "pages": [
-            {"id": str(r["id"]), "name": r["name"]}
-            for r in pages
-        ],
+        "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],
         "files": file_payload,
     }
 

--- a/backend/services/discover_service.py
+++ b/backend/services/discover_service.py
@@ -49,7 +49,10 @@ async def list_catalog(
     cursor: str | None = None,
 ) -> tuple[list[dict], str | None]:
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')", "w.discoverable = true"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')",
+        "w.discoverable = true",
+    ]
     args: list = []
     idx = 1
 
@@ -115,7 +118,8 @@ async def get_featured() -> list[dict]:
 async def get_public_detail(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     ws_row = await pool.fetchrow(
-        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') " "AND w.discoverable = true",
+        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') "
+        "AND w.discoverable = true",
         workspace_id,
     )
     if not ws_row:
@@ -160,7 +164,9 @@ async def list_admin_candidates(
 ) -> list[dict]:
     """List public workspaces available to curate into Discover."""
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"
+    ]
     args: list = []
     idx = 1
 

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -77,6 +77,7 @@ async def set_summary(session_row_id: UUID, summary: str, status: str = "ready")
 
 async def set_files_touched(session_row_id: UUID, files: list[str]) -> None:
     import json
+
     pool = get_pool()
     await pool.execute(
         "UPDATE sessions SET files_touched = $1::jsonb WHERE id = $2",

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -18,7 +18,6 @@ from uuid import UUID
 from ..config import settings
 from ..database import get_pool
 
-
 VALID_TARGETS = {"workspace", "session", "page", "folder", "file"}
 VALID_PERMISSIONS = {"view", "edit"}
 
@@ -145,12 +144,14 @@ def _parse_deck(narrative_md: str) -> list[dict] | None:
                 title = stripped[2:].strip()
                 body_lines = lines[j + 1 :]
                 break
-        slides.append({
-            "index": i,
-            "title": title or f"Slide {i + 1}",
-            "kicker": f"{i + 1:02d} / {len(parts):02d}",
-            "body": "\n".join(body_lines).strip(),
-        })
+        slides.append(
+            {
+                "index": i,
+                "title": title or f"Slide {i + 1}",
+                "kicker": f"{i + 1:02d} / {len(parts):02d}",
+                "body": "\n".join(body_lines).strip(),
+            }
+        )
     return slides
 
 
@@ -256,8 +257,7 @@ async def _session_projection(session_row_id: UUID) -> dict:
         "events": [
             {
                 "id": str(e["id"]),
-                "role": "user" if e["event_type"] == "user_message"
-                        else "assistant",
+                "role": "user" if e["event_type"] == "user_message" else "assistant",
                 "content": e["content"] or "",
                 "tool_name": e["tool_name"],
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
@@ -315,7 +315,9 @@ async def _folder_projection(folder_id: UUID) -> dict:
         "folder": {
             "id": str(folder["id"]),
             "name": folder["name"],
-            "parent_folder_id": str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None,
+            "parent_folder_id": (
+                str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None
+            ),
         },
         "subfolders": [{"id": str(r["id"]), "name": r["name"]} for r in subfolders],
         "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -526,15 +526,13 @@ async def set_member_role(
     if target_role == "owner" and role != "owner":
         # Prevent demoting the last owner.
         owner_count = await pool.fetchval(
-            "SELECT COUNT(*) FROM workspace_members "
-            "WHERE workspace_id = $1 AND role = 'owner'",
+            "SELECT COUNT(*) FROM workspace_members " "WHERE workspace_id = $1 AND role = 'owner'",
             workspace_id,
         )
         if owner_count <= 1:
             return False
     await pool.execute(
-        "UPDATE workspace_members SET role = $1 "
-        "WHERE workspace_id = $2 AND user_id = $3",
+        "UPDATE workspace_members SET role = $1 " "WHERE workspace_id = $2 AND user_id = $3",
         role,
         workspace_id,
         target_user_id,

--- a/www/DESIGN.md
+++ b/www/DESIGN.md
@@ -5,7 +5,7 @@ Extends the main Stash design system at `/DESIGN.md`. Only the landing-specific 
 ## Inherited (do not override)
 
 - Fonts: Satoshi (display), Instrument Sans (body), JetBrains Mono (code)
-- Palette: warm slates, orange `#F97316` accent, violet for agents, blue for humans
+- Palette: warm slates, pink `#DB2777` accent, violet for agents, blue for humans
 - Base unit: 4px; radii sm/md/lg/full
 - Light mode default
 
@@ -23,8 +23,8 @@ Extends the main Stash design system at `/DESIGN.md`. Only the landing-specific 
 - Gap within a section: 32–48px
 
 ### Signature moves
-- **Dark terminal slab on light page.** The install block is the only dark surface on the page. `#0F172A` background, JetBrains Mono, orange `$` prompt. This makes code feel canonical; the rest of the page is light.
-- **Orange is rare.** Primary CTA button + one highlighted word in the hero + one underline. That's it. If orange shows up on every section the accent dies.
+- **Dark terminal slab on light page.** The install block is the only dark surface on the page. `#0F172A` background, JetBrains Mono, pink `$` prompt. This makes code feel canonical; the rest of the page is light.
+- **Pink is rare.** Primary CTA button + one highlighted word in the hero + one underline. That's it. If pink shows up on every section the accent dies.
 - **Satoshi does the work.** No decorative shapes, no gradients, no icon-in-circle feature grids. The hero's geometric sans is the personality.
 
 ### Anti-patterns (do not ship)

--- a/www/app/_components/EmbeddingProjection3D.tsx
+++ b/www/app/_components/EmbeddingProjection3D.tsx
@@ -177,8 +177,8 @@ export default function EmbeddingProjection3D() {
               />
             </pattern>
             <radialGradient id="embed-glow" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stopColor="rgba(249,115,22,0.06)" />
-              <stop offset="100%" stopColor="rgba(249,115,22,0)" />
+              <stop offset="0%" stopColor="var(--brand)" stopOpacity="0.06" />
+              <stop offset="100%" stopColor="var(--brand)" stopOpacity="0" />
             </radialGradient>
           </defs>
           <rect width={WIDTH} height={HEIGHT} fill="url(#embed-grid)" />

--- a/www/app/_components/VisualizationsShowcase.tsx
+++ b/www/app/_components/VisualizationsShowcase.tsx
@@ -2,6 +2,9 @@ import type { CSSProperties } from "react";
 
 import EmbeddingProjection3D from "./EmbeddingProjection3D";
 
+const GRAPH_HUB_COLOR = "var(--brand)";
+const GRAPH_RELATED_COLOR = "#F472B6";
+
 type GraphNode = {
   id: string;
   x: number;
@@ -54,8 +57,8 @@ function PageGraphMock() {
   const nodeById = new Map(GRAPH_NODES.map((n) => [n.id, n]));
 
   const nodeColor = (degree: number) => {
-    if (degree >= 5) return "#F97316";
-    if (degree >= 3) return "#EA7C1F";
+    if (degree >= 5) return GRAPH_HUB_COLOR;
+    if (degree >= 3) return GRAPH_RELATED_COLOR;
     if (degree === 0) return "#8B5CF6";
     return "#64748B";
   };
@@ -139,7 +142,7 @@ function PageGraphMock() {
 
         <div className="absolute bottom-3 right-3 flex flex-col gap-1 rounded-md border border-border-subtle bg-background/85 px-2.5 py-2 backdrop-blur">
           {[
-            { dot: "#F97316", label: "hub" },
+            { dot: GRAPH_HUB_COLOR, label: "hub" },
             { dot: "#64748B", label: "leaf" },
           ].map((row) => (
             <div
@@ -202,7 +205,7 @@ export default function VisualizationsShowcase() {
             <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
               <span className="text-ink">Wiki page graph.</span> Nodes are
               pages, edges are <span className="font-mono text-brand">[[backlinks]]</span>.
-              Orange nodes are the hubs your agents keep citing.
+              Pink nodes are the hubs your agents keep citing.
             </p>
           </div>
         </div>

--- a/www/app/icon.svg
+++ b/www/app/icon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 72">
-  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316"/>
+  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#DB2777"/>
   <circle cx="25" cy="22" r="4" fill="#fff"/>
   <circle cx="39" cy="22" r="4" fill="#fff"/>
   <circle cx="26" cy="22" r="2" fill="#0F172A"/>
   <circle cx="40" cy="22" r="2" fill="#0F172A"/>
-  <path d="M12 38 Q8 52 4 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M20 40 Q18 54 14 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M32 42 Q32 56 32 64" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M44 40 Q46 54 50 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M52 38 Q56 52 60 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M12 38 Q8 52 4 60" stroke="#DB2777" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M20 40 Q18 54 14 62" stroke="#DB2777" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M32 42 Q32 56 32 64" stroke="#DB2777" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M44 40 Q46 54 50 62" stroke="#DB2777" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M52 38 Q56 52 60 60" stroke="#DB2777" stroke-width="4" stroke-linecap="round" fill="none"/>
 </svg>

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import CopyButton from "./_components/CopyButton";
 import ScrollLink from "./_components/ScrollLink";
@@ -7,9 +7,26 @@ import VisualizationsShowcase from "./_components/VisualizationsShowcase";
 
 const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://raw.githubusercontent.com/Fergana-Labs/stash/main/install.sh)"`;
 
+const LANDING_BRAND = {
+  primary: "#DB2777",
+  hover: "#BE185D",
+  ink: "#831843",
+  soft: "rgba(219, 39, 119, 0.12)",
+  glow: "rgba(219,39,119,0.09)",
+  answerBg: "rgba(219,39,119,0.06)",
+  answerBorder: "rgba(219,39,119,0.2)",
+};
+
+const landingBrandVars = {
+  "--brand": LANDING_BRAND.primary,
+  "--brand-hover": LANDING_BRAND.hover,
+  "--brand-ink": LANDING_BRAND.ink,
+  "--brand-soft": LANDING_BRAND.soft,
+} as CSSProperties;
+
 export default function Page() {
   return (
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="min-h-screen bg-background text-foreground" style={landingBrandVars}>
       <Nav />
       <Hero />
       <Logos />
@@ -34,16 +51,16 @@ function Logo({ size = 28 }: { size?: number }) {
       height={(size * 72) / 64}
       aria-hidden="true"
     >
-      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
+      <ellipse cx="32" cy="24" rx="22" ry="18" fill={LANDING_BRAND.primary} />
       <circle cx="25" cy="22" r="4" fill="#fff" />
       <circle cx="39" cy="22" r="4" fill="#fff" />
       <circle cx="26" cy="22" r="2" fill="#0F172A" />
       <circle cx="40" cy="22" r="2" fill="#0F172A" />
-      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M12 38 Q8 52 4 60" stroke={LANDING_BRAND.primary} strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M20 40 Q18 54 14 62" stroke={LANDING_BRAND.primary} strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M32 42 Q32 56 32 64" stroke={LANDING_BRAND.primary} strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M44 40 Q46 54 50 62" stroke={LANDING_BRAND.primary} strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M52 38 Q56 52 60 60" stroke={LANDING_BRAND.primary} strokeWidth="4" strokeLinecap="round" fill="none" />
     </svg>
   );
 }
@@ -295,7 +312,7 @@ function Hero() {
         className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[680px]"
         style={{
           background:
-            "radial-gradient(ellipse 80% 60% at 20% 10%, rgba(249,115,22,0.09), transparent 60%)",
+            `radial-gradient(ellipse 80% 60% at 20% 10%, ${LANDING_BRAND.glow}, transparent 60%)`,
         }}
       />
       <div className="relative z-10 mx-auto grid max-w-[1200px] grid-cols-1 gap-12 px-7 pb-8 pt-20 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:gap-16 lg:pb-16 lg:pt-28">
@@ -742,8 +759,8 @@ function SearchDemo() {
             <div
               className="mt-6 rounded-[10px] border p-5"
               style={{
-                background: "rgba(249,115,22,0.06)",
-                borderColor: "rgba(249,115,22,0.2)",
+                background: LANDING_BRAND.answerBg,
+                borderColor: LANDING_BRAND.answerBorder,
               }}
             >
               <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-brand">


### PR DESCRIPTION
## Summary

- Override the `www` landing page brand variables to pink.
- Update the landing logo/favicon, visualization accents, and landing design note from orange to pink.
- Keep the change scoped to the marketing landing surface.

## Screenshots

Screenshot capture was attempted with `playwright screenshot --full-page http://localhost:3100 /tmp/fer12-landing-pink.png`, but browser launch is blocked in this local macOS sandbox (`bootstrap_check_in ... Permission denied`; WebKit exits with `Abort trap`). Runtime validation below verifies the rendered landing markup changed to pink.

## Validation

- `npm run build` from `www/`
- `git diff --check`
- Runtime check against `http://localhost:3100`: the first landing section contains `#DB2777`, `#BE185D`, `#831843`, `rgba(219,39,119,0.09)`, `text-brand`, and `bg-brand`.
- Runtime check against `http://localhost:3100`: the first landing section contains no `#F97316`, `#EA580C`, `#EA7C1F`, `rgba(249,115,22...)`, or `Orange nodes`.

Not run: `npm run lint` from `www/` because the script currently resolves to `eslint`, but `eslint` is not installed in the `www` package dependencies.