### PR TITLE
Strip search + redundant chrome from sessions/stashes/files

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -222,7 +222,7 @@ export default function SessionViewerPage() {
             )}
           </div>
         </main>
-        <SessionAside detail={sessionDetail} stashes={containingStashes} turns={turns} />
+        <SessionAside detail={sessionDetail} stashes={containingStashes} />
       </div>
     </div>
   );
@@ -231,17 +231,12 @@ export default function SessionViewerPage() {
 function SessionAside({
   detail,
   stashes,
-  turns,
 }: {
   detail: SessionDetail | null;
   stashes: WorkspaceStash[];
-  turns: MessageTurn[];
 }) {
   const filesTouched = normalizeStringList(detail?.files_touched);
   const artifacts = detail?.artifacts ?? [];
-  const toolCalls = turns
-    .map((turn, index) => ({ ...turn, index }))
-    .filter((turn) => turn.toolName);
 
   return (
     <aside className="hidden lg:block">
@@ -283,27 +278,6 @@ function SessionAside({
           {filesTouched.length === 0 && artifacts.length === 0 && (
             <div className="mt-2 text-[12px] leading-relaxed text-muted">
               No artifacts recorded.
-            </div>
-          )}
-        </div>
-
-        <div className="card-soft p-3.5">
-          <div className="sys-label">Tool calls</div>
-          {toolCalls.length > 0 ? (
-            <div className="mt-2 flex flex-col gap-1.5">
-              {toolCalls.map((turn) => (
-                <a key={turn.id} href={`#tool-call-${turn.index}`} className="linkrow px-2 py-1.5">
-                  <span className="font-mono text-[11.5px] text-foreground">{turn.toolName}</span>
-                  <span className="flex-1" />
-                  <span className="sys-label" style={{ fontSize: 10 }}>
-                    {turn.time ?? "tool"}
-                  </span>
-                </a>
-              ))}
-            </div>
-          ) : (
-            <div className="mt-2 text-[12px] leading-relaxed text-muted">
-              No tool calls recorded.
             </div>
           )}
         </div>

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -46,7 +46,6 @@ export default function StashSessionsPage() {
   const [error, setError] = useState("");
   const [view, setView] = useState<ViewKey>("list");
   const [sort, setSort] = useState<SortKey>("recent");
-  const [query, setQuery] = useState("");
 
   useBreadcrumbs([{ label: "Sessions" }], `${workspaceId}/sessions`);
 
@@ -76,33 +75,21 @@ export default function StashSessionsPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  const filtered = useMemo(() => {
-    if (!sessions) return null;
-    const q = query.trim().toLowerCase();
-    if (!q) return sessions;
-    return sessions.filter((s) =>
-      [s.agent_name, s.user_name, s.first_prompt_preview, s.session_id]
-        .map((v) => (v ?? "").toLowerCase())
-        .some((v) => v.includes(q))
-    );
-  }, [sessions, query]);
-
   const sorted = useMemo(() => {
-    if (!filtered) return null;
-    const copy = [...filtered];
+    if (!sessions) return null;
+    const copy = [...sessions];
     if (sort === "recent") copy.sort((a, b) => sessionTime(b) - sessionTime(a));
     else if (sort === "oldest") copy.sort((a, b) => sessionTime(a) - sessionTime(b));
     else if (sort === "events") copy.sort((a, b) => b.event_count - a.event_count);
     else copy.sort((a, b) => sessionTitle(a).localeCompare(sessionTitle(b)));
     return copy;
-  }, [filtered, sort]);
+  }, [sessions, sort]);
 
   if (loading)
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user) return null;
 
   const total = sessions?.length ?? 0;
-  const visible = sorted?.length ?? 0;
 
   function setViewPersisted(next: ViewKey) {
     setView(next);
@@ -121,7 +108,7 @@ export default function StashSessionsPage() {
             Sessions
           </h1>
           <span className="sys-label" style={{ fontSize: 10.5 }}>
-            {query.trim() ? `${visible} of ${total}` : `${total} total`}
+            {total} total
           </span>
         </div>
 
@@ -135,7 +122,7 @@ export default function StashSessionsPage() {
           <SessionUpload workspaceId={workspaceId} onUploaded={load} />
         </div>
 
-        {/* Toolbar: View · Sort · Search. Drives the rendering below. */}
+        {/* Toolbar: View · Sort. Drives the rendering below. */}
         <div className="mb-3 flex flex-wrap items-center gap-3 border-b border-border pb-2.5">
           <SegmentedControl
             label="View"
@@ -149,16 +136,6 @@ export default function StashSessionsPage() {
             options={SORTS}
             onChange={(v) => setSort(v as SortKey)}
           />
-          <div className="flex max-w-[260px] flex-1 items-center gap-2 rounded-md border border-border bg-base px-2 py-1">
-            <SearchGlyph />
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search title, agent, user…"
-              className="min-w-0 flex-1 border-0 bg-transparent text-[12.5px] text-foreground placeholder:text-muted focus:outline-none"
-            />
-          </div>
         </div>
 
         {sorted && (
@@ -166,8 +143,6 @@ export default function StashSessionsPage() {
             view={view}
             sessions={sorted}
             workspaceId={workspaceId}
-            queryActive={query.trim().length > 0}
-            totalUnfiltered={total}
           />
         )}
       </div>
@@ -179,23 +154,15 @@ function SessionsView({
   view,
   sessions,
   workspaceId,
-  queryActive,
-  totalUnfiltered,
 }: {
   view: ViewKey;
   sessions: SessionSummary[];
   workspaceId: string;
-  queryActive: boolean;
-  totalUnfiltered: number;
 }) {
   if (sessions.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
-        {queryActive
-          ? "No sessions match your search."
-          : totalUnfiltered === 0
-            ? "No sessions yet."
-            : "No sessions to show."}
+        No sessions yet.
       </div>
     );
   }
@@ -356,15 +323,6 @@ function Chev({ open }: { open: boolean }) {
       strokeLinejoin="round"
     >
       <polyline points="9 18 15 12 9 6" />
-    </svg>
-  );
-}
-
-function SearchGlyph() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted">
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
     </svg>
   );
 }

--- a/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
@@ -27,7 +27,6 @@ export default function WorkspaceStashesPage() {
 
   const [stashes, setStashes] = useState<WorkspaceStash[] | null>(null);
   const [filter, setFilter] = useState<Filter>("all");
-  const [query, setQuery] = useState("");
   const [error, setError] = useState("");
 
   const load = useCallback(async () => {
@@ -59,21 +58,10 @@ export default function WorkspaceStashesPage() {
     const ordered = [...stashes].sort(
       (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
     );
-    const byFilter =
-      filter === "all"
-        ? ordered
-        : filter === "external"
-          ? ordered.filter((s) => s.is_external)
-          : ordered.filter((s) => s.access === filter && !s.is_external);
-    const q = query.trim().toLowerCase();
-    if (!q) return byFilter;
-    return byFilter.filter((stash) =>
-      [stash.title, stash.description, stash.slug]
-        .join(" ")
-        .toLowerCase()
-        .includes(q)
-    );
-  }, [stashes, filter, query]);
+    if (filter === "all") return ordered;
+    if (filter === "external") return ordered.filter((s) => s.is_external);
+    return ordered.filter((s) => s.access === filter && !s.is_external);
+  }, [stashes, filter]);
 
   const native = useMemo(
     () => filtered.filter((s) => !s.forked_from_stash_id),
@@ -91,19 +79,10 @@ export default function WorkspaceStashesPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-[1120px] px-12 pb-20 pt-8">
-        {/* Hero */}
-        <div className="flex items-end justify-between gap-4">
-          <div className="min-w-0">
-            <p className="sys-label">All Stashes in workspace</p>
-            <h1 className="mb-1 mt-1 font-display text-[34px] font-bold tracking-[-0.02em]">
-              Stashes
-            </h1>
-            <p className="m-0 max-w-[620px] text-[13.5px] text-dim">
-              Stashes bundle pages, sessions, and tables into one shareable
-              surface. Privacy lives here — every item in a Stash inherits its
-              permission level.
-            </p>
-          </div>
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="m-0 font-display text-[34px] font-bold tracking-[-0.02em]">
+            Stashes
+          </h1>
           <button
             type="button"
             onClick={() => shareModal.open({ workspaceId, tab: "new" })}
@@ -146,17 +125,6 @@ export default function WorkspaceStashesPage() {
               );
             })}
           </div>
-          <span className="flex-1" />
-          <div className="flex min-w-[220px] max-w-[280px] flex-1 items-center gap-2 rounded-md border border-border bg-base px-2 py-1">
-            <SearchGlyph />
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search title, description, slug…"
-              className="min-w-0 flex-1 border-0 bg-transparent text-[12.5px] text-foreground placeholder:text-muted focus:outline-none"
-            />
-          </div>
         </div>
 
         <ExternalStashLinkForm
@@ -172,9 +140,7 @@ export default function WorkspaceStashesPage() {
           <div className="mt-12 rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[12.5px] text-muted">
             {stashes.length === 0
               ? "No Stashes yet."
-              : query.trim()
-                ? "No Stashes match your search."
-                : "No Stashes match this filter."}
+              : "No Stashes match this filter."}
           </div>
         ) : filter === "all" && forked.length > 0 && native.length > 0 ? (
           <>
@@ -297,14 +263,6 @@ function PlusGlyph() {
   );
 }
 
-function SearchGlyph() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted">
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
-    </svg>
-  );
-}
 
 function StashGroup({
   title,

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createFolder,
   createPage,
@@ -16,7 +15,6 @@ import {
   updateFolder,
   updatePage,
   uploadFile,
-  type FolderBreadcrumb,
   type FolderContents,
 } from "../../../lib/api";
 import type {
@@ -150,8 +148,6 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     ];
   }, [folderId, contents, tree, rootFiles]);
 
-  const breadcrumbs: FolderBreadcrumb[] = contents?.breadcrumbs ?? [];
-
   async function refreshAll() {
     await Promise.all([loadTree(), loadContents()]);
   }
@@ -256,15 +252,10 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Top strip: breadcrumb + toolbar */}
-      <div className="flex flex-wrap items-center gap-3 border-b border-border bg-surface px-4 py-2.5">
-        <Breadcrumbs
-          workspaceId={workspaceId}
-          breadcrumbs={breadcrumbs}
-          currentName={contents?.folder.name}
-          onDropToCrumb={reparent}
-        />
-        <span className="flex-1" />
+      {/* Top strip — toolbar only. The page path is already shown in
+          AppShell's breadcrumb, so an in-page breadcrumb would just
+          duplicate it. */}
+      <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-border bg-surface px-4 py-2.5">
         <button
           type="button"
           onClick={handleUploadFile}
