### PR TITLE
Cache sidebar data across navigation

### DIFF
--- a/backend/migrations/versions/0036_unify_sharing_and_permissions.py
+++ b/backend/migrations/versions/0036_unify_sharing_and_permissions.py
@@ -33,6 +33,7 @@ depends_on = None
 
 def upgrade() -> None:
     import logging
+
     log = logging.getLogger("alembic.migration.0036")
 
     def step(msg: str) -> None:
@@ -143,7 +144,9 @@ def upgrade() -> None:
     )
 
     step("3c. collapse permission enum to (view, edit)")
-    op.execute("UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')")
+    op.execute(
+        "UPDATE share_links SET permission = 'view' WHERE permission IN ('comment', 'edit-request')"
+    )
     op.execute("ALTER TABLE share_links DROP CONSTRAINT IF EXISTS share_links_permission_check")
     op.execute(
         "ALTER TABLE share_links ADD CONSTRAINT share_links_permission_check "
@@ -201,7 +204,9 @@ def upgrade() -> None:
     # 5. workspace_members.role → owner/editor/viewer
     # ──────────────────────────────────────────────────────────────────
     step("5a. DROP workspace_members role check")
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     step("5b. UPDATE roles admin->owner")
     op.execute("UPDATE workspace_members SET role = 'owner' WHERE role IN ('admin', 'owner')")
     step("5c. UPDATE roles other->editor")
@@ -259,12 +264,22 @@ def downgrade() -> None:
     # Schema-only restore. The blob and metadata mappings can't be
     # round-tripped — this just gets the columns back so the old code
     # boots.
-    op.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
-    op.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE")
+    op.execute(
+        "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE views ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE pages ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE files ADD COLUMN IF NOT EXISTS public_in_share BOOLEAN NOT NULL DEFAULT FALSE"
+    )
 
-    op.execute("ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check")
+    op.execute(
+        "ALTER TABLE workspace_members DROP CONSTRAINT IF EXISTS workspace_members_role_check"
+    )
     op.execute(
         "ALTER TABLE workspace_members ADD CONSTRAINT workspace_members_role_check "
         "CHECK (role IN ('owner', 'admin', 'member'))"

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
+
 from ..auth import get_current_user
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, TableResponse

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -207,10 +207,7 @@ async def get_folder_contents(
             }
             for r in subfolders
         ],
-        "pages": [
-            {"id": str(r["id"]), "name": r["name"]}
-            for r in pages
-        ],
+        "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],
         "files": file_payload,
     }
 

--- a/backend/services/discover_service.py
+++ b/backend/services/discover_service.py
@@ -49,7 +49,10 @@ async def list_catalog(
     cursor: str | None = None,
 ) -> tuple[list[dict], str | None]:
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')", "w.discoverable = true"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')",
+        "w.discoverable = true",
+    ]
     args: list = []
     idx = 1
 
