### PR TITLE
Use human authors for session grouping

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -99,7 +99,11 @@ async def list_my_sessions(
           he.session_id,
           he.workspace_id,
           w.name AS workspace_name,
-          COALESCE(MAX(u.display_name), MAX(u.name), MAX(he.agent_name), 'Unknown user') AS user_name,
+          COALESCE(
+            MAX(NULLIF(u.display_name, '')),
+            MAX(NULLIF(u.name, '')),
+            'Unknown user'
+          ) AS user_name,
           MAX(he.agent_name) AS agent_name,
           COUNT(*)::INT AS event_count,
           MIN(he.created_at) AS started_at,
@@ -117,7 +121,7 @@ async def list_my_sessions(
         LEFT JOIN users u ON u.id = he.created_by
         WHERE {' AND '.join(where)}
         GROUP BY he.session_id, he.workspace_id, w.name
-        ORDER BY last_event_at DESC, COALESCE(MAX(u.display_name), MAX(u.name), MAX(he.agent_name), 'Unknown user') ASC, session_id ASC
+        ORDER BY last_event_at DESC, user_name ASC, session_id ASC
         LIMIT {int(limit)}
         """,
         *args,

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -41,6 +41,7 @@ async def _list_sessions(workspace_id: UUID, user_id: UUID) -> list[dict]:
             "id": s["id"],
             "session_id": s["session_id"],
             "title": _auto_session_title(s),
+            "user_name": s["user_name"],
             "agent_name": s["agent_name"] or "",
             "size_bytes": int(s["size_bytes"] or 0),
             "last_at": s["last_at"],

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -319,6 +319,13 @@ async def list_workspace_sessions(workspace_id: UUID, user_id: UUID) -> list[dic
         "SELECT h.session_id, "
         "       s.id::text AS id, "
         "       MAX(h.agent_name) AS agent_name, "
+        "       COALESCE("
+        "         (ARRAY_AGG(NULLIF(u.display_name, '') ORDER BY h.created_at) "
+        "          FILTER (WHERE NULLIF(u.display_name, '') IS NOT NULL))[1], "
+        "         (ARRAY_AGG(NULLIF(u.name, '') ORDER BY h.created_at) "
+        "          FILTER (WHERE NULLIF(u.name, '') IS NOT NULL))[1], "
+        "         'Unknown user'"
+        "       ) AS user_name, "
         "       COALESCE(MAX(s.summary), '') AS summary, "
         "       COUNT(*)::INT AS event_count, "
         "       SUM(LENGTH(h.content))::BIGINT AS size_bytes, "
@@ -326,10 +333,11 @@ async def list_workspace_sessions(workspace_id: UUID, user_id: UUID) -> list[dic
         "       MAX(h.created_at) AS last_at "
         "FROM history_events h "
         "JOIN sessions s ON s.workspace_id = h.workspace_id AND s.session_id = h.session_id "
+        "LEFT JOIN users u ON u.id = h.created_by "
         "WHERE h.workspace_id = $1 AND h.session_id IS NOT NULL "
         f"AND {readable_session_event_condition('h', 2)} "
         "GROUP BY h.session_id, s.id "
-        "ORDER BY last_at DESC, agent_name ASC, session_id ASC",
+        "ORDER BY last_at DESC, user_name ASC, session_id ASC",
         workspace_id,
         user_id,
     )

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -39,7 +39,8 @@ async def upsert_session(
         "VALUES ($1, $2, $3, $4, $5) "
         "ON CONFLICT (workspace_id, session_id) DO UPDATE SET "
         "  agent_name = COALESCE(NULLIF(EXCLUDED.agent_name, ''), sessions.agent_name), "
-        "  cwd = COALESCE(EXCLUDED.cwd, sessions.cwd) "
+        "  cwd = COALESCE(EXCLUDED.cwd, sessions.cwd), "
+        "  created_by = COALESCE(sessions.created_by, EXCLUDED.created_by) "
         f"RETURNING {_SELECT_COLS}",
         workspace_id,
         session_id,

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -142,6 +142,44 @@ async def test_upload_adds_session_to_default_stash(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_workspace_sidebar_sessions_include_human_author(client: AsyncClient):
+    key = await _register(client)
+    ws = await _workspace(client, key)
+    headers = {"Authorization": f"Bearer {key}"}
+    me = await client.get("/api/v1/users/me", headers=headers)
+    assert me.status_code == 200
+    author = me.json()["display_name"] or me.json()["name"]
+
+    pushed = await client.post(
+        f"/api/v1/workspaces/{ws}/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "claude",
+                    "event_type": "user_message",
+                    "content": "Plan the release",
+                    "session_id": "sess-human-author",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert pushed.status_code == 201
+
+    overview = await client.get(f"/api/v1/workspaces/{ws}/overview", headers=headers)
+    assert overview.status_code == 200
+    [overview_session] = overview.json()["sessions"]
+    assert overview_session["user_name"] == author
+    assert overview_session["agent_name"] == "claude"
+
+    sidebar = await client.get(f"/api/v1/workspaces/{ws}/sidebar", headers=headers)
+    assert sidebar.status_code == 200
+    [sidebar_session] = sidebar.json()["sessions"]
+    assert sidebar_session["user_name"] == author
+    assert sidebar_session["agent_name"] == "claude"
+
+
+@pytest.mark.asyncio
 async def test_session_detail_returns_files_touched_and_artifacts_list(client: AsyncClient):
     key = await _register(client)
     ws = await _workspace(client, key)

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -372,7 +372,7 @@ function SessionTableRow({
   workspaceId: string;
   session: SessionSummary;
 }) {
-  const user = displaySessionUserName(session.user_name || session.agent_name, "Unknown");
+  const user = displaySessionUserName(session.user_name, "Unknown");
   const agent = session.agent_name || "agent";
   const avatar = avatarFor(user);
 

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -100,7 +100,8 @@ const sidebarWithStash = {
       id: "session-row-1",
       session_id: "session-1",
       title: "Planning session",
-      agent_name: "Codex",
+      user_name: "Henry",
+      agent_name: "Claude",
       size_bytes: 256,
       last_at: "2026-05-11T00:00:00Z",
       updated_at: "2026-05-11T00:00:00Z",
@@ -142,7 +143,8 @@ const sidebarWithTree = {
       id: "session-row-1",
       session_id: "session-1",
       title: "Planning session",
-      agent_name: "Codex",
+      user_name: "Henry",
+      agent_name: "Claude",
       size_bytes: 256,
       last_at: "2026-05-11T00:00:00Z",
       updated_at: "2026-05-11T00:00:00Z",
@@ -329,6 +331,8 @@ describe("AppSidebar tree expansion", () => {
     // never collapse it — only the chevron can collapse.
     const day = await screen.findByText(/May 11/);
     expect(detailsFor(day.textContent ?? "")).toHaveAttribute("open");
+    expect(screen.getByText("Henry")).toBeTruthy();
+    expect(screen.queryByText("Claude")).toBeNull();
     expect(screen.getByText("Planning session")).toBeTruthy();
 
     fireEvent.click(day);

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -652,7 +652,7 @@ function groupSidebarSessions(sessions: WorkspaceSidebarSession[]): SessionTreeD
   for (const session of sessions) {
     const date = sessionDate(session.last_at || session.updated_at);
     const key = date ? bucketKey(date, bucket) : UNKNOWN_SESSION_DATE;
-    const user = displaySidebarSessionUser(session.agent_name);
+    const user = displaySidebarSessionUser(session.user_name);
     const users = byBucket.get(key) ?? new Map<string, WorkspaceSidebarSession[]>();
     users.set(user, [...(users.get(user) ?? []), session]);
     byBucket.set(key, users);

--- a/frontend/src/components/share/StashShareModal.test.tsx
+++ b/frontend/src/components/share/StashShareModal.test.tsx
@@ -42,6 +42,7 @@ describe("StashShareModal session sharing", () => {
           id: "session-row-uuid",
           session_id: "session-route-id",
           title: "Debug auth flow",
+          user_name: "Henry",
           agent_name: "Henry's Codex",
           size_bytes: 1024,
           last_at: "2026-05-14T12:00:00Z",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1225,6 +1225,7 @@ export interface WorkspaceSidebarSession {
   id: string | null;
   session_id: string;
   title: string;
+  user_name: string | null;
   agent_name: string;
   size_bytes: number;
   last_at: string;

--- a/frontend/src/lib/sessionGrouping.test.ts
+++ b/frontend/src/lib/sessionGrouping.test.ts
@@ -65,11 +65,11 @@ describe("groupSessionsByUser", () => {
     expect(grouped[0].sessions.map((s) => s.session_id)).toEqual(["ada-new", "ada-old"]);
   });
 
-  it("falls back to agent_name when user_name is missing", () => {
+  it("keeps missing users out of agent-name buckets", () => {
     const grouped = groupSessionsByUser([
       session({ session_id: "x", user_name: null, agent_name: "claude" }),
     ]);
-    expect(grouped[0].key).toBe("claude");
+    expect(grouped[0].key).toBe("Unknown user");
   });
 });
 

--- a/frontend/src/lib/sessionGrouping.ts
+++ b/frontend/src/lib/sessionGrouping.ts
@@ -13,14 +13,14 @@ export function displaySessionUserName(
 ): string {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) return fallback;
-  return trimmed.toLowerCase() === "codex" ? "Sam" : trimmed;
+  return trimmed;
 }
 
 export function groupSessionsByDayAndUser(sessions: SessionSummary[]): SessionDayGroup[] {
   const days = new Map<string, Map<string, SessionSummary[]>>();
   for (const session of sortedSessions(sessions)) {
     const dayKey = sessionDayKey(session.last_event_at || session.started_at);
-    const user = displaySessionUserName(session.user_name || session.agent_name, "Unknown user");
+    const user = displaySessionUserName(session.user_name, "Unknown user");
     if (!days.has(dayKey)) days.set(dayKey, new Map());
     const users = days.get(dayKey)!;
     users.set(user, [...(users.get(user) ?? []), session]);
@@ -48,8 +48,8 @@ function sortedSessions(sessions: SessionSummary[]): SessionSummary[] {
     const timeDiff = sessionTime(b) - sessionTime(a);
     if (timeDiff !== 0) return timeDiff;
 
-    const userA = displaySessionUserName(a.user_name || a.agent_name, "");
-    const userB = displaySessionUserName(b.user_name || b.agent_name, "");
+    const userA = displaySessionUserName(a.user_name, "");
+    const userB = displaySessionUserName(b.user_name, "");
     const userDiff = userA.localeCompare(userB);
     if (userDiff !== 0) return userDiff;
 
@@ -90,9 +90,7 @@ export type SessionFlatGroup = {
 };
 
 export function groupSessionsByUser(sessions: SessionSummary[]): SessionFlatGroup[] {
-  return groupBy(sessions, (s) =>
-    displaySessionUserName(s.user_name || s.agent_name, "Unknown user")
-  );
+  return groupBy(sessions, (s) => displaySessionUserName(s.user_name, "Unknown user"));
 }
 
 export function groupSessionsByAgent(sessions: SessionSummary[]): SessionFlatGroup[] {


### PR DESCRIPTION
## What changed

- Added `user_name` to workspace sidebar session payloads from the event creator user.
- Updated the sidebar and Sessions page author grouping to use `user_name` only, instead of falling back to `agent_name`.
- Removed the hardcoded `codex -> Sam` display alias.
- Preserved `agent_name` for explicit agent labels/filters.

## Why

The workspace sidebar was treating `agent_name` as an author bucket, so production sessions recorded from Claude Code could appear under `claude` or `claude-subagent`. Those values are valid agent/source labels, but they are not human authors.

## Validation

- `pytest --no-cov backend/tests/test_transcripts.py`
- `ruff check backend/services/memory_service.py backend/services/session_service.py backend/routers/workspace_knowledge.py backend/routers/sessions.py backend/tests/test_transcripts.py`
- `cd frontend && npm test -- --run src/lib/sessionGrouping.test.ts src/components/AppSidebar.test.tsx src/components/share/StashShareModal.test.tsx`
- `cd frontend && npm run lint`

## Screenshots

No screenshot attached: this changes which data field is used for session author grouping, not the layout or visual styling.