### PR TITLE
Make Stash access invites view-first

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -216,10 +216,6 @@ class StashInviteListResponse(BaseModel):
     invites: list[StashInviteResponse]
 
 
-class AcceptStashInviteRequest(BaseModel):
-    workspace_id: UUID
-
-
 class WorkspaceMember(BaseModel):
     user_id: UUID
     name: str

--- a/backend/routers/stash_invites.py
+++ b/backend/routers/stash_invites.py
@@ -6,10 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ..auth import get_current_user
 from ..models import (
-    AcceptStashInviteRequest,
     StashInviteListResponse,
     StashInviteResponse,
-    StashResponse,
 )
 from ..services import stash_invite_service
 
@@ -20,25 +18,6 @@ router = APIRouter(prefix="/api/v1/stash-invites", tags=["stash-invites"])
 async def list_stash_invites(current_user: dict = Depends(get_current_user)):
     invites = await stash_invite_service.list_pending_invites(current_user["id"])
     return StashInviteListResponse(invites=[StashInviteResponse(**invite) for invite in invites])
-
-
-@router.post("/{invite_id}/accept", response_model=StashResponse)
-async def accept_stash_invite(
-    invite_id: UUID,
-    req: AcceptStashInviteRequest,
-    current_user: dict = Depends(get_current_user),
-):
-    try:
-        stash = await stash_invite_service.accept_invite(
-            invite_id,
-            current_user["id"],
-            req.workspace_id,
-        )
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
-    if not stash:
-        raise HTTPException(status_code=404, detail="Stash invite not found")
-    return StashResponse(**stash)
 
 
 @router.post("/{invite_id}/dismiss", status_code=204)

--- a/backend/services/stash_invite_service.py
+++ b/backend/services/stash_invite_service.py
@@ -3,7 +3,6 @@
 from uuid import UUID
 
 from ..database import get_pool
-from . import stash_service, workspace_service
 
 
 async def create_or_update_invite(
@@ -80,30 +79,13 @@ async def list_pending_invites(user_id: UUID) -> list[dict]:
     return [dict(row) for row in rows]
 
 
-async def accept_invite(invite_id: UUID, user_id: UUID, workspace_id: UUID) -> dict | None:
+async def mark_invite_accepted_for_stash(
+    *,
+    stash_id: UUID,
+    user_id: UUID,
+    workspace_id: UUID,
+) -> None:
     pool = get_pool()
-    invite = await pool.fetchrow(
-        """
-        SELECT si.id, si.stash_id, s.slug
-        FROM stash_invites si
-        JOIN stashes s ON s.id = si.stash_id
-        WHERE si.id = $1
-          AND si.recipient_user_id = $2
-          AND si.status = 'pending'
-        """,
-        invite_id,
-        user_id,
-    )
-    if not invite:
-        return None
-
-    if not await workspace_service.is_member(workspace_id, user_id):
-        raise PermissionError("Not a workspace member")
-
-    stash = await stash_service.add_external_stash(workspace_id, invite["slug"], user_id)
-    if not stash:
-        return None
-
     await pool.execute(
         """
         UPDATE stash_invites
@@ -111,14 +93,14 @@ async def accept_invite(invite_id: UUID, user_id: UUID, workspace_id: UUID) -> d
             target_workspace_id = $1,
             responded_at = now(),
             updated_at = now()
-        WHERE id = $2
+        WHERE stash_id = $2
           AND recipient_user_id = $3
+          AND status = 'pending'
         """,
         workspace_id,
-        invite_id,
+        stash_id,
         user_id,
     )
-    return stash
 
 
 async def dismiss_invite(invite_id: UUID, user_id: UUID) -> bool:

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -774,6 +774,13 @@ async def add_external_stash(workspace_id: UUID, slug: str, added_by: UUID) -> d
         stash["id"],
     )
     if existing:
+        from . import stash_invite_service
+
+        await stash_invite_service.mark_invite_accepted_for_stash(
+            stash_id=stash["id"],
+            user_id=added_by,
+            workspace_id=workspace_id,
+        )
         return _mark_external(await _attach_items(dict(existing)), workspace_id)
 
     async with pool.acquire() as conn:
@@ -812,6 +819,13 @@ async def add_external_stash(workspace_id: UUID, slug: str, added_by: UUID) -> d
                 )
             await _replace_items(conn, fork["id"], forked_items)
 
+    from . import stash_invite_service
+
+    await stash_invite_service.mark_invite_accepted_for_stash(
+        stash_id=stash["id"],
+        user_id=added_by,
+        workspace_id=workspace_id,
+    )
     return _mark_external(await _attach_items(dict(fork)), workspace_id)
 
 

