### PR TITLE
[codex] Use header breadcrumbs on workspace pages

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/page.tsx
@@ -96,33 +96,7 @@ export default function FolderDetailPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-[980px] px-12 pb-20 pt-8">
-        {/* Breadcrumb path */}
-        <div className="flex items-center gap-1.5 text-[12.5px] text-muted">
-          <Link href={`/workspaces/${workspaceId}`} className="text-dim hover:text-foreground">
-            Home
-          </Link>
-          {contents?.breadcrumbs.map((crumb, i) => {
-            const isLast = i === contents.breadcrumbs.length - 1;
-            return (
-              <span key={crumb.id} className="flex items-center gap-1.5">
-                <span className="text-muted/60">/</span>
-                {isLast ? (
-                  <span className="font-medium text-foreground">{crumb.name}</span>
-                ) : (
-                  <Link
-                    href={`/workspaces/${workspaceId}/folders/${crumb.id}`}
-                    className="hover:text-foreground"
-                  >
-                    {crumb.name}
-                  </Link>
-                )}
-              </span>
-            );
-          })}
-        </div>
-
-        {/* Header */}
-        <div className="mt-3.5 flex items-end justify-between gap-4">
+        <div className="flex items-end justify-between gap-4">
           <div className="min-w-0">
             <span className="inline-flex h-11 w-11 items-center justify-center rounded-[10px] border border-border bg-surface text-dim">
               <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="1.6">

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import SessionUpload from "../../../../components/SessionUpload";
 import { SessionsIcon, SettingsIcon } from "../../../../components/StashIcons";
 import { useAuth } from "../../../../hooks/useAuth";
@@ -23,6 +24,8 @@ export default function StashSessionsPage() {
   const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState("");
+
+  useBreadcrumbs([{ label: "Sessions" }], `${workspaceId}/sessions`);
 
   const load = useCallback(async () => {
     try {
@@ -66,51 +69,43 @@ export default function StashSessionsPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-12 py-8">
-          <nav className="mb-4 flex flex-wrap items-center gap-1.5 text-[12.5px] text-muted">
-            <Link href={`/workspaces/${workspaceId}`} className="hover:text-foreground">
-              Home
-            </Link>
-            <span className="text-muted/60">/</span>
-            <span className="font-medium text-foreground">Sessions</span>
-          </nav>
-
-          <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
-            <SessionsIcon />
-          </div>
-          <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
-            Sessions
-          </h1>
-
-          {error && (
-            <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
-              {error}
-            </div>
-          )}
-
-          <div className="mt-5 mb-4 space-y-3">
-            <SessionUpload workspaceId={workspaceId} onUploaded={load} />
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by agent, prompt, or session id…"
-              className="w-full rounded-md border border-border bg-base px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-300)] focus:outline-none"
-            />
-          </div>
-
-          {rows && (
-            <SessionsTable
-              workspaceId={workspaceId}
-              sessions={rows}
-              emptyText={
-                sessions && sessions.length === 0
-                  ? "No sessions yet."
-                  : "No sessions match your search."
-              }
-            />
-          )}
+        <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
+          <SessionsIcon />
         </div>
+        <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
+          Sessions
+        </h1>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-5 mb-4 space-y-3">
+          <SessionUpload workspaceId={workspaceId} onUploaded={load} />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by agent, prompt, or session id…"
+            className="w-full rounded-md border border-border bg-base px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-300)] focus:outline-none"
+          />
+        </div>
+
+        {rows && (
+          <SessionsTable
+            workspaceId={workspaceId}
+            sessions={rows}
+            emptyText={
+              sessions && sessions.length === 0
+                ? "No sessions yet."
+                : "No sessions match your search."
+            }
+          />
+        )}
       </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Removed the page-local breadcrumb row from the workspace Sessions page.
- Added the Sessions crumb to the shared header breadcrumb state so the top bar shows `Home / Sessions`.
- Removed the duplicate page-local breadcrumb row from folder detail pages, which already publish folder crumbs to the header.

## Screenshots
Captured during local QA; screenshots will be attached in a PR comment.

## Validation
- `npm run lint`
- `npm test -- AppShell.test.tsx`
- `npm run build`
- `npm test`
- Playwright smoke check against `http://localhost:3457/workspaces/<workspaceId>/sessions` and `/folders/<folderId>` verified `main nav` count is `0` and the header breadcrumb contains the active page.