### PR TITLE
CLI + MCP parity for file/folder rename + move

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -265,6 +265,27 @@ class StashClient:
     def delete_folder(self, workspace_id: str, folder_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}")
 
+    def update_folder(
+        self,
+        workspace_id: str,
+        folder_id: str,
+        *,
+        name: str | None = None,
+        parent_folder_id: str | None = None,
+        move_to_root: bool = False,
+    ) -> dict:
+        body: dict = {}
+        if name is not None:
+            body["name"] = name
+        if move_to_root:
+            body["move_to_root"] = True
+        elif parent_folder_id is not None:
+            body["parent_folder_id"] = parent_folder_id
+        return self._patch(
+            f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}",
+            json=body,
+        )
+
     def get_workspace_tree(self, workspace_id: str) -> dict:
         return self._get(f"/api/v1/workspaces/{workspace_id}/tree")
 
@@ -453,6 +474,27 @@ class StashClient:
 
     def delete_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/files/{file_id}")
+
+    def update_ws_file(
+        self,
+        workspace_id: str,
+        file_id: str,
+        *,
+        name: str | None = None,
+        folder_id: str | None = None,
+        move_to_root: bool = False,
+    ) -> dict:
+        body: dict = {}
+        if name is not None:
+            body["name"] = name
+        if move_to_root:
+            body["move_to_root"] = True
+        elif folder_id is not None:
+            body["folder_id"] = folder_id
+        return self._patch(
+            f"/api/v1/workspaces/{workspace_id}/files/{file_id}",
+            json=body,
+        )
 
     def get_ws_file_text(self, workspace_id: str, file_id: str) -> dict:
         return self._get(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/text")

--- a/cli/main.py
+++ b/cli/main.py
@@ -1672,6 +1672,37 @@ def files_create_folder(
         console.print(f"[green]Folder '{data['name']}' created.[/green]  ID: {data['id']}")
 
 
+@files_app.command("edit-folder")
+def files_edit_folder(
+    folder_id: str = typer.Argument(...),
+    name: str = typer.Option(None, "--name", help="Rename the folder."),
+    parent: str = typer.Option(None, "--parent", help="Move under this parent folder id."),
+    to_root: bool = typer.Option(False, "--to-root", help="Move to workspace root."),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Rename and/or reparent a folder."""
+    if parent and to_root:
+        console.print("[red]--parent and --to-root are mutually exclusive[/red]")
+        raise typer.Exit(1)
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            data = c.update_folder(
+                ws,
+                folder_id,
+                name=name,
+                parent_folder_id=parent,
+                move_to_root=to_root,
+            )
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+    else:
+        console.print(f"[green]Folder updated.[/green] {data['name']}  [dim]{data['id']}[/dim]")
+
+
 @files_app.command("pages")
 def files_pages(
     workspace_id: str = typer.Option(None, "--ws"),
@@ -2895,6 +2926,37 @@ def files_list(
             f"  {f['id']}  [bold]{f['name']}[/bold]  "
             f"[dim]{f.get('content_type', '')}  {size_kb:.1f} KB[/dim]"
         )
+
+
+@files_app.command("edit-file")
+def files_edit_file(
+    file_id: str = typer.Argument(...),
+    name: str = typer.Option(None, "--name", help="Rename the file."),
+    folder: str = typer.Option(None, "--folder", help="Move into this folder id."),
+    to_root: bool = typer.Option(False, "--to-root", help="Move to workspace root."),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Rename and/or move a file. Pass any subset of --name / --folder / --to-root."""
+    if folder and to_root:
+        console.print("[red]--folder and --to-root are mutually exclusive[/red]")
+        raise typer.Exit(1)
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            data = c.update_ws_file(
+                ws,
+                file_id,
+                name=name,
+                folder_id=folder,
+                move_to_root=to_root,
+            )
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+    else:
+        console.print(f"[green]File updated.[/green] {data['name']}  [dim]{data['id']}[/dim]")
 
 
 @files_app.command("rm")

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -118,6 +118,28 @@ def stash_create_folder(
 
 
 @mcp.tool()
+def stash_edit_folder(
+    folder_id: str,
+    name: str = "",
+    parent_folder_id: str = "",
+    move_to_root: bool = False,
+    workspace_id: str = "",
+) -> str:
+    """Rename and/or reparent a folder. Pass any subset of name / parent_folder_id / move_to_root."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(
+        client.update_folder(
+            ws,
+            folder_id,
+            name=name or None,
+            parent_folder_id=parent_folder_id or None,
+            move_to_root=move_to_root,
+        )
+    )
+
+
+@mcp.tool()
 def stash_delete_folder(folder_id: str, workspace_id: str = "") -> str:
     """Delete a folder (and everything inside it) from the workspace."""
     client, default_ws = _client()
@@ -385,6 +407,28 @@ def stash_upload_file(file_path: str, workspace_id: str = "") -> str:
     client, default_ws = _client()
     ws = _require_ws(workspace_id or default_ws)
     return _json(client.upload_ws_file(ws, file_path))
+
+
+@mcp.tool()
+def stash_edit_file(
+    file_id: str,
+    name: str = "",
+    folder_id: str = "",
+    move_to_root: bool = False,
+    workspace_id: str = "",
+) -> str:
+    """Rename and/or move a file. Pass any subset of name / folder_id / move_to_root."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(
+        client.update_ws_file(
+            ws,
+            file_id,
+            name=name or None,
+            folder_id=folder_id or None,
+            move_to_root=move_to_root,
+        )
+    )
 
 
 @mcp.tool()

--- a/cli/tests/test_update_file_and_folder.py
+++ b/cli/tests/test_update_file_and_folder.py
@@ -1,0 +1,71 @@
+from cli.client import StashClient
+
+
+def _stub_client():
+    """A StashClient with _patch stubbed to capture calls. We bypass __init__
+    so we don't need real config; only _patch is exercised."""
+    client = StashClient.__new__(StashClient)
+    calls: list[tuple[str, dict]] = []
+
+    def fake_patch(path: str, json=None) -> dict:
+        calls.append((path, json))
+        return {"id": "x", "name": (json or {}).get("name", "x")}
+
+    client._patch = fake_patch  # type: ignore[method-assign]
+    return client, calls
+
+
+def test_update_ws_file_rename_only() -> None:
+    c, calls = _stub_client()
+    c.update_ws_file("WS", "F1", name="new.md")
+    assert calls == [("/api/v1/workspaces/WS/files/F1", {"name": "new.md"})]
+
+
+def test_update_ws_file_move_to_folder() -> None:
+    c, calls = _stub_client()
+    c.update_ws_file("WS", "F1", folder_id="FOLD")
+    assert calls == [("/api/v1/workspaces/WS/files/F1", {"folder_id": "FOLD"})]
+
+
+def test_update_ws_file_move_to_root_wins_over_folder_id() -> None:
+    # If both are passed, move_to_root takes precedence — matches the
+    # backend's elif structure (routers/files.py).
+    c, calls = _stub_client()
+    c.update_ws_file("WS", "F1", folder_id="FOLD", move_to_root=True)
+    assert calls == [("/api/v1/workspaces/WS/files/F1", {"move_to_root": True})]
+
+
+def test_update_ws_file_rename_and_move_combined() -> None:
+    c, calls = _stub_client()
+    c.update_ws_file("WS", "F1", name="new.md", folder_id="FOLD")
+    assert calls == [
+        ("/api/v1/workspaces/WS/files/F1", {"name": "new.md", "folder_id": "FOLD"})
+    ]
+
+
+def test_update_ws_file_empty_request_is_legal() -> None:
+    # Backend returns the file unchanged when no fields are sent; we should
+    # not silently inject any defaults.
+    c, calls = _stub_client()
+    c.update_ws_file("WS", "F1")
+    assert calls == [("/api/v1/workspaces/WS/files/F1", {})]
+
+
+def test_update_folder_rename_only() -> None:
+    c, calls = _stub_client()
+    c.update_folder("WS", "D1", name="Inbox 2")
+    assert calls == [("/api/v1/workspaces/WS/folders/D1", {"name": "Inbox 2"})]
+
+
+def test_update_folder_move_to_parent() -> None:
+    c, calls = _stub_client()
+    c.update_folder("WS", "D1", parent_folder_id="P1")
+    assert calls == [
+        ("/api/v1/workspaces/WS/folders/D1", {"parent_folder_id": "P1"})
+    ]
+
+
+def test_update_folder_move_to_root_wins_over_parent() -> None:
+    c, calls = _stub_client()
+    c.update_folder("WS", "D1", parent_folder_id="P1", move_to_root=True)
+    assert calls == [("/api/v1/workspaces/WS/folders/D1", {"move_to_root": True})]


### PR DESCRIPTION
## Summary

- `143c09b` shipped backend rename (`PATCH /files/{id}` now accepts `name`) and a UI that calls it from the preview pane and folder header. It did not touch the CLI or MCP, so users driving via `stash files` or an MCP-connected agent could not hit the same endpoint.
- This PR closes that gap: `cli/client.py` gains `update_ws_file()` and `update_folder()`, `cli/main.py` gains `stash files edit-file` and `edit-folder` Typer commands, and `cli/mcp_server.py` gains `stash_edit_file` and `stash_edit_folder` MCP tools.
- Shape and naming mirror the existing `edit-page` precedent (`client.update_page`, `files_edit_page`, `stash_edit_page`). When both `folder`/`parent` and `to_root` are passed, `move_to_root` wins, matching the backend's `elif` in `routers/files.py`.

## Test plan

- [x] `pytest cli/tests` — all 17 tests pass (9 existing + 8 new wire-format tests in `test_update_file_and_folder.py`)
- [x] `stash files edit-file --help` and `stash files edit-folder --help` render the expected flags
- [x] `mcp.list_tools()` registers `stash_edit_file` and `stash_edit_folder` with the correct input schemas
- [ ] Live smoke against a running backend:
  - `stash files edit-file <id> --name "renamed.md"` → name in `stash files list` updates
  - `stash files edit-file <id> --folder <folder_id>` then `--to-root` round-trip
  - `stash files edit-folder <id> --name "Inbox 2"` and `--to-root`
  - `--folder X --to-root` together exits non-zero with the mutual-exclusion message
- [ ] UI regression: rename a file from the preview pane and confirm the same endpoint still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)