### PR TITLE
[codex] Add full page search flow

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -531,6 +531,7 @@ class HistoryEventResponse(BaseModel):
     attachments: list[dict] | None = None
     created_at: datetime
     workspace_name: str | None = None
+    rank: float | None = None
 
 
 class HistoryEventListResponse(BaseModel):

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -32,6 +32,7 @@ interface SearchResult {
   sourceName: string;
   detail: string;
   updatedAt: string;
+  relevance: number;
 }
 
 interface SearchableStash extends WorkspaceStash {
@@ -266,7 +267,7 @@ function SearchPageInner() {
           ? descendantFolderIds(selectedSidebar.files.folders, selectedFolderId)
           : new Set<string>();
         nextResults.push(
-          ...searchPages(pageGroups, {
+          ...searchPages(pageGroups, q, {
             selectedFolderId,
             selectedPageId,
             folderIds,
@@ -513,7 +514,7 @@ function SearchPageInner() {
                     Results
                   </h2>
                   <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted">
-                    {results.length}
+                    {results.length} ranked by relevance
                   </p>
                 </div>
                 <div className="flex flex-col gap-2">
@@ -565,6 +566,14 @@ function searchSingleSession(
   );
   if (matches.length === 0) return [];
 
+  const bestMatch = matches.reduce((best, event) => {
+    const bestScore = scoreSessionEvent(query, sessionId, best);
+    const eventScore = scoreSessionEvent(query, sessionId, event);
+    if (eventScore !== bestScore) return eventScore > bestScore ? event : best;
+    if (!best.created_at) return event;
+    if (!event.created_at) return best;
+    return new Date(event.created_at) > new Date(best.created_at) ? event : best;
+  }, matches[0]);
   const latest = matches.reduce((best, event) => {
     if (!best.created_at) return event;
     if (!event.created_at) return best;
@@ -578,23 +587,25 @@ function searchSingleSession(
       title: sessionId,
       href: `/workspaces/${workspace.id}/sessions/${encodeURIComponent(sessionId)}`,
       sourceName: workspace.name,
-      detail: sessionEventSnippet(matches[0], query),
+      detail: sessionEventSnippet(bestMatch, query),
       updatedAt: latest.created_at ?? new Date().toISOString(),
+      relevance: scoreSessionEvent(query, sessionId, bestMatch),
     },
   ];
 }
 
 function searchStashes(stashes: SearchableStash[], query: string): SearchResult[] {
-  const q = query.toLowerCase();
   return stashes
-    .filter((stash) => {
-      const text = [stash.title, stash.description, stash.workspace_name]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return text.includes(q);
+    .map((stash) => {
+      const relevance = scoreValues(query, [
+        { value: stash.title, weight: 8 },
+        { value: stash.description, weight: 3 },
+        { value: stash.workspace_name, weight: 1 },
+      ]);
+      return { stash, relevance };
     })
-    .map((stash) => ({
+    .filter(({ relevance }) => relevance > 0)
+    .map(({ stash, relevance }) => ({
       id: stash.id,
       kind: "Stash" as const,
       title: stash.title,
@@ -604,6 +615,7 @@ function searchStashes(stashes: SearchableStash[], query: string): SearchResult[
         (stash.forked_from_stash_id ? "Forked Stash" : "Stash") +
         ` / ${stash.description || `${stash.items.length} items`}`,
       updatedAt: stash.updated_at,
+      relevance,
     }));
 }
 
@@ -617,7 +629,15 @@ function searchSessionsFromEvents(
       if (!event.session_id) continue;
       const id = `${workspace.id}:${event.session_id}`;
       const existing = resultsBySession.get(id);
-      if (existing && new Date(existing.updatedAt) >= new Date(event.created_at)) continue;
+      const relevance = scoreWorkspaceEvent(query, event);
+      if (
+        existing &&
+        (existing.relevance > relevance ||
+          (existing.relevance === relevance &&
+            new Date(existing.updatedAt) >= new Date(event.created_at)))
+      ) {
+        continue;
+      }
       resultsBySession.set(id, {
         id,
         kind: "Session",
@@ -626,6 +646,7 @@ function searchSessionsFromEvents(
         sourceName: workspace.name,
         detail: sessionSearchSnippet(event, query),
         updatedAt: event.created_at,
+        relevance,
       });
     }
   }
@@ -664,6 +685,7 @@ function sessionEventSnippet(event: SessionEvent, query: string): string {
 
 function searchPages(
   groups: { workspace: Workspace; pages: Page[] }[],
+  query: string,
   scope: {
     selectedFolderId: string;
     selectedPageId: string;
@@ -685,9 +707,10 @@ function searchPages(
         sourceName: workspace.name,
         detail:
           page.content_type === "html"
-            ? stripHtml(page.content_html).slice(0, 220) || "HTML page"
+            ? stripHtml(page.content_html ?? "").slice(0, 220) || "HTML page"
             : page.content_markdown?.slice(0, 220) || "Markdown page",
         updatedAt: page.updated_at,
+        relevance: scorePage(query, page),
       }))
   );
 }
@@ -723,16 +746,15 @@ function searchPublicStashItems(
   query: string,
   scope: { includePages: boolean; includeSessions: boolean }
 ): SearchResult[] {
-  const q = query.toLowerCase();
   return detail.items.flatMap((item, index) => {
     if (item.object_type === "folder" && scope.includePages) {
-      return searchPublicFolder(detail, item, index, q);
+      return searchPublicFolder(detail, item, index, query);
     }
     if (item.object_type === "page" && scope.includePages) {
-      return searchPublicPage(detail, item, index, q);
+      return searchPublicPage(detail, item, index, query);
     }
     if (item.object_type === "session" && scope.includeSessions) {
-      return searchPublicSession(detail, item, index, q);
+      return searchPublicSession(detail, item, index, query);
     }
     return [];
   });
@@ -764,6 +786,12 @@ function searchPublicFolder(
       sourceName: detail.stash.title,
       detail: pageSnippet(page.content_markdown, page.content_html),
       updatedAt: page.updated_at || detail.stash.updated_at,
+      relevance: scoreValues(query, [
+        { value: page.name, weight: 8 },
+        { value: page.content_markdown, weight: 2 },
+        { value: stripHtml(page.content_html ?? ""), weight: 2 },
+        { value: detail.stash.title, weight: 1 },
+      ]),
     }));
 }
 
@@ -795,6 +823,12 @@ function searchPublicPage(
       sourceName: detail.stash.title,
       detail: pageSnippet(page.content_markdown, page.content_html),
       updatedAt: page.updated_at || detail.stash.updated_at,
+      relevance: scoreValues(query, [
+        { value: page.name, weight: 8 },
+        { value: page.content_markdown, weight: 2 },
+        { value: stripHtml(page.content_html ?? ""), weight: 2 },
+        { value: detail.stash.title, weight: 1 },
+      ]),
     },
   ];
 }
@@ -840,16 +874,24 @@ function searchPublicSession(
       sourceName: detail.stash.title,
       detail: sessionSnippet(session),
       updatedAt: session.finished_at || session.started_at || detail.stash.updated_at,
+      relevance: scoreValues(query, [
+        { value: session.summary, weight: 8 },
+        { value: session.session_id, weight: 5 },
+        { value: session.agent_name, weight: 2 },
+        { value: eventText, weight: 1 },
+        { value: detail.stash.title, weight: 1 },
+      ]),
     },
   ];
 }
 
 function textIncludes(query: string, ...values: (string | null | undefined)[]): boolean {
-  return values
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase()
-    .includes(query);
+  const text = normalizeSearchText(values.filter(Boolean).join(" "));
+  const terms = searchTerms(query);
+  if (!text || terms.length === 0) return false;
+
+  const phrase = terms.join(" ");
+  return text.includes(phrase) || terms.every((term) => text.includes(term));
 }
 
 function pageSnippet(markdown?: string | null, html?: string | null): string {
@@ -870,9 +912,87 @@ function sessionSnippet(session: {
 }
 
 function sortResults(results: SearchResult[]): SearchResult[] {
-  return [...results].sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  return [...results].sort((a, b) => {
+    if (b.relevance !== a.relevance) return b.relevance - a.relevance;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
+function scoreSessionEvent(query: string, sessionId: string, event: SessionEvent): number {
+  return scoreValues(query, [
+    { value: sessionId, weight: 8 },
+    { value: event.agent_name, weight: 3 },
+    { value: event.tool_name, weight: 2 },
+    { value: event.content, weight: 1 },
+  ]);
+}
+
+function scoreWorkspaceEvent(query: string, event: WorkspaceHistoryEvent): number {
+  const rank = typeof event.rank === "number" ? event.rank * 1000 : 0;
+  return (
+    rank +
+    scoreValues(query, [
+      { value: event.session_id, weight: 6 },
+      { value: event.agent_name, weight: 3 },
+      { value: event.tool_name, weight: 2 },
+      { value: event.event_type, weight: 1 },
+      { value: event.content, weight: 1 },
+    ])
   );
+}
+
+function scorePage(query: string, page: Page): number {
+  const rankedPage = page as Page & { rank?: number; similarity?: number };
+  const rank = typeof rankedPage.rank === "number" ? rankedPage.rank * 1000 : 0;
+  const similarity = typeof rankedPage.similarity === "number" ? rankedPage.similarity * 100 : 0;
+
+  return (
+    rank +
+    similarity +
+    scoreValues(query, [
+      { value: page.name, weight: 8 },
+      { value: page.content_markdown, weight: 2 },
+      { value: stripHtml(page.content_html ?? ""), weight: 2 },
+    ])
+  );
+}
+
+function scoreValues(
+  query: string,
+  values: { value: string | null | undefined; weight: number }[]
+): number {
+  const terms = searchTerms(query);
+  if (terms.length === 0) return 0;
+
+  const phrase = terms.join(" ");
+  let score = 0;
+  for (const { value, weight } of values) {
+    const text = normalizeSearchText(value ?? "");
+    if (!text) continue;
+
+    const words = new Set(text.split(" "));
+    if (text === phrase) score += 100 * weight;
+    if (text.startsWith(phrase)) score += 40 * weight;
+    if (text.includes(phrase)) score += 30 * weight;
+    if (terms.every((term) => text.includes(term))) score += 12 * weight;
+
+    for (const term of terms) {
+      if (words.has(term)) {
+        score += 8 * weight;
+      } else if (text.includes(term)) {
+        score += 3 * weight;
+      }
+    }
+  }
+  return score;
+}
+
+function searchTerms(query: string): string[] {
+  return normalizeSearchText(query).split(" ").filter(Boolean);
+}
+
+function normalizeSearchText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
 function stripHtml(html: string): string {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -323,6 +323,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         open={cmdkOpen}
         onClose={() => setCmdkOpen(false)}
         workspaceId={activeWorkspaceId}
+        workspaceName={activeWorkspace?.name}
         searchScope={searchScope}
       />
     </div>

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { MouseEvent, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CommandPalette from "./CommandPalette";
+import {
+  getCachedWorkspaceSidebar,
+  readCachedWorkspaceSidebar,
+} from "../lib/stashNavigationCache";
+import { semanticSearchPages } from "../lib/api";
+
+const searchPlaceholder = "Search Stash or jump to a page, session, or file...";
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  }) => (
+    <a
+      href={href}
+      {...props}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.(event);
+      }}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../lib/stashNavigationCache", () => ({
+  readCachedWorkspaceSidebar: vi.fn(),
+  getCachedWorkspaceSidebar: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  semanticSearchPages: vi.fn(),
+}));
+
+const sidebar = {
+  sessions: [],
+  stashes: [],
+  files: {
+    folders: [],
+    pages: [{ id: "page-1", name: "Launch Roadmap.md", folder_id: null }],
+    files: [],
+  },
+};
+
+function renderPalette() {
+  return render(
+    <CommandPalette
+      open
+      onClose={vi.fn()}
+      workspaceId="ws-1"
+      workspaceName="Demo Workspace"
+      searchScope={{
+        kind: "workspace",
+        label: "Demo Workspace",
+        detail: "Search this workspace",
+        params: { workspace: "ws-1" },
+      }}
+    />
+  );
+}
+
+describe("CommandPalette search", () => {
+  beforeEach(() => {
+    router.push.mockClear();
+    vi.clearAllMocks();
+    vi.mocked(readCachedWorkspaceSidebar).mockReturnValue(sidebar);
+    vi.mocked(getCachedWorkspaceSidebar).mockResolvedValue(sidebar);
+    vi.mocked(semanticSearchPages).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens full-page search when Enter is pressed from the search input", () => {
+    renderPalette();
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "roadmap" },
+    });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(router.push).toHaveBeenCalledWith("/search?workspace=ws-1&q=roadmap");
+  });
+
+  it("keeps jump results available after the full-page search action", () => {
+    renderPalette();
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "roadmap" },
+    });
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(router.push).toHaveBeenCalledWith("/workspaces/ws-1/p/page-1");
+  });
+});

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -14,6 +14,7 @@ interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
   workspaceId: string | null;
+  workspaceName?: string | null;
   searchScope: SearchScope | null;
 }
 
@@ -28,6 +29,7 @@ export default function CommandPalette({
   open,
   onClose,
   workspaceId,
+  workspaceName,
   searchScope,
 }: CommandPaletteProps) {
   const router = useRouter();
@@ -59,15 +61,21 @@ export default function CommandPalette({
   }, [open, workspaceId]);
 
   useEffect(() => {
-    if (!open || !query.trim()) {
-      setResults(searchScope ? [scopedSearchResult(searchScope, query)] : []);
+    if (!open) {
+      setResults([]);
+      setSelected(0);
+      return;
+    }
+    const fullPageSearch = fullPageSearchResult(searchScope, workspaceId, workspaceName, query);
+    if (!query.trim()) {
+      setResults([fullPageSearch]);
       setSelected(0);
       return;
     }
     const q = query.toLowerCase();
 
     // Local spine fuzzy match (instant)
-    const local: Result[] = searchScope ? [scopedSearchResult(searchScope, query)] : [];
+    const local: Result[] = [fullPageSearch];
     if (spine && workspaceId) {
       const filesTree = spine.files;
       filesTree.pages.forEach((p) => {
@@ -132,7 +140,7 @@ export default function CommandPalette({
       }
     }, 250);
     return () => clearTimeout(timer);
-  }, [query, open, spine, workspaceId, searchScope]);
+  }, [query, open, spine, workspaceId, workspaceName, searchScope]);
 
   useEffect(() => {
     if (!open) return;
@@ -179,7 +187,7 @@ export default function CommandPalette({
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Jump to a page, session, skill, or file…"
+            placeholder="Search Stash or jump to a page, session, or file..."
             className="flex-1 bg-transparent text-[14px] text-foreground placeholder:text-muted focus:outline-none"
             autoFocus
           />
@@ -217,7 +225,7 @@ export default function CommandPalette({
           </div>
         ) : (
           <div className="px-4 py-6 text-center text-[13px] text-muted">
-            Start typing to search this stash…
+            Start typing to search this stash...
           </div>
         )}
       </div>
@@ -225,15 +233,25 @@ export default function CommandPalette({
   );
 }
 
-function scopedSearchResult(scope: SearchScope, query: string): Result {
-  const params = new URLSearchParams(scope.params);
+function fullPageSearchResult(
+  scope: SearchScope | null,
+  workspaceId: string | null,
+  workspaceName: string | null | undefined,
+  query: string
+): Result {
+  const params = new URLSearchParams(scope?.params);
+  if (!scope && workspaceId) params.set("workspace", workspaceId);
+
   const q = query.trim();
   if (q) params.set("q", q);
 
+  const label = scope?.label ?? workspaceName ?? (workspaceId ? "this workspace" : "Stash");
+  const hrefParams = params.toString();
+
   return {
     kind: "search",
-    label: q ? `Search ${scope.label} for "${q}"` : `Search ${scope.label}`,
-    href: `/search?${params.toString()}`,
-    detail: scope.detail,
+    label: q ? `Search ${label} for "${q}"` : `Search ${label}`,
+    href: hrefParams ? `/search?${hrefParams}` : "/search",
+    detail: scope?.detail ?? (workspaceId ? "Search this workspace" : "Search all workspaces"),
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1129,6 +1129,7 @@ export interface WorkspaceHistoryEvent {
   metadata: Record<string, unknown>;
   attachments: Record<string, unknown>[] | null;
   created_at: string;
+  rank?: number | null;
 }
 
 export async function searchWorkspaceEvents(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -67,6 +67,8 @@ export interface Page {
   updated_by: string | null;
   created_at: string;
   updated_at: string;
+  rank?: number;
+  similarity?: number;
 }
 
 // Lightweight tree node — pages live as `pages: PageSummary[]` in each folder.


### PR DESCRIPTION
## Summary
- make the top search palette default to a full-page search action, so pressing Enter opens `/search` with the current scope and query
- keep jump-to-page/session/file results available below the search action
- rank full-page search results by relevance across pages, sessions, and Stashes, using backend FTS rank where available and recency as a tiebreaker
- expose event FTS rank through the API response and add focused CommandPalette coverage

## Screenshots
Captured locally for the PR workflow and kept out of the repo:
- Command palette search action: `/tmp/stash-fullpage-search-command.png`
- Full-page ranked results: `/tmp/stash-fullpage-search-results.png`

## Validation
- `npm test -- CommandPalette.test.tsx AppShell.test.tsx`
- `npm run lint`
- `npm run build`
- `ruff check backend/models.py`
- `pytest backend/tests/test_files_search.py backend/tests/test_permissions.py::test_private_stash_hides_session_surfaces_until_user_is_added --cov-fail-under=0`
- Playwright browser check: typed `launch` in workspace search, pressed Enter, landed on `/search?workspace=...&q=launch`, and saw ranked results