### PR TITLE
Fix page downloads and markdown editor sync

### DIFF
--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -7,6 +7,7 @@ Configured via environment variables.
 import logging
 import os
 from datetime import UTC
+from urllib.parse import quote
 from uuid import uuid4
 
 import httpx
@@ -40,6 +41,10 @@ def _storage_key(workspace_id: str | None, filename: str) -> str:
     return f"{prefix}/{uuid4().hex[:12]}/{filename}"
 
 
+def _object_uri(key: str) -> str:
+    return f"/{S3_BUCKET}/{quote(key, safe='/')}"
+
+
 async def upload_file(
     workspace_id: str | None,
     filename: str,
@@ -65,7 +70,7 @@ async def upload_file(
     # Canonical request components
     host = S3_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
     scheme = "https" if S3_ENDPOINT.startswith("https") else "http"
-    uri = f"/{S3_BUCKET}/{key}"
+    uri = _object_uri(key)
 
     payload_hash = hashlib.sha256(content).hexdigest()
 
@@ -124,7 +129,7 @@ async def upload_file(
 async def get_file_url(key: str, expires_in: int = 3600) -> str:
     """Generate a presigned GET URL for a storage key."""
     if S3_PUBLIC_URL:
-        return f"{S3_PUBLIC_URL.rstrip('/')}/{key}"
+        return f"{S3_PUBLIC_URL.rstrip('/')}/{quote(key, safe='/')}"
 
     if not is_configured():
         raise RuntimeError("S3 storage is not configured")
@@ -132,15 +137,13 @@ async def get_file_url(key: str, expires_in: int = 3600) -> str:
     import hashlib
     import hmac
     from datetime import datetime
-    from urllib.parse import quote
-
     now = datetime.now(UTC)
     date_stamp = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")
 
     host = S3_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
     scheme = "https" if S3_ENDPOINT.startswith("https") else "http"
-    uri = f"/{S3_BUCKET}/{key}"
+    uri = _object_uri(key)
 
     credential_scope = f"{date_stamp}/{S3_REGION}/s3/aws4_request"
     credential = f"{S3_ACCESS_KEY}/{credential_scope}"
@@ -203,7 +206,7 @@ async def delete_file(key: str) -> None:
 
     host = S3_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
     scheme = "https" if S3_ENDPOINT.startswith("https") else "http"
-    uri = f"/{S3_BUCKET}/{key}"
+    uri = _object_uri(key)
 
     payload_hash = hashlib.sha256(b"").hexdigest()
 

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -137,6 +137,7 @@ async def get_file_url(key: str, expires_in: int = 3600) -> str:
     import hashlib
     import hmac
     from datetime import datetime
+
     now = datetime.now(UTC)
     date_stamp = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -1,0 +1,17 @@
+from backend.services import storage_service
+
+
+def test_object_uri_encodes_key_path_segments(monkeypatch):
+    monkeypatch.setattr(storage_service, "S3_BUCKET", "stash")
+
+    uri = storage_service._object_uri("workspace/abc123/Screen Shot #1.png")
+
+    assert uri == "/stash/workspace/abc123/Screen%20Shot%20%231.png"
+
+
+async def test_public_file_url_encodes_key(monkeypatch):
+    monkeypatch.setattr(storage_service, "S3_PUBLIC_URL", "http://localhost:9000/stash")
+
+    url = await storage_service.get_file_url("workspace/abc123/Screen Shot #1.png")
+
+    assert url == "http://localhost:9000/stash/workspace/abc123/Screen%20Shot%20%231.png"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -407,9 +407,9 @@ details > summary::-webkit-details-marker {
   line-height: 1.3;
 }
 
-.markdown-content h1 { font-size: 1.25em; }
-.markdown-content h2 { font-size: 1.15em; }
-.markdown-content h3 { font-size: 1.05em; }
+.markdown-content h1 { font-size: 1.5em; }
+.markdown-content h2 { font-size: 1.3em; }
+.markdown-content h3 { font-size: 1.15em; }
 
 .markdown-content strong {
   font-weight: 700;

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -4,11 +4,13 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "../../../components/AppShell";
 import CustomSelect from "../../../components/CustomSelect";
+import DownloadMenu, { downloadBlob } from "../../../components/DownloadMenu";
 import { useAuth } from "../../../hooks/useAuth";
 import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import { useShareModal } from "../../../lib/shareModalContext";
 import {
   getPublicStash,
+  fetchAuthed,
   getTable, updateTable,
   deleteTable, addTableColumn, updateTableColumn,
   deleteTableColumn, reorderTableColumns, listTableRows, searchTableRows,
@@ -461,17 +463,20 @@ function TableEditorPageInner() {
       await loadRows(); await loadTable();
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to import"); }
   };
-  const handleCsvExport = () => {
+  const handleCsvExport = async () => {
     if (!table || !wsId) return;
     const base = `/api/v1/workspaces/${wsId}/tables`;
     const p = new URLSearchParams();
     if (sortBy) { p.set("sort_by", sortBy); p.set("sort_order", sortOrder); }
     if (filters.length > 0) p.set("filters", JSON.stringify(filters));
     const url = `${base}/${tableId}/export/csv${p.toString() ? "?" + p : ""}`;
-    const token = localStorage.getItem("api_key") || "";
-    fetch(url, { headers: { Authorization: `Bearer ${token}` } }).then((r) => r.blob()).then((blob) => {
-      const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = `${table.name.replace(/\s+/g, "_")}.csv`; a.click(); URL.revokeObjectURL(a.href);
-    }).catch(() => setError("Export failed"));
+    const response = await fetchAuthed(url);
+    if (!response.ok) {
+      setError("Export failed");
+      return;
+    }
+    const blob = await response.blob();
+    downloadBlob(blob, "text/csv", `${table.name.replace(/\s+/g, "_")}.csv`);
   };
 
   // --- Selection ---
@@ -617,7 +622,16 @@ function TableEditorPageInner() {
             {!readOnly && wsId && <button onClick={() => setShowEmbeddings((p) => !p)} className={`text-xs px-2 py-1 rounded ${showEmbeddings ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Embeddings</button>}
             <button onClick={() => setShowColVisibility((p) => !p)} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Columns</button>
             <button onClick={() => setWrapCells((p) => !p)} className={`text-xs px-2 py-1 rounded ${wrapCells ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>{wrapCells ? "Wrap" : "Compact"}</button>
-            {!readOnly && <button onClick={handleCsvExport} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Export</button>}
+            {!readOnly && (
+              <DownloadMenu
+                options={[
+                  {
+                    label: "CSV (.csv)",
+                    onSelect: () => void handleCsvExport(),
+                  },
+                ]}
+              />
+            )}
             {!readOnly && <button onClick={() => fileInputRef.current?.click()} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>}
             {!readOnly && <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleCsvImport(e.target.files[0]); e.target.value = ""; }} />}
             {!readOnly && selectedRows.size > 0 && <button onClick={handleBulkDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -16,6 +16,7 @@ import {
   type FolderBreadcrumb,
 } from "../../../../../lib/api";
 import type { FileInfo } from "../../../../../lib/types";
+import DownloadMenu, { downloadUrl } from "../../../../../components/DownloadMenu";
 import EditableTitle from "../../../../../components/workspace/EditableTitle";
 
 function isCsv(ct: string) {
@@ -220,19 +221,17 @@ function FileViewerPageInner() {
               read-only · via Stash
             </span>
           )}
-          {file?.url && (
-            <a
-              href={file.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              download={file.name}
-              className="rounded-md p-1.5 text-muted hover:bg-raised"
-              title="Download"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
-              </svg>
-            </a>
+          {file?.url ? (
+            <DownloadMenu
+              options={[
+                {
+                  label: "Original file",
+                  onSelect: () => void downloadUrl(file.url, file.name),
+                },
+              ]}
+            />
+          ) : (
+            null
           )}
         </div>
       </div>

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -2,9 +2,14 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
-import DownloadMenu, { downloadBlob } from "../../../../../components/DownloadMenu";
+import DownloadMenu, {
+  downloadBlob,
+  downloadRenderedPdf,
+  htmlToPdfBlocks,
+  markdownToPdfBlocks,
+} from "../../../../../components/DownloadMenu";
 import { StashIcon } from "../../../../../components/StashIcons";
 import HtmlPageView from "../../../../../components/workspace/HtmlPageView";
 import EditableTitle from "../../../../../components/workspace/EditableTitle";
@@ -21,6 +26,7 @@ import {
 import type { Page } from "../../../../../lib/types";
 
 function wrapHtml(title: string, body: string): string {
+  if (/^\s*(<!doctype|<html[\s>])/i.test(body)) return body;
   return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(
     title
   )}</title><style>body{font-family:system-ui,sans-serif;max-width:720px;margin:2em auto;padding:0 1em;line-height:1.6;color:#1a1a1a}h1,h2,h3{line-height:1.25}pre{background:#f6f6f6;padding:1em;overflow:auto;border-radius:6px}code{background:#f6f6f6;padding:.1em .3em;border-radius:3px}</style></head><body>${body}</body></html>`;
@@ -44,6 +50,7 @@ export default function StashPageView() {
   const [containingStashes, setContainingStashes] = useState<WorkspaceStash[]>([]);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
   const [error, setError] = useState("");
+  const saveSeq = useRef(0);
 
   useBreadcrumbs(
     [
@@ -74,9 +81,11 @@ export default function StashPageView() {
 
   const handleSave = useCallback(
     async (content: string) => {
+      const seq = saveSeq.current + 1;
+      saveSeq.current = seq;
       try {
         const updated = await updatePage(workspaceId, pageId, { content });
-        setPage(updated);
+        if (saveSeq.current === seq) setPage(updated);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Save failed");
       }
@@ -97,6 +106,7 @@ export default function StashPageView() {
   if (!user) return null;
 
   const isHtml = page?.content_type === "html";
+  const pageTitle = page ? page.name.replace(/\.(md|html)$/i, "") : "";
   const updatedAt = page?.updated_at
     ? new Date(page.updated_at).toLocaleString(undefined, {
         month: "short",
@@ -120,16 +130,13 @@ export default function StashPageView() {
           <h1 className="mb-1 mt-3 font-display text-[38px] font-bold leading-tight tracking-[-0.025em]">
             {page ? (
               <EditableTitle
-                value={(page.name || "").replace(/\.md$/, "")}
+                value={pageTitle}
                 onSave={async (next) => {
-                  // Preserve the .md suffix when the underlying page name
-                  // was a markdown file. Tiptap docs are saved without
-                  // extension, html pages keep .html, so only restore .md.
-                  const had = page.name.toLowerCase().endsWith(".md");
-                  const newName = had && !next.toLowerCase().endsWith(".md") ? `${next}.md` : next;
+                  const extension = page.content_type === "html" ? ".html" : ".md";
+                  const newName = next.toLowerCase().endsWith(extension) ? next : `${next}${extension}`;
                   const updated = await updatePage(workspaceId, pageId, { name: newName });
                   setPage(updated);
-                  return updated.name.replace(/\.md$/, "");
+                  return updated.name.replace(/\.(md|html)$/i, "");
                 }}
               />
             ) : (
@@ -163,30 +170,51 @@ export default function StashPageView() {
             <span className="flex-1" />
             {page && (
               <DownloadMenu
-                options={[
-                  {
-                    label: "Markdown (.md)",
-                    onSelect: () =>
-                      downloadBlob(
-                        page.content_markdown ?? "",
-                        "text/markdown",
-                        `${page.name.replace(/\.md$/, "")}.md`
-                      ),
-                  },
-                  {
-                    label: "HTML (.html)",
-                    onSelect: () =>
-                      downloadBlob(
-                        wrapHtml(page.name, page.content_html ?? ""),
-                        "text/html",
-                        `${page.name.replace(/\.md$/, "")}.html`
-                      ),
-                  },
-                  {
-                    label: "PDF (print)",
-                    onSelect: () => window.print(),
-                  },
-                ]}
+                options={
+                  isHtml
+                    ? [
+                        {
+                          label: "HTML (.html)",
+                          onSelect: () =>
+                            downloadBlob(
+                              wrapHtml(pageTitle, page.content_html ?? ""),
+                              "text/html",
+                              `${pageTitle}.html`
+                            ),
+                        },
+                        {
+                          label: "PDF (.pdf)",
+                          onSelect: () =>
+                            downloadRenderedPdf({
+                              title: pageTitle,
+                              subtitle: updatedAt ? `Last edited ${updatedAt}` : undefined,
+                              blocks: htmlToPdfBlocks(page.content_html ?? ""),
+                              filename: `${pageTitle}.pdf`,
+                            }),
+                        },
+                      ]
+                    : [
+                        {
+                          label: "Markdown (.md)",
+                          onSelect: () =>
+                            downloadBlob(
+                              page.content_markdown ?? "",
+                              "text/markdown",
+                              `${pageTitle}.md`
+                            ),
+                        },
+                        {
+                          label: "PDF (.pdf)",
+                          onSelect: () =>
+                            downloadRenderedPdf({
+                              title: pageTitle,
+                              subtitle: updatedAt ? `Last edited ${updatedAt}` : undefined,
+                              blocks: markdownToPdfBlocks(page.content_markdown ?? ""),
+                              filename: `${pageTitle}.pdf`,
+                            }),
+                        },
+                      ]
+                }
               />
             )}
           </div>
@@ -218,16 +246,6 @@ export default function StashPageView() {
               <p className="text-muted">Loading…</p>
             )}
           </article>
-
-          {page && !isHtml && (
-            <div className="mt-6 flex items-center gap-2 rounded-lg border border-dashed border-border bg-surface px-3 py-2.5 text-[12.5px] text-muted">
-              <span className="font-mono text-dim">/</span>
-              <span>
-                press <KeyHint>/</KeyHint> for blocks · <KeyHint>@</KeyHint> for pages or
-                people · <KeyHint>⌘+J</KeyHint> to ask the workspace
-              </span>
-            </div>
-          )}
         </main>
 
         <StashAside stashes={containingStashes} />
@@ -268,14 +286,6 @@ function StashAside({ stashes }: { stashes: WorkspaceStash[] }) {
         )}
       </div>
     </aside>
-  );
-}
-
-function KeyHint({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="rounded-[3px] bg-raised px-[5px] font-mono text-[11px] text-dim">
-      {children}
-    </span>
   );
 }
 

--- a/frontend/src/components/DownloadMenu.tsx
+++ b/frontend/src/components/DownloadMenu.tsx
@@ -54,8 +54,9 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
   );
 }
 
-export function downloadBlob(content: string, mimeType: string, filename: string) {
-  const blob = new Blob([content], { type: mimeType });
+export function downloadBlob(content: BlobPart | BlobPart[], mimeType: string, filename: string) {
+  const parts = Array.isArray(content) ? content : [content];
+  const blob = new Blob(parts, { type: mimeType });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -64,4 +65,240 @@ export function downloadBlob(content: string, mimeType: string, filename: string
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+export async function downloadUrl(url: string, filename: string) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("Download failed");
+  const blob = await response.blob();
+  downloadBlob(blob, blob.type || "application/octet-stream", filename);
+}
+
+export interface PdfBlock {
+  text: string;
+  level?: 1 | 2 | 3;
+  kind?: "paragraph" | "list" | "table" | "meta";
+}
+
+export function downloadRenderedPdf({
+  title,
+  subtitle,
+  blocks,
+  filename,
+}: {
+  title: string;
+  subtitle?: string;
+  blocks: PdfBlock[];
+  filename: string;
+}) {
+  const pdf = buildSimplePdf([
+    { text: title || "Untitled", level: 1 },
+    ...(subtitle ? [{ text: subtitle, kind: "meta" as const }] : []),
+    ...blocks,
+  ]);
+  downloadBlob(pdf, "application/pdf", filename);
+}
+
+export function markdownToPdfBlocks(markdown: string): PdfBlock[] {
+  const blocks: PdfBlock[] = [];
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  let paragraph: string[] = [];
+
+  function flushParagraph() {
+    const text = paragraph.join(" ").trim();
+    if (text) blocks.push({ text: plainMarkdown(text), kind: "paragraph" });
+    paragraph = [];
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flushParagraph();
+      continue;
+    }
+
+    const heading = trimmed.match(/^(#{1,3})\s+(.+)$/);
+    if (heading) {
+      flushParagraph();
+      blocks.push({
+        text: plainMarkdown(heading[2]),
+        level: heading[1].length as 1 | 2 | 3,
+      });
+      continue;
+    }
+
+    const unordered = trimmed.match(/^[-*+]\s+(.+)$/);
+    const ordered = trimmed.match(/^\d+\.\s+(.+)$/);
+    if (unordered || ordered) {
+      flushParagraph();
+      blocks.push({ text: `- ${plainMarkdown((unordered || ordered)?.[1] || "")}`, kind: "list" });
+      continue;
+    }
+
+    if (trimmed.includes("|")) {
+      flushParagraph();
+      blocks.push({
+        text: plainMarkdown(trimmed.replace(/^\|/, "").replace(/\|$/, "").replace(/\|/g, " | ")),
+        kind: "table",
+      });
+      continue;
+    }
+
+    paragraph.push(trimmed);
+  }
+
+  flushParagraph();
+  return blocks;
+}
+
+export function htmlToPdfBlocks(html: string): PdfBlock[] {
+  const document = new DOMParser().parseFromString(html, "text/html");
+  const root = document.body?.childNodes.length ? document.body : document.documentElement;
+  const blocks: PdfBlock[] = [];
+
+  function walk(node: Node) {
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const element = node as HTMLElement;
+    const tag = element.tagName.toLowerCase();
+    const text = element.innerText?.replace(/\s+/g, " ").trim();
+
+    if (tag === "h1" || tag === "h2" || tag === "h3") {
+      if (text) blocks.push({ text, level: Number(tag.slice(1)) as 1 | 2 | 3 });
+      return;
+    }
+
+    if (tag === "p" || tag === "li" || tag === "blockquote") {
+      if (text) blocks.push({ text: tag === "li" ? `- ${text}` : text, kind: tag === "li" ? "list" : "paragraph" });
+      return;
+    }
+
+    if (tag === "tr") {
+      const cells = Array.from(element.querySelectorAll("th,td"))
+        .map((cell) => cell.textContent?.replace(/\s+/g, " ").trim())
+        .filter(Boolean);
+      if (cells.length) blocks.push({ text: cells.join(" | "), kind: "table" });
+      return;
+    }
+
+    if (tag === "img") {
+      const alt = element.getAttribute("alt") || element.getAttribute("src") || "Image";
+      blocks.push({ text: `[Image: ${alt}]`, kind: "paragraph" });
+      return;
+    }
+
+    element.childNodes.forEach(walk);
+  }
+
+  root.childNodes.forEach(walk);
+  return blocks;
+}
+
+function plainMarkdown(value: string): string {
+  return value
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt) => `[Image: ${alt || "image"}]`)
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
+    .replace(/[*_`~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildSimplePdf(blocks: PdfBlock[]): string {
+  const pageWidth = 612;
+  const pageHeight = 792;
+  const margin = 54;
+  const bottom = 54;
+  const maxWidth = pageWidth - margin * 2;
+  const pages: string[][] = [[]];
+  let y = pageHeight - margin;
+
+  function addLine(text: string, fontSize: number, bold: boolean, gapAfter = 4) {
+    if (y < bottom + fontSize) {
+      pages.push([]);
+      y = pageHeight - margin;
+    }
+    const font = bold ? "F2" : "F1";
+    pages[pages.length - 1].push(
+      `BT /${font} ${fontSize} Tf ${margin.toFixed(2)} ${y.toFixed(2)} Td (${escapePdfText(text)}) Tj ET`
+    );
+    y -= fontSize + gapAfter;
+  }
+
+  for (const block of blocks) {
+    const fontSize = block.level === 1 ? 22 : block.level === 2 ? 17 : block.level === 3 ? 14 : block.kind === "meta" ? 9 : 11;
+    const bold = !!block.level || block.kind === "table";
+    const gap = block.level ? 8 : block.kind === "meta" ? 12 : 5;
+    const text = normalizePdfText(block.text);
+    if (!text) continue;
+    for (const line of wrapPdfLine(text, maxWidth, fontSize)) {
+      addLine(line, fontSize, bold, gap);
+    }
+    if (!block.level) y -= 3;
+  }
+
+  const objects: string[] = [];
+  const addObject = (body: string) => {
+    objects.push(body);
+    return objects.length;
+  };
+
+  const fontRegular = addObject("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+  const fontBold = addObject("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>");
+  const pageRefs: number[] = [];
+
+  for (const lines of pages) {
+    const stream = lines.join("\n");
+    const contentRef = addObject(`<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`);
+    const pageRef = addObject(
+      `<< /Type /Page /Parent 0 0 R /MediaBox [0 0 ${pageWidth} ${pageHeight}] /Resources << /Font << /F1 ${fontRegular} 0 R /F2 ${fontBold} 0 R >> >> /Contents ${contentRef} 0 R >>`
+    );
+    pageRefs.push(pageRef);
+  }
+
+  const pagesRef = addObject(`<< /Type /Pages /Kids [${pageRefs.map((ref) => `${ref} 0 R`).join(" ")}] /Count ${pageRefs.length} >>`);
+  const catalogRef = addObject(`<< /Type /Catalog /Pages ${pagesRef} 0 R >>`);
+
+  for (const ref of pageRefs) {
+    objects[ref - 1] = objects[ref - 1].replace("/Parent 0 0 R", `/Parent ${pagesRef} 0 R`);
+  }
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  objects.forEach((body, index) => {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+  });
+  const xref = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 1; i < offsets.length; i += 1) {
+    pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root ${catalogRef} 0 R >>\nstartxref\n${xref}\n%%EOF`;
+  return pdf;
+}
+
+function wrapPdfLine(text: string, maxWidth: number, fontSize: number): string[] {
+  const maxChars = Math.max(12, Math.floor(maxWidth / (fontSize * 0.52)));
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxChars) {
+      current = next;
+      continue;
+    }
+    if (current) lines.push(current);
+    current = word.length > maxChars ? word.slice(0, maxChars) : word;
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+function normalizePdfText(text: string): string {
+  return text.normalize("NFKD").replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+function escapePdfText(text: string): string {
+  return text.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
 }

--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Heading from "@tiptap/extension-heading";
@@ -16,7 +16,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
 import EditorToolbar from "./EditorToolbar";
 import { Page, FileInfo } from "../../lib/types";
-import { listFiles } from "../../lib/api";
+import { listFiles, uploadFile } from "../../lib/api";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 
@@ -25,10 +25,9 @@ export type SaveStatus = "saved" | "dirty" | "saving";
 interface MarkdownEditorProps {
   workspaceId: string | null;
   file: Page;
-  onSave: (content: string) => void;
+  onSave: (content: string) => void | Promise<void>;
   confirmSave?: () => boolean;
   onSaveStatusChange?: (status: SaveStatus) => void;
-  onRename?: (name: string) => void;
   /** Called on clicks to same-origin stash routes so the page
    *  can SPA-select the target instead of reloading. */
   onNavigateInternal?: (href: string) => void;
@@ -40,40 +39,41 @@ export default function MarkdownEditor({
   onSave,
   confirmSave,
   onSaveStatusChange,
-  onRename,
   onNavigateInternal,
 }: MarkdownEditorProps) {
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSaved = useRef<string>(file.content_markdown);
+  const loadedFileId = useRef<string>(file.id);
+  const appliedMarkdown = useRef<string>(file.content_markdown);
+  const saveMarkdownRef = useRef<(md: string) => void>(() => {});
+  const insertUploadedFilesRef = useRef<(files: FileList | File[]) => void>(() => {});
 
   // Resolved markdown — relative image refs like ![](a69cb715b010.jpg) get
   // rewritten to absolute signed URLs if a matching workspace file exists.
   // While the lookup is in-flight, show the raw markdown so the page never
   // flashes empty.
+  const [sourceMarkdown, setSourceMarkdown] = useState<string>(file.content_markdown);
   const [resolvedMarkdown, setResolvedMarkdown] = useState<string>(file.content_markdown);
 
   useEffect(() => {
     let cancelled = false;
-    setResolvedMarkdown(file.content_markdown);
+    setResolvedMarkdown(sourceMarkdown);
     if (!workspaceId) return;
-    const relativeNames = extractRelativeImageNames(file.content_markdown);
+    const relativeNames = extractRelativeImageNames(sourceMarkdown);
     if (relativeNames.size === 0) return;
     listFiles(workspaceId)
       .then((files) => {
         if (cancelled) return;
         const map = buildFileNameMap(files, relativeNames);
         if (map.size === 0) return;
-        setResolvedMarkdown(rewriteRelativeImages(file.content_markdown, map));
+        setResolvedMarkdown(rewriteRelativeImages(sourceMarkdown, map));
       })
-      .catch(() => {
-        // Network flake is non-fatal — the raw markdown is still visible.
-      });
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, file.content_markdown]);
+  }, [workspaceId, sourceMarkdown]);
 
   const initialContent = useMemo(
     () => markdownToInitialJSON(resolvedMarkdown),
@@ -134,6 +134,22 @@ export default function MarkdownEditor({
         class: "max-w-none min-h-[200px] focus:outline-none file-page-body",
       },
       handleDOMEvents: {
+        paste: (_view, event) => {
+          const files = event.clipboardData?.files;
+          if (!files || files.length === 0) return false;
+          const hasImage = Array.from(files).some((file) => file.type.startsWith("image/"));
+          if (!hasImage) return false;
+          event.preventDefault();
+          insertUploadedFilesRef.current(files);
+          return true;
+        },
+        drop: (_view, event) => {
+          const files = event.dataTransfer?.files;
+          if (!files || files.length === 0) return false;
+          event.preventDefault();
+          insertUploadedFilesRef.current(files);
+          return true;
+        },
         click: (_view, event) => {
           const target = event.target as HTMLElement | null;
           const anchor = target?.closest?.("a");
@@ -171,26 +187,69 @@ export default function MarkdownEditor({
       setDirty(true);
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
-        if (confirmSave && !confirmSave()) return;
-        setSaving(true);
-        lastSaved.current = md;
-        onSave(md);
-        setDirty(false);
-        setSaving(false);
+        saveTimer.current = null;
+        saveMarkdownRef.current(md);
       }, AUTOSAVE_DEBOUNCE_MS);
     },
   });
 
-  // When the resolved markdown changes (e.g. after file lookup completes),
-  // replace the editor's content. We guard against unsaved user edits by
-  // only replacing when the editor is still showing the original content.
+  const saveMarkdown = useCallback(async (md: string) => {
+    if (confirmSave && !confirmSave()) return;
+    setSaving(true);
+    await onSave(md);
+    const currentMd = editor ? serializeMarkdown(editor.getJSON(), md) : md;
+    if (currentMd === md) {
+      lastSaved.current = md;
+      setDirty(false);
+    }
+    setSaving(false);
+  }, [confirmSave, editor, onSave]);
+
+  const insertUploadedFiles = useCallback(async (files: FileList | File[]) => {
+    if (!workspaceId || !editor) return;
+    for (const fileToUpload of Array.from(files)) {
+      const result = await uploadFile(workspaceId, fileToUpload);
+      if (result.content_type.startsWith("image/")) {
+        editor.chain().focus().setImage({ src: result.url, alt: result.name }).run();
+      } else {
+        editor.chain().focus().setLink({ href: result.url }).insertContent(result.name).run();
+      }
+    }
+  }, [editor, workspaceId]);
+
+  useEffect(() => {
+    saveMarkdownRef.current = (md: string) => {
+      void saveMarkdown(md);
+    };
+  }, [saveMarkdown]);
+
+  useEffect(() => {
+    insertUploadedFilesRef.current = (files: FileList | File[]) => {
+      void insertUploadedFiles(files);
+    };
+  }, [insertUploadedFiles]);
+
   useEffect(() => {
     if (!editor) return;
-    const currentMd = serializeMarkdown(editor.getJSON(), lastSaved.current);
-    // Only reset if the editor's content still matches what we last loaded
-    // (i.e. user hasn't typed anything since).
-    if (currentMd !== lastSaved.current) return;
+    if (loadedFileId.current === file.id) return;
+    loadedFileId.current = file.id;
+    lastSaved.current = file.content_markdown;
+    appliedMarkdown.current = file.content_markdown;
+    setSourceMarkdown(file.content_markdown);
+    editor.commands.setContent(markdownToInitialJSON(file.content_markdown));
+    setDirty(false);
+    setSaving(false);
+  }, [editor, file.content_markdown, file.id]);
+
+  // Parent save responses for the same page are intentionally ignored. The
+  // editor is the local source of truth after mount, which avoids older save
+  // responses replacing newer in-progress typing.
+  useEffect(() => {
+    if (!editor) return;
+    const currentMd = serializeMarkdown(editor.getJSON(), appliedMarkdown.current);
+    if (currentMd !== appliedMarkdown.current) return;
     editor.commands.setContent(initialContent);
+    appliedMarkdown.current = resolvedMarkdown;
     lastSaved.current = resolvedMarkdown;
   }, [editor, initialContent, resolvedMarkdown]);
 
@@ -209,14 +268,12 @@ export default function MarkdownEditor({
         if (editor) {
           const md = serializeMarkdown(editor.getJSON(), lastSaved.current);
           if (md !== lastSaved.current) {
-            if (confirmSave && !confirmSave()) return;
-            lastSaved.current = md;
-            onSave(md);
+            saveMarkdownRef.current(md);
           }
         }
       }
     };
-  }, [confirmSave, editor, onSave]);
+  }, [editor]);
 
   // Ctrl/Cmd+S → flush immediately
   useEffect(() => {
@@ -229,54 +286,18 @@ export default function MarkdownEditor({
           saveTimer.current = null;
         }
         const md = serializeMarkdown(editor.getJSON(), lastSaved.current);
-        if (confirmSave && !confirmSave()) return;
-        lastSaved.current = md;
-        onSave(md);
-        setDirty(false);
+        saveMarkdownRef.current(md);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [confirmSave, editor, onSave]);
-
-  const [title, setTitle] = useState(file.name);
-  const titleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTitle = e.target.value;
-    setTitle(newTitle);
-    if (!onRename || !newTitle.trim()) return;
-    if (titleTimer.current) clearTimeout(titleTimer.current);
-    titleTimer.current = setTimeout(() => onRename(newTitle.trim()), AUTOSAVE_DEBOUNCE_MS);
-  };
-
-  const updatedLabel = file.updated_at
-    ? `Updated ${new Date(file.updated_at).toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })}`
-    : "";
+  }, [editor]);
 
   return (
     <div className="flex h-full flex-col">
       <EditorToolbar editor={editor} workspaceId={workspaceId} />
       <div className="flex-1 overflow-y-auto bg-background">
         <div className="mx-auto w-full max-w-[820px] px-12 py-10">
-          <header className="mb-8">
-            {updatedLabel && (
-              <p className="mb-2 font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted">
-                {updatedLabel}
-              </p>
-            )}
-            <input
-              type="text"
-              value={title}
-              onChange={handleTitleChange}
-              placeholder="Untitled"
-              className="w-full border-none bg-transparent font-display text-[40px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground outline-none placeholder:text-muted/40"
-            />
-          </header>
           <EditorContent editor={editor} className="file-page-content" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fix markdown/html download options so markdown pages export .md + .pdf and HTML pages export .html + .pdf.
- Replace browser print PDF export with generated text/vector PDFs.
- Remove duplicated markdown title/updated block and the unsupported command hint.
- Prevent stale page save responses from resetting in-progress markdown edits.
- Support pasted/dropped image uploads in markdown and make rendered h3 headings more distinct.
- Use the shared download menu for table CSV export and file downloads.

## Verification
- npm run lint
- npm test
- npm run build

## Screenshots
- Captured locally with mocked page data: /tmp/moltchat-downloads-markdown.png
- Not uploaded to the PR because public screenshot upload was blocked by approval policy.