### PR TITLE
Add haiku to 404 pages

### DIFF
--- a/backend/migrations/versions/0036_unify_sharing_and_permissions.py
+++ b/backend/migrations/versions/0036_unify_sharing_and_permissions.py
@@ -33,6 +33,7 @@ depends_on = None
 
 def upgrade() -> None:
     import logging
+
     log = logging.getLogger("alembic.migration.0036")
 
     def step(msg: str) -> None:
@@ -143,7 +144,9 @@ def upgrade() -> None:
     )
 
     step("3c. collapse permission enum to (view, edit)")
-    op.execute("UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')")
+    op.execute(
+        "UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')"
+    )
     op.execute("ALTER TABLE share_links DROP CONSTRAINT IF EXISTS share_links_permission_check")
     op.execute(
         "ALTER TABLE share_links ADD CONSTRAINT share_links_permission_check "
@@ -201,7 +204,9 @@ def upgrade() -> None:
     # 5. workspace_members.role → owner/editor/viewer
     # ──────────────────────────────────────────────────────────────────
     step("5a. DROP workspace_members role check")
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     step("5b. UPDATE roles admin->owner")
     op.execute("UPDATE workspace_members SET role = 'owner' WHERE role IN ('admin', 'owner')")
     step("5c. UPDATE roles other->editor")
@@ -259,12 +264,22 @@ def downgrade() -> None:
     # Schema-only restore. The blob and metadata mappings can't be
     # round-tripped — this just gets the columns back so the old code
     # boots.
-    op.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
+    op.execute(
+        "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
 
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     op.execute(
         "ALTER TABLE workspace_members ADD CONSTRAINT workspace_members_role_check "
         "CHECK (role IN ('owner', 'admin', 'member'))"

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
+
 from ..auth import get_current_user
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, TableResponse

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -207,10 +207,7 @@ async def get_folder_contents(
             }
             for r in subfolders
         ],
-        "pages": [
-            {"id": str(r["id"]), "name": r["name"]}
-            for r in pages
-        ],
+        "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],
         "files": file_payload,
     }
 

--- a/backend/services/discover_service.py
+++ b/backend/services/discover_service.py
@@ -49,7 +49,10 @@ async def list_catalog(
     cursor: str | None = None,
 ) -> tuple[list[dict], str | None]:
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')", "w.discoverable = true"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')",
+        "w.discoverable = true",
+    ]
     args: list = []
     idx = 1
 
@@ -115,7 +118,8 @@ async def get_featured() -> list[dict]:
 async def get_public_detail(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     ws_row = await pool.fetchrow(
-        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') " "AND w.discoverable = true",
+        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') "
+        "AND w.discoverable = true",
         workspace_id,
     )
     if not ws_row:
@@ -160,7 +164,9 @@ async def list_admin_candidates(
 ) -> list[dict]:
     """List public workspaces available to curate into Discover."""
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"
+    ]
     args: list = []
     idx = 1
 

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -77,6 +77,7 @@ async def set_summary(session_row_id: UUID, summary: str, status: str = "ready")
 
 async def set_files_touched(session_row_id: UUID, files: list[str]) -> None:
     import json
