### PR TITLE
[codex] Remove search bar shadow

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -172,7 +172,7 @@ function TopSearchButton({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-7 w-full items-center gap-2 rounded-md border border-border bg-surface px-2.5 text-left text-[12.5px] text-muted shadow-sm hover:border-[var(--color-brand-300)] hover:bg-raised hover:text-foreground"
+      className="flex h-7 w-full items-center gap-2 rounded-md border border-border bg-surface px-2.5 text-left text-[12.5px] text-muted hover:border-[var(--color-brand-300)] hover:bg-raised hover:text-foreground"
       aria-label="Search"
     >
       <svg


### PR DESCRIPTION
## Summary
- Removed the lone `shadow-sm` treatment from the top-bar search button so it matches the product chrome.
- Kept the existing border, hover, sizing, and command shortcut treatment unchanged.

## Validation
- `npm run lint -- src/components/AppShell.tsx`
- `npm test -- src/components/AppShell.test.tsx`
- Playwright browser check confirmed the search button computed `box-shadow` is `none`.

## Screenshot
![stash-searchbar-shadowless.png](https://github.com/user-attachments/assets/4b8a3b8c-a949-4414-a088-2834b5d1a379)