### PR TITLE
Stash deep-links land in canonical viewers

### DIFF
--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -309,16 +309,19 @@ function StashPageBody({
             title="Files"
             items={[...(groups.folder ?? []), ...(groups.page ?? []), ...(groups.file ?? [])]}
             stashSlug={stash.slug}
+            workspaceId={stash.workspace_id}
           />
           <StashItemSection
             title="Sessions"
             items={groups.session ?? []}
             stashSlug={stash.slug}
+            workspaceId={stash.workspace_id}
           />
           <StashItemSection
             title="Tables"
             items={groups.table ?? []}
             stashSlug={stash.slug}
+            workspaceId={stash.workspace_id}
           />
           {items.length === 0 && (
             <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[13px] text-muted">
@@ -837,10 +840,12 @@ function StashItemSection({
   title,
   items,
   stashSlug,
+  workspaceId,
 }: {
   title: string;
   items: PublicStashItem[];
   stashSlug: string;
+  workspaceId: string;
 }) {
   if (items.length === 0) return null;
   return (
@@ -853,15 +858,15 @@ function StashItemSection({
       </div>
       <div className="flex flex-col gap-1">
         {items.map((item) => (
-          <StashItemRow key={`${item.object_type}-${item.object_id}`} item={item} stashSlug={stashSlug} />
+          <StashItemRow key={`${item.object_type}-${item.object_id}`} item={item} stashSlug={stashSlug} workspaceId={workspaceId} />
         ))}
       </div>
     </section>
   );
 }
 
-function StashItemRow({ item, stashSlug }: { item: PublicStashItem; stashSlug: string }) {
-  const href = hrefForItem(item, stashSlug);
+function StashItemRow({ item, stashSlug, workspaceId }: { item: PublicStashItem; stashSlug: string; workspaceId: string }) {
+  const href = hrefForItem(item, stashSlug, workspaceId);
   const sub = subtitleForItem(item);
   const tint = tintForKind(item.object_type);
 
@@ -897,18 +902,29 @@ function StashItemRow({ item, stashSlug }: { item: PublicStashItem; stashSlug: s
   );
 }
 
-// Stash-scoped item URLs. Every link goes through /stashes/{slug}/items
-// so the backend's stash readability check is the single gate. Items in a
-// public stash become reachable to anyone with the link; items in a
-// private or workspace stash stay gated to the people who can read that
-// stash — regardless of whether the viewer is in the owning workspace.
-function hrefForItem(item: PublicStashItem, stashSlug: string): string | null {
+// Stash-scoped item URLs. Files and tables route to their canonical
+// viewer pages with a `?stash=<slug>` hint so the viewer fetches via
+// the public stash payload (no workspace membership required). Folders,
+// pages, and sessions use the stash-scoped fallback viewer which
+// renders the inlined content from the stash payload.
+//
+// Either way the only authorization is the backend's stash readability
+// check inside getPublicStash — workspace-scoped endpoints stay strict.
+function hrefForItem(
+  item: PublicStashItem,
+  stashSlug: string,
+  workspaceId: string
+): string | null {
+  if (item.object_type === "file") {
+    return `/workspaces/${workspaceId}/f/${item.object_id}?stash=${encodeURIComponent(stashSlug)}`;
+  }
+  if (item.object_type === "table") {
+    return `/tables/${item.object_id}?stash=${encodeURIComponent(stashSlug)}&workspaceId=${workspaceId}`;
+  }
   if (
     item.object_type === "page" ||
     item.object_type === "folder" ||
-    item.object_type === "file" ||
-    item.object_type === "session" ||
-    item.object_type === "table"
+    item.object_type === "session"
   ) {
     return `/stashes/${stashSlug}/items/${item.object_type}/${item.object_id}`;
   }

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -305,21 +305,24 @@ function StashPageBody({
         {/* Compact item lists by kind. Items deep-link to the editor /
             viewer in the owning workspace — no inline rendering. */}
         <div className="mt-6 flex flex-col gap-6">
+          {/* Two high-level taxonomies: Files (folders + pages + files +
+              tables — anything you could drop into Drive) and Sessions
+              (agent transcripts). Tables are a structured kind of file,
+              so they live under Files rather than as a separate section. */}
           <StashItemSection
             title="Files"
-            items={[...(groups.folder ?? []), ...(groups.page ?? []), ...(groups.file ?? [])]}
+            items={[
+              ...(groups.folder ?? []),
+              ...(groups.page ?? []),
+              ...(groups.file ?? []),
+              ...(groups.table ?? []),
+            ]}
             stashSlug={stash.slug}
             workspaceId={stash.workspace_id}
           />
           <StashItemSection
             title="Sessions"
             items={groups.session ?? []}
-            stashSlug={stash.slug}
-            workspaceId={stash.workspace_id}
-          />
-          <StashItemSection
-            title="Tables"
-            items={groups.table ?? []}
             stashSlug={stash.slug}
             workspaceId={stash.workspace_id}
           />

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../../hooks/useAuth";
 import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import { useShareModal } from "../../../lib/shareModalContext";
 import {
+  getPublicStash,
   getTable, updateTable,
   deleteTable, addTableColumn, updateTableColumn,
   deleteTableColumn, reorderTableColumns, listTableRows, searchTableRows,
@@ -17,6 +18,7 @@ import {
   setTableEmbeddingConfig, backfillTableEmbeddings,
 } from "../../../lib/api";
 import type { Table, TableColumn, TableRow, TableView } from "../../../lib/types";
+import Link from "next/link";
 
 // --- Constants ---
 const TYPE_ICONS: Record<string, string> = {
@@ -46,6 +48,12 @@ function TableEditorPageInner() {
   const router = useRouter();
   const tableId = params.tableId as string;
   const urlWorkspaceId = searchParams.get("workspaceId");
+  // Stash mode: `?stash=<slug>` switches the data source to the public
+  // stash payload (which the backend gates by stash readability). All
+  // mutating UI is hidden in this mode.
+  const stashSlug = searchParams.get("stash");
+  const readOnly = !!stashSlug;
+  const [stashTitle, setStashTitle] = useState<string | null>(null);
   const { user, loading, logout } = useAuth();
 
   // Core state
@@ -133,6 +141,50 @@ function TableEditorPageInner() {
   // --- Data Loading ---
   const loadTable = useCallback(async () => {
     try {
+      if (stashSlug) {
+        // Synthesize a Table from the stash's inlined item content. The
+        // backend serializes columns + the first 500 rows when the stash
+        // is readable; that's the source of truth in stash mode.
+        const stash = await getPublicStash(stashSlug);
+        setStashTitle(stash.stash.title);
+        const item = stash.items.find(
+          (it) => it.object_type === "table" && it.object_id === tableId
+        );
+        if (!item || !item.inline) {
+          setError("Table isn't in this Stash.");
+          return;
+        }
+        const inline = item.inline as {
+          description?: string;
+          columns?: TableColumn[];
+          rows?: { data: Record<string, unknown>; row_order?: number }[];
+        };
+        const synth: Table = {
+          id: tableId,
+          workspace_id: stash.stash.workspace_id,
+          name: item.label || "Table",
+          description: inline.description ?? "",
+          columns: (inline.columns ?? []).map((c) => ({ ...c })),
+          views: [],
+          created_at: "",
+          updated_at: "",
+        } as unknown as Table;
+        setResolvedWorkspaceId(stash.stash.workspace_id);
+        setTable(synth);
+        const synthRows: TableRow[] = (inline.rows ?? []).map((r, i) => ({
+          id: `stash-${i}`,
+          table_id: tableId,
+          data: r.data,
+          row_order: r.row_order ?? i,
+          created_at: "",
+          updated_at: "",
+          created_by: "",
+        } as unknown as TableRow));
+        setRows(synthRows);
+        setTotalCount(synthRows.length);
+        setOffset(synthRows.length);
+        return;
+      }
       if (resolvedWorkspaceId) {
         setTable(await getTable(resolvedWorkspaceId, tableId));
         return;
@@ -150,7 +202,7 @@ function TableEditorPageInner() {
         }
       }
     } catch { setError("Table not found"); }
-  }, [tableId, resolvedWorkspaceId]);
+  }, [tableId, resolvedWorkspaceId, stashSlug]);
 
   const buildRowParams = useCallback((pageOffset: number) => {
     const p: { sort_by?: string; sort_order?: string; limit?: number; offset?: number; filters?: object[] } = {
@@ -162,6 +214,10 @@ function TableEditorPageInner() {
   }, [sortBy, sortOrder, filters]);
 
   const loadRows = useCallback(async () => {
+    // In stash mode the rows are already populated inline by loadTable
+    // (the backend caps the inline payload at 500 rows). Search/filter
+    // happen client-side from that snapshot.
+    if (readOnly) return;
     try {
       if (searchQuery) {
         const res = await searchTableRows(wsId, tableId, searchQuery, { limit: PAGE_SIZE, offset: 0 });
@@ -171,7 +227,7 @@ function TableEditorPageInner() {
         setRows(res?.rows ?? []); setTotalCount(res?.total_count ?? 0); setOffset(res?.rows?.length ?? 0);
       }
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to load rows"); }
-  }, [tableId, wsId, buildRowParams, searchQuery]);
+  }, [tableId, wsId, buildRowParams, searchQuery, readOnly]);
 
   const loadMore = useCallback(async () => {
     if (loadingMore || !hasMore) return;
@@ -188,15 +244,17 @@ function TableEditorPageInner() {
   }, [tableId, wsId, offset, loadingMore, hasMore, buildRowParams, searchQuery]);
 
   const loadSummary = useCallback(async () => {
-    if (!showSummary) return;
+    if (!showSummary || readOnly) return;
     try {
       const s = await summarizeTableRows(wsId, tableId, filters.length > 0 ? filters : undefined);
       setSummary(s);
     } catch { /* ignore */ }
-  }, [tableId, wsId, filters, showSummary]);
+  }, [tableId, wsId, filters, showSummary, readOnly]);
 
-  useEffect(() => { if (user) loadTable(); }, [user, loadTable]);
-  useEffect(() => { if (user && table) loadRows(); }, [user, table, loadRows]);
+  // Stash mode is anonymous-readable, so load eagerly. Workspace mode
+  // waits for auth before hitting workspace-scoped endpoints.
+  useEffect(() => { if (readOnly || user) loadTable(); }, [readOnly, user, loadTable]);
+  useEffect(() => { if ((readOnly || user) && table) loadRows(); }, [readOnly, user, table, loadRows]);
   useEffect(() => { if (user && table) loadSummary(); }, [user, table, loadSummary]);
 
   // Initialize embedding state from table config
@@ -318,6 +376,7 @@ function TableEditorPageInner() {
 
   // --- Cell editing ---
   const startEditing = (rowId: string, colId: string, currentValue: unknown) => {
+    if (readOnly) return;
     setEditingCell({ rowId, colId }); setCellValue(currentValue != null ? String(currentValue) : "");
   };
   const commitEdit = async (nextValue = cellValue) => {
@@ -446,9 +505,11 @@ function TableEditorPageInner() {
     return "";
   };
 
-  useEffect(() => { if (!loading && !user) router.push("/login"); }, [user, loading, router]);
-  if (loading) return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
-  if (!user) return null;
+  // Stash-scoped readers can be anonymous when the stash is public; only
+  // redirect to /login in workspace mode.
+  useEffect(() => { if (!readOnly && !loading && !user) router.push("/login"); }, [readOnly, user, loading, router]);
+  if (loading && !readOnly) return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
+  if (!user && !readOnly) return null;
 
   // --- Render row ---
   const renderRow = (row: TableRow, idx: number) => (
@@ -491,23 +552,35 @@ function TableEditorPageInner() {
       })}
       <td className="px-1 py-0" />
       <td className="px-1 py-0 whitespace-nowrap">
-        <button onClick={() => handleDuplicateRow(row.id)} className="text-xs text-muted/50 hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Duplicate">\u2398</button>
-        <button onClick={() => handleDeleteRow(row.id)} className="text-xs text-red-400/50 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Delete">&times;</button>
+        {!readOnly && (
+          <>
+            <button onClick={() => handleDuplicateRow(row.id)} className="text-xs text-muted/50 hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Duplicate">\u2398</button>
+            <button onClick={() => handleDeleteRow(row.id)} className="text-xs text-red-400/50 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Delete">&times;</button>
+          </>
+        )}
       </td>
     </tr>
   );
 
-  return (
-    <AppShell user={user} onLogout={logout}>
+  const tableContent = (
       <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
         {/* Files / Table context bar */}
         <div className="flex items-center gap-0 px-4 border-b border-border bg-surface flex-shrink-0">
-          <button
-            onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
-            className="px-4 py-2.5 text-sm font-medium transition-colors text-dim hover:text-foreground"
-          >
-            Files
-          </button>
+          {readOnly && stashSlug ? (
+            <Link
+              href={`/stashes/${stashSlug}`}
+              className="px-4 py-2.5 text-sm font-medium transition-colors text-dim hover:text-foreground"
+            >
+              &larr; {stashTitle ?? "Stash"}
+            </Link>
+          ) : (
+            <button
+              onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
+              className="px-4 py-2.5 text-sm font-medium transition-colors text-dim hover:text-foreground"
+            >
+              Files
+            </button>
+          )}
           <button
             className="px-4 py-2.5 text-sm font-medium transition-colors relative text-brand"
           >
@@ -517,14 +590,18 @@ function TableEditorPageInner() {
         </div>
         {/* Toolbar */}
         <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface flex-shrink-0 flex-wrap">
-          <button
-            onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
-            className="text-muted hover:text-foreground text-sm"
-            aria-label="Back to Files"
-          >
-            &larr;
-          </button>
-          {editingName ? (
+          {!readOnly && (
+            <button
+              onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
+              className="text-muted hover:text-foreground text-sm"
+              aria-label="Back to Files"
+            >
+              &larr;
+            </button>
+          )}
+          {readOnly ? (
+            <h1 className="text-lg font-bold font-display text-foreground">{table?.name || "Loading..."}</h1>
+          ) : editingName ? (
             <input value={nameInput} onChange={(e) => setNameInput(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") handleRename(); if (e.key === "Escape") setEditingName(false); }} onBlur={handleRename} className="text-lg font-bold font-display bg-transparent border-b border-brand outline-none text-foreground" autoFocus />
           ) : (
             <h1 onClick={() => { setEditingName(true); setNameInput(table?.name || ""); }} className="text-lg font-bold font-display text-foreground cursor-pointer hover:text-brand transition-colors">{table?.name || "Loading..."}</h1>
@@ -537,8 +614,8 @@ function TableEditorPageInner() {
           {table && <>
             <span className="text-[11px] font-mono text-muted">{visibleColumns.length}/{sortedColumns.length} cols</span>
             <span className="text-[11px] font-mono text-muted">{totalCount} rows</span>
-            <button onClick={addFilter} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Filter</button>
-            {(filters.length > 0 || sortBy) && <button onClick={handleSaveLayout} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Save layout</button>}
+            {!readOnly && <button onClick={addFilter} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Filter</button>}
+            {!readOnly && (filters.length > 0 || sortBy) && <button onClick={handleSaveLayout} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Save layout</button>}
             {/* Group by */}
             <CustomSelect
               value={groupByCol}
@@ -552,15 +629,15 @@ function TableEditorPageInner() {
               className="min-w-[132px] rounded border border-border bg-raised px-2 py-1 text-xs text-foreground"
               menuClassName="text-xs"
             />
-            <button onClick={() => setShowSummary((p) => !p)} className={`text-xs px-2 py-1 rounded ${showSummary ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Summary</button>
-            {wsId && <button onClick={() => setShowEmbeddings((p) => !p)} className={`text-xs px-2 py-1 rounded ${showEmbeddings ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Embeddings</button>}
+            {!readOnly && <button onClick={() => setShowSummary((p) => !p)} className={`text-xs px-2 py-1 rounded ${showSummary ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Summary</button>}
+            {!readOnly && wsId && <button onClick={() => setShowEmbeddings((p) => !p)} className={`text-xs px-2 py-1 rounded ${showEmbeddings ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Embeddings</button>}
             <button onClick={() => setShowColVisibility((p) => !p)} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Columns</button>
             <button onClick={() => setWrapCells((p) => !p)} className={`text-xs px-2 py-1 rounded ${wrapCells ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>{wrapCells ? "Wrap" : "Compact"}</button>
-            <button onClick={handleCsvExport} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Export</button>
-            <button onClick={() => fileInputRef.current?.click()} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>
-            <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleCsvImport(e.target.files[0]); e.target.value = ""; }} />
-            {selectedRows.size > 0 && <button onClick={handleBulkDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}
-            {wsId && table && (
+            {!readOnly && <button onClick={handleCsvExport} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Export</button>}
+            {!readOnly && <button onClick={() => fileInputRef.current?.click()} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>}
+            {!readOnly && <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleCsvImport(e.target.files[0]); e.target.value = ""; }} />}
+            {!readOnly && selectedRows.size > 0 && <button onClick={handleBulkDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}
+            {!readOnly && wsId && table && (
               <button
                 onClick={() =>
                   shareModal.open({
@@ -573,7 +650,12 @@ function TableEditorPageInner() {
                 Share
               </button>
             )}
-            <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>
+            {!readOnly && <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>}
+            {readOnly && (
+              <span className="rounded-md bg-surface px-2 py-1 text-[10.5px] font-medium uppercase tracking-wide text-muted">
+                read-only &middot; via Stash
+              </span>
+            )}
           </>}
         </div>
 
@@ -702,7 +784,16 @@ function TableEditorPageInner() {
                   <th className="w-8 px-1 py-2 text-center border-r border-border sticky left-0 z-20 bg-surface"><input type="checkbox" checked={selectedRows.size === rows.length && rows.length > 0} onChange={toggleSelectAll} className="accent-brand" /></th>
                   <th className="w-10 px-2 py-2 text-[10px] font-medium text-muted text-center border-r border-border sticky left-8 z-20 bg-surface shadow-[2px_0_4px_-2px_rgba(0,0,0,0.1)]">#</th>
                   {visibleColumns.map((col) => (
-                    <th key={col.id} className={`px-3 py-2 text-left text-xs font-medium text-muted border-r border-border min-w-[140px] select-none cursor-pointer hover:bg-raised transition-colors ${dragCol === col.id ? "opacity-50" : ""}`} draggable onDragStart={() => setDragCol(col.id)} onDragOver={(e) => e.preventDefault()} onDrop={() => handleColumnDrop(col.id)} onDragEnd={() => setDragCol(null)} onContextMenu={(e) => { e.preventDefault(); setColMenu({ colId: col.id, x: e.clientX, y: e.clientY }); }}>
+                    <th
+                      key={col.id}
+                      className={`px-3 py-2 text-left text-xs font-medium text-muted border-r border-border min-w-[140px] select-none cursor-pointer hover:bg-raised transition-colors ${dragCol === col.id ? "opacity-50" : ""}`}
+                      draggable={!readOnly}
+                      onDragStart={() => { if (!readOnly) setDragCol(col.id); }}
+                      onDragOver={(e) => { if (!readOnly) e.preventDefault(); }}
+                      onDrop={() => { if (!readOnly) handleColumnDrop(col.id); }}
+                      onDragEnd={() => setDragCol(null)}
+                      onContextMenu={(e) => { if (readOnly) return; e.preventDefault(); setColMenu({ colId: col.id, x: e.clientX, y: e.clientY }); }}
+                    >
                       <span className="flex items-center gap-1.5" onClick={() => handleSort(col.id)}>
                         <span className="text-[10px] text-muted/60 font-mono">{TYPE_ICONS[col.type] || "?"}</span>
                         {col.name}
@@ -710,7 +801,9 @@ function TableEditorPageInner() {
                       </span>
                     </th>
                   ))}
-                  <th className="w-10 px-2 py-2 border-r border-border"><button onClick={() => setShowAddCol(true)} className="w-6 h-6 rounded bg-raised hover:bg-brand/15 text-muted hover:text-brand text-sm font-bold">+</button></th>
+                  <th className="w-10 px-2 py-2 border-r border-border">
+                    {!readOnly && <button onClick={() => setShowAddCol(true)} className="w-6 h-6 rounded bg-raised hover:bg-brand/15 text-muted hover:text-brand text-sm font-bold">+</button>}
+                  </th>
                   <th className="w-16" />
                 </tr>
               </thead>
@@ -762,7 +855,7 @@ function TableEditorPageInner() {
             </table>
 
             {/* Add row + infinite scroll sentinel */}
-            <button onClick={handleAddRow} className="w-full py-2 text-sm text-muted hover:text-foreground hover:bg-raised border-b border-border/50 transition-colors text-left px-4">+ New row</button>
+            {!readOnly && <button onClick={handleAddRow} className="w-full py-2 text-sm text-muted hover:text-foreground hover:bg-raised border-b border-border/50 transition-colors text-left px-4">+ New row</button>}
             {hasMore && <div ref={sentinelRef} className="py-4 text-center text-xs text-muted">{loadingMore ? "Loading..." : `${totalCount - offset} more rows`}</div>}
           </div>
         )}
@@ -856,6 +949,17 @@ function TableEditorPageInner() {
           </div>
         )}
       </div>
+  );
+
+  // Anonymous stash viewers don't have a workspace context to power the
+  // sidebar, so they get the bare table. Signed-in users see the full
+  // AppShell either way.
+  if (!user) {
+    return <main className="flex min-h-screen flex-col bg-background">{tableContent}</main>;
+  }
+  return (
+    <AppShell user={user} onLogout={logout}>
+      {tableContent}
     </AppShell>
   );
 }

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
@@ -9,6 +10,7 @@ import { useAuth } from "../../../../../hooks/useAuth";
 import {
   getFile,
   getFolderContents,
+  getPublicStash,
   ingestCsvFile,
   updateFile,
   type FolderBreadcrumb,
@@ -36,30 +38,94 @@ function isText(ct: string) {
 }
 
 export default function FileViewerPage() {
+  return (
+    <Suspense fallback={<div className="flex h-screen items-center justify-center text-muted">Loading…</div>}>
+      <FileViewerPageInner />
+    </Suspense>
+  );
+}
+
+function FileViewerPageInner() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const workspaceId = params.workspaceId as string;
   const fileId = params.fileId as string;
-  const { user, loading } = useAuth();
+  // When ?stash=<slug> is present, the viewer reads through the public
+  // stash payload instead of the workspace endpoint. This lets non-members
+  // of the owning workspace open files that the stash owner has shared,
+  // with the stash's permission gate the only authorization check.
+  const stashSlug = searchParams.get("stash");
+  const readOnly = !!stashSlug;
+  const { user, loading, logout: _logout } = useAuth();
+  // logout isn't used here; kept for parity with other workspace pages.
+  void _logout;
 
   const [file, setFile] = useState<FileInfo | null>(null);
   const [folderChain, setFolderChain] = useState<FolderBreadcrumb[]>([]);
   const [textBody, setTextBody] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [stashTitle, setStashTitle] = useState<string | null>(null);
 
   useBreadcrumbs(
-    [
-      ...folderChain.map((c) => ({
-        label: c.name,
-        href: `/workspaces/${workspaceId}/folders/${c.id}`,
-      })),
-      { label: file ? file.name : "File" },
-    ],
-    `${workspaceId}/file/${fileId}/${file?.name ?? ""}/${folderChain.map((c) => c.id).join(",")}`
+    readOnly
+      ? [
+          { label: "Stashes", href: "/stashes" },
+          { label: stashTitle ?? "Stash", href: stashSlug ? `/stashes/${stashSlug}` : "/stashes" },
+          { label: file ? file.name : "File" },
+        ]
+      : [
+          ...folderChain.map((c) => ({
+            label: c.name,
+            href: `/workspaces/${workspaceId}/folders/${c.id}`,
+          })),
+          { label: file ? file.name : "File" },
+        ],
+    `${workspaceId}/file/${fileId}/${file?.name ?? ""}/${folderChain.map((c) => c.id).join(",")}/${stashSlug ?? ""}`
   );
 
   const load = useCallback(async () => {
     try {
+      if (stashSlug) {
+        // Stash-scoped read. The backend inlines the file's metadata + a
+        // signed download URL when the stash is readable, so we synthesize
+        // a FileInfo from that and skip the workspace endpoint entirely.
+        const stash = await getPublicStash(stashSlug);
+        setStashTitle(stash.stash.title);
+        const item = stash.items.find(
+          (it) => it.object_type === "file" && it.object_id === fileId
+        );
+        if (!item || !item.inline) {
+          setError("File isn't in this Stash.");
+          return;
+        }
+        const inline = item.inline as {
+          name?: string;
+          content_type?: string;
+          size_bytes?: number;
+          url?: string;
+          created_at?: string;
+        };
+        const synth: FileInfo = {
+          id: fileId,
+          workspace_id: stash.stash.workspace_id,
+          folder_id: null,
+          name: inline.name ?? item.label,
+          content_type: inline.content_type ?? "",
+          size_bytes: inline.size_bytes ?? 0,
+          url: inline.url ?? "",
+          uploaded_by: "",
+          created_at: inline.created_at ?? "",
+        };
+        setFile(synth);
+        setFolderChain([]);
+        if (synth.url && (isText(synth.content_type) || isMarkdown(synth.content_type, synth.name))) {
+          const res = await fetch(synth.url);
+          if (res.ok) setTextBody(await res.text());
+        }
+        return;
+      }
+
       const f = await getFile(workspaceId, fileId);
       setFile(f);
       if (f.folder_id) {
@@ -96,25 +162,41 @@ export default function FileViewerPage() {
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load file");
     }
-  }, [workspaceId, fileId, router]);
+  }, [workspaceId, fileId, router, stashSlug]);
 
   useEffect(() => {
-    if (user) load();
-  }, [user, load]);
+    // Stash mode is anonymous-readable, so load eagerly. Workspace mode
+    // waits for the auth check before hitting the workspace endpoint.
+    if (readOnly || user) load();
+  }, [readOnly, user, load]);
 
   useEffect(() => {
-    if (!loading && !user) router.push("/login");
-  }, [user, loading, router]);
+    // Only redirect to login in workspace mode. Stash-scoped readers can
+    // be anonymous when the stash is public.
+    if (!readOnly && !loading && !user) router.push("/login");
+  }, [readOnly, user, loading, router]);
 
-  if (loading)
+  if (loading && !readOnly)
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
-  if (!user) return null;
+  if (!user && !readOnly) return null;
 
   return (
     <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-        <div className="flex items-center justify-between border-b border-border px-5 py-2.5 text-[13px]">
-          <div className="flex items-center gap-2">
-            {file ? (
+      <div className="flex items-center justify-between border-b border-border px-5 py-2.5 text-[13px]">
+        <div className="flex min-w-0 items-center gap-2">
+          {readOnly && stashSlug && (
+            <Link
+              href={`/stashes/${stashSlug}`}
+              className="text-muted hover:text-foreground"
+              title={`Back to ${stashTitle ?? "Stash"}`}
+            >
+              ←
+            </Link>
+          )}
+          {file ? (
+            readOnly ? (
+              <span className="font-mono font-medium text-foreground truncate">{file.name}</span>
+            ) : (
               <EditableTitle
                 value={file.name}
                 className="font-mono font-medium text-foreground"
@@ -124,42 +206,47 @@ export default function FileViewerPage() {
                   return updated.name;
                 }}
               />
-            ) : null}
-            {file && (
-              <span className="text-muted">
-                {file.content_type} · {formatBytes(file.size_bytes)}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            {/* File sharing now happens through the workspace Share button. */}
-            {file?.url && (
-              <a
-                href={file.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                download={file.name}
-                className="rounded-md p-1.5 text-muted hover:bg-raised"
-                title="Download"
-              >
-                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
-                </svg>
-              </a>
-            )}
-          </div>
+            )
+          ) : null}
+          {file && (
+            <span className="text-muted">
+              {file.content_type} · {formatBytes(file.size_bytes)}
+            </span>
+          )}
         </div>
-
-        {error && (
-          <div className="border-b border-red-300/40 bg-red-500/10 px-5 py-2 text-[13px] text-red-500">
-            {error}
-          </div>
-        )}
-
-        <div className="flex-1 overflow-auto bg-base scroll-thin">
-          {file && <FileBody file={file} text={textBody} />}
+        <div className="flex items-center gap-1">
+          {readOnly && (
+            <span className="rounded-md bg-surface px-2 py-1 text-[10.5px] font-medium uppercase tracking-wide text-muted">
+              read-only · via Stash
+            </span>
+          )}
+          {file?.url && (
+            <a
+              href={file.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              download={file.name}
+              className="rounded-md p-1.5 text-muted hover:bg-raised"
+              title="Download"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
+              </svg>
+            </a>
+          )}
         </div>
       </div>
+
+      {error && (
+        <div className="border-b border-red-300/40 bg-red-500/10 px-5 py-2 text-[13px] text-red-500">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto bg-base scroll-thin">
+        {file && <FileBody file={file} text={textBody} />}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

When you click a table or file inside a public Stash, you now get the **real** viewer — full table grid (search, group-by, columns, wrap, sticky row numbers, monospace cells) or the full file viewer (iframe PDF, image, html, markdown, text) — instead of the stripped-down read-only stub from the previous PR. Mutating affordances are hidden under a `readOnly` flag, but everything else looks and feels identical to the workspace experience.

### Data model
Both viewers detect `?stash=<slug>` in the URL and switch their read path to `getPublicStash(slug)` — the same endpoint the stash detail page uses. That endpoint is gated by stash readability (public → anyone, workspace → members, private → explicit stash members) and only returns the items inside that stash. **No workspace-scoped endpoints are relaxed.** A non-member of the owning workspace can read a public stash's items via the new path; private/workspace items stay gated as before.

### File viewer (`/workspaces/[ws]/f/[id]?stash=<slug>`)
- Reads file metadata + download URL from the stash payload's inline `file` object
- Hides `EditableTitle` rename
- Shows a "← Stash" back link in the chrome
- Allows anonymous users (no `/login` redirect in stash mode)
- Iframe / image / markdown / text bodies all unchanged

### Table viewer (`/tables/[id]?stash=<slug>&workspaceId=<ws>`)
- Reads columns + rows from the stash payload's inline `table` object (capped at 500 rows by the backend serializer — same as the embed view)
- Renders the full canonical grid: sticky checkboxes + row numbers + monospace cells + group-by + summary footer + saved layouts
- Hides mutators: rename, filter, save layout, summary, embeddings, export, import, share, delete, add column, add row, dup/delete row, context menu, cell edit
- Keeps reads/UI: search, group-by, column visibility, wrap toggle, sort
- Allows anonymous users (no `/login` redirect, no AppShell when there's no user)

### Routes
`hrefForItem` in `StashPageClient.tsx`:
- `file` → `/workspaces/{ws}/f/{id}?stash={slug}`
- `table` → `/tables/{id}?stash={slug}&workspaceId={ws}`
- `page` / `folder` / `session` → `/stashes/{slug}/items/{type}/{id}` (fallback viewer kept; can be migrated to canonical in a follow-up)

## Test plan

- [ ] As `sam` (non-member of the owning workspace), open the demo stash and click the table → canonical grid renders with read-only chip, no edit buttons.
- [ ] Same path for the PDF → iframe renders, download button works.
- [ ] As `screenshotbot` (the owner), visit the canonical table without `?stash` → full editing UI is back.
- [ ] Anonymous (signed-out) viewer hits the public stash URL → table + file viewers render without the sidebar, no login redirect.
- [ ] Private/workspace stash — items only reachable via the stash for users who can read the stash; no leak across stashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)