### PR TITLE
Sign-up to first share URL: zero-install agent publish path

### DIFF
--- a/backend/migrations/versions/0042_workspace_member_is_primary.py
+++ b/backend/migrations/versions/0042_workspace_member_is_primary.py
@@ -1,0 +1,44 @@
+"""Mark each user's primary workspace.
+
+The auto-provisioned workspace created at signup is the user's "primary" — the
+fallback target when an agent calls /publish without a workspace_id. A partial
+unique index enforces at most one primary per user.
+
+Backfills existing users by marking their earliest membership primary so the
+fallback works for accounts created before this column existed.
+
+Revision ID: 0042
+Revises: 0041
+"""
+
+from alembic import op
+
+revision = "0042"
+down_revision = "0041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE workspace_members "
+        "ADD COLUMN IF NOT EXISTS is_primary BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS workspace_members_one_primary_per_user "
+        "ON workspace_members (user_id) WHERE is_primary"
+    )
+    op.execute(
+        "UPDATE workspace_members wm SET is_primary = TRUE "
+        "FROM ("
+        "  SELECT DISTINCT ON (user_id) user_id, workspace_id "
+        "  FROM workspace_members "
+        "  ORDER BY user_id, joined_at ASC"
+        ") earliest "
+        "WHERE wm.user_id = earliest.user_id AND wm.workspace_id = earliest.workspace_id"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS workspace_members_one_primary_per_user")
+    op.execute("ALTER TABLE workspace_members DROP COLUMN IF EXISTS is_primary")

--- a/backend/models.py
+++ b/backend/models.py
@@ -662,7 +662,7 @@ class PublishRequest(BaseModel):
     one. Folder is optional; defaults to a workspace's "AI Drafts" folder
     that's auto-created on first use."""
 
-    workspace_id: UUID
+    workspace_id: UUID | None = None
     title: str = Field(..., min_length=1, max_length=255)
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -22,21 +22,30 @@ async def publish(
     req: PublishRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    if not await workspace_service.is_member(req.workspace_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Not a workspace member")
+    if req.workspace_id is None:
+        workspace_id = await workspace_service.get_primary_for_user(current_user["id"])
+        if workspace_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="No primary workspace; pass workspace_id explicitly",
+            )
+    else:
+        workspace_id = req.workspace_id
+        if not await workspace_service.is_member(workspace_id, current_user["id"]):
+            raise HTTPException(status_code=403, detail="Not a workspace member")
 
     if req.folder_id is not None:
         folder = await wiki_service.get_folder(req.folder_id)
-        if not folder or folder["workspace_id"] != req.workspace_id:
+        if not folder or folder["workspace_id"] != workspace_id:
             raise HTTPException(status_code=404, detail="Folder not found in this workspace")
         target_folder = folder
     else:
         target_folder = await wiki_service.find_or_create_root_folder(
-            req.workspace_id, AI_DRAFTS_FOLDER_NAME, current_user["id"]
+            workspace_id, AI_DRAFTS_FOLDER_NAME, current_user["id"]
         )
 
     page = await wiki_service.create_page(
-        workspace_id=req.workspace_id,
+        workspace_id=workspace_id,
         name=req.title,
         created_by=current_user["id"],
         folder_id=target_folder["id"],
@@ -49,7 +58,7 @@ async def publish(
     await permission_service.set_visibility("page", page["id"], req.audience)
 
     view = await view_service.find_or_create_share_link_view(
-        workspace_id=req.workspace_id,
+        workspace_id=workspace_id,
         owner_id=current_user["id"],
         object_type="page",
         object_id=page["id"],
@@ -59,7 +68,7 @@ async def publish(
     return PublishResponse(
         page_id=page["id"],
         folder_id=target_folder["id"],
-        workspace_id=req.workspace_id,
+        workspace_id=workspace_id,
         visibility=req.audience,
         url=f"{base}/v/{view['slug']}",
         view_id=view["id"],

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -41,6 +41,7 @@ async def register_user(
         description="",
         creator_id=user["id"],
         is_public=False,
+        is_primary=True,
     )
     return user, api_key
 

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -11,8 +11,14 @@ async def create_workspace(
     description: str,
     creator_id: UUID,
     is_public: bool = False,
+    is_primary: bool = False,
 ) -> dict:
-    """Create a workspace with the creator as owner."""
+    """Create a workspace with the creator as owner.
+
+    Pass is_primary=True to mark the creator's membership as their primary
+    workspace — used by /publish as the fallback target when no workspace_id
+    is supplied. Only the auto-provisioned signup workspace should pass this.
+    """
     pool = get_pool()
     invite_code = ""
     for _ in range(5):
@@ -37,11 +43,12 @@ async def create_workspace(
     )
     ws = dict(row)
     ws["is_public"] = is_public
-    # Auto-add creator as owner
     await pool.execute(
-        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        "INSERT INTO workspace_members (workspace_id, user_id, role, is_primary) "
+        "VALUES ($1, $2, 'owner', $3)",
         ws["id"],
         creator_id,
+        is_primary,
     )
     if is_public:
         from . import permission_service
@@ -49,6 +56,28 @@ async def create_workspace(
         await permission_service.set_visibility("workspace", ws["id"], "public")
     ws["member_count"] = 1
     return ws
+
+
+async def get_primary_for_user(user_id: UUID) -> UUID | None:
+    """Return the workspace_id this user's /publish calls fall back to.
+
+    Prefers the membership flagged is_primary (set when the workspace was
+    auto-provisioned at signup). Falls back to the earliest membership so
+    accounts without a flagged primary still resolve to a sensible workspace.
+    """
+    pool = get_pool()
+    primary = await pool.fetchval(
+        "SELECT workspace_id FROM workspace_members "
+        "WHERE user_id = $1 AND is_primary = TRUE",
+        user_id,
+    )
+    if primary:
+        return primary
+    return await pool.fetchval(
+        "SELECT workspace_id FROM workspace_members "
+        "WHERE user_id = $1 ORDER BY joined_at ASC LIMIT 1",
+        user_id,
+    )
 
 
 async def get_workspace(workspace_id: UUID) -> dict | None:

--- a/backend/tests/test_publish.py
+++ b/backend/tests/test_publish.py
@@ -1,0 +1,87 @@
+"""Tests for /api/v1/publish — the one-call publish endpoint used by AI agents.
+
+Covers the workspace_id-optional fallback added so a fresh user can call
+publish without first looking up their workspace id.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    name = unique_name()
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+@pytest.mark.asyncio
+async def test_publish_falls_back_to_primary_workspace(client: AsyncClient):
+    key = await _register(client)
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "title": "Hello",
+            "content": "<h1>Hello</h1>",
+            "content_type": "html",
+            "audience": "link",
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["url"].endswith(f"/v/{body['view_slug']}")
+    assert body["page_id"]
+    assert body["workspace_id"]
+
+
+@pytest.mark.asyncio
+async def test_publish_with_explicit_workspace_id_still_works(client: AsyncClient):
+    key = await _register(client)
+    mine = await client.get("/api/v1/workspaces/mine", headers=_auth(key))
+    workspace_id = mine.json()["workspaces"][0]["id"]
+
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "workspace_id": workspace_id,
+            "title": "Hello explicit",
+            "content": "<h1>Hi</h1>",
+            "content_type": "html",
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["workspace_id"] == workspace_id
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_non_member_workspace(client: AsyncClient):
+    """An explicit workspace_id the caller doesn't belong to is forbidden,
+    even if they have a primary workspace they could fall back to."""
+    owner_key = await _register(client)
+    other_key = await _register(client)
+    owner_ws = (
+        await client.get("/api/v1/workspaces/mine", headers=_auth(owner_key))
+    ).json()["workspaces"][0]["id"]
+
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "workspace_id": owner_ws,
+            "title": "Sneaky",
+            "content": "x",
+            "content_type": "html",
+        },
+        headers=_auth(other_key),
+    )
+    assert resp.status_code == 403

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -34,17 +34,25 @@ function LoginPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const cliSession = searchParams.get("cli");
+  const initialMode = searchParams.get("mode") === "register" ? "register" : "login";
   const { user, loading, logout, refresh } = useAuth();
-  const [mode, setMode] = useState<"login" | "register">("login");
+  const [mode, setMode] = useState<"login" | "register">(initialMode);
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [cliApproved, setCliApproved] = useState(false);
+  const [justRegistered, setJustRegistered] = useState(false);
 
-  // Normal redirect for non-CLI logins
+  // Normal redirect for non-CLI logins. New registrations go to /onboarding;
+  // returning logins land on a workspace.
   useEffect(() => {
     if (loading || !user || cliSession) return;
+
+    if (justRegistered) {
+      router.push("/onboarding");
+      return;
+    }
 
     listMyWorkspaces().then(({ workspaces }) => {
       if (workspaces.length === 1) {
@@ -55,7 +63,7 @@ function LoginPageInner() {
     }).catch(() => {
       router.push("/");
     });
-  }, [user, loading, cliSession, router]);
+  }, [user, loading, cliSession, router, justRegistered]);
 
   // Wait for useAuth to load before rendering — otherwise the signed-out form
   // flashes on every /login hit even for already-signed-in users.
@@ -104,6 +112,9 @@ function LoginPageInner() {
 
       const data = await res.json();
       setToken(data.api_key);
+      if (mode === "register" && !cliSession) {
+        setJustRegistered(true);
+      }
 
       if (cliSession) {
         const approveRes = await fetch(

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useRouter } from "next/navigation";
+import Header from "../../components/Header";
+import { useAuth } from "../../hooks/useAuth";
+import { getToken, listMyWorkspaces } from "../../lib/api";
+
+// Read the token from localStorage in an SSR-safe way. `useSyncExternalStore`
+// gives us the right value on first client render and re-runs on storage
+// events, without setState-in-effect.
+function useStashToken(): string | null {
+  return useSyncExternalStore(
+    (cb) => {
+      window.addEventListener("storage", cb);
+      return () => window.removeEventListener("storage", cb);
+    },
+    () => getToken(),
+    () => null,
+  );
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+const TOPIC_PLACEHOLDER = "<your topic — e.g. 'how our rate limiter works'>";
+
+function buildPromptBlock(apiKey: string, apiUrl: string): string {
+  return `Make an HTML page about ${TOPIC_PLACEHOLDER}. Make it information-dense, use SVG diagrams where they help, and optimize it to be read once.
+
+When you're done, publish it to Stash and print the share URL by running:
+
+curl -sS -X POST ${apiUrl}/api/v1/publish \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'EOF'
+{
+  "title": "<your title>",
+  "content_type": "html",
+  "content": "<your generated HTML>",
+  "audience": "link"
+}
+EOF`;
+}
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { user, loading, logout } = useAuth();
+  const apiKey = useStashToken();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!loading && apiKey === null) {
+      router.replace("/login");
+    }
+  }, [loading, apiKey, router]);
+
+  const promptBlock = apiKey ? buildPromptBlock(apiKey, API_URL) : "";
+
+  async function handleCopy() {
+    if (!promptBlock) return;
+    await navigator.clipboard.writeText(promptBlock);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleSkip() {
+    const { workspaces } = await listMyWorkspaces();
+    if (workspaces.length > 0) {
+      router.push(`/workspaces/${workspaces[0].id}`);
+    } else {
+      router.push("/");
+    }
+  }
+
+  if (loading || !apiKey) {
+    return <div className="min-h-screen flex items-center justify-center text-muted">Loading…</div>;
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header user={user} onLogout={logout} />
+      <main className="flex-1 px-4 py-12">
+        <div className="mx-auto w-full max-w-2xl space-y-8">
+          <div className="space-y-3 text-center">
+            <div className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full bg-surface border border-border text-[10px] font-mono uppercase tracking-[0.18em] text-muted">
+              <span className="w-1 h-1 rounded-full bg-brand animate-pulse" />
+              Step 1 of 1
+            </div>
+            <h1 className="font-display text-[32px] leading-[1.05] font-bold tracking-tight text-foreground">
+              Make your first page
+            </h1>
+            <p className="text-sm text-dim max-w-md mx-auto">
+              Paste this into Claude Code, Cursor, or Codex. Your agent will write the
+              HTML and publish it. You&rsquo;ll get a share URL back.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-border bg-surface overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-background/40">
+              <div className="text-[11px] font-mono uppercase tracking-wider text-muted">
+                Prompt + curl
+              </div>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="text-[11px] font-medium text-brand hover:text-brand-hover transition-colors"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <pre className="p-4 text-[12px] leading-relaxed text-foreground font-mono whitespace-pre-wrap break-all overflow-x-auto">
+              {promptBlock}
+            </pre>
+          </div>
+
+          <div className="rounded-xl border border-border-subtle bg-background/40 p-4 text-[12px] text-dim leading-relaxed">
+            <strong className="text-foreground font-medium">What happens next:</strong>{" "}
+            your agent generates HTML and runs the curl command. The response prints a
+            URL like <code className="text-foreground">https://app.joinstash.ai/v/abc123</code>.
+            Open it &mdash; your page is live and shareable. We&rsquo;ll help you bring
+            teammates in from there.
+          </div>
+
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="text-[12px] text-muted hover:text-foreground transition-colors"
+            >
+              Skip &mdash; just take me to my workspace
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/stashes/[stashId]/page.tsx
+++ b/frontend/src/app/stashes/[stashId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -99,15 +99,21 @@ function CardGrid({ items, hover }: { items: CardItem[]; hover: "brand" | "indig
 export default function StashHomePage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const stashId = params.stashId as string;
   const { user, loading, logout } = useAuth();
+
+  // Deep-link from the /v/[slug] creator-actions card: auto-open the members
+  // modal when the URL says ?invite=open. Captured at mount so a later URL
+  // change doesn't re-trigger.
+  const initialInviteOpen = searchParams.get("invite") === "open";
 
   const [stash, setStash] = useState<Workspace | null>(null);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [spine, setSpine] = useState<StashOverview | null>(null);
   const [views, setViews] = useState<StashView[]>([]);
   const [error, setError] = useState("");
-  const [membersOpen, setMembersOpen] = useState(false);
+  const [membersOpen, setMembersOpen] = useState(initialInviteOpen);
   const shareModal = useShareModal();
   const shareVersion = shareModal.version;
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/frontend/src/app/v/[slug]/CreatorActions.tsx
+++ b/frontend/src/app/v/[slug]/CreatorActions.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "../../../hooks/useAuth";
+
+const MARKETING_URL = process.env.NEXT_PUBLIC_MARKETING_URL || "https://joinstash.ai";
+
+type Props = {
+  ownerId: string;
+  workspaceId: string;
+};
+
+export default function CreatorActions({ ownerId, workspaceId }: Props) {
+  const { user, loading } = useAuth();
+  if (loading || !user || user.id !== ownerId) return null;
+
+  return (
+    <aside className="mt-12 rounded-2xl border border-border bg-surface p-6 space-y-5">
+      <div className="space-y-1.5">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-brand">
+          You shipped one. Now make it shared.
+        </p>
+        <h2 className="font-display text-[20px] font-bold text-ink leading-tight">
+          Don&rsquo;t leave your agent&rsquo;s work in scattered URLs.
+        </h2>
+        <p className="text-[13px] text-dim leading-relaxed max-w-[560px]">
+          Pull every page, transcript, and artifact your agents make into one space
+          you and your team can browse, search, and build on.
+        </p>
+      </div>
+
+      <ol className="space-y-3">
+        <li>
+          <Link
+            href={`/stashes/${workspaceId}?invite=open`}
+            className="group flex items-start gap-3 rounded-xl border border-border-subtle bg-background/40 hover:border-brand/60 hover:bg-background/60 transition-colors px-4 py-3"
+          >
+            <span className="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full bg-brand/10 text-brand text-[11px] font-mono font-semibold">
+              1
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-[13px] font-medium text-foreground group-hover:text-brand transition-colors">
+                Share with a teammate &mdash; turn this into a Stash
+              </span>
+              <span className="block text-[12px] text-muted mt-0.5">
+                Invite someone in. The page becomes part of a shared, ongoing space
+                instead of a one-off URL.
+              </span>
+            </span>
+            <Arrow />
+          </Link>
+        </li>
+        <li>
+          <a
+            href={`${MARKETING_URL}/docs/quickstart?from=creator-cta`}
+            target="_blank"
+            rel="noreferrer"
+            className="group flex items-start gap-3 rounded-xl border border-border-subtle bg-background/40 hover:border-brand/60 hover:bg-background/60 transition-colors px-4 py-3"
+          >
+            <span className="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full bg-brand/10 text-brand text-[11px] font-mono font-semibold">
+              2
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-[13px] font-medium text-foreground group-hover:text-brand transition-colors">
+                Install the CLI for the full integration
+              </span>
+              <span className="block text-[12px] text-muted mt-0.5">
+                Drop the curl &mdash; let your agent publish via MCP, and stream
+                every session into the same space.
+              </span>
+            </span>
+            <Arrow />
+          </a>
+        </li>
+      </ol>
+    </aside>
+  );
+}
+
+function Arrow() {
+  return (
+    <svg
+      className="shrink-0 mt-0.5 text-muted group-hover:text-brand transition-colors"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 12h14M13 5l7 7-7 7" />
+    </svg>
+  );
+}

--- a/frontend/src/app/v/[slug]/page.tsx
+++ b/frontend/src/app/v/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import HtmlPageView from "../../../components/workspace/HtmlPageView";
+import CreatorActions from "./CreatorActions";
 import ViewForkButton from "./ViewForkButton";
 
 const BACKEND_ORIGIN =
@@ -55,6 +56,7 @@ type ViewPublic = {
     created_at: string;
     updated_at: string;
     workspace_id: string;
+    owner_id: string;
   };
   workspace_name: string;
   workspace_is_public: boolean;
@@ -137,6 +139,8 @@ export default async function ViewPage({
           <Item key={`${it.object_type}-${it.object_id}`} idx={i} item={it} />
         ))}
       </div>
+
+      <CreatorActions ownerId={view.owner_id} workspaceId={view.workspace_id} />
     </main>
   );
 }

--- a/www/app/publish/page.tsx
+++ b/www/app/publish/page.tsx
@@ -1,0 +1,419 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import CopyButton from "../_components/CopyButton";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://app.joinstash.ai";
+const TWEET_URL = "https://x.com/trq212/status/2052809885763747935";
+
+const SAMPLE_PROMPT = `Make an HTML page about how our rate limiter works. Be information-dense, use SVG diagrams, code snippets, optimize for one-time read.
+
+When you're done, publish to Stash and print the share URL:
+
+curl -sS -X POST ${APP_URL}/api/v1/publish \\
+  -H "Authorization: Bearer $STASH_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'EOF'
+{ "title": "...", "content_type": "html", "content": "...", "audience": "link" }
+EOF`;
+
+export const metadata: Metadata = {
+  title: "Your agent makes HTML. We make it shareable. · Stash",
+  description:
+    "Stash takes the HTML your coding agent produces and turns it into a share URL. One prompt, one curl, one link your teammates can open.",
+  openGraph: {
+    title: "Your agent makes HTML. We make it shareable.",
+    description:
+      "One prompt to your coding agent — get a share URL back. Built for the unreasonable effectiveness of HTML.",
+    type: "website",
+    url: "/publish",
+    siteName: "Stash",
+  },
+};
+
+export default function PublishLandingPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <Nav />
+      <Hero />
+      <Pitch />
+      <Demo />
+      <UseCases />
+      <ClosingCTA />
+    </main>
+  );
+}
+
+function Logo({ size = 28 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 64 72"
+      width={size}
+      height={(size * 72) / 64}
+      aria-hidden="true"
+    >
+      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
+      <circle cx="25" cy="22" r="4" fill="#fff" />
+      <circle cx="39" cy="22" r="4" fill="#fff" />
+      <circle cx="26" cy="22" r="2" fill="#0F172A" />
+      <circle cx="40" cy="22" r="2" fill="#0F172A" />
+      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}
+
+function Nav() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-border-subtle bg-background/80 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-7">
+        <Link
+          href="/"
+          className="flex items-center gap-2.5 font-display text-[20px] font-black tracking-[-0.03em] text-ink"
+        >
+          <Logo size={28} />
+          stash
+        </Link>
+        <nav className="flex items-center gap-2 text-[14px] text-dim">
+          <Link
+            href="/docs"
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
+          >
+            Docs
+          </Link>
+          <Link
+            href={`${APP_URL}/login`}
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
+          >
+            Sign in
+          </Link>
+          <Link
+            href={`${APP_URL}/login?mode=register&from=publish`}
+            className="inline-flex h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white transition hover:bg-brand-hover"
+          >
+            Get started free
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative overflow-hidden">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[680px]"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 30% 10%, rgba(249,115,22,0.12), transparent 60%)",
+        }}
+      />
+      <div className="relative z-10 mx-auto max-w-[1100px] px-7 pb-12 pt-20 lg:pt-28">
+        <a
+          href={TWEET_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-2.5 rounded-full border border-border bg-white/70 py-[5px] pl-[5px] pr-3.5 text-[12px] text-dim shadow-sm transition hover:border-brand/40 hover:text-ink"
+        >
+          <span className="rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-white">
+            Why
+          </span>
+          <span>
+            Inspired by Thariq Shihipar (Anthropic):{" "}
+            <em>The Unreasonable Effectiveness of HTML</em>
+          </span>
+          <span className="font-mono text-muted">→</span>
+        </a>
+
+        <h1 className="mt-7 max-w-[920px] text-balance font-display text-[clamp(44px,6.4vw,80px)] font-black leading-[0.95] tracking-[-0.045em] text-ink">
+          Your agent makes <span className="text-brand">HTML.</span>
+          <br />
+          We make it <span className="text-brand">shareable.</span>
+        </h1>
+
+        <p className="mt-7 max-w-[640px] text-[18px] leading-[1.55] text-foreground">
+          Markdown specs go unread. HTML pages get opened, scrolled, and
+          forwarded. The catch: most teams have nowhere to put them. One prompt
+          to your coding agent, one curl, one link your teammates can open. No
+          MCP setup, no S3 bucket.
+        </p>
+
+        <div className="mt-9 flex flex-wrap items-center gap-3">
+          <Link
+            href={`${APP_URL}/login?mode=register&from=publish`}
+            className="inline-flex h-12 items-center rounded-lg bg-brand px-6 text-[15px] font-semibold text-white transition hover:bg-brand-hover"
+          >
+            Get a share URL in 60 seconds
+          </Link>
+          <a
+            href="#how"
+            className="inline-flex h-12 items-center rounded-lg border border-border px-5 text-[15px] font-medium text-ink transition hover:border-ink"
+          >
+            See how it works
+          </a>
+        </div>
+
+        <p className="mt-5 max-w-[640px] font-mono text-[12px] uppercase tracking-[0.12em] text-muted">
+          Free · works with Claude Code, Cursor, Codex, OpenCode
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function Pitch() {
+  return (
+    <section className="border-t border-border-subtle bg-surface">
+      <div className="mx-auto max-w-[1100px] px-7 py-20">
+        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted">
+          Why HTML, why now
+        </p>
+        <h2 className="mt-3 max-w-[760px] font-display text-[clamp(28px,3.2vw,42px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+          Markdown was for humans typing alone. HTML is for agents working with
+          you.
+        </h2>
+        <p className="mt-5 max-w-[680px] text-[15px] leading-[1.6] text-foreground">
+          As{" "}
+          <a
+            href={TWEET_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-brand underline decoration-brand/30 underline-offset-4 hover:decoration-brand"
+          >
+            Thariq Shihipar at Anthropic put it
+          </a>
+          : the chance of someone actually reading your spec, report, or PR
+          writeup is much higher in HTML. The friction was always{" "}
+          <em>where to put it</em>. Stash is the answer.
+        </p>
+
+        <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-3">
+          <PitchCard
+            tag="Information density"
+            title="One file, every shape of information."
+            body="Tables, SVG diagrams, color, code, sliders, canvases. Everything markdown forced into a fenced block, HTML renders in line. Your agent gets a richer canvas; you get a richer artifact."
+          />
+          <PitchCard
+            tag="Ease of sharing"
+            title="No S3, no attachment, no rendering quirks."
+            body="The curl call publishes the page and prints a URL. Your teammates open it in a browser and read it. The page lives in your workspace, indexed and searchable, not lost in chat."
+          />
+          <PitchCard
+            tag="Stay in the loop"
+            title="You stop skimming. You start reading."
+            body="A 100-line markdown plan is a wall. The same content as HTML — with sections, diagrams, navigation — is something you actually read end-to-end. You stay in the loop with what your agent is doing."
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PitchCard({
+  tag,
+  title,
+  body,
+}: {
+  tag: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <article className="rounded-2xl border border-border-subtle bg-background p-6">
+      <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-brand">
+        {tag}
+      </p>
+      <h3 className="mt-3 font-display text-[20px] font-bold leading-[1.2] tracking-[-0.01em] text-ink">
+        {title}
+      </h3>
+      <p className="mt-3 text-[14px] leading-[1.6] text-foreground">{body}</p>
+    </article>
+  );
+}
+
+function Demo() {
+  return (
+    <section id="how" className="border-t border-border-subtle">
+      <div className="mx-auto max-w-[1100px] px-7 py-20">
+        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted">
+          The 60 seconds
+        </p>
+        <h2 className="mt-3 font-display text-[clamp(28px,3.2vw,42px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+          Sign up. Paste one block. Done.
+        </h2>
+
+        <ol className="mt-10 space-y-6">
+          <Step
+            n={1}
+            title="Sign up"
+            body="Create an account on Stash. We auto-provision a workspace for you and hand you a personal API key."
+          />
+          <Step
+            n={2}
+            title="Paste this prompt into your coding agent"
+            body="Drop the block into Claude Code, Cursor, Codex, or OpenCode. The agent writes the HTML and runs the curl that publishes it."
+          >
+            <div
+              className="mt-4 overflow-hidden rounded-[14px] border border-white/5 bg-inverted"
+              style={{ boxShadow: "var(--shadow-terminal)" }}
+            >
+              <div className="flex items-center justify-between border-b border-white/5 px-3.5 py-2.5">
+                <div className="flex items-center gap-3">
+                  <div className="flex gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-white/10" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-white/10" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-white/10" />
+                  </div>
+                  <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-on-inverted-dim">
+                    prompt.txt
+                  </span>
+                </div>
+                <CopyButton
+                  value={SAMPLE_PROMPT}
+                  label="copy"
+                  copiedLabel="copied ✓"
+                  className="inline-flex h-[26px] items-center rounded-md border border-white/10 bg-transparent px-2.5 font-mono text-[10.5px] uppercase tracking-[0.1em] text-on-inverted-dim transition hover:border-white/30 hover:text-white data-[copied=true]:border-[rgba(34,197,94,0.5)] data-[copied=true]:text-[#22C55E]"
+                />
+              </div>
+              <pre className="overflow-x-auto px-5 py-5 font-mono text-[12.5px] leading-[1.7] text-on-inverted whitespace-pre-wrap break-words">
+                {SAMPLE_PROMPT}
+              </pre>
+            </div>
+          </Step>
+          <Step
+            n={3}
+            title="Open the URL the agent prints"
+            body="The curl prints a link like app.joinstash.ai/v/abc123. Your page is live, public-with-the-link, and lives in your workspace where you can rename it, share it, or pull it into a Stash with teammates later."
+          />
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+function Step({
+  n,
+  title,
+  body,
+  children,
+}: {
+  n: number;
+  title: string;
+  body: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <li className="flex gap-5">
+      <span className="shrink-0 inline-flex h-9 w-9 items-center justify-center rounded-full bg-brand/10 font-mono text-[13px] font-semibold text-brand">
+        {n}
+      </span>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-display text-[18px] font-bold tracking-[-0.01em] text-ink">
+          {title}
+        </h3>
+        <p className="mt-1.5 max-w-[680px] text-[14.5px] leading-[1.6] text-foreground">
+          {body}
+        </p>
+        {children}
+      </div>
+    </li>
+  );
+}
+
+function UseCases() {
+  const cases: { title: string; body: string }[] = [
+    {
+      title: "Specs, planning, exploration",
+      body: "Six side-by-side onboarding mockups in one HTML grid. An implementation plan with diagrams and code. The artifact you actually pass to the next session.",
+    },
+    {
+      title: "Code review & PR explainers",
+      body: "Render the diff, color-code findings by severity, annotate the streaming logic. Better than the default GitHub diff for the parts your reviewer needs.",
+    },
+    {
+      title: "Design & prototypes",
+      body: "Sketch a checkout button with sliders for animation params. Tune in the values. Copy the parameters back into the prompt to ship the real component.",
+    },
+    {
+      title: "Reports & research",
+      body: "Synthesize across your codebase, Slack, and git history into a single readable explainer with SVG flowcharts. The thing you wish you had before the incident review.",
+    },
+    {
+      title: "Custom editing interfaces",
+      body: "A throwaway drag-and-drop board for reprioritizing 30 Linear tickets. A form-based editor for feature flags with dependency warnings. Export the result back as JSON.",
+    },
+    {
+      title: "Joyful artifacts",
+      body: "It just feels better. You make the thing, you read the thing, you send the thing. Your team reads it back. The work compounds instead of evaporating.",
+    },
+  ];
+  return (
+    <section className="border-t border-border-subtle bg-surface">
+      <div className="mx-auto max-w-[1100px] px-7 py-20">
+        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted">
+          Use cases
+        </p>
+        <h2 className="mt-3 max-w-[760px] font-display text-[clamp(28px,3.2vw,42px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+          What people are publishing.
+        </h2>
+        <p className="mt-4 max-w-[640px] text-[15px] leading-[1.6] text-foreground">
+          The categories are Thariq&rsquo;s. The point is the same: anything you
+          can ask for, your agent can render as HTML. We make it shareable.
+        </p>
+        <div className="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {cases.map((c) => (
+            <article
+              key={c.title}
+              className="rounded-xl border border-border-subtle bg-background p-5"
+            >
+              <h3 className="font-display text-[16px] font-bold tracking-[-0.01em] text-ink">
+                {c.title}
+              </h3>
+              <p className="mt-2 text-[13.5px] leading-[1.55] text-foreground">
+                {c.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ClosingCTA() {
+  return (
+    <section className="border-t border-border-subtle">
+      <div className="mx-auto max-w-[1100px] px-7 py-20 text-center">
+        <h2 className="mx-auto max-w-[720px] font-display text-[clamp(30px,3.6vw,46px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+          Make the thing. Share the link. Compound the work.
+        </h2>
+        <p className="mx-auto mt-5 max-w-[560px] text-[16px] leading-[1.6] text-foreground">
+          Sign up free. Sixty seconds to your first share URL. No credit card,
+          no install.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href={`${APP_URL}/login?mode=register&from=publish`}
+            className="inline-flex h-12 items-center rounded-lg bg-brand px-6 text-[15px] font-semibold text-white transition hover:bg-brand-hover"
+          >
+            Get started free
+          </Link>
+          <a
+            href={TWEET_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-12 items-center rounded-lg border border-border px-5 text-[15px] font-medium text-ink transition hover:border-ink"
+          >
+            Read Thariq&rsquo;s post
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

A brand-new user can now go from sign-up to a **public HTML share URL in one prompt to their existing coding agent**, using just `curl`. No CLI install, no MCP setup. The CLI install becomes the *upsell*, not the prerequisite.

The wedge is straight from [Thariq Shihipar's "Unreasonable Effectiveness of HTML"](https://x.com/trq212/status/2052809885763747935): your agent already makes great HTML; we make it shareable.

## What changed

**Backend**
- `POST /api/v1/publish` `workspace_id` is now optional. Falls back to the user's primary workspace so an agent can call publish without first looking one up.
- Migration `0042` adds `workspace_members.is_primary` with a partial unique index per user. Backfills the earliest membership for existing users so the fallback works for everyone.
- `register_user` marks the auto-provisioned signup workspace as the user's primary.

**Frontend (app)**
- New `/onboarding` page: renders the prompt + curl block with the user's API key baked in. SSR-safe localStorage read via `useSyncExternalStore`.
- `/login` redirects new registrations to `/onboarding` instead of the workspace home.
- `/v/[slug]` gets a creator-only actions card under the page content, framed around the shared-agent-artifacts pitch:
  1. **Share with a teammate &mdash; turn this into a Stash** (existing workspace + invite flow)
  2. **Install the CLI for the full integration** (links to docs/quickstart)

**Frontend (marketing)**
- New dedicated landing page at `www/app/publish/page.tsx` — separate funnel for social/share. Hero, three pitch panels (Information density / Ease of sharing / Stay in the loop), 60-second demo terminal block with copyable prompt, six use-case tiles from Thariq's post, and a closing CTA.
- The main marketing site (`www/app/page.tsx`) is **untouched**.

**Tests**
- `backend/tests/test_publish.py` covers the optional-`workspace_id` fallback, the explicit-workspace happy path, and rejection when an explicit workspace is passed by a non-member.

## Screenshots

### `/publish` marketing landing
![publish landing](https://github.com/user-attachments/assets/publish-hero.png)

### `/onboarding` post-signup
![onboarding](https://github.com/user-attachments/assets/onboarding.png)

### `/onboarding` mobile
![onboarding mobile](https://github.com/user-attachments/assets/publish-mobile.png)

(Will attach above PNGs as a comment after PR creation since they live in /tmp.)

## Test plan

- [ ] Apply migration `0042` to the dev/staging DB.
- [ ] `pytest backend/tests/test_publish.py backend/tests/test_workspaces.py` (already passing locally).
- [ ] Sign up on staging in an incognito window; confirm landing on `/onboarding` with a live token in the curl block.
- [ ] Paste the prompt+curl block into Claude Code; confirm it generates HTML, runs the curl, and prints a `/v/{slug}` URL.
- [ ] Open the URL in the same browser session; confirm the creator-only sidebar renders with both CTAs.
- [ ] Open the URL in an incognito window; confirm the creator sidebar is hidden for anonymous viewers.
- [ ] Visit `/publish` on the marketing site; confirm hero CTA routes to `/login?mode=register&from=publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)