### PR TITLE
Add haiku to 404 pages

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -141,6 +141,15 @@ export default function NotFound() {
         Not found
       </p>
 
+      <div
+        className="mt-6 font-display text-base leading-7 text-foreground/75"
+        aria-label="404 haiku"
+      >
+        <p>Lost page, quiet path</p>
+        <p>Stash keeps one small lantern lit</p>
+        <p>Home waits close at hand</p>
+      </div>
+
       <Link
         href="/"
         className="mt-8 inline-flex h-10 items-center rounded-md bg-brand px-5 text-sm font-medium text-white shadow-sm transition hover:bg-brand-hover"

--- a/www/app/not-found.tsx
+++ b/www/app/not-found.tsx
@@ -124,6 +124,15 @@ export default function NotFound() {
         This page doesn&apos;t exist, or it was moved.
       </p>
 
+      <div
+        className="mt-6 text-[15px] leading-7 text-dim"
+        aria-label="404 haiku"
+      >
+        <p>Lost page, quiet path</p>
+        <p>Stash keeps one small lantern lit</p>
+        <p>Home waits close at hand</p>
+      </div>
+
       <Link
         href="/"
         className="mt-8 inline-flex h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"


### PR DESCRIPTION
## Summary

- Add a three-line haiku to the product app 404 page.
- Add the same haiku to the public www 404 page.
- Preserve the existing missing-page headings and home navigation actions.

## Validation

- `rg -n "Lost page, quiet path|Stash keeps one small lantern lit|Home waits close at hand|aria-label=\"404 haiku\"" frontend/src/app/not-found.tsx www/app/not-found.tsx`
- `git diff --check`
- `ruff check backend/ cli/ && black --check backend/ cli/`
- `npm run lint` in `frontend` passed with existing warnings and 0 errors.
- `npm run build` in `frontend` passed.
- `rg -n "Lost page, quiet path|Stash keeps one small lantern lit|Home waits close at hand|aria-label=\"404 haiku\"" frontend/.next/server/app/_not-found.html`
- `npm run build` in `www` could not run locally because `www/node_modules/.bin/next` is absent in this workspace; the sandbox cannot reach `registry.npmjs.org` to install dependencies. Remote Vercel preview is expected to provide the www build proof.

## Screenshots

Screenshot upload is unavailable from this sandbox: no Playwright MCP is present, previous local Chromium launch hit a macOS Mach port permission error, and the GitHub connector does not expose media upload. The validation above includes source and built HTML proof for the rendered 404 haiku.

Closes FER-8