### PR TITLE
[codex] Format backend and CLI with Black

### DIFF
--- a/backend/migrations/versions/0053_stash_access_privacy.py
+++ b/backend/migrations/versions/0053_stash_access_privacy.py
@@ -49,7 +49,9 @@ CREATE TABLE IF NOT EXISTS stash_members (
 
 
 def downgrade() -> None:
-    op.execute("ALTER TABLE stashes ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false")
+    op.execute(
+        "ALTER TABLE stashes ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false"
+    )
     op.execute("UPDATE stashes SET is_public = access = 'public'")
     op.execute("DROP TABLE IF EXISTS stash_members CASCADE")
     op.execute("ALTER TABLE stashes DROP CONSTRAINT IF EXISTS stashes_access_check")

--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -83,7 +83,9 @@ async def list_activity(
           FROM history_events he
           JOIN accessible_workspaces aw ON aw.id = he.workspace_id
           WHERE he.session_id IS NOT NULL
-            AND """ + memory_service.readable_session_event_condition("he", 1) + """
+            AND """
+        + memory_service.readable_session_event_condition("he", 1)
+        + """
           GROUP BY aw.id, aw.name, he.session_id
         )
         UNION ALL
@@ -98,7 +100,9 @@ async def list_activity(
           FROM pages p
           JOIN accessible_workspaces aw ON aw.id = p.workspace_id
           WHERE COALESCE(p.metadata->>'shared_in_stash_id', '') = ''
-            AND """ + permission_service.readable_content_condition("page", "p", 1) + """
+            AND """
+        + permission_service.readable_content_condition("page", "p", 1)
+        + """
         )
         UNION ALL
         (
@@ -111,7 +115,9 @@ async def list_activity(
                  aw.name AS workspace_name
           FROM files f
           JOIN accessible_workspaces aw ON aw.id = f.workspace_id
-          WHERE """ + permission_service.readable_content_condition("file", "f", 1) + """
+          WHERE """
+        + permission_service.readable_content_condition("file", "f", 1)
+        + """
         )
         UNION ALL
         (

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -214,7 +214,9 @@ async def get_folder_contents(
             "AND COALESCE(metadata->>'shared_in_stash_id', '') = ''",
             folder_row["id"],
         )
-        child_files = await pool.fetch("SELECT id FROM files WHERE folder_id = $1", folder_row["id"])
+        child_files = await pool.fetch(
+            "SELECT id FROM files WHERE folder_id = $1", folder_row["id"]
+        )
         folder_row["page_count"] = len(
             await files_tree_service._filter_readable(
                 [dict(row) for row in child_pages],

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -297,7 +297,9 @@ async def get_public_stash(
         )
 
     workspace_name = stash.pop("_workspace_name", "")
-    can_write = bool(current_user and await stash_service.user_can_write(stash["id"], current_user["id"]))
+    can_write = bool(
+        current_user and await stash_service.user_can_write(stash["id"], current_user["id"])
+    )
     return StashPublicResponse(
         stash=StashResponse(**stash),
         workspace_name=workspace_name,

--- a/backend/routers/workspaces.py
+++ b/backend/routers/workspaces.py
@@ -87,7 +87,9 @@ async def update_workspace(
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
     if role not in workspace_service.ROLES_CAN_WRITE:
-        raise HTTPException(status_code=403, detail="Workspace editors and admins can update workspace")
+        raise HTTPException(
+            status_code=403, detail="Workspace editors and admins can update workspace"
+        )
     ws = await workspace_service.update_workspace(
         workspace_id,
         name=req.name,
@@ -227,7 +229,9 @@ async def create_invite_token(
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
     if role not in workspace_service.ROLES_ADMIN:
-        raise HTTPException(status_code=403, detail="Only workspace admins can create invite tokens")
+        raise HTTPException(
+            status_code=403, detail="Only workspace admins can create invite tokens"
+        )
     ws = await workspace_service.get_workspace(workspace_id)
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -267,7 +271,9 @@ async def revoke_invite_token(
 ):
     role = await workspace_service.get_member_role(workspace_id, current_user["id"])
     if role not in workspace_service.ROLES_ADMIN:
-        raise HTTPException(status_code=403, detail="Only workspace admins can revoke invite tokens")
+        raise HTTPException(
+            status_code=403, detail="Only workspace admins can revoke invite tokens"
+        )
     ok = await invite_token_service.revoke_token(token_id, workspace_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Token not found or already revoked")

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -286,16 +286,22 @@ async def _get_source_counts(user_id: UUID, workspace_id: UUID | None = None) ->
                  WHERE p.workspace_id = $2
                    AND COALESCE(p.metadata->>'shared_in_stash_id', '') = ''
                    AND p.content_markdown IS NOT NULL AND p.content_markdown != ''
-                   AND """ + permission_service.readable_content_condition("page", "p", 1) + """) AS pages,
+                   AND """
+            + permission_service.readable_content_condition("page", "p", 1)
+            + """) AS pages,
                 (SELECT COUNT(*) FROM table_rows tr
                  WHERE tr.table_id IN (
                    SELECT t.id FROM tables t
                    WHERE t.workspace_id = $2
-                     AND """ + permission_service.readable_content_condition("table", "t", 1) + """)
+                     AND """
+            + permission_service.readable_content_condition("table", "t", 1)
+            + """)
                    AND tr.data IS NOT NULL) AS rows,
                 (SELECT COUNT(*) FROM history_events he
                  WHERE he.workspace_id = $2
-                   AND """ + memory_service.readable_session_event_condition("he", 1) + """) AS events
+                   AND """
+            + memory_service.readable_session_event_condition("he", 1)
+            + """) AS events
             """,
             user_id,
             workspace_id,
@@ -308,18 +314,24 @@ async def _get_source_counts(user_id: UUID, workspace_id: UUID | None = None) ->
                  WHERE p.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
                    AND COALESCE(p.metadata->>'shared_in_stash_id', '') = ''
                    AND p.content_markdown IS NOT NULL AND p.content_markdown != ''
-                   AND """ + permission_service.readable_content_condition("page", "p", 1) + """) AS pages,
+                   AND """
+            + permission_service.readable_content_condition("page", "p", 1)
+            + """) AS pages,
                 (SELECT COUNT(*) FROM table_rows tr
                  WHERE tr.table_id IN (
                      SELECT t.id FROM tables t
                      WHERE (t.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
                         OR (t.workspace_id IS NULL AND t.created_by = $1))
-                       AND (t.workspace_id IS NULL OR """ + permission_service.readable_content_condition("table", "t", 1) + """))
+                       AND (t.workspace_id IS NULL OR """
+            + permission_service.readable_content_condition("table", "t", 1)
+            + """))
                    AND tr.data IS NOT NULL) AS rows,
                 (SELECT COUNT(*) FROM history_events he
                  WHERE (he.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
                     OR (he.workspace_id IS NULL AND he.created_by = $1))
-                   AND (he.workspace_id IS NULL OR """ + memory_service.readable_session_event_condition("he", 1) + """)) AS events
+                   AND (he.workspace_id IS NULL OR """
+            + memory_service.readable_session_event_condition("he", 1)
+            + """)) AS events
             """,
             user_id,
         )

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -112,7 +112,9 @@ async def _validate_item_partition(conn, access: str, items: list, stash_id: UUI
                     "Private Stashes can only include items that are not in workspace or public Stashes"
                 )
             if access != "private" and row["access"] == "private":
-                raise ValueError("Items in private Stashes cannot be added to workspace or public Stashes")
+                raise ValueError(
+                    "Items in private Stashes cannot be added to workspace or public Stashes"
+                )
 
 
 async def _partition_targets(conn, object_type: str, object_id: UUID) -> list[tuple[str, UUID]]:
@@ -248,6 +250,7 @@ async def _object_title(object_type: str, object_id: UUID) -> str:
     else:
         row = None
     return row["name"] if row else "Shared item"
+
 
 async def update_stash(
     stash_id: UUID,

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -96,10 +96,6 @@ async def test_user_activity_can_filter_to_one_workspace(client: AsyncClient):
     )
     assert resp.status_code == 200
 
-    events = [
-        event
-        for event in resp.json()
-        if event["kind"] == "session.uploaded"
-    ]
+    events = [event for event in resp.json() if event["kind"] == "session.uploaded"]
     assert {event["target_id"] for event in events} == {"first-session"}
     assert {event["workspace_id"] for event in events} == {first_workspace["id"]}

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -521,9 +521,7 @@ async def test_stash_member_api_grants_and_revokes_private_page_access(
         headers=_auth(owner_key),
     )
     assert members_resp.status_code == 200
-    assert [member["user_id"] for member in members_resp.json()["members"]] == [
-        collaborator["id"]
-    ]
+    assert [member["user_id"] for member in members_resp.json()["members"]] == [collaborator["id"]]
     assert await permission_service.check_access(
         "page",
         uuid.UUID(page["id"]),
@@ -762,9 +760,7 @@ async def test_private_stash_hides_session_surfaces_until_user_is_added(
         headers=_auth(member_key),
     )
     assert search_resp.status_code == 200
-    assert [event["session_id"] for event in search_resp.json()["events"]] == [
-        "private-session-1"
-    ]
+    assert [event["session_id"] for event in search_resp.json()["events"]] == ["private-session-1"]
 
     activity_resp = await client.get(
         "/api/v1/me/activity",
@@ -1013,7 +1009,9 @@ async def test_folder_stash_inlines_folder_files(pool, monkeypatch):
 async def test_object_level_permission_mutators_are_not_routes(client: AsyncClient):
     api_key, _owner = await _register(client)
     workspace = (
-        await client.post("/api/v1/workspaces", json={"name": "No object shares"}, headers=_auth(api_key))
+        await client.post(
+            "/api/v1/workspaces", json={"name": "No object shares"}, headers=_auth(api_key)
+        )
     ).json()
     folder = (
         await client.post(

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -163,7 +163,9 @@ async def test_magic_invite_redeem_assigns_editor_role(client: AsyncClient):
     owner_key, _ = await _register(client)
     joiner_key, joiner = await _register(client)
     ws = (
-        await client.post("/api/v1/workspaces", json={"name": "Magic Team"}, headers=_auth(owner_key))
+        await client.post(
+            "/api/v1/workspaces", json={"name": "Magic Team"}, headers=_auth(owner_key)
+        )
     ).json()
 
     invite = await client.post(

--- a/cli/client.py
+++ b/cli/client.py
@@ -502,17 +502,13 @@ class StashClient:
         base = f"/api/v1/workspaces/{workspace_id}/tables"
         return self._post(f"{base}/{table_id}/rows", json={"data": data})
 
-    def insert_table_rows_batch(
-        self, workspace_id: str, table_id: str, rows: list[dict]
-    ) -> dict:
+    def insert_table_rows_batch(self, workspace_id: str, table_id: str, rows: list[dict]) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables"
         return self._post(
             f"{base}/{table_id}/rows/batch", json={"rows": [{"data": r} for r in rows]}
         )
 
-    def update_table_row(
-        self, workspace_id: str, table_id: str, row_id: str, data: dict
-    ) -> dict:
+    def update_table_row(self, workspace_id: str, table_id: str, row_id: str, data: dict) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables"
         return self._patch(f"{base}/{table_id}/rows/{row_id}", json={"data": data})
 

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -521,11 +521,11 @@ def upload_conversation(
         result = client.upload_transcript(
             workspace_id=workspace_id,
             session_id=conv.session_id,
-        transcript_path=transcript_path,
-        agent_name=conv.agent,
-        cwd=conv.cwd,
-        default_stash_id=default_stash_id,
-    )
+            transcript_path=transcript_path,
+            agent_name=conv.agent,
+            cwd=conv.cwd,
+            default_stash_id=default_stash_id,
+        )
     finally:
         if materialized:
             os.unlink(transcript_path)

--- a/cli/main.py
+++ b/cli/main.py
@@ -1107,9 +1107,7 @@ def upload(
     path: str = typer.Argument(..., help="Directory or file to upload."),
     name: str = typer.Option("", "--name", "-n", help="Name for the uploaded folder."),
     workspace_id: str = typer.Option(None, "--ws"),
-    public: bool = typer.Option(
-        True, "--public/--private", help="Publish a shareable Stash."
-    ),
+    public: bool = typer.Option(True, "--public/--private", help="Publish a shareable Stash."),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Upload local files into workspace pages and publish them as a Stash."""
@@ -1259,9 +1257,7 @@ def stashes_create(
     workspace_id: str = typer.Option("", "--workspace", help="Workspace ID; falls back to .stash."),
     description: str = typer.Option("", "--description"),
     public: bool = typer.Option(False, "--public", help="Publish immediately."),
-    discover: bool = typer.Option(
-        False, "--discover", help="List the public Stash in Discover."
-    ),
+    discover: bool = typer.Option(False, "--discover", help="List the public Stash in Discover."),
     items_json: str = typer.Option(
         "[]",
         "--items",
@@ -1313,10 +1309,10 @@ def stashes_create(
 def stashes_publish(
     stash_id: str = typer.Argument(...),
     private: bool = typer.Option(False, "--private", help="Make the Stash private."),
-    workspace: bool = typer.Option(False, "--workspace-access", help="Make the Stash workspace-visible."),
-    discover: bool = typer.Option(
-        False, "--discover", help="List the public Stash in Discover."
+    workspace: bool = typer.Option(
+        False, "--workspace-access", help="Make the Stash workspace-visible."
     ),
+    discover: bool = typer.Option(False, "--discover", help="List the public Stash in Discover."),
 ):
     """Change a Stash's access level."""
     if discover and (private or workspace):
@@ -1911,7 +1907,9 @@ def files_edit_page(
 # Sessions
 # ===========================================================================
 
-hist_app = typer.Typer(help="Sessions — agent transcripts and event logs.", invoke_without_command=True)
+hist_app = typer.Typer(
+    help="Sessions — agent transcripts and event logs.", invoke_without_command=True
+)
 app.add_typer(hist_app, name="sessions")
 
 


### PR DESCRIPTION
## Summary
- run Black over `backend/` and `cli/` to fix the formatting failures from the CI backend lint job
- keep the diff mechanical only: wrapping, import layout, and call formatting

## Validation
- `black --check backend/ cli/`
- `ruff check backend/ cli/`