### PR TITLE
[codex] Show only active workspace in sidebar

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -181,10 +181,10 @@ function openSectionState(): Record<string, boolean> {
   return JSON.parse(localStorage.getItem("stash_sidebar_open_sections") ?? "{}");
 }
 
-function renderSidebar() {
+function renderSidebar(activeWorkspaceId?: string) {
   return render(
     <ShareModalProvider>
-      <AppSidebar user={user} onCmdkOpen={vi.fn()} />
+      <AppSidebar user={user} onCmdkOpen={vi.fn()} activeWorkspaceId={activeWorkspaceId} />
     </ShareModalProvider>
   );
 }
@@ -253,20 +253,20 @@ describe("AppSidebar tree expansion", () => {
     expect(detailsFor("Stashes")).toHaveAttribute("open");
   });
 
-  it("renders shared memberships in their own group", async () => {
+  it("renders only the active workspace without a shared workspace group", async () => {
     vi.mocked(listMyWorkspaces).mockResolvedValue({
       workspaces: [workspace, sharedWorkspace],
     });
 
-    renderSidebar();
+    renderSidebar("ws-2");
 
-    await screen.findByText("Shared Stash");
+    await screen.findByText("Sessions");
 
     const sidebarText = document.body.textContent ?? "";
-    expect(sidebarText.indexOf("SHARED WORKSPACES")).toBeLessThan(
-      sidebarText.indexOf("Shared Stash")
-    );
-    expect(screen.getAllByText("Shared Stash")).toHaveLength(1);
+    expect(sidebarText).not.toContain("SHARED WORKSPACES");
+    expect(sidebarText).not.toContain("Demo Stash");
+    expect(getWorkspaceSidebar).toHaveBeenCalledWith("ws-2");
+    expect(getWorkspaceSidebar).not.toHaveBeenCalledWith("ws-1");
   });
 
   it("restores explicit section state from localStorage", async () => {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -49,10 +49,6 @@ interface AppSidebarProps {
   activeWorkspaceId?: string | null;
 }
 
-interface WorkspaceNode extends Workspace {
-  shared?: boolean;
-}
-
 type SidebarSection = "sessions" | "files" | "stashes";
 type DropSection = "sessions" | "files";
 type DropStatus = "idle" | "over" | "saving" | "done" | "error";
@@ -71,7 +67,6 @@ interface SidebarDropState {
   message: string;
 }
 
-const OPEN_WORKSPACES_KEY = "stash_sidebar_open_workspaces";
 const OPEN_SECTIONS_KEY = "stash_sidebar_open_sections";
 const COLLAPSED_STASHES_KEY = "stash_sidebar_collapsed_stashes";
 const PINNED_FS_KEY = "stash_sidebar_pinned_files_folders";
@@ -403,8 +398,6 @@ function SectionAddButton({
 function WorkspaceTree({
   workspace,
   spine,
-  showName,
-  pathname,
   openSections,
   onSectionOpenChange,
   dropState,
@@ -421,10 +414,8 @@ function WorkspaceTree({
   onAddPage,
   onAddStash,
 }: {
-  workspace: WorkspaceNode;
+  workspace: Workspace;
   spine: WorkspaceSidebar | null;
-  showName?: boolean;
-  pathname: string;
   openSections: Record<SidebarSection, boolean>;
   onSectionOpenChange: (section: SidebarSection, open: boolean) => void;
   dropState: SidebarDropState;
@@ -466,14 +457,6 @@ function WorkspaceTree({
 
   return (
       <div className="space-y-0.5">
-      {showName && (
-        <NavRow
-          href={`/workspaces/${workspace.id}`}
-          icon={<StashIcon />}
-          label={workspace.name}
-          active={pathname === `/workspaces/${workspace.id}`}
-        />
-      )}
       <details
         open={openSections.sessions}
         onToggle={(e) => onSectionOpenChange("sessions", e.currentTarget.open)}
@@ -1050,7 +1033,7 @@ function FilesBlock({
   onUnpinAll,
   onAddPage,
 }: {
-  workspace: WorkspaceNode;
+  workspace: Workspace;
   spine: WorkspaceSidebar | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -1290,7 +1273,7 @@ function StashesBlock({
   onStashCollapsedChange,
   onAddStash,
 }: {
-  workspace: WorkspaceNode;
+  workspace: Workspace;
   spine: WorkspaceSidebar | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -1471,9 +1454,6 @@ export default function AppSidebar({
   const currentWorkspaceId = activeWorkspaceId ?? routeWorkspaceId;
   const [mine, setMine] = useState<Workspace[]>(cachedWorkspaces?.mine ?? []);
   const [shared, setShared] = useState<Workspace[]>(cachedWorkspaces?.shared ?? []);
-  const [openWorkspaces] = useState<Record<string, boolean>>(() =>
-    readBooleanMap(OPEN_WORKSPACES_KEY)
-  );
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
     readBooleanMap(OPEN_SECTIONS_KEY)
   );
@@ -1519,13 +1499,15 @@ export default function AppSidebar({
     });
   }, []);
 
-  useEffect(() => {
-    const workspaceIds = new Set<string>([
-      ...Object.keys(openWorkspaces).filter((workspaceId) => openWorkspaces[workspaceId]),
-      ...mine.map((workspace) => workspace.id),
-      ...shared.map((workspace) => workspace.id),
-    ]);
+  const workspaces = [...mine, ...shared];
+  const visibleWorkspace =
+    workspaces.find((workspace) => workspace.id === currentWorkspaceId) ??
+    workspaces[0] ??
+    null;
 
+  useEffect(() => {
+    const workspaceIds = new Set<string>();
+    if (visibleWorkspace) workspaceIds.add(visibleWorkspace.id);
     if (activeTreeWorkspaceId) workspaceIds.add(activeTreeWorkspaceId);
 
     Array.from(workspaceIds)
@@ -1535,7 +1517,7 @@ export default function AppSidebar({
           .then((sp) => setSpines((all) => ({ ...all, [workspaceId]: sp })))
           .catch(() => {});
       });
-  }, [activeTreeWorkspaceId, mine, shared, openWorkspaces, spines]);
+  }, [activeTreeWorkspaceId, visibleWorkspace, spines]);
 
   function sectionOpen(workspaceId: string, section: SidebarSection): boolean {
     // Explicit user preference (open or closed) wins. Otherwise default open.
@@ -1941,71 +1923,31 @@ export default function AppSidebar({
         />
       </nav>
 
-      {shared.length > 0 && (
-        <>
-          <div className="mt-4 flex items-center justify-between px-3 pb-1">
-            <span className="text-[11px] font-semibold tracking-wide text-muted">
-              SHARED WORKSPACES
-            </span>
-          </div>
-          <nav className="px-1 text-[13.5px]">
-            {shared.map((s) => (
-              <WorkspaceTree
-                key={s.id}
-                workspace={{ ...s, shared: true }}
-                spine={spines[s.id] ?? null}
-                showName
-                pathname={pathname}
-                openSections={getOpenSections(s.id)}
-                onSectionOpenChange={(section, open) =>
-                  handleSectionOpenChange(s.id, section, open)
-                }
-                dropState={dropState}
-                onDropFiles={handleDropFiles}
-                onDropHover={handleDropHover}
-                pinnedFolders={pinnedState[s.id]?.folders ?? EMPTY_PIN_STATE.folders}
-                pinnedFiles={pinnedState[s.id]?.files ?? EMPTY_PIN_STATE.files}
-                pinnedLabels={pinnedLabelsState[s.id] ?? { folders: {}, files: {} }}
-                collapsedStashes={collapsedStashes}
-                onPinToggle={(kind, id, label) => handlePinToggle(kind, s.id, id, label)}
-                onUnpinAll={handleUnpinAll}
-                onStashCollapsedChange={handleStashCollapsedChange}
-                onAddSession={handleAddSession}
-                onAddPage={handleAddPage}
-                onAddStash={handleAddStash}
-              />
-            ))}
-          </nav>
-        </>
-      )}
-
       <nav className="mt-4 px-1 text-[13.5px]">
-        {mine.map((s) => (
+        {visibleWorkspace ? (
           <WorkspaceTree
-            key={s.id}
-            workspace={s}
-            spine={spines[s.id] ?? null}
-            pathname={pathname}
-            openSections={getOpenSections(s.id)}
+            key={visibleWorkspace.id}
+            workspace={visibleWorkspace}
+            spine={spines[visibleWorkspace.id] ?? null}
+            openSections={getOpenSections(visibleWorkspace.id)}
             onSectionOpenChange={(section, open) =>
-              handleSectionOpenChange(s.id, section, open)
+              handleSectionOpenChange(visibleWorkspace.id, section, open)
             }
             dropState={dropState}
             onDropFiles={handleDropFiles}
             onDropHover={handleDropHover}
-            pinnedFolders={pinnedState[s.id]?.folders ?? EMPTY_PIN_STATE.folders}
-            pinnedFiles={pinnedState[s.id]?.files ?? EMPTY_PIN_STATE.files}
-            pinnedLabels={pinnedLabelsState[s.id] ?? { folders: {}, files: {} }}
+            pinnedFolders={pinnedState[visibleWorkspace.id]?.folders ?? EMPTY_PIN_STATE.folders}
+            pinnedFiles={pinnedState[visibleWorkspace.id]?.files ?? EMPTY_PIN_STATE.files}
+            pinnedLabels={pinnedLabelsState[visibleWorkspace.id] ?? { folders: {}, files: {} }}
             collapsedStashes={collapsedStashes}
-            onPinToggle={(kind, id, label) => handlePinToggle(kind, s.id, id, label)}
+            onPinToggle={(kind, id, label) => handlePinToggle(kind, visibleWorkspace.id, id, label)}
             onUnpinAll={handleUnpinAll}
             onStashCollapsedChange={handleStashCollapsedChange}
             onAddSession={handleAddSession}
             onAddPage={handleAddPage}
             onAddStash={handleAddStash}
           />
-        ))}
-        {mine.length === 0 && (
+        ) : (
           <div className="px-3 py-1.5 text-[12px] italic text-muted">
             No workspaces yet.
           </div>


### PR DESCRIPTION
## Summary

Removes the sidebar's shared-workspace grouping so the sidebar only shows the currently active workspace tree.

## Changes

- Render a single visible workspace in `AppSidebar`, selected from the active workspace route/prop.
- Stop preloading and displaying every owned/shared workspace tree in the sidebar.
- Update the sidebar regression test to assert shared memberships do not create a `SHARED WORKSPACES` section or load inactive workspace sidebars.

## Screenshot

![stash-sidebar-single-workspace.png](https://github.com/user-attachments/assets/c2b58ac9-432b-4198-9404-3f5e5903e3e2)

## Test plan

- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run build`
- [x] Manual Playwright check against local demo workspace: sidebar has no `SHARED WORKSPACES` label and only one visible `Sessions` section.

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Documentation updated if behaviour changed: not needed
- [x] CHANGELOG.md updated: not needed for this UI copy fix