@@ -326,73 +317,6 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
         />
       </div>
     </div>
-  );
-}
-
-function Breadcrumbs({
-  workspaceId,
-  breadcrumbs,
-  currentName,
-  onDropToCrumb,
-}: {
-  workspaceId: string;
-  breadcrumbs: FolderBreadcrumb[];
-  currentName?: string;
-  onDropToCrumb: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-}) {
-  // "Files" root is also a drop target — drop onto it to move to workspace root.
-  function dropProps(targetFolderId: string | null) {
-    return {
-      onDragOver(e: DragEvent<HTMLAnchorElement>) {
-        if (!e.dataTransfer.types.includes(FB_DRAG_MIME)) return;
-        e.preventDefault();
-        e.dataTransfer.dropEffect = "move";
-      },
-      onDrop(e: DragEvent<HTMLAnchorElement>) {
-        const raw = e.dataTransfer.getData(FB_DRAG_MIME);
-        if (!raw) return;
-        e.preventDefault();
-        try {
-          const payload = JSON.parse(raw) as FBDragPayload;
-          onDropToCrumb(payload, targetFolderId);
-        } catch {
-          /* malformed payload — ignore */
-        }
-      },
-    };
-  }
-
-  return (
-    <nav className="flex min-w-0 items-center gap-1.5 text-[12.5px]">
-      <Link
-        href={`/workspaces/${workspaceId}/files`}
-        className="rounded px-1 py-0.5 text-dim hover:bg-raised hover:text-foreground"
-        {...dropProps(null)}
-      >
-        Files
-      </Link>
-      {breadcrumbs.map((crumb, i) => {
-        const last = i === breadcrumbs.length - 1;
-        return (
-          <span key={crumb.id} className="flex min-w-0 items-center gap-1.5">
-            <span className="text-muted/60">/</span>
-            {last ? (
-              <span className="truncate font-medium text-foreground">
-                {currentName ?? crumb.name}
-              </span>
-            ) : (
-              <Link
-                href={`/workspaces/${workspaceId}/folders/${crumb.id}`}
-                className="rounded px-1 py-0.5 text-dim hover:bg-raised hover:text-foreground"
-                {...dropProps(crumb.id)}
-              >
-                {crumb.name}
-              </Link>
-            )}
-          </span>
-        );
-      })}
-    </nav>
   );
 }
 


### PR DESCRIPTION
## Summary
Quick density pass:

- **Sessions index**: search box removed; toolbar is just `View · Sort`.
- **Stashes index**: removed the "All Stashes in workspace" label, the
  "Stashes bundle pages, sessions, and tables…" paragraph, and the
  search input. Header is now `Stashes` + `+ New Stash`.
- **File browser**: in-page breadcrumb removed — `AppShell` already shows
  the page path in the top bar; two stacked breadcrumbs read as
  duplicated chrome.
- **Session viewer**: "Tool calls" right-aside card removed. Inline tool
  calls in the transcript are the canonical surface.

## Test plan
- [x] `npm run lint` clean
- [x] `npx vitest run` — 47/47 pass