### PR TITLE
Use overlapping chat bubbles for the Sessions sidebar icon

### DIFF
--- a/frontend/src/components/StashIcons.tsx
+++ b/frontend/src/components/StashIcons.tsx
@@ -1,7 +1,7 @@
-import ChatOutlinedIcon from "@mui/icons-material/ChatOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import ExploreOutlinedIcon from "@mui/icons-material/ExploreOutlined";
 import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
+import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
 import NotificationsNoneOutlinedIcon from "@mui/icons-material/NotificationsNoneOutlined";
@@ -72,7 +72,7 @@ export function WorkspaceIcon(props: IconProps) {
 }
 
 export function SessionsIcon(props: IconProps) {
-  return <MaterialIcon icon={ChatOutlinedIcon} {...props} />;
+  return <MaterialIcon icon={ForumOutlinedIcon} {...props} />;
 }
 
 export function FolderIcon(props: IconProps) {


### PR DESCRIPTION
## Summary
- Sessions was using MUI's `ChatOutlined` — a single rounded chat box with dots, which read as a generic "message" glyph next to the folder (Files) and octopus (Stashes) icons.
- Swap for `ForumOutlined` so Sessions reads unambiguously as a chat-bubbles (conversation) icon at the tiny sidebar size.

## Test plan
- [ ] Open the workspace sidebar and confirm the Sessions section header shows two overlapping chat bubbles.
- [ ] Confirm the same icon appears wherever `SessionsIcon` is used (e.g. workspace home tiles, command palette session rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)