### PR TITLE
Drop the vestigial Files/Table tab bar on the table viewer

### DIFF
--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -564,33 +564,17 @@ function TableEditorPageInner() {
 
   const tableContent = (
       <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-        {/* Files / Table context bar */}
-        <div className="flex items-center gap-0 px-4 border-b border-border bg-surface flex-shrink-0">
+        {/* Toolbar */}
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface flex-shrink-0 flex-wrap">
           {readOnly && stashSlug ? (
             <Link
               href={`/stashes/${stashSlug}`}
-              className="px-4 py-2.5 text-sm font-medium transition-colors text-dim hover:text-foreground"
+              className="inline-flex items-center gap-1 text-sm text-muted hover:text-foreground"
+              aria-label={`Back to ${stashTitle ?? "Stash"}`}
             >
               &larr; {stashTitle ?? "Stash"}
             </Link>
           ) : (
-            <button
-              onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
-              className="px-4 py-2.5 text-sm font-medium transition-colors text-dim hover:text-foreground"
-            >
-              Files
-            </button>
-          )}
-          <button
-            className="px-4 py-2.5 text-sm font-medium transition-colors relative text-brand"
-          >
-            Table
-            <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-brand rounded-t" />
-          </button>
-        </div>
-        {/* Toolbar */}
-        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface flex-shrink-0 flex-wrap">
-          {!readOnly && (
             <button
               onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
               className="text-muted hover:text-foreground text-sm"


### PR DESCRIPTION
## Summary

The bar above the toolbar looked like tabs but wasn't:
- **Files** → back-to-workspace-home button styled as a tab
- **Table** → hardcoded active label with a brand underline, no sibling view to switch to

In stash mode the redundancy was worse: the toolbar back-arrow and the tab bar's "← Stash" link both pointed at the same place. Workspace users saw two stacked back-affordances.

This PR deletes the bar and folds the back-affordance into the toolbar:
- Workspace mode → plain `← Back to Files` arrow (unchanged)
- Stash mode → `← <Stash title>` link pointing at the source stash

Net: one back affordance, less chrome above the data.

## Test plan
- [ ] Open a workspace table via `/tables/{id}?workspaceId={ws}` → toolbar has `←` next to the editable title; no tabs above.
- [ ] Open the same table via a public stash (`?stash=<slug>`) → toolbar has `← <Stash title>` next to the read-only title.
- [ ] Tab key navigation: `←` is still focusable as the first toolbar control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)