--- a/backend/tests/test_stash_invites.py
+++ b/backend/tests/test_stash_invites.py
@@ -21,7 +21,7 @@ def _auth(api_key: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_stash_invite_can_be_accepted_into_workspace(client: AsyncClient):
+async def test_stash_invite_grants_view_access_before_adding(client: AsyncClient):
     owner_key, _owner = await _register(client, "stash_invite_owner")
     recipient_key, recipient = await _register(client, "stash_invite_recipient")
 
@@ -73,13 +73,23 @@ async def test_stash_invite_can_be_accepted_into_workspace(client: AsyncClient):
     assert invite["source_workspace_id"] == source_workspace["id"]
     assert invite["permission"] == "read"
 
-    accepted = await client.post(
-        f"/api/v1/stash-invites/{invite['id']}/accept",
+    viewed = await client.get(
+        f"/api/v1/stashes/{stash['slug']}",
+        headers=_auth(recipient_key),
+    )
+    assert viewed.status_code == 200
+    assert viewed.json()["stash"]["id"] == stash["id"]
+
+    still_pending = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert len(still_pending.json()["invites"]) == 1
+
+    added = await client.post(
+        f"/api/v1/stashes/{stash['slug']}/add-to-workspace",
         json={"workspace_id": target_workspace["id"]},
         headers=_auth(recipient_key),
     )
-    assert accepted.status_code == 200
-    fork = accepted.json()
+    assert added.status_code == 201
+    fork = added.json()
     assert fork["is_external"] is True
     assert fork["workspace_id"] == target_workspace["id"]
     assert fork["forked_from_stash_id"] == stash["id"]
@@ -135,3 +145,9 @@ async def test_stash_invite_can_be_dismissed(client: AsyncClient):
 
     remaining = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
     assert remaining.json()["invites"] == []
+
+    viewed = await client.get(
+        f"/api/v1/stashes/{stash['slug']}",
+        headers=_auth(recipient_key),
+    )
+    assert viewed.status_code == 200

--- a/frontend/src/app/stashes/[slug]/AddToWorkspaceButton.tsx
+++ b/frontend/src/app/stashes/[slug]/AddToWorkspaceButton.tsx
@@ -100,7 +100,7 @@ export default function AddToWorkspaceButton({ slug, sourceWorkspaceId }: Props)
         <div className="absolute right-0 top-12 z-20 w-[300px] rounded-lg border border-border-subtle bg-surface p-3 text-left shadow-lg">
           {attached ? (
             <div className="space-y-2">
-              <p className="text-[13px] font-medium text-foreground">Forked into workspace</p>
+              <p className="text-[13px] font-medium text-foreground">Added to workspace</p>
               <button
                 type="button"
                 onClick={() => router.push(`/workspaces/${attached.added_to_workspace_id}`)}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -268,7 +268,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         />
 
         <div className="flex items-center justify-end gap-1">
-          <StashInviteCenter activeWorkspaceId={activeWorkspaceId} />
+          <StashInviteCenter />
           {activeWorkspaceId && (
             <button
               className="mr-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"

--- a/frontend/src/components/StashInviteCenter.test.tsx
+++ b/frontend/src/components/StashInviteCenter.test.tsx
@@ -2,9 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StashInviteCenter from "./StashInviteCenter";
 import {
-  acceptStashInvite,
   dismissStashInvite,
-  listMyWorkspaces,
   listStashInvites,
 } from "../lib/api";
 
@@ -17,9 +15,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("../lib/api", () => ({
-  acceptStashInvite: vi.fn(),
   dismissStashInvite: vi.fn(),
-  listMyWorkspaces: vi.fn(),
   listStashInvites: vi.fn(),
 }));
 
@@ -38,40 +34,10 @@ const invite = {
   created_at: "2026-05-17T12:00:00Z",
 };
 
-const targetWorkspace = {
-  id: "workspace-2",
-  name: "Recipient Workspace",
-  description: "",
-  creator_id: "user-2",
-  invite_code: "invite",
-  member_count: 1,
-  created_at: "2026-05-17T12:00:00Z",
-  updated_at: "2026-05-17T12:00:00Z",
-};
-
 describe("StashInviteCenter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listStashInvites).mockResolvedValue([invite]);
-    vi.mocked(listMyWorkspaces).mockResolvedValue({ workspaces: [targetWorkspace] });
-    vi.mocked(acceptStashInvite).mockResolvedValue({
-      id: "forked-stash",
-      workspace_id: "workspace-2",
-      slug: "partner-stash-fork",
-      title: "Partner Stash",
-      description: "",
-      owner_id: "user-2",
-      access: "workspace",
-      discoverable: false,
-      cover_image_url: null,
-      view_count: 0,
-      items: [],
-      is_external: true,
-      added_to_workspace_id: "workspace-2",
-      forked_from_stash_id: "stash-1",
-      created_at: "2026-05-17T12:00:00Z",
-      updated_at: "2026-05-17T12:00:00Z",
-    });
     vi.mocked(dismissStashInvite).mockResolvedValue(undefined);
   });
 
@@ -79,17 +45,29 @@ describe("StashInviteCenter", () => {
     cleanup();
   });
 
-  it("accepts a pending invite into the selected workspace", async () => {
-    render(<StashInviteCenter activeWorkspaceId="workspace-2" />);
+  it("opens a shared Stash for review", async () => {
+    render(<StashInviteCenter />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Stash invites (1)" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Stash access (1)" }));
 
     await screen.findByText("Partner Stash");
-    fireEvent.click(screen.getByRole("button", { name: "Add Stash" }));
+    expect(
+      screen.getByText("Henry has given you view access to their Stash.")
+    ).toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(acceptStashInvite).toHaveBeenCalledWith("invite-1", "workspace-2")
-    );
-    expect(nav.push).toHaveBeenCalledWith("/stashes/partner-stash-fork");
+    fireEvent.click(screen.getByRole("button", { name: "View Stash" }));
+
+    expect(nav.push).toHaveBeenCalledWith("/stashes/partner-stash");
+  });
+
+  it("dismisses an access notification", async () => {
+    render(<StashInviteCenter />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Stash access (1)" }));
+    await screen.findByText("Partner Stash");
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    await waitFor(() => expect(dismissStashInvite).toHaveBeenCalledWith("invite-1"));
+    expect(screen.queryByText("Partner Stash")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StashInviteCenter.tsx
+++ b/frontend/src/components/StashInviteCenter.tsx
@@ -1,28 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
-  acceptStashInvite,
   dismissStashInvite,
-  listMyWorkspaces,
   listStashInvites,
   type StashInvite,
 } from "../lib/api";
-import type { Workspace } from "../lib/types";
 import { NotificationsIcon } from "./StashIcons";
 
-export default function StashInviteCenter({
-  activeWorkspaceId,
-}: {
-  activeWorkspaceId: string | null;
-}) {
+export default function StashInviteCenter() {
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [invites, setInvites] = useState<StashInvite[]>([]);
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [selectedWorkspaces, setSelectedWorkspaces] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [busyInviteId, setBusyInviteId] = useState<string | null>(null);
   const [error, setError] = useState("");
@@ -39,12 +30,7 @@ export default function StashInviteCenter({
     setLoading(true);
     setError("");
     try {
-      const [nextInvites, workspaceData] = await Promise.all([
-        listStashInvites(),
-        listMyWorkspaces(),
-      ]);
-      setInvites(nextInvites);
-      setWorkspaces(workspaceData.workspaces);
+      setInvites(await listStashInvites());
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load Stash invites");
     } finally {
@@ -80,34 +66,9 @@ export default function StashInviteCenter({
     };
   }, [open]);
 
-  const workspaceIds = useMemo(() => new Set(workspaces.map((workspace) => workspace.id)), [workspaces]);
-
-  function selectedWorkspaceId(invite: StashInvite): string {
-    const selected = selectedWorkspaces[invite.id];
-    if (selected && workspaceIds.has(selected)) return selected;
-    if (activeWorkspaceId && workspaceIds.has(activeWorkspaceId)) return activeWorkspaceId;
-    return workspaces[0]?.id ?? "";
-  }
-
-  async function accept(invite: StashInvite) {
-    const workspaceId = selectedWorkspaceId(invite);
-    if (!workspaceId) {
-      setError("Create or join a workspace before adding this Stash.");
-      return;
-    }
-
-    setBusyInviteId(invite.id);
-    setError("");
-    try {
-      const stash = await acceptStashInvite(invite.id, workspaceId);
-      setInvites((current) => current.filter((item) => item.id !== invite.id));
-      setOpen(false);
-      router.push(`/stashes/${stash.slug}`);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to add Stash");
-    } finally {
-      setBusyInviteId(null);
-    }
+  function view(invite: StashInvite) {
+    setOpen(false);
+    router.push(`/stashes/${invite.stash_slug}`);
   }
 
   async function dismiss(invite: StashInvite) {
@@ -129,8 +90,8 @@ export default function StashInviteCenter({
         type="button"
         onClick={() => setOpen((value) => !value)}
         className="relative rounded p-1 text-muted hover:bg-raised hover:text-foreground"
-        aria-label={`Stash invites${invites.length ? ` (${invites.length})` : ""}`}
-        title="Stash invites"
+        aria-label={`Stash access${invites.length ? ` (${invites.length})` : ""}`}
+        title="Stash access"
       >
         <NotificationsIcon className="h-4 w-4" />
         {invites.length > 0 ? (
@@ -144,9 +105,9 @@ export default function StashInviteCenter({
         <div className="absolute right-0 top-8 z-50 w-[360px] rounded-lg border border-border bg-base shadow-xl">
           <div className="flex items-center justify-between border-b border-border px-4 py-3">
             <div>
-              <h2 className="text-[14px] font-semibold text-foreground">Stash invites</h2>
+              <h2 className="text-[14px] font-semibold text-foreground">Stash access</h2>
               <p className="mt-0.5 text-[11.5px] text-muted">
-                Add shared Stashes to one of your workspaces.
+                Review Stashes shared directly with you.
               </p>
             </div>
             <button
@@ -169,12 +130,11 @@ export default function StashInviteCenter({
               <p className="px-2 py-8 text-center text-[12.5px] text-muted">Loading…</p>
             ) : invites.length === 0 ? (
               <p className="px-2 py-8 text-center text-[12.5px] text-muted">
-                No pending Stash invites.
+                No new Stash access.
               </p>
             ) : (
               <div className="flex flex-col gap-2">
                 {invites.map((invite) => {
-                  const workspaceId = selectedWorkspaceId(invite);
                   const inviter = invite.invited_by_display_name || invite.invited_by_name;
                   const busy = busyInviteId === invite.id;
 
@@ -188,35 +148,12 @@ export default function StashInviteCenter({
                           {invite.stash_description || "No description."}
                         </p>
                         <p className="mt-2 text-[11px] text-muted">
-                          {inviter} shared from {invite.source_workspace_name}
+                          {inviter} has given you view access to their Stash.
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted">
+                          From {invite.source_workspace_name}
                         </p>
                       </div>
-
-                      <label className="mt-3 block">
-                        <span className="text-[10.5px] font-semibold uppercase tracking-wide text-muted">
-                          Add to workspace
-                        </span>
-                        <select
-                          value={workspaceId}
-                          onChange={(event) =>
-                            setSelectedWorkspaces((current) => ({
-                              ...current,
-                              [invite.id]: event.target.value,
-                            }))
-                          }
-                          className="mt-1 w-full rounded-md border border-border bg-base px-2 py-1.5 text-[12px] text-foreground"
-                        >
-                          {workspaces.length === 0 ? (
-                            <option value="">No workspaces available</option>
-                          ) : (
-                            workspaces.map((workspace) => (
-                              <option key={workspace.id} value={workspace.id}>
-                                {workspace.name}
-                              </option>
-                            ))
-                          )}
-                        </select>
-                      </label>
 
                       <div className="mt-3 flex justify-end gap-1.5">
                         <button
@@ -229,11 +166,11 @@ export default function StashInviteCenter({
                         </button>
                         <button
                           type="button"
-                          disabled={busy || !workspaceId}
-                          onClick={() => void accept(invite)}
+                          disabled={busy}
+                          onClick={() => view(invite)}
                           className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
                         >
-                          {busy ? "Adding…" : "Add Stash"}
+                          View Stash
                         </button>
                       </div>
                     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -977,16 +977,6 @@ export async function listStashInvites(): Promise<StashInvite[]> {
   return data.invites;
 }
 
-export async function acceptStashInvite(
-  inviteId: string,
-  workspaceId: string
-): Promise<WorkspaceStash> {
-  return apiFetch(`/api/v1/stash-invites/${inviteId}/accept`, {
-    method: "POST",
-    body: JSON.stringify({ workspace_id: workspaceId }),
-  });
-}
-
 export async function dismissStashInvite(inviteId: string): Promise<void> {
   await apiFetch(`/api/v1/stash-invites/${inviteId}/dismiss`, { method: "POST" });
 }


### PR DESCRIPTION
## Summary
- Change Stash access notifications so they open the shared Stash for review instead of adding it directly to a workspace.
- Remove the direct invite-accept API path and mark pending access notifications accepted when the normal Stash detail add-to-workspace action succeeds.
- Update copy from invite-to-add language to view-access language.

## Product notes
- This follows up on #296, which added the initial link paste and in-product notification flows.
- Invited users can now view the full Stash first, then choose whether to add it from the Stash page.
- Dismissing the notification only dismisses the notification; it does not revoke the granted Stash access.

## Screenshots
### Access notification
![access-notification.png](https://github.com/user-attachments/assets/1c9d4a3b-3e2b-48ea-bb45-d1af94b9b677)

### View before adding
![stash-view-before-add.png](https://github.com/user-attachments/assets/12c46aab-dae8-4acf-b01d-4a8dc6c0773d)

### Add from Stash view
![add-from-stash-view.png](https://github.com/user-attachments/assets/7078af34-3a0b-4c09-95b0-7369e927e56c)

## Tests
- `ruff check .`
- `black --check backend/ cli/`
- `pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm test`
- `cd frontend && npm run build`