### PR TITLE
[codex] Replace workspace icon with octopus glyph

### DIFF
--- a/frontend/public/design/icons.jsx
+++ b/frontend/public/design/icons.jsx
@@ -71,9 +71,21 @@ const I = (props) => ({
     </svg>
   ),
   Stash: (
-    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
-      <path d="M4 7h16l-1.3 11a2 2 0 0 1-2 1.8H7.3a2 2 0 0 1-2-1.8L4 7z"/>
-      <path d="M9 7V5a3 3 0 0 1 6 0v2"/>
+    <svg viewBox="0 0 24 24" width="14" height="14" shapeRendering="crispEdges" {...props}>
+      <g fill="currentColor">
+        <rect x="8" y="4" width="8" height="2"/>
+        <rect x="6" y="6" width="12" height="8"/>
+        <rect x="4" y="9" width="2" height="5"/>
+        <rect x="18" y="9" width="2" height="5"/>
+        <rect x="5" y="14" width="3" height="3"/>
+        <rect x="10" y="14" width="2" height="5"/>
+        <rect x="14" y="14" width="2" height="5"/>
+        <rect x="17" y="14" width="3" height="3"/>
+      </g>
+      <g fill="var(--bg-base)">
+        <rect x="9" y="8" width="2" height="2"/>
+        <rect x="13" y="8" width="2" height="2"/>
+      </g>
     </svg>
   ),
   Activity: (

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -20,6 +20,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import AppShell from "../../../components/AppShell";
 import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
+import { StashIcon } from "../../../components/StashIcons";
 import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
@@ -465,7 +466,7 @@ function StashIconUpload({
     // eslint-disable-next-line @next/next/no-img-element
     <img src={iconUrl} alt="" className="h-full w-full object-cover" />
   ) : (
-    <StashHeaderGlyph />
+    <StashIcon className="text-[24px]" />
   );
 
   if (!canWrite) {
@@ -802,15 +803,6 @@ function groupStashItems(items: PublicStashItem[]): StashItemGroup {
     groups[item.object_type] = [...(groups[item.object_type] ?? []), item];
   }
   return groups;
-}
-
-function StashHeaderGlyph() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-      <path d="M4 7h16l-1.3 11a2 2 0 0 1-2 1.8H7.3a2 2 0 0 1-2-1.8L4 7z" />
-      <path d="M9 7V5a3 3 0 0 1 6 0v2" />
-    </svg>
-  );
 }
 
 // Compact item list — each item deep-links to its editor / viewer in the

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -12,7 +12,7 @@ import TiptapLink from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import MembersModal from "../../../components/MembersModal";
 import StashQuickAdd from "../../../components/StashQuickAdd";
-import { StashIcon } from "../../../components/StashIcons";
+import { WorkspaceIcon } from "../../../components/StashIcons";
 import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
@@ -140,7 +140,7 @@ export default function WorkspaceHomePage() {
                   // eslint-disable-next-line @next/next/no-img-element
                   <img src={workspace.icon_url} alt="" className="h-full w-full object-cover" />
                 ) : (
-                  <StashIcon />
+                  <WorkspaceIcon />
                 )}
               </span>
               <div className="min-w-0">
@@ -384,4 +384,3 @@ function WorkspaceDescriptionEditor({
     </section>
   );
 }
-

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import DownloadMenu from "../../../../../components/DownloadMenu";
+import { StashIcon } from "../../../../../components/StashIcons";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
   fetchAuthed,
@@ -325,12 +326,7 @@ function FileGlyph() {
 }
 
 function StashGlyph() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="flex-shrink-0">
