### PR TITLE
[codex] Open workspace invites from home Share

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -66,6 +66,16 @@ vi.mock("./StashInviteCenter", () => ({
   default: () => <button aria-label="Stash invites">Invites</button>,
 }));
 
+vi.mock("./MembersModal", () => ({
+  default: ({
+    open,
+    title,
+  }: {
+    open: boolean;
+    title?: string;
+  }) => (open ? <div role="dialog" aria-label={title}>Invite modal</div> : null),
+}));
+
 
 const user = {
   id: "user-1",
@@ -274,6 +284,26 @@ describe("AppShell sidebar collapse", () => {
     await waitFor(() => expect(home).toHaveAttribute("href", "/workspaces/ws-1"));
     expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
+  });
+
+  it("opens workspace invites from Share on the workspace home route", async () => {
+    nav.pathname = "/workspaces/ws-1";
+    mockWorkspaceCache();
+
+    render(
+      <ShareModalProvider>
+        <AppShell user={user} onLogout={vi.fn()}>
+          <div>Workspace content</div>
+        </AppShell>
+      </ShareModalProvider>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "Invite people to Workspace" })
+    ).toBeInTheDocument();
+    expect(publishStash).not.toHaveBeenCalled();
   });
 
   it("renders breadcrumbs as a Home-rooted file path", async () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { useShareModal } from "../lib/shareModalContext";
 import { type Crumb, useBreadcrumbsValue } from "./BreadcrumbContext";
 import { getCachedWorkspaces, readCachedWorkspaces } from "../lib/stashNavigationCache";
 import { useEscapeKey } from "../hooks/useEscapeKey";
+import MembersModal from "./MembersModal";
 
 interface AppShellProps {
   user: User;
@@ -103,6 +104,10 @@ function inferDirectShareTarget(
   }
 
   return null;
+}
+
+function isWorkspaceHomePath(pathname: string): boolean {
+  return /^\/workspaces\/[^/?#]+\/?$/.test(pathname);
 }
 
 function inferSearchScope(
@@ -235,6 +240,7 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
     () => readCachedWorkspaces(user.id)?.all ?? []
   );
   const [cmdkOpen, setCmdkOpen] = useState(false);
+  const [membersOpen, setMembersOpen] = useState(false);
   const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const [shareMessage, setShareMessage] = useState("");
 
@@ -276,6 +282,11 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
 
   async function copyCurrentViewLink() {
     if (!activeWorkspaceId) return;
+
+    if (isWorkspaceHomePath(pathname)) {
+      setMembersOpen(true);
+      return;
+    }
 
     const target = directShareTarget;
     if (!target) {
@@ -407,6 +418,15 @@ export default function AppShell({ user, onLogout, children }: AppShellProps) {
         workspaceName={activeWorkspace?.name}
         searchScope={searchScope}
       />
+      {activeWorkspaceId && (
+        <MembersModal
+          workspaceId={activeWorkspaceId}
+          open={membersOpen}
+          onClose={() => setMembersOpen(false)}
+          title="Invite people to Workspace"
+          autoFocusInvite
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MembersModal.tsx
+++ b/frontend/src/components/MembersModal.tsx
@@ -16,6 +16,8 @@ interface MembersModalProps {
   workspaceId: string;
   open: boolean;
   onClose: () => void;
+  title?: string;
+  autoFocusInvite?: boolean;
 }
 
 const PALETTE = [
@@ -37,7 +39,13 @@ function roleLabel(role: string): string {
   return role;
 }
 
-export default function MembersModal({ workspaceId, open, onClose }: MembersModalProps) {
+export default function MembersModal({
+  workspaceId,
+  open,
+  onClose,
+  title = "Members",
+  autoFocusInvite = false,
+}: MembersModalProps) {
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [meId, setMeId] = useState<string | null>(null);
   const [username, setUsername] = useState("");
@@ -117,7 +125,7 @@ export default function MembersModal({ workspaceId, open, onClose }: MembersModa
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onClick={onClose}>
       <div className="w-full max-w-md rounded-2xl border border-border bg-base shadow-xl" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between border-b border-border px-5 py-3">
-          <h2 className="font-display text-[15px] font-semibold text-foreground">Members</h2>
+          <h2 className="font-display text-[15px] font-semibold text-foreground">{title}</h2>
           <button onClick={onClose} className="text-muted hover:text-foreground">✕</button>
         </div>
 
@@ -170,6 +178,7 @@ export default function MembersModal({ workspaceId, open, onClose }: MembersModa
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="Invite by username"
+              autoFocus={autoFocusInvite}
               className="flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-400)] focus:outline-none"
             />
             <button


### PR DESCRIPTION
## Summary
- Reuses the existing workspace `MembersModal` when the top Share button is clicked from `/workspaces/:workspaceId`.
- Opens that modal as an invite-focused dialog with the username invite field focused.
- Leaves page/session routes on the existing direct Stash link sharing behavior.

## Screenshot
![Workspace homepage Share opens invite modal](https://gist.githubusercontent.com/henry-dowling/3fd670c050ed201370a2c13ee20b0d88/raw/72e8526dd57a11ece838f3b84cd23b5e2ca07809/workspace-invite-share-modal.svg)

## Validation
- `npm test -- AppShell.test.tsx`
- `npm run lint`
- `npm run build` (passes with the existing Next.js multiple-lockfile warning)
- Playwright QA against local app: created a test workspace, clicked top-bar Share on the workspace homepage, and verified the invite modal opened.