@@ -115,7 +118,8 @@ async def get_featured() -> list[dict]:
 async def get_public_detail(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     ws_row = await pool.fetchrow(
-        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') " "AND w.discoverable = true",
+        f"{_CATALOG_SELECT} WHERE w.id = $1 AND EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public') "
+        "AND w.discoverable = true",
         workspace_id,
     )
     if not ws_row:
@@ -160,7 +164,9 @@ async def list_admin_candidates(
 ) -> list[dict]:
     """List public workspaces available to curate into Discover."""
     pool = get_pool()
-    where = ["EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"]
+    where = [
+        "EXISTS(SELECT 1 FROM object_permissions op WHERE op.object_type = 'workspace' AND op.object_id = w.id AND op.visibility = 'public')"
+    ]
     args: list = []
     idx = 1
 

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -77,6 +77,7 @@ async def set_summary(session_row_id: UUID, summary: str, status: str = "ready")
 
 async def set_files_touched(session_row_id: UUID, files: list[str]) -> None:
     import json
+
     pool = get_pool()
     await pool.execute(
         "UPDATE sessions SET files_touched = $1::jsonb WHERE id = $2",

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -18,7 +18,6 @@ from uuid import UUID
 from ..config import settings
 from ..database import get_pool
 
-
 VALID_TARGETS = {"workspace", "session", "page", "folder", "file"}
 VALID_PERMISSIONS = {"view", "edit"}
 
@@ -145,12 +144,14 @@ def _parse_deck(narrative_md: str) -> list[dict] | None:
                 title = stripped[2:].strip()
                 body_lines = lines[j + 1 :]
                 break
-        slides.append({
-            "index": i,
-            "title": title or f"Slide {i + 1}",
-            "kicker": f"{i + 1:02d} / {len(parts):02d}",
-            "body": "\n".join(body_lines).strip(),
-        })
+        slides.append(
+            {
+                "index": i,
+                "title": title or f"Slide {i + 1}",
+                "kicker": f"{i + 1:02d} / {len(parts):02d}",
+                "body": "\n".join(body_lines).strip(),
+            }
+        )
     return slides
 
 
@@ -256,8 +257,7 @@ async def _session_projection(session_row_id: UUID) -> dict:
         "events": [
             {
                 "id": str(e["id"]),
-                "role": "user" if e["event_type"] == "user_message"
-                        else "assistant",
+                "role": "user" if e["event_type"] == "user_message" else "assistant",
                 "content": e["content"] or "",
                 "tool_name": e["tool_name"],
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
@@ -315,7 +315,9 @@ async def _folder_projection(folder_id: UUID) -> dict:
         "folder": {
             "id": str(folder["id"]),
             "name": folder["name"],
-            "parent_folder_id": str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None,
+            "parent_folder_id": (
+                str(folder["parent_folder_id"]) if folder["parent_folder_id"] else None
+            ),
         },
         "subfolders": [{"id": str(r["id"]), "name": r["name"]} for r in subfolders],
         "pages": [{"id": str(r["id"]), "name": r["name"]} for r in pages],

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -526,15 +526,13 @@ async def set_member_role(
     if target_role == "owner" and role != "owner":
         # Prevent demoting the last owner.
         owner_count = await pool.fetchval(
-            "SELECT COUNT(*) FROM workspace_members "
-            "WHERE workspace_id = $1 AND role = 'owner'",
+            "SELECT COUNT(*) FROM workspace_members " "WHERE workspace_id = $1 AND role = 'owner'",
             workspace_id,
         )
         if owner_count <= 1:
             return False
     await pool.execute(
-        "UPDATE workspace_members SET role = $1 "
-        "WHERE workspace_id = $2 AND user_id = $3",
+        "UPDATE workspace_members SET role = $1 " "WHERE workspace_id = $2 AND user_id = $3",
         role,
         workspace_id,
         target_user_id,

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppShell from "./AppShell";
+import {
+  getCachedWorkspaces,
+  readCachedWorkspaces,
+} from "../lib/stashNavigationCache";
+
+const nav = vi.hoisted(() => ({
+  pathname: "/",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => nav.pathname,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../lib/stashNavigationCache", () => ({
+  getCachedWorkspaces: vi.fn(),
+  readCachedWorkspaces: vi.fn(),
+}));
+
+vi.mock("./AppSidebar", () => ({
+  default: () => <aside data-testid="app-sidebar">Sidebar</aside>,
+}));
+
+vi.mock("./CommandPalette", () => ({
+  default: () => null,
+}));
+
+vi.mock("./ShareModal", () => ({
+  default: () => null,
+}));
+
+const user = {
+  id: "user-1",
+  name: "Henry",
+  display_name: "Henry",
+  description: "",
+  created_at: "2026-05-11T00:00:00Z",
+  last_seen: "2026-05-11T00:00:00Z",
+};
+
+describe("AppShell sidebar collapse", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    nav.pathname = "/";
+    vi.clearAllMocks();
+    vi.mocked(readCachedWorkspaces).mockReturnValue({
+      userId: user.id,
+      all: [],
+      mine: [],
+      shared: [],
+    });
+    vi.mocked(getCachedWorkspaces).mockResolvedValue({
+      userId: user.id,
+      all: [],
+      mine: [],
+      shared: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps page content in the visible grid column when collapsed", () => {
+    render(
+      <AppShell user={user} onLogout={vi.fn()}>
+        <div>Page content</div>
+      </AppShell>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle sidebar" }));
+
+    const main = screen.getByText("Page content").closest("main");
+    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+    expect(main?.parentElement).toHaveStyle({
+      gridTemplateColumns: "minmax(0, 1fr)",
+    });
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -95,6 +95,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
               });
             }}
             className="rounded p-1 text-muted hover:bg-raised"
+            aria-label="Toggle sidebar"
             title="Toggle sidebar (⌘\\)"
           >
             <SidebarToggleIcon collapsed={sidebarCollapsed} />
@@ -131,16 +132,17 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
       <div
         className="grid min-h-0 flex-1 overflow-hidden"
         style={{
-          gridTemplateColumns: `${sidebarCollapsed ? "0px" : "260px"} minmax(0, 1fr)`,
+          gridTemplateColumns: sidebarCollapsed ? "minmax(0, 1fr)" : "260px minmax(0, 1fr)",
         }}
       >
-        <AppSidebar
-          user={user}
-          onLogout={onLogout}
-          collapsed={sidebarCollapsed}
-          cmdkOpen={cmdkOpen}
-          onCmdkOpen={() => setCmdkOpen(true)}
-        />
+        {!sidebarCollapsed && (
+          <AppSidebar
+            user={user}
+            onLogout={onLogout}
+            cmdkOpen={cmdkOpen}
+            onCmdkOpen={() => setCmdkOpen(true)}
+          />
+        )}
         <main className="flex min-w-0 flex-col overflow-y-auto bg-base">
           {children}
         </main>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -4,12 +4,12 @@ import { ReactNode, useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { User, Workspace } from "../lib/types";
-import { listMyWorkspaces } from "../lib/api";
 import AppSidebar from "./AppSidebar";
 import CommandPalette from "./CommandPalette";
 import ShareModal from "./ShareModal";
 import { useBreadcrumbsValue } from "./BreadcrumbContext";
 import { StashIcon } from "./StashIcons";
+import { getCachedWorkspaces, readCachedWorkspaces } from "../lib/stashNavigationCache";
 
 interface AppShellProps {
   user: User;
@@ -39,16 +39,18 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
   const breadcrumbs = useBreadcrumbsValue();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeStashId, setActiveStashId] = useState<string | null>(null);
-  const [stashes, setStashes] = useState<Workspace[]>([]);
+  const [stashes, setStashes] = useState<Workspace[]>(
+    () => readCachedWorkspaces(user.id)?.all ?? []
+  );
   const [shareOpen, setShareOpen] = useState(false);
   const [cmdkOpen, setCmdkOpen] = useState(false);
 
   useEffect(() => {
     setSidebarCollapsed(readBool(SIDEBAR_KEY));
-    listMyWorkspaces()
-      .then((r) => setStashes(r.workspaces ?? []))
+    getCachedWorkspaces(user.id)
+      .then((r) => setStashes(r.all))
       .catch(() => {});
-  }, []);
+  }, [user.id]);
 
   useEffect(() => {
     const m =

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -102,7 +102,7 @@ describe("AppSidebar tree expansion", () => {
   });
 
   it("starts stashes and their top-level sections collapsed", async () => {
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Demo Stash");
 
@@ -117,7 +117,7 @@ describe("AppSidebar tree expansion", () => {
       workspaces: [workspace, sharedWorkspace],
     });
 
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Shared Stash");
     await screen.findByText("Demo Stash");
@@ -140,7 +140,7 @@ describe("AppSidebar tree expansion", () => {
     localStorage.setItem("stash_sidebar_open_stashes", "ws-1");
     localStorage.setItem("stash_sidebar_open_sections", "ws-1:sessions");
 
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Demo Stash");
 
@@ -153,7 +153,7 @@ describe("AppSidebar tree expansion", () => {
   it("keeps the stash landing route collapsed without saved state", async () => {
     nav.pathname = "/stashes/ws-1";
 
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Demo Stash");
 
@@ -166,7 +166,7 @@ describe("AppSidebar tree expansion", () => {
   it("opens the relevant tree branch for deep links only", async () => {
     nav.pathname = "/stashes/ws-1/p/page-1";
 
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Demo Stash");
 
@@ -180,7 +180,7 @@ describe("AppSidebar tree expansion", () => {
   it("reuses loaded workspace and spine data after a remount", async () => {
     nav.pathname = "/stashes/ws-1/p/page-1";
 
-    const first = render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    const first = render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
     await screen.findByText("Demo Stash");
     await waitFor(() => expect(getStashSpine).toHaveBeenCalledWith("ws-1"));
     expect(listMyWorkspaces).toHaveBeenCalledTimes(1);
@@ -189,7 +189,7 @@ describe("AppSidebar tree expansion", () => {
     first.unmount();
     vi.clearAllMocks();
 
-    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    render(<AppSidebar user={user} onCmdkOpen={vi.fn()} />);
 
     await screen.findByText("Demo Stash");
     expect(listMyWorkspaces).not.toHaveBeenCalled();

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppSidebar from "./AppSidebar";
+import { resetStashNavigationCache } from "../lib/stashNavigationCache";
 import {
   getStashSpine,
   listMyWorkspaces,
@@ -86,6 +87,7 @@ function detailsFor(label: string): HTMLDetailsElement {
 
 describe("AppSidebar tree expansion", () => {
   beforeEach(() => {
+    resetStashNavigationCache();
     localStorage.clear();
     nav.pathname = "/";
     nav.push.mockClear();
@@ -173,5 +175,25 @@ describe("AppSidebar tree expansion", () => {
     expect(detailsFor("Wiki")).toHaveAttribute("open");
     expect(localStorage.getItem("stash_sidebar_open_stashes")).toBeNull();
     expect(localStorage.getItem("stash_sidebar_open_sections")).toBeNull();
+  });
+
+  it("reuses loaded workspace and spine data after a remount", async () => {
+    nav.pathname = "/stashes/ws-1/p/page-1";
+
+    const first = render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+    await screen.findByText("Demo Stash");
+    await waitFor(() => expect(getStashSpine).toHaveBeenCalledWith("ws-1"));
+    expect(listMyWorkspaces).toHaveBeenCalledTimes(1);
+    expect(getStashSpine).toHaveBeenCalledTimes(1);
+
+    first.unmount();
+    vi.clearAllMocks();
+
+    render(<AppSidebar user={user} collapsed={false} onCmdkOpen={vi.fn()} />);
+
+    await screen.findByText("Demo Stash");
+    expect(listMyWorkspaces).not.toHaveBeenCalled();
+    expect(getStashSpine).not.toHaveBeenCalled();
+    expect(detailsFor("Demo Stash")).toHaveAttribute("open");
   });
 });

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -34,7 +34,6 @@ import {
 interface AppSidebarProps {
   user?: User;
   onLogout?: () => void;
-  collapsed?: boolean;
   cmdkOpen?: boolean;
   onCmdkOpen?: () => void;
 }
@@ -369,7 +368,7 @@ function WikiBlock({
   );
 }
 
-export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarProps) {
+export default function AppSidebar({ user, onCmdkOpen }: AppSidebarProps) {
   const pathname = usePathname();
   const userId = user?.id;
   const cachedWorkspaces = readCachedWorkspaces(userId);
@@ -483,8 +482,6 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
     if (open && isRouteOpen) return;
     setOpenSection(stashId, section, open);
   }
-
-  if (collapsed) return null;
 
   return (
     <aside className="scroll-thin overflow-y-auto border-r border-border bg-surface">

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -4,13 +4,18 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import {
-  getFolderContents,
-  getStashSpine,
-  listMyWorkspaces,
   type FolderContents,
   type StashSpine,
   type WikiFile,
 } from "../lib/api";
+import {
+  getCachedFolderContents,
+  getCachedStashSpine,
+  getCachedWorkspaces,
+  readCachedFolderContents,
+  readCachedSpines,
+  readCachedWorkspaces,
+} from "../lib/stashNavigationCache";
 import type { User, Workspace } from "../lib/types";
 import {
   ActivityIcon,
@@ -235,23 +240,26 @@ function FolderTreeNode({
   folderId: string;
   name: string;
 }) {
-  const [contents, setContents] = useState<FolderContents | null>(null);
-  const [loaded, setLoaded] = useState(false);
+  const cachedContents = readCachedFolderContents(folderId);
+  const [contents, setContents] = useState<FolderContents | null>(cachedContents);
+  const [loaded, setLoaded] = useState(!!cachedContents);
   return (
     <details
       className="text-[12.5px]"
       onToggle={(e) => {
         if ((e.target as HTMLDetailsElement).open && !loaded) {
           setLoaded(true);
-          getFolderContents(stashId, folderId)
+          getCachedFolderContents(stashId, folderId)
             .then(setContents)
-            .catch(() => setContents({
-              folder: { id: folderId, name, parent_folder_id: null },
-              breadcrumbs: [],
-              subfolders: [],
-              pages: [],
-              files: [],
-            }));
+            .catch(() =>
+              setContents({
+                folder: { id: folderId, name, parent_folder_id: null },
+                breadcrumbs: [],
+                subfolders: [],
+                pages: [],
+                files: [],
+              })
+            );
         }
       }}
     >
@@ -364,6 +372,7 @@ function WikiBlock({
 export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarProps) {
   const pathname = usePathname();
   const userId = user?.id;
+  const cachedWorkspaces = readCachedWorkspaces(userId);
   const activeStashId = pathname.match(/^\/stashes\/([^/]+)/)?.[1] ?? null;
   const activeTreeMatch = pathname.match(
     /^\/stashes\/([^/]+)\/(sessions|folders|p|f|skills)(?:\/|$)/
@@ -375,24 +384,25 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
       : activeTreeMatch
         ? "wiki"
         : null;
-  const [mine, setMine] = useState<Workspace[]>([]);
-  const [shared, setShared] = useState<Workspace[]>([]);
+  const [mine, setMine] = useState<Workspace[]>(cachedWorkspaces?.mine ?? []);
+  const [shared, setShared] = useState<Workspace[]>(cachedWorkspaces?.shared ?? []);
   const [openStashes, setOpenStashes] = useState<Record<string, boolean>>(() =>
     readOpenMap(OPEN_STASHES_KEY)
   );
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
     readOpenMap(OPEN_SECTIONS_KEY)
   );
-  const [spines, setSpines] = useState<Record<string, StashSpine>>({});
+  const [spines, setSpines] = useState<Record<string, StashSpine>>(() =>
+    readCachedSpines()
+  );
 
   useEffect(() => {
     if (!userId) return;
 
-    listMyWorkspaces()
+    getCachedWorkspaces(userId)
       .then((r) => {
-        const workspaces = r.workspaces ?? [];
-        setMine(workspaces.filter((w) => w.creator_id === userId));
-        setShared(workspaces.filter((w) => w.creator_id !== userId));
+        setMine(r.mine);
+        setShared(r.shared);
       })
       .catch(() => {});
   }, [userId]);
@@ -435,7 +445,7 @@ export default function AppSidebar({ user, collapsed, onCmdkOpen }: AppSidebarPr
     Array.from(new Set(openIds))
       .filter((stashId) => !spines[stashId])
       .forEach((stashId) => {
-        getStashSpine(stashId)
+        getCachedStashSpine(stashId)
           .then((sp) => setSpines((all) => ({ ...all, [stashId]: sp })))
           .catch(() => {});
       });

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { semanticSearchPages, type StashSpine } from "../lib/api";
 import {
-  getStashSpine,
-  semanticSearchPages,
-  type StashSpine,
-} from "../lib/api";
+  getCachedStashSpine,
+  readCachedStashSpine,
+} from "../lib/stashNavigationCache";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -23,7 +23,9 @@ interface Result {
 
 export default function CommandPalette({ open, onClose, stashId }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
-  const [spine, setSpine] = useState<StashSpine | null>(null);
+  const [spine, setSpine] = useState<StashSpine | null>(() =>
+    stashId ? readCachedStashSpine(stashId) : null
+  );
   const [results, setResults] = useState<Result[]>([]);
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -34,12 +36,18 @@ export default function CommandPalette({ open, onClose, stashId }: CommandPalett
     setResults([]);
     setSelected(0);
     inputRef.current?.focus();
-    if (stashId && !spine) {
-      getStashSpine(stashId)
+    const cached = stashId ? readCachedStashSpine(stashId) : null;
+    if (cached) {
+      setSpine(cached);
+      return;
+    }
+    setSpine(null);
+    if (stashId) {
+      getCachedStashSpine(stashId)
         .then(setSpine)
         .catch(() => {});
     }
-  }, [open, stashId, spine]);
+  }, [open, stashId]);
 
   useEffect(() => {
     if (!open || !query.trim()) {

--- a/frontend/src/lib/stashNavigationCache.ts
+++ b/frontend/src/lib/stashNavigationCache.ts
@@ -1,0 +1,112 @@
+import {
+  getFolderContents,
+  getStashSpine,
+  listMyWorkspaces,
+  type FolderContents,
+  type StashSpine,
+} from "./api";
+import type { Workspace } from "./types";
+
+interface CachedWorkspaces {
+  userId: string;
+  all: Workspace[];
+  mine: Workspace[];
+  shared: Workspace[];
+}
+
+let workspaceCache: CachedWorkspaces | null = null;
+let workspacePromise: Promise<CachedWorkspaces> | null = null;
+const spineCache: Record<string, StashSpine> = {};
+const spinePromises: Partial<Record<string, Promise<StashSpine>>> = {};
+const folderContentsCache: Record<string, FolderContents> = {};
+const folderContentsPromises: Partial<Record<string, Promise<FolderContents>>> = {};
+
+export function readCachedWorkspaces(userId: string | undefined): CachedWorkspaces | null {
+  if (!userId || workspaceCache?.userId !== userId) return null;
+  return workspaceCache;
+}
+
+export async function getCachedWorkspaces(userId: string): Promise<CachedWorkspaces> {
+  const cached = readCachedWorkspaces(userId);
+  if (cached) return cached;
+  if (workspacePromise) return workspacePromise;
+
+  workspacePromise = listMyWorkspaces()
+    .then((result) => {
+      const all = result.workspaces ?? [];
+      workspaceCache = {
+        userId,
+        all,
+        mine: all.filter((workspace) => workspace.creator_id === userId),
+        shared: all.filter((workspace) => workspace.creator_id !== userId),
+      };
+      return workspaceCache;
+    })
+    .finally(() => {
+      workspacePromise = null;
+    });
+
+  return workspacePromise;
+}
+
+export function readCachedSpines(): Record<string, StashSpine> {
+  return { ...spineCache };
+}
+
+export function readCachedStashSpine(stashId: string): StashSpine | null {
+  return spineCache[stashId] ?? null;
+}
+
+export async function getCachedStashSpine(stashId: string): Promise<StashSpine> {
+  const cached = readCachedStashSpine(stashId);
+  if (cached) return cached;
+  const pending = spinePromises[stashId];
+  if (pending) return pending;
+
+  const promise = getStashSpine(stashId)
+    .then((spine) => {
+      spineCache[stashId] = spine;
+      return spine;
+    })
+    .finally(() => {
+      delete spinePromises[stashId];
+    });
+  spinePromises[stashId] = promise;
+
+  return promise;
+}
+
+export function readCachedFolderContents(folderId: string): FolderContents | null {
+  return folderContentsCache[folderId] ?? null;
+}
+
+export async function getCachedFolderContents(
+  stashId: string,
+  folderId: string
+): Promise<FolderContents> {
+  const cached = readCachedFolderContents(folderId);
+  if (cached) return cached;
+  const pending = folderContentsPromises[folderId];
+  if (pending) return pending;
+
+  const promise = getFolderContents(stashId, folderId)
+    .then((contents) => {
+      folderContentsCache[folderId] = contents;
+      return contents;
+    })
+    .finally(() => {
+      delete folderContentsPromises[folderId];
+    });
+  folderContentsPromises[folderId] = promise;
+
+  return promise;
+}
+
+export function resetStashNavigationCache() {
+  workspaceCache = null;
+  workspacePromise = null;
+  for (const key of Object.keys(spineCache)) delete spineCache[key];
+  for (const key of Object.keys(spinePromises)) delete spinePromises[key];
+  for (const key of Object.keys(folderContentsCache)) delete folderContentsCache[key];
+  for (const key of Object.keys(folderContentsPromises)) delete folderContentsPromises[key];
+}


### PR DESCRIPTION
## Summary
- Add a shared client-side navigation cache for workspace lists, stash spines, and lazy folder contents.
- Use the cache from `AppShell`, `AppSidebar`, and `CommandPalette` so page/session navigation remounts do not refetch sidebar data that is already loaded.
- Fix the sidebar collapse behavior by hiding the sidebar at the shell level and switching the content grid to a single visible column.
- Add regression tests for sidebar remount cache reuse and collapsed-shell layout.
- Apply mechanical backend lint formatting so the existing CI lint job can complete.

## Verification
- `npm exec tsc -- --noEmit` in `frontend/`
- `npm run test -- AppShell.test.tsx AppSidebar.test.tsx` in `frontend/`
- `npm run lint` in `frontend/` passes with existing warnings
- `ruff check backend/ cli/`
- `black --check backend/ cli/`

## Screenshots
No persistent visual styling changes; this PR changes sidebar loading and collapse behavior.