### PR TITLE
Sidebar: unified collapse rules + last-workspace root fallback

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -113,9 +113,23 @@ function LoggedInHome({
         const result = await listMyWorkspaces();
         if (cancelled) return;
         setWorkspaces(result.workspaces);
-        if (result.workspaces.length > 0) {
-          router.replace(`/workspaces/${result.workspaces[0].id}`);
+        if (result.workspaces.length === 0) return;
+
+        // Prefer the workspace the user was in last time they had the app
+        // open. AppSidebar writes this to localStorage every time you visit a
+        // /workspaces/[id] route. If the cached id is no longer a workspace
+        // the user belongs to (left, deleted, etc.), fall back to mine[0]
+        // which the backend returns ordered by created_at DESC (newest first).
+        let target = result.workspaces[0].id;
+        try {
+          const last = localStorage.getItem("stash_sidebar_last_workspace");
+          if (last && result.workspaces.some((w) => w.id === last)) {
+            target = last;
+          }
+        } catch {
+          /* localStorage unavailable — fall back silently */
         }
+        router.replace(`/workspaces/${target}`);
       } catch {
         if (!cancelled) setError("Failed to load workspaces");
       } finally {

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -462,32 +462,29 @@ describe("AppSidebar tree expansion", () => {
     expect(detailsFor("Sessions")).toHaveAttribute("open");
   });
 
-  it("collapses individual stashes and restores that browser state", async () => {
+  it("starts each stash collapsed and does not persist its open state", async () => {
     vi.mocked(getWorkspaceSidebar).mockResolvedValue(sidebarWithStash);
 
     const first = renderSidebar();
 
     await screen.findByText("Project Alpha");
-    expect(screen.getByText("Launch session")).toBeTruthy();
-
-    fireEvent.click(screen.getByLabelText("Collapse Project Alpha"));
-
+    // Stashes default to closed — opening the Stashes section shouldn't
+    // explode every stash's items at once.
     expect(screen.queryByText("Launch session")).toBeNull();
-    expect(localStorage.getItem("stash_sidebar_collapsed_stashes")).toBe(
-      JSON.stringify({ "ws-1:stash-1": true })
-    );
+
+    fireEvent.click(screen.getByLabelText("Expand Project Alpha"));
+    expect(await screen.findByText("Launch session")).toBeTruthy();
+
+    // State is intentionally local to the row — nothing should land in
+    // localStorage under the legacy persisted-collapse key.
+    expect(localStorage.getItem("stash_sidebar_collapsed_stashes")).toBeNull();
 
     first.unmount();
 
     renderSidebar();
-
     await screen.findByText("Project Alpha");
+    // Re-mount: back to collapsed, exactly as a fresh page load would be.
     expect(screen.queryByText("Launch session")).toBeNull();
-
-    fireEvent.click(screen.getByLabelText("Expand Project Alpha"));
-
-    expect(await screen.findByText("Launch session")).toBeTruthy();
-    expect(localStorage.getItem("stash_sidebar_collapsed_stashes")).toBe("{}");
   });
 
   it("rejects non-jsonl files dropped on the Sessions section", async () => {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   type WorkspacePage,
   type WorkspaceSidebar,
   type WorkspaceSidebarSession,
+  type WorkspaceSidebarStash,
   uploadFile,
   uploadTranscript,
 } from "../lib/api";
@@ -74,7 +75,6 @@ interface SidebarDropState {
 
 const OPEN_WORKSPACES_KEY = "stash_sidebar_open_workspaces";
 const OPEN_SECTIONS_KEY = "stash_sidebar_open_sections";
-const COLLAPSED_STASHES_KEY = "stash_sidebar_collapsed_stashes";
 const PINNED_FS_KEY = "stash_sidebar_pinned_files_folders";
 const PINNED_FS_LABELS_KEY = "stash_sidebar_pinned_files_folders_labels";
 const LAST_WORKSPACE_KEY = "stash_sidebar_last_workspace";
@@ -150,10 +150,6 @@ function writePinnedLabelMap(value: Record<string, PinnedLabels>) {
 
 function sectionKey(workspaceId: string, section: SidebarSection): string {
   return `${workspaceId}:${section}`;
-}
-
-function stashCollapseKey(workspaceId: string, stashId: string): string {
-  return `${workspaceId}:${stashId}`;
 }
 
 function dropKey(workspaceId: string, section: DropSection): string {
@@ -428,10 +424,8 @@ function WorkspaceTree({
   pinnedFolders,
   pinnedFiles,
   pinnedLabels,
-  collapsedStashes,
   onPinToggle,
   onUnpinAll,
-  onStashCollapsedChange,
   onAddSession,
   onAddPage,
   onAddStash,
@@ -447,10 +441,8 @@ function WorkspaceTree({
   pinnedFolders: string[];
   pinnedFiles: string[];
   pinnedLabels: PinnedLabels;
-  collapsedStashes: Record<string, boolean>;
   onPinToggle: (kind: PinKind, workspaceId: string, id: string, label?: string) => void;
   onUnpinAll: (workspaceId: string) => void;
-  onStashCollapsedChange: (workspaceId: string, stashId: string, collapsed: boolean) => void;
   onAddSession: (workspaceId: string) => void;
   onAddPage: (workspaceId: string) => void;
   onAddStash: (workspaceId: string) => void;
@@ -488,10 +480,6 @@ function WorkspaceTree({
         spine={spine}
         open={openSections.stashes}
         onOpenChange={(nextOpen) => onSectionOpenChange("stashes", nextOpen)}
-        collapsedStashes={collapsedStashes}
-        onStashCollapsedChange={(stashId, collapsed) =>
-          onStashCollapsedChange(workspace.id, stashId, collapsed)
-        }
         onAddStash={() => onAddStash(workspace.id)}
       />
 
@@ -907,6 +895,73 @@ function buildStashTreeItems(
         label: item.label_override ?? `${item.object_type} ${item.object_id}`,
       };
     });
+}
+
+// Each stash row in the sidebar manages its own open/closed state. State is
+// intentionally local (and not persisted) so that the Stashes section follows
+// the same default-collapsed pattern as Files folders and Sessions user
+// folders — opening the Stashes section doesn't explode every stash's
+// contents on the user.
+function StashSidebarRow({
+  workspaceId,
+  stash,
+  foldersById,
+  pagesById,
+  filesById,
+  sessionById,
+  sessionBySessionId,
+}: {
+  workspaceId: string;
+  stash: WorkspaceSidebarStash;
+  foldersById: Map<string, WorkspaceFolder>;
+  pagesById: Map<string, WorkspacePage>;
+  filesById: Map<string, WorkspaceFile>;
+  sessionById: Map<string, WorkspaceSidebarSession>;
+  sessionBySessionId: Map<string, WorkspaceSidebarSession>;
+}) {
+  const [open, setOpen] = useState(false);
+  const children = buildStashTreeItems(
+    workspaceId,
+    stash.items ?? [],
+    foldersById,
+    pagesById,
+    filesById,
+    sessionById,
+    sessionBySessionId
+  );
+  return (
+    <div className="space-y-0.5">
+      <div className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised">
+        <ChevronToggle
+          open={open}
+          ariaLabel={`${open ? "Collapse" : "Expand"} ${stash.title}`}
+          onToggle={() => setOpen((current) => !current)}
+        />
+        <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
+          <StashIcon />
+        </span>
+        <Link
+          href={`/stashes/${stash.slug}`}
+          className="flex-1 truncate text-foreground hover:text-[var(--color-brand-700)]"
+        >
+          {stash.title}
+        </Link>
+      </div>
+      {open ? (
+        <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
+          {children.length === 0 ? (
+            <div className="px-2 py-1 text-[11px] italic text-muted">
+              no visible items
+            </div>
+          ) : (
+            children.map((item) => (
+              <StashTreeRow key={item.key} row={item} />
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function StashTreeRow({ row }: { row: StashTreeItem }) {
@@ -1351,16 +1406,12 @@ function StashesBlock({
   spine,
   open,
   onOpenChange,
-  collapsedStashes,
-  onStashCollapsedChange,
   onAddStash,
 }: {
   workspace: WorkspaceNode;
   spine: WorkspaceSidebar | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  collapsedStashes: Record<string, boolean>;
-  onStashCollapsedChange: (stashId: string, collapsed: boolean) => void;
   onAddStash: () => void;
 }) {
   const stashes = spine?.stashes ?? [];
@@ -1393,7 +1444,7 @@ function StashesBlock({
     if (items.length === 0 && !includeEmpty) return null;
 
     return (
-      <div className="space-y-0.5 border-l border-border pl-2">
+      <div className="space-y-0.5">
         {title ? (
           <div className="px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted">
             {title}
@@ -1402,53 +1453,18 @@ function StashesBlock({
         {items.length === 0 ? (
           <div className="px-2 py-1 text-[11px] italic text-muted">empty</div>
         ) : (
-          items.map((stash) => {
-            const collapsed =
-              collapsedStashes[stashCollapseKey(workspace.id, stash.id)] === true;
-            const children = buildStashTreeItems(
-              workspace.id,
-              stash.items ?? [],
-              foldersById,
-              pagesById,
-              filesById,
-              sessionById,
-              sessionBySessionId
-            );
-
-            return (
-              <div key={`${title}-${stash.id}`} className="space-y-0.5">
-                <div className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised">
-                  <ChevronToggle
-                    open={!collapsed}
-                    ariaLabel={`${collapsed ? "Expand" : "Collapse"} ${stash.title}`}
-                    onToggle={() => onStashCollapsedChange(stash.id, !collapsed)}
-                  />
-                  <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
-                    <StashIcon />
-                  </span>
-                  <Link
-                    href={`/stashes/${stash.slug}`}
-                    className="flex-1 truncate text-foreground hover:text-[var(--color-brand-700)]"
-                  >
-                    {stash.title}
-                  </Link>
-                </div>
-                {!collapsed ? (
-                  <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
-                    {children.length === 0 ? (
-                      <div className="px-2 py-1 text-[11px] italic text-muted">
-                        no visible items
-                      </div>
-                    ) : (
-                      children.map((item) => (
-                        <StashTreeRow key={item.key} row={item} />
-                      ))
-                    )}
-                  </div>
-                ) : null}
-              </div>
-            );
-          })
+          items.map((stash) => (
+            <StashSidebarRow
+              key={`${title}-${stash.id}`}
+              workspaceId={workspace.id}
+              stash={stash}
+              foldersById={foldersById}
+              pagesById={pagesById}
+              filesById={filesById}
+              sessionById={sessionById}
+              sessionBySessionId={sessionBySessionId}
+            />
+          ))
         )}
       </div>
     );
@@ -1724,9 +1740,6 @@ export default function AppSidebar({
   const [pinnedLabelsState, setPinnedLabelsState] = useState<Record<string, PinnedLabels>>(
     () => readPinnedLabelMap()
   );
-  const [collapsedStashes, setCollapsedStashes] = useState<Record<string, boolean>>(
-    () => readBooleanMap(COLLAPSED_STASHES_KEY)
-  );
   const [pageCreateWorkspaceId, setPageCreateWorkspaceId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -1795,24 +1808,6 @@ export default function AppSidebar({
       activeTreeWorkspaceId === workspaceId && activeTreeSection === section;
     if (open && routeOpen && explicit === undefined) return;
     setOpenSection(workspaceId, section, open);
-  }
-
-  function handleStashCollapsedChange(
-    workspaceId: string,
-    stashId: string,
-    collapsed: boolean
-  ) {
-    setCollapsedStashes((current) => {
-      const key = stashCollapseKey(workspaceId, stashId);
-      const next = { ...current };
-      if (collapsed) {
-        next[key] = true;
-      } else {
-        delete next[key];
-      }
-      writeBooleanMap(COLLAPSED_STASHES_KEY, next);
-      return next;
-    });
   }
 
   function clearDropLater(workspaceId: string, section: DropSection) {
@@ -2202,10 +2197,8 @@ export default function AppSidebar({
             pinnedFolders={pinnedState[activeWorkspace.id]?.folders ?? EMPTY_PIN_STATE.folders}
             pinnedFiles={pinnedState[activeWorkspace.id]?.files ?? EMPTY_PIN_STATE.files}
             pinnedLabels={pinnedLabelsState[activeWorkspace.id] ?? { folders: {}, files: {} }}
-            collapsedStashes={collapsedStashes}
             onPinToggle={(kind, id, label) => handlePinToggle(kind, activeWorkspace.id, id, label)}
             onUnpinAll={handleUnpinAll}
-            onStashCollapsedChange={handleStashCollapsedChange}
             onAddSession={handleAddSession}
             onAddPage={handleAddPage}
             onAddStash={handleAddStash}


### PR DESCRIPTION
## Unified collapse rules

Same contract across all three sidebar sections:

| Level | Default | Persisted |
|---|---|---|
| Section header (Stashes / Sessions / Files) | open | yes |
| Children (each stash / session bucket / folder) | **closed** | **no** |

Single exception: the most-recent session bucket auto-opens, since you almost always want to see today's runs.

Previously the Stashes section was the outlier — each stash defaulted to open and the collapse state was persisted in localStorage, so opening the Stashes section exploded every stash's items at once. Removed the `COLLAPSED_STASHES_KEY` plumbing and replaced the inline `renderStashGroup` map with a `StashSidebarRow` component that owns its own local `useState(false)`.

Also dropped the duplicate `border-l pl-2` on the renderStashGroup wrapper so stashes sit at one indent (matching Sessions/Files) instead of two.

## Default workspace

`/` now prefers the user's last-visited workspace (read from the `stash_sidebar_last_workspace` localStorage key the sidebar already maintains) when redirecting. Falls back to `mine[0]` if the cached id is no longer a workspace the user belongs to.

The sidebar's own fallback chain remains: URL → `lastWorkspaceId` → `mine[0]` → `shared[0]`.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 37/37 pass (one test rewritten to assert the new contract: stashes start collapsed, no localStorage writes)
- [ ] Walkthrough on Vercel preview: open Stashes → each stash closed; click one → expands inline. Open Sessions → only first bucket open; expand a user folder → see sessions. Visit a workspace → close tab → reopen at `/` → lands you back in that workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)