### PR TITLE
[codex] Make landing page green

### DIFF
--- a/www/DESIGN.md
+++ b/www/DESIGN.md
@@ -5,7 +5,7 @@ Extends the main Stash design system at `/DESIGN.md`. Only the landing-specific 
 ## Inherited (do not override)
 
 - Fonts: Satoshi (display), Instrument Sans (body), JetBrains Mono (code)
-- Palette: warm slates, orange `#F97316` accent, violet for agents, blue for humans
+- Palette: warm slates, green `#22C55E` accent, violet for agents, blue for humans
 - Base unit: 4px; radii sm/md/lg/full
 - Light mode default
 
@@ -23,8 +23,8 @@ Extends the main Stash design system at `/DESIGN.md`. Only the landing-specific 
 - Gap within a section: 32–48px
 
 ### Signature moves
-- **Dark terminal slab on light page.** The install block is the only dark surface on the page. `#0F172A` background, JetBrains Mono, orange `$` prompt. This makes code feel canonical; the rest of the page is light.
-- **Orange is rare.** Primary CTA button + one highlighted word in the hero + one underline. That's it. If orange shows up on every section the accent dies.
+- **Dark terminal slab on light page.** The install block is the only dark surface on the page. `#0F172A` background, JetBrains Mono, green `$` prompt. This makes code feel canonical; the rest of the page is light.
+- **Green is rare.** Primary CTA button + one highlighted word in the hero + one underline. That's it. If green shows up on every section the accent dies.
 - **Satoshi does the work.** No decorative shapes, no gradients, no icon-in-circle feature grids. The hero's geometric sans is the personality.
 
 ### Anti-patterns (do not ship)

