### PR TITLE
Truncate per-input embeddings under 8192-token cap

### DIFF
--- a/backend/services/embeddings/openai_compat.py
+++ b/backend/services/embeddings/openai_compat.py
@@ -15,6 +15,11 @@ from .base import BaseEmbedder
 
 logger = logging.getLogger(__name__)
 
+# OpenAI-compatible endpoints cap each input at 8192 tokens. We approximate
+# ~4 chars/token (matching the batch-sharding budget) and clip at 30k chars
+# (~7500 tokens) so one oversize transcript doesn't fail the whole batch.
+_PER_INPUT_CHAR_CAP = 30_000
+
 
 class OpenAICompatEmbedder(BaseEmbedder):
     name = "openai"
@@ -46,6 +51,8 @@ class OpenAICompatEmbedder(BaseEmbedder):
         if not self.api_key or not texts:
             return None
 
+        inputs = [t[:_PER_INPUT_CHAR_CAP] for t in texts]
+
         client = self._get_client()
         try:
             resp = await client.post(
@@ -56,7 +63,7 @@ class OpenAICompatEmbedder(BaseEmbedder):
                 },
                 json={
                     "model": self.model,
-                    "input": texts,
+                    "input": inputs,
                     "dimensions": self.dims,
                 },
             )


### PR DESCRIPTION
## Summary
- OpenAI-compatible embedding endpoints cap each input at 8192 tokens; oversized inputs were failing whole batches (visible as `OpenAI-compat embedding rejected: 400 ... maximum input length is 8192 tokens` in logs for `input[0]`, `input[22]`, etc.).
- Clip each input to ~30k chars (~7500 tokens, matching the existing 4-chars/token approximation used by the 300k batch sharder) before sending.

## Test plan
- [ ] Re-run a workload that previously triggered the 8192-token warning (large transcript/wiki embed) and confirm no 400s in backend logs
- [ ] Verify normal-sized inputs still embed and rank as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)