### PR TITLE
Standardize file viewer header (markdown / html / pdf / image / table)

### DIFF
--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -582,9 +582,7 @@ function TableEditorPageInner() {
           backLink={
             readOnly && stashSlug
               ? { label: stashTitle ?? "Stash", href: `/stashes/${stashSlug}` }
-              : wsId
-                ? { label: "Files", href: `/workspaces/${wsId}` }
-                : undefined
+              : undefined
           }
           tags={[{ label: "table", tone: "muted" }]}
           meta={[

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -18,7 +18,7 @@ import {
   setTableEmbeddingConfig, backfillTableEmbeddings,
 } from "../../../lib/api";
 import type { Table, TableColumn, TableRow, TableView } from "../../../lib/types";
-import Link from "next/link";
+import FileViewerHeader from "../../../components/workspace/FileViewerHeader";
 
 // --- Constants ---
 const TYPE_ICONS: Record<string, string> = {
@@ -62,8 +62,6 @@ function TableEditorPageInner() {
   const [rows, setRows] = useState<TableRow[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [error, setError] = useState("");
-  const [editingName, setEditingName] = useState(false);
-  const [nameInput, setNameInput] = useState("");
 
   // Sort, filter, search
   const [sortBy, setSortBy] = useState("");
@@ -309,13 +307,6 @@ function TableEditorPageInner() {
   const removeFilter = (idx: number) => setFilters((prev) => prev.filter((_, i) => i !== idx));
 
   // --- Table ops ---
-  const handleRename = async () => {
-    if (!table || !nameInput.trim()) return;
-    try {
-      const updated = await updateTable(resolvedWorkspaceId, tableId, { name: nameInput.trim() });
-      setTable(updated); setEditingName(false);
-    } catch (err) { setError(err instanceof Error ? err.message : "Failed to rename"); }
-  };
   const handleDelete = async () => {
     if (!confirm("Delete this table and all its data?")) return;
     try {
@@ -562,42 +553,59 @@ function TableEditorPageInner() {
     </tr>
   );
 
+  const tableUpdatedAt = table?.updated_at
+    ? new Date(table.updated_at).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+
   const tableContent = (
       <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <FileViewerHeader
+          icon={<TableGlyph />}
+          iconColor="#059669"
+          title={table?.name ?? "Loading…"}
+          onRenameTitle={
+            table && !readOnly
+              ? async (next) => {
+                  const updated = await updateTable(resolvedWorkspaceId, tableId, { name: next });
+                  setTable(updated);
+                  return updated.name;
+                }
+              : undefined
+          }
+          readOnly={readOnly}
+          readOnlyLabel="read-only · via Stash"
+          backLink={
+            readOnly && stashSlug
+              ? { label: stashTitle ?? "Stash", href: `/stashes/${stashSlug}` }
+              : wsId
+                ? { label: "Files", href: `/workspaces/${wsId}` }
+                : undefined
+          }
+          tags={[{ label: "table", tone: "muted" }]}
+          meta={[
+            `${visibleColumns.length}/${sortedColumns.length} cols`,
+            `${totalCount} rows`,
+            tableUpdatedAt ? `Updated ${tableUpdatedAt}` : "",
+          ].filter(Boolean)}
+          downloadOptions={
+            table && !readOnly && wsId
+              ? [{ label: "CSV (.csv)", onSelect: handleCsvExport }]
+              : undefined
+          }
+        />
         {/* Toolbar */}
-        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface flex-shrink-0 flex-wrap">
-          {readOnly && stashSlug ? (
-            <Link
-              href={`/stashes/${stashSlug}`}
-              className="inline-flex items-center gap-1 text-sm text-muted hover:text-foreground"
-              aria-label={`Back to ${stashTitle ?? "Stash"}`}
-            >
-              &larr; {stashTitle ?? "Stash"}
-            </Link>
-          ) : (
-            <button
-              onClick={() => router.push(wsId ? `/workspaces/${wsId}` : "/")}
-              className="text-muted hover:text-foreground text-sm"
-              aria-label="Back to Files"
-            >
-              &larr;
-            </button>
-          )}
-          {readOnly ? (
-            <h1 className="text-lg font-bold font-display text-foreground">{table?.name || "Loading..."}</h1>
-          ) : editingName ? (
-            <input value={nameInput} onChange={(e) => setNameInput(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") handleRename(); if (e.key === "Escape") setEditingName(false); }} onBlur={handleRename} className="text-lg font-bold font-display bg-transparent border-b border-brand outline-none text-foreground" autoFocus />
-          ) : (
-            <h1 onClick={() => { setEditingName(true); setNameInput(table?.name || ""); }} className="text-lg font-bold font-display text-foreground cursor-pointer hover:text-brand transition-colors">{table?.name || "Loading..."}</h1>
-          )}
+        <div className="mt-2 flex items-center gap-2 px-4 py-2.5 border-y border-border bg-surface flex-shrink-0 flex-wrap">
           {/* Search */}
           <div className="flex-1 max-w-xs">
             <input value={searchQuery} onChange={(e) => { setSearchQuery(e.target.value); setIsSearching(true); }} placeholder="Search all columns..." className="w-full px-3 py-1.5 text-xs bg-raised border border-border rounded text-foreground outline-none focus:ring-1 focus:ring-brand" />
           </div>
           <div className="flex-1" />
           {table && <>
-            <span className="text-[11px] font-mono text-muted">{visibleColumns.length}/{sortedColumns.length} cols</span>
-            <span className="text-[11px] font-mono text-muted">{totalCount} rows</span>
             {!readOnly && <button onClick={addFilter} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Filter</button>}
             {!readOnly && (filters.length > 0 || sortBy) && <button onClick={handleSaveLayout} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Save layout</button>}
             {/* Group by */}
@@ -635,11 +643,6 @@ function TableEditorPageInner() {
               </button>
             )}
             {!readOnly && <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>}
-            {readOnly && (
-              <span className="rounded-md bg-surface px-2 py-1 text-[10.5px] font-medium uppercase tracking-wide text-muted">
-                read-only &middot; via Stash
-              </span>
-            )}
           </>}
         </div>
 
@@ -945,5 +948,14 @@ function TableEditorPageInner() {
     <AppShell user={user} onLogout={logout}>
       {tableContent}
     </AppShell>
+  );
+}
+
+function TableGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <path d="M3 10h18M3 16h18M9 4v16M15 4v16" />
+    </svg>
   );
 }

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useState } from "react";
-import Link from "next/link";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
@@ -16,7 +15,7 @@ import {
   type FolderBreadcrumb,
 } from "../../../../../lib/api";
 import type { FileInfo } from "../../../../../lib/types";
-import EditableTitle from "../../../../../components/workspace/EditableTitle";
+import FileViewerHeader from "../../../../../components/workspace/FileViewerHeader";
 
 function isCsv(ct: string) {
   return ct?.includes("csv") || ct === "text/csv";
@@ -180,62 +179,46 @@ function FileViewerPageInner() {
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user && !readOnly) return null;
 
+  const fileKindLabel = file ? kindLabel(file.content_type, file.name) : "";
+  const updatedAt = file?.created_at
+    ? new Date(file.created_at).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+  const tags = file ? [{ label: fileKindLabel, tone: "muted" as const }] : undefined;
+  const meta: string[] = [];
+  if (file) meta.push(formatBytes(file.size_bytes));
+  if (updatedAt) meta.push(`Uploaded ${updatedAt}`);
+
   return (
-    <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-      <div className="flex items-center justify-between border-b border-border px-5 py-2.5 text-[13px]">
-        <div className="flex min-w-0 items-center gap-2">
-          {readOnly && stashSlug && (
-            <Link
-              href={`/stashes/${stashSlug}`}
-              className="text-muted hover:text-foreground"
-              title={`Back to ${stashTitle ?? "Stash"}`}
-            >
-              ←
-            </Link>
-          )}
-          {file ? (
-            readOnly ? (
-              <span className="font-mono font-medium text-foreground truncate">{file.name}</span>
-            ) : (
-              <EditableTitle
-                value={file.name}
-                className="font-mono font-medium text-foreground"
-                onSave={async (next) => {
-                  const updated = await updateFile(workspaceId, file.id, { name: next });
-                  setFile(updated);
-                  return updated.name;
-                }}
-              />
-            )
-          ) : null}
-          {file && (
-            <span className="text-muted">
-              {file.content_type} · {formatBytes(file.size_bytes)}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          {readOnly && (
-            <span className="rounded-md bg-surface px-2 py-1 text-[10.5px] font-medium uppercase tracking-wide text-muted">
-              read-only · via Stash
-            </span>
-          )}
-          {file?.url && (
-            <a
-              href={file.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              download={file.name}
-              className="rounded-md p-1.5 text-muted hover:bg-raised"
-              title="Download"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
-              </svg>
-            </a>
-          )}
-        </div>
-      </div>
+    <div className="scroll-thin flex flex-1 min-h-0 flex-col overflow-hidden">
+      <FileViewerHeader
+        icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
+        iconColor={kindIconColor(file?.content_type ?? "")}
+        title={file?.name ?? "File"}
+        onRenameTitle={
+          file
+            ? async (next) => {
+                const updated = await updateFile(workspaceId, file.id, { name: next });
+                setFile(updated);
+                return updated.name;
+              }
+            : undefined
+        }
+        readOnly={readOnly}
+        readOnlyLabel="read-only · via Stash"
+        backLink={readOnly && stashSlug ? { label: stashTitle ?? "Stash", href: `/stashes/${stashSlug}` } : undefined}
+        tags={tags}
+        meta={meta}
+        downloadOptions={
+          file?.url
+            ? [{ label: `Download ${file.name}`, onSelect: () => triggerDownload(file.url, file.name) }]
+            : undefined
+        }
+      />
 
       {error && (
         <div className="border-b border-red-300/40 bg-red-500/10 px-5 py-2 text-[13px] text-red-500">
@@ -307,4 +290,79 @@ function formatBytes(b: number): string {
   if (b < 1024) return `${b} B`;
   if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
   return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function kindLabel(contentType: string, name: string): string {
+  if (isPdf(contentType)) return "pdf";
+  if (isImage(contentType)) return "image";
+  if (isHtml(contentType)) return "html";
+  if (isMarkdown(contentType, name)) return "markdown";
+  if (isText(contentType)) return "text";
+  return "file";
+}
+
+function kindIconColor(contentType: string): string {
+  if (isPdf(contentType)) return "#E11D48";
+  if (isImage(contentType)) return "#7C3AED";
+  if (isHtml(contentType)) return "var(--color-brand-600)";
+  return "var(--text-muted)";
+}
+
+function triggerDownload(url: string, name: string) {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = name;
+  a.target = "_blank";
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+function KindGlyph({ contentType, name }: { contentType: string; name: string }) {
+  if (isPdf(contentType)) {
+    return (
+      <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+        <path d="M14 3v5h5" />
+        <path d="M9 14h6" />
+        <path d="M9 17h3" />
+      </svg>
+    );
+  }
+  if (isImage(contentType)) {
+    return (
+      <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <circle cx="9" cy="9.5" r="1.4" />
+        <path d="M21 16l-5-5-9 9" />
+      </svg>
+    );
+  }
+  if (isHtml(contentType)) {
+    return (
+      <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M3 9h18" />
+        <circle cx="6" cy="6.5" r="0.6" fill="currentColor" />
+        <circle cx="8.2" cy="6.5" r="0.6" fill="currentColor" />
+      </svg>
+    );
+  }
+  if (isMarkdown(contentType, name)) {
+    return (
+      <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+        <path d="M14 3v5h5" />
+        <path d="M9 13h6M9 17h4" />
+      </svg>
+    );
+  }
+  // generic file
+  return (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6">
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+    </svg>
+  );
 }

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -4,10 +4,10 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
-import DownloadMenu, { downloadBlob } from "../../../../../components/DownloadMenu";
+import { downloadBlob } from "../../../../../components/DownloadMenu";
 import { StashIcon } from "../../../../../components/StashIcons";
 import HtmlPageView from "../../../../../components/workspace/HtmlPageView";
-import EditableTitle from "../../../../../components/workspace/EditableTitle";
+import FileViewerHeader from "../../../../../components/workspace/FileViewerHeader";
 import MarkdownEditor, { type SaveStatus } from "../../../../../components/workspace/MarkdownEditor";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
@@ -106,98 +106,65 @@ export default function StashPageView() {
       })
     : null;
 
+  const baseName = page ? page.name.replace(/\.md$/i, "") : "";
+
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
-      <div className="brand-banner" />
-      <div className="mx-auto -mt-[22px] grid max-w-[1100px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]">
+      <FileViewerHeader
+        icon={isHtml ? <HtmlGlyph /> : <PageGlyph />}
+        iconColor={isHtml ? "var(--color-brand-600)" : "var(--text-muted)"}
+        title={baseName}
+        onRenameTitle={
+          page
+            ? async (next) => {
+                // Preserve the .md suffix on markdown pages so the
+                // backend's file kind detection keeps working.
+                const had = page.name.toLowerCase().endsWith(".md");
+                const newName = had && !next.toLowerCase().endsWith(".md") ? `${next}.md` : next;
+                const updated = await updatePage(workspaceId, pageId, { name: newName });
+                setPage(updated);
+                return updated.name.replace(/\.md$/i, "");
+              }
+            : undefined
+        }
+        tags={isHtml ? [{ label: "html", tone: "brand" }] : undefined}
+        meta={updatedAt ? [`Last edited ${updatedAt}`] : undefined}
+        saveStatus={page && !isHtml ? saveStatus : null}
+        downloadOptions={
+          page
+            ? [
+                {
+                  label: "Markdown (.md)",
+                  onSelect: () =>
+                    downloadBlob(
+                      page.content_markdown ?? "",
+                      "text/markdown",
+                      `${baseName}.md`
+                    ),
+                },
+                {
+                  label: "HTML (.html)",
+                  onSelect: () =>
+                    downloadBlob(
+                      wrapHtml(page.name, page.content_html ?? ""),
+                      "text/html",
+                      `${baseName}.html`
+                    ),
+                },
+                { label: "PDF (print)", onSelect: () => window.print() },
+              ]
+            : undefined
+        }
+      />
+      <div className="mx-auto mt-6 grid max-w-[1100px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]">
         <main className="min-w-0">
-          <span
-            className="inline-flex h-14 w-14 items-center justify-center rounded-[12px] border border-border bg-base"
-            style={{ color: isHtml ? "var(--color-brand-600)" : "var(--text-muted)" }}
-          >
-            {isHtml ? <HtmlGlyph /> : <PageGlyph />}
-          </span>
-          <h1 className="mb-1 mt-3 font-display text-[38px] font-bold leading-tight tracking-[-0.025em]">
-            {page ? (
-              <EditableTitle
-                value={(page.name || "").replace(/\.md$/, "")}
-                onSave={async (next) => {
-                  // Preserve the .md suffix when the underlying page name
-                  // was a markdown file. Tiptap docs are saved without
-                  // extension, html pages keep .html, so only restore .md.
-                  const had = page.name.toLowerCase().endsWith(".md");
-                  const newName = had && !next.toLowerCase().endsWith(".md") ? `${next}.md` : next;
-                  const updated = await updatePage(workspaceId, pageId, { name: newName });
-                  setPage(updated);
-                  return updated.name.replace(/\.md$/, "");
-                }}
-              />
-            ) : (
-              ""
-            )}
-          </h1>
-
-          <div className="flex items-center gap-2.5 text-[12px] text-muted">
-            {isHtml && <span className="tag tag-brand">html</span>}
-            {updatedAt && <span>Last edited {updatedAt}</span>}
-            {page && !isHtml && (
-              <>
-                <span>·</span>
-                <span
-                  className={
-                    saveStatus === "saving"
-                      ? "text-amber-500"
-                      : saveStatus === "dirty"
-                        ? "text-amber-600"
-                        : "text-emerald-600"
-                  }
-                >
-                  {saveStatus === "saving"
-                    ? "Saving…"
-                    : saveStatus === "dirty"
-                      ? "Unsaved"
-                      : "Saved"}
-                </span>
-              </>
-            )}
-            <span className="flex-1" />
-            {page && (
-              <DownloadMenu
-                options={[
-                  {
-                    label: "Markdown (.md)",
-                    onSelect: () =>
-                      downloadBlob(
-                        page.content_markdown ?? "",
-                        "text/markdown",
-                        `${page.name.replace(/\.md$/, "")}.md`
-                      ),
-                  },
-                  {
-                    label: "HTML (.html)",
-                    onSelect: () =>
-                      downloadBlob(
-                        wrapHtml(page.name, page.content_html ?? ""),
-                        "text/html",
-                        `${page.name.replace(/\.md$/, "")}.html`
-                      ),
-                  },
-                  {
-                    label: "PDF (print)",
-                    onSelect: () => window.print(),
-                  },
-                ]}
-              />
-            )}
-          </div>
-
           {error && (
-            <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+            <div className="mb-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
               {error}
             </div>
           )}
 
-          <article className="mt-7 text-[15px] leading-relaxed text-foreground">
+          <article className="text-[15px] leading-relaxed text-foreground">
             {page ? (
               isHtml ? (
                 <HtmlPageView

--- a/frontend/src/components/workspace/FileViewerHeader.tsx
+++ b/frontend/src/components/workspace/FileViewerHeader.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+
+import DownloadMenu from "../DownloadMenu";
+import EditableTitle from "./EditableTitle";
+
+export type FileViewerSaveStatus = "saved" | "dirty" | "saving";
+
+interface BackLink {
+  label: string;
+  href: string;
+}
+
+interface Tag {
+  label: string;
+  tone?: "brand" | "muted";
+}
+
+interface FileViewerHeaderProps {
+  /** Big rounded glyph in the identity strip. */
+  icon: ReactNode;
+  /** Tint applied to the icon container's `color`. */
+  iconColor?: string;
+  /** The displayed title. */
+  title: string;
+  /** When set + !readOnly, the title is editable. Returns the canonical title. */
+  onRenameTitle?: (next: string) => Promise<string>;
+  /** Read-only mode hides rename + write affordances and shows a chip. */
+  readOnly?: boolean;
+  /** Chip text in read-only mode. Defaults to "read-only". */
+  readOnlyLabel?: string;
+  /** Back link rendered above the title (e.g. "← Demo Stash"). */
+  backLink?: BackLink;
+  /** Small label chips before the meta items. */
+  tags?: Tag[];
+  /**
+   * Free-form meta items rendered before the spacer + download menu. Use
+   * short strings like "Last edited Jun 5" or "12 KB".
+   */
+  meta?: ReactNode[];
+  /** "saved" | "dirty" | "saving" — colored save-status text. Hidden in read-only mode. */
+  saveStatus?: FileViewerSaveStatus | null;
+  /** Right-aligned download menu options. Omit to hide. */
+  downloadOptions?: { label: string; onSelect: () => void }[];
+  /** Anything that should sit between the save-status and the download menu. */
+  rightExtras?: ReactNode;
+}
+
+/**
+ * Standard header for the file/page/table viewers. Renders a thin brand
+ * banner, a big rounded icon, the file title (editable or read-only),
+ * and a meta row with type tags, save status, and a Download menu.
+ *
+ * The page viewer (`/workspaces/[ws]/p/[id]`), the file viewer
+ * (`/workspaces/[ws]/f/[id]`), and the table viewer (`/tables/[id]`) all
+ * use this so the entry visual for "you are looking at a thing" is the
+ * same shape across kinds.
+ */
+export default function FileViewerHeader({
+  icon,
+  iconColor,
+  title,
+  onRenameTitle,
+  readOnly,
+  readOnlyLabel = "read-only",
+  backLink,
+  tags,
+  meta,
+  saveStatus,
+  downloadOptions,
+  rightExtras,
+}: FileViewerHeaderProps) {
+  const iconStyle: CSSProperties = {
+    color: iconColor ?? "var(--text-muted)",
+  };
+
+  return (
+    <>
+      <div className="brand-banner" />
+      <div className="mx-auto -mt-[22px] max-w-[1100px] px-12 pt-0">
+        {backLink && (
+          <Link
+            href={backLink.href}
+            className="mb-2 inline-flex items-center gap-1 text-[12px] text-muted hover:text-foreground"
+          >
+            &larr; {backLink.label}
+          </Link>
+        )}
+        <span
+          className="inline-flex h-14 w-14 items-center justify-center rounded-[12px] border border-border bg-base"
+          style={iconStyle}
+        >
+          {icon}
+        </span>
+        <h1 className="mb-1 mt-3 font-display text-[38px] font-bold leading-tight tracking-[-0.025em]">
+          {readOnly || !onRenameTitle ? (
+            <span>{title}</span>
+          ) : (
+            <EditableTitle value={title} onSave={onRenameTitle} />
+          )}
+        </h1>
+
+        <div className="flex flex-wrap items-center gap-2.5 text-[12px] text-muted">
+          {tags?.map((tag, i) => (
+            <span
+              key={`${tag.label}-${i}`}
+              className={"tag " + (tag.tone === "brand" ? "tag-brand" : "tag-muted")}
+            >
+              {tag.label}
+            </span>
+          ))}
+          {meta?.map((item, i) => (
+            <span key={i}>{item}</span>
+          ))}
+          {!readOnly && saveStatus && (
+            <>
+              <span>·</span>
+              <span
+                className={
+                  saveStatus === "saving"
+                    ? "text-amber-500"
+                    : saveStatus === "dirty"
+                      ? "text-amber-600"
+                      : "text-emerald-600"
+                }
+              >
+                {saveStatus === "saving"
+                  ? "Saving…"
+                  : saveStatus === "dirty"
+                    ? "Unsaved"
+                    : "Saved"}
+              </span>
+            </>
+          )}
+          {readOnly && (
+            <span className="rounded-md bg-surface px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-muted">
+              {readOnlyLabel}
+            </span>
+          )}
+          <span className="flex-1" />
+          {rightExtras}
+          {downloadOptions && downloadOptions.length > 0 && (
+            <DownloadMenu options={downloadOptions} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/workspace/FileViewerHeader.tsx
+++ b/frontend/src/components/workspace/FileViewerHeader.tsx
@@ -79,7 +79,14 @@ export default function FileViewerHeader({
   return (
     <>
       <div className="brand-banner" />
-      <div className="mx-auto -mt-[22px] max-w-[1100px] px-12 pt-0">
+      {/* `w-full` is load-bearing: when the parent is a `flex-col`, `mx-auto`
+          alone collapses this container to shrink-to-fit and centers it,
+          so PDF / HTML / image / table headers end up indented while the
+          markdown page (block-level parent) lays out left-aligned. With
+          `w-full` the container always claims its parent's cross-axis
+          width before the max-width cap kicks in, so all viewers align
+          to the same left edge. */}
+      <div className="mx-auto w-full -mt-[22px] max-w-[1100px] px-12 pt-0">
         {backLink && (
           <Link
             href={backLink.href}


### PR DESCRIPTION
## Summary

The markdown page viewer had a distinctive header (brand banner + big rounded icon + huge editable title + tag + last-edited + Download menu) but the file viewer (pdf, html, image, text, markdown files) used a thin horizontal bar and the table viewer had its own dense toolbar header. Three viewers, three different identity strips.

Extract the markdown page's header into a shared `FileViewerHeader` and wire it into:

- \`/workspaces/[ws]/p/[pageId]\` — markdown / html pages
- \`/workspaces/[ws]/f/[fileId]\` — pdf / html / image / markdown / text files
- \`/tables/[tableId]\` — tables (header above the dense toolbar)

### What the header gives every viewer
- Soft brand banner stripe at top
- 56×56 rounded icon tile, content-type tinted (rose for PDF, violet for image, brand for HTML, green for tables, muted otherwise)
- Big 38px editable title (read-only in stash mode, with a "read-only · via Stash" chip)
- Tag chip ("markdown" / "html" / "pdf" / "image" / "text" / "table")
- Meta items (size, uploaded/updated date, cols/rows for tables)
- Save status (green / amber when applicable)
- Optional back-link slot for stash-scoped views ("← <Stash title>")
- Right-aligned DownloadMenu — Markdown / HTML / PDF for pages, raw download for files, CSV for tables

### Cleanups in passing
- Page viewer's local EditableTitle wiring is now inside the shared header.
- File viewer's bespoke download-icon button is replaced by the shared DownloadMenu.
- Table viewer's vestigial \`editingName\` / \`nameInput\` / \`handleRename\` state is removed — rename goes through the header's \`onRenameTitle\`.
- Duplicate cols/rows count + read-only chip are removed from the table's dense toolbar (the header carries them now).

## Test plan

- [ ] Open a markdown page → header looks identical to before (this is the reference design).
- [ ] Open a PDF / HTML / image / text file under \`/workspaces/.../f/...\` → same banner + icon + title + meta + Download shape.
- [ ] Open a table → header above, dense toolbar (Filter, Group, Columns, Compact, Export, etc.) below.
- [ ] Rename via the big title → backend updates and the new name persists.
- [ ] In a public Stash, open a table or PDF → back-link reads "← <Stash>", title is non-editable, read-only chip is present.

## Screenshots
Captured local — markdown / pdf / html / table headers all share the same identity strip now. Will attach to PR thread after Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)