### PR TITLE
Responsive vs fixed-aspect layout modes for HTML pages

### DIFF
--- a/backend/migrations/versions/0041_html_page_layout.py
+++ b/backend/migrations/versions/0041_html_page_layout.py
@@ -1,0 +1,37 @@
+"""Add html_layout column to pages.
+
+HTML pages render inside a sandboxed iframe. The iframe has no idea how tall
+its content "wants" to be, so the parent has to decide the box. Two modes:
+
+- 'responsive' (default): inject a tiny ResizeObserver+postMessage bootstrap
+  into the rendered HTML so the page reports its natural height back to the
+  parent, which then sizes the iframe to fit. Right for documents, cards,
+  dashboards — content where the height is a property of the content.
+
+- 'fixed-aspect': lock the iframe to a 16:9 box. Right for slides / decks
+  where the canvas is intentional and growing it would break the design.
+
+Both modes share the same sandbox; only the parent's sizing strategy differs.
+
+Revision ID: 0041
+Revises: 0040
+"""
+
+from alembic import op
+
+revision = "0041"
+down_revision = "0040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE pages ADD COLUMN IF NOT EXISTS html_layout "
+        "VARCHAR(16) NOT NULL DEFAULT 'responsive' "
+        "CHECK (html_layout IN ('responsive', 'fixed-aspect'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE pages DROP COLUMN IF EXISTS html_layout")

--- a/backend/models.py
+++ b/backend/models.py
@@ -364,6 +364,7 @@ class PageCreateRequest(BaseModel):
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
     content_html: str = ""
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect)$")
 
 
 class PageUpdateRequest(BaseModel):
@@ -372,6 +373,7 @@ class PageUpdateRequest(BaseModel):
     content: str | None = None
     content_type: str | None = Field(None, pattern=r"^(markdown|html)$")
     content_html: str | None = None
+    html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect)$")
     move_to_root: bool = False
 
 
@@ -383,6 +385,7 @@ class PageResponse(BaseModel):
     content_markdown: str
     content_type: str = "markdown"
     content_html: str = ""
+    html_layout: str = "responsive"
     content_hash: str | None = None
     metadata: dict = {}
     created_by: UUID
@@ -663,6 +666,7 @@ class PublishRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect)$")
     audience: str = Field("link", pattern=r"^(link|public)$")
     folder_id: UUID | None = None
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -265,7 +265,7 @@ async def public_page(
 
     page = await pool.fetchrow(
         "SELECT p.id, p.name, p.content_type, p.content_markdown, p.content_html, "
-        "p.folder_id, p.workspace_id, p.updated_at, "
+        "p.html_layout, p.folder_id, p.workspace_id, p.updated_at, "
         "f.name AS folder_name "
         "FROM pages p LEFT JOIN folders f ON f.id = p.folder_id WHERE p.id = $1",
         page_id,

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -43,6 +43,7 @@ async def publish(
         content=req.content if req.content_type == "markdown" else "",
         content_type=req.content_type,
         content_html=req.content if req.content_type == "html" else "",
+        html_layout=req.html_layout,
     )
 
     await permission_service.set_visibility("page", page["id"], req.audience)

--- a/backend/routers/wiki.py
+++ b/backend/routers/wiki.py
@@ -273,6 +273,7 @@ async def create_page(
             content=req.content,
             content_type=req.content_type,
             content_html=req.content_html,
+            html_layout=req.html_layout,
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))
@@ -343,6 +344,7 @@ async def update_page(
             content=req.content,
             content_type=req.content_type,
             content_html=req.content_html,
+            html_layout=req.html_layout,
             move_to_root=req.move_to_root,
         )
     except DuplicatePageName as e:

--- a/backend/services/view_service.py
+++ b/backend/services/view_service.py
@@ -389,7 +389,7 @@ async def inline_items(view: dict, viewer_id: UUID | None = None) -> list[dict]:
                     "  SELECT f.id FROM folders f JOIN subtree s ON f.parent_folder_id = s.id"
                     ") "
                     "SELECT p.id, p.name, p.content_markdown, p.content_html, p.content_type, "
-                    "p.updated_at FROM pages p "
+                    "p.html_layout, p.updated_at FROM pages p "
                     "WHERE p.folder_id IN (SELECT id FROM subtree) "
                     "ORDER BY p.created_at, p.name",
                     obj_id,
@@ -408,6 +408,7 @@ async def inline_items(view: dict, viewer_id: UUID | None = None) -> list[dict]:
                             "content_type": p["content_type"],
                             "content_markdown": p["content_markdown"],
                             "content_html": p["content_html"],
+                            "html_layout": p["html_layout"],
                             "updated_at": p["updated_at"].isoformat(),
                         }
                         for p in visible_pages
