### PR TITLE
[codex] Make Share copy current view Stash links

### DIFF
--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StashPageClient from "./StashPageClient";
+import { getPublicStash } from "../../../lib/api";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../../../lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  createSharedStashPage: vi.fn(),
+  getPublicStash: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useAuth", () => ({
+  useAuth: () => ({ user: null, loading: false, logout: vi.fn() }),
+}));
+
+vi.mock("./AddToWorkspaceButton", () => ({
+  default: () => <button type="button">Add to workspace</button>,
+}));
+
+describe("StashPageClient sharing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.pushState({}, "", "/stashes/shared-stash");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.mocked(getPublicStash).mockResolvedValue({
+      stash: {
+        id: "stash-1",
+        workspace_id: "workspace-1",
+        slug: "shared-stash",
+        title: "Shared Stash",
+        description: "",
+        owner_id: "user-1",
+        access: "public",
+        discoverable: false,
+        cover_image_url: null,
+        view_count: 0,
+        items: [],
+        is_external: false,
+        added_to_workspace_id: null,
+        forked_from_stash_id: null,
+        created_at: "2026-05-11T00:00:00Z",
+        updated_at: "2026-05-11T00:00:00Z",
+      },
+      workspace_name: "Demo Workspace",
+      items: [],
+      can_write: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("copies the current Stash link instead of creating another Stash", async () => {
+    render(<StashPageClient slug="shared-stash" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/stashes/shared-stash`
+      )
+    );
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -150,6 +150,7 @@ function StashPageBody({
               </svg>
               <span className="min-w-0 flex-1 truncate">Search this Stash</span>
             </Link>
+            <CopyStashLinkButton slug={stash.slug} />
             <AddToWorkspaceButton slug={stash.slug} sourceWorkspaceId={stash.workspace_id} />
           </div>
         </div>
@@ -227,6 +228,36 @@ function StashPageBody({
       </div>
     </div>
   );
+}
+
+function CopyStashLinkButton({ slug }: { slug: string }) {
+  const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(absoluteUrl(`/stashes/${slug}`));
+      setStatus("copied");
+      window.setTimeout(() => setStatus("idle"), 1600);
+    } catch {
+      setStatus("error");
+      window.setTimeout(() => setStatus("idle"), 3000);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void copyLink()}
+      className="rounded-lg border border-border-subtle bg-base px-4 py-2 text-[14px] font-medium text-foreground transition hover:border-brand hover:text-brand"
+    >
+      {status === "copied" ? "Copied" : status === "error" ? "Copy failed" : "Share"}
+    </button>
+  );
+}
+
+function absoluteUrl(path: string): string {
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
 }
 
 function SharedPageComposer({

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppShell from "./AppShell";
 import { BreadcrumbProvider, useBreadcrumbs } from "./BreadcrumbContext";
 import { ShareModalProvider } from "../lib/shareModalContext";
+import { getSessionDetail, publishStash } from "../lib/api";
 import {
   getCachedWorkspaces,
   readCachedWorkspaces,
@@ -39,6 +40,11 @@ vi.mock("next/link", () => ({
 vi.mock("../lib/stashNavigationCache", () => ({
   getCachedWorkspaces: vi.fn(),
   readCachedWorkspaces: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  getSessionDetail: vi.fn(),
+  publishStash: vi.fn(),
 }));
 
 vi.mock("./AppSidebar", () => ({
@@ -110,6 +116,11 @@ describe("AppShell sidebar collapse", () => {
     nav.pathname = "/";
     commandPaletteState.props = null;
     vi.clearAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.mocked(publishStash).mockResolvedValue(publishedStashResult("shared-link"));
     vi.mocked(readCachedWorkspaces).mockReturnValue({
       userId: user.id,
       all: [],
@@ -164,6 +175,89 @@ describe("AppShell sidebar collapse", () => {
     expect(commandPaletteState.props?.searchScope?.kind).toBe("session");
   });
 
+  it("creates and copies a one-page Stash link from a page route", async () => {
+    nav.pathname = "/workspaces/ws-1/p/page-1";
+    mockWorkspaceCache();
+
+    render(
+      <ShareModalProvider>
+        <AppShell user={user} onLogout={vi.fn()}>
+          <div>Page content</div>
+        </AppShell>
+      </ShareModalProvider>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(publishStash).toHaveBeenCalledWith(
+        "ws-1",
+        "Shared page",
+        [
+          {
+            object_type: "page",
+            object_id: "page-1",
+            position: 0,
+            label_override: "Shared page",
+          },
+        ],
+        { discoverable: false }
+      )
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://app.joinstash.ai/stashes/shared-link"
+    );
+  });
+
+  it("creates and copies a one-session Stash link from a session route", async () => {
+    nav.pathname = "/workspaces/ws-1/sessions/session-route-id";
+    mockWorkspaceCache();
+    vi.mocked(getSessionDetail).mockResolvedValue({
+      id: "session-row-uuid",
+      workspace_id: "ws-1",
+      session_id: "session-route-id",
+      agent_name: "codex",
+      cwd: null,
+      summary: "Debug auth flow. Confirm token expiry.",
+      summary_status: "done",
+      files_touched: [],
+      started_at: null,
+      finished_at: null,
+      created_by: "user-1",
+      artifacts: [],
+    });
+
+    render(
+      <ShareModalProvider>
+        <AppShell user={user} onLogout={vi.fn()}>
+          <div>Session content</div>
+        </AppShell>
+      </ShareModalProvider>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(publishStash).toHaveBeenCalledWith(
+        "ws-1",
+        "Debug auth flow",
+        [
+          {
+            object_type: "session",
+            object_id: "session-row-uuid",
+            position: 0,
+            label_override: "Debug auth flow",
+          },
+        ],
+        { discoverable: false }
+      )
+    );
+    expect(getSessionDetail).toHaveBeenCalledWith("ws-1", "session-route-id");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://app.joinstash.ai/stashes/shared-link"
+    );
+  });
+
   it("keeps Home clickable on the workspace home route", async () => {
     nav.pathname = "/workspaces/ws-1";
     mockWorkspaceCache();
@@ -210,3 +304,28 @@ describe("AppShell sidebar collapse", () => {
     expect(within(header!).queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
   });
 });
+
+function publishedStashResult(slug: string) {
+  return {
+    stash: {
+      id: "stash-1",
+      workspace_id: "ws-1",
+      slug,
+      title: "Shared link",
+      description: "",
+      owner_id: "user-1",
+      access: "public",
+      discoverable: false,
+      view_count: 0,
+      items: [],
+      is_external: false,
+      added_to_workspace_id: null,
+      forked_from_stash_id: null,
+      created_at: "2026-05-11T00:00:00Z",
+      updated_at: "2026-05-11T00:00:00Z",
+    },
+    url: `https://app.joinstash.ai/stashes/${slug}`,
+    stash_id: "stash-1",
+    stash_slug: slug,
+  };
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { StashItemSpec } from "../lib/api";
+import { getSessionDetail, publishStash, type SessionDetail, type StashItemSpec } from "../lib/api";
 import { User, Workspace } from "../lib/types";
 import AppSidebar from "./AppSidebar";
 import CommandPalette from "./CommandPalette";
@@ -27,6 +27,12 @@ export interface SearchScope {
   detail: string;
   params: Record<string, string>;
 }
+
+type DirectShareTarget =
+  | { kind: "page"; workspaceId: string; pageId: string; title: string }
+  | { kind: "session"; workspaceId: string; sessionId: string };
+
+type ShareStatus = "idle" | "creating" | "copied" | "error";
 
 function readBool(key: string): boolean {
   if (typeof window === "undefined") return false;
@@ -71,6 +77,32 @@ function SidebarToggleIcon({ collapsed }: { collapsed: boolean }) {
 function lastCrumbLabel(crumbs: Crumb[] | null): string | null {
   const label = crumbs?.[crumbs.length - 1]?.label.trim();
   return label || null;
+}
+
+function inferDirectShareTarget(
+  pathname: string,
+  breadcrumbs: Crumb[] | null
+): DirectShareTarget | null {
+  const pageMatch = pathname.match(/^\/workspaces\/([^/]+)\/p\/([^/?#]+)/);
+  if (pageMatch) {
+    return {
+      kind: "page",
+      workspaceId: pageMatch[1],
+      pageId: pageMatch[2],
+      title: lastCrumbLabel(breadcrumbs) ?? "Shared page",
+    };
+  }
+
+  const sessionMatch = pathname.match(/^\/workspaces\/([^/]+)\/sessions\/([^/?#]+)/);
+  if (sessionMatch) {
+    return {
+      kind: "session",
+      workspaceId: sessionMatch[1],
+      sessionId: decodeURIComponent(sessionMatch[2]),
+    };
+  }
+
+  return null;
 }
 
 function inferSearchScope(
@@ -203,6 +235,8 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
     () => readCachedWorkspaces(user.id)?.all ?? []
   );
   const [cmdkOpen, setCmdkOpen] = useState(false);
+  const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
+  const [shareMessage, setShareMessage] = useState("");
 
   useEffect(() => {
     setSidebarCollapsed(readBool(SIDEBAR_KEY));
@@ -238,6 +272,56 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
   const activeWorkspace = workspaces.find((s) => s.id === activeWorkspaceId);
   const searchScope = inferSearchScope(pathname, activeWorkspace, breadcrumbs);
   const initial = (user.display_name || user.name || "?")[0].toUpperCase();
+  const directShareTarget = inferDirectShareTarget(pathname, breadcrumbs);
+
+  async function copyCurrentViewLink() {
+    if (!activeWorkspaceId) return;
+
+    const target = directShareTarget;
+    if (!target) {
+      shareModal.open({
+        workspaceId: activeWorkspaceId,
+        workspaceName: activeWorkspace?.name,
+        initial: inferShareInitial(pathname),
+      });
+      return;
+    }
+
+    setShareStatus("creating");
+    setShareMessage("");
+    try {
+      const result =
+        target.kind === "page"
+          ? await publishStash(
+              target.workspaceId,
+              target.title,
+              [
+                {
+                  object_type: "page",
+                  object_id: target.pageId,
+                  position: 0,
+                  label_override: target.title,
+                },
+              ],
+              { discoverable: false }
+            )
+          : await publishSessionStash(target);
+      await navigator.clipboard.writeText(result.url);
+      setShareStatus("copied");
+      setShareMessage("Link copied");
+      window.setTimeout(() => {
+        setShareStatus("idle");
+        setShareMessage("");
+      }, 1600);
+    } catch (e) {
+      setShareStatus("error");
+      setShareMessage(e instanceof Error ? e.message : "Share failed");
+      window.setTimeout(() => {
+        setShareStatus("idle");
+        setShareMessage("");
+      }, 3000);
+    }
+  }
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-base">
@@ -270,18 +354,25 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         <div className="flex items-center justify-end gap-1">
           <StashInviteCenter activeWorkspaceId={activeWorkspaceId} />
           {activeWorkspaceId && (
-            <button
-              className="mr-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-              onClick={() =>
-                shareModal.open({
-                  workspaceId: activeWorkspaceId,
-                  workspaceName: activeWorkspace?.name,
-                  initial: inferShareInitial(pathname),
-                })
-              }
-            >
-              Share
-            </button>
+            <div className="mr-1 flex items-center gap-2">
+              {shareMessage && (
+                <span
+                  className={
+                    "max-w-[180px] truncate text-[11.5px] " +
+                    (shareStatus === "error" ? "text-red-500" : "text-muted")
+                  }
+                >
+                  {shareMessage}
+                </span>
+              )}
+              <button
+                className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                onClick={() => void copyCurrentViewLink()}
+                disabled={shareStatus === "creating"}
+              >
+                {shareStatus === "creating" ? "Creating..." : shareStatus === "copied" ? "Copied" : "Share"}
+              </button>
+            </div>
           )}
           <UserMenu
             initial={initial}
@@ -318,6 +409,33 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
       />
     </div>
   );
+}
+
+async function publishSessionStash(target: Extract<DirectShareTarget, { kind: "session" }>) {
+  const session = await getSessionDetail(target.workspaceId, target.sessionId);
+  const title = sessionShareTitle(session);
+  return publishStash(
+    target.workspaceId,
+    title,
+    [
+      {
+        object_type: "session",
+        object_id: session.id,
+        position: 0,
+        label_override: title,
+      },
+    ],
+    { discoverable: false }
+  );
+}
+
+function sessionShareTitle(session: SessionDetail): string {
+  const summary = session.summary?.trim();
+  if (summary) {
+    const firstSentence = summary.split(".")[0]?.trim();
+    if (firstSentence) return firstSentence;
+  }
+  return `#${session.session_id}`;
 }
 
 function UserMenu({


### PR DESCRIPTION
## Summary

- Makes the workspace header `Share` action create and copy a public one-item Stash link when viewing a page or session.
- Resolves session route IDs to the backing session row before publishing the one-session Stash.
- Adds a public Stash page `Share` button that copies the current Stash URL instead of creating another Stash.
- Keeps the existing create/manage Share modal for workspace contexts that are not a single page or session.

## Validation

- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Playwright browser QA against local stack at `http://localhost:49957`: page Share copied a `/stashes/...` URL, session Share copied a `/stashes/...` URL, and public Stash Share copied the current Stash URL.

## Screenshots

### Page Share

![Page Share](https://gist.githubusercontent.com/henry-dowling/dc12c8bcde737bc4021923bf7eed3814/raw/b30c0af87ab2988b0b20c2f3165e8534ac144edc/stash-share-page.svg)

### Session Share

![Session Share](https://gist.githubusercontent.com/henry-dowling/dc12c8bcde737bc4021923bf7eed3814/raw/cb749b36bcfb9dee42bee7318a9b8b9cae3d08e3/stash-share-session.svg)

### Stash Share

![Stash Share](https://gist.githubusercontent.com/henry-dowling/dc12c8bcde737bc4021923bf7eed3814/raw/a23fdbd6c01159ff002d669809f462442b06d3c4/stash-share-public-stash.svg)
