### PR TITLE
Drop duplicate inline title from page viewer

### DIFF
--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -28,7 +28,6 @@ interface MarkdownEditorProps {
   onSave: (content: string) => void;
   confirmSave?: () => boolean;
   onSaveStatusChange?: (status: SaveStatus) => void;
-  onRename?: (name: string) => void;
   /** Called on clicks to same-origin stash routes so the page
    *  can SPA-select the target instead of reloading. */
   onNavigateInternal?: (href: string) => void;
@@ -40,7 +39,6 @@ export default function MarkdownEditor({
   onSave,
   confirmSave,
   onSaveStatusChange,
-  onRename,
   onNavigateInternal,
 }: MarkdownEditorProps) {
   const [dirty, setDirty] = useState(false);
@@ -239,44 +237,11 @@ export default function MarkdownEditor({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [confirmSave, editor, onSave]);
 
-  const [title, setTitle] = useState(file.name);
-  const titleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTitle = e.target.value;
-    setTitle(newTitle);
-    if (!onRename || !newTitle.trim()) return;
-    if (titleTimer.current) clearTimeout(titleTimer.current);
-    titleTimer.current = setTimeout(() => onRename(newTitle.trim()), AUTOSAVE_DEBOUNCE_MS);
-  };
-
-  const updatedLabel = file.updated_at
-    ? `Updated ${new Date(file.updated_at).toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })}`
-    : "";
-
   return (
     <div className="flex h-full flex-col">
       <EditorToolbar editor={editor} workspaceId={workspaceId} />
       <div className="flex-1 overflow-y-auto bg-background">
         <div className="mx-auto w-full max-w-[820px] px-12 py-10">
-          <header className="mb-8">
-            {updatedLabel && (
-              <p className="mb-2 font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted">
-                {updatedLabel}
-              </p>
-            )}
-            <input
-              type="text"
-              value={title}
-              onChange={handleTitleChange}
-              placeholder="Untitled"
-              className="w-full border-none bg-transparent font-display text-[40px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground outline-none placeholder:text-muted/40"
-            />
-          </header>
           <EditorContent editor={editor} className="file-page-content" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The standardize-header PR (#329) added `FileViewerHeader` above every viewer, including `/workspaces/[ws]/p/[pageId]`. `MarkdownEditor` still rendered its own inline `<header>` with an editable title input + "Updated …" label, so the page title and last-edited date showed up **twice** — once in the new `FileViewerHeader` at the top, and again at the top of the editor body.
- This drops the editor's inline title header (and the now-unused `onRename` prop on `MarkdownEditor`) and lets `FileViewerHeader` be the single source of title + rename + last-edited.
- Only the page viewer was affected — the file viewer at `/workspaces/[ws]/f/[fileId]` renders markdown via plain `<Markdown>` (no internal title), so it was already single-title.

## Before
On `/workspaces/[ws]/p/[pageId]`, "Product Chat" + "Last edited …" rendered in the header, then immediately below the body opened with "UPDATED MAY 13, 2026" + "Product Chat" again as a giant editable input.

## After
Only the top `FileViewerHeader` shows the title + last-edited. The editor body starts at the first content block.

## Test plan
- [ ] Open any page at `/workspaces/[ws]/p/[pageId]` and confirm only one title block (in the header) is visible.
- [ ] Rename via the header's inline title and confirm it persists on reload.
- [ ] Confirm `/workspaces/[ws]/f/[fileId]` for a markdown file still shows a single title (unchanged).
- [ ] Confirm the editor still saves, autosaves, and shows the `Saved`/`Saving`/`Unsaved` status in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)