--- a/www/app/_components/EmbeddingProjection3D.tsx
+++ b/www/app/_components/EmbeddingProjection3D.tsx
@@ -177,8 +177,8 @@ export default function EmbeddingProjection3D() {
               />
             </pattern>
             <radialGradient id="embed-glow" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stopColor="rgba(249,115,22,0.06)" />
-              <stop offset="100%" stopColor="rgba(249,115,22,0)" />
+              <stop offset="0%" stopColor="rgba(34,197,94,0.06)" />
+              <stop offset="100%" stopColor="rgba(34,197,94,0)" />
             </radialGradient>
           </defs>
           <rect width={WIDTH} height={HEIGHT} fill="url(#embed-grid)" />

--- a/www/app/_components/VisualizationsShowcase.tsx
+++ b/www/app/_components/VisualizationsShowcase.tsx
@@ -54,8 +54,8 @@ function PageGraphMock() {
   const nodeById = new Map(GRAPH_NODES.map((n) => [n.id, n]));
 
   const nodeColor = (degree: number) => {
-    if (degree >= 5) return "#F97316";
-    if (degree >= 3) return "#EA7C1F";
+    if (degree >= 5) return "var(--brand)";
+    if (degree >= 3) return "var(--brand-hover)";
     if (degree === 0) return "#8B5CF6";
     return "#64748B";
   };
@@ -139,7 +139,7 @@ function PageGraphMock() {
 
         <div className="absolute bottom-3 right-3 flex flex-col gap-1 rounded-md border border-border-subtle bg-background/85 px-2.5 py-2 backdrop-blur">
           {[
-            { dot: "#F97316", label: "hub" },
+            { dot: "var(--brand)", label: "hub" },
             { dot: "#64748B", label: "leaf" },
           ].map((row) => (
             <div
@@ -202,7 +202,7 @@ export default function VisualizationsShowcase() {
             <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
               <span className="text-ink">Wiki page graph.</span> Nodes are
               pages, edges are <span className="font-mono text-brand">[[backlinks]]</span>.
-              Orange nodes are the hubs your agents keep citing.
+              Green nodes are the hubs your agents keep citing.
             </p>
           </div>
         </div>

--- a/www/app/globals.css
+++ b/www/app/globals.css
@@ -16,10 +16,10 @@
   --text-on-inverted: #E2E8F0;
   --text-on-inverted-dim: #94A3B8;
 
-  --brand: #F97316;
-  --brand-hover: #EA580C;
-  --brand-ink: #7C2D12;
-  --brand-soft: rgba(249, 115, 22, 0.12);
+  --brand: #22C55E;
+  --brand-hover: #16A34A;
+  --brand-ink: #14532D;
+  --brand-soft: rgba(34, 197, 94, 0.12);
 
   --agent: #8B5CF6;
   --agent-soft: rgba(139, 92, 246, 0.14);

--- a/www/app/icon.svg
+++ b/www/app/icon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 72">
-  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316"/>
+  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#22C55E"/>
   <circle cx="25" cy="22" r="4" fill="#fff"/>
   <circle cx="39" cy="22" r="4" fill="#fff"/>
   <circle cx="26" cy="22" r="2" fill="#0F172A"/>
   <circle cx="40" cy="22" r="2" fill="#0F172A"/>
-  <path d="M12 38 Q8 52 4 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M20 40 Q18 54 14 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M32 42 Q32 56 32 64" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M44 40 Q46 54 50 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M52 38 Q56 52 60 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M12 38 Q8 52 4 60" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M20 40 Q18 54 14 62" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M32 42 Q32 56 32 64" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M44 40 Q46 54 50 62" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M52 38 Q56 52 60 60" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
 </svg>

--- a/www/app/not-found.tsx
+++ b/www/app/not-found.tsx
@@ -11,7 +11,7 @@ function LostOctopus() {
       style={{ animation: "bob 3s ease-in-out infinite" }}
     >
       <g transform="rotate(-8, 100, 70)">
-        <ellipse cx="100" cy="70" rx="52" ry="42" fill="#F97316" />
+        <ellipse cx="100" cy="70" rx="52" ry="42" fill="var(--brand)" />
         <circle cx="82" cy="64" r="10" fill="#fff" />
         <circle cx="118" cy="64" r="10" fill="#fff" />
         <circle cx="79" cy="62" r="5" fill="#0F172A" />
@@ -23,12 +23,12 @@ function LostOctopus() {
           strokeLinecap="round"
           fill="none"
         />
-        <ellipse cx="100" cy="84" rx="5" ry="6" fill="#EA580C" />
+        <ellipse cx="100" cy="84" rx="5" ry="6" fill="var(--brand-hover)" />
       </g>
 
       <path
         d="M56 108 Q28 128 16 158 Q12 170 20 168"
-        stroke="#F97316"
+        stroke="var(--brand)"
         strokeWidth="8"
         strokeLinecap="round"
         fill="none"
@@ -36,7 +36,7 @@ function LostOctopus() {
       />
       <path
         d="M72 114 Q54 140 42 170 Q38 182 46 178"
-        stroke="#F97316"
+        stroke="var(--brand)"
         strokeWidth="8"
         strokeLinecap="round"
         fill="none"
@@ -44,14 +44,14 @@ function LostOctopus() {
       />
       <path
         d="M98 118 Q96 158 100 194"
-        stroke="#F97316"
+        stroke="var(--brand)"
         strokeWidth="8"
         strokeLinecap="round"
         fill="none"
       />
       <path
         d="M124 114 Q142 140 154 170 Q158 182 150 178"
-        stroke="#F97316"
+        stroke="var(--brand)"
         strokeWidth="8"
         strokeLinecap="round"
         fill="none"
@@ -59,7 +59,7 @@ function LostOctopus() {
       />
       <path
         d="M140 108 Q168 128 180 158 Q184 170 176 168"
-        stroke="#F97316"
+        stroke="var(--brand)"
         strokeWidth="8"
         strokeLinecap="round"
         fill="none"
@@ -71,7 +71,7 @@ function LostOctopus() {
         y="28"
         fontSize="28"
         fontWeight="bold"
-        fill="#F97316"
+        fill="var(--brand)"
         opacity="0.6"
         style={{ animation: "float 2s ease-in-out infinite" }}
       >

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -34,16 +34,16 @@ function Logo({ size = 28 }: { size?: number }) {
       height={(size * 72) / 64}
       aria-hidden="true"
     >
-      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
+      <ellipse cx="32" cy="24" rx="22" ry="18" fill="var(--brand)" />
       <circle cx="25" cy="22" r="4" fill="#fff" />
       <circle cx="39" cy="22" r="4" fill="#fff" />
       <circle cx="26" cy="22" r="2" fill="#0F172A" />
       <circle cx="40" cy="22" r="2" fill="#0F172A" />
-      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M12 38 Q8 52 4 60" stroke="var(--brand)" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M20 40 Q18 54 14 62" stroke="var(--brand)" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M32 42 Q32 56 32 64" stroke="var(--brand)" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M44 40 Q46 54 50 62" stroke="var(--brand)" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M52 38 Q56 52 60 60" stroke="var(--brand)" strokeWidth="4" strokeLinecap="round" fill="none" />
     </svg>
   );
 }
@@ -295,7 +295,7 @@ function Hero() {
         className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[680px]"
         style={{
           background:
-            "radial-gradient(ellipse 80% 60% at 20% 10%, rgba(249,115,22,0.09), transparent 60%)",
+            "radial-gradient(ellipse 80% 60% at 20% 10%, rgba(34,197,94,0.09), transparent 60%)",
         }}
       />
       <div className="relative z-10 mx-auto grid max-w-[1200px] grid-cols-1 gap-12 px-7 pb-8 pt-20 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:gap-16 lg:pb-16 lg:pt-28">
@@ -742,8 +742,8 @@ function SearchDemo() {
             <div
               className="mt-6 rounded-[10px] border p-5"
               style={{
-                background: "rgba(249,115,22,0.06)",
-                borderColor: "rgba(249,115,22,0.2)",
+                background: "rgba(34,197,94,0.06)",
+                borderColor: "rgba(34,197,94,0.2)",
               }}
             >
               <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-brand">

--- a/www/public/octopus-logo.svg
+++ b/www/public/octopus-logo.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 72" width="200" height="225">
-  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316"/>
+  <ellipse cx="32" cy="24" rx="22" ry="18" fill="#22C55E"/>
   <circle cx="25" cy="22" r="4" fill="#fff"/>
   <circle cx="39" cy="22" r="4" fill="#fff"/>
   <circle cx="26" cy="22" r="2" fill="#0F172A"/>
   <circle cx="40" cy="22" r="2" fill="#0F172A"/>
-  <path d="M12 38 Q8 52 4 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M20 40 Q18 54 14 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M32 42 Q32 56 32 64" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M44 40 Q46 54 50 62" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
-  <path d="M52 38 Q56 52 60 60" stroke="#F97316" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M12 38 Q8 52 4 60" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M20 40 Q18 54 14 62" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M32 42 Q32 56 32 64" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M44 40 Q46 54 50 62" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M52 38 Q56 52 60 60" stroke="#22C55E" stroke-width="4" stroke-linecap="round" fill="none"/>
 </svg>


### PR DESCRIPTION
## Summary
- Change the landing page brand color from orange to green.
- Update matching landing SVG assets, mock visualization accents, 404 octopus, and landing design notes.
- Keep the change scoped to the `www` landing/theme surface.

## Validation
- `git diff --check HEAD~1..HEAD`
- `npm run build` from `www`
- Source scan over changed landing files found no old orange brand constants.
- Runtime/screenshot attempt: local Next listeners are blocked in this sandbox with `listen EPERM`, localhost:3100 timed out, and Playwright browser launches failed under the macOS sandbox. The built `/` artifact was inspected and shows the green brand tokens in the first-viewport markup/CSS while old orange tokens are absent.

Closes FER-13