### PR TITLE
[codex] Show stash authors

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -140,6 +140,8 @@ class StashResponse(BaseModel):
     title: str
     description: str
     owner_id: UUID
+    owner_name: str
+    owner_display_name: str | None = None
     access: str
     discoverable: bool
     cover_image_url: str | None = None

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -28,18 +28,15 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
 
 
-_STASH_SELECT = (
-    "SELECT v.id, v.workspace_id, v.slug, v.title, v.description, v.owner_id, "
-    "v.access, "
-    "v.discoverable, v.cover_image_url, v.icon_url, v.view_count, v.forked_from_stash_id, "
-    "v.created_at, v.updated_at FROM stashes v"
-)
 _STASH_COLS = (
     "v.id, v.workspace_id, v.slug, v.title, v.description, v.owner_id, "
+    "owner_user.name AS owner_name, owner_user.display_name AS owner_display_name, "
     "v.access, "
     "v.discoverable, v.cover_image_url, v.icon_url, v.view_count, v.forked_from_stash_id, "
     "v.created_at, v.updated_at"
 )
+_STASH_FROM = "FROM stashes v JOIN users owner_user ON owner_user.id = v.owner_id"
+_STASH_SELECT = f"SELECT {_STASH_COLS} {_STASH_FROM}"
 
 
 async def _attach_items(stash: dict) -> dict:
@@ -210,13 +207,11 @@ async def create_stash(
     async with pool.acquire() as conn:
         async with conn.transaction():
             await _validate_item_partition(conn, access, items, None)
-            row = await conn.fetchrow(
+            inserted = await conn.fetchrow(
                 "INSERT INTO stashes (workspace_id, slug, title, description, owner_id, "
                 "access, discoverable, cover_image_url, icon_url) "
                 "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) "
-                "RETURNING id, workspace_id, slug, title, description, owner_id, "
-                "access, discoverable, cover_image_url, icon_url, view_count, "
-                "forked_from_stash_id, created_at, updated_at",
+                "RETURNING id",
                 workspace_id,
                 slug,
                 title,
@@ -227,7 +222,8 @@ async def create_stash(
                 cover_image_url,
                 icon_url,
             )
-            await _replace_items(conn, row["id"], items)
+            await _replace_items(conn, inserted["id"], items)
+    row = await pool.fetchrow(f"{_STASH_SELECT} WHERE v.id = $1", inserted["id"])
     out = dict(row)
     return await _attach_items(out)
 
@@ -791,14 +787,12 @@ async def add_external_stash(workspace_id: UUID, slug: str, added_by: UUID) -> d
 
     async with pool.acquire() as conn:
         async with conn.transaction():
-            fork = await conn.fetchrow(
+            inserted = await conn.fetchrow(
                 "INSERT INTO stashes "
                 "(workspace_id, slug, title, description, owner_id, access, discoverable, "
                 "cover_image_url, icon_url, forked_from_stash_id) "
                 "VALUES ($1, $2, $3, $4, $5, 'workspace', false, $6, $7, $8) "
-                "RETURNING id, workspace_id, slug, title, description, owner_id, access, "
-                "discoverable, cover_image_url, icon_url, view_count, forked_from_stash_id, "
-                "created_at, updated_at",
+                "RETURNING id",
                 workspace_id,
                 _slugify(stash["title"]),
                 stash["title"],
@@ -825,7 +819,7 @@ async def add_external_stash(workspace_id: UUID, slug: str, added_by: UUID) -> d
                         "label_override": item.get("label_override"),
                     }
                 )
-            await _replace_items(conn, fork["id"], forked_items)
+            await _replace_items(conn, inserted["id"], forked_items)
 
     from . import stash_invite_service
 
@@ -834,6 +828,7 @@ async def add_external_stash(workspace_id: UUID, slug: str, added_by: UUID) -> d
         user_id=added_by,
         workspace_id=workspace_id,
     )
+    fork = await pool.fetchrow(f"{_STASH_SELECT} WHERE v.id = $1", inserted["id"])
     return _mark_external(await _attach_items(dict(fork)), workspace_id)
 
 
@@ -861,7 +856,7 @@ async def list_object_stashes(
     rows = []
     for target_type, target_id in await _containing_targets(pool, object_type, object_id):
         target_rows = await pool.fetch(
-            f"SELECT {_STASH_COLS} FROM stashes v "
+            f"SELECT {_STASH_COLS} {_STASH_FROM} "
             "JOIN stash_items vi ON vi.stash_id = v.id "
             "WHERE v.workspace_id = $1 AND vi.object_type = $2 AND vi.object_id = $3 "
             "ORDER BY v.updated_at DESC",

--- a/backend/tests/test_discover.py
+++ b/backend/tests/test_discover.py
@@ -43,7 +43,7 @@ async def _create_page(client: AsyncClient, api_key: str, workspace_id: str, nam
 
 @pytest.mark.asyncio
 async def test_discover_lists_discoverable_public_product_stashes(client: AsyncClient):
-    api_key, _ = await _register(client)
+    api_key, user = await _register(client)
     workspace = await _create_workspace(client, api_key, "Discovery workspace")
     public_page = await _create_page(client, api_key, workspace["id"], "Public brief")
     private_page = await _create_page(client, api_key, workspace["id"], "Private brief")
@@ -79,7 +79,21 @@ async def test_discover_lists_discoverable_public_product_stashes(client: AsyncC
         headers=_auth(api_key),
     )
     assert published.status_code == 201
-    slug = published.json()["stash"]["slug"]
+    published_stash = published.json()["stash"]
+    slug = published_stash["slug"]
+    assert published_stash["owner_name"] == user["name"]
+    assert published_stash["owner_display_name"] == user["display_name"]
+
+    workspace_stashes = await client.get(
+        f"/api/v1/workspaces/{workspace['id']}/stashes",
+        headers=_auth(api_key),
+    )
+    assert workspace_stashes.status_code == 200
+    workspace_stash = next(
+        stash for stash in workspace_stashes.json()["stashes"] if stash["slug"] == slug
+    )
+    assert workspace_stash["owner_name"] == user["name"]
+    assert workspace_stash["owner_display_name"] == user["display_name"]
 
     catalog = await client.get("/api/v1/discover/stashes")
     assert catalog.status_code == 200
@@ -93,6 +107,8 @@ async def test_discover_lists_discoverable_public_product_stashes(client: AsyncC
     detail = await client.get(f"/api/v1/stashes/{slug}")
     assert detail.status_code == 200
     assert detail.json()["stash"]["discoverable"] is True
+    assert detail.json()["stash"]["owner_name"] == user["name"]
+    assert detail.json()["stash"]["owner_display_name"] == user["display_name"]
 
     unlisted_detail = await client.get(f"/api/v1/stashes/{public_unlisted.json()['stash']['slug']}")
     assert unlisted_detail.status_code == 200

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -97,6 +97,8 @@ function stashDetail(
       title: "Shared Stash",
       description: "",
       owner_id: "user-1",
+      owner_name: "henry",
+      owner_display_name: "Henry",
       access: "public",
       discoverable: false,
       cover_image_url: null,
@@ -192,5 +194,15 @@ describe("StashPageClient sharing", () => {
 
     expect(title).toHaveTextContent("Shared Stash");
     expect(title).not.toHaveTextContent("workspace");
+  });
+
+  it("shows the stash author in the detail header", async () => {
+    vi.mocked(getPublicStash).mockResolvedValueOnce(
+      stashDetail({ owner_name: "sam", owner_display_name: "Sam" })
+    );
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    expect(await screen.findByText("by Sam")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -204,6 +204,7 @@ function StashPageBody({
     position: i,
     label_override: it.label,
   }));
+  const author = stash.owner_display_name || stash.owner_name;
 
   return (
     <div className="scroll-thin min-h-screen bg-background">
@@ -234,6 +235,8 @@ function StashPageBody({
                 {stash.title}
               </h1>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-muted">
+                <span>by {author}</span>
+                <span className="text-muted/60">·</span>
                 <span>
                   {items.length} item{items.length === 1 ? "" : "s"}
                 </span>

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -364,6 +364,8 @@ function publishedStashResult(slug: string) {
       title: "Shared link",
       description: "",
       owner_id: "user-1",
+      owner_name: "henry",
+      owner_display_name: "Henry",
       access: "public",
       discoverable: false,
       cover_image_url: null,

--- a/frontend/src/components/share/StashShareModal.test.tsx
+++ b/frontend/src/components/share/StashShareModal.test.tsx
@@ -59,6 +59,8 @@ describe("StashShareModal session sharing", () => {
       title: "Debug auth flow",
       description: "",
       owner_id: "user-1",
+      owner_name: "henry",
+      owner_display_name: "Henry",
       access: "workspace",
       discoverable: false,
       cover_image_url: null,

--- a/frontend/src/components/stash/StashCard.tsx
+++ b/frontend/src/components/stash/StashCard.tsx
@@ -12,6 +12,8 @@ export interface StashCardData {
   title: string;
   description: string;
   cover_image_url: string | null;
+  owner_name?: string;
+  owner_display_name?: string | null;
   access?: "workspace" | "private" | "public";
   is_external?: boolean;
   updated_at?: string;
@@ -38,6 +40,7 @@ export default function StashCard({ stash, cover, badge, footer }: StashCardProp
   const itemCount = stash.item_count ?? stash.items?.length ?? 0;
   const visibility = stash.access;
   const dotColor = visibility ? VIS_COLOR[visibility] : null;
+  const author = authorName(stash);
 
   return (
     <Link
@@ -80,6 +83,7 @@ export default function StashCard({ stash, cover, badge, footer }: StashCardProp
           {stash.description || "No description."}
         </p>
         <div className="sys-label mt-2.5" style={{ fontSize: 10.5 }}>
+          {author && `by ${author} · `}
           {itemCount} item{itemCount === 1 ? "" : "s"}
           {stash.updated_at && ` · updated ${relativeTime(stash.updated_at)}`}
         </div>
@@ -92,6 +96,10 @@ export default function StashCard({ stash, cover, badge, footer }: StashCardProp
       </div>
     </Link>
   );
+}
+
+function authorName(stash: StashCardData): string {
+  return stash.owner_display_name || stash.owner_name || "";
 }
 
 function relativeTime(iso: string): string {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -750,6 +750,8 @@ export interface CreatedStash {
   title: string;
   description: string;
   owner_id: string;
+  owner_name: string;
+  owner_display_name: string | null;
   access: "workspace" | "private" | "public";
   discoverable: boolean;
   cover_image_url: string | null;
@@ -825,6 +827,8 @@ export interface WorkspaceStash {
   title: string;
   description: string;
   owner_id: string;
+  owner_name: string;
+  owner_display_name: string | null;
   access: "workspace" | "private" | "public";
   discoverable: boolean;
   cover_image_url: string | null;


### PR DESCRIPTION
## Summary

- Include stash owner display fields in the shared `StashResponse` payload.
- Show the stash author in workspace stash cards and on the stash detail header.
- Cover create/list/detail responses and the detail header in tests.

## Screenshots

### Stash Detail
![stash-author-detail.png](https://github.com/user-attachments/assets/6dd78784-474f-4fa0-a13e-561aa48885e7)

### Workspace Stash Grid
![stash-author-grid.png](https://github.com/user-attachments/assets/69cae42c-1125-4224-8f0f-c0d8c1778808)

## Validation

- `ruff check .`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_author DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_author pytest --no-cov backend/tests`
- `cd frontend && npm run lint`
- `cd frontend && npm test`
- `cd frontend && npm run build`