### PR TITLE
Add Stash link and invite sharing flows

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from .routers import (
     publish,
     sessions,
     skill,
+    stash_invites,
     stashes,
     tables,
     transcripts,
@@ -99,6 +100,7 @@ app.include_router(users.router)
 app.include_router(workspaces.router)
 app.include_router(workspace_knowledge.router)
 app.include_router(discover.router)
+app.include_router(stash_invites.router)
 app.include_router(stashes.ws_router)
 app.include_router(stashes.public_router)
 app.include_router(files_tree.router)

--- a/backend/migrations/versions/0057_stash_invites.py
+++ b/backend/migrations/versions/0057_stash_invites.py
@@ -1,0 +1,40 @@
+"""Add in-product Stash invitations.
+
+Revision ID: 0057
+Revises: 0056
+"""
+
+from alembic import op
+
+revision = "0057"
+down_revision = "0056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+CREATE TABLE IF NOT EXISTS stash_invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    stash_id UUID NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+    recipient_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    invited_by_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    permission VARCHAR(16) NOT NULL DEFAULT 'read'
+        CHECK(permission IN ('read', 'write', 'admin')),
+    status VARCHAR(16) NOT NULL DEFAULT 'pending'
+        CHECK(status IN ('pending', 'accepted', 'dismissed')),
+    target_workspace_id UUID REFERENCES workspaces(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    responded_at TIMESTAMPTZ,
+    UNIQUE(stash_id, recipient_user_id)
+)
+""")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_stash_invites_recipient_status "
+        "ON stash_invites(recipient_user_id, status, created_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS stash_invites CASCADE")

--- a/backend/models.py
+++ b/backend/models.py
@@ -197,6 +197,29 @@ class AddExternalStashRequest(BaseModel):
     workspace_id: UUID
 
 
+class StashInviteResponse(BaseModel):
+    id: UUID
+    stash_id: UUID
+    stash_slug: str
+    stash_title: str
+    stash_description: str
+    source_workspace_id: UUID
+    source_workspace_name: str
+    invited_by_user_id: UUID
+    invited_by_name: str
+    invited_by_display_name: str | None = None
+    permission: str
+    created_at: datetime
+
+
+class StashInviteListResponse(BaseModel):
+    invites: list[StashInviteResponse]
+
+
+class AcceptStashInviteRequest(BaseModel):
+    workspace_id: UUID
+
+
 class WorkspaceMember(BaseModel):
     user_id: UUID
     name: str

--- a/backend/routers/stash_invites.py
+++ b/backend/routers/stash_invites.py
@@ -1,0 +1,51 @@
+"""Current-user Stash invite notifications."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user
+from ..models import (
+    AcceptStashInviteRequest,
+    StashInviteListResponse,
+    StashInviteResponse,
+    StashResponse,
+)
+from ..services import stash_invite_service
+
+router = APIRouter(prefix="/api/v1/stash-invites", tags=["stash-invites"])
+
+
+@router.get("", response_model=StashInviteListResponse)
+async def list_stash_invites(current_user: dict = Depends(get_current_user)):
+    invites = await stash_invite_service.list_pending_invites(current_user["id"])
+    return StashInviteListResponse(invites=[StashInviteResponse(**invite) for invite in invites])
+
+
+@router.post("/{invite_id}/accept", response_model=StashResponse)
+async def accept_stash_invite(
+    invite_id: UUID,
+    req: AcceptStashInviteRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    try:
+        stash = await stash_invite_service.accept_invite(
+            invite_id,
+            current_user["id"],
+            req.workspace_id,
+        )
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    if not stash:
+        raise HTTPException(status_code=404, detail="Stash invite not found")
+    return StashResponse(**stash)
+
+
+@router.post("/{invite_id}/dismiss", status_code=204)
+async def dismiss_stash_invite(
+    invite_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    dismissed = await stash_invite_service.dismiss_invite(invite_id, current_user["id"])
+    if not dismissed:
+        raise HTTPException(status_code=404, detail="Stash invite not found")

--- a/backend/services/stash_invite_service.py
+++ b/backend/services/stash_invite_service.py
@@ -1,0 +1,139 @@
+"""In-product Stash invitations."""
+
+from uuid import UUID
+
+from ..database import get_pool
+from . import stash_service, workspace_service
+
+
+async def create_or_update_invite(
+    *,
+    stash_id: UUID,
+    recipient_user_id: UUID,
+    invited_by_user_id: UUID,
+    permission: str,
+) -> dict | None:
+    if recipient_user_id == invited_by_user_id:
+        return None
+
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        INSERT INTO stash_invites
+          (stash_id, recipient_user_id, invited_by_user_id, permission, status,
+           target_workspace_id, responded_at)
+        VALUES ($1, $2, $3, $4, 'pending', NULL, NULL)
+        ON CONFLICT (stash_id, recipient_user_id) DO UPDATE
+        SET invited_by_user_id = EXCLUDED.invited_by_user_id,
+            permission = EXCLUDED.permission,
+            status = 'pending',
+            target_workspace_id = NULL,
+            responded_at = NULL,
+            updated_at = now()
+        RETURNING id, stash_id, recipient_user_id, invited_by_user_id, permission,
+                  status, target_workspace_id, created_at, updated_at, responded_at
+        """,
+        stash_id,
+        recipient_user_id,
+        invited_by_user_id,
+        permission,
+    )
+    return dict(row) if row else None
+
+
+async def delete_pending_invite(stash_id: UUID, recipient_user_id: UUID) -> None:
+    pool = get_pool()
+    await pool.execute(
+        "DELETE FROM stash_invites "
+        "WHERE stash_id = $1 AND recipient_user_id = $2 AND status = 'pending'",
+        stash_id,
+        recipient_user_id,
+    )
+
+
+async def list_pending_invites(user_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT si.id,
+               si.stash_id,
+               s.slug AS stash_slug,
+               s.title AS stash_title,
+               s.description AS stash_description,
+               s.workspace_id AS source_workspace_id,
+               w.name AS source_workspace_name,
+               si.invited_by_user_id,
+               u.name AS invited_by_name,
+               u.display_name AS invited_by_display_name,
+               si.permission,
+               si.created_at
+        FROM stash_invites si
+        JOIN stashes s ON s.id = si.stash_id
+        JOIN workspaces w ON w.id = s.workspace_id
+        JOIN users u ON u.id = si.invited_by_user_id
+        WHERE si.recipient_user_id = $1
+          AND si.status = 'pending'
+        ORDER BY si.created_at DESC, si.id DESC
+        """,
+        user_id,
+    )
+    return [dict(row) for row in rows]
+
+
+async def accept_invite(invite_id: UUID, user_id: UUID, workspace_id: UUID) -> dict | None:
+    pool = get_pool()
+    invite = await pool.fetchrow(
+        """
+        SELECT si.id, si.stash_id, s.slug
+        FROM stash_invites si
+        JOIN stashes s ON s.id = si.stash_id
+        WHERE si.id = $1
+          AND si.recipient_user_id = $2
+          AND si.status = 'pending'
+        """,
+        invite_id,
+        user_id,
+    )
+    if not invite:
+        return None
+
+    if not await workspace_service.is_member(workspace_id, user_id):
+        raise PermissionError("Not a workspace member")
+
+    stash = await stash_service.add_external_stash(workspace_id, invite["slug"], user_id)
+    if not stash:
+        return None
+
+    await pool.execute(
+        """
+        UPDATE stash_invites
+        SET status = 'accepted',
+            target_workspace_id = $1,
+            responded_at = now(),
+            updated_at = now()
+        WHERE id = $2
+          AND recipient_user_id = $3
+        """,
+        workspace_id,
+        invite_id,
+        user_id,
+    )
+    return stash
+
+
+async def dismiss_invite(invite_id: UUID, user_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        """
+        UPDATE stash_invites
+        SET status = 'dismissed',
+            responded_at = now(),
+            updated_at = now()
+        WHERE id = $1
+          AND recipient_user_id = $2
+          AND status = 'pending'
+        """,
+        invite_id,
+        user_id,
+    )
+    return result == "UPDATE 1"

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -1240,6 +1240,15 @@ async def add_member(
     if not user:
         return None
 
+    from . import stash_invite_service
+
+    await stash_invite_service.create_or_update_invite(
+        stash_id=stash_id,
+        recipient_user_id=user_id,
+        invited_by_user_id=granted_by,
+        permission=permission,
+    )
+
     member = dict(row)
     member["name"] = user["name"]
     member["display_name"] = user["display_name"]
@@ -1255,6 +1264,9 @@ async def remove_member(stash_id: UUID, user_id: UUID) -> bool:
     )
     removed = result == "DELETE 1"
     if removed:
+        from . import stash_invite_service
+
+        await stash_invite_service.delete_pending_invite(stash_id, user_id)
         await pool.execute("UPDATE stashes SET updated_at = now() WHERE id = $1", stash_id)
     return removed
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -95,6 +95,7 @@ _TRUNCATE_TABLES = [
     "webhooks",
     "documents",
     "files",
+    "stash_invites",
     "stash_members",
     "stash_items",
     "stashes",

--- a/backend/tests/test_stash_invites.py
+++ b/backend/tests/test_stash_invites.py
@@ -1,0 +1,137 @@
+"""Tests for in-product Stash invite notifications."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient, name: str | None = None) -> tuple[str, dict]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name or unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+@pytest.mark.asyncio
+async def test_stash_invite_can_be_accepted_into_workspace(client: AsyncClient):
+    owner_key, _owner = await _register(client, "stash_invite_owner")
+    recipient_key, recipient = await _register(client, "stash_invite_recipient")
+
+    source_workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Source workspace"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    target_workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Recipient workspace"},
+            headers=_auth(recipient_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{source_workspace['id']}/pages/new",
+            json={"name": "Partner plan", "content": "private context"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    stash = (
+        await client.post(
+            f"/api/v1/workspaces/{source_workspace['id']}/stashes",
+            json={
+                "title": "Partner Stash",
+                "access": "private",
+                "items": [{"object_type": "page", "object_id": page["id"]}],
+            },
+            headers=_auth(owner_key),
+        )
+    ).json()
+
+    added_member = await client.post(
+        f"/api/v1/stashes/{stash['id']}/members",
+        json={"user_id": recipient["id"], "permission": "read"},
+        headers=_auth(owner_key),
+    )
+    assert added_member.status_code == 201
+
+    invites = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert invites.status_code == 200
+    [invite] = invites.json()["invites"]
+    assert invite["stash_id"] == stash["id"]
+    assert invite["stash_title"] == "Partner Stash"
+    assert invite["source_workspace_id"] == source_workspace["id"]
+    assert invite["permission"] == "read"
+
+    accepted = await client.post(
+        f"/api/v1/stash-invites/{invite['id']}/accept",
+        json={"workspace_id": target_workspace["id"]},
+        headers=_auth(recipient_key),
+    )
+    assert accepted.status_code == 200
+    fork = accepted.json()
+    assert fork["is_external"] is True
+    assert fork["workspace_id"] == target_workspace["id"]
+    assert fork["forked_from_stash_id"] == stash["id"]
+
+    remaining = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert remaining.json()["invites"] == []
+
+
+@pytest.mark.asyncio
+async def test_stash_invite_can_be_dismissed(client: AsyncClient):
+    owner_key, _owner = await _register(client, "stash_dismiss_owner")
+    recipient_key, recipient = await _register(client, "stash_dismiss_recipient")
+
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Source workspace"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Draft", "content": "hello"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    stash = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/stashes",
+            json={
+                "title": "Dismissable Stash",
+                "access": "private",
+                "items": [{"object_type": "page", "object_id": page["id"]}],
+            },
+            headers=_auth(owner_key),
+        )
+    ).json()
+    await client.post(
+        f"/api/v1/stashes/{stash['id']}/members",
+        json={"user_id": recipient["id"], "permission": "read"},
+        headers=_auth(owner_key),
+    )
+
+    invites = (await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))).json()
+    invite_id = invites["invites"][0]["id"]
+
+    dismissed = await client.post(
+        f"/api/v1/stash-invites/{invite_id}/dismiss",
+        headers=_auth(recipient_key),
+    )
+    assert dismissed.status_code == 204
+
+    remaining = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert remaining.json()["invites"] == []

--- a/frontend/src/app/stashes/[slug]/AddToWorkspaceButton.tsx
+++ b/frontend/src/app/stashes/[slug]/AddToWorkspaceButton.tsx
@@ -133,7 +133,7 @@ export default function AddToWorkspaceButton({ slug, sourceWorkspaceId }: Props)
                 onClick={() => void attachToWorkspace(selectedWorkspaceId)}
                 className="w-full rounded-md bg-brand px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
               >
-                Add live Stash
+                Add Stash
               </button>
             </div>
           ) : (

--- a/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useShareModal } from "../../../../lib/shareModalContext";
-import { listStashes, type WorkspaceStash } from "../../../../lib/api";
+import { addExternalStash, ApiError, listStashes, type WorkspaceStash } from "../../../../lib/api";
+import { stashSlugFromInput } from "../../../../lib/stashLinks";
 
 type Filter = "all" | "workspace" | "private" | "public" | "external";
 
@@ -136,6 +137,14 @@ export default function WorkspaceStashesPage() {
           })}
         </div>
 
+        <ExternalStashLinkForm
+          workspaceId={workspaceId}
+          onAdded={() => {
+            setFilter("external");
+            void load();
+          }}
+        />
+
         {/* Grid */}
         {filtered.length === 0 ? (
           <div className="mt-12 rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[12.5px] text-muted">
@@ -156,6 +165,78 @@ export default function WorkspaceStashesPage() {
         )}
       </div>
     </div>
+  );
+}
+
+function ExternalStashLinkForm({
+  workspaceId,
+  onAdded,
+}: {
+  workspaceId: string;
+  onAdded: () => void;
+}) {
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const slug = stashSlugFromInput(input);
+    if (!slug) {
+      setError("Paste a Stash URL like /stashes/product-plan or a Stash slug.");
+      setMessage("");
+      return;
+    }
+
+    setBusy(true);
+    setError("");
+    setMessage("");
+    try {
+      const stash = await addExternalStash(slug, workspaceId);
+      setInput("");
+      setMessage(
+        stash.is_external
+          ? `Added ${stash.title} to this workspace.`
+          : `${stash.title} is already in this workspace.`
+      );
+      onAdded();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not add Stash");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      className="mt-4 rounded-lg border border-border-subtle bg-surface px-3 py-3"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="min-w-0 flex-1">
+          <label className="text-[12px] font-medium text-foreground" htmlFor="external-stash-link">
+            Add external Stash by link
+          </label>
+          <input
+            id="external-stash-link"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="https://.../stashes/product-plan"
+            className="mt-1 w-full rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={busy || !input.trim()}
+          className="rounded-md bg-[var(--color-brand-600)] px-3 py-2 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-45 sm:mt-6"
+        >
+          {busy ? "Adding…" : "Add Stash"}
+        </button>
+      </div>
+      {error ? <p className="mt-2 text-[12px] text-red-500">{error}</p> : null}
+      {message ? <p className="mt-2 text-[12px] text-muted">{message}</p> : null}
+    </form>
   );
 }
 

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -57,6 +57,10 @@ vi.mock("./CommandPalette", () => ({
   },
 }));
 
+vi.mock("./StashInviteCenter", () => ({
+  default: () => <button aria-label="Stash invites">Invites</button>,
+}));
+
 
 const user = {
   id: "user-1",

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import type { StashItemSpec } from "../lib/api";
 import { User, Workspace } from "../lib/types";
 import AppSidebar from "./AppSidebar";
 import CommandPalette from "./CommandPalette";
+import StashInviteCenter from "./StashInviteCenter";
 import { useShareModal } from "../lib/shareModalContext";
 import { type Crumb, useBreadcrumbsValue } from "./BreadcrumbContext";
 import { StashIcon } from "./StashIcons";
@@ -280,6 +281,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         />
 
         <div className="flex items-center justify-end gap-1">
+          <StashInviteCenter activeWorkspaceId={activeWorkspaceId} />
           {activeWorkspaceId && (
             <button
               className="mr-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"

--- a/frontend/src/components/StashIcons.tsx
+++ b/frontend/src/components/StashIcons.tsx
@@ -5,6 +5,7 @@ import ExploreOutlinedIcon from "@mui/icons-material/ExploreOutlined";
 import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
+import NotificationsNoneOutlinedIcon from "@mui/icons-material/NotificationsNoneOutlined";
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
@@ -73,6 +74,10 @@ export function HelpIcon(props: IconProps) {
 
 export function SettingsIcon(props: IconProps) {
   return <MaterialIcon icon={SettingsOutlinedIcon} {...props} />;
+}
+
+export function NotificationsIcon(props: IconProps) {
+  return <MaterialIcon icon={NotificationsNoneOutlinedIcon} {...props} />;
 }
 
 export function PersonIcon(props: IconProps) {

--- a/frontend/src/components/StashInviteCenter.test.tsx
+++ b/frontend/src/components/StashInviteCenter.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StashInviteCenter from "./StashInviteCenter";
+import {
+  acceptStashInvite,
+  dismissStashInvite,
+  listMyWorkspaces,
+  listStashInvites,
+} from "../lib/api";
+
+const nav = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: nav.push }),
+}));
+
+vi.mock("../lib/api", () => ({
+  acceptStashInvite: vi.fn(),
+  dismissStashInvite: vi.fn(),
+  listMyWorkspaces: vi.fn(),
+  listStashInvites: vi.fn(),
+}));
+
+const invite = {
+  id: "invite-1",
+  stash_id: "stash-1",
+  stash_slug: "partner-stash",
+  stash_title: "Partner Stash",
+  stash_description: "Shared launch context",
+  source_workspace_id: "source-workspace",
+  source_workspace_name: "Source Workspace",
+  invited_by_user_id: "user-1",
+  invited_by_name: "henry",
+  invited_by_display_name: "Henry",
+  permission: "read" as const,
+  created_at: "2026-05-17T12:00:00Z",
+};
+
+const targetWorkspace = {
+  id: "workspace-2",
+  name: "Recipient Workspace",
+  description: "",
+  creator_id: "user-2",
+  invite_code: "invite",
+  member_count: 1,
+  created_at: "2026-05-17T12:00:00Z",
+  updated_at: "2026-05-17T12:00:00Z",
+};
+
+describe("StashInviteCenter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listStashInvites).mockResolvedValue([invite]);
+    vi.mocked(listMyWorkspaces).mockResolvedValue({ workspaces: [targetWorkspace] });
+    vi.mocked(acceptStashInvite).mockResolvedValue({
+      id: "forked-stash",
+      workspace_id: "workspace-2",
+      slug: "partner-stash-fork",
+      title: "Partner Stash",
+      description: "",
+      owner_id: "user-2",
+      access: "workspace",
+      discoverable: false,
+      cover_image_url: null,
+      view_count: 0,
+      items: [],
+      is_external: true,
+      added_to_workspace_id: "workspace-2",
+      forked_from_stash_id: "stash-1",
+      created_at: "2026-05-17T12:00:00Z",
+      updated_at: "2026-05-17T12:00:00Z",
+    });
+    vi.mocked(dismissStashInvite).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("accepts a pending invite into the selected workspace", async () => {
+    render(<StashInviteCenter activeWorkspaceId="workspace-2" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Stash invites (1)" }));
+
+    await screen.findByText("Partner Stash");
+    fireEvent.click(screen.getByRole("button", { name: "Add Stash" }));
+
+    await waitFor(() =>
+      expect(acceptStashInvite).toHaveBeenCalledWith("invite-1", "workspace-2")
+    );
+    expect(nav.push).toHaveBeenCalledWith("/stashes/partner-stash-fork");
+  });
+});

--- a/frontend/src/components/StashInviteCenter.tsx
+++ b/frontend/src/components/StashInviteCenter.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  acceptStashInvite,
+  dismissStashInvite,
+  listMyWorkspaces,
+  listStashInvites,
+  type StashInvite,
+} from "../lib/api";
+import type { Workspace } from "../lib/types";
+import { NotificationsIcon } from "./StashIcons";
+
+export default function StashInviteCenter({
+  activeWorkspaceId,
+}: {
+  activeWorkspaceId: string | null;
+}) {
+  const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [invites, setInvites] = useState<StashInvite[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [selectedWorkspaces, setSelectedWorkspaces] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [busyInviteId, setBusyInviteId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const loadInvites = useCallback(async () => {
+    try {
+      setInvites(await listStashInvites());
+    } catch {
+      setInvites([]);
+    }
+  }, []);
+
+  const loadPanel = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [nextInvites, workspaceData] = await Promise.all([
+        listStashInvites(),
+        listMyWorkspaces(),
+      ]);
+      setInvites(nextInvites);
+      setWorkspaces(workspaceData.workspaces);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load Stash invites");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadInvites();
+  }, [loadInvites]);
+
+  useEffect(() => {
+    if (!open) return;
+    void loadPanel();
+  }, [loadPanel, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onMouseDown(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const workspaceIds = useMemo(() => new Set(workspaces.map((workspace) => workspace.id)), [workspaces]);
+
+  function selectedWorkspaceId(invite: StashInvite): string {
+    const selected = selectedWorkspaces[invite.id];
+    if (selected && workspaceIds.has(selected)) return selected;
+    if (activeWorkspaceId && workspaceIds.has(activeWorkspaceId)) return activeWorkspaceId;
+    return workspaces[0]?.id ?? "";
+  }
+
+  async function accept(invite: StashInvite) {
+    const workspaceId = selectedWorkspaceId(invite);
+    if (!workspaceId) {
+      setError("Create or join a workspace before adding this Stash.");
+      return;
+    }
+
+    setBusyInviteId(invite.id);
+    setError("");
+    try {
+      const stash = await acceptStashInvite(invite.id, workspaceId);
+      setInvites((current) => current.filter((item) => item.id !== invite.id));
+      setOpen(false);
+      router.push(`/stashes/${stash.slug}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add Stash");
+    } finally {
+      setBusyInviteId(null);
+    }
+  }
+
+  async function dismiss(invite: StashInvite) {
+    setBusyInviteId(invite.id);
+    setError("");
+    try {
+      await dismissStashInvite(invite.id);
+      setInvites((current) => current.filter((item) => item.id !== invite.id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to dismiss invite");
+    } finally {
+      setBusyInviteId(null);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="relative rounded p-1 text-muted hover:bg-raised hover:text-foreground"
+        aria-label={`Stash invites${invites.length ? ` (${invites.length})` : ""}`}
+        title="Stash invites"
+      >
+        <NotificationsIcon className="h-4 w-4" />
+        {invites.length > 0 ? (
+          <span className="absolute -right-0.5 -top-0.5 inline-flex min-w-4 items-center justify-center rounded-full bg-[var(--color-brand-600)] px-1 text-[10px] font-semibold leading-4 text-white">
+            {invites.length}
+          </span>
+        ) : null}
+      </button>
+
+      {open ? (
+        <div className="absolute right-0 top-8 z-50 w-[360px] rounded-lg border border-border bg-base shadow-xl">
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <div>
+              <h2 className="text-[14px] font-semibold text-foreground">Stash invites</h2>
+              <p className="mt-0.5 text-[11.5px] text-muted">
+                Add shared Stashes to one of your workspaces.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void loadPanel()}
+              className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-muted hover:text-foreground"
+            >
+              Refresh
+            </button>
+          </div>
+
+          <div className="max-h-[460px] overflow-y-auto p-3">
+            {error ? (
+              <div className="mb-2 rounded-md border border-red-300/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-500">
+                {error}
+              </div>
+            ) : null}
+
+            {loading ? (
+              <p className="px-2 py-8 text-center text-[12.5px] text-muted">Loading…</p>
+            ) : invites.length === 0 ? (
+              <p className="px-2 py-8 text-center text-[12.5px] text-muted">
+                No pending Stash invites.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {invites.map((invite) => {
+                  const workspaceId = selectedWorkspaceId(invite);
+                  const inviter = invite.invited_by_display_name || invite.invited_by_name;
+                  const busy = busyInviteId === invite.id;
+
+                  return (
+                    <div key={invite.id} className="rounded-lg border border-border-subtle bg-surface p-3">
+                      <div className="min-w-0">
+                        <h3 className="truncate text-[13px] font-semibold text-foreground">
+                          {invite.stash_title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-[12px] leading-relaxed text-muted">
+                          {invite.stash_description || "No description."}
+                        </p>
+                        <p className="mt-2 text-[11px] text-muted">
+                          {inviter} shared from {invite.source_workspace_name}
+                        </p>
+                      </div>
+
+                      <label className="mt-3 block">
+                        <span className="text-[10.5px] font-semibold uppercase tracking-wide text-muted">
+                          Add to workspace
+                        </span>
+                        <select
+                          value={workspaceId}
+                          onChange={(event) =>
+                            setSelectedWorkspaces((current) => ({
+                              ...current,
+                              [invite.id]: event.target.value,
+                            }))
+                          }
+                          className="mt-1 w-full rounded-md border border-border bg-base px-2 py-1.5 text-[12px] text-foreground"
+                        >
+                          {workspaces.length === 0 ? (
+                            <option value="">No workspaces available</option>
+                          ) : (
+                            workspaces.map((workspace) => (
+                              <option key={workspace.id} value={workspace.id}>
+                                {workspace.name}
+                              </option>
+                            ))
+                          )}
+                        </select>
+                      </label>
+
+                      <div className="mt-3 flex justify-end gap-1.5">
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void dismiss(invite)}
+                          className="rounded-md border border-border-subtle px-2.5 py-1.5 text-[12px] text-muted hover:text-foreground disabled:opacity-50"
+                        >
+                          Dismiss
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busy || !workspaceId}
+                          onClick={() => void accept(invite)}
+                          className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                        >
+                          {busy ? "Adding…" : "Add Stash"}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -955,6 +955,42 @@ export async function removeExternalStash(
   });
 }
 
+// --- Stash invites ---
+
+export interface StashInvite {
+  id: string;
+  stash_id: string;
+  stash_slug: string;
+  stash_title: string;
+  stash_description: string;
+  source_workspace_id: string;
+  source_workspace_name: string;
+  invited_by_user_id: string;
+  invited_by_name: string;
+  invited_by_display_name: string | null;
+  permission: StashMemberPermission;
+  created_at: string;
+}
+
+export async function listStashInvites(): Promise<StashInvite[]> {
+  const data = await apiFetch<{ invites: StashInvite[] }>("/api/v1/stash-invites");
+  return data.invites;
+}
+
+export async function acceptStashInvite(
+  inviteId: string,
+  workspaceId: string
+): Promise<WorkspaceStash> {
+  return apiFetch(`/api/v1/stash-invites/${inviteId}/accept`, {
+    method: "POST",
+    body: JSON.stringify({ workspace_id: workspaceId }),
+  });
+}
+
+export async function dismissStashInvite(inviteId: string): Promise<void> {
+  await apiFetch(`/api/v1/stash-invites/${inviteId}/dismiss`, { method: "POST" });
+}
+
 // --- Workspace-wide page index ---
 
 export interface WorkspacePageEntry {

--- a/frontend/src/lib/stashLinks.test.ts
+++ b/frontend/src/lib/stashLinks.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { stashSlugFromInput } from "./stashLinks";
+
+describe("stashSlugFromInput", () => {
+  it("extracts a Stash slug from a full URL", () => {
+    expect(stashSlugFromInput("https://joinstash.ai/stashes/partner-plan?x=1")).toBe(
+      "partner-plan"
+    );
+  });
+
+  it("extracts a Stash slug from a relative URL", () => {
+    expect(stashSlugFromInput("/stashes/private-brief#top")).toBe("private-brief");
+  });
+
+  it("accepts a pasted slug", () => {
+    expect(stashSlugFromInput("partner-plan")).toBe("partner-plan");
+  });
+
+  it("rejects unrelated URLs", () => {
+    expect(stashSlugFromInput("https://joinstash.ai/workspaces/ws-1")).toBe("");
+  });
+});

--- a/frontend/src/lib/stashLinks.ts
+++ b/frontend/src/lib/stashLinks.ts
@@ -1,0 +1,11 @@
+export function stashSlugFromInput(input: string): string {
+  const value = input.trim();
+  if (!value) return "";
+
+  const pathMatch = value.match(/(?:^|\/)stashes\/([^/?#]+)/i);
+  if (pathMatch?.[1]) return pathMatch[1];
+
+  if (/^[A-Za-z0-9][A-Za-z0-9-]*$/.test(value)) return value;
+
+  return "";
+}


### PR DESCRIPTION
## Summary
- Add a paste-a-link form on the workspace Stashes page so a user can add an external Stash from a full `/stashes/{slug}` URL or plain slug.
- Add in-product Stash access notifications when a Stash member is added. The notification now opens the shared Stash for review instead of adding it directly.
- Keep the normal Stash detail page as the place where the viewer chooses whether to add the Stash to one of their workspaces; adding it clears the pending access notification.

## Product notes
- This covers both requested entry points: collaborator link paste and notification-center access discovery.
- The notification copy now says the inviter has given the viewer access to their Stash, not that the viewer has been invited to add it.
- The accepted/pasted Stash uses the product’s current add-to-workspace behavior, which creates an external Stash fork in the target workspace.

## Screenshots
### Paste link entry
![paste-link-entry.png](https://github.com/user-attachments/assets/93dd3753-9020-4ffe-925c-2c57289a3530)

### Paste link added
![paste-link-added.png](https://github.com/user-attachments/assets/69cf78c1-9eb3-4499-b032-6fdfda073caa)

### Access notification
![access-notification.png](https://github.com/user-attachments/assets/85b84282-2448-4a60-a4c7-027868bcdbac)

### View before adding
![stash-view-before-add.png](https://github.com/user-attachments/assets/d2d12162-301c-4834-b02f-6357248dabbe)

### Add from Stash view
![add-from-stash-view.png](https://github.com/user-attachments/assets/05d5c569-550e-44d6-8b40-68c8d7d30c3b)

## Tests
- `ruff check .`
- `black --check backend/ cli/`
- `pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm test`
- `cd frontend && npm run build`