### PR TITLE
[codex] Add Stash-level sharing

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # --- Users ---
 
@@ -124,10 +124,10 @@ class StashCreateRequest(BaseModel):
 
 
 class StashUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     title: str | None = Field(None, min_length=1, max_length=160)
     description: str | None = Field(None, max_length=2000)
-    access: str | None = Field(None, pattern=r"^(workspace|private|public)$")
-    discoverable: bool | None = None
     cover_image_url: str | None = None
     icon_url: str | None = None
     items: list[StashItem] | None = None
@@ -157,11 +157,6 @@ class StashListResponse(BaseModel):
     stashes: list[StashResponse]
 
 
-class StashMemberRequest(BaseModel):
-    user_id: UUID
-    permission: str = Field("read", pattern=r"^(read|write|admin)$")
-
-
 class StashSharePersonRequest(BaseModel):
     user_id: UUID | None = None
     username: str | None = Field(None, min_length=1, max_length=64)
@@ -182,10 +177,6 @@ class StashMemberResponse(BaseModel):
     permission: str
     granted_by: UUID | None
     created_at: datetime
-
-
-class StashMembersResponse(BaseModel):
-    members: list[StashMemberResponse]
 
 
 class StashShareOwnerResponse(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -162,6 +162,19 @@ class StashMemberRequest(BaseModel):
     permission: str = Field("read", pattern=r"^(read|write|admin)$")
 
 
+class StashSharePersonRequest(BaseModel):
+    user_id: UUID | None = None
+    username: str | None = Field(None, min_length=1, max_length=64)
+    permission: str = Field("read", pattern=r"^(read|write|admin)$")
+
+
+class StashShareUpdateRequest(BaseModel):
+    access: str | None = Field(None, pattern=r"^(workspace|private|public)$")
+    discoverable: bool | None = None
+    people: list[StashSharePersonRequest] = Field(default_factory=list)
+    remove_user_ids: list[UUID] = Field(default_factory=list)
+
+
 class StashMemberResponse(BaseModel):
     user_id: UUID
     name: str
@@ -172,6 +185,19 @@ class StashMemberResponse(BaseModel):
 
 
 class StashMembersResponse(BaseModel):
+    members: list[StashMemberResponse]
+
+
+class StashShareOwnerResponse(BaseModel):
+    user_id: UUID
+    name: str
+    display_name: str | None
+
+
+class StashShareResponse(BaseModel):
+    stash: StashResponse
+    url: str
+    owner: StashShareOwnerResponse
     members: list[StashMemberResponse]
 
 
@@ -194,6 +220,7 @@ class StashPublicResponse(BaseModel):
     workspace_name: str
     items: list[StashItemInlined]
     can_write: bool = False
+    can_manage_access: bool = False
 
 
 class AddExternalStashRequest(BaseModel):

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -18,6 +18,8 @@ from ..models import (
     StashMembersResponse,
     StashPublicResponse,
     StashResponse,
+    StashShareResponse,
+    StashShareUpdateRequest,
     StashUpdateRequest,
 )
 from ..services import permission_service, stash_service, workspace_service
@@ -209,6 +211,51 @@ async def _require_can_manage_stash(stash_id: UUID, user_id: UUID) -> None:
         raise HTTPException(status_code=403, detail="Not allowed to manage this stash")
 
 
+async def _stash_share_response(stash_id: UUID) -> StashShareResponse:
+    stash = await stash_service.get_stash(stash_id)
+    if not stash:
+        raise HTTPException(status_code=404, detail="Stash not found")
+
+    pool = get_pool()
+    owner = await pool.fetchrow(
+        "SELECT id AS user_id, name, display_name FROM users WHERE id = $1",
+        stash["owner_id"],
+    )
+    if not owner:
+        raise HTTPException(status_code=404, detail="Stash owner not found")
+
+    members = await stash_service.list_members(stash_id)
+    base = settings.PUBLIC_URL.rstrip("/")
+    return StashShareResponse(
+        stash=StashResponse(**stash),
+        url=f"{base}/stashes/{stash['slug']}",
+        owner=dict(owner),
+        members=[StashMemberResponse(**member) for member in members],
+    )
+
+
+async def _resolve_share_person(pool, person) -> UUID:
+    if bool(person.user_id) == bool(person.username):
+        raise HTTPException(status_code=400, detail="Provide exactly one user_id or username")
+
+    if person.user_id:
+        user = await pool.fetchrow("SELECT id FROM users WHERE id = $1", person.user_id)
+        label = str(person.user_id)
+    else:
+        username = person.username.strip() if person.username else ""
+        if not username:
+            raise HTTPException(status_code=400, detail="username is required")
+        user = await pool.fetchrow(
+            "SELECT id FROM users WHERE lower(name) = lower($1)",
+            username,
+        )
+        label = username
+
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User '{label}' not found")
+    return user["id"]
+
+
 @public_router.get("/{stash_id}/members", response_model=StashMembersResponse)
 async def list_stash_members(
     stash_id: UUID,
@@ -254,6 +301,69 @@ async def remove_stash_member(
 ):
     await _require_can_manage_stash(stash_id, current_user["id"])
     await stash_service.remove_member(stash_id, user_id)
+
+
+@public_router.get("/{stash_id}/share", response_model=StashShareResponse)
+async def get_stash_share(
+    stash_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_can_manage_stash(stash_id, current_user["id"])
+    return await _stash_share_response(stash_id)
+
+
+@public_router.patch("/{stash_id}/share", response_model=StashShareResponse)
+async def update_stash_share(
+    stash_id: UUID,
+    req: StashShareUpdateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _require_can_manage_stash(stash_id, current_user["id"])
+    stash = await stash_service.get_stash(stash_id)
+    if not stash:
+        raise HTTPException(status_code=404, detail="Stash not found")
+
+    if req.access is not None or req.discoverable is not None:
+        try:
+            updated = await stash_service.update_stash(
+                stash_id,
+                current_user["id"],
+                access=req.access,
+                discoverable=req.discoverable,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        if not updated:
+            raise HTTPException(status_code=404, detail="Stash not found")
+
+    pool = get_pool()
+    grants: dict[UUID, str] = {}
+    for person in req.people:
+        user_id = await _resolve_share_person(pool, person)
+        if user_id == stash["owner_id"]:
+            raise HTTPException(status_code=400, detail="Stash owner already has access")
+        grants[user_id] = person.permission
+
+    remove_user_ids = set(req.remove_user_ids)
+    if stash["owner_id"] in remove_user_ids:
+        raise HTTPException(status_code=400, detail="Cannot remove the Stash owner")
+    if remove_user_ids.intersection(grants):
+        raise HTTPException(status_code=400, detail="Cannot grant and remove the same user")
+
+    for user_id, permission in grants.items():
+        member = await stash_service.add_member(
+            stash_id,
+            user_id,
+            permission,
+            current_user["id"],
+        )
+        if not member:
+            raise HTTPException(status_code=404, detail="Stash not found")
+
+    for user_id in remove_user_ids:
+        await stash_service.remove_member(stash_id, user_id)
+
+    return await _stash_share_response(stash_id)
 
 
 @public_router.post("/{stash_id}/shared-pages", response_model=PageResponse, status_code=201)
@@ -303,11 +413,15 @@ async def get_public_stash(
     can_write = bool(
         current_user and await stash_service.user_can_write(stash["id"], current_user["id"])
     )
+    can_manage_access = bool(
+        current_user and await stash_service.user_can_admin(stash["id"], current_user["id"])
+    )
     return StashPublicResponse(
         stash=StashResponse(**stash),
         workspace_name=workspace_name,
         items=items,
         can_write=can_write,
+        can_manage_access=can_manage_access,
     )
 
 

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -13,9 +13,7 @@ from ..models import (
     PageCreateRequest,
     PageResponse,
     StashCreateRequest,
-    StashMemberRequest,
     StashMemberResponse,
-    StashMembersResponse,
     StashPublicResponse,
     StashResponse,
     StashShareResponse,
@@ -178,8 +176,6 @@ async def update_stash(
             current_user["id"],
             title=req.title,
             description=req.description,
-            access=req.access,
-            discoverable=req.discoverable,
             cover_image_url=req.cover_image_url,
             icon_url=req.icon_url,
             items=req.items,
@@ -254,53 +250,6 @@ async def _resolve_share_person(pool, person) -> UUID:
     if not user:
         raise HTTPException(status_code=404, detail=f"User '{label}' not found")
     return user["id"]
-
-
-@public_router.get("/{stash_id}/members", response_model=StashMembersResponse)
-async def list_stash_members(
-    stash_id: UUID,
-    current_user: dict = Depends(get_current_user),
-):
-    await _require_can_manage_stash(stash_id, current_user["id"])
-    members = await stash_service.list_members(stash_id)
-    return StashMembersResponse(members=[StashMemberResponse(**member) for member in members])
-
-
-@public_router.post("/{stash_id}/members", response_model=StashMemberResponse, status_code=201)
-async def add_stash_member(
-    stash_id: UUID,
-    req: StashMemberRequest,
-    current_user: dict = Depends(get_current_user),
-):
-    await _require_can_manage_stash(stash_id, current_user["id"])
-
-    pool = get_pool()
-    user = await pool.fetchrow("SELECT id FROM users WHERE id = $1", req.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    try:
-        member = await stash_service.add_member(
-            stash_id,
-            req.user_id,
-            req.permission,
-            current_user["id"],
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    if not member:
-        raise HTTPException(status_code=404, detail="Stash not found")
-    return StashMemberResponse(**member)
-
-
-@public_router.delete("/{stash_id}/members/{user_id}", status_code=204)
-async def remove_stash_member(
-    stash_id: UUID,
-    user_id: UUID,
-    current_user: dict = Depends(get_current_user),
-):
-    await _require_can_manage_stash(stash_id, current_user["id"])
-    await stash_service.remove_member(stash_id, user_id)
 
 
 @public_router.get("/{stash_id}/share", response_model=StashShareResponse)

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -370,12 +370,12 @@ async def test_workspace_stash_content_requires_stash_write_permission(client: A
     )
     assert denied.status_code == 404
 
-    grant = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": member["id"], "permission": "write"},
+    grant = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": member["id"], "permission": "write"}]},
         headers=_auth(owner_key),
     )
-    assert grant.status_code == 201
+    assert grant.status_code == 200
 
     allowed = await client.patch(
         f"/api/v1/workspaces/{workspace['id']}/pages/{page['id']}",
@@ -423,12 +423,12 @@ async def test_invited_private_external_stash_can_be_added_to_workspace(client: 
             headers=_auth(owner_key),
         )
     ).json()
-    grant = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": collaborator["id"], "permission": "read"},
+    grant = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": collaborator["id"], "permission": "read"}]},
         headers=_auth(owner_key),
     )
-    assert grant.status_code == 201
+    assert grant.status_code == 200
 
     added = await client.post(
         f"/api/v1/stashes/{stash['slug']}/add-to-workspace",
@@ -467,7 +467,7 @@ async def test_invited_private_external_stash_can_be_added_to_workspace(client: 
 
 
 @pytest.mark.asyncio
-async def test_stash_member_api_grants_and_revokes_private_page_access(
+async def test_stash_share_api_grants_and_revokes_private_page_access(
     client: AsyncClient,
 ):
     owner_key, owner = await _register(client, "stash_owner")
@@ -475,7 +475,7 @@ async def test_stash_member_api_grants_and_revokes_private_page_access(
 
     workspace_resp = await client.post(
         "/api/v1/workspaces",
-        json={"name": "Member API workspace"},
+        json={"name": "Share API workspace"},
         headers=_auth(owner_key),
     )
     assert workspace_resp.status_code == 201
@@ -508,20 +508,20 @@ async def test_stash_member_api_grants_and_revokes_private_page_access(
         require_write=True,
     )
 
-    add_resp = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": collaborator["id"], "permission": "write"},
+    add_resp = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": collaborator["id"], "permission": "write"}]},
         headers=_auth(owner_key),
     )
-    assert add_resp.status_code == 201
-    assert add_resp.json()["permission"] == "write"
+    assert add_resp.status_code == 200
+    assert add_resp.json()["members"][0]["permission"] == "write"
 
-    members_resp = await client.get(
-        f"/api/v1/stashes/{stash['id']}/members",
+    share_resp = await client.get(
+        f"/api/v1/stashes/{stash['id']}/share",
         headers=_auth(owner_key),
     )
-    assert members_resp.status_code == 200
-    assert [member["user_id"] for member in members_resp.json()["members"]] == [collaborator["id"]]
+    assert share_resp.status_code == 200
+    assert [member["user_id"] for member in share_resp.json()["members"]] == [collaborator["id"]]
     assert await permission_service.check_access(
         "page",
         uuid.UUID(page["id"]),
@@ -529,24 +529,74 @@ async def test_stash_member_api_grants_and_revokes_private_page_access(
         require_write=True,
     )
 
-    forbidden_resp = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": owner["id"], "permission": "read"},
+    forbidden_resp = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": owner["id"], "permission": "read"}]},
         headers=_auth(collaborator_key),
     )
     assert forbidden_resp.status_code == 403
 
-    delete_resp = await client.delete(
-        f"/api/v1/stashes/{stash['id']}/members/{collaborator['id']}",
+    delete_resp = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"remove_user_ids": [collaborator["id"]]},
         headers=_auth(owner_key),
     )
-    assert delete_resp.status_code == 204
+    assert delete_resp.status_code == 200
     assert not await permission_service.check_access(
         "page",
         uuid.UUID(page["id"]),
         uuid.UUID(collaborator["id"]),
         require_write=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_generic_stash_update_rejects_share_state_fields(client: AsyncClient):
+    owner_key, _owner = await _register(client, "stash_update_owner")
+
+    workspace_resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "Share state boundary workspace"},
+        headers=_auth(owner_key),
+    )
+    assert workspace_resp.status_code == 201
+    workspace = workspace_resp.json()
+
+    page_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/pages/new",
+        json={"name": "Boundary page", "content": "# Boundary page"},
+        headers=_auth(owner_key),
+    )
+    assert page_resp.status_code == 201
+    page = page_resp.json()
+
+    stash_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/stashes",
+        json={
+            "title": "Boundary Stash",
+            "access": "private",
+            "items": [{"object_type": "page", "object_id": page["id"]}],
+        },
+        headers=_auth(owner_key),
+    )
+    assert stash_resp.status_code == 201
+    stash = stash_resp.json()
+
+    rejected = await client.patch(
+        f"/api/v1/stashes/{stash['id']}",
+        json={"access": "public", "discoverable": True},
+        headers=_auth(owner_key),
+    )
+    assert rejected.status_code == 422
+
+    shared = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"access": "public", "discoverable": True},
+        headers=_auth(owner_key),
+    )
+    assert shared.status_code == 200
+    assert shared.json()["stash"]["access"] == "public"
+    assert shared.json()["stash"]["discoverable"] is True
 
 
 @pytest.mark.asyncio
@@ -584,12 +634,12 @@ async def test_stash_write_member_can_create_shared_page_outside_workspace_files
     assert stash_resp.status_code == 201
     stash = stash_resp.json()
 
-    add_resp = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": collaborator["id"], "permission": "write"},
+    add_resp = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": collaborator["id"], "permission": "write"}]},
         headers=_auth(owner_key),
     )
-    assert add_resp.status_code == 201
+    assert add_resp.status_code == 200
 
     shared_resp = await client.post(
         f"/api/v1/stashes/{stash['id']}/shared-pages",

--- a/backend/tests/test_stash_invites.py
+++ b/backend/tests/test_stash_invites.py
@@ -151,3 +151,82 @@ async def test_stash_invite_can_be_dismissed(client: AsyncClient):
         headers=_auth(recipient_key),
     )
     assert viewed.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stash_share_api_grants_and_revokes_stash_level_access(client: AsyncClient):
+    owner_key, owner = await _register(client, unique_name("stash_share_owner"))
+    recipient_key, recipient = await _register(client, unique_name("stash_share_recipient"))
+
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Share API workspace"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Private brief", "content": "stash-only context"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    stash = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/stashes",
+            json={
+                "title": "Share API Stash",
+                "access": "private",
+                "items": [{"object_type": "page", "object_id": page["id"]}],
+            },
+            headers=_auth(owner_key),
+        )
+    ).json()
+
+    shared = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={
+            "people": [{"username": recipient["name"], "permission": "read"}],
+        },
+        headers=_auth(owner_key),
+    )
+    assert shared.status_code == 200
+    body = shared.json()
+    assert body["stash"]["id"] == stash["id"]
+    assert body["url"].endswith(f"/stashes/{stash['slug']}")
+    assert body["owner"]["user_id"] == owner["id"]
+    assert body["members"][0]["user_id"] == recipient["id"]
+    assert body["members"][0]["permission"] == "read"
+
+    workspace_members = await client.get(
+        f"/api/v1/workspaces/{workspace['id']}/members",
+        headers=_auth(owner_key),
+    )
+    assert recipient["id"] not in [member["user_id"] for member in workspace_members.json()]
+
+    viewed = await client.get(
+        f"/api/v1/stashes/{stash['slug']}",
+        headers=_auth(recipient_key),
+    )
+    assert viewed.status_code == 200
+
+    invites = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert len(invites.json()["invites"]) == 1
+
+    removed = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"remove_user_ids": [recipient["id"]]},
+        headers=_auth(owner_key),
+    )
+    assert removed.status_code == 200
+    assert removed.json()["members"] == []
+
+    no_longer_viewable = await client.get(
+        f"/api/v1/stashes/{stash['slug']}",
+        headers=_auth(recipient_key),
+    )
+    assert no_longer_viewable.status_code == 404
+
+    remaining = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
+    assert remaining.json()["invites"] == []

