### PR TITLE
Workspace home / stash homepage / sidebar polish

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -180,7 +180,7 @@ async def _verify_workspace_access(workspace_id: UUID, user_id: UUID) -> None:
 
 @router.get("/activity-timeline")
 async def activity_timeline(
-    days: int = Query(30, ge=1, le=90),
+    days: int = Query(30, ge=1, le=365),
     bucket: str = Query("day"),
     workspace_id: UUID | None = Query(None),
     current_user: dict = Depends(get_current_user),

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -157,25 +157,35 @@ async def get_activity_timeline(
     # Authorization: when scoped to a workspace, the caller has already been
     # access-checked by the route; otherwise restrict to pages in workspaces
     # the user is a member of.
-    page_query = (
-        """
-        SELECT DATE_TRUNC($2, p.updated_at) AS bucket_date, COUNT(*) AS cnt
-        FROM pages p
-        WHERE p.updated_at >= $3
-        """
-    )
-    page_args: list = [user_id, bucket, cutoff]
     if workspace_id is not None:
-        page_query += " AND p.workspace_id = $4"
-        page_args.append(workspace_id)
-    else:
-        page_query += (
-            " AND p.workspace_id IN ("
-            " SELECT workspace_id FROM workspace_members WHERE user_id = $1"
-            " )"
+        page_rows = await pool.fetch(
+            """
+            SELECT DATE_TRUNC($1, p.updated_at) AS bucket_date, COUNT(*) AS cnt
+            FROM pages p
+            WHERE p.updated_at >= $2 AND p.workspace_id = $3
+            GROUP BY bucket_date
+            ORDER BY bucket_date
+            """,
+            bucket,
+            cutoff,
+            workspace_id,
         )
-    page_query += " GROUP BY bucket_date ORDER BY bucket_date"
-    page_rows = await pool.fetch(page_query, *page_args)
+    else:
+        page_rows = await pool.fetch(
+            """
+            SELECT DATE_TRUNC($1, p.updated_at) AS bucket_date, COUNT(*) AS cnt
+            FROM pages p
+            WHERE p.updated_at >= $2
+              AND p.workspace_id IN (
+                SELECT workspace_id FROM workspace_members WHERE user_id = $3
+              )
+            GROUP BY bucket_date
+            ORDER BY bucket_date
+            """,
+            bucket,
+            cutoff,
+            user_id,
+        )
 
     if page_rows:
         agents_set.add("Pages")

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -102,7 +102,7 @@ async def get_activity_timeline(
 ) -> dict:
     """Agent activity bucketed by time for the timeline visualization."""
     pool = get_pool()
-    days = min(days, 90)
+    days = min(days, 365)
     if bucket not in ("hour", "day", "week"):
         bucket = "day"
 
@@ -151,6 +151,46 @@ async def get_activity_timeline(
 
         b["agents"][agent]["total"] += cnt
         b["agents"][agent]["by_type"][etype] = b["agents"][agent]["by_type"].get(etype, 0) + cnt
+
+    # Pages get their own pseudo-agent row so the GitHub-contribution-style
+    # timeline shows human page edits alongside agent session activity.
+    # Authorization: when scoped to a workspace, the caller has already been
+    # access-checked by the route; otherwise restrict to pages in workspaces
+    # the user is a member of.
+    page_query = (
+        """
+        SELECT DATE_TRUNC($2, p.updated_at) AS bucket_date, COUNT(*) AS cnt
+        FROM pages p
+        WHERE p.updated_at >= $3
+        """
+    )
+    page_args: list = [user_id, bucket, cutoff]
+    if workspace_id is not None:
+        page_query += " AND p.workspace_id = $4"
+        page_args.append(workspace_id)
+    else:
+        page_query += (
+            " AND p.workspace_id IN ("
+            " SELECT workspace_id FROM workspace_members WHERE user_id = $1"
+            " )"
+        )
+    page_query += " GROUP BY bucket_date ORDER BY bucket_date"
+    page_rows = await pool.fetch(page_query, *page_args)
+
+    if page_rows:
+        agents_set.add("Pages")
+        for row in page_rows:
+            date_str = row["bucket_date"].isoformat()
+            cnt = row["cnt"]
+            if date_str not in buckets_map:
+                buckets_map[date_str] = {"date": date_str, "agents": {}}
+            b = buckets_map[date_str]
+            if "Pages" not in b["agents"]:
+                b["agents"]["Pages"] = {"total": 0, "by_type": {}}
+            b["agents"]["Pages"]["total"] += cnt
+            b["agents"]["Pages"]["by_type"]["page.updated"] = (
+                b["agents"]["Pages"]["by_type"].get("page.updated", 0) + cnt
+            )
 
     return {
         "agents": sorted(agents_set),

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
-import ActivityFeed from "../../components/ActivityFeed";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import AppShell from "../../components/AppShell";
+import {
+  FileIcon,
+  PageIcon,
+  SessionsIcon,
+  StashIcon,
+} from "../../components/StashIcons";
 import { useAuth } from "../../hooks/useAuth";
 import {
   getWorkspace,
@@ -11,6 +17,43 @@ import {
   listWorkspaceActivity,
   type ActivityEvent,
 } from "../../lib/api";
+
+type FilterKey = "all" | "sessions" | "pages" | "stashes";
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: "all", label: "Everything" },
+  { key: "sessions", label: "Sessions" },
+  { key: "pages", label: "Pages" },
+  { key: "stashes", label: "Stashes" },
+];
+
+const AVATAR_CLASSES = [
+  "av-rose",
+  "av-indigo",
+  "av-emerald",
+  "av-amber",
+  "av-sky",
+  "av-fuchsia",
+  "av-violet",
+];
+
+function avatarClassFor(name: string): string {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) h = (h * 33 + name.charCodeAt(i)) >>> 0;
+  return AVATAR_CLASSES[h % AVATAR_CLASSES.length];
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return "just now";
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d} d ago`;
+  return new Date(iso).toLocaleDateString();
+}
 
 export default function ActivityPage() {
   return (
@@ -28,20 +71,23 @@ function ActivityPageInner() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [workspaceName, setWorkspaceName] = useState("");
   const [fetching, setFetching] = useState(true);
+  const [filter, setFilter] = useState<FilterKey>("all");
+  // Captured once so the "last 24h" window doesn't drift across re-renders.
+  const [nowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!user) return;
-
     let cancelled = false;
     const eventsPromise = workspaceId
-      ? listWorkspaceActivity(workspaceId, 100)
-      : listActivity(100);
+      ? listWorkspaceActivity(workspaceId, 200)
+      : listActivity(200);
     const workspacePromise = workspaceId ? getWorkspace(workspaceId) : null;
 
     Promise.all([eventsPromise, workspacePromise])
       .then(([nextEvents, workspace]) => {
-        if (!cancelled) setEvents(nextEvents);
-        if (!cancelled && workspace) setWorkspaceName(workspace.name);
+        if (cancelled) return;
+        setEvents(nextEvents);
+        if (workspace) setWorkspaceName(workspace.name);
       })
       .catch(() => {})
       .finally(() => {
@@ -57,31 +103,238 @@ function ActivityPageInner() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
+  const stats = useMemo(() => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    const since = nowMs - dayMs;
+    const recent = events.filter((e) => new Date(e.ts).getTime() >= since);
+    return {
+      sessions24h: recent.filter((e) => e.kind === "session.uploaded").length,
+      pages24h: recent.filter((e) => e.kind === "page.updated").length,
+      files24h: recent.filter((e) => e.kind === "file.uploaded").length,
+      total: events.length,
+    };
+  }, [events, nowMs]);
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return events;
+    if (filter === "sessions")
+      return events.filter((e) => e.kind === "session.uploaded");
+    if (filter === "pages")
+      return events.filter(
+        (e) => e.kind === "page.updated" || e.kind === "file.uploaded"
+      );
+    if (filter === "stashes")
+      return events.filter((e) => e.kind === "stash.published");
+    return events;
+  }, [events, filter]);
+
   if (loading) return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user) return null;
 
   return (
     <AppShell user={user} onLogout={logout}>
-      <div className="mx-auto max-w-3xl px-12 py-10">
-        <h1 className="font-display text-[30px] font-bold tracking-tight text-foreground">
-          Activity
-        </h1>
-        <p className="mt-1 text-[13px] text-muted">
+      <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
+        {/* Hero */}
+        <div className="sys-label">Activity</div>
+        <h1 className="mt-1.5 font-display text-[32px] font-black leading-[1.05] tracking-[-0.025em]">
           {workspaceId
-            ? `Recent work in ${workspaceName || "this workspace"}.`
-            : "Recent changes across your workspaces."}
+            ? `What's new in ${workspaceName || "this workspace"}.`
+            : "Recent work across your workspaces."}
+        </h1>
+        <p className="mt-1 max-w-[620px] text-[14.5px] text-dim">
+          {fetching
+            ? "Loading…"
+            : `${stats.sessions24h} session${stats.sessions24h === 1 ? "" : "s"}, ${stats.pages24h} page edit${stats.pages24h === 1 ? "" : "s"}, and ${stats.files24h} file upload${stats.files24h === 1 ? "" : "s"} in the last 24 hours.`}
         </p>
 
-        {fetching ? (
-          <p className="mt-8 text-[13px] text-muted">Loading…</p>
-        ) : events.length === 0 ? (
-          <p className="mt-8 text-[13px] text-muted">
-            No activity yet. Push a transcript, edit a page, or upload a file.
-          </p>
-        ) : (
-          <ActivityFeed events={events} showWorkspace={!workspaceId} />
-        )}
+        {/* Stat strip */}
+        <div className="mt-5 grid grid-cols-4 gap-2.5">
+          <StatCard label="Sessions today" value={stats.sessions24h} tint="var(--color-agent)" />
+          <StatCard label="Pages edited" value={stats.pages24h} tint="var(--color-human)" />
+          <StatCard label="Files uploaded" value={stats.files24h} tint="#16A34A" />
+          <StatCard label="Total events" value={stats.total} tint="var(--text-muted)" />
+        </div>
+
+        {/* Filters */}
+        <div className="mt-8 flex items-center justify-between border-b border-border pb-2">
+          <div className="flex gap-1">
+            {FILTERS.map((f) => {
+              const active = filter === f.key;
+              return (
+                <button
+                  key={f.key}
+                  onClick={() => setFilter(f.key)}
+                  className={
+                    "rounded-md px-2.5 py-1 text-[12.5px] " +
+                    (active
+                      ? "bg-raised font-semibold text-foreground"
+                      : "text-muted hover:text-foreground")
+                  }
+                >
+                  {f.label}
+                </button>
+              );
+            })}
+          </div>
+          <span className="sys-label">sorted · recent</span>
+        </div>
+
+        {/* Feed */}
+        <div className="mt-3.5 flex flex-col gap-2.5">
+          {fetching ? (
+            <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
+              Loading…
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
+              {events.length === 0
+                ? "No activity yet. Push a transcript, edit a page, or upload a file."
+                : `No ${filter === "all" ? "" : filter + " "}activity matches this filter.`}
+            </div>
+          ) : (
+            filtered.map((event, i) => (
+              <FeedCard
+                key={`${event.kind}-${event.target_id}-${i}`}
+                event={event}
+                showWorkspace={!workspaceId}
+              />
+            ))
+          )}
+        </div>
       </div>
     </AppShell>
   );
+}
+
+function StatCard({
+  label,
+  value,
+  tint,
+}: {
+  label: string;
+  value: number;
+  tint: string;
+}) {
+  return (
+    <div className="card p-3.5">
+      <div
+        className="font-display text-[26px] font-bold leading-[1.1] tracking-[-0.02em]"
+        style={{ color: tint }}
+      >
+        {value}
+      </div>
+      <div className="sys-label mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+function FeedCard({ event, showWorkspace }: { event: ActivityEvent; showWorkspace: boolean }) {
+  const name = event.actor.display_name || event.actor.name;
+  const avClass = avatarClassFor(name);
+  const initials = name.slice(0, 2).toUpperCase();
+  const verb = verbFor(event.kind);
+  const tag = tagFor(event.kind);
+  const href = hrefFor(event);
+
+  return (
+    <article className="card flex items-start gap-3 px-4 py-3.5">
+      <span
+        className={`avatar ${avClass}`}
+        style={{ width: 28, height: 28, fontSize: 11 }}
+      >
+        {initials}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-2 text-[13px] text-dim">
+          <span>
+            <strong className="text-foreground">{name}</strong> {verb}
+          </span>
+          <span className="sys-label" style={{ fontSize: 10.5 }}>
+            {relativeTime(event.ts)}
+          </span>
+          {tag && <span className={`tag tag-${tag.kind}`}>{tag.label}</span>}
+        </div>
+        <h3 className="my-1.5 font-display text-[17px] font-bold leading-tight tracking-[-0.01em]">
+          <span className="mr-1.5 inline-flex align-middle text-muted">
+            <EventGlyph kind={event.kind} />
+          </span>
+          {event.target_label || event.target_id}
+        </h3>
+        <div className="mt-2 flex flex-wrap items-center gap-2.5 text-[11.5px] text-muted">
+          {showWorkspace && event.workspace_name && event.workspace_id && (
+            <Link
+              href={`/workspaces/${event.workspace_id}`}
+              className="font-mono hover:text-foreground"
+            >
+              {event.workspace_name}
+            </Link>
+          )}
+          <span className="flex-1" />
+          {href && (
+            <Link
+              href={href}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[12px] text-dim hover:bg-raised hover:text-foreground"
+            >
+              Open →
+            </Link>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function verbFor(kind: string): string {
+  if (kind === "session.uploaded") return "pushed a session";
+  if (kind === "page.updated") return "edited a page";
+  if (kind === "file.uploaded") return "uploaded a file";
+  if (kind === "member.joined") return "joined the workspace";
+  if (kind === "stash.published") return "published a Stash";
+  return kind;
+}
+
+function tagFor(kind: string): { kind: "agent" | "human"; label: string } | null {
+  if (kind === "session.uploaded") return { kind: "agent", label: "agent" };
+  if (kind === "page.updated" || kind === "file.uploaded")
+    return { kind: "human", label: "human" };
+  return null;
+}
+
+function hrefFor(event: ActivityEvent): string | null {
+  if (!event.workspace_id) return null;
+  if (event.kind === "session.uploaded")
+    return `/workspaces/${event.workspace_id}/sessions/${encodeURIComponent(event.target_id)}`;
+  if (event.kind === "page.updated")
+    return `/workspaces/${event.workspace_id}/p/${event.target_id}`;
+  if (event.kind === "file.uploaded")
+    return `/workspaces/${event.workspace_id}/f/${event.target_id}`;
+  return null;
+}
+
+function EventGlyph({ kind }: { kind: string }) {
+  if (kind === "session.uploaded")
+    return (
+      <span style={{ color: "var(--color-agent)" }}>
+        <SessionsIcon />
+      </span>
+    );
+  if (kind === "page.updated")
+    return (
+      <span className="text-muted">
+        <PageIcon />
+      </span>
+    );
+  if (kind === "file.uploaded")
+    return (
+      <span className="text-muted">
+        <FileIcon />
+      </span>
+    );
+  if (kind === "stash.published")
+    return (
+      <span style={{ color: "var(--color-brand-600)" }}>
+        <StashIcon />
+      </span>
+    );
+  return null;
 }

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -98,6 +97,24 @@ export default function StashPageClient({ slug }: { slug: string }) {
   );
 }
 
+// Stable cover gradient per stash, mirroring the cover-1..6 utilities used
+// elsewhere in the design. djb2-ish hash → bucket index so the same stash
+// always gets the same cover.
+function coverIndexFor(id: string): number {
+  let h = 5381;
+  for (let i = 0; i < id.length; i++) h = (h * 33 + id.charCodeAt(i)) >>> 0;
+  return h % 6;
+}
+
+const COVER_GRADIENTS = [
+  "linear-gradient(135deg, #FED7AA, #FCA5A5)",
+  "linear-gradient(135deg, #DDD6FE, #BFDBFE)",
+  "linear-gradient(135deg, #A7F3D0, #BAE6FD)",
+  "linear-gradient(135deg, #FDE68A, #FECACA)",
+  "linear-gradient(135deg, #C7D2FE, #FBCFE8)",
+  "linear-gradient(135deg, #FECDD3, #FEF3C7)",
+];
+
 function StashPageBody({
   data,
   onRefresh,
@@ -107,116 +124,78 @@ function StashPageBody({
 }) {
   const { stash, workspace_name, items, can_write } = data;
   const groups = groupStashItems(items);
-  const fileCount =
-    (groups.folder?.length ?? 0) + (groups.page?.length ?? 0) + (groups.file?.length ?? 0);
-  const sessionCount = groups.session?.length ?? 0;
-  const tableCount = groups.table?.length ?? 0;
 
   const visibility: "public" | "private" | "workspace" = stash.access;
   const visClass = visibility === "public" ? "public" : visibility === "private" ? "private" : "";
+  const cover = stash.cover_image_url
+    ? { backgroundImage: `url(${stash.cover_image_url})` }
+    : { backgroundImage: COVER_GRADIENTS[coverIndexFor(stash.id)] };
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="border-b border-border-subtle bg-surface">
-        <div className="mx-auto flex max-w-[1180px] items-center justify-between gap-4 px-7 py-3.5">
-          <div className="min-w-0">
-            <p className="sys-label">{workspace_name} · workspace</p>
-            <h1 className="mt-0.5 flex min-w-0 items-center gap-2.5 font-display text-[22px] font-bold tracking-[-0.015em]">
-              <span className="text-[var(--color-brand-600)]">
-                <StashHeaderGlyph />
-              </span>
-              <span className="truncate">{stash.title}</span>
-              <span className={`stash-chip ${visClass}`.trim()}>
-                <span className="dot" />
-                {visibility}
-              </span>
-            </h1>
+    <div className="scroll-thin min-h-screen bg-background">
+      {/* Cover banner mirrors the workspace home identity strip. */}
+      <div className="h-[72px] w-full bg-cover bg-center" style={cover} />
+
+      <div className="mx-auto max-w-[920px] px-12 pb-20">
+        {/* Identity strip: icon overlaps banner, title + meta + actions.
+            Layout/spacing identical to workspace home's identity strip. */}
+        <div className="flex items-start justify-between gap-3 pt-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="-mt-9 flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-[10px] border-2 border-base bg-base text-[var(--color-brand-700)] shadow-sm">
+              <StashHeaderGlyph />
+            </span>
+            <div className="min-w-0">
+              <h1 className="m-0 flex min-w-0 items-center gap-2 truncate font-display text-[20px] font-bold leading-tight tracking-[-0.015em] text-foreground">
+                <span className="truncate">{stash.title}</span>
+                <span className={`stash-chip ${visClass}`.trim()}>
+                  <span className="dot" />
+                  {visibility}
+                </span>
+              </h1>
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-muted">
+                <span>
+                  {items.length} item{items.length === 1 ? "" : "s"}
+                </span>
+                {stash.updated_at && (
+                  <>
+                    <span className="text-muted/60">·</span>
+                    <span>updated {relativeTime(stash.updated_at)}</span>
+                  </>
+                )}
+                {workspace_name && (
+                  <>
+                    <span className="text-muted/60">·</span>
+                    <span className="truncate">in {workspace_name}</span>
+                  </>
+                )}
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Link
-              href={`/search?stash=${encodeURIComponent(stash.slug)}`}
-              className="hidden h-8 min-w-[220px] items-center gap-2 rounded-md border border-border bg-base px-2.5 text-[12.5px] text-muted hover:border-[var(--color-brand-300)] hover:bg-raised hover:text-foreground sm:flex"
-              aria-label="Search this Stash"
-            >
-              <svg
-                className="h-3.5 w-3.5 shrink-0"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
-                <circle cx="11" cy="11" r="8" />
-                <path d="m21 21-4.3-4.3" />
-              </svg>
-              <span className="min-w-0 flex-1 truncate">Search this Stash</span>
-            </Link>
+          <div className="flex flex-shrink-0 items-center gap-1.5 pt-1">
             <CopyStashLinkButton slug={stash.slug} />
             <AddToWorkspaceButton slug={stash.slug} sourceWorkspaceId={stash.workspace_id} />
           </div>
         </div>
-      </div>
 
-      <div className="mx-auto grid max-w-[1180px] gap-8 px-7 py-8 lg:grid-cols-[220px_minmax(0,1fr)]">
-        <aside className="hidden lg:block">
-          <nav className="sticky top-6 space-y-1 text-[13px]">
-            <a
-              href="#home"
-              className="block rounded-md px-2 py-1.5 font-medium text-foreground hover:bg-raised"
-            >
-              Home
-            </a>
-            {fileCount > 0 ? (
-              <a
-                href="#files"
-                className="block rounded-md px-2 py-1.5 text-dim hover:bg-raised hover:text-foreground"
-              >
-                Files
-              </a>
-            ) : null}
-            {sessionCount > 0 ? (
-              <a
-                href="#sessions"
-                className="block rounded-md px-2 py-1.5 text-dim hover:bg-raised hover:text-foreground"
-              >
-                Sessions
-              </a>
-            ) : null}
-            {tableCount > 0 ? (
-              <a
-                href="#tables"
-                className="block rounded-md px-2 py-1.5 text-dim hover:bg-raised hover:text-foreground"
-              >
-                Tables
-              </a>
-            ) : null}
-          </nav>
-        </aside>
-
-        <div className="min-w-0">
-          <section id="home" className="scroll-mt-8 border-b border-border-subtle pb-7">
-            <p className="sys-label">
-              Stash · {items.length} item{items.length === 1 ? "" : "s"} · {stash.view_count} view
-              {stash.view_count === 1 ? "" : "s"}
-            </p>
-            <h2 className="mt-3.5 font-display text-[44px] font-black leading-[1.05] tracking-[-0.025em] text-foreground">
-              {stash.title}
-            </h2>
-            <div className="card-soft mt-5 max-w-[760px] p-[18px]">
-              <div className="sys-label">About this Stash</div>
-              <p className="mt-2 whitespace-pre-wrap text-[14.5px] leading-[1.7] text-foreground">
-                {stash.description || "No description yet."}
+        {/* About this Stash — read-only mirror of workspace home's editor. */}
+        {stash.description && (
+          <section className="mt-6">
+            <div className="sys-label mb-1.5">About this Stash</div>
+            <div className="rounded-[10px] border border-border bg-surface/40 px-[18px] py-[14px]">
+              <p className="m-0 whitespace-pre-wrap text-[14.5px] leading-[1.7] text-foreground">
+                {stash.description}
               </p>
             </div>
-            <div className="mt-[18px] grid grid-cols-2 gap-2 sm:grid-cols-4">
-              <SummaryStat label="Pages" value={fileCount} tint="var(--text-primary)" />
-              <SummaryStat label="Sessions" value={sessionCount} tint="var(--color-agent)" />
-              <SummaryStat label="Tables" value={tableCount} tint="#16A34A" />
-              <SummaryStat label="Views" value={stash.view_count} tint="var(--color-brand-600)" />
-            </div>
           </section>
+        )}
 
-          {can_write ? <SharedPageComposer stashId={stash.id} onCreated={onRefresh} /> : null}
+        {can_write ? (
+          <div className="mt-6">
+            <SharedPageComposer stashId={stash.id} onCreated={onRefresh} />
+          </div>
+        ) : null}
 
+        <div className="mt-2">
           <StashSection
             id="files"
             title="Files"
@@ -228,6 +207,18 @@ function StashPageBody({
       </div>
     </div>
   );
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return "just now";
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d} d ago`;
+  return new Date(iso).toLocaleDateString();
 }
 
 function CopyStashLinkButton({ slug }: { slug: string }) {
@@ -358,20 +349,6 @@ function groupStashItems(items: PublicStashItem[]): StashItemGroup {
     groups[item.object_type] = [...(groups[item.object_type] ?? []), item];
   }
   return groups;
-}
-
-function SummaryStat({ label, value, tint }: { label: string; value: number; tint?: string }) {
-  return (
-    <div className="card p-3">
-      <div
-        className="font-display text-[24px] font-bold leading-[1.1] tracking-[-0.02em]"
-        style={{ color: tint ?? "var(--text-primary)" }}
-      >
-        {value}
-      </div>
-      <div className="sys-label mt-0.5">{label}</div>
-    </div>
-  );
 }
 
 function StashHeaderGlyph() {

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Heading from "@tiptap/extension-heading";
@@ -11,37 +11,27 @@ import Italic from "@tiptap/extension-italic";
 import TiptapLink from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import MembersModal from "../../../components/MembersModal";
-import {
-  FileIcon,
-  PageIcon,
-  SessionsIcon,
-  StashIcon,
-} from "../../../components/StashIcons";
+import StashQuickAdd from "../../../components/StashQuickAdd";
+import { StashIcon } from "../../../components/StashIcons";
+import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
+import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
 import {
-  type ActivityEvent,
+  getActivityTimeline,
+  getEmbeddingProjection,
   getWorkspace,
   getWorkspaceMembers,
   joinWorkspace,
-  listStashes,
-  listWorkspaceActivity,
   updateWorkspace,
-  type WorkspaceStash,
 } from "../../../lib/api";
-import { useShareModal } from "../../../lib/shareModalContext";
-import type { Workspace, WorkspaceMember } from "../../../lib/types";
+import type {
+  ActivityTimeline,
+  EmbeddingProjection,
+  Workspace,
+  WorkspaceMember,
+} from "../../../lib/types";
 
 const AUTOSAVE_MS = 1500;
-
-type FilterKey = "all" | "sessions" | "pages" | "stashes" | "discover";
-
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: "all", label: "Everything" },
-  { key: "sessions", label: "Sessions" },
-  { key: "pages", label: "Pages" },
-  { key: "stashes", label: "Stashes" },
-  { key: "discover", label: "From discover" },
-];
 
 const AVATAR_CLASSES = [
   "av-rose",
@@ -76,35 +66,35 @@ export default function WorkspaceHomePage() {
   const router = useRouter();
   const workspaceId = params.workspaceId as string;
   const { user, loading } = useAuth();
-  const shareModal = useShareModal();
-  const shareVersion = shareModal.version;
 
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
-  const [stashes, setStashes] = useState<WorkspaceStash[]>([]);
-  const [events, setEvents] = useState<ActivityEvent[]>([]);
-  const [filter, setFilter] = useState<FilterKey>("all");
+  const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
+  const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
   const [error, setError] = useState("");
   const [membersOpen, setMembersOpen] = useState(false);
 
   const load = useCallback(async () => {
-    const [w, m, s, a] = await Promise.allSettled([
+    const [w, m, t, p] = await Promise.allSettled([
       getWorkspace(workspaceId),
       getWorkspaceMembers(workspaceId),
-      listStashes(workspaceId),
-      listWorkspaceActivity(workspaceId, 50),
+      // 365 days because seeded dev data is dated; for production the
+      // visualization remains legible at this window (1 row per agent × 365
+      // 14px cells = ~1.4kpx wide, fits with horizontal scroll).
+      getActivityTimeline(365, "day", workspaceId),
+      getEmbeddingProjection(500, undefined, workspaceId),
     ]);
     if (w.status === "fulfilled") setWorkspace(w.value);
     else setError("Workspace not found");
     if (m.status === "fulfilled") setMembers(m.value);
-    if (s.status === "fulfilled") setStashes(s.value);
-    if (a.status === "fulfilled") setEvents(a.value);
+    if (t.status === "fulfilled") setTimeline(t.value);
+    if (p.status === "fulfilled") setProjection(p.value);
   }, [workspaceId]);
 
   useEffect(() => {
     if (!user) return;
     load();
-  }, [user, load, shareVersion]);
+  }, [user, load]);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
@@ -122,32 +112,6 @@ export default function WorkspaceHomePage() {
     }
   }
 
-  // "Now" is captured once on mount so the 24h window doesn't drift on every
-  // re-render (which would also trip the react-hooks/purity rule on useMemo).
-  const [nowMs] = useState(() => Date.now());
-  const stats = useMemo(() => {
-    const dayMs = 24 * 60 * 60 * 1000;
-    const since = nowMs - dayMs;
-    const recent = events.filter((e) => new Date(e.ts).getTime() >= since);
-    const sessionsToday = recent.filter((e) => e.kind === "session.uploaded").length;
-    const pagesEdited = recent.filter((e) => e.kind === "page.updated").length;
-    const external = stashes.filter((s) => s.access === "public").length;
-    return {
-      sessionsToday,
-      pagesEdited,
-      activeStashes: stashes.length,
-      externalStashes: external,
-    };
-  }, [events, stashes, nowMs]);
-
-  const filtered = useMemo(() => {
-    if (filter === "all") return events;
-    if (filter === "sessions") return events.filter((e) => e.kind === "session.uploaded");
-    if (filter === "pages") return events.filter((e) => e.kind === "page.updated" || e.kind === "file.uploaded");
-    if (filter === "stashes") return events.filter((e) => e.kind === "stash.published");
-    return [];
-  }, [events, filter]);
-
   if (loading)
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user) return null;
@@ -155,20 +119,64 @@ export default function WorkspaceHomePage() {
   return (
     <>
       <div className="scroll-thin flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
-          <div className="flex justify-end gap-1.5">
-            <Link
-              href={`/workspaces/${workspaceId}/stashes`}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-base px-2.5 py-1 text-[12.5px] font-medium text-foreground hover:bg-raised"
-            >
-              <PlusGlyph /> New Stash
-            </Link>
-            <button
-              onClick={() => setMembersOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-base px-2.5 py-1 text-[12.5px] font-medium text-foreground hover:bg-raised"
-            >
-              Members
-            </button>
+        {/* Cover banner — workspace-customized image, color gradient, or default brand gradient */}
+        <div
+          className="h-[72px] w-full bg-gradient-to-r from-[var(--color-brand-200)] via-amber-100 to-rose-100 bg-cover bg-center"
+          style={
+            workspace?.cover_image_url
+              ? { backgroundImage: `url(${workspace.cover_image_url})` }
+              : workspace?.color_gradient
+                ? { backgroundImage: workspace.color_gradient }
+                : undefined
+          }
+        />
+
+        <div className="mx-auto max-w-[920px] px-12 pb-20">
+          {/* Identity strip: icon + name + members preview + meta + actions */}
+          <div className="flex items-start justify-between gap-3 pt-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="-mt-9 flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-[10px] border-2 border-base bg-base text-[28px] text-[var(--color-brand-700)] shadow-sm">
+                {workspace?.icon_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={workspace.icon_url} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <StashIcon />
+                )}
+              </span>
+              <div className="min-w-0">
+                <h2 className="m-0 truncate font-display text-[20px] font-bold leading-tight tracking-[-0.015em] text-foreground">
+                  {workspace?.name || "Workspace"}
+                </h2>
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-muted">
+                  <button
+                    type="button"
+                    onClick={() => setMembersOpen(true)}
+                    title="View members"
+                    className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-raised"
+                  >
+                    <MemberStack members={members} />
+                  </button>
+                  {workspace?.updated_at && (
+                    <>
+                      <span className="text-muted/60">·</span>
+                      <span>updated {relativeTime(workspace.updated_at)}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-shrink-0 items-center gap-1.5 pt-1">
+              {isMember && (
+                <Link
+                  href={`/workspaces/${workspaceId}/settings`}
+                  title="Workspace settings"
+                  aria-label="Workspace settings"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-raised hover:text-foreground"
+                >
+                  <SettingsGlyph />
+                </Link>
+              )}
+            </div>
           </div>
 
           {error && (
@@ -189,13 +197,14 @@ export default function WorkspaceHomePage() {
             </div>
           )}
 
-          {/* Stat strip */}
-          <div className="mt-4 grid grid-cols-4 gap-2.5">
-            <StatCard label="Sessions today" value={stats.sessionsToday} tint="var(--color-agent)" />
-            <StatCard label="Pages edited" value={stats.pagesEdited} tint="var(--color-human)" />
-            <StatCard label="Active Stashes" value={stats.activeStashes} tint="var(--color-brand-500)" />
-            <StatCard label="External" value={stats.externalStashes} tint="var(--text-muted)" />
-          </div>
+          {/* Quick-add: paste URL or drop a file. .jsonl files route to
+              session-transcript upload; anything else uploads to Files. */}
+          {isMember && (
+            <section className="mt-6">
+              <div className="sys-label mb-1.5">Quick add — paste a URL, drop a file, drop a .jsonl transcript</div>
+              <StashQuickAdd workspaceId={workspaceId} onAdded={load} />
+            </section>
+          )}
 
           <WorkspaceDescriptionEditor
             workspace={workspace}
@@ -203,47 +212,35 @@ export default function WorkspaceHomePage() {
             onSaved={(updated) => setWorkspace(updated)}
           />
 
-          {/* Filters */}
-          <div className="mt-8 flex items-center justify-between border-b border-border pb-2">
-            <div className="flex gap-1">
-              {FILTERS.map((f) => {
-                const active = filter === f.key;
-                return (
-                  <button
-                    key={f.key}
-                    onClick={() => setFilter(f.key)}
-                    className={
-                      "rounded-md px-2.5 py-1 text-[12.5px] " +
-                      (active
-                        ? "bg-raised font-semibold text-foreground"
-                        : "text-muted hover:text-foreground")
-                    }
-                  >
-                    {f.label}
-                  </button>
-                );
-              })}
+          {/* Visualizations: agent activity over time + 3D embedding view.
+              Section renders even when empty so users see the placeholder
+              and know what's coming once data exists. */}
+          <section className="mt-8">
+            <div className="sys-label mb-1.5">Agent activity — past year</div>
+            <div className="card-soft overflow-x-auto p-3">
+              {timeline && timeline.agents.length > 0 ? (
+                <AgentActivityTimeline data={timeline} />
+              ) : (
+                <div className="px-2 py-6 text-center text-[12.5px] text-muted">
+                  No agent sessions yet. Push a transcript via Quick add or the CLI to populate this view.
+                </div>
+              )}
             </div>
-            <span className="sys-label">sorted · recent</span>
-          </div>
+          </section>
 
-          {/* Feed */}
-          <div className="mt-3.5 flex flex-col gap-2.5">
-            {filtered.length === 0 ? (
-              <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
-                {filter === "discover"
-                  ? "Discover suggestions will show here when available."
-                  : "No recent activity to show."}
-              </div>
-            ) : (
-              filtered.map((event, i) => (
-                <FeedCard
-                  key={`${event.kind}-${event.target_id}-${i}`}
-                  event={event}
-                />
-              ))
-            )}
-          </div>
+          <section className="mt-6">
+            <div className="sys-label mb-1.5">Embedding space — workspace knowledge map</div>
+            <div className="card-soft p-3">
+              {projection && projection.points.length > 0 ? (
+                <EmbeddingSpaceExplorer data={projection} />
+              ) : (
+                <div className="px-2 py-6 text-center text-[12.5px] text-muted">
+                  No embeddings indexed yet. Pages, table rows, and session events get embedded as they&apos;re added.
+                </div>
+              )}
+            </div>
+          </section>
+
         </div>
       </div>
       <MembersModal
@@ -255,139 +252,39 @@ export default function WorkspaceHomePage() {
   );
 }
 
-function StatCard({
-  label,
-  value,
-  tint,
-}: {
-  label: string;
-  value: number;
-  tint: string;
-}) {
+function SettingsGlyph() {
   return (
-    <div className="card p-3.5">
-      <div
-        className="font-display text-[26px] font-bold leading-[1.1] tracking-[-0.02em]"
-        style={{ color: tint }}
-      >
-        {value}
-      </div>
-      <div className="sys-label mt-0.5">{label}</div>
-    </div>
-  );
-}
-
-function FeedCard({ event }: { event: ActivityEvent }) {
-  const name = event.actor.display_name || event.actor.name;
-  const avClass = avatarClassFor(name);
-  const initials = name.slice(0, 2).toUpperCase();
-  const verb = verbFor(event.kind);
-  const tag = tagFor(event.kind);
-  const href = hrefFor(event);
-
-  return (
-    <article className="card flex items-start gap-3 px-4 py-3.5">
-      <span
-        className={`avatar ${avClass}`}
-        style={{ width: 28, height: 28, fontSize: 11 }}
-      >
-        {initials}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-2 text-[13px] text-dim">
-          <span>
-            <strong className="text-foreground">{name}</strong> {verb}
-          </span>
-          <span className="sys-label" style={{ fontSize: 10.5 }}>
-            {relativeTime(event.ts)}
-          </span>
-          {tag && <span className={`tag tag-${tag.kind}`}>{tag.label}</span>}
-        </div>
-        <h3 className="my-1.5 font-display text-[17px] font-bold leading-tight tracking-[-0.01em]">
-          <span className="mr-1.5 inline-flex align-middle text-muted">
-            <EventGlyph kind={event.kind} />
-          </span>
-          {event.target_label || event.target_id}
-        </h3>
-        <div className="mt-2 flex flex-wrap items-center gap-2.5 text-[11.5px] text-muted">
-          {event.workspace_name && (
-            <span className="font-mono">{event.workspace_name}</span>
-          )}
-          <span className="flex-1" />
-          {href && (
-            <Link
-              href={href}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[12px] text-dim hover:bg-raised hover:text-foreground"
-            >
-              Open →
-            </Link>
-          )}
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function verbFor(kind: string): string {
-  if (kind === "session.uploaded") return "pushed a session";
-  if (kind === "page.updated") return "edited a page";
-  if (kind === "file.uploaded") return "uploaded a file";
-  if (kind === "member.joined") return "joined the workspace";
-  if (kind === "stash.published") return "published a Stash";
-  return kind;
-}
-
-function tagFor(kind: string): { kind: "agent" | "human"; label: string } | null {
-  if (kind === "session.uploaded") return { kind: "agent", label: "agent" };
-  if (kind === "page.updated" || kind === "file.uploaded")
-    return { kind: "human", label: "human" };
-  return null;
-}
-
-function hrefFor(event: ActivityEvent): string | null {
-  if (!event.workspace_id) return null;
-  if (event.kind === "session.uploaded")
-    return `/workspaces/${event.workspace_id}/sessions/${encodeURIComponent(event.target_id)}`;
-  if (event.kind === "page.updated")
-    return `/workspaces/${event.workspace_id}/p/${event.target_id}`;
-  if (event.kind === "file.uploaded")
-    return `/workspaces/${event.workspace_id}/f/${event.target_id}`;
-  return null;
-}
-
-function EventGlyph({ kind }: { kind: string }) {
-  if (kind === "session.uploaded")
-    return (
-      <span style={{ color: "var(--color-agent)" }}>
-        <SessionsIcon />
-      </span>
-    );
-  if (kind === "page.updated")
-    return (
-      <span className="text-muted">
-        <PageIcon />
-      </span>
-    );
-  if (kind === "file.uploaded")
-    return (
-      <span className="text-muted">
-        <FileIcon />
-      </span>
-    );
-  if (kind === "stash.published")
-    return (
-      <span style={{ color: "var(--color-brand-600)" }}>
-        <StashIcon />
-      </span>
-    );
-  return null;
-}
-
-function PlusGlyph() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-      <path d="M12 5v14M5 12h14" />
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
     </svg>
+  );
+}
+
+function MemberStack({ members }: { members: WorkspaceMember[] }) {
+  if (!members.length) return null;
+  const display = members.slice(0, 4);
+  const overflow = members.length - display.length;
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className="flex -space-x-1">
+        {display.map((m) => {
+          const label = (m.display_name || m.name || "?").trim();
+          return (
+            <span
+              key={m.user_id}
+              className={`avatar ${avatarClassFor(label)}`}
+              style={{ width: 18, height: 18, fontSize: 8.5, border: "1.5px solid var(--bg-base)" }}
+              title={label}
+            >
+              {label.slice(0, 2).toUpperCase()}
+            </span>
+          );
+        })}
+      </span>
+      {overflow > 0 && <span className="text-[10.5px] text-muted">+{overflow}</span>}
+      <span>{members.length} member{members.length === 1 ? "" : "s"}</span>
+    </span>
   );
 }
 
@@ -453,6 +350,14 @@ function WorkspaceDescriptionEditor({
     lastSaved.current = description;
   }, [description, editor]);
 
+  // useEditor() captures `editable` at creation time. When membership loads
+  // after first paint, toggle it on the live editor so the description
+  // becomes typeable without a remount.
+  useEffect(() => {
+    if (!editor) return;
+    editor.setEditable(canEdit);
+  }, [editor, canEdit]);
+
   useEffect(() => {
     return () => {
       if (saveTimer.current) clearTimeout(saveTimer.current);
@@ -465,9 +370,18 @@ function WorkspaceDescriptionEditor({
   return (
     <section className="mt-6">
       <div className="sys-label mb-1.5">About this workspace</div>
-      <div className="card-soft p-[18px]">
+      <div
+        onClick={() => editor?.commands.focus()}
+        className={
+          "rounded-[10px] border transition-colors " +
+          (canEdit
+            ? "border-dashed border-border bg-surface/40 px-[18px] py-[14px] cursor-text hover:border-[var(--color-brand-300)] hover:bg-[var(--color-brand-50)]/40 focus-within:border-[var(--color-brand-400)] focus-within:bg-base"
+            : "border-border bg-surface/40 px-[18px] py-[14px]")
+        }
+      >
         <EditorContent editor={editor} />
       </div>
     </section>
   );
 }
+

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -735,6 +735,7 @@ function SessionUserFolder({
   // Default collapsed — opening a date bucket already reveals N user rows,
   // and auto-expanding each one explodes the whole tree on first paint.
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
   return (
     <details open={open} className="text-[12px]">
       <summary
@@ -753,14 +754,18 @@ function SessionUserFolder({
         <span className="text-[10px] text-muted">{bucket.sessions.length}</span>
       </summary>
       <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
-        {bucket.sessions.map((s) => (
-          <NavRow
-            key={s.session_id}
-            href={`/workspaces/${workspaceId}/sessions/${encodeURIComponent(s.session_id)}`}
-            icon={<span className="text-muted"><SessionsIcon /></span>}
-            label={sessionLabelForSidebar(s)}
-          />
-        ))}
+        {bucket.sessions.map((s) => {
+          const href = `/workspaces/${workspaceId}/sessions/${encodeURIComponent(s.session_id)}`;
+          return (
+            <NavRow
+              key={s.session_id}
+              href={href}
+              icon={<span className="text-muted"><SessionsIcon /></span>}
+              label={sessionLabelForSidebar(s)}
+              active={pathname === href}
+            />
+          );
+        })}
       </div>
     </details>
   );
@@ -920,6 +925,9 @@ function StashSidebarRow({
   sessionBySessionId: Map<string, WorkspaceSidebarSession>;
 }) {
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const href = `/stashes/${stash.slug}`;
+  const active = pathname === href;
   const children = buildStashTreeItems(
     workspaceId,
     stash.items ?? [],
@@ -931,18 +939,35 @@ function StashSidebarRow({
   );
   return (
     <div className="space-y-0.5">
-      <div className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised">
+      <div
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-0.5 " +
+          (active
+            ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
+            : "hover:bg-raised")
+        }
+      >
         <ChevronToggle
           open={open}
           ariaLabel={`${open ? "Collapse" : "Expand"} ${stash.title}`}
           onToggle={() => setOpen((current) => !current)}
         />
-        <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
+        <span
+          className={
+            "flex h-4 w-4 items-center justify-center text-[14px] " +
+            (active ? "text-[var(--color-brand-700)]" : "text-muted")
+          }
+        >
           <StashIcon />
         </span>
         <Link
-          href={`/stashes/${stash.slug}`}
-          className="flex-1 truncate text-foreground hover:text-[var(--color-brand-700)]"
+          href={href}
+          className={
+            "flex-1 truncate " +
+            (active
+              ? "font-medium text-[var(--color-brand-800)]"
+              : "text-foreground hover:text-[var(--color-brand-700)]")
+          }
         >
           {stash.title}
         </Link>
@@ -965,6 +990,7 @@ function StashSidebarRow({
 }
 
 function StashTreeRow({ row }: { row: StashTreeItem }) {
+  const pathname = usePathname();
   if (!row.href) {
     return (
       <div className="page-row flex items-center gap-2 rounded-md px-2 py-0.5 text-[12.5px] text-muted">
@@ -975,7 +1001,12 @@ function StashTreeRow({ row }: { row: StashTreeItem }) {
   }
 
   return (
-    <NavRow href={row.href} icon={row.icon} label={row.label} />
+    <NavRow
+      href={row.href}
+      icon={row.icon}
+      label={row.label}
+      active={pathname === row.href}
+    />
   );
 }
 
@@ -992,11 +1023,17 @@ function FileNavRow({
   onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
   onPinMenu?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }) {
+  const pathname = usePathname();
   const isCsvLinked =
     file.content_type?.includes("csv") && file.linked_table_id;
   const href = isCsvLinked
     ? `/tables/${file.linked_table_id}?workspaceId=${workspaceId}`
     : `/workspaces/${workspaceId}/f/${file.id}`;
+  // Table files compare against pathname without query string; everything else
+  // is an exact match.
+  const active = isCsvLinked
+    ? pathname === `/tables/${file.linked_table_id}`
+    : pathname === href;
   return (
     <NavRow
       href={href}
@@ -1009,6 +1046,7 @@ function FileNavRow({
       onClick={onClick}
       trailing={null}
       onContextMenu={onPinMenu}
+      active={active}
     />
   );
 }
@@ -1047,6 +1085,9 @@ function FolderTreeNode({
   const [contents, setContents] = useState<FolderContents | null>(cachedContents);
   const [loaded, setLoaded] = useState(!!cachedContents);
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const folderHref = `/workspaces/${workspaceId}/folders/${folderId}`;
+  const folderActive = pathname === folderHref;
 
   const loadContents = useCallback(() => {
     if (loaded) return;
@@ -1092,19 +1133,34 @@ function FolderTreeNode({
           e.preventDefault();
           openFolder();
         }}
-        className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised"
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-0.5 " +
+          (folderActive
+            ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
+            : "hover:bg-raised")
+        }
       >
         <ChevronToggle open={open} onToggle={handleToggle} />
-        <span className="flex h-4 w-4 items-center justify-center text-muted">
+        <span
+          className={
+            "flex h-4 w-4 items-center justify-center " +
+            (folderActive ? "text-[var(--color-brand-700)]" : "text-muted")
+          }
+        >
           <FolderIcon />
         </span>
         <Link
-          href={`/workspaces/${workspaceId}/folders/${folderId}`}
+          href={folderHref}
           onClick={(event) => {
             event.stopPropagation();
             openFolder();
           }}
-          className="flex-1 truncate text-left text-foreground hover:text-[var(--color-brand-700)]"
+          className={
+            "flex-1 truncate text-left " +
+            (folderActive
+              ? "font-medium text-[var(--color-brand-800)]"
+              : "text-foreground hover:text-[var(--color-brand-700)]")
+          }
         >
           {name}
         </Link>
@@ -1126,14 +1182,18 @@ function FolderTreeNode({
               onPinMenu={onPinMenu}
             />
           ))}
-        {contents?.pages.map((p) => (
-          <NavRow
-            key={p.id}
-            href={`/workspaces/${workspaceId}/p/${p.id}`}
-            icon={<PageIcon className="text-muted" />}
-            label={p.name}
-          />
-        ))}
+        {contents?.pages.map((p) => {
+          const pageHref = `/workspaces/${workspaceId}/p/${p.id}`;
+          return (
+            <NavRow
+              key={p.id}
+              href={pageHref}
+              icon={<PageIcon className="text-muted" />}
+              label={p.name}
+              active={pathname === pageHref}
+            />
+          );
+        })}
         {contents?.files
           .filter((f) => !isFilePinned(f.id))
           .map((f) => (
@@ -1189,6 +1249,7 @@ function FilesBlock({
   onUnpinAll: () => void;
   onAddPage: () => void;
 }) {
+  const pathname = usePathname();
   const tree = spine?.files;
   const folders = tree?.folders ?? [];
   const pages = tree?.pages ?? [];
@@ -1330,6 +1391,7 @@ function FilesBlock({
                     href={folder.href}
                     icon={folder.icon}
                     label={folder.label}
+                    active={pathname === folder.href}
                     onContextMenu={(event) =>
                       showPinMenu(event, "folder", folder.id, folder.label, true)
                     }
@@ -1341,6 +1403,7 @@ function FilesBlock({
                     href={file.href}
                     icon={file.icon}
                     label={file.label}
+                    active={pathname === file.href}
                     onContextMenu={(event) =>
                       showPinMenu(event, "file", file.id, file.label, true)
                     }
@@ -1359,15 +1422,19 @@ function FilesBlock({
             onPinMenu={showPinMenu}
           />
         ))}
-        {rootPages.slice(0, PREVIEW_ITEM_LIMIT).map((p) => (
-          <NavRow
-            key={p.id}
-            href={`/workspaces/${workspace.id}/p/${p.id}`}
-            icon={<PageIcon className="text-muted" />}
-            label={p.name}
-            onClick={() => onOpenChange(true)}
-          />
-        ))}
+        {rootPages.slice(0, PREVIEW_ITEM_LIMIT).map((p) => {
+          const pageHref = `/workspaces/${workspace.id}/p/${p.id}`;
+          return (
+            <NavRow
+              key={p.id}
+              href={pageHref}
+              icon={<PageIcon className="text-muted" />}
+              label={p.name}
+              active={pathname === pageHref}
+              onClick={() => onOpenChange(true)}
+            />
+          );
+        })}
         {rootFiles.slice(0, PREVIEW_ITEM_LIMIT).map((f) => (
           <FileNavRow
             key={f.id}

--- a/frontend/src/components/StashQuickAdd.tsx
+++ b/frontend/src/components/StashQuickAdd.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, type DragEvent, type FormEvent } from "react";
-import { createPage, uploadFile } from "../lib/api";
+import { createPage, uploadFile, uploadTranscript } from "../lib/api";
 
 interface StashQuickAddProps {
   workspaceId: string;
@@ -57,9 +57,20 @@ export default function StashQuickAdd({ workspaceId, onAdded }: StashQuickAddPro
     if (!list.length || status === "saving") return;
     setStatus("saving");
     flashHint(list.length === 1 ? `Uploading ${list[0].name}…` : `Uploading ${list.length} files…`, 8000);
+    let sessionCount = 0;
+    let fileCount = 0;
     try {
       for (const f of list) {
-        await uploadFile(workspaceId, f);
+        // .jsonl transcripts are sessions, not files — same drop target,
+        // different code path. Anything else goes to Files.
+        if (f.name.toLowerCase().endsWith(".jsonl")) {
+          const sessionId = f.name.replace(/\.jsonl$/i, "").trim() || "session";
+          await uploadTranscript(workspaceId, f, sessionId, "manual-upload");
+          sessionCount += 1;
+        } else {
+          await uploadFile(workspaceId, f);
+          fileCount += 1;
+        }
       }
     } catch {
       setStatus("error");
@@ -68,7 +79,10 @@ export default function StashQuickAdd({ workspaceId, onAdded }: StashQuickAddPro
       return;
     }
     setStatus("saved");
-    flashHint(list.length === 1 ? `${list[0].name} added to Files` : `${list.length} files added to Files`);
+    const parts: string[] = [];
+    if (sessionCount > 0) parts.push(`${sessionCount} session${sessionCount === 1 ? "" : "s"}`);
+    if (fileCount > 0) parts.push(`${fileCount} file${fileCount === 1 ? "" : "s"}`);
+    flashHint(parts.length ? `Added ${parts.join(" + ")}` : "Added");
     onAdded?.();
     window.setTimeout(() => setStatus("idle"), 1500);
   }


### PR DESCRIPTION
## Summary

Three interconnected polish passes:

### Workspace home
- Activity hero + filter tabs + feed cards moved off this page entirely; `/activity` now hosts the full dashboard (stat strip + filter tabs + rich FeedCard items).
- **About this workspace** is obviously editable for members now — dashed border, `cursor: text`, hover state tints to brand, click-anywhere-on-the-box focuses the Tiptap editor. `editor.setEditable(canEdit)` flips when membership finishes loading.
- **Quick add** now routes `.jsonl` drops to `uploadTranscript` and everything else to `uploadFile` — the standalone SessionUpload section is gone.
- Agent activity timeline window widened to 365 days (backend caps lifted from 90 → 365); empty-state copy replaces the conditional hide.
- Backend timeline now emits a **`Pages`** pseudo-agent row populated from `pages.updated_at`, so page edits show up in the same GitHub-contribution grid as agent sessions.

### Stash homepage
Rebuilt to mirror workspace home:
- 920px width, cover banner with a deterministic `cover-1..6` gradient per stash id when no `cover_image_url`.
- Identity strip: icon overlapping banner, title + visibility chip inline, meta row (`N items · updated X ago · in {workspace_name}`), Copy-link + Add-to-workspace actions on the right.
- About block: same dashed-border container as workspace home, read-only.
- Existing Files / Sessions / Tables item rendering preserved.

Dropped the workspace top-strip, sticky left rail, 4-stat strip, and standalone "Search this Stash" button to match workspace home's clean top-down flow.

### Sidebar
Active-row highlighting now works for every opened item — sessions, pages, folders, files, stashes (root + pinned + inside-stash items). Each leaf renderer calls `usePathname()` and passes `active` to NavRow.

## Test plan
- [x] `npm run lint` clean
- [x] `npx vitest run` — 44/44 pass
- [ ] Walkthrough: open a workspace → confirm About box is editable, viz shows, quick-add accepts .jsonl. Open a stash → identity strip matches workspace home shape. Click items in the sidebar → corresponding row highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)