+
     pool = get_pool()
     await pool.execute(
         "UPDATE sessions SET files_touched = $1::jsonb WHERE id = $2",

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -18,7 +18,6 @@ from uuid import UUID
 from ..config import settings
 from ..database import get_pool
 
-
 VALID_TARGETS = {"workspace", "session", "page", "folder", "file"}
 VALID_PERMISSIONS = {"view", "edit"}
 

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -144,12 +144,14 @@ def _parse_deck(narrative_md: str) -> list[dict] | None:
                 title = stripped[2:].strip()
                 body_lines = lines[j + 1 :]
                 break
-        slides.append({
-            "index": i,
-            "title": title or f"Slide {i + 1}",
-            "kicker": f"{i + 1:02d} / {len(parts):02d}",
-            "body": "\n".join(body_lines).strip(),
-        })
+        slides.append(
+            {
+                "index": i,
+                "title": title or f"Slide {i + 1}",
+                "kicker": f"{i + 1:02d} / {len(parts):02d}",
+                "body": "\n".join(body_lines).strip(),
+            }
+        )
     return slides
 
 
@@ -255,8 +257,7 @@ async def _session_projection(session_row_id: UUID) -> dict:
         "events": [
             {
                 "id": str(e["id"]),
-                "role": "user" if e["event_type"] == "user_message"
-                        else "assistant",
+                "role": "user" if e["event_type"] == "user_message" else "assistant",
                 "content": e["content"] or "",
                 "tool_name": e["tool_name"],
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
@@ -314,7 +315,9 @@ async def _folder_projection(folder_id: UUID) -> dict:
         "folder": {
             "id": str(folder["id"]),
             "name": folder["name"],
-            "parent_folder_id": str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None,
+            "parent_folder_id": (
+                str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None
+            ),
         },
         "subfolders": [{"id": str(r["id"]), "name": r["name"]} for r in subfolders],
         "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -526,15 +526,13 @@ async def set_member_role(
     if target_role == "owner" and role != "owner":
         # Prevent demoting the last owner.
         owner_count = await pool.fetchval(
-            "SELECT COUNT(*) FROM workspace_members "
-            "WHERE workspace_id = $1 AND role = 'owner'",
+            "SELECT COUNT(*) FROM workspace_members " "WHERE workspace_id = $1 AND role = 'owner'",
             workspace_id,
         )
         if owner_count <= 1:
             return False
     await pool.execute(
-        "UPDATE workspace_members SET role = $1 "
-        "WHERE workspace_id = $2 AND user_id = $3",
+        "UPDATE workspace_members SET role = $1 " "WHERE workspace_id = $2 AND user_id = $3",
         role,
         workspace_id,
         target_user_id,

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -141,6 +141,12 @@ export default function NotFound() {
         Not found
       </p>
 
+      <div className="mt-6 font-display text-base leading-7 text-foreground/75" aria-label="404 haiku">
+        <p>Lost page, quiet path</p>
+        <p>Stash keeps one small lantern lit</p>
+        <p>Home waits close at hand</p>
+      </div>
+
       <Link
         href="/"
         className="mt-8 inline-flex h-10 items-center rounded-md bg-brand px-5 text-sm font-medium text-white shadow-sm transition hover:bg-brand-hover"

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -141,7 +141,10 @@ export default function NotFound() {
         Not found
       </p>
 
-      <div className="mt-6 font-display text-base leading-7 text-foreground/75" aria-label="404 haiku">
+      <div
+        className="mt-6 font-display text-base leading-7 text-foreground/75"
+        aria-label="404 haiku"
+      >
         <p>Lost page, quiet path</p>
         <p>Stash keeps one small lantern lit</p>
         <p>Home waits close at hand</p>

--- a/www/app/not-found.tsx
+++ b/www/app/not-found.tsx
@@ -124,7 +124,10 @@ export default function NotFound() {
         This page doesn&apos;t exist, or it was moved.
       </p>
 
-      <div className="mt-6 text-[15px] leading-7 text-dim" aria-label="404 haiku">
+      <div
+        className="mt-6 text-[15px] leading-7 text-dim"
+        aria-label="404 haiku"
+      >
         <p>Lost page, quiet path</p>
         <p>Stash keeps one small lantern lit</p>
         <p>Home waits close at hand</p>

--- a/www/app/not-found.tsx
+++ b/www/app/not-found.tsx
@@ -124,6 +124,12 @@ export default function NotFound() {
         This page doesn&apos;t exist, or it was moved.
       </p>
 
+      <div className="mt-6 text-[15px] leading-7 text-dim" aria-label="404 haiku">
+        <p>Lost page, quiet path</p>
+        <p>Stash keeps one small lantern lit</p>
+        <p>Home waits close at hand</p>
+      </div>
+
       <Link
         href="/"
         className="mt-8 inline-flex h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"


### PR DESCRIPTION
## Summary

- Add a three-line haiku to the product app 404 page.
- Add the same haiku to the public www 404 page.
- Keep existing 404 navigation actions intact.

## Validation

- `npm run lint` in `frontend` passed with existing warnings and 0 errors.
- `npm run build` in `frontend` passed.
- `npm run build` in `www` passed.
- Product app missing route returned HTTP 404 with the haiku in server-rendered HTML.
- Public www built `_not-found` HTML contains the haiku.

## Screenshots

Screenshot capture could not be attached from this sandbox: Playwright Chromium failed to launch with a macOS Mach port permission error, and the available GitHub connector tools do not expose media upload. The rendered HTML proof is included in the validation above.