--- a/backend/tests/test_stash_invites.py
+++ b/backend/tests/test_stash_invites.py
@@ -58,12 +58,12 @@ async def test_stash_invite_grants_view_access_before_adding(client: AsyncClient
         )
     ).json()
 
-    added_member = await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": recipient["id"], "permission": "read"},
+    added_member = await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": recipient["id"], "permission": "read"}]},
         headers=_auth(owner_key),
     )
-    assert added_member.status_code == 201
+    assert added_member.status_code == 200
 
     invites = await client.get("/api/v1/stash-invites", headers=_auth(recipient_key))
     assert invites.status_code == 200
@@ -128,9 +128,9 @@ async def test_stash_invite_can_be_dismissed(client: AsyncClient):
             headers=_auth(owner_key),
         )
     ).json()
-    await client.post(
-        f"/api/v1/stashes/{stash['id']}/members",
-        json={"user_id": recipient["id"], "permission": "read"},
+    await client.patch(
+        f"/api/v1/stashes/{stash['id']}/share",
+        json={"people": [{"user_id": recipient["id"], "permission": "read"}]},
         headers=_auth(owner_key),
     )
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -184,8 +184,25 @@ class StashClient:
             },
         )
 
+    def update_stash_share(self, stash_id: str, **fields) -> dict:
+        return self._patch(f"/api/v1/stashes/{stash_id}/share", json=fields)
+
     def update_stash(self, stash_id: str, **fields) -> dict:
-        return self._patch(f"/api/v1/stashes/{stash_id}", json=fields)
+        share_fields = {}
+        for name in ("access", "discoverable"):
+            if name in fields:
+                share_fields[name] = fields.pop(name)
+
+        if not fields and not share_fields:
+            return self._patch(f"/api/v1/stashes/{stash_id}", json={})
+
+        stash = None
+        if fields:
+            stash = self._patch(f"/api/v1/stashes/{stash_id}", json=fields)
+        if share_fields:
+            share = self.update_stash_share(stash_id, **share_fields)
+            stash = share["stash"]
+        return stash
 
     def delete_stash(self, stash_id: str) -> None:
         self._delete(f"/api/v1/stashes/{stash_id}")

--- a/cli/tests/test_update_stash.py
+++ b/cli/tests/test_update_stash.py
@@ -1,0 +1,56 @@
+from cli.client import StashClient
+
+
+def _stub_client():
+    client = StashClient.__new__(StashClient)
+    calls: list[tuple[str, dict]] = []
+
+    def fake_patch(path: str, json=None) -> dict:
+        body = json or {}
+        calls.append((path, body))
+        if path.endswith("/share"):
+            return {
+                "stash": {
+                    "id": "stash-1",
+                    "access": body.get("access", "workspace"),
+                    "discoverable": body.get("discoverable", False),
+                }
+            }
+        return {"id": "stash-1", **body}
+
+    client._patch = fake_patch  # type: ignore[method-assign]
+    return client, calls
+
+
+def test_update_stash_metadata_uses_stash_endpoint() -> None:
+    client, calls = _stub_client()
+
+    stash = client.update_stash("stash-1", title="Roadmap", description="Plan")
+
+    assert stash == {"id": "stash-1", "title": "Roadmap", "description": "Plan"}
+    assert calls == [
+        ("/api/v1/stashes/stash-1", {"title": "Roadmap", "description": "Plan"})
+    ]
+
+
+def test_update_stash_access_uses_share_endpoint() -> None:
+    client, calls = _stub_client()
+
+    stash = client.update_stash("stash-1", access="public", discoverable=True)
+
+    assert stash == {"id": "stash-1", "access": "public", "discoverable": True}
+    assert calls == [
+        ("/api/v1/stashes/stash-1/share", {"access": "public", "discoverable": True})
+    ]
+
+
+def test_update_stash_mixed_fields_splits_endpoints() -> None:
+    client, calls = _stub_client()
+
+    stash = client.update_stash("stash-1", title="Roadmap", access="private")
+
+    assert stash == {"id": "stash-1", "access": "private", "discoverable": False}
+    assert calls == [
+        ("/api/v1/stashes/stash-1", {"title": "Roadmap"}),
+        ("/api/v1/stashes/stash-1/share", {"access": "private"}),
+    ]

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -32,8 +32,11 @@ vi.mock("../../../lib/api", () => ({
     }
   },
   getPublicStash: vi.fn(),
+  getStashShare: vi.fn(),
   updateStash: vi.fn(),
+  updateStashShare: vi.fn(),
   uploadFile: vi.fn(),
+  searchUsers: vi.fn(),
   getActivityTimeline: vi.fn(),
   getEmbeddingProjection: vi.fn(),
 }));