@@ -415,8 +416,8 @@ async def inline_items(view: dict, viewer_id: UUID | None = None) -> list[dict]:
                 }
         elif obj_type == "page":
             p = await pool.fetchrow(
-                "SELECT id, name, content_markdown, content_html, content_type, updated_at "
-                "FROM pages WHERE id = $1",
+                "SELECT id, name, content_markdown, content_html, content_type, "
+                "html_layout, updated_at FROM pages WHERE id = $1",
                 obj_id,
             )
             if p:
@@ -428,6 +429,7 @@ async def inline_items(view: dict, viewer_id: UUID | None = None) -> list[dict]:
                         "content_type": p["content_type"],
                         "content_markdown": p["content_markdown"],
                         "content_html": p["content_html"],
+                        "html_layout": p["html_layout"],
                         "updated_at": p["updated_at"].isoformat(),
                     }
                 }
@@ -636,7 +638,7 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
 
                     pages = await conn.fetch(
                         "SELECT id, folder_id, name, content_markdown, content_html, "
-                        "content_type, content_hash, metadata FROM pages "
+                        "content_type, html_layout, content_hash, metadata FROM pages "
                         "WHERE folder_id = ANY($1::uuid[])",
                         list(folder_id_map.keys()),
                     )
@@ -648,14 +650,15 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                         await conn.execute(
                             "INSERT INTO pages "
                             "(workspace_id, folder_id, name, content_markdown, content_html, "
-                            "content_type, content_hash, metadata, created_by) "
-                            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                            "content_type, html_layout, content_hash, metadata, created_by) "
+                            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
                             new_ws_id,
                             folder_id_map.get(p["folder_id"]),
                             p["name"],
                             p["content_markdown"] or "",
                             p["content_html"] or "",
                             p["content_type"],
+                            p["html_layout"],
                             p["content_hash"],
                             p["metadata"] or {},
                             forker_id,
@@ -664,7 +667,7 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                 elif t == "page":
                     src = await conn.fetchrow(
                         "SELECT name, content_markdown, content_html, content_type, "
-                        "content_hash, metadata FROM pages WHERE id = $1",
+                        "html_layout, content_hash, metadata FROM pages WHERE id = $1",
                         src_id,
                     )
                     if not src:
@@ -672,13 +675,14 @@ async def fork_view(slug: str, forker_id: UUID, name: str | None = None) -> dict
                     await conn.execute(
                         "INSERT INTO pages "
                         "(workspace_id, name, content_markdown, content_html, "
-                        "content_type, content_hash, metadata, created_by) "
-                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                        "content_type, html_layout, content_hash, metadata, created_by) "
+                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                         new_ws_id,
                         src["name"],
                         src["content_markdown"] or "",
                         src["content_html"] or "",
                         src["content_type"],
+                        src["html_layout"],
                         src["content_hash"],
                         src["metadata"] or {},
                         forker_id,

--- a/backend/services/wiki_service.py
+++ b/backend/services/wiki_service.py
@@ -223,6 +223,7 @@ async def create_page(
     metadata: dict | None = None,
     content_type: str = "markdown",
     content_html: str = "",
+    html_layout: str = "responsive",
 ) -> dict:
     pool = get_pool()
     if folder_id is not None:
@@ -236,10 +237,10 @@ async def create_page(
         row = await pool.fetchrow(
             "INSERT INTO pages "
             "(workspace_id, folder_id, name, content_markdown, content_html, content_type, "
-            "content_hash, metadata, created_by, updated_by) "
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $9) "
+            "html_layout, content_hash, metadata, created_by, updated_by) "
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $10) "
             "RETURNING id, workspace_id, folder_id, name, content_markdown, content_html, "
-            "content_type, content_hash, metadata, created_by, updated_by, "
+            "content_type, html_layout, content_hash, metadata, created_by, updated_by, "
             "created_at, updated_at",
             workspace_id,
             folder_id,
@@ -247,6 +248,7 @@ async def create_page(
             content,
             content_html,
             content_type,
+            html_layout,
             ch,
             meta,
             created_by,
@@ -267,7 +269,7 @@ async def get_page(page_id: UUID, workspace_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, workspace_id, folder_id, name, content_markdown, content_html, "
-        "content_type, content_hash, metadata, "
+        "content_type, html_layout, content_hash, metadata, "
         "created_by, updated_by, created_at, updated_at "
         "FROM pages WHERE id = $1 AND workspace_id = $2",
         page_id,
@@ -305,6 +307,7 @@ async def update_page(
     content: str | None = None,
     content_type: str | None = None,
     content_html: str | None = None,
+    html_layout: str | None = None,
     move_to_root: bool = False,
     metadata: dict | None = None,
     on_conflict: Callable[[dict], Awaitable[str]] | None = None,
@@ -359,6 +362,10 @@ async def update_page(
             sets.append(f"content_type = ${idx}")
             args.append(content_type)
             idx += 1
+        if html_layout is not None:
+            sets.append(f"html_layout = ${idx}")
+            args.append(html_layout)
+            idx += 1
         if content_changed:
             new_type = content_type or current_type or "markdown"
             new_md = (
@@ -389,7 +396,7 @@ async def update_page(
             row = await pool.fetchrow(
                 f"UPDATE pages SET {', '.join(sets)} WHERE {where} "
                 "RETURNING id, workspace_id, folder_id, name, content_markdown, content_html, "
-                "content_type, content_hash, metadata, "
+                "content_type, html_layout, content_hash, metadata, "
                 "created_by, updated_by, created_at, updated_at",
                 *args,
             )
@@ -414,7 +421,7 @@ async def update_page(
 
         fresh = await pool.fetchrow(
             "SELECT id, workspace_id, folder_id, name, content_markdown, content_html, "
-            "content_type, content_hash, metadata, "
+            "content_type, html_layout, content_hash, metadata, "
             "created_by, updated_by, created_at, updated_at "
             "FROM pages WHERE id = $1 AND workspace_id = $2",
             page_id,
@@ -438,7 +445,7 @@ async def update_page(
     logger.warning("update_page exhausted retries for page %s", page_id)
     fresh = await pool.fetchrow(
         "SELECT id, workspace_id, folder_id, name, content_markdown, content_html, "
-        "content_type, content_hash "
+        "content_type, html_layout, content_hash "
         "FROM pages WHERE id = $1 AND workspace_id = $2",
         page_id,
         workspace_id,

--- a/frontend/src/app/s/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/s/[workspaceId]/p/[pageId]/page.tsx
@@ -35,6 +35,7 @@ interface PublicPage {
   content_type: "markdown" | "html";
   content_markdown: string;
   content_html: string;
+  html_layout: "responsive" | "fixed-aspect";
   folder_id: string | null;
   folder_name: string | null;
   workspace_id: string;
@@ -84,7 +85,11 @@ export default async function PublicPageReader({
 
       <article className="mt-8">
         {page.content_type === "html" ? (
-          <HtmlPageView html={page.content_html || ""} title={page.name} />
+          <HtmlPageView
+            html={page.content_html || ""}
+            title={page.name}
+            layout={page.html_layout}
+          />
         ) : (
           <div className="markdown-content">
             <Markdown remarkPlugins={[remarkGfm]}>{page.content_markdown || "(empty)"}</Markdown>

--- a/frontend/src/app/stashes/[stashId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/p/[pageId]/page.tsx
@@ -181,7 +181,11 @@ export default function StashPageView() {
           <article className="mt-8 text-[15px] leading-relaxed text-foreground">
             {page ? (
               page.content_type === "html" ? (
-                <HtmlPageView html={page.content_html || ""} title={page.name} />
+                <HtmlPageView
+                  html={page.content_html || ""}
+                  title={page.name}
+                  layout={page.html_layout}
+                />
               ) : (
                 <MarkdownEditor
                   workspaceId={stashId}

--- a/frontend/src/app/v/[slug]/embed/page.tsx
+++ b/frontend/src/app/v/[slug]/embed/page.tsx
@@ -58,10 +58,14 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
     return <p className="text-[12px] italic text-muted">Item unavailable.</p>;
   }
   if (item.object_type === "page") {
-    const p = (item.inline as { page?: { content_type?: string; content_markdown?: string; content_html?: string; name?: string } }).page;
+    const p = (item.inline as { page?: { content_type?: string; content_markdown?: string; content_html?: string; html_layout?: "responsive" | "fixed-aspect"; name?: string } }).page;
     if (!p) return null;
     return p.content_type === "html" ? (
-      <HtmlPageView html={p.content_html || ""} title={p.name || item.label} />
+      <HtmlPageView
+        html={p.content_html || ""}
+        title={p.name || item.label}
+        layout={p.html_layout}
+      />
     ) : (
       <div className="markdown-content">
         <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>
@@ -70,7 +74,7 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
   }
   if (item.object_type === "folder") {
     const inline = item.inline as {
-      pages?: { id: string; name: string; content_type?: string; content_markdown?: string; content_html?: string }[];
+      pages?: { id: string; name: string; content_type?: string; content_markdown?: string; content_html?: string; html_layout?: "responsive" | "fixed-aspect" }[];
     };
     return (
       <div className="space-y-4">
@@ -78,7 +82,11 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
           <div key={p.id}>
             <h2 className="mb-2 font-display text-[15px] font-bold text-ink">{p.name}</h2>
             {p.content_type === "html" ? (
-              <HtmlPageView html={p.content_html || ""} title={p.name} />
+              <HtmlPageView
+                html={p.content_html || ""}
+                title={p.name}
+                layout={p.html_layout}
+              />
             ) : (
               <div className="markdown-content">
                 <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -170,6 +170,7 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
         content_type?: "markdown" | "html";
         content_markdown: string;
         content_html?: string;
+        html_layout?: "responsive" | "fixed-aspect";
       }[];
     };
     return (
@@ -179,7 +180,11 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
             <h3 className="font-display text-[16px] font-bold text-ink">{p.name}</h3>
             {p.content_type === "html" ? (
               <div className="mt-2">
-                <HtmlPageView html={p.content_html || ""} title={p.name} />
+                <HtmlPageView
+                  html={p.content_html || ""}
+                  title={p.name}
+                  layout={p.html_layout}
+                />
               </div>
             ) : (
               <div className="mt-2 markdown-content">
@@ -202,12 +207,17 @@ function ItemBody({ item }: { item: ViewItemInlined }) {
         content_type?: "markdown" | "html";
         content_markdown: string;
         content_html?: string;
+        html_layout?: "responsive" | "fixed-aspect";
       };
     };
     const p = inline.page;
     if (!p) return <p className="text-[13px] italic text-muted">This page is no longer available.</p>;
     return p.content_type === "html" ? (
-      <HtmlPageView html={p.content_html || ""} title={p.name} />
+      <HtmlPageView
+        html={p.content_html || ""}
+        title={p.name}
+        layout={p.html_layout}
+      />
     ) : (
       <div className="markdown-content">
         <Markdown remarkPlugins={[remarkGfm]}>

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -1,26 +1,120 @@
 "use client";
 
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+export type HtmlLayout = "responsive" | "fixed-aspect";
+
 type Props = {
   html: string;
   title: string;
+  layout?: HtmlLayout;
 };
 
-// HTML page renderer. The iframe sandbox is the entire defense — content
-// gets a unique opaque origin, can't read parent cookies/storage, can't
-// navigate the top frame. Scripts run, but in a vacuum, which is what
-// makes AI-generated HTML safe to display.
-export default function HtmlPageView({ html, title }: Props) {
+// Iframes don't auto-size to their content — the parent has to decide the
+// box. Two modes:
+//
+// - "fixed-aspect": locks a 16:9 canvas. Right for slides/decks where the
+//   page has an intentional design size.
+// - "responsive": injects a tiny bootstrap into the sandboxed document that
+//   reports its scrollHeight back on every ResizeObserver tick AND on demand
+//   when the parent pings. The parent pings on iframe load to avoid losing
+//   the first measurement to hydration-timing races, then keeps listening
+//   for spontaneous resize messages.
+//
+// Both modes share `sandbox="allow-scripts"` — postMessage works across the
+// opaque-origin boundary, so we don't widen the sandbox for resize.
+export default function HtmlPageView({ html, title, layout = "responsive" }: Props) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [height, setHeight] = useState<number | null>(null);
+  const channel = `stash-resize-${useId()}`;
+
+  const srcDoc = useMemo(
+    () => (layout === "responsive" ? injectResizeBootstrap(html, channel) : html),
+    [html, layout, channel],
+  );
+
+  useEffect(() => {
+    if (layout !== "responsive") return;
+    function onMessage(e: MessageEvent) {
+      const data = e.data;
+      if (
+        data &&
+        typeof data === "object" &&
+        data.type === "stash:resize" &&
+        data.channel === channel &&
+        typeof data.height === "number"
+      ) {
+        setHeight(Math.max(0, Math.ceil(data.height)));
+      }
+    }
+    window.addEventListener("message", onMessage);
+    // The iframe's bootstrap posts its height once at load time, but if the
+    // iframe finished loading before this effect attached, that initial post
+    // was lost. Probe the iframe so it re-posts now that we're listening.
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "stash:probe", channel },
+      "*",
+    );
+    return () => window.removeEventListener("message", onMessage);
+  }, [layout, channel]);
+
+  // Future iframe loads (srcDoc swap, navigation) re-trigger a probe.
+  function onIframeLoad() {
+    if (layout !== "responsive") return;
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "stash:probe", channel },
+      "*",
+    );
+  }
+
+  if (layout === "fixed-aspect") {
+    return (
+      <iframe
+        ref={iframeRef}
+        srcDoc={html}
+        sandbox="allow-scripts"
+        title={title}
+        style={{ width: "100%", aspectRatio: "16 / 9", border: 0, display: "block" }}
+      />
+    );
+  }
+
   return (
     <iframe
-      srcDoc={html}
+      ref={iframeRef}
+      srcDoc={srcDoc}
       sandbox="allow-scripts"
       title={title}
+      onLoad={onIframeLoad}
       style={{
         width: "100%",
-        aspectRatio: "16 / 9",
+        height: height ?? 200,
         border: 0,
         display: "block",
       }}
     />
   );
+}
+
+// Appended just before </body>. Lives inside the sandbox like any other
+// script in the document — adding it doesn't widen the trust boundary.
+function injectResizeBootstrap(html: string, channel: string): string {
+  const script = `<script>(function(){
+    var c=${JSON.stringify(channel)};
+    function post(){
+      var h=Math.max(
+        document.documentElement.scrollHeight,
+        document.body ? document.body.scrollHeight : 0
+      );
+      parent.postMessage({type:"stash:resize",channel:c,height:h},"*");
+    }
+    new ResizeObserver(post).observe(document.documentElement);
+    if(document.body) new ResizeObserver(post).observe(document.body);
+    window.addEventListener("message",function(e){
+      if(e.data && e.data.type==="stash:probe" && e.data.channel===c) post();
+    });
+    post();
+  })();</script>`;
+  if (/<\/body>/i.test(html)) return html.replace(/<\/body>/i, `${script}</body>`);
+  return html + script;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -426,7 +426,11 @@ export async function createPage(
   name: string,
   folderId?: string | null,
   content?: string,
-  options?: { content_type?: "markdown" | "html"; content_html?: string }
+  options?: {
+    content_type?: "markdown" | "html";
+    content_html?: string;
+    html_layout?: "responsive" | "fixed-aspect";
+  }
 ): Promise<Page> {
   return apiFetch(`/api/v1/workspaces/${workspaceId}/pages/new`, {
     method: "POST",
@@ -436,6 +440,7 @@ export async function createPage(
       content: content || "",
       content_type: options?.content_type ?? "markdown",
       content_html: options?.content_html ?? "",
+      html_layout: options?.html_layout ?? "responsive",
     }),
   });
 }
@@ -453,6 +458,7 @@ export async function updatePage(
     content?: string;
     content_type?: "markdown" | "html";
     content_html?: string;
+    html_layout?: "responsive" | "fixed-aspect";
     move_to_root?: boolean;
   }
 ): Promise<Page> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -60,6 +60,8 @@ export interface Folder {
   updated_at: string;
 }
 
+export type HtmlLayout = "responsive" | "fixed-aspect";
+
 export interface Page {
   id: string;
   workspace_id: string;
@@ -68,6 +70,7 @@ export interface Page {
   content_type: PageContentType;
   content_markdown: string;
   content_html: string;
+  html_layout: HtmlLayout;
   created_by: string;
   updated_by: string | null;
   created_at: string;


### PR DESCRIPTION
## Summary

- HTML pages now carry an `html_layout` field (`responsive` | `fixed-aspect`, default `responsive`) that controls how `HtmlPageView` sizes the sandboxed iframe.
- `responsive` injects a `ResizeObserver` + `postMessage` bootstrap into the rendered HTML so the page reports its natural height back to the parent, which grows the iframe to fit. Right for documents, dashboards, cards.
- `fixed-aspect` keeps the 16:9 canvas. Right for slide decks where the design size is intentional.
- The sandbox is unchanged (`allow-scripts`, no `allow-same-origin`); `postMessage` works across the opaque-origin boundary so we don't widen the trust surface. A parent-side probe on iframe mount sidesteps a hydration-timing race where the iframe's initial post would fire before the parent's listener attached.

Wired through: migration 0041, `PageCreateRequest` / `PageUpdateRequest` / `PageResponse` / `PublishRequest`, `create_page` / `update_page` / `get_page`, view inlining (`/v/[slug]`, `/v/[slug]/embed`), public reader (`/s/[workspaceId]/p/[pageId]`), stash page viewer, and fork copy paths.

## Screenshots

**Responsive doc — iframe grows to fit content**

(See attached `html-responsive.png`)

**Fixed-aspect slide — locked 16:9 canvas**

(See attached `html-fixed-aspect.png`)

## Test plan

- [x] Migration applies cleanly (`alembic upgrade head` → `pages.html_layout VARCHAR(16) NOT NULL DEFAULT 'responsive'`)
- [x] `frontend` typechecks (`npx tsc --noEmit`)
- [x] Seeded one responsive + one fixed-aspect HTML page; verified in browser:
  - responsive iframe resized to 586px to fit content
  - fixed-aspect iframe at 1.779 ratio (≈16:9), no bootstrap injected
- [x] No console errors; no hydration warnings
- [ ] Agents picking `html_layout` via `/api/v1/publish` or `POST /pages/new` get the layout they ask for (round-trip not yet covered by tests — add if we want one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)