### PR TITLE
[codex] Remove duplicate sessions search

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -6,13 +6,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import SessionUpload from "../../../../components/SessionUpload";
 import { SessionsIcon, SettingsIcon } from "../../../../components/StashIcons";
 import { useAuth } from "../../../../hooks/useAuth";
-import {
-  listMySessions,
-  type SessionSummary,
-} from "../../../../lib/api";
-import {
-  displaySessionUserName,
-} from "../../../../lib/sessionGrouping";
+import { listMySessions, type SessionSummary } from "../../../../lib/api";
+import { displaySessionUserName } from "../../../../lib/sessionGrouping";
 
 export default function StashSessionsPage() {
   const params = useParams();
@@ -21,7 +16,6 @@ export default function StashSessionsPage() {
   const { user, loading } = useAuth();
 
   const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
-  const [query, setQuery] = useState("");
   const [error, setError] = useState("");
 
   const load = useCallback(async () => {
@@ -41,23 +35,10 @@ export default function StashSessionsPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  const filtered = useMemo(() => {
-    if (!sessions) return null;
-    const q = query.trim().toLowerCase();
-    if (!q) return sessions;
-    return sessions.filter((s) => {
-      const haystack = [s.agent_name, s.first_prompt_preview, s.session_id]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(q);
-    });
-  }, [sessions, query]);
-
   const rows = useMemo(() => {
-    if (!filtered) return null;
-    return [...filtered].sort((a, b) => sessionTime(b) - sessionTime(a));
-  }, [filtered]);
+    if (!sessions) return null;
+    return [...sessions].sort((a, b) => sessionTime(b) - sessionTime(a));
+  }, [sessions]);
 
   if (loading)
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
@@ -66,67 +47,48 @@ export default function StashSessionsPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-12 py-8">
-          <nav className="mb-4 flex flex-wrap items-center gap-1.5 text-[12.5px] text-muted">
-            <Link href={`/workspaces/${workspaceId}`} className="hover:text-foreground">
-              Home
-            </Link>
-            <span className="text-muted/60">/</span>
-            <span className="font-medium text-foreground">Sessions</span>
-          </nav>
+        <nav className="mb-4 flex flex-wrap items-center gap-1.5 text-[12.5px] text-muted">
+          <Link href={`/workspaces/${workspaceId}`} className="hover:text-foreground">
+            Home
+          </Link>
+          <span className="text-muted/60">/</span>
+          <span className="font-medium text-foreground">Sessions</span>
+        </nav>
 
-          <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
-            <SessionsIcon />
-          </div>
-          <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
-            Sessions
-          </h1>
-
-          {error && (
-            <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
-              {error}
-            </div>
-          )}
-
-          <div className="mt-5 mb-4 space-y-3">
-            <SessionUpload workspaceId={workspaceId} onUploaded={load} />
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by agent, prompt, or session id…"
-              className="w-full rounded-md border border-border bg-base px-3 py-1.5 text-[13px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-300)] focus:outline-none"
-            />
-          </div>
-
-          {rows && (
-            <SessionsTable
-              workspaceId={workspaceId}
-              sessions={rows}
-              emptyText={
-                sessions && sessions.length === 0
-                  ? "No sessions yet."
-                  : "No sessions match your search."
-              }
-            />
-          )}
+        <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
+          <SessionsIcon />
         </div>
+        <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
+          Sessions
+        </h1>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-5 mb-4">
+          <SessionUpload workspaceId={workspaceId} onUploaded={load} />
+        </div>
+
+        {rows && <SessionsTable workspaceId={workspaceId} sessions={rows} />}
       </div>
+    </div>
   );
 }
 
 function SessionsTable({
   workspaceId,
   sessions,
-  emptyText,
 }: {
   workspaceId: string;
   sessions: SessionSummary[];
-  emptyText: string;
 }) {
   if (sessions.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
-        {emptyText}
+        No sessions yet.
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Removed the Sessions page's local search input so the workspace Sessions view relies on the global top search bar only.

## Why

The Sessions view had two search controls: the global search in the app header and a second page-local filter under the session upload dropzone. That made search behavior feel split and redundant.

## User impact

Users now see one search entry point on the Sessions page. The session list still loads and sorts the full session set by recency.

## Screenshot

Post-merge screenshot of the updated Sessions view: https://app.joinstash.ai/stashes/sessions-search-cleanup-merged-screenshot-dz3b0w

## Validation

- `npm run lint`
- `npm run build`
- Playwright browser check with mocked auth/API data confirmed the duplicate Sessions search input is absent and captured the screenshot above.