### PR TITLE
[codex] Pivot activity graph to human-agent commits

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -185,7 +185,7 @@ async def activity_timeline(
     workspace_id: UUID | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
-    """Agent activity bucketed by time for the dashboard timeline."""
+    """Human + coding-agent session commits bucketed by time for the dashboard timeline."""
     if workspace_id is not None:
         await _verify_workspace_access(workspace_id, current_user["id"])
     return await analytics_service.get_activity_timeline(

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -100,7 +100,7 @@ async def get_activity_timeline(
     bucket: str = "day",
     workspace_id: UUID | None = None,
 ) -> dict:
-    """Agent activity bucketed by time for the timeline visualization."""
+    """Human + coding-agent session commits bucketed by time."""
     pool = get_pool()
     days = min(days, 365)
     if bucket not in ("hour", "day", "week"):
@@ -116,94 +116,62 @@ async def get_activity_timeline(
 
     rows = await pool.fetch(
         _accessible_events_cte(ws_idx=ws_idx) + """
+        , session_commits AS (
+            SELECT
+                me.workspace_id,
+                me.session_id,
+                DATE_TRUNC($2, MIN(me.created_at)) AS bucket_date,
+                (
+                    ARRAY_AGG(me.agent_name ORDER BY me.created_at)
+                    FILTER (WHERE me.agent_name IS NOT NULL AND me.agent_name != '')
+                )[1] AS agent_name,
+                (
+                    ARRAY_AGG(me.created_by ORDER BY me.created_at)
+                    FILTER (WHERE me.created_by IS NOT NULL)
+                )[1] AS actor_id
+            FROM history_events me
+            JOIN accessible_events a ON a.event_id = me.id
+            WHERE me.created_at >= $3
+              AND me.session_id IS NOT NULL
+            GROUP BY me.workspace_id, me.session_id
+        )
         SELECT
-            DATE_TRUNC($2, me.created_at) AS bucket_date,
-            me.agent_name,
-            me.event_type,
+            sc.bucket_date,
+            COALESCE(NULLIF(u.display_name, ''), u.name, 'Unknown human') AS human_name,
+            COALESCE(NULLIF(sc.agent_name, ''), 'unknown agent') AS agent_name,
             COUNT(*) AS cnt
-        FROM history_events me
-        JOIN accessible_events a ON a.event_id = me.id
-        WHERE me.created_at >= $3
-        GROUP BY bucket_date, me.agent_name, me.event_type
+        FROM session_commits sc
+        LEFT JOIN users u ON u.id = sc.actor_id
+        GROUP BY sc.bucket_date, human_name, agent_name
         ORDER BY bucket_date
         """,
         *args,
     )
 
-    # Build response shape
-    agents_set: set[str] = set()
+    contributors_set: set[str] = set()
     buckets_map: dict[str, dict] = {}
 
     for row in rows:
         date_str = row["bucket_date"].isoformat()
-        agent = row["agent_name"] or "unknown"
-        etype = row["event_type"] or "other"
+        contributor = f"{row['human_name']} / {row['agent_name']}"
         cnt = row["cnt"]
 
-        agents_set.add(agent)
+        contributors_set.add(contributor)
 
         if date_str not in buckets_map:
-            buckets_map[date_str] = {"date": date_str, "agents": {}}
+            buckets_map[date_str] = {"date": date_str, "contributors": {}}
 
         b = buckets_map[date_str]
-        if agent not in b["agents"]:
-            b["agents"][agent] = {"total": 0, "by_type": {}}
+        if contributor not in b["contributors"]:
+            b["contributors"][contributor] = {"total": 0, "by_type": {}}
 
-        b["agents"][agent]["total"] += cnt
-        b["agents"][agent]["by_type"][etype] = b["agents"][agent]["by_type"].get(etype, 0) + cnt
-
-    # Pages get their own pseudo-agent row so the GitHub-contribution-style
-    # timeline shows human page edits alongside agent session activity.
-    # Authorization: when scoped to a workspace, the caller has already been
-    # access-checked by the route; otherwise restrict to pages in workspaces
-    # the user is a member of.
-    if workspace_id is not None:
-        page_rows = await pool.fetch(
-            """
-            SELECT DATE_TRUNC($1, p.updated_at) AS bucket_date, COUNT(*) AS cnt
-            FROM pages p
-            WHERE p.updated_at >= $2 AND p.workspace_id = $3
-            GROUP BY bucket_date
-            ORDER BY bucket_date
-            """,
-            bucket,
-            cutoff,
-            workspace_id,
+        b["contributors"][contributor]["total"] += cnt
+        b["contributors"][contributor]["by_type"]["session.commit"] = (
+            b["contributors"][contributor]["by_type"].get("session.commit", 0) + cnt
         )
-    else:
-        page_rows = await pool.fetch(
-            """
-            SELECT DATE_TRUNC($1, p.updated_at) AS bucket_date, COUNT(*) AS cnt
-            FROM pages p
-            WHERE p.updated_at >= $2
-              AND p.workspace_id IN (
-                SELECT workspace_id FROM workspace_members WHERE user_id = $3
-              )
-            GROUP BY bucket_date
-            ORDER BY bucket_date
-            """,
-            bucket,
-            cutoff,
-            user_id,
-        )
-
-    if page_rows:
-        agents_set.add("Pages")
-        for row in page_rows:
-            date_str = row["bucket_date"].isoformat()
-            cnt = row["cnt"]
-            if date_str not in buckets_map:
-                buckets_map[date_str] = {"date": date_str, "agents": {}}
-            b = buckets_map[date_str]
-            if "Pages" not in b["agents"]:
-                b["agents"]["Pages"] = {"total": 0, "by_type": {}}
-            b["agents"]["Pages"]["total"] += cnt
-            b["agents"]["Pages"]["by_type"]["page.updated"] = (
-                b["agents"]["Pages"]["by_type"].get("page.updated", 0) + cnt
-            )
 
     return {
-        "agents": sorted(agents_set),
+        "contributors": sorted(contributors_set),
         "buckets": list(buckets_map.values()),
     }
 

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -43,6 +43,59 @@ async def _event(client: AsyncClient, api_key: str, workspace_id: str, session_i
 
 
 @pytest.mark.asyncio
+async def test_activity_timeline_pivots_on_human_and_agent_sessions(client: AsyncClient):
+    register_resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": unique_name("activity_timeline"),
+            "display_name": "Timeline Human",
+            "password": "securepassword1",
+        },
+    )
+    assert register_resp.status_code == 201
+    api_key = register_resp.json()["api_key"]
+    workspace = await _workspace(client, api_key, "Timeline Workspace")
+
+    for content in ("first event", "second event"):
+        event_resp = await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/sessions/events",
+            json={
+                "agent_name": "codex",
+                "event_type": "assistant_message",
+                "content": content,
+                "session_id": "same-session",
+            },
+            headers=_auth(api_key),
+        )
+        assert event_resp.status_code == 201
+
+    page_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/pages/new",
+        json={"name": "Not a contributor", "content": "page content"},
+        headers=_auth(api_key),
+    )
+    assert page_resp.status_code == 201
+
+    resp = await client.get(
+        "/api/v1/me/activity-timeline",
+        params={"days": 365, "workspace_id": workspace["id"]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    timeline = resp.json()
+    assert timeline["contributors"] == ["Timeline Human / codex"]
+    assert "Pages" not in timeline["contributors"]
+
+    totals = [
+        contributor["total"]
+        for bucket in timeline["buckets"]
+        for contributor in bucket["contributors"].values()
+    ]
+    assert totals == [1]
+
+
+@pytest.mark.asyncio
 async def test_user_activity_is_scoped_to_accessible_workspaces(client: AsyncClient):
     owner_key = await _register(client, "activity_owner")
     other_key = await _register(client, "activity_other")

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -734,7 +734,7 @@ async def test_private_stash_hides_session_surfaces_until_user_is_added(
         headers=_auth(member_key),
     )
     assert timeline_resp.status_code == 200
-    assert timeline_resp.json()["agents"] == []
+    assert timeline_resp.json()["contributors"] == []
 
     await _add_stash_member(pool, stash["id"], member_id, owner_id, "read")
 
@@ -776,7 +776,7 @@ async def test_private_stash_hides_session_surfaces_until_user_is_added(
         headers=_auth(member_key),
     )
     assert timeline_resp.status_code == 200
-    assert timeline_resp.json()["agents"] == ["agent"]
+    assert timeline_resp.json()["contributors"] == ["session_privacy_owner / agent"]
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StashPageClient from "./StashPageClient";
@@ -71,7 +77,7 @@ vi.mock("../../../lib/api", () => ({
   getEmbeddingProjection: vi.fn(),
 }));
 
-vi.mock("../../../components/viz/AgentActivityTimeline", () => ({
+vi.mock("../../../components/viz/ContributorActivityTimeline", () => ({
   default: () => null,
 }));
 vi.mock("../../../components/viz/EmbeddingSpaceExplorer", () => ({
@@ -87,7 +93,7 @@ vi.mock("./AddToWorkspaceButton", () => ({
 }));
 
 function stashDetail(
-  stash: Partial<PublicStashDetail["stash"]> = {}
+  stash: Partial<PublicStashDetail["stash"]> = {},
 ): PublicStashDetail {
   return {
     stash: {
@@ -133,7 +139,7 @@ describe("StashPageClient sharing", () => {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
     vi.mocked(getActivityTimeline).mockResolvedValue({
-      agents: [],
+      contributors: [],
       buckets: [],
     });
     vi.mocked(getEmbeddingProjection).mockResolvedValue({
@@ -161,8 +167,8 @@ describe("StashPageClient sharing", () => {
 
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        `${window.location.origin}/stashes/shared-stash`
-      )
+        `${window.location.origin}/stashes/shared-stash`,
+      ),
     );
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
   });
@@ -175,15 +181,19 @@ describe("StashPageClient sharing", () => {
 
     render(<StashPageClient slug="shared-stash" />);
 
-    expect(await screen.findByRole("button", { name: "+ Add things" })).toBeInTheDocument();
     expect(
-      screen.queryByPlaceholderText("Paste a link, type a note, or drop a file")
+      await screen.findByRole("button", { name: "+ Add things" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(
+        "Paste a link, type a note, or drop a file",
+      ),
     ).not.toBeInTheDocument();
   });
 
   it("does not render stash access as a title badge", async () => {
     vi.mocked(getPublicStash).mockResolvedValueOnce(
-      stashDetail({ access: "workspace" })
+      stashDetail({ access: "workspace" }),
     );
 
     render(<StashPageClient slug="shared-stash" />);

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -20,7 +20,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import AppShell from "../../../components/AppShell";
 import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
-import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
+import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
 import { useEscapeKey } from "../../../hooks/useEscapeKey";
@@ -37,7 +37,9 @@ import {
 import type { ActivityTimeline, EmbeddingProjection } from "../../../lib/types";
 import AddToWorkspaceButton from "./AddToWorkspaceButton";
 
-type StashItemGroup = Partial<Record<PublicStashItem["object_type"], PublicStashItem[]>>;
+type StashItemGroup = Partial<
+  Record<PublicStashItem["object_type"], PublicStashItem[]>
+>;
 
 // Same autosave window as workspace home — slow enough to coalesce
 // keystrokes, fast enough to feel near-realtime.
@@ -60,7 +62,7 @@ function StashChrome({
       { label: "Stashes", href: "/stashes" },
       { label: data?.stash.title ?? "Stash" },
     ],
-    `stash/${data?.stash.id ?? "loading"}`
+    `stash/${data?.stash.id ?? "loading"}`,
   );
   if (loading) {
     return (
@@ -119,9 +121,12 @@ export default function StashPageClient({ slug }: { slug: string }) {
     return (
       <StashChrome data={null}>
         <div className="mx-auto max-w-md py-24 text-center">
-          <h1 className="font-display text-[28px] font-bold text-foreground">Stash not found</h1>
+          <h1 className="font-display text-[28px] font-bold text-foreground">
+            Stash not found
+          </h1>
           <p className="mt-2 text-[14px] leading-relaxed text-dim">
-            {error || "This Stash is private, revoked, or unavailable to the current user."}
+            {error ||
+              "This Stash is private, revoked, or unavailable to the current user."}
           </p>
         </div>
       </StashChrome>
@@ -173,7 +178,9 @@ function StashPageBody({
   const groups = groupStashItems(items);
   const [addOpen, setAddOpen] = useState(false);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
-  const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
+  const [projection, setProjection] = useState<EmbeddingProjection | null>(
+    null,
+  );
 
   useEffect(() => {
     // Visualizations are workspace-scoped — they show the owning workspace's
@@ -263,7 +270,10 @@ function StashPageBody({
             ) : (
               // Forking only makes sense when the viewer doesn't already have
               // write access to this stash in its own workspace.
-              <AddToWorkspaceButton slug={stash.slug} sourceWorkspaceId={stash.workspace_id} />
+              <AddToWorkspaceButton
+                slug={stash.slug}
+                sourceWorkspaceId={stash.workspace_id}
+              />
             )}
           </div>
         </div>
@@ -319,29 +329,33 @@ function StashPageBody({
           )}
         </div>
 
-        {/* Visualizations: agent activity + 3D embedding view of the
+        {/* Visualizations: human/agent session activity + 3D embedding view of the
             owning workspace — same shape as workspace home. */}
         <section className="mt-8">
-          <div className="sys-label mb-1.5">Agent activity — past year</div>
+          <div className="sys-label mb-1.5">Human / agent commits — past year</div>
           <div className="card-soft overflow-x-auto p-3">
-            {timeline && timeline.agents.length > 0 ? (
-              <AgentActivityTimeline data={timeline} />
+            {timeline && timeline.contributors.length > 0 ? (
+              <ContributorActivityTimeline data={timeline} />
             ) : (
               <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No agent sessions yet. Add a session to this Stash or push a transcript via the CLI.
+                No agent session commits yet. Add a session to this Stash or
+                push a transcript via the CLI.
               </div>
             )}
           </div>
         </section>
 
         <section className="mt-6">
-          <div className="sys-label mb-1.5">Embedding space — workspace knowledge map</div>
+          <div className="sys-label mb-1.5">
+            Embedding space — workspace knowledge map
+          </div>
           <div className="card-soft p-3">
             {projection && projection.points.length > 0 ? (
               <EmbeddingSpaceExplorer data={projection} />
             ) : (
               <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No embeddings indexed yet. Pages, table rows, and session events get embedded as they&apos;re added.
+                No embeddings indexed yet. Pages, table rows, and session events
+                get embedded as they&apos;re added.
               </div>
             )}
           </div>
@@ -413,7 +427,11 @@ function BannerImage({
     >
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/25 group-hover:opacity-100">
         <span className="rounded-md bg-black/60 px-2 py-1 text-[11.5px] font-medium text-white">
-          {uploading ? "Uploading…" : hasCustomCover ? "Change banner" : "Add banner"}
+          {uploading
+            ? "Uploading…"
+            : hasCustomCover
+              ? "Change banner"
+              : "Add banner"}
         </span>
       </div>
       <input
@@ -631,7 +649,10 @@ function ShareStashButton({
   useEffect(() => {
     if (!open) return;
     function onDown(e: globalThis.MouseEvent) {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
         setOpen(false);
       }
     }
@@ -641,7 +662,9 @@ function ShareStashButton({
 
   async function copyLink() {
     try {
-      await navigator.clipboard.writeText(absoluteUrl(`/stashes/${stash.slug}`));
+      await navigator.clipboard.writeText(
+        absoluteUrl(`/stashes/${stash.slug}`),
+      );
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1600);
     } catch {
@@ -649,7 +672,9 @@ function ShareStashButton({
     }
   }
 
-  async function applyChanges(next: Partial<{ access: typeof vis; discoverable: boolean }>) {
+  async function applyChanges(
+    next: Partial<{ access: typeof vis; discoverable: boolean }>,
+  ) {
     setSaving(true);
     try {
       await updateStash(stash.id, next);
@@ -806,7 +831,14 @@ function groupStashItems(items: PublicStashItem[]): StashItemGroup {
 
 function StashHeaderGlyph() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+    >
       <path d="M4 7h16l-1.3 11a2 2 0 0 1-2 1.8H7.3a2 2 0 0 1-2-1.8L4 7z" />
       <path d="M9 7V5a3 3 0 0 1 6 0v2" />
     </svg>
@@ -831,28 +863,47 @@ function StashItemSection({
   return (
     <section>
       <div className="mb-2 flex items-baseline gap-2 border-b border-border-subtle pb-1.5">
-        <h2 className="m-0 font-display text-[15px] font-semibold text-foreground">{title}</h2>
+        <h2 className="m-0 font-display text-[15px] font-semibold text-foreground">
+          {title}
+        </h2>
         <span className="sys-label" style={{ fontSize: 10.5 }}>
           {items.length}
         </span>
       </div>
       <div className="flex flex-col gap-1">
         {items.map((item) => (
-          <StashItemRow key={`${item.object_type}-${item.object_id}`} item={item} stashSlug={stashSlug} workspaceId={workspaceId} />
+          <StashItemRow
+            key={`${item.object_type}-${item.object_id}`}
+            item={item}
+            stashSlug={stashSlug}
+            workspaceId={workspaceId}
+          />
         ))}
       </div>
     </section>
   );
 }
 
-function StashItemRow({ item, stashSlug, workspaceId }: { item: PublicStashItem; stashSlug: string; workspaceId: string }) {
+function StashItemRow({
+  item,
+  stashSlug,
+  workspaceId,
+}: {
+  item: PublicStashItem;
+  stashSlug: string;
+  workspaceId: string;
+}) {
   const href = hrefForItem(item, stashSlug, workspaceId);
   const sub = subtitleForItem(item);
   const tint = tintForKind(item.object_type);
 
   const content = (
     <>
-      <span className={"flex h-5 w-5 flex-shrink-0 items-center justify-center " + tint}>
+      <span
+        className={
+          "flex h-5 w-5 flex-shrink-0 items-center justify-center " + tint
+        }
+      >
         <KindGlyph kind={item.object_type} />
       </span>
       <span className="min-w-0 flex-1">
@@ -864,7 +915,9 @@ function StashItemRow({ item, stashSlug, workspaceId }: { item: PublicStashItem;
         )}
       </span>
       {href && (
-        <span className="hidden text-[11.5px] text-muted sm:inline">Open →</span>
+        <span className="hidden text-[11.5px] text-muted sm:inline">
+          Open →
+        </span>
       )}
     </>
   );
@@ -893,7 +946,7 @@ function StashItemRow({ item, stashSlug, workspaceId }: { item: PublicStashItem;
 function hrefForItem(
   item: PublicStashItem,
   stashSlug: string,
-  workspaceId: string
+  workspaceId: string,
 ): string | null {
   if (item.object_type === "file") {
     return `/workspaces/${workspaceId}/f/${item.object_id}?stash=${encodeURIComponent(stashSlug)}`;
@@ -913,11 +966,21 @@ function hrefForItem(
 
 function subtitleForItem(item: PublicStashItem): string {
   if (item.object_type === "session") {
-    const s = item.inline?.session as { agent_name?: string; events?: unknown[] } | undefined;
-    if (s) return [s.agent_name, s.events?.length ? `${s.events.length} events` : null].filter(Boolean).join(" · ");
+    const s = item.inline?.session as
+      | { agent_name?: string; events?: unknown[] }
+      | undefined;
+    if (s)
+      return [
+        s.agent_name,
+        s.events?.length ? `${s.events.length} events` : null,
+      ]
+        .filter(Boolean)
+        .join(" · ");
   }
   if (item.object_type === "file") {
-    const f = item.inline as { content_type?: string; size_bytes?: number } | undefined;
+    const f = item.inline as
+      | { content_type?: string; size_bytes?: number }
+      | undefined;
     if (f?.content_type) return f.content_type;
   }
   if (item.object_type === "page") {
@@ -937,32 +1000,67 @@ function tintForKind(kind: PublicStashItem["object_type"]): string {
 function KindGlyph({ kind }: { kind: PublicStashItem["object_type"] }) {
   if (kind === "folder")
     return (
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <svg
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      >
         <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
       </svg>
     );
   if (kind === "page")
     return (
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <svg
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      >
         <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
         <path d="M14 3v5h5" />
       </svg>
     );
   if (kind === "session")
     return (
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <svg
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      >
         <path d="M21 12c0 4.4-4 8-9 8-1.4 0-2.8-.3-4-.8L3 21l1.5-4C3.6 15.7 3 13.9 3 12c0-4.4 4-8 9-8s9 3.6 9 8z" />
       </svg>
     );
   if (kind === "table")
     return (
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <svg
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      >
         <rect x="3" y="4" width="18" height="16" rx="2" />
         <path d="M3 10h18M3 16h18M9 4v16M15 4v16" />
       </svg>
     );
   return (
-    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+    >
       <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
       <path d="M14 3v5h5" />
     </svg>

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -13,7 +13,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import MembersModal from "../../../components/MembersModal";
 import StashQuickAdd from "../../../components/StashQuickAdd";
 import { StashIcon } from "../../../components/StashIcons";
-import AgentActivityTimeline from "../../../components/viz/AgentActivityTimeline";
+import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
 import {
@@ -54,7 +54,9 @@ export default function WorkspaceHomePage() {
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
-  const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
+  const [projection, setProjection] = useState<EmbeddingProjection | null>(
+    null,
+  );
   const [error, setError] = useState("");
   const [membersOpen, setMembersOpen] = useState(false);
 
@@ -63,7 +65,7 @@ export default function WorkspaceHomePage() {
       getWorkspace(workspaceId),
       getWorkspaceMembers(workspaceId),
       // 365 days because seeded dev data is dated; for production the
-      // visualization remains legible at this window (1 row per agent × 365
+      // visualization remains legible at this window (1 row per contributor × 365
       // 14px cells = ~1.4kpx wide, fits with horizontal scroll).
       getActivityTimeline(365, "day", workspaceId),
       getEmbeddingProjection(500, undefined, workspaceId),
@@ -97,7 +99,11 @@ export default function WorkspaceHomePage() {
   }
 
   if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+    return (
+      <div className="flex h-screen items-center justify-center text-muted">
+        Loading…
+      </div>
+    );
   if (!user) return null;
 
   return (
@@ -122,7 +128,11 @@ export default function WorkspaceHomePage() {
               <span className="-mt-9 flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-[10px] border-2 border-base bg-base text-[28px] text-[var(--color-brand-700)] shadow-sm">
                 {workspace?.icon_url ? (
                   // eslint-disable-next-line @next/next/no-img-element
-                  <img src={workspace.icon_url} alt="" className="h-full w-full object-cover" />
+                  <img
+                    src={workspace.icon_url}
+                    alt=""
+                    className="h-full w-full object-cover"
+                  />
                 ) : (
                   <StashIcon />
                 )}
@@ -171,7 +181,9 @@ export default function WorkspaceHomePage() {
 
           {!isMember && workspace && (
             <div className="mt-4 flex items-center justify-between rounded-lg border border-border bg-surface px-4 py-3 text-[13px]">
-              <span className="text-muted">You aren&apos;t a member of this workspace.</span>
+              <span className="text-muted">
+                You aren&apos;t a member of this workspace.
+              </span>
               <button
                 onClick={handleJoin}
                 className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
@@ -185,7 +197,9 @@ export default function WorkspaceHomePage() {
               session-transcript upload; anything else uploads to Files. */}
           {isMember && (
             <section className="mt-6">
-              <div className="sys-label mb-1.5">Quick add — paste a URL, drop a file, drop a .jsonl transcript</div>
+              <div className="sys-label mb-1.5">
+                Quick add — paste a URL, drop a file, drop a .jsonl transcript
+              </div>
               <StashQuickAdd workspaceId={workspaceId} onAdded={load} />
             </section>
           )}
@@ -196,35 +210,38 @@ export default function WorkspaceHomePage() {
             onSaved={(updated) => setWorkspace(updated)}
           />
 
-          {/* Visualizations: agent activity over time + 3D embedding view.
+          {/* Visualizations: human/agent session activity + 3D embedding view.
               Section renders even when empty so users see the placeholder
               and know what's coming once data exists. */}
           <section className="mt-8">
-            <div className="sys-label mb-1.5">Agent activity — past year</div>
+            <div className="sys-label mb-1.5">Human / agent commits — past year</div>
             <div className="card-soft overflow-x-auto p-3">
-              {timeline && timeline.agents.length > 0 ? (
-                <AgentActivityTimeline data={timeline} />
+              {timeline && timeline.contributors.length > 0 ? (
+                <ContributorActivityTimeline data={timeline} />
               ) : (
                 <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                  No agent sessions yet. Push a transcript via Quick add or the CLI to populate this view.
+                  No agent session commits yet. Push a transcript via Quick add
+                  or the CLI to populate this view.
                 </div>
               )}
             </div>
           </section>
 
           <section className="mt-6">
-            <div className="sys-label mb-1.5">Embedding space — workspace knowledge map</div>
+            <div className="sys-label mb-1.5">
+              Embedding space — workspace knowledge map
+            </div>
             <div className="card-soft p-3">
               {projection && projection.points.length > 0 ? (
                 <EmbeddingSpaceExplorer data={projection} />
               ) : (
                 <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                  No embeddings indexed yet. Pages, table rows, and session events get embedded as they&apos;re added.
+                  No embeddings indexed yet. Pages, table rows, and session
+                  events get embedded as they&apos;re added.
                 </div>
               )}
             </div>
           </section>
-
         </div>
       </div>
       <MembersModal
@@ -238,7 +255,16 @@ export default function WorkspaceHomePage() {
 
 function SettingsGlyph() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <circle cx="12" cy="12" r="3" />
       <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
     </svg>
@@ -302,7 +328,9 @@ function WorkspaceDescriptionEditor({
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(async () => {
         lastSaved.current = html;
-        const updated = await updateWorkspace(workspace.id, { description: html });
+        const updated = await updateWorkspace(workspace.id, {
+          description: html,
+        });
         onSaved(updated);
       }, AUTOSAVE_MS);
     },

--- a/frontend/src/components/viz/ContributorActivityTimeline.tsx
+++ b/frontend/src/components/viz/ContributorActivityTimeline.tsx
@@ -5,22 +5,22 @@ import type { ActivityTimeline } from "../../lib/types";
 
 interface Props {
   data: ActivityTimeline;
-  onAgentClick?: (agent: string) => void;
+  onContributorClick?: (contributor: string) => void;
 }
 
 const CELL_SIZE = 14;
 const CELL_GAP = 2;
-const LABEL_WIDTH = 120;
+const LABEL_WIDTH = 180;
 const PADDING = 16;
 
 // Orange intensity scale matching brand color
 const INTENSITY_COLORS = [
-  "rgba(249, 115, 22, 0.0)",   // 0: transparent
-  "rgba(249, 115, 22, 0.15)",  // low
-  "rgba(249, 115, 22, 0.35)",  // medium-low
-  "rgba(249, 115, 22, 0.55)",  // medium
-  "rgba(249, 115, 22, 0.75)",  // medium-high
-  "rgba(249, 115, 22, 1.0)",   // high
+  "rgba(249, 115, 22, 0.0)", // 0: transparent
+  "rgba(249, 115, 22, 0.15)", // low
+  "rgba(249, 115, 22, 0.35)", // medium-low
+  "rgba(249, 115, 22, 0.55)", // medium
+  "rgba(249, 115, 22, 0.75)", // medium-high
+  "rgba(249, 115, 22, 1.0)", // high
 ];
 
 function getIntensity(count: number, maxCount: number): number {
@@ -37,22 +37,24 @@ function getIntensity(count: number, maxCount: number): number {
 interface TooltipInfo {
   x: number;
   y: number;
-  agent: string;
+  contributor: string;
   date: string;
   total: number;
   byType: Record<string, number>;
 }
 
-export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
+export default function ContributorActivityTimeline({
+  data,
+  onContributorClick,
+}: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
-  const [hoverAgent, setHoverAgent] = useState<string | null>(null);
+  const [hoverContributor, setHoverContributor] = useState<string | null>(null);
 
-  // Compute max count for intensity scaling
   const maxCount = data.buckets.reduce((max, b) => {
-    for (const agent of Object.values(b.agents)) {
-      if (agent.total > max) max = agent.total;
+    for (const contributor of Object.values(b.contributors)) {
+      if (contributor.total > max) max = contributor.total;
     }
     return max;
   }, 0);
@@ -64,11 +66,13 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const agents = data.agents;
+    const contributors = data.contributors;
     const buckets = data.buckets;
 
-    const totalWidth = LABEL_WIDTH + PADDING + buckets.length * (CELL_SIZE + CELL_GAP);
-    const totalHeight = PADDING + agents.length * (CELL_SIZE + CELL_GAP) + PADDING;
+    const totalWidth =
+      LABEL_WIDTH + PADDING + buckets.length * (CELL_SIZE + CELL_GAP);
+    const totalHeight =
+      PADDING + contributors.length * (CELL_SIZE + CELL_GAP) + PADDING;
 
     const dpr = window.devicePixelRatio || 2;
     canvas.width = totalWidth * dpr;
@@ -79,37 +83,36 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
 
     ctx.clearRect(0, 0, totalWidth, totalHeight);
 
-    // Agent labels (violet)
     ctx.font = "500 11px 'JetBrains Mono', monospace";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     ctx.fillStyle = "#8B5CF6";
 
-    for (let i = 0; i < agents.length; i++) {
+    for (let i = 0; i < contributors.length; i++) {
       const y = PADDING + i * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2;
-      const label = agents[i].length > 10 ? agents[i].slice(0, 9) + "..." : agents[i];
+      const label =
+        contributors[i].length > 22
+          ? contributors[i].slice(0, 21) + "..."
+          : contributors[i];
       ctx.fillText(label, LABEL_WIDTH, y);
     }
 
-    // Grid cells
     for (let bi = 0; bi < buckets.length; bi++) {
       const bucket = buckets[bi];
       const x = LABEL_WIDTH + PADDING + bi * (CELL_SIZE + CELL_GAP);
 
-      for (let ai = 0; ai < agents.length; ai++) {
+      for (let ai = 0; ai < contributors.length; ai++) {
         const y = PADDING + ai * (CELL_SIZE + CELL_GAP);
-        const agentData = bucket.agents[agents[ai]];
-        const count = agentData?.total ?? 0;
+        const contributorData = bucket.contributors[contributors[ai]];
+        const count = contributorData?.total ?? 0;
         const intensity = getIntensity(count, maxCount);
 
-        // Cell background
         if (intensity === 0) {
           ctx.fillStyle = "rgba(148, 163, 184, 0.08)";
         } else {
           ctx.fillStyle = INTENSITY_COLORS[intensity];
         }
 
-        // Rounded rect
         const r = 2;
         ctx.beginPath();
         ctx.roundRect(x, y, CELL_SIZE, CELL_SIZE, r);
@@ -122,12 +125,23 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
     const canvas = canvasRef.current;
     if (!canvas) return null;
     const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.clientWidth / (LABEL_WIDTH + PADDING + data.buckets.length * (CELL_SIZE + CELL_GAP));
+    const scaleX =
+      canvas.clientWidth /
+      (LABEL_WIDTH + PADDING + data.buckets.length * (CELL_SIZE + CELL_GAP));
     const mx = (e.clientX - rect.left) / scaleX;
     const my = (e.clientY - rect.top) / scaleX;
-    const bi = Math.floor((mx - LABEL_WIDTH - PADDING) / (CELL_SIZE + CELL_GAP));
+    const bi = Math.floor(
+      (mx - LABEL_WIDTH - PADDING) / (CELL_SIZE + CELL_GAP),
+    );
     const ai = Math.floor((my - PADDING) / (CELL_SIZE + CELL_GAP));
-    return { mx, my, bi, ai, clientX: e.clientX - rect.left, clientY: e.clientY - rect.top };
+    return {
+      mx,
+      my,
+      bi,
+      ai,
+      clientX: e.clientX - rect.left,
+      clientY: e.clientY - rect.top,
+    };
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
@@ -135,21 +149,22 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
     if (!p) return;
     const { bi, ai, clientX, clientY } = p;
 
-    // Any hover over a valid row — the whole row is a click target for the agent filter
-    const agent = ai >= 0 && ai < data.agents.length ? data.agents[ai] : null;
-    setHoverAgent(agent);
+    // Any hover over a valid row makes the whole row clickable for filters.
+    const contributor =
+      ai >= 0 && ai < data.contributors.length ? data.contributors[ai] : null;
+    setHoverContributor(contributor);
 
-    if (bi >= 0 && bi < data.buckets.length && agent) {
+    if (bi >= 0 && bi < data.buckets.length && contributor) {
       const bucket = data.buckets[bi];
-      const agentData = bucket.agents[agent];
-      if (agentData && agentData.total > 0) {
+      const contributorData = bucket.contributors[contributor];
+      if (contributorData && contributorData.total > 0) {
         setTooltip({
           x: clientX,
           y: clientY,
-          agent,
+          contributor,
           date: bucket.date.split("T")[0],
-          total: agentData.total,
-          byType: agentData.by_type,
+          total: contributorData.total,
+          byType: contributorData.by_type,
         });
         return;
       }
@@ -158,13 +173,18 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
   };
 
   const handleClick = (e: React.MouseEvent) => {
-    if (!onAgentClick) return;
+    if (!onContributorClick) return;
     const p = pointToCell(e);
     if (!p) return;
-    if (p.ai >= 0 && p.ai < data.agents.length) onAgentClick(data.agents[p.ai]);
+    if (p.ai >= 0 && p.ai < data.contributors.length) {
+      onContributorClick(data.contributors[p.ai]);
+    }
   };
 
-  const cursor = onAgentClick && hoverAgent ? "cursor-pointer" : "cursor-crosshair";
+  const cursor =
+    onContributorClick && hoverContributor
+      ? "cursor-pointer"
+      : "cursor-crosshair";
 
   return (
     <div ref={containerRef} className="relative overflow-x-auto">
@@ -172,7 +192,10 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
         ref={canvasRef}
         className={cursor}
         onMouseMove={handleMouseMove}
-        onMouseLeave={() => { setTooltip(null); setHoverAgent(null); }}
+        onMouseLeave={() => {
+          setTooltip(null);
+          setHoverContributor(null);
+        }}
         onClick={handleClick}
       />
       {tooltip && (
@@ -181,16 +204,19 @@ export default function AgentActivityTimeline({ data, onAgentClick }: Props) {
           style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
         >
           <div className="text-xs font-medium text-foreground">
-            <span className="text-violet-400">{tooltip.agent}</span>
+            <span className="text-violet-400">{tooltip.contributor}</span>
             <span className="text-muted mx-1">&middot;</span>
             <span className="text-muted font-mono">{tooltip.date}</span>
           </div>
           <div className="text-[11px] text-muted mt-1">
-            {tooltip.total} events
+            {tooltip.total} session commit{tooltip.total === 1 ? "" : "s"}
           </div>
           <div className="mt-1 space-y-0.5">
             {Object.entries(tooltip.byType).map(([type, count]) => (
-              <div key={type} className="flex justify-between gap-4 text-[10px]">
+              <div
+                key={type}
+                className="flex justify-between gap-4 text-[10px]"
+              >
                 <span className="text-muted font-mono">{type}</span>
                 <span className="text-foreground">{count}</span>
               </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -96,7 +96,17 @@ export interface WorkspaceTree {
 export interface TableColumn {
   id: string;
   name: string;
-  type: "text" | "number" | "boolean" | "date" | "datetime" | "url" | "email" | "select" | "multiselect" | "json";
+  type:
+    | "text"
+    | "number"
+    | "boolean"
+    | "date"
+    | "datetime"
+    | "url"
+    | "email"
+    | "select"
+    | "multiselect"
+    | "json";
   order: number;
   required: boolean;
   default: string | number | boolean | string[] | null;
@@ -165,10 +175,13 @@ export interface Attachment {
 // --- Dashboard Visualizations ---
 
 export interface ActivityTimeline {
-  agents: string[];
+  contributors: string[];
   buckets: {
     date: string;
-    agents: Record<string, { total: number; by_type: Record<string, number> }>;
+    contributors: Record<
+      string,
+      { total: number; by_type: Record<string, number> }
+    >;
   }[];
 }
 


### PR DESCRIPTION
## Summary

- Reworked the activity timeline API from agent/event rows to `human / agent` contributor rows.
- Counts one session commit per `session_id`, so multi-event sessions no longer paint as repeated activity.
- Removed the synthetic `Pages` pseudo-agent row and renamed the frontend timeline component/contract around contributors.

## Screenshot

Screenshot Stash: https://app.joinstash.ai/stashes/human-agent-commits-timeline-screenshot-xp3ahg

## Validation

- `pytest backend/tests/test_activity.py backend/tests/test_permissions.py`
- `ruff check backend/services/analytics_service.py backend/routers/aggregate.py backend/tests/test_activity.py backend/tests/test_permissions.py`
- `cd frontend && npm test -- StashPageClient.test.tsx`
- `cd frontend && npm run lint`