### PR TITLE
[codex] Remove stash visibility badge

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -623,25 +623,6 @@ details > summary::-webkit-details-marker {
 .tag-warning { background: rgba(234,179,8,0.18); color: #854D0E; }
 .tag-muted { background: var(--bg-raised); color: var(--text-dim); }
 
-/* Stash visibility chip */
-.stash-chip {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 11.5px;
-  border: 1px solid #FED7AA;
-  background: #FFF7ED;
-  color: #C2410C;
-  font-weight: 500;
-}
-.stash-chip .dot {
-  width: 6px; height: 6px; border-radius: 999px; background: #F97316;
-}
-.stash-chip.private { border-color: #E5E7EB; background: #F9FAFB; color: #4B5563; }
-.stash-chip.private .dot { background: #9CA3AF; }
-.stash-chip.public { border-color: #BBF7D0; background: #F0FDF4; color: #15803D; }
-.stash-chip.public .dot { background: #22C55E; }
-
 /* Soft brand-gradient banner — used at top of pages */
 .brand-banner {
   height: 56px;

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -6,6 +6,7 @@ import {
   getActivityTimeline,
   getEmbeddingProjection,
   getPublicStash,
+  type PublicStashDetail,
 } from "../../../lib/api";
 
 const authState = vi.hoisted(() => ({
@@ -79,6 +80,36 @@ vi.mock("./AddToWorkspaceButton", () => ({
   default: () => <button type="button">Add to workspace</button>,
 }));
 
+function stashDetail(
+  stash: Partial<PublicStashDetail["stash"]> = {}
+): PublicStashDetail {
+  return {
+    stash: {
+      id: "stash-1",
+      workspace_id: "workspace-1",
+      slug: "shared-stash",
+      title: "Shared Stash",
+      description: "",
+      owner_id: "user-1",
+      access: "public",
+      discoverable: false,
+      cover_image_url: null,
+      icon_url: null,
+      view_count: 0,
+      items: [],
+      is_external: false,
+      added_to_workspace_id: null,
+      forked_from_stash_id: null,
+      created_at: "2026-05-11T00:00:00Z",
+      updated_at: "2026-05-11T00:00:00Z",
+      ...stash,
+    },
+    workspace_name: "Demo Workspace",
+    items: [],
+    can_write: false,
+  };
+}
+
 describe("StashPageClient sharing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -104,30 +135,7 @@ describe("StashPageClient sharing", () => {
       stats: { total_embeddings: 0, projected: 0 },
       cached: false,
     });
-    vi.mocked(getPublicStash).mockResolvedValue({
-      stash: {
-        id: "stash-1",
-        workspace_id: "workspace-1",
-        slug: "shared-stash",
-        title: "Shared Stash",
-        description: "",
-        owner_id: "user-1",
-        access: "public",
-        discoverable: false,
-        cover_image_url: null,
-        icon_url: null,
-        view_count: 0,
-        items: [],
-        is_external: false,
-        added_to_workspace_id: null,
-        forked_from_stash_id: null,
-        created_at: "2026-05-11T00:00:00Z",
-        updated_at: "2026-05-11T00:00:00Z",
-      },
-      workspace_name: "Demo Workspace",
-      items: [],
-      can_write: false,
-    });
+    vi.mocked(getPublicStash).mockResolvedValue(stashDetail());
   });
 
   afterEach(() => {
@@ -151,5 +159,16 @@ describe("StashPageClient sharing", () => {
       )
     );
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("does not render stash access as a title badge", async () => {
+    vi.mocked(getPublicStash).mockResolvedValueOnce(stashDetail({ access: "workspace" }));
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    const title = await screen.findByRole("heading", { name: "Shared Stash" });
+
+    expect(title).toHaveTextContent("Shared Stash");
+    expect(title).not.toHaveTextContent("workspace");
   });
 });

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -194,8 +194,6 @@ function StashPageBody({
     };
   }, [stash.workspace_id]);
 
-  const visibility: "public" | "private" | "workspace" = stash.access;
-  const visClass = visibility === "public" ? "public" : visibility === "private" ? "private" : "";
   const cover = stash.cover_image_url
     ? { backgroundImage: `url(${stash.cover_image_url})` }
     : { backgroundImage: COVER_GRADIENTS[coverIndexFor(stash.id)] };
@@ -232,12 +230,8 @@ function StashPageBody({
               onChanged={onRefresh}
             />
             <div className="min-w-0">
-              <h1 className="m-0 flex min-w-0 items-center gap-2 truncate font-display text-[20px] font-bold leading-tight tracking-[-0.015em] text-foreground">
-                <span className="truncate">{stash.title}</span>
-                <span className={`stash-chip ${visClass}`.trim()}>
-                  <span className="dot" />
-                  {visibility}
-                </span>
+              <h1 className="m-0 truncate font-display text-[20px] font-bold leading-tight tracking-[-0.015em] text-foreground">
+                {stash.title}
               </h1>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-muted">
                 <span>


### PR DESCRIPTION
## Summary
- Removed the access visibility pill from the public stash detail title.
- Deleted the now-unused `.stash-chip` CSS.
- Added a regression test that keeps `workspace` access out of the title text.

## Validation
- `npm test -- StashPageClient.test.tsx`
- `npm run lint`
- Playwright browser check against `/stashes/shared-stash`: heading text is only the stash title and `.stash-chip` count is `0`.

## Screenshots
- Product screenshot posted in the PR thread.