### PR TITLE
[codex] Make breadcrumbs home rooted

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -1,7 +1,8 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppShell from "./AppShell";
+import { BreadcrumbProvider, useBreadcrumbs } from "./BreadcrumbContext";
 import { ShareModalProvider } from "../lib/shareModalContext";
 import {
   getCachedWorkspaces,
@@ -67,6 +68,40 @@ const user = {
   last_seen: "2026-05-11T00:00:00Z",
 };
 
+const workspace = {
+  id: "ws-1",
+  name: "Demo Stash",
+  description: "",
+  creator_id: user.id,
+  invite_code: "invite",
+  created_at: "2026-05-11T00:00:00Z",
+  updated_at: "2026-05-11T00:00:00Z",
+  member_count: 1,
+};
+
+function BreadcrumbPage() {
+  useBreadcrumbs(
+    [
+      { label: "Product", href: "/workspaces/ws-1/folders/folder-1" },
+      { label: "Launch plan" },
+    ],
+    "breadcrumb-page"
+  );
+
+  return <div>Page content</div>;
+}
+
+function mockWorkspaceCache() {
+  const cache = {
+    userId: user.id,
+    all: [workspace],
+    mine: [],
+    shared: [],
+  };
+  vi.mocked(readCachedWorkspaces).mockReturnValue(cache);
+  vi.mocked(getCachedWorkspaces).mockResolvedValue(cache);
+}
+
 describe("AppShell sidebar collapse", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -112,23 +147,7 @@ describe("AppShell sidebar collapse", () => {
 
   it("opens top-bar search with session scope", () => {
     nav.pathname = "/workspaces/ws-1/sessions/session-123";
-    vi.mocked(readCachedWorkspaces).mockReturnValue({
-      userId: user.id,
-      all: [
-        {
-          id: "ws-1",
-          name: "Demo Stash",
-          description: "",
-          creator_id: user.id,
-          invite_code: "invite",
-          created_at: "2026-05-11T00:00:00Z",
-          updated_at: "2026-05-11T00:00:00Z",
-          member_count: 1,
-        },
-      ],
-      mine: [],
-      shared: [],
-    });
+    mockWorkspaceCache();
 
     render(
       <ShareModalProvider>
@@ -142,5 +161,50 @@ describe("AppShell sidebar collapse", () => {
 
     expect(screen.getByTestId("command-palette")).toHaveTextContent("session:this session");
     expect(commandPaletteState.props?.searchScope?.kind).toBe("session");
+  });
+
+  it("keeps Home clickable on the workspace home route", async () => {
+    nav.pathname = "/workspaces/ws-1";
+    mockWorkspaceCache();
+
+    render(
+      <ShareModalProvider>
+        <AppShell user={user} onLogout={vi.fn()}>
+          <div>Workspace content</div>
+        </AppShell>
+      </ShareModalProvider>
+    );
+
+    const home = screen.getByRole("link", { name: "Home" });
+    await waitFor(() => expect(home).toHaveAttribute("href", "/workspaces/ws-1"));
+    expect(screen.queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
+  });
+
+  it("renders breadcrumbs as a Home-rooted file path", async () => {
+    nav.pathname = "/workspaces/ws-1/p/page-1";
+    mockWorkspaceCache();
+
+    render(
+      <BreadcrumbProvider>
+        <ShareModalProvider>
+          <AppShell user={user} onLogout={vi.fn()}>
+            <BreadcrumbPage />
+          </AppShell>
+        </ShareModalProvider>
+      </BreadcrumbProvider>
+    );
+
+    const home = await screen.findByRole("link", { name: "Home" });
+    await waitFor(() => expect(home).toHaveAttribute("href", "/workspaces/ws-1"));
+
+    const header = home.closest("header");
+    expect(header).not.toBeNull();
+    expect(within(header!).getByRole("link", { name: "Product" })).toHaveAttribute(
+      "href",
+      "/workspaces/ws-1/folders/folder-1"
+    );
+    expect(within(header!).getByText("Launch plan")).toBeInTheDocument();
+    expect(within(header!).getAllByText("/")).toHaveLength(2);
+    expect(within(header!).queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -11,7 +11,6 @@ import {
 
 const nav = vi.hoisted(() => ({
   pathname: "/",
-  back: vi.fn(),
 }));
 
 const commandPaletteState = vi.hoisted(() => ({
@@ -20,7 +19,6 @@ const commandPaletteState = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   usePathname: () => nav.pathname,
-  useRouter: () => ({ back: nav.back }),
 }));
 
 vi.mock("next/link", () => ({
@@ -106,7 +104,6 @@ describe("AppShell sidebar collapse", () => {
   beforeEach(() => {
     localStorage.clear();
     nav.pathname = "/";
-    nav.back.mockClear();
     commandPaletteState.props = null;
     vi.clearAllMocks();
     vi.mocked(readCachedWorkspaces).mockReturnValue({
@@ -177,6 +174,7 @@ describe("AppShell sidebar collapse", () => {
 
     const home = screen.getByRole("link", { name: "Home" });
     await waitFor(() => expect(home).toHaveAttribute("href", "/workspaces/ws-1"));
+    expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,7 +9,6 @@ import AppSidebar from "./AppSidebar";
 import CommandPalette from "./CommandPalette";
 import { useShareModal } from "../lib/shareModalContext";
 import { type Crumb, useBreadcrumbsValue } from "./BreadcrumbContext";
-import { StashIcon } from "./StashIcons";
 import { getCachedWorkspaces, readCachedWorkspaces } from "../lib/stashNavigationCache";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 
@@ -269,7 +268,6 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
               <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
-          <WorkspaceLabel workspace={activeWorkspace} />
           <Breadcrumb activeWorkspace={activeWorkspace} pageCrumbs={breadcrumbs} />
         </div>
 
@@ -401,23 +399,6 @@ function UserMenu({
   );
 }
 
-function WorkspaceLabel({ workspace }: { workspace: Workspace | undefined }) {
-  if (!workspace) return null;
-
-  return (
-    <Link
-      href={`/workspaces/${workspace.id}`}
-      className="ml-1.5 flex min-w-0 items-center gap-1.5 rounded px-1.5 py-1 text-foreground hover:bg-raised"
-      title={workspace.name}
-    >
-      <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
-        <StashIcon />
-      </span>
-      <span className="max-w-[180px] truncate font-medium">{workspace.name}</span>
-    </Link>
-  );
-}
-
 function Breadcrumb({
   activeWorkspace,
   pageCrumbs,
@@ -425,13 +406,14 @@ function Breadcrumb({
   activeWorkspace: Workspace | undefined;
   pageCrumbs: { label: string; href?: string; onClick?: () => void }[] | null;
 }) {
-  let items: { label: string; href?: string }[] = [];
+  const home = {
+    label: "Home",
+    href: activeWorkspace ? `/workspaces/${activeWorkspace.id}` : "/",
+  };
+
+  let items: { label: string; href?: string }[] = [home];
   if (pageCrumbs && pageCrumbs.length > 0) {
-    items = pageCrumbs.map((c) => ({ label: c.label, href: c.href }));
-  } else if (activeWorkspace) {
-    items = [{ label: "Home", href: `/workspaces/${activeWorkspace.id}` }];
-  } else {
-    items = [{ label: "Home", href: "/" }];
+    items = [...items, ...pageCrumbs.map((c) => ({ label: c.label, href: c.href }))];
   }
 
   return (
@@ -440,8 +422,8 @@ function Breadcrumb({
         const last = i === items.length - 1;
         return (
           <span key={i} className="flex min-w-0 items-center gap-1">
-            <span className="text-muted/60">/</span>
-            {!last && c.href ? (
+            {i > 0 && <span className="text-muted/60">/</span>}
+            {c.href && (!last || c.label === "Home") ? (
               <Link href={c.href} className="truncate hover:text-foreground">
                 {c.label}
               </Link>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import type { StashItemSpec } from "../lib/api";
 import { User, Workspace } from "../lib/types";
 import AppSidebar from "./AppSidebar";
@@ -194,7 +194,6 @@ function TopSearchButton({
 
 export default function AppShell({ user, onLogout, children }: AppShellProps) {
   const pathname = usePathname();
-  const router = useRouter();
   const breadcrumbs = useBreadcrumbsValue();
   const shareModal = useShareModal();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -257,16 +256,6 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
             title="Toggle sidebar (⌘\\)"
           >
             <SidebarToggleIcon collapsed={sidebarCollapsed} />
-          </button>
-          <button
-            onClick={() => router.back()}
-            className="rounded p-1 text-muted hover:bg-raised"
-            aria-label="Back"
-            title="Back"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
           </button>
           <Breadcrumb activeWorkspace={activeWorkspace} pageCrumbs={breadcrumbs} />
         </div>


### PR DESCRIPTION
## Summary
- Remove the workspace-name link from the top breadcrumb row.
- Remove the top-bar Back button so navigation starts with the sidebar toggle and Home path.
- Always render breadcrumbs as a Home-rooted path, with Home linking to the current workspace home when a workspace is active.
- Add AppShell coverage for clickable Home breadcrumbs, file-path rendering, and the removed Back button.

## Validation
- `npm test -- AppShell.test.tsx`
- `npm run lint -- src/components/AppShell.tsx src/components/AppShell.test.tsx`
- Playwright browser check against mocked API responses, captured below.

## Screenshot
![stash-breadcrumbs-no-back-header.png](https://github.com/user-attachments/assets/f2a91698-5ec4-4d13-9349-d1943787b756)