-      <path d="M4 7h16l-1.3 11a2 2 0 0 1-2 1.8H7.3a2 2 0 0 1-2-1.8L4 7z" />
-      <path d="M9 7V5a3 3 0 0 1 6 0v2" />
-    </svg>
-  );
+  return <StashIcon className="text-[12px]" />;
 }
 
 function formatBytes(bytes: number): string {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -41,6 +41,7 @@ import {
   SettingsIcon,
   StashIcon,
   TableIcon,
+  WorkspaceIcon,
 } from "./StashIcons";
 
 interface AppSidebarProps {
@@ -1623,8 +1624,8 @@ function WorkspaceSwitcher({
         aria-expanded={open}
         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised"
       >
-        <span className="flex h-6 w-6 items-center justify-center rounded-[5px] bg-[var(--color-brand-600)] text-[11px] font-bold text-white">
-          {(active?.name ?? "S").slice(0, 1).toUpperCase()}
+        <span className="flex h-6 w-6 items-center justify-center rounded-[5px] bg-[var(--color-brand-100)] text-[var(--color-brand-700)]">
+          <WorkspaceIcon className="text-[16px]" />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block truncate font-display text-[13.5px] font-semibold tracking-tight text-foreground">
@@ -1727,12 +1728,9 @@ function WorkspaceMenuItem({
       }
     >
       <span
-        className={
-          "flex h-5 w-5 items-center justify-center rounded-[4px] text-[10px] font-bold text-white " +
-          (active ? "bg-[var(--color-brand-700)]" : "bg-[var(--color-brand-600)]")
-        }
+        className="flex h-5 w-5 items-center justify-center rounded-[4px] bg-[var(--color-brand-100)] text-[var(--color-brand-700)]"
       >
-        {workspace.name.slice(0, 1).toUpperCase()}
+        <WorkspaceIcon className="text-[13px]" />
       </span>
       <span className="min-w-0 flex-1 truncate font-medium">{workspace.name}</span>
       {active && (

--- a/frontend/src/components/StashIcons.tsx
+++ b/frontend/src/components/StashIcons.tsx
@@ -1,4 +1,3 @@
-import AnalyticsOutlinedIcon from "@mui/icons-material/AnalyticsOutlined";
 import ChatOutlinedIcon from "@mui/icons-material/ChatOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import ExploreOutlinedIcon from "@mui/icons-material/ExploreOutlined";
@@ -36,8 +35,40 @@ function MaterialIcon({
   );
 }
 
+function LowResOctopusIcon({ className }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={iconClass(className)}
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      shapeRendering="crispEdges"
+    >
+      <g fill="currentColor">
+        <rect x="8" y="4" width="8" height="2" />
+        <rect x="6" y="6" width="12" height="8" />
+        <rect x="4" y="9" width="2" height="5" />
+        <rect x="18" y="9" width="2" height="5" />
+        <rect x="5" y="14" width="3" height="3" />
+        <rect x="10" y="14" width="2" height="5" />
+        <rect x="14" y="14" width="2" height="5" />
+        <rect x="17" y="14" width="3" height="3" />
+      </g>
+      <g fill="var(--bg-base)">
+        <rect x="9" y="8" width="2" height="2" />
+        <rect x="13" y="8" width="2" height="2" />
+      </g>
+    </svg>
+  );
+}
+
 export function StashIcon(props: IconProps) {
-  return <MaterialIcon icon={AnalyticsOutlinedIcon} {...props} />;
+  return <LowResOctopusIcon {...props} />;
+}
+
+export function WorkspaceIcon(props: IconProps) {
+  return <LowResOctopusIcon {...props} />;
 }
 
 export function SessionsIcon(props: IconProps) {


### PR DESCRIPTION
## Summary
- Replaced the shared Stash glyph with a blocky low-res octopus mark that matches the existing octopus logo direction.
- Added a dedicated `WorkspaceIcon` alias and used it for the workspace switcher, workspace menu rows, and workspace header fallback.
- Removed the old bucket-shaped stash glyph from stash detail/session surfaces and the design icon preview.

## Why
The previous bucket-shaped stash glyph read too much like a trash can, especially at sidebar/header sizes. The new mark keeps the icon abstract and brand-adjacent while staying simple at small sizes.

## Validation
- `cd frontend && npm run lint`
- `cd frontend && npm test -- AppSidebar StashPageClient`
- `cd frontend && npm run build`
- Playwright browser checks with mocked API responses for workspace and stash pages

## Screenshots
Product screenshots are attached in the PR thread.