@@ -93,6 +96,7 @@ describe("StashPageClient sharing", () => {
       workspace_name: "Demo Workspace",
       items: [],
       can_write: false,
+      can_manage_access: false,
     });
   });
 

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -20,11 +20,11 @@ import Placeholder from "@tiptap/extension-placeholder";
 import AppShell from "../../../components/AppShell";
 import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
+import StashShareDialog from "../../../components/stash/StashShareDialog";
 import StashQuickAdd from "../../../components/StashQuickAdd";
 import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
-import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import {
   ApiError,
   getActivityTimeline,
@@ -153,7 +153,7 @@ function StashPageBody({
   data: PublicStashDetail;
   onRefresh: () => Promise<void>;
 }) {
-  const { stash, workspace_name, items, can_write } = data;
+  const { stash, workspace_name, items, can_write, can_manage_access } = data;
   const groups = groupStashItems(items);
   const [addOpen, setAddOpen] = useState(false);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
@@ -242,7 +242,13 @@ function StashPageBody({
             </div>
           </div>
           <div className="flex flex-shrink-0 items-center gap-1.5 pt-1">
-            <ShareStashButton stash={stash} canWrite={can_write} onChanged={onRefresh} />
+            <ShareStashButton
+              stash={stash}
+              workspaceName={workspace_name}
+              canWrite={can_write}
+              canManageAccess={can_manage_access}
+              onChanged={onRefresh}
+            />
             {can_write ? (
               <button
                 type="button"
@@ -609,187 +615,42 @@ function relativeTime(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
 
-// Single place to manage sharing: copy public URL, choose visibility,
-// toggle discoverability. Anonymous viewers and non-writers only see the
-// "Copy link" path.
+// Opens the Stash-level share sheet. Workspace invitations live in the
+// workspace member modal instead.
 function ShareStashButton({
   stash,
+  workspaceName,
   canWrite,
+  canManageAccess,
   onChanged,
 }: {
   stash: PublicStashDetail["stash"];
+  workspaceName: string;
   canWrite: boolean;
+  canManageAccess: boolean;
   onChanged: () => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [vis, setVis] = useState(stash.access);
-  const [discoverable, setDiscoverable] = useState(stash.discoverable);
-  const [saving, setSaving] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
-
-  useEscapeKey(open, () => setOpen(false));
-
-  useEffect(() => {
-    if (!open) return;
-    function onDown(e: globalThis.MouseEvent) {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
-
-  async function copyLink() {
-    try {
-      await navigator.clipboard.writeText(absoluteUrl(`/stashes/${stash.slug}`));
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1600);
-    } catch {
-      /* ignore */
-    }
-  }
-
-  async function applyChanges(next: Partial<{ access: typeof vis; discoverable: boolean }>) {
-    setSaving(true);
-    try {
-      await updateStash(stash.id, next);
-      await onChanged();
-    } finally {
-      setSaving(false);
-    }
-  }
 
   return (
-    <div className="relative">
+    <>
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => setOpen(true)}
         className="inline-flex items-center gap-1.5 rounded-md border border-border bg-base px-2.5 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
       >
         <ShareGlyph /> Share
       </button>
-      {open && (
-        <div
-          ref={popoverRef}
-          className="absolute right-0 top-full z-40 mt-1.5 w-[300px] rounded-lg border border-border bg-base p-3 shadow-lg"
-        >
-          <div className="sys-label mb-1">Public URL</div>
-          <div className="flex gap-1.5">
-            <input
-              readOnly
-              value={absoluteUrl(`/stashes/${stash.slug}`)}
-              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[11.5px] font-mono text-foreground"
-            />
-            <button
-              type="button"
-              onClick={() => void copyLink()}
-              className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
-            >
-              {copied ? "Copied" : "Copy"}
-            </button>
-          </div>
-
-          {canWrite && (
-            <>
-              <div className="sys-label mb-1 mt-3">Visibility</div>
-              <div className="flex flex-col gap-1">
-                <VisOption
-                  label="Workspace"
-                  hint="Anyone in the owning workspace can view"
-                  value="workspace"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-                <VisOption
-                  label="Private"
-                  hint="Only the owner and explicit members"
-                  value="private"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-                <VisOption
-                  label="Public"
-                  hint="Anyone with the URL can view"
-                  value="public"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-              </div>
-
-              {vis === "public" && (
-                <label className="mt-3 flex cursor-pointer items-center gap-2 rounded-md border border-border bg-surface px-2 py-1.5">
-                  <input
-                    type="checkbox"
-                    checked={discoverable}
-                    onChange={(e) => {
-                      setDiscoverable(e.target.checked);
-                      void applyChanges({ discoverable: e.target.checked });
-                    }}
-                  />
-                  <span className="text-[12px] text-foreground">
-                    List on Discover
-                  </span>
-                </label>
-              )}
-
-              {saving && (
-                <div className="mt-2 text-[11px] text-muted">Saving…</div>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function VisOption({
-  label,
-  hint,
-  value,
-  current,
-  onChange,
-}: {
-  label: string;
-  hint: string;
-  value: "workspace" | "private" | "public";
-  current: "workspace" | "private" | "public";
-  onChange: (next: "workspace" | "private" | "public") => void;
-}) {
-  const active = value === current;
-  return (
-    <button
-      type="button"
-      onClick={() => onChange(value)}
-      className={
-        "flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[12px] " +
-        (active ? "bg-[var(--color-brand-50)]" : "hover:bg-raised")
-      }
-    >
-      <span
-        className={
-          "mt-[3px] inline-block h-3 w-3 flex-shrink-0 rounded-full border-2 " +
-          (active
-            ? "border-[var(--color-brand-600)] bg-[var(--color-brand-500)]"
-            : "border-border bg-base")
-        }
+      <StashShareDialog
+        stash={stash}
+        workspaceName={workspaceName}
+        canWrite={canWrite}
+        canManageAccess={canManageAccess}
+        open={open}
+        onClose={() => setOpen(false)}
+        onChanged={onChanged}
       />
-      <span className="min-w-0">
-        <span className="block font-medium text-foreground">{label}</span>
-        <span className="block text-[11px] text-muted">{hint}</span>
-      </span>
-    </button>
+    </>
   );
 }
 
@@ -802,11 +663,6 @@ function ShareGlyph() {
       <path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98" />
     </svg>
   );
-}
-
-function absoluteUrl(path: string): string {
-  if (typeof window === "undefined") return path;
-  return `${window.location.origin}${path}`;
 }
 
 function groupStashItems(items: PublicStashItem[]): StashItemGroup {

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -245,7 +245,6 @@ function StashPageBody({
             <ShareStashButton
               stash={stash}
               workspaceName={workspace_name}
-              canWrite={can_write}
               canManageAccess={can_manage_access}
               onChanged={onRefresh}
             />
@@ -620,13 +619,11 @@ function relativeTime(iso: string): string {
 function ShareStashButton({
   stash,
   workspaceName,
-  canWrite,
   canManageAccess,
   onChanged,
 }: {
   stash: PublicStashDetail["stash"];
   workspaceName: string;
-  canWrite: boolean;
   canManageAccess: boolean;
   onChanged: () => Promise<void>;
 }) {
@@ -644,7 +641,6 @@ function ShareStashButton({
       <StashShareDialog
         stash={stash}
         workspaceName={workspaceName}
-        canWrite={canWrite}
         canManageAccess={canManageAccess}
         open={open}
         onClose={() => setOpen(false)}

--- a/frontend/src/components/MembersModal.tsx
+++ b/frontend/src/components/MembersModal.tsx
@@ -131,8 +131,18 @@ export default function MembersModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onClick={onClose}>
       <div className="w-full max-w-md rounded-2xl border border-border bg-base shadow-xl" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between border-b border-border px-5 py-3">
-          <h2 className="font-display text-[15px] font-semibold text-foreground">{title}</h2>
+        <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="font-display text-[15px] font-semibold text-foreground">{title}</h2>
+              <span className="rounded-full bg-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted ring-1 ring-border">
+                Workspace-level
+              </span>
+            </div>
+            <p className="mt-1 text-[12px] text-muted">
+              People added here can access workspace-visible content.
+            </p>
+          </div>
           <button onClick={onClose} className="text-muted hover:text-foreground">✕</button>
         </div>
 

--- a/frontend/src/components/stash/StashShareDialog.test.tsx
+++ b/frontend/src/components/stash/StashShareDialog.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StashShareDialog from "./StashShareDialog";
+import {
+  getStashShare,
+  searchUsers,
+  updateStashShare,
+} from "../../lib/api";
+
+vi.mock("../../lib/api", () => ({
+  getStashShare: vi.fn(),
+  searchUsers: vi.fn(),
+  updateStash: vi.fn(),
+  updateStashShare: vi.fn(),
+}));
+
+const stash = {
+  id: "stash-1",
+  workspace_id: "workspace-1",
+  slug: "shared-stash",
+  title: "Shared Stash",
+  description: "",
+  owner_id: "user-1",
+  access: "private" as const,
+  discoverable: false,
+  cover_image_url: null,
+  icon_url: null,
+  view_count: 0,
+  items: [],
+  is_external: false,
+  added_to_workspace_id: null,
+  forked_from_stash_id: null,
+  created_at: "2026-05-11T00:00:00Z",
+  updated_at: "2026-05-11T00:00:00Z",
+};
+
+const share = {
+  stash,
+  url: "https://app.joinstash.ai/stashes/shared-stash",
+  owner: {
+    user_id: "user-1",
+    name: "owner",
+    display_name: "Owner",
+  },
+  members: [],
+};
+
+describe("StashShareDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getStashShare).mockResolvedValue(share);
+    vi.mocked(searchUsers).mockResolvedValue([
+      {
+        id: "user-2",
+        name: "sam",
+        display_name: "Sam account",
+      },
+    ]);
+    vi.mocked(updateStashShare).mockResolvedValue({
+      ...share,
+      members: [
+        {
+          user_id: "user-2",
+          name: "sam",
+          display_name: "Sam account",
+          permission: "read",
+          granted_by: "user-1",
+          created_at: "2026-05-11T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("labels Stash-level sharing and grants a selected user access", async () => {
+    const onChanged = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <StashShareDialog
+        stash={stash}
+        workspaceName="Demo Workspace"
+        canWrite
+        canManageAccess
+        open
+        onClose={vi.fn()}
+        onChanged={onChanged}
+      />
+    );
+
+    await screen.findByText("Stash-level");
+    expect(
+      screen.getByText("People added here can access this Stash without joining Demo Workspace.")
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Add people by username"), {
+      target: { value: "sam" },
+    });
+    fireEvent.click(await screen.findByText("@sam"));
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() =>
+      expect(updateStashShare).toHaveBeenCalledWith("stash-1", {
+        people: [{ user_id: "user-2", permission: "read" }],
+      })
+    );
+    expect(await screen.findByText("Sam account")).toBeInTheDocument();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/stash/StashShareDialog.test.tsx
+++ b/frontend/src/components/stash/StashShareDialog.test.tsx
@@ -10,7 +10,6 @@ import {
 vi.mock("../../lib/api", () => ({
   getStashShare: vi.fn(),
   searchUsers: vi.fn(),
-  updateStash: vi.fn(),
   updateStashShare: vi.fn(),
 }));
 
@@ -82,7 +81,6 @@ describe("StashShareDialog", () => {
       <StashShareDialog
         stash={stash}
         workspaceName="Demo Workspace"
-        canWrite
         canManageAccess
         open
         onClose={vi.fn()}

--- a/frontend/src/components/stash/StashShareDialog.tsx
+++ b/frontend/src/components/stash/StashShareDialog.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "re
 import {
   getStashShare,
   searchUsers,
-  updateStash,
   updateStashShare,
   type StashMember,
   type StashMemberPermission,
@@ -50,7 +49,6 @@ const EMPTY_MEMBERS: StashMember[] = [];
 export default function StashShareDialog({
   stash,
   workspaceName,
-  canWrite,
   canManageAccess,
   open,
   onClose,
@@ -58,7 +56,6 @@ export default function StashShareDialog({
 }: {
   stash: WorkspaceStash;
   workspaceName: string;
-  canWrite: boolean;
   canManageAccess: boolean;
   open: boolean;
   onClose: () => void;
@@ -223,13 +220,8 @@ export default function StashShareDialog({
     setBusy("access");
     setMessage("");
     try {
-      if (canManageAccess) {
-        const next = await updateStashShare(stash.id, { access: nextAccess });
-        await refreshShare(next, true);
-      } else {
-        await updateStash(stash.id, { access: nextAccess });
-        await onChanged();
-      }
+      const next = await updateStashShare(stash.id, { access: nextAccess });
+      await refreshShare(next, true);
       setMessage("Stash access updated.");
     } catch (error) {
       setVis(currentStash.access);
@@ -244,13 +236,8 @@ export default function StashShareDialog({
     setBusy("discover");
     setMessage("");
     try {
-      if (canManageAccess) {
-        const next = await updateStashShare(stash.id, { discoverable: nextDiscoverable });
-        await refreshShare(next, true);
-      } else {
-        await updateStash(stash.id, { discoverable: nextDiscoverable });
-        await onChanged();
-      }
+      const next = await updateStashShare(stash.id, { discoverable: nextDiscoverable });
+      await refreshShare(next, true);
       setMessage("Stash access updated.");
     } catch (error) {
       setDiscoverable(currentStash.discoverable);
@@ -417,7 +404,7 @@ export default function StashShareDialog({
             </section>
           ) : null}
 
-          {canWrite ? (
+          {canManageAccess ? (
             <section className="mt-5 border-t border-border-subtle pt-4">
               <div className="sys-label mb-2">General Stash access</div>
               <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/stash/StashShareDialog.tsx
+++ b/frontend/src/components/stash/StashShareDialog.tsx
@@ -1,0 +1,516 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import {
+  getStashShare,
+  searchUsers,
+  updateStash,
+  updateStashShare,
+  type StashMember,
+  type StashMemberPermission,
+  type StashShare,
+  type WorkspaceStash,
+} from "../../lib/api";
+import type { UserSearchResult } from "../../lib/types";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
+import CustomSelect from "../CustomSelect";
+
+type StashAccess = "workspace" | "private" | "public";
+
+const PERMISSION_OPTIONS = [
+  { value: "read", label: "Viewer" },
+  { value: "write", label: "Editor" },
+  { value: "admin", label: "Manager" },
+];
+
+const ACCESS_OPTIONS: {
+  value: StashAccess;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    value: "private",
+    label: "Restricted",
+    hint: "Only people added to this Stash",
+  },
+  {
+    value: "workspace",
+    label: "Workspace",
+    hint: "Anyone in the owning Workspace",
+  },
+  {
+    value: "public",
+    label: "Public",
+    hint: "Anyone with the Stash link",
+  },
+];
+
+const EMPTY_MEMBERS: StashMember[] = [];
+
+export default function StashShareDialog({
+  stash,
+  workspaceName,
+  canWrite,
+  canManageAccess,
+  open,
+  onClose,
+  onChanged,
+}: {
+  stash: WorkspaceStash;
+  workspaceName: string;
+  canWrite: boolean;
+  canManageAccess: boolean;
+  open: boolean;
+  onClose: () => void;
+  onChanged: () => Promise<void>;
+}) {
+  const [share, setShare] = useState<StashShare | null>(null);
+  const [vis, setVis] = useState<StashAccess>(stash.access);
+  const [discoverable, setDiscoverable] = useState(stash.discoverable);
+  const [query, setQuery] = useState("");
+  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(null);
+  const [suggestions, setSuggestions] = useState<UserSearchResult[]>([]);
+  const [permission, setPermission] = useState<StashMemberPermission>("read");
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState("");
+  const [message, setMessage] = useState("");
+
+  useEscapeKey(open, onClose);
+
+  useEffect(() => {
+    if (!open) return;
+    setShare(null);
+    setVis(stash.access);
+    setDiscoverable(stash.discoverable);
+    setQuery("");
+    setSelectedUser(null);
+    setSuggestions([]);
+    setPermission("read");
+    setCopied(false);
+    setMessage("");
+
+    if (!canManageAccess) return;
+    setBusy("load");
+    getStashShare(stash.id)
+      .then((next) => {
+        setShare(next);
+        setVis(next.stash.access);
+        setDiscoverable(next.stash.discoverable);
+      })
+      .catch((error) => setMessage(error instanceof Error ? error.message : "Could not load Stash access"))
+      .finally(() => setBusy(""));
+  }, [canManageAccess, open, stash]);
+
+  useEffect(() => {
+    if (!open || !canManageAccess || selectedUser) {
+      setSuggestions([]);
+      return;
+    }
+
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      searchUsers(trimmed)
+        .then((users) => {
+          if (!cancelled) setSuggestions(users);
+        })
+        .catch(() => {
+          if (!cancelled) setSuggestions([]);
+        });
+    }, 150);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [canManageAccess, open, query, selectedUser]);
+
+  const currentStash = share?.stash ?? stash;
+  const members = share?.members ?? EMPTY_MEMBERS;
+  const link = share?.url ?? absoluteUrl(`/stashes/${currentStash.slug}`);
+  const workspaceLabel = workspaceName || "the owning Workspace";
+
+  const memberIds = useMemo(() => new Set(members.map((member) => member.user_id)), [members]);
+  const visibleSuggestions = suggestions.filter((user) => !memberIds.has(user.id));
+
+  if (!open) return null;
+
+  async function copyLink() {
+    await navigator.clipboard.writeText(link);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }
+
+  async function refreshShare(next: StashShare, reloadPage = false) {
+    setShare(next);
+    setVis(next.stash.access);
+    setDiscoverable(next.stash.discoverable);
+    if (reloadPage) await onChanged();
+  }
+
+  async function addPerson(event: FormEvent) {
+    event.preventDefault();
+    const username = query.trim();
+    if (!selectedUser && !username) return;
+
+    setBusy("add");
+    setMessage("");
+    try {
+      const next = await updateStashShare(stash.id, {
+        people: [
+          selectedUser
+            ? { user_id: selectedUser.id, permission }
+            : { username, permission },
+        ],
+      });
+      await refreshShare(next);
+      setQuery("");
+      setSelectedUser(null);
+      setSuggestions([]);
+      setPermission("read");
+      setMessage("Stash access updated.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not update Stash access");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function changeMemberPermission(member: StashMember, nextPermission: string) {
+    setBusy(member.user_id);
+    setMessage("");
+    try {
+      const next = await updateStashShare(stash.id, {
+        people: [
+          {
+            user_id: member.user_id,
+            permission: nextPermission as StashMemberPermission,
+          },
+        ],
+      });
+      await refreshShare(next);
+      setMessage("Stash access updated.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not update Stash access");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function removeMember(member: StashMember) {
+    setBusy(member.user_id);
+    setMessage("");
+    try {
+      const next = await updateStashShare(stash.id, {
+        remove_user_ids: [member.user_id],
+      });
+      await refreshShare(next);
+      setMessage("Removed from this Stash.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not remove Stash access");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function changeAccess(nextAccess: StashAccess) {
+    setVis(nextAccess);
+    setBusy("access");
+    setMessage("");
+    try {
+      if (canManageAccess) {
+        const next = await updateStashShare(stash.id, { access: nextAccess });
+        await refreshShare(next, true);
+      } else {
+        await updateStash(stash.id, { access: nextAccess });
+        await onChanged();
+      }
+      setMessage("Stash access updated.");
+    } catch (error) {
+      setVis(currentStash.access);
+      setMessage(error instanceof Error ? error.message : "Could not update Stash access");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function changeDiscoverable(nextDiscoverable: boolean) {
+    setDiscoverable(nextDiscoverable);
+    setBusy("discover");
+    setMessage("");
+    try {
+      if (canManageAccess) {
+        const next = await updateStashShare(stash.id, { discoverable: nextDiscoverable });
+        await refreshShare(next, true);
+      } else {
+        await updateStash(stash.id, { discoverable: nextDiscoverable });
+        await onChanged();
+      }
+      setMessage("Stash access updated.");
+    } catch (error) {
+      setDiscoverable(currentStash.discoverable);
+      setMessage(error instanceof Error ? error.message : "Could not update Discover");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-xl border border-border bg-base shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="font-display text-[16px] font-semibold text-foreground">
+                Share this Stash
+              </h2>
+              <span className="rounded-full bg-[var(--color-brand-50)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-brand-700)]">
+                Stash-level
+              </span>
+            </div>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted">
+              People added here can access this Stash without joining {workspaceLabel}.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-foreground"
+            aria-label="Close Stash sharing"
+          >
+            x
+          </button>
+        </div>
+
+        <div className="max-h-[72vh] overflow-y-auto px-5 py-4">
+          <section>
+            <div className="sys-label mb-1">Stash link</div>
+            <div className="flex gap-1.5">
+              <input
+                readOnly
+                value={link}
+                className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[11.5px] font-mono text-foreground"
+              />
+              <button
+                type="button"
+                onClick={() => void copyLink()}
+                className="rounded-md border border-border bg-base px-2.5 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+          </section>
+
+          {canManageAccess ? (
+            <section className="mt-4">
+              <div className="sys-label mb-2">People with access to this Stash</div>
+              {busy === "load" ? (
+                <p className="py-4 text-[12.5px] text-muted">Loading Stash access...</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {share ? (
+                    <PersonRow
+                      label={share.owner.display_name || share.owner.name}
+                      sub={`@${share.owner.name}`}
+                      initials={initials(share.owner.display_name || share.owner.name)}
+                      control={
+                        <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted ring-1 ring-border">
+                          Owner
+                        </span>
+                      }
+                    />
+                  ) : null}
+
+                  {members.map((member) => (
+                    <PersonRow
+                      key={member.user_id}
+                      label={member.display_name || member.name}
+                      sub={`@${member.name}`}
+                      initials={initials(member.display_name || member.name)}
+                      control={
+                        <div className="flex items-center gap-1.5">
+                          <CustomSelect
+                            value={member.permission}
+                            options={PERMISSION_OPTIONS}
+                            onChange={(nextPermission) => void changeMemberPermission(member, nextPermission)}
+                            disabled={busy === member.user_id}
+                            className="min-w-[92px] rounded border border-border bg-surface px-1.5 py-1 text-[10px] uppercase tracking-wide text-foreground"
+                            menuClassName="text-[11px]"
+                            align="right"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => void removeMember(member)}
+                            disabled={busy === member.user_id}
+                            className="px-1 text-[13px] text-muted hover:text-red-500 disabled:opacity-40"
+                            title="Remove from this Stash"
+                          >
+                            x
+                          </button>
+                        </div>
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+
+              <form onSubmit={addPerson} className="mt-3">
+                <div className="flex gap-2">
+                  <div className="relative min-w-0 flex-1">
+                    <input
+                      value={query}
+                      onChange={(event) => {
+                        setQuery(event.target.value);
+                        setSelectedUser(null);
+                      }}
+                      placeholder="Add people by username"
+                      className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-400)] focus:outline-none"
+                    />
+                    {visibleSuggestions.length > 0 ? (
+                      <div className="absolute left-0 right-0 top-full z-[60] mt-1 overflow-hidden rounded-md border border-border bg-surface py-1 shadow-lg">
+                        {visibleSuggestions.map((user) => (
+                          <button
+                            key={user.id}
+                            type="button"
+                            onClick={() => {
+                              setSelectedUser(user);
+                              setQuery(user.name);
+                              setSuggestions([]);
+                            }}
+                            className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-foreground hover:bg-raised"
+                          >
+                            <Avatar label={user.display_name || user.name} />
+                            <span className="min-w-0 flex-1 truncate">
+                              {user.display_name || user.name}
+                            </span>
+                            <span className="text-[11px] text-muted">@{user.name}</span>
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                  <CustomSelect
+                    value={permission}
+                    options={PERMISSION_OPTIONS}
+                    onChange={(next) => setPermission(next as StashMemberPermission)}
+                    className="min-w-[92px] rounded-md border border-border bg-surface px-2 py-1.5 text-[11px] text-foreground"
+                    menuClassName="text-[11px]"
+                    align="right"
+                  />
+                  <button
+                    type="submit"
+                    disabled={busy === "add" || !query.trim()}
+                    className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-40"
+                  >
+                    Add
+                  </button>
+                </div>
+              </form>
+            </section>
+          ) : null}
+
+          {canWrite ? (
+            <section className="mt-5 border-t border-border-subtle pt-4">
+              <div className="sys-label mb-2">General Stash access</div>
+              <div className="flex flex-col gap-1.5">
+                {ACCESS_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    disabled={busy === "access"}
+                    onClick={() => void changeAccess(option.value)}
+                    className={
+                      "flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-left disabled:opacity-50 " +
+                      (vis === option.value
+                        ? "border-[var(--color-brand-500)] bg-[var(--color-brand-50)]"
+                        : "border-border bg-surface hover:bg-raised")
+                    }
+                  >
+                    <span className="min-w-0">
+                      <span className="block text-[12.5px] font-medium text-foreground">
+                        {option.label}
+                      </span>
+                      <span className="block text-[11.5px] text-muted">{option.hint}</span>
+                    </span>
+                    <span
+                      className={
+                        "h-2.5 w-2.5 rounded-full border " +
+                        (vis === option.value
+                          ? "border-[var(--color-brand-600)] bg-[var(--color-brand-600)]"
+                          : "border-border")
+                      }
+                    />
+                  </button>
+                ))}
+              </div>
+
+              {vis === "public" ? (
+                <label className="mt-3 flex cursor-pointer items-center gap-2 rounded-md border border-border bg-surface px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={discoverable}
+                    disabled={busy === "discover"}
+                    onChange={(event) => void changeDiscoverable(event.target.checked)}
+                  />
+                  <span className="text-[12px] text-foreground">List on Discover</span>
+                </label>
+              ) : null}
+            </section>
+          ) : null}
+
+          {message ? <p className="mt-3 text-[12px] text-muted">{message}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PersonRow({
+  label,
+  sub,
+  initials,
+  control,
+}: {
+  label: string;
+  sub: string;
+  initials: string;
+  control: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 text-[13px]">
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-emerald-100 text-[10px] font-semibold text-emerald-800">
+        {initials}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">{label}</span>
+        <span className="block truncate text-[11px] text-muted">{sub}</span>
+      </span>
+      {control}
+    </div>
+  );
+}
+
+function Avatar({ label }: { label: string }) {
+  return (
+    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-100 text-[9px] font-semibold text-indigo-800">
+      {initials(label)}
+    </span>
+  );
+}
+
+function initials(label: string): string {
+  return label.trim().slice(0, 2).toUpperCase() || "US";
+}
+
+function absoluteUrl(path: string): string {
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -862,6 +862,7 @@ export interface PublicStashDetail {
   workspace_name: string;
   items: PublicStashItem[];
   can_write: boolean;
+  can_manage_access: boolean;
 }
 
 export async function listStashes(workspaceId: string): Promise<WorkspaceStash[]> {
@@ -924,6 +925,44 @@ export async function addStashMember(
 
 export async function removeStashMember(stashId: string, userId: string): Promise<void> {
   await apiFetch(`/api/v1/stashes/${stashId}/members/${userId}`, { method: "DELETE" });
+}
+
+export interface StashShareOwner {
+  user_id: string;
+  name: string;
+  display_name: string | null;
+}
+
+export interface StashShare {
+  stash: WorkspaceStash;
+  url: string;
+  owner: StashShareOwner;
+  members: StashMember[];
+}
+
+export interface StashSharePersonInput {
+  user_id?: string;
+  username?: string;
+  permission: StashMemberPermission;
+}
+
+export async function getStashShare(stashId: string): Promise<StashShare> {
+  return apiFetch(`/api/v1/stashes/${stashId}/share`);
+}
+
+export async function updateStashShare(
+  stashId: string,
+  data: {
+    access?: "workspace" | "private" | "public";
+    discoverable?: boolean;
+    people?: StashSharePersonInput[];
+    remove_user_ids?: string[];
+  }
+): Promise<StashShare> {
+  return apiFetch(`/api/v1/stashes/${stashId}/share`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
 }
 
 export async function getPublicStash(slug: string): Promise<PublicStashDetail> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -892,8 +892,6 @@ export async function updateStash(
   data: {
     title?: string;
     description?: string;
-    access?: "workspace" | "private" | "public";
-    discoverable?: boolean;
     cover_image_url?: string | null;
     icon_url?: string | null;
     items?: StashItemSpec[];
@@ -903,28 +901,6 @@ export async function updateStash(
     method: "PATCH",
     body: JSON.stringify(data),
   });
-}
-
-export async function listStashMembers(stashId: string): Promise<StashMember[]> {
-  const data = await apiFetch<{ members: StashMember[] }>(
-    `/api/v1/stashes/${stashId}/members`
-  );
-  return data.members;
-}
-
-export async function addStashMember(
-  stashId: string,
-  userId: string,
-  permission: StashMemberPermission
-): Promise<StashMember> {
-  return apiFetch(`/api/v1/stashes/${stashId}/members`, {
-    method: "POST",
-    body: JSON.stringify({ user_id: userId, permission }),
-  });
-}
-
-export async function removeStashMember(stashId: string, userId: string): Promise<void> {
-  await apiFetch(`/api/v1/stashes/${stashId}/members/${userId}`, { method: "DELETE" });
 }
 
 export interface StashShareOwner {


### PR DESCRIPTION
## Summary

- Add a Stash share API at `GET/PATCH /api/v1/stashes/{stash_id}/share` with owner, link, explicit members, visibility, grants, and removals.
- Add a Stash-level share dialog for copying the Stash link, managing explicit Stash access, and changing general Stash visibility.
- Label Stash sharing and Workspace inviting separately so the access boundary is clear.

## Validation

- `pytest backend/tests/test_stash_invites.py`
- `ruff check .`
- `cd frontend && npm test -- StashShareDialog StashPageClient.test.tsx`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Playwright browser QA: added a user through the Stash share dialog and captured Stash/Workspace share screenshots.

## Screenshots

Screenshots are attached in the PR thread.