### PR TITLE
[codex] Remove sessions page header icon

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import SessionUpload from "../../../../components/SessionUpload";
-import { SessionsIcon, SettingsIcon } from "../../../../components/StashIcons";
+import { SettingsIcon } from "../../../../components/StashIcons";
 import { useAuth } from "../../../../hooks/useAuth";
 import {
   listMySessions,
@@ -74,9 +74,6 @@ export default function StashSessionsPage() {
             <span className="font-medium text-foreground">Sessions</span>
           </nav>
 
-          <div className="mb-1 flex h-10 w-10 items-center justify-center text-4xl text-muted">
-            <SessionsIcon />
-          </div>
           <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
             Sessions
           </h1>


### PR DESCRIPTION
## Summary
- Remove the standalone Sessions icon above the Sessions page title.
- Keep the current shared header breadcrumb, title, upload control, and table behavior unchanged.

## Why
The icon was decorative only, had no action attached, and consumed vertical page space before the primary Sessions controls.

## Screenshot
![stash-icons-sessions-resolved.png](https://github.com/user-attachments/assets/9bf204af-f8c7-4250-9a53-0a9ce8b1681f)

## Validation
- `npm run lint` from `frontend/`
- Playwright browser check with mocked API responses for `/workspaces/ws-demo/sessions`
- Merged current `origin/main` into `icons` and resolved the Sessions page conflict