### PR TITLE
[codex] Remove Stash share manage tab

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
@@ -85,7 +85,7 @@ export default function WorkspaceStashesPage() {
           </h1>
           <button
             type="button"
-            onClick={() => shareModal.open({ workspaceId, tab: "new" })}
+            onClick={() => shareModal.open({ workspaceId })}
             className="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
           >
             <PlusGlyph /> New Stash

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1961,7 +1961,7 @@ export default function AppSidebar({
   }
 
   function handleAddStash(workspaceId: string) {
-    shareModal.open({ workspaceId, tab: "new" });
+    shareModal.open({ workspaceId });
   }
 
   async function handleDropFiles(workspaceId: string, section: DropSection, files: FileList) {

--- a/frontend/src/components/share/StashShareModal.test.tsx
+++ b/frontend/src/components/share/StashShareModal.test.tsx
@@ -2,26 +2,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StashShareModal from "./StashShareModal";
 import { ShareModalProvider, useShareModal } from "../../lib/shareModalContext";
-import {
-  addStashMember,
-  createStash,
-  getWorkspaceSidebar,
-  listStashMembers,
-  listStashes,
-  searchUsers,
-} from "../../lib/api";
+import { createStash, getWorkspaceSidebar } from "../../lib/api";
 
 vi.mock("../../lib/api", () => ({
-  addStashMember: vi.fn(),
   createStash: vi.fn(),
-  deleteStash: vi.fn(),
   getWorkspaceSidebar: vi.fn(),
-  listStashMembers: vi.fn(),
-  listStashes: vi.fn(),
   publishStash: vi.fn(),
-  removeExternalStash: vi.fn(),
-  removeStashMember: vi.fn(),
-  searchUsers: vi.fn(),
 }));
 
 function OpenSessionShareButton() {
@@ -47,23 +33,6 @@ function OpenSessionShareButton() {
   );
 }
 
-function OpenManageButton() {
-  const shareModal = useShareModal();
-  return (
-    <button
-      onClick={() =>
-        shareModal.open({
-          workspaceId: "workspace-1",
-          workspaceName: "Demo Workspace",
-          tab: "manage",
-        })
-      }
-    >
-      Manage stashes
-    </button>
-  );
-}
-
 describe("StashShareModal session sharing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -82,9 +51,6 @@ describe("StashShareModal session sharing", () => {
       files: { folders: [], pages: [], files: [] },
       stashes: [],
     });
-    vi.mocked(listStashes).mockResolvedValue([]);
-    vi.mocked(listStashMembers).mockResolvedValue([]);
-    vi.mocked(searchUsers).mockResolvedValue([]);
     vi.mocked(createStash).mockResolvedValue({
       id: "stash-1",
       workspace_id: "workspace-1",
@@ -121,6 +87,7 @@ describe("StashShareModal session sharing", () => {
     fireEvent.click(screen.getByRole("button", { name: "Share session" }));
 
     await screen.findByRole("heading", { name: "Share session as Stash" });
+    expect(screen.queryByRole("button", { name: "Manage" })).not.toBeInTheDocument();
     await screen.findByText("1 item selected");
     await waitFor(() =>
       expect(screen.getByPlaceholderText("Debug auth flow")).toBeInTheDocument()
@@ -143,6 +110,11 @@ describe("StashShareModal session sharing", () => {
         { access: "workspace" }
       )
     );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: "Share session as Stash" })
+      ).not.toBeInTheDocument()
+    );
   });
 
   it("closes the share modal with Escape", async () => {
@@ -162,67 +134,5 @@ describe("StashShareModal session sharing", () => {
     expect(
       screen.queryByRole("heading", { name: "Share session as Stash" })
     ).not.toBeInTheDocument();
-  });
-
-  it("invites a searched user to a Stash from the Manage tab", async () => {
-    vi.mocked(listStashes).mockResolvedValue([
-      {
-        id: "stash-1",
-        workspace_id: "workspace-1",
-        slug: "private-plan",
-        title: "Private plan",
-        description: "",
-        owner_id: "user-1",
-        access: "private",
-        discoverable: false,
-        cover_image_url: null,
-        icon_url: null,
-        view_count: 0,
-        items: [],
-        is_external: false,
-        added_to_workspace_id: null,
-        forked_from_stash_id: null,
-        created_at: "2026-05-14T12:00:00Z",
-        updated_at: "2026-05-14T12:00:00Z",
-      },
-    ]);
-    vi.mocked(searchUsers).mockResolvedValue([
-      { id: "user-2", name: "ada", display_name: "Ada Lovelace" },
-    ]);
-    vi.mocked(addStashMember).mockResolvedValue({
-      user_id: "user-2",
-      name: "ada",
-      display_name: "Ada Lovelace",
-      permission: "write",
-      granted_by: "user-1",
-      created_at: "2026-05-14T12:00:00Z",
-    });
-
-    render(
-      <ShareModalProvider>
-        <OpenManageButton />
-        <StashShareModal />
-      </ShareModalProvider>
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Manage stashes" }));
-
-    await screen.findByText("Private plan");
-    fireEvent.click(screen.getByRole("button", { name: /People/ }));
-    fireEvent.change(screen.getByLabelText("Permission for Private plan"), {
-      target: { value: "write" },
-    });
-    fireEvent.change(screen.getByPlaceholderText("Search people by username"), {
-      target: { value: "ada" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-
-    await screen.findByText("Ada Lovelace");
-    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
-
-    await waitFor(() =>
-      expect(addStashMember).toHaveBeenCalledWith("stash-1", "user-2", "write")
-    );
-    await screen.findByText("@ada · can edit");
   });
 });

--- a/frontend/src/components/share/StashShareModal.tsx
+++ b/frontend/src/components/share/StashShareModal.tsx
@@ -2,27 +2,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  addStashMember,
   createStash,
   publishStash,
-  deleteStash,
   getWorkspaceSidebar,
-  listStashes,
-  listStashMembers,
-  removeStashMember,
-  searchUsers,
-  updateStash,
-  type StashMember,
-  type StashMemberPermission,
   type WorkspaceSidebar,
-  type WorkspaceStash,
   type StashItemSpec,
 } from "../../lib/api";
-import type { UserSearchResult } from "../../lib/types";
 import { useShareModal } from "../../lib/shareModalContext";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 
-type Tab = "new" | "manage";
 type StashAccess = "workspace" | "private" | "public";
 
 type RowGroup = "Folders" | "Pages" | "Files" | "Tables";
@@ -60,11 +48,9 @@ function selectedCount(s: SelectedState): number {
 
 export default function StashShareModal() {
   const { state, close, bumpVersion } = useShareModal();
-  const { open, workspaceId, workspaceName, initial, tab: initialTab } = state;
+  const { open, workspaceId, workspaceName, initial } = state;
 
-  const [tab, setTab] = useState<Tab>(initialTab ?? "new");
   const [spine, setSpine] = useState<WorkspaceSidebar | null>(null);
-  const [stashes, setStashes] = useState<WorkspaceStash[]>([]);
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<SelectedState>(EMPTY_SELECTED);
   const [title, setTitle] = useState("");
@@ -72,32 +58,24 @@ export default function StashShareModal() {
   const [shareToDiscover, setShareToDiscover] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-  const [copiedSlug, setCopiedSlug] = useState<string | null>(null);
 
   useEscapeKey(open, close);
 
   const refresh = useCallback(async () => {
     if (!workspaceId) return;
-    const [spineResult, stashesResult] = await Promise.allSettled([
-      getWorkspaceSidebar(workspaceId),
-      listStashes(workspaceId),
-    ]);
-    if (spineResult.status === "fulfilled") setSpine(spineResult.value);
-    if (stashesResult.status === "fulfilled") setStashes(stashesResult.value);
+    setSpine(await getWorkspaceSidebar(workspaceId));
   }, [workspaceId]);
 
   useEffect(() => {
     if (!open) return;
-    setTab(initialTab ?? "new");
     setSearch("");
     setError("");
     setTitle("");
     setAccess("workspace");
     setShareToDiscover(false);
-    setCopiedSlug(null);
     setSelected(buildInitialSelection(initial, null));
     refresh();
-  }, [open, initialTab, initial, refresh]);
+  }, [open, initial, refresh]);
 
   useEffect(() => {
     if (!open || !spine || !initial?.some((item) => item.object_type === "session")) return;
@@ -223,32 +201,15 @@ export default function StashShareModal() {
       if (stash.access === "public") {
         await navigator.clipboard.writeText(absoluteUrl(`/stashes/${stash.slug}`)).catch(() => {});
       }
-      setCopiedSlug(stash.slug);
       setSelected(EMPTY_SELECTED);
       setTitle("");
       setShareToDiscover(false);
-      await refresh();
       bumpVersion();
-      setTab("manage");
+      close();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create share");
     } finally {
       setSubmitting(false);
-    }
-  };
-
-  const onDelete = async (stash: WorkspaceStash) => {
-    const isFork = Boolean(stash.forked_from_stash_id);
-    const message = isFork
-      ? "Delete this forked Stash?"
-      : "Delete this Stash? Anyone with the public URL will get a 404.";
-    if (!confirm(message)) return;
-    try {
-      await deleteStash(stash.id);
-      setStashes((v) => v.filter((x) => x.id !== stash.id));
-      bumpVersion();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to revoke");
     }
   };
 
@@ -262,111 +223,43 @@ export default function StashShareModal() {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-border-subtle px-5 py-3">
-          <div className="flex items-center gap-3">
-            <h2 className="font-display text-[15px] font-semibold text-foreground">
-              {modalTitle(initial, workspaceName)}
-            </h2>
-            <div className="flex rounded-md border border-border bg-surface text-[12px]">
-              <TabButton active={tab === "new"} onClick={() => setTab("new")}>
-                New Stash
-              </TabButton>
-              <TabButton
-                active={tab === "manage"}
-                onClick={() => setTab("manage")}
-                badge={stashes.length}
-              >
-                Manage
-              </TabButton>
-            </div>
-          </div>
+          <h2 className="font-display text-[15px] font-semibold text-foreground">
+            {modalTitle(initial, workspaceName)}
+          </h2>
           <button onClick={close} className="text-muted hover:text-foreground" aria-label="Close">
             ✕
           </button>
         </div>
 
-        {tab === "new" ? (
-          <NewShareTab
-            search={search}
-            setSearch={setSearch}
-            filteredRows={filteredRows}
-            filteredSessions={filteredSessions}
-            selected={selected}
-            onToggleRow={onToggleRow}
-            onToggleSession={onToggleSession}
-            onToggleAllVisible={onToggleAllVisible}
-            onClearAll={onClearAll}
-            onToggleGroupRows={onToggleGroupRows}
-            onToggleGroupSessions={onToggleGroupSessions}
-            title={title}
-            setTitle={setTitle}
-            placeholderTitle={defaultTitle}
-            access={access}
-            setAccess={(next) => {
-              setAccess(next);
-              if (next !== "public") setShareToDiscover(false);
-            }}
-            shareToDiscover={shareToDiscover}
-            setShareToDiscover={setShareToDiscover}
-            submitting={submitting}
-            onSubmit={onSubmit}
-            total={total}
-            error={error}
-          />
-        ) : (
-          <ManageTab
-            stashes={stashes}
-            rows={rows}
-            sessions={sessions}
-            onDelete={onDelete}
-            onUpdated={(updated) => {
-              setStashes((current) =>
-                current.map((stash) => (stash.id === updated.id ? updated : stash))
-              );
-              bumpVersion();
-            }}
-            copiedSlug={copiedSlug}
-            setCopiedSlug={setCopiedSlug}
-            error={error}
-          />
-        )}
+        <NewShareTab
+          search={search}
+          setSearch={setSearch}
+          filteredRows={filteredRows}
+          filteredSessions={filteredSessions}
+          selected={selected}
+          onToggleRow={onToggleRow}
+          onToggleSession={onToggleSession}
+          onToggleAllVisible={onToggleAllVisible}
+          onClearAll={onClearAll}
+          onToggleGroupRows={onToggleGroupRows}
+          onToggleGroupSessions={onToggleGroupSessions}
+          title={title}
+          setTitle={setTitle}
+          placeholderTitle={defaultTitle}
+          access={access}
+          setAccess={(next) => {
+            setAccess(next);
+            if (next !== "public") setShareToDiscover(false);
+          }}
+          shareToDiscover={shareToDiscover}
+          setShareToDiscover={setShareToDiscover}
+          submitting={submitting}
+          onSubmit={onSubmit}
+          total={total}
+          error={error}
+        />
       </div>
     </div>
-  );
-}
-
-function TabButton({
-  active,
-  onClick,
-  badge,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  badge?: number;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={
-        "flex items-center gap-1.5 px-3 py-1 transition-colors " +
-        (active
-          ? "bg-[var(--color-brand-600)] text-white"
-          : "text-foreground hover:bg-raised")
-      }
-    >
-      {children}
-      {typeof badge === "number" && badge > 0 && (
-        <span
-          className={
-            "rounded-full px-1.5 text-[10px] font-mono " +
-            (active ? "bg-white/25 text-white" : "bg-base text-muted ring-1 ring-border")
-          }
-        >
-          {badge}
-        </span>
-      )}
-    </button>
   );
 }
 
@@ -601,491 +494,6 @@ function NewShareTab(props: {
       </div>
     </>
   );
-}
-
-function ManageTab(props: {
-  stashes: WorkspaceStash[];
-  rows: SelectableRow[];
-  sessions: SessionRow[];
-  onDelete: (stash: WorkspaceStash) => void;
-  onUpdated: (stash: WorkspaceStash) => void;
-  copiedSlug: string | null;
-  setCopiedSlug: (s: string | null) => void;
-  error: string;
-}) {
-  const { stashes, rows, sessions, onDelete, onUpdated, copiedSlug, setCopiedSlug, error } = props;
-  if (stashes.length === 0) {
-    return (
-      <div className="px-5 py-10 text-center text-[12.5px] text-muted">
-        No Stashes yet. Use the New Stash tab to create one.
-      </div>
-    );
-  }
-  return (
-    <div className="scroll-thin flex-1 overflow-y-auto px-5 py-3">
-      {error && (
-        <div className="mb-3 rounded-md border border-red-300/40 bg-red-500/10 px-3 py-1.5 text-[12px] text-red-400">
-          {error}
-        </div>
-      )}
-      <ul className="flex flex-col gap-2">
-        {stashes.map((stash) => (
-          <ManagedStashCard
-            key={stash.id}
-            stash={stash}
-            rows={rows}
-            sessions={sessions}
-            onDelete={onDelete}
-            onUpdated={onUpdated}
-            copiedSlug={copiedSlug}
-            setCopiedSlug={setCopiedSlug}
-          />
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function ManagedStashCard({
-  stash,
-  rows,
-  sessions,
-  onDelete,
-  onUpdated,
-  copiedSlug,
-  setCopiedSlug,
-}: {
-  stash: WorkspaceStash;
-  rows: SelectableRow[];
-  sessions: SessionRow[];
-  onDelete: (stash: WorkspaceStash) => void;
-  onUpdated: (stash: WorkspaceStash) => void;
-  copiedSlug: string | null;
-  setCopiedSlug: (s: string | null) => void;
-}) {
-  const [members, setMembers] = useState<StashMember[]>([]);
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<UserSearchResult[]>([]);
-  const [permission, setPermission] = useState<StashMemberPermission>("read");
-  const [expanded, setExpanded] = useState(false);
-  const [itemsOpen, setItemsOpen] = useState(false);
-  const [itemSearch, setItemSearch] = useState("");
-  const [selectedItemKeys, setSelectedItemKeys] = useState<Set<string>>(new Set());
-  const [savingItems, setSavingItems] = useState(false);
-  const [loadingMembers, setLoadingMembers] = useState(false);
-  const [searching, setSearching] = useState(false);
-  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
-  const [memberError, setMemberError] = useState("");
-
-  const url = absoluteUrl(`/stashes/${stash.slug}`);
-  const isCopied = copiedSlug === stash.slug;
-  const isFork = Boolean(stash.forked_from_stash_id);
-  const canManageItems = !stash.is_external || isFork;
-  const kind = isFork ? "Fork" : "Native";
-  const itemLabels = useMemo(() => buildItemLabelMap(rows, sessions), [rows, sessions]);
-  const existingKeys = useMemo(() => new Set(stash.items.map(itemKey)), [stash.items]);
-  const addableItems = useMemo(() => {
-    const q = itemSearch.trim().toLowerCase();
-    const rowItems = rows
-      .filter((row) => !existingKeys.has(itemKey(row)))
-      .filter((row) => !q || `${row.label} ${row.sub}`.toLowerCase().includes(q))
-      .map((row) => ({
-        key: itemKey(row),
-        label: row.label,
-        sub: row.sub,
-        item: toStashItem(row),
-      }));
-    const sessionItems = sessions
-      .filter((session) => !existingKeys.has(itemKey({ object_type: "session", object_id: session.object_id })))
-      .filter((session) => !q || `${session.label} ${session.sub}`.toLowerCase().includes(q))
-      .map((session) => ({
-        key: itemKey({ object_type: "session", object_id: session.object_id }),
-        label: session.label,
-        sub: session.sub,
-        item: toStashItem(session),
-      }));
-    return [...sessionItems, ...rowItems].slice(0, 30);
-  }, [existingKeys, itemSearch, rows, sessions]);
-
-  const refreshMembers = useCallback(async () => {
-    setLoadingMembers(true);
-    setMemberError("");
-    try {
-      setMembers(await listStashMembers(stash.id));
-    } catch (e) {
-      setMemberError(e instanceof Error ? e.message : "Failed to load people");
-    } finally {
-      setLoadingMembers(false);
-    }
-  }, [stash.id]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    refreshMembers();
-  }, [expanded, refreshMembers]);
-
-  const onSearch = async () => {
-    const value = query.trim();
-    if (!value) {
-      setResults([]);
-      return;
-    }
-    setSearching(true);
-    setMemberError("");
-    try {
-      setResults(await searchUsers(value));
-    } catch (e) {
-      setMemberError(e instanceof Error ? e.message : "Search failed");
-    } finally {
-      setSearching(false);
-    }
-  };
-
-  const onAddMember = async (user: UserSearchResult) => {
-    setUpdatingUserId(user.id);
-    setMemberError("");
-    try {
-      const member = await addStashMember(stash.id, user.id, permission);
-      setMembers((current) => [
-        ...current.filter((item) => item.user_id !== member.user_id),
-        member,
-      ]);
-      setResults([]);
-      setQuery("");
-    } catch (e) {
-      setMemberError(e instanceof Error ? e.message : "Failed to invite person");
-    } finally {
-      setUpdatingUserId(null);
-    }
-  };
-
-  const onRemoveMember = async (member: StashMember) => {
-    setUpdatingUserId(member.user_id);
-    setMemberError("");
-    try {
-      await removeStashMember(stash.id, member.user_id);
-      setMembers((current) => current.filter((item) => item.user_id !== member.user_id));
-    } catch (e) {
-      setMemberError(e instanceof Error ? e.message : "Failed to remove person");
-    } finally {
-      setUpdatingUserId(null);
-    }
-  };
-
-  const saveItems = async (items: StashItemSpec[]) => {
-    setSavingItems(true);
-    setMemberError("");
-    try {
-      const updated = await updateStash(stash.id, { items: normalizeItems(items) });
-      setSelectedItemKeys(new Set());
-      onUpdated(updated);
-    } catch (e) {
-      setMemberError(e instanceof Error ? e.message : "Failed to update Stash items");
-    } finally {
-      setSavingItems(false);
-    }
-  };
-
-  const onRemoveItem = (key: string) => {
-    saveItems(stash.items.filter((item) => itemKey(item) !== key));
-  };
-
-  const onAddSelectedItems = () => {
-    const additions = addableItems
-      .filter((item) => selectedItemKeys.has(item.key))
-      .map((item) => item.item);
-    if (additions.length === 0) return;
-    saveItems([...stash.items, ...additions]);
-  };
-
-  return (
-    <li className="rounded-lg border border-border-subtle bg-surface px-3 py-2.5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-medium text-foreground">{stash.title}</div>
-          <div className="mt-0.5 text-[11px] text-muted">
-            {stash.items.length} item{stash.items.length === 1 ? "" : "s"} ·{" "}
-            {kind} ·{" "}
-            {stash.discoverable ? "Discover · " : ""}
-            {stash.view_count} view{stash.view_count === 1 ? "" : "s"}
-          </div>
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-1 block truncate font-mono text-[11px] text-[var(--color-brand-700)] hover:underline"
-          >
-            {url}
-          </a>
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <button
-            onClick={async () => {
-              await navigator.clipboard.writeText(url).catch(() => {});
-              setCopiedSlug(stash.slug);
-              setTimeout(() => setCopiedSlug(null), 1200);
-            }}
-            className="rounded-md border border-border-subtle px-2 py-1 text-[11px] hover:border-brand hover:text-brand"
-          >
-            {isCopied ? "Copied" : "Copy"}
-          </button>
-          <button
-            onClick={() => onDelete(stash)}
-            className="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-muted hover:border-red-400 hover:text-red-400"
-          >
-            {isFork ? "Delete fork" : "Revoke"}
-          </button>
-        </div>
-      </div>
-
-      {canManageItems && (
-        <>
-          <button
-            onClick={() => setItemsOpen((value) => !value)}
-            className="mt-3 flex w-full items-center justify-between border-t border-border-subtle pt-2 text-left text-[11px] font-medium text-foreground hover:text-brand"
-            aria-expanded={itemsOpen}
-          >
-            <span>
-              Items
-              <span className="ml-1 font-normal text-muted">{stash.items.length}</span>
-            </span>
-            <span className="text-muted">{itemsOpen ? "Hide" : "Edit"}</span>
-          </button>
-
-          {itemsOpen && (
-            <div className="pt-2">
-              {memberError && (
-                <div className="mb-2 rounded-md border border-red-300/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-400">
-                  {memberError}
-                </div>
-              )}
-              <div className="flex flex-col gap-1">
-                {stash.items.map((item) => {
-                  const key = itemKey(item);
-                  return (
-                    <div
-                      key={key}
-                      className="flex items-center justify-between gap-2 rounded-md px-2 py-1 hover:bg-raised"
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate text-[12px] text-foreground">
-                          {itemLabels.get(key) || item.label_override || item.object_id}
-                        </div>
-                        <div className="truncate text-[10.5px] text-muted">{item.object_type}</div>
-                      </div>
-                      <button
-                        onClick={() => onRemoveItem(key)}
-                        disabled={savingItems}
-                        className="shrink-0 rounded-md border border-border-subtle px-2 py-1 text-[11px] text-muted hover:border-red-400 hover:text-red-400 disabled:opacity-50"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-
-              <div className="mt-3 flex gap-1.5">
-                <input
-                  value={itemSearch}
-                  onChange={(e) => setItemSearch(e.target.value)}
-                  placeholder="Search items to add"
-                  className="min-w-0 flex-1 rounded-md border border-border-subtle bg-base px-2 py-1 text-[12px] outline-none focus:border-brand"
-                />
-                <button
-                  onClick={onAddSelectedItems}
-                  disabled={savingItems || selectedItemKeys.size === 0}
-                  className="rounded-md border border-border-subtle px-2 py-1 text-[11px] hover:border-brand hover:text-brand disabled:opacity-50"
-                >
-                  Add {selectedItemKeys.size || ""}
-                </button>
-              </div>
-
-              {addableItems.length > 0 && (
-                <div className="mt-2 max-h-44 overflow-y-auto">
-                  {addableItems.map((candidate) => (
-                    <label
-                      key={candidate.key}
-                      className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-raised"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedItemKeys.has(candidate.key)}
-                        onChange={() =>
-                          setSelectedItemKeys((current) => {
-                            const next = new Set(current);
-                            if (next.has(candidate.key)) next.delete(candidate.key);
-                            else next.add(candidate.key);
-                            return next;
-                          })
-                        }
-                        className="h-3.5 w-3.5 accent-[var(--color-brand-600)]"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-[12px] text-foreground">
-                          {candidate.label}
-                        </span>
-                        <span className="block truncate text-[10.5px] text-muted">
-                          {candidate.sub}
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </>
-      )}
-
-      <button
-        onClick={() => setExpanded((value) => !value)}
-        className="mt-3 flex w-full items-center justify-between border-t border-border-subtle pt-2 text-left text-[11px] font-medium text-foreground hover:text-brand"
-        aria-expanded={expanded}
-      >
-        <span>
-          People
-          <span className="ml-1 font-normal text-muted">
-            {expanded && loadingMembers ? "loading" : members.length}
-          </span>
-        </span>
-        <span className="text-muted">{expanded ? "Hide" : "Invite"}</span>
-      </button>
-
-      {expanded && (
-        <div className="pt-2">
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-[11px] text-muted">Invite by username</div>
-            <div className="flex shrink-0 items-center gap-1.5">
-              <select
-                value={permission}
-                onChange={(e) => setPermission(e.target.value as StashMemberPermission)}
-                className="h-7 rounded-md border border-border-subtle bg-base px-2 text-[11px] text-foreground"
-                aria-label={`Permission for ${stash.title}`}
-              >
-                <option value="read">Can view</option>
-                <option value="write">Can edit</option>
-                <option value="admin">Can manage</option>
-              </select>
-            </div>
-          </div>
-
-          <div className="mt-2 flex gap-1.5">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") onSearch();
-              }}
-              placeholder="Search people by username"
-              className="min-w-0 flex-1 rounded-md border border-border-subtle bg-base px-2 py-1 text-[12px] outline-none focus:border-brand"
-            />
-            <button
-              onClick={onSearch}
-              disabled={searching}
-              className="rounded-md border border-border-subtle px-2 py-1 text-[11px] hover:border-brand hover:text-brand disabled:opacity-50"
-            >
-              {searching ? "Searching" : "Search"}
-            </button>
-          </div>
-
-          {memberError && (
-            <div className="mt-2 rounded-md border border-red-300/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-400">
-              {memberError}
-            </div>
-          )}
-
-          {results.length > 0 && (
-            <div className="mt-2 flex flex-col gap-1">
-              {results.map((user) => (
-                <div
-                  key={user.id}
-                  className="flex items-center justify-between gap-2 rounded-md bg-raised px-2 py-1"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate text-[12px] text-foreground">
-                      {user.display_name || user.name}
-                    </div>
-                    <div className="truncate text-[10.5px] text-muted">@{user.name}</div>
-                  </div>
-                  <button
-                    onClick={() => onAddMember(user)}
-                    disabled={updatingUserId === user.id}
-                    className="shrink-0 rounded-md border border-border-subtle px-2 py-1 text-[11px] hover:border-brand hover:text-brand disabled:opacity-50"
-                  >
-                    Invite
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {members.length > 0 && (
-            <div className="mt-2 flex flex-col gap-1">
-              {members.map((member) => (
-                <div
-                  key={member.user_id}
-                  className="flex items-center justify-between gap-2 rounded-md px-2 py-1 hover:bg-raised"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate text-[12px] text-foreground">
-                      {member.display_name || member.name}
-                    </div>
-                    <div className="truncate text-[10.5px] text-muted">
-                      @{member.name} · {permissionLabel(member.permission)}
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => onRemoveMember(member)}
-                    disabled={updatingUserId === member.user_id}
-                    className="shrink-0 rounded-md border border-border-subtle px-2 py-1 text-[11px] text-muted hover:border-red-400 hover:text-red-400 disabled:opacity-50"
-                  >
-                    Remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </li>
-  );
-}
-
-function itemKey(item: Pick<StashItemSpec, "object_type" | "object_id">): string {
-  return `${item.object_type}:${item.object_id}`;
-}
-
-function toStashItem(row: SelectableRow | SessionRow): StashItemSpec {
-  if ("session_id" in row) {
-    return {
-      object_type: "session",
-      object_id: row.object_id,
-      label_override: row.label,
-    };
-  }
-  return {
-    object_type: row.object_type,
-    object_id: row.object_id,
-  };
-}
-
-function buildItemLabelMap(rows: SelectableRow[], sessions: SessionRow[]): Map<string, string> {
-  const labels = new Map<string, string>();
-  for (const row of rows) labels.set(itemKey(row), row.label);
-  for (const session of sessions) {
-    labels.set(itemKey({ object_type: "session", object_id: session.object_id }), session.label);
-  }
-  return labels;
-}
-
-function normalizeItems(items: StashItemSpec[]): StashItemSpec[] {
-  return items.map((item, position) => ({
-    object_type: item.object_type,
-    object_id: item.object_id,
-    position,
-    label_override: item.label_override ?? null,
-  }));
 }
 
 function GroupBlock({
@@ -1365,12 +773,6 @@ function titleCase(s: string): string {
 function absoluteUrl(path: string): string {
   if (typeof window === "undefined") return path;
   return `${window.location.origin}${path}`;
-}
-
-function permissionLabel(permission: StashMemberPermission): string {
-  if (permission === "admin") return "can manage";
-  if (permission === "write") return "can edit";
-  return "can view";
 }
 
 function modalTitle(initial: StashItemSpec[] | undefined, workspaceName: string | undefined) {

--- a/frontend/src/lib/shareModalContext.tsx
+++ b/frontend/src/lib/shareModalContext.tsx
@@ -15,7 +15,6 @@ export interface ShareModalOpenOptions {
   workspaceId: string;
   workspaceName?: string;
   initial?: StashItemSpec[];
-  tab?: "new" | "manage";
 }
 
 interface ShareModalState extends ShareModalOpenOptions {
@@ -47,7 +46,6 @@ export function ShareModalProvider({ children }: { children: ReactNode }) {
       workspaceId: opts.workspaceId,
       workspaceName: opts.workspaceName,
       initial: opts.initial,
-      tab: opts.tab ?? "new",
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- Removes the `Manage` tab from the Stash share modal so the v0 flow is create-only.
- Deletes the modal-only Stash management UI for copying/revoking links, editing items, and inviting members.
- Removes the `tab` option from the share modal context and updates callers to open the single create flow.

## Screenshot
![Create-only Stash share modal](https://gist.githubusercontent.com/henry-dowling/125262c13aca0a8d205e6af5b10464f9/raw/511296556ab6f71ac4e1b52be9a33f4857ae7f0b/stash-share-modal-create-only.svg)

## Validation
- `npm test`
- `npm run lint -- src/components/share/StashShareModal.tsx src/lib/shareModalContext.tsx src/components/AppSidebar.tsx 'src/app/workspaces/[workspaceId]/stashes/page.tsx' src/components/share/StashShareModal.test.tsx`
- `npm run build` (passes with existing Next.js multiple-lockfile warning)
- Playwright screenshot QA against local frontend with mocked API data: opened the Stashes page and verified the create modal renders without the Manage option.