### PR TITLE
Inline rename for pages, files, folders

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -615,6 +615,7 @@ class FileListResponse(BaseModel):
 class FileUpdateRequest(BaseModel):
     folder_id: UUID | None = None
     move_to_root: bool = False
+    name: str | None = None
 
 
 class SessionTranscriptResponse(BaseModel):

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -242,8 +242,9 @@ async def update_ws_file(
     req: FileUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Reparent a file. Pass folder_id=<UUID> to move into a folder, or
-    move_to_root=true to move to the workspace root."""
+    """Update a file. Supports rename (`name`) and reparent
+    (`folder_id` / `move_to_root`). Any subset can be passed; an empty
+    request returns the file unchanged."""
     await _check_write(workspace_id, current_user["id"])
     pool = get_pool()
     file_row = await pool.fetchrow(
@@ -256,8 +257,21 @@ async def update_ws_file(
     if not await _can_access_file(file_id, workspace_id, current_user["id"], require_write=True):
         raise HTTPException(status_code=404, detail="File not found")
 
+    # Build the SET clause dynamically so we only touch fields the caller
+    # actually sent — keeps name and folder_id independent.
+    updates: list[str] = []
+    params: list = []
+
+    if req.name is not None:
+        name = req.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Name cannot be empty")
+        params.append(name)
+        updates.append(f"name = ${len(params)}")
+
     if req.move_to_root:
-        next_folder_id = None
+        params.append(None)
+        updates.append(f"folder_id = ${len(params)}")
     elif req.folder_id is not None:
         # Target folder must belong to the same workspace; otherwise files
         # could escape their workspace by getting reparented across the
@@ -268,16 +282,19 @@ async def update_ws_file(
         )
         if not owner or owner["workspace_id"] != workspace_id:
             raise HTTPException(status_code=404, detail="Folder not found")
-        next_folder_id = req.folder_id
-    else:
-        # No-op request — return the file unchanged rather than 400.
+        params.append(req.folder_id)
+        updates.append(f"folder_id = ${len(params)}")
+
+    if not updates:
         return await _file_to_response(dict(file_row))
 
+    params.append(file_id)
+    file_id_pos = len(params)
+    params.append(workspace_id)
+    ws_pos = len(params)
     updated = await pool.fetchrow(
-        "UPDATE files SET folder_id = $1 WHERE id = $2 AND workspace_id = $3 RETURNING *",
-        next_folder_id,
-        file_id,
-        workspace_id,
+        f"UPDATE files SET {', '.join(updates)} WHERE id = ${file_id_pos} AND workspace_id = ${ws_pos} RETURNING *",
+        *params,
     )
     return await _file_to_response(dict(updated))
 

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -10,9 +10,11 @@ import {
   getFile,
   getFolderContents,
   ingestCsvFile,
+  updateFile,
   type FolderBreadcrumb,
 } from "../../../../../lib/api";
 import type { FileInfo } from "../../../../../lib/types";
+import EditableTitle from "../../../../../components/workspace/EditableTitle";
 
 function isCsv(ct: string) {
   return ct?.includes("csv") || ct === "text/csv";
@@ -112,7 +114,17 @@ export default function FileViewerPage() {
     <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
         <div className="flex items-center justify-between border-b border-border px-5 py-2.5 text-[13px]">
           <div className="flex items-center gap-2">
-            <span className="font-mono font-medium text-foreground">{file?.name}</span>
+            {file ? (
+              <EditableTitle
+                value={file.name}
+                className="font-mono font-medium text-foreground"
+                onSave={async (next) => {
+                  const updated = await updateFile(workspaceId, file.id, { name: next });
+                  setFile(updated);
+                  return updated.name;
+                }}
+              />
+            ) : null}
             {file && (
               <span className="text-muted">
                 {file.content_type} · {formatBytes(file.size_bytes)}

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -7,6 +7,7 @@ import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import DownloadMenu, { downloadBlob } from "../../../../../components/DownloadMenu";
 import { StashIcon } from "../../../../../components/StashIcons";
 import HtmlPageView from "../../../../../components/workspace/HtmlPageView";
+import EditableTitle from "../../../../../components/workspace/EditableTitle";
 import MarkdownEditor, { type SaveStatus } from "../../../../../components/workspace/MarkdownEditor";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
@@ -117,7 +118,23 @@ export default function StashPageView() {
             {isHtml ? <HtmlGlyph /> : <PageGlyph />}
           </span>
           <h1 className="mb-1 mt-3 font-display text-[38px] font-bold leading-tight tracking-[-0.025em]">
-            {(page?.name || "").replace(/\.md$/, "")}
+            {page ? (
+              <EditableTitle
+                value={(page.name || "").replace(/\.md$/, "")}
+                onSave={async (next) => {
+                  // Preserve the .md suffix when the underlying page name
+                  // was a markdown file. Tiptap docs are saved without
+                  // extension, html pages keep .html, so only restore .md.
+                  const had = page.name.toLowerCase().endsWith(".md");
+                  const newName = had && !next.toLowerCase().endsWith(".md") ? `${next}.md` : next;
+                  const updated = await updatePage(workspaceId, pageId, { name: newName });
+                  setPage(updated);
+                  return updated.name.replace(/\.md$/, "");
+                }}
+              />
+            ) : (
+              ""
+            )}
           </h1>
 
           <div className="flex items-center gap-2.5 text-[12px] text-muted">

--- a/frontend/src/components/workspace/EditableTitle.tsx
+++ b/frontend/src/components/workspace/EditableTitle.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+
+interface Props {
+  /** Current value, controlled from outside. */
+  value: string;
+  /**
+   * Called when the user commits a new value (Enter or blur). Resolve the
+   * promise with the canonical name to display after save; reject (or
+   * throw) to surface an error and revert.
+   */
+  onSave: (next: string) => Promise<string | void>;
+  /** Optional: locks editing entirely (read-only views). */
+  disabled?: boolean;
+  /** CSS class applied to the rendered text/input. */
+  className?: string;
+  /** Placeholder shown when the input is empty. */
+  placeholder?: string;
+  /** Optional title attribute on the static span. */
+  title?: string;
+}
+
+// Inline-edit-on-click pattern used by the page header, file viewer header,
+// and the file-browser folder strip. Commits on Enter or blur, reverts on
+// Escape, and trims whitespace before save. Empty saves are rejected
+// silently (revert to the previous value).
+export default function EditableTitle({
+  value,
+  onSave,
+  disabled,
+  className,
+  placeholder,
+  title,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // External value changed while we're not editing → reflect it.
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  async function commit() {
+    const next = draft.trim();
+    if (!next || next === value) {
+      setDraft(value);
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      const result = await onSave(next);
+      setDraft(typeof result === "string" ? result : next);
+      setEditing(false);
+    } catch {
+      // On error, revert to the original. The caller is responsible for
+      // surfacing the error to the user (toast / banner) — this component
+      // just owns the inline edit lifecycle.
+      setDraft(value);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function onKey(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setDraft(value);
+      setEditing(false);
+    }
+  }
+
+  if (disabled || !editing) {
+    return (
+      <span
+        className={
+          (className ?? "") +
+          (disabled
+            ? ""
+            : " cursor-text rounded px-1 py-0.5 -mx-1 hover:bg-raised")
+        }
+        title={disabled ? title : title ?? "Click to rename"}
+        onClick={() => {
+          if (!disabled) setEditing(true);
+        }}
+      >
+        {value}
+      </span>
+    );
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      value={draft}
+      disabled={saving}
+      onChange={(e) => setDraft(e.target.value)}
+      onKeyDown={onKey}
+      onBlur={commit}
+      placeholder={placeholder}
+      className={
+        (className ?? "") +
+        " rounded border border-[var(--color-brand-300)] bg-base px-1 py-0.5 -mx-1 outline-none focus:border-[var(--color-brand-500)]"
+      }
+    />
+  );
+}

--- a/frontend/src/components/workspace/file-browser/ItemPreviewPane.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemPreviewPane.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import EditableTitle from "../EditableTitle";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
 import type { ItemKind } from "./FolderItemGrid";
 
@@ -17,9 +18,16 @@ interface Props {
   selection: PreviewSelection | null;
   onOpen: (s: PreviewSelection) => void;
   onDelete: (s: PreviewSelection) => Promise<void>;
+  onRename: (s: PreviewSelection, next: string) => Promise<string>;
 }
 
-export default function ItemPreviewPane({ workspaceId, selection, onOpen, onDelete }: Props) {
+export default function ItemPreviewPane({
+  workspaceId,
+  selection,
+  onOpen,
+  onDelete,
+  onRename,
+}: Props) {
   void workspaceId; // currently unused; kept for future deep-link actions
   if (!selection) {
     return (
@@ -51,7 +59,10 @@ export default function ItemPreviewPane({ workspaceId, selection, onOpen, onDele
           </span>
           <div className="min-w-0 flex-1">
             <div className="break-words text-[14px] font-semibold text-foreground">
-              {selection.name}
+              <EditableTitle
+                value={selection.name}
+                onSave={(next) => onRename(selection, next)}
+              />
             </div>
             <div className="mt-0.5 text-[11.5px] text-muted">{selection.subtitle}</div>
           </div>

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -22,6 +22,7 @@ import type {
   PageSummary,
   WorkspaceTree,
 } from "../../../lib/types";
+import EditableTitle from "../EditableTitle";
 import FolderTreePane from "./FolderTreePane";
 import FolderItemGrid, { type GridItem, type ItemKind } from "./FolderItemGrid";
 import ItemPreviewPane, { type PreviewSelection } from "./ItemPreviewPane";
@@ -250,12 +251,46 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     }
   }
 
+  // Rename callback used by both the in-strip folder name and the preview
+  // pane's "Rename…" action. Dispatches by kind because each lives in a
+  // different table with its own API.
+  async function renameItem(
+    kind: "folder" | "page" | "html" | "table" | "file",
+    id: string,
+    next: string
+  ): Promise<string> {
+    if (kind === "folder") {
+      const updated = await updateFolder(workspaceId, id, { name: next });
+      await refreshAll();
+      return updated.name;
+    }
+    if (kind === "page" || kind === "html") {
+      const updated = await updatePage(workspaceId, id, { name: next });
+      await refreshAll();
+      return updated.name;
+    }
+    const updated = await updateFile(workspaceId, id, { name: next });
+    await refreshAll();
+    return updated.name;
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Top strip — toolbar only. The page path is already shown in
-          AppShell's breadcrumb, so an in-page breadcrumb would just
-          duplicate it. */}
-      <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-border bg-surface px-4 py-2.5">
+      {/* Top strip: current folder name (rename target) + toolbar. The page
+          path is shown in AppShell's top-bar breadcrumb, so we only repeat
+          the *current* folder here as an inline-editable title. */}
+      <div className="flex flex-wrap items-center gap-3 border-b border-border bg-surface px-4 py-2.5">
+        {folderId && contents?.folder ? (
+          <h2 className="m-0 min-w-0 font-display text-[15px] font-semibold leading-tight text-foreground">
+            <EditableTitle
+              value={contents.folder.name}
+              onSave={(next) => renameItem("folder", folderId, next)}
+            />
+          </h2>
+        ) : (
+          <span className="text-[12.5px] font-medium text-muted">Files</span>
+        )}
+        <span className="flex-1" />
         <button
           type="button"
           onClick={handleUploadFile}
@@ -314,6 +349,11 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           selection={selected}
           onOpen={(s) => navigateTo(gridFromPreview(s))}
           onDelete={handleDelete}
+          onRename={async (s, next) => {
+            const finalName = await renameItem(s.kind, s.id, next);
+            setSelected({ ...s, name: finalName });
+            return finalName;
+          }}
         />
       </div>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -655,7 +655,7 @@ export async function deleteFile(workspaceId: string, fileId: string): Promise<v
 export async function updateFile(
   workspaceId: string,
   fileId: string,
-  data: { folder_id?: string | null; move_to_root?: boolean }
+  data: { folder_id?: string | null; move_to_root?: boolean; name?: string }
 ): Promise<FileInfo> {
   return apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}`, {
     method: "PATCH",


### PR DESCRIPTION
## Summary

Adds inline-edit-on-click for object titles across the app. One small reusable component, four call sites, plus a backend hook.

- **`EditableTitle`** — `components/workspace/EditableTitle.tsx`. Click → input, Enter/blur commits, Escape reverts, blank reverts. Caller passes `onSave` returning the canonical name.
- **Page detail** (`/workspaces/[id]/p/[id]`): `<h1>` wraps `EditableTitle`. Preserves a trailing `.md` when present.
- **File viewer** (`/workspaces/[id]/f/[id]`): top-strip filename wraps `EditableTitle`.
- **File browser**: when inside a folder, the current folder name is rendered as an editable header. The preview pane's item title is also editable, so any selected tile (folder/page/file/table) can be renamed in one place.
- **Backend**: `PATCH /api/v1/workspaces/{id}/files/{file_id}` now accepts `name` in addition to `folder_id`/`move_to_root`. SET clause built dynamically — fields are independent.

## Test plan
- [x] `npm run lint` clean
- [x] `npx vitest run` — 47/47 pass
- [x] `python -m pytest backend/tests/test_permissions.py` — 24/24 pass
- [x] `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)