### PR TITLE
Fix sign-out: federated Auth0 logout, instant UI, and avatar menu

### DIFF
--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -43,12 +43,20 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     (async () => {
       try {
         await exchange();
-        if (cancelled) return;
-        const { workspaces } = await listMyWorkspaces();
-        router.push(workspaces.length === 1 ? `/workspaces/${workspaces[0].id}` : "/");
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Sign-in failed");
+        return;
       }
+      if (cancelled) return;
+      // Exchange succeeded — the user is signed in. If the workspace lookup
+      // hiccups (transient backend), don't flash a "sign-in failed" error;
+      // just land on /, which can reload the list itself.
+      const target = await listMyWorkspaces()
+        .then(({ workspaces }) =>
+          workspaces.length === 1 ? `/workspaces/${workspaces[0].id}` : "/",
+        )
+        .catch(() => "/");
+      if (!cancelled) router.push(target);
     })();
     return () => {
       cancelled = true;

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { User, Workspace } from "../lib/types";
@@ -104,16 +104,9 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         </div>
 
         <div className="flex items-center gap-1">
-          <Link
-            href="/settings"
-            className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-100 text-[10px] font-semibold text-[var(--color-brand-700)]"
-            title={user.display_name || user.name}
-          >
-            {initial}
-          </Link>
           {activeStashId && (
             <button
-              className="ml-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+              className="mr-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
               onClick={() =>
                 shareModal.open({
                   stashId: activeStashId,
@@ -124,13 +117,11 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
               Share
             </button>
           )}
-          <button onClick={onLogout} className="rounded p-1 text-muted hover:bg-raised" title="Sign out">
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-              <circle cx="5" cy="12" r="1.5" />
-              <circle cx="12" cy="12" r="1.5" />
-              <circle cx="19" cy="12" r="1.5" />
-            </svg>
-          </button>
+          <UserMenu
+            initial={initial}
+            label={user.display_name || user.name}
+            onLogout={onLogout}
+          />
         </div>
       </header>
 
@@ -158,6 +149,79 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         onClose={() => setCmdkOpen(false)}
         stashId={activeStashId}
       />
+    </div>
+  );
+}
+
+function UserMenu({
+  initial,
+  label,
+  onLogout,
+}: {
+  initial: string;
+  label: string;
+  onLogout: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={label}
+        className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-100 text-[10px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
+      >
+        {initial}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-40 mt-1.5 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
+        >
+          <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted">
+            Signed in as <span className="text-foreground">{label}</span>
+          </div>
+          <Link
+            href="/settings"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="block px-3 py-1.5 text-foreground hover:bg-raised"
+          >
+            Settings
+          </Link>
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onLogout();
+            }}
+            className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { ApiError, clearToken, getMe, getToken, logoutServer } from "../lib/api";
+import { ApiError, clearToken, getMe, getToken } from "../lib/api";
 import { User } from "../lib/types";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 /**
  * Auth hook. Reads the API key from localStorage and loads /users/me.
@@ -52,22 +53,26 @@ export function useAuth() {
     return () => window.removeEventListener("storage", onStorage);
   }, [loadUser]);
 
-  const logout = useCallback(async () => {
-    // Revoke server-side first so a captured token can't outlive the click.
-    // Best-effort: if the network drops, we still clear the local token.
-    try {
-      await logoutServer();
-    } catch {
-      // swallow — server may already be down, key may already be revoked
-    }
+  const logout = useCallback(() => {
+    // Drop local state first so the UI flips to signed-out the moment the
+    // user clicks — don't make them wait on a server round-trip. Revoke the
+    // key in the background; `keepalive` lets the request survive the
+    // navigation we're about to do.
+    const token = getToken();
     clearToken();
     setUser(null);
-    if (AUTH0_ENABLED) {
-      // Destroys the Next.js app-session cookie and redirects to Auth0's
-      // /v2/logout so the tenant SSO cookie is also cleared — otherwise "sign
-      // in again" silently re-auths into the same account.
-      window.location.href = "/auth/logout";
+    if (token) {
+      fetch(`${API_URL}/api/v1/users/logout`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        keepalive: true,
+      }).catch(() => {});
     }
+    // Hard navigation so module-level caches reset. `?federated` makes the
+    // Auth0 SDK kill the tenant SSO cookie too — without it, /login silently
+    // re-auths via the surviving SSO cookie and lands the user back on their
+    // workspace page.
+    window.location.href = AUTH0_ENABLED ? "/auth/logout?federated" : "/login";
   }, []);
 
   return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,10 +134,6 @@ export async function updateMe(data: {
   });
 }
 
-export async function logoutServer(): Promise<void> {
-  await apiFetch("/api/v1/users/logout", { method: "POST" });
-}
-
 export interface ApiKeyInfo {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
Three sign-out / sign-in problems, one PR.

### 1. Three-dot icon was wired to direct sign-out
Three dots universally read as "more options menu." Replaced with a proper avatar dropdown — click the avatar to get Settings + Sign out (`AppShell.tsx`).

### 2. Sign-out on Auth0 deploys silently re-authenticated
`useAuth.logout` did `await logoutServer()` → `clearToken()` → `setUser(null)` → `window.location.href = "/auth/logout"`. The Auth0 SDK route cleared the app session cookie but **not** the Auth0 tenant SSO cookie. The browser landed back on `/login`, `Auth0LoginPanel` saw a live SSO session via `/auth/profile`, and `ExchangeAndRedirect` silently minted a new `mc_…` key and routed the user to `/workspaces/{id}`. Net effect: clicked sign out, ended up back on the main workspace page, still signed in.

Now:
- Token + React state clear **synchronously**, so the UI flips immediately.
- Server revoke is fired with `keepalive: true` so it survives the navigation we're about to do.
- Hard `window.location.href` navigation — `/auth/logout?federated` under Auth0 (the SDK reads `?federated` and kills the tenant SSO cookie too) or `/login` in OSS mode.

Also drops the now-unused `logoutServer` from `api.ts`.

### 3. Transient `listMyWorkspaces` failure flagged as auth error in Auth0 flow
Split the try/catch in `ExchangeAndRedirect.tsx` so a workspace lookup failure after a successful token exchange falls back to `/` instead of stranding the user on "Sign-in failed". The password login path already did this.

## Verified locally (OSS mode)
- Sign out from `/` → `/login`, token gone, old token returns 401 from backend (revoke happened via keepalive fetch).
- Sign out from `/stashes/{id}` → same.
- Avatar dropdown opens/closes via click + Escape + click-outside.
- Share button still appears on workspace pages.

## Needs verification (Auth0 mode)
The federated logout fix requires the `Allowed Logout URLs` in Auth0 tenant config to include the app's base URL. Worth checking that the tenant accepts `?federated`.

## Test plan
- [ ] OSS: click Sign out, land on /login, token gone
- [ ] Auth0: click Sign out, land on /login, Auth0 SSO cookie gone, no silent re-auth
- [ ] Both: click avatar → Settings → /settings; click avatar → Sign out
- [ ] Both: keyboard — Escape closes dropdown
- [ ] Auth0: simulate listMyWorkspaces 500 right after exchange → user lands on `/`, not "Sign-in failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
