### PR TITLE
Add stash Sessions page; split sidebar toggle from row navigation

### DIFF
--- a/frontend/src/app/stashes/[stashId]/sessions/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/sessions/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import AppShell from "../../../../components/AppShell";
+import { SessionsIcon } from "../../../../components/StashIcons";
+import { useAuth } from "../../../../hooks/useAuth";
+import {
+  getWorkspace,
+  listMySessions,
+  type SessionSummary,
+} from "../../../../lib/api";
+import type { Workspace } from "../../../../lib/types";
+
+export default function StashSessionsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const stashId = params.stashId as string;
+  const { user, loading, logout } = useAuth();
+
+  const [stash, setStash] = useState<Workspace | null>(null);
+  const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const [workspace, list] = await Promise.all([
+        getWorkspace(stashId),
+        listMySessions(stashId, 200),
+      ]);
+      setStash(workspace);
+      setSessions(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load sessions");
+    }
+  }, [stashId]);
+
+  useEffect(() => {
+    if (user) load();
+  }, [user, load]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  const filtered = useMemo(() => {
+    if (!sessions) return null;
+    const q = query.trim().toLowerCase();
+    if (!q) return sessions;
+    return sessions.filter((s) => {
+      const haystack = [s.agent_name, s.first_prompt_preview, s.session_id]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [sessions, query]);
+
+  if (loading)
+    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (!user) return null;
+
+  return (
+    <AppShell user={user} onLogout={logout}>
+      <div className="scroll-thin flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-12 py-8">
+          <nav className="mb-4 flex flex-wrap items-center gap-1.5 text-[12.5px] text-muted">
+            <Link href={`/stashes/${stashId}`} className="hover:text-foreground">
+              {stash?.name || "Stash"}
+            </Link>
+            <span className="flex items-center gap-1.5">
+              <span className="text-muted/60">/</span>
+              <span className="font-medium text-foreground">Sessions</span>
+            </span>
+          </nav>
+
+          <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
+            <SessionsIcon />
+          </div>
+          <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
+            Sessions
+          </h1>
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+              {error}
+            </div>
+          )}
+
+          <div className="mt-5 mb-4">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by agent, prompt, or session id…"
+              className="w-full rounded-md border border-border bg-base px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-300)] focus:outline-none"
+            />
+          </div>
+
+          {filtered && (
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              {filtered.map((s) => (
+                <Link
+                  key={s.session_id}
+                  href={`/stashes/${stashId}/sessions/${encodeURIComponent(s.session_id)}`}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-base p-3 text-left transition-colors hover:border-[var(--color-brand-200)] hover:bg-[var(--color-brand-50)]"
+                >
+                  <span className="flex h-7 w-7 items-center justify-center text-2xl text-muted">
+                    <SessionsIcon />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="truncate text-[13.5px] font-semibold text-foreground">
+                      {sessionTitle(s)}
+                    </div>
+                    <div className="truncate text-[11.5px] text-muted">
+                      {sessionSubtitle(s)}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+              {filtered.length === 0 && (
+                <div className="col-span-full rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
+                  {sessions && sessions.length === 0
+                    ? "No sessions yet."
+                    : "No sessions match your search."}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function sessionTitle(s: SessionSummary): string {
+  if (s.agent_name) return s.agent_name;
+  const id = s.session_id;
+  const short = id.replace(/^session[-_]/, "").slice(0, 8);
+  return short || id;
+}
+
+function sessionSubtitle(s: SessionSummary): string {
+  const preview = (s.first_prompt_preview || "").trim().replace(/\s+/g, " ");
+  const truncated = preview.length > 80 ? preview.slice(0, 80) + "…" : preview;
+  const when = formatRelative(s.last_event_at);
+  if (truncated && when) return `${truncated} · ${when}`;
+  return truncated || when || `${s.event_count} events`;
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 7) return `${diffD}d ago`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -72,19 +72,30 @@ function sectionKey(stashId: string, section: SidebarSection): string {
   return `${stashId}:${section}`;
 }
 
-function Chevron() {
+function ChevronToggle({ onToggle }: { onToggle: () => void }) {
   return (
-    <svg
-      className="chev h-3 w-3 text-muted"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggle();
+      }}
+      className="-ml-0.5 flex h-4 w-4 items-center justify-center rounded text-muted hover:bg-base/60 hover:text-foreground"
+      aria-label="Toggle"
     >
-      <polyline points="9 18 15 12 9 6" />
-    </svg>
+      <svg
+        className="chev h-3 w-3"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+    </button>
   );
 }
 
@@ -143,8 +154,11 @@ function StashTree({
       onToggle={(e) => onOpenChange(e.currentTarget.open)}
       className="group/stash"
     >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 text-[13px] hover:bg-raised">
-        <Chevron />
+      <summary
+        onClick={(e) => e.preventDefault()}
+        className="page-row flex items-center gap-1 rounded-md px-2 py-1 text-[13px] hover:bg-raised"
+      >
+        <ChevronToggle onToggle={() => onOpenChange(!open)} />
         <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
           <StashIcon />
         </span>
@@ -164,12 +178,22 @@ function StashTree({
           onToggle={(e) => onSectionOpenChange("sessions", e.currentTarget.open)}
           className="text-[13px]"
         >
-          <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
-            <Chevron />
+          <summary
+            onClick={(e) => e.preventDefault()}
+            className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised"
+          >
+            <ChevronToggle
+              onToggle={() => onSectionOpenChange("sessions", !openSections.sessions)}
+            />
             <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
               <SessionsIcon />
             </span>
-            <span className="flex-1 truncate font-medium text-foreground">Sessions</span>
+            <Link
+              href={`/stashes/${stash.id}/sessions`}
+              className="flex-1 truncate font-medium text-foreground hover:text-[var(--color-brand-700)]"
+            >
+              Sessions
+            </Link>
             <span className="text-[10.5px] text-muted">{spine?.sessions.length ?? 0}</span>
           </summary>
           <div className="ml-3 space-y-0.5 border-l border-border pl-2">
@@ -242,28 +266,34 @@ function FolderTreeNode({
   const cachedContents = readCachedFolderContents(folderId);
   const [contents, setContents] = useState<FolderContents | null>(cachedContents);
   const [loaded, setLoaded] = useState(!!cachedContents);
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = useCallback(() => {
+    const next = !open;
+    setOpen(next);
+    if (next && !loaded) {
+      setLoaded(true);
+      getCachedFolderContents(stashId, folderId)
+        .then(setContents)
+        .catch(() =>
+          setContents({
+            folder: { id: folderId, name, parent_folder_id: null },
+            breadcrumbs: [],
+            subfolders: [],
+            pages: [],
+            files: [],
+          })
+        );
+    }
+  }, [open, loaded, stashId, folderId, name]);
+
   return (
-    <details
-      className="text-[12.5px]"
-      onToggle={(e) => {
-        if ((e.target as HTMLDetailsElement).open && !loaded) {
-          setLoaded(true);
-          getCachedFolderContents(stashId, folderId)
-            .then(setContents)
-            .catch(() =>
-              setContents({
-                folder: { id: folderId, name, parent_folder_id: null },
-                breadcrumbs: [],
-                subfolders: [],
-                pages: [],
-                files: [],
-              })
-            );
-        }
-      }}
-    >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised">
-        <Chevron />
+    <details open={open} className="text-[12.5px]">
+      <summary
+        onClick={(e) => e.preventDefault()}
+        className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised"
+      >
+        <ChevronToggle onToggle={handleToggle} />
         <span className="flex h-4 w-4 items-center justify-center text-muted">
           <FolderIcon />
         </span>
@@ -332,8 +362,14 @@ function WikiBlock({
       onToggle={(e) => onOpenChange(e.currentTarget.open)}
       className="text-[13px]"
     >
-      <summary className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised">
-        <Chevron />
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          onOpenChange(!open);
+        }}
+        className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised"
+      >
+        <ChevronToggle onToggle={() => onOpenChange(!open)} />
         <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
           <WikiIcon />
         </span>


### PR DESCRIPTION
## Summary

- **New page** at `/stashes/[stashId]/sessions` — full searchable list of every session in the stash (the sidebar only previews 8). Search filters by agent name, prompt preview, and session id. Cards link into the existing `/stashes/[id]/sessions/[sessionId]` detail page.
- **Sidebar split**: the chevron is now the only toggle. Clicking a row label (stash name, "Sessions", folder name) navigates to that page instead of also toggling the accordion. Folder rows now reliably open the existing folder page at `/stashes/[id]/folders/[folderId]`.
- "Sessions" section header is now a `<Link>` to the new index page.
- No backend changes — `GET /api/v1/me/sessions?workspace_id=...` already returns everything we need.

## Files

- New: `frontend/src/app/stashes/[stashId]/sessions/page.tsx`
- Changed: `frontend/src/components/AppSidebar.tsx` — extracted `ChevronToggle` button; added `onClick={e => e.preventDefault()}` on each `<summary>` to cancel the native `<details>` toggle; `FolderTreeNode` is now controlled-open via local state.

## Test plan

- [ ] Visit `/stashes/<your-stash>/sessions` — see the full list, sorted by `last_event_at` desc.
- [ ] Type a few characters in the search box — list narrows by agent / prompt / session id.
- [ ] Click a session card — routes to the existing session detail page.
- [ ] In the sidebar:
  - [ ] Click chevron on a stash → expands; URL unchanged.
  - [ ] Click stash name → routes to `/stashes/<id>`; accordion state unchanged.
  - [ ] Click chevron next to "Sessions" → expands.
  - [ ] Click "Sessions" label → routes to `/stashes/<id>/sessions`.
  - [ ] Click chevron next to a folder → expands and lazy-loads contents.
  - [ ] Click folder name → routes to `/stashes/<id>/folders/<id>`.

## Screenshots

Screenshots need a live stash with sessions and folders. Couldn't capture them locally (no backend in this environment) — will attach after the preview deploy or follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)