### PR TITLE
Make descriptions edit like page content

### DIFF
--- a/backend/migrations/versions/0059_page_comments.py
+++ b/backend/migrations/versions/0059_page_comments.py
@@ -18,8 +18,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         CREATE TABLE IF NOT EXISTS page_comment_threads (
           id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
           page_id       UUID NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
@@ -32,14 +31,12 @@ def upgrade() -> None:
           resolved_by   UUID REFERENCES users(id),
           orphaned      BOOLEAN NOT NULL DEFAULT FALSE
         )
-        """
-    )
+        """)
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_page_comment_threads_page_id "
         "ON page_comment_threads(page_id)"
     )
-    op.execute(
-        """
+    op.execute("""
         CREATE TABLE IF NOT EXISTS page_comment_messages (
           id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
           thread_id   UUID NOT NULL REFERENCES page_comment_threads(id) ON DELETE CASCADE,
@@ -48,8 +45,7 @@ def upgrade() -> None:
           created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
           edited_at   TIMESTAMPTZ
         )
-        """
-    )
+        """)
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_page_comment_messages_thread_id "
         "ON page_comment_messages(thread_id)"

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -561,9 +561,7 @@ async def reply_to_thread(
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
-    thread = await comment_service.add_reply(
-        thread_id, body=req.body, author_id=current_user["id"]
-    )
+    thread = await comment_service.add_reply(thread_id, body=req.body, author_id=current_user["id"])
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
     return CommentThread(**thread)
@@ -605,9 +603,7 @@ async def delete_comment_thread(
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
-    result = await comment_service.delete_thread(
-        thread_id, user_id=current_user["id"]
-    )
+    result = await comment_service.delete_thread(thread_id, user_id=current_user["id"])
     if result == "not_found":
         raise HTTPException(status_code=404, detail="Thread not found")
     if result == "forbidden":
@@ -631,9 +627,7 @@ async def delete_comment_message(
     await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
-    status, thread = await comment_service.delete_message(
-        message_id, user_id=current_user["id"]
-    )
+    status, thread = await comment_service.delete_message(message_id, user_id=current_user["id"])
     if status == "not_found":
         raise HTTPException(status_code=404, detail="Message not found")
     if status == "forbidden":

--- a/backend/services/comment_service.py
+++ b/backend/services/comment_service.py
@@ -143,9 +143,7 @@ async def create_thread(
 
 async def add_reply(thread_id: UUID, *, body: str, author_id: UUID) -> dict | None:
     pool = get_pool()
-    exists = await pool.fetchval(
-        "SELECT 1 FROM page_comment_threads WHERE id = $1", thread_id
-    )
+    exists = await pool.fetchval("SELECT 1 FROM page_comment_threads WHERE id = $1", thread_id)
     if not exists:
         return None
     await pool.execute(
@@ -160,9 +158,7 @@ async def add_reply(thread_id: UUID, *, body: str, author_id: UUID) -> dict | No
     return await _fetch_thread(thread_id)
 
 
-async def set_resolved(
-    thread_id: UUID, *, resolved: bool, user_id: UUID
-) -> dict | None:
+async def set_resolved(thread_id: UUID, *, resolved: bool, user_id: UUID) -> dict | None:
     pool = get_pool()
     if resolved:
         updated = await pool.fetchval(
@@ -190,9 +186,7 @@ async def set_resolved(
     return await _fetch_thread(thread_id)
 
 
-async def delete_message(
-    message_id: UUID, *, user_id: UUID
-) -> tuple[str, dict | None]:
+async def delete_message(message_id: UUID, *, user_id: UUID) -> tuple[str, dict | None]:
     """Delete a single message. The author is the only one allowed.
 
     Returns (status, thread):
@@ -212,9 +206,7 @@ async def delete_message(
         return ("forbidden", None)
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await conn.execute(
-                "DELETE FROM page_comment_messages WHERE id = $1", message_id
-            )
+            await conn.execute("DELETE FROM page_comment_messages WHERE id = $1", message_id)
             remaining = await conn.fetchval(
                 "SELECT COUNT(*) FROM page_comment_messages WHERE thread_id = $1",
                 row["thread_id"],

--- a/backend/tests/test_page_comments.py
+++ b/backend/tests/test_page_comments.py
@@ -139,9 +139,7 @@ async def test_delete_thread_forbidden_for_other_user(client: AsyncClient) -> No
     ).json()
 
     # Join the workspace as a second user via the invite code.
-    workspace = (
-        await client.get(f"/api/v1/workspaces/{ws_id}", headers=owner_headers)
-    ).json()
+    workspace = (await client.get(f"/api/v1/workspaces/{ws_id}", headers=owner_headers)).json()
     other_key = await _register(client)
     other_headers = _auth(other_key)
     await client.post(

--- a/backend/workers/session_summarizer.py
+++ b/backend/workers/session_summarizer.py
@@ -50,6 +50,7 @@ async def _advisory_lock(namespace: int, resource: str):
             except Exception:
                 pass
 
+
 TICK_SECONDS = 10.0
 ERROR_SLEEP_SECONDS = 30.0
 MAX_ATTEMPTS = 4

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -243,6 +243,25 @@ details > summary::-webkit-details-marker {
   outline: 1px solid #ca8a04;
 }
 
+.description-editor-content {
+  min-height: 1.7em;
+}
+
+.ProseMirror.description-editor-content p {
+  margin: 0.25em 0;
+}
+
+.ProseMirror.description-editor-content p:first-child,
+.ProseMirror.description-editor-content h1:first-child,
+.ProseMirror.description-editor-content h2:first-child,
+.ProseMirror.description-editor-content h3:first-child {
+  margin-top: 0;
+}
+
+.ProseMirror.description-editor-content p:last-child {
+  margin-bottom: 0;
+}
+
 /* ProseMirror heading styles */
 .ProseMirror h1 {
   font-family: var(--font-display), sans-serif;

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -9,16 +9,12 @@ import {
   type ReactNode,
   type ChangeEvent,
 } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import Heading from "@tiptap/extension-heading";
-import Bold from "@tiptap/extension-bold";
-import Italic from "@tiptap/extension-italic";
-import TiptapLink from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
 
 import AppShell from "../../../components/AppShell";
 import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
+import DescriptionEditor, {
+  isBlankDescription,
+} from "../../../components/DescriptionEditor";
 import { PublicStashSkeleton, SkeletonBlock } from "../../../components/SkeletonStates";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
 import { StashIcon } from "../../../components/StashIcons";
@@ -42,10 +38,6 @@ import AddToWorkspaceButton from "./AddToWorkspaceButton";
 type StashItemGroup = Partial<
   Record<PublicStashItem["object_type"], PublicStashItem[]>
 >;
-
-// Same autosave window as workspace home — slow enough to coalesce
-// keystrokes, fast enough to feel near-realtime.
-const AUTOSAVE_MS = 1500;
 
 // Signed-in viewers see the Stash inside AppShell (sidebar + top bar) so
 // navigation context is preserved. Anonymous viewers see the raw page.
@@ -280,8 +272,6 @@ function StashPageBody({
           </div>
         </div>
 
-        {/* About this Stash — inline editable for writers, read-only for
-            viewers. Mirrors the workspace home editor. */}
         <StashDescriptionEditor
           stashId={stash.id}
           description={stash.description}
@@ -521,10 +511,6 @@ function StashIconUpload({
   );
 }
 
-// Inline-editable About section. Renders nothing for viewers when the
-// description is empty so the page stays uncluttered. Mirrors the
-// workspace home editor: TipTap + autosave-on-idle + click-to-focus
-// affordance with dashed border that goes solid on focus.
 function StashDescriptionEditor({
   stashId,
   description,
@@ -536,86 +522,20 @@ function StashDescriptionEditor({
   canEdit: boolean;
   onSaved: () => void;
 }) {
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSaved = useRef<string>(description);
-
-  useEffect(() => {
-    lastSaved.current = description;
-  }, [description]);
-
-  const editor = useEditor({
-    immediatelyRender: false,
-    editable: canEdit,
-    content: description || "<p></p>",
-    extensions: [
-      StarterKit.configure({
-        blockquote: false,
-        codeBlock: false,
-        heading: false,
-        bold: false,
-        italic: false,
-        link: false,
-        underline: false,
-      }),
-      Heading.configure({ levels: [1, 2, 3] }),
-      Bold,
-      Italic,
-      TiptapLink.configure({ openOnClick: true, autolink: true }),
-      Placeholder.configure({ placeholder: "Describe this Stash…" }),
-    ],
-    editorProps: {
-      attributes: {
-        class: "min-h-[120px] focus:outline-none file-page-body",
-      },
-    },
-    onUpdate: ({ editor: ed }) => {
-      const html = ed.getHTML();
-      if (html === lastSaved.current) return;
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      saveTimer.current = setTimeout(async () => {
-        lastSaved.current = html;
-        await updateStash(stashId, { description: html });
-        onSaved();
-      }, AUTOSAVE_MS);
-    },
-  });
-
-  useEffect(() => {
-    if (!editor) return;
-    if (editor.getHTML() === description) return;
-    editor.commands.setContent(description || "<p></p>", { emitUpdate: false });
-    lastSaved.current = description;
-  }, [description, editor]);
-
-  // useEditor() captures `editable` at creation time. When permission
-  // info loads after first paint, toggle it on the live editor.
-  useEffect(() => {
-    if (!editor) return;
-    editor.setEditable(canEdit);
-  }, [editor, canEdit]);
-
-  useEffect(() => {
-    return () => {
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-    };
-  }, []);
-
-  if (!canEdit && !description) return null;
+  if (!canEdit && isBlankDescription(description)) return null;
 
   return (
-    <section className="mt-6">
-      <div className="sys-label mb-1.5">About this Stash</div>
-      <div
-        onClick={() => editor?.commands.focus()}
-        className={
-          "rounded-[10px] border transition-colors " +
-          (canEdit
-            ? "border-dashed border-border bg-surface/40 px-[18px] py-[14px] cursor-text hover:border-[var(--color-brand-300)] hover:bg-[var(--color-brand-50)]/40 focus-within:border-[var(--color-brand-400)] focus-within:bg-base"
-            : "border-border bg-surface/40 px-[18px] py-[14px]")
-        }
-      >
-        <EditorContent editor={editor} />
-      </div>
+    <section className="mt-5">
+      <DescriptionEditor
+        value={description}
+        canEdit={canEdit}
+        placeholder="Describe this Stash…"
+        ariaLabel="Stash description"
+        onSave={async (html) => {
+          await updateStash(stashId, { description: html });
+          onSaved();
+        }}
+      />
     </section>
   );
 }

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -290,10 +290,6 @@ export default function StashPageView() {
     : null;
 
   const baseName = page ? page.name.replace(/\.md$/i, "") : "";
-  const openThreadCount = threads.filter(
-    (t) => !t.resolved_at && !t.orphaned
-  ).length;
-
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <FileViewerHeader

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -2,14 +2,10 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import Heading from "@tiptap/extension-heading";
-import Bold from "@tiptap/extension-bold";
-import Italic from "@tiptap/extension-italic";
-import TiptapLink from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
+import { useCallback, useEffect, useState } from "react";
+import DescriptionEditor, {
+  isBlankDescription,
+} from "../../../components/DescriptionEditor";
 import MembersModal from "../../../components/MembersModal";
 import { SkeletonBlock, WorkspaceHomeSkeleton } from "../../../components/SkeletonStates";
 import StashQuickAdd from "../../../components/StashQuickAdd";
@@ -31,8 +27,6 @@ import type {
   Workspace,
   WorkspaceMember,
 } from "../../../lib/types";
-
-const AUTOSAVE_MS = 1500;
 
 function relativeTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -193,6 +187,12 @@ export default function WorkspaceHomePage() {
             </div>
           )}
 
+          <WorkspaceDescriptionEditor
+            workspace={workspace}
+            canEdit={isMember}
+            onSaved={(updated) => setWorkspace(updated)}
+          />
+
           {/* Quick-add: paste URL or drop a file. .jsonl files route to
               session-transcript upload; anything else uploads to Files. */}
           {isMember && (
@@ -203,12 +203,6 @@ export default function WorkspaceHomePage() {
               <StashQuickAdd workspaceId={workspaceId} onAdded={load} />
             </section>
           )}
-
-          <WorkspaceDescriptionEditor
-            workspace={workspace}
-            canEdit={isMember}
-            onSaved={(updated) => setWorkspace(updated)}
-          />
 
           {/* Visualizations: human/agent session activity + 3D embedding view.
               Section renders even when empty so users see the placeholder
@@ -292,92 +286,23 @@ function WorkspaceDescriptionEditor({
   canEdit: boolean;
   onSaved: (updated: Workspace) => void;
 }) {
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastSaved = useRef<string>("");
   const description = workspace?.description ?? "";
 
-  useEffect(() => {
-    lastSaved.current = description;
-  }, [description]);
-
-  const editor = useEditor({
-    immediatelyRender: false,
-    editable: canEdit,
-    content: description || "<p></p>",
-    extensions: [
-      StarterKit.configure({
-        blockquote: false,
-        codeBlock: false,
-        heading: false,
-        bold: false,
-        italic: false,
-        link: false,
-        underline: false,
-      }),
-      Heading.configure({ levels: [1, 2, 3] }),
-      Bold,
-      Italic,
-      TiptapLink.configure({ openOnClick: true, autolink: true }),
-      Placeholder.configure({ placeholder: "Describe this workspace…" }),
-    ],
-    editorProps: {
-      attributes: {
-        class: "min-h-[120px] focus:outline-none file-page-body",
-      },
-    },
-    onUpdate: ({ editor: ed }) => {
-      if (!workspace) return;
-      const html = ed.getHTML();
-      if (html === lastSaved.current) return;
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      saveTimer.current = setTimeout(async () => {
-        lastSaved.current = html;
-        const updated = await updateWorkspace(workspace.id, {
-          description: html,
-        });
-        onSaved(updated);
-      }, AUTOSAVE_MS);
-    },
-  });
-
-  useEffect(() => {
-    if (!editor) return;
-    if (editor.getHTML() === description) return;
-    editor.commands.setContent(description || "<p></p>", { emitUpdate: false });
-    lastSaved.current = description;
-  }, [description, editor]);
-
-  // useEditor() captures `editable` at creation time. When membership loads
-  // after first paint, toggle it on the live editor so the description
-  // becomes typeable without a remount.
-  useEffect(() => {
-    if (!editor) return;
-    editor.setEditable(canEdit);
-  }, [editor, canEdit]);
-
-  useEffect(() => {
-    return () => {
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-    };
-  }, []);
-
   if (!workspace) return null;
-  if (!canEdit && !description) return null;
+  if (!canEdit && isBlankDescription(description)) return null;
 
   return (
-    <section className="mt-6">
-      <div className="sys-label mb-1.5">About this workspace</div>
-      <div
-        onClick={() => editor?.commands.focus()}
-        className={
-          "rounded-[10px] border transition-colors " +
-          (canEdit
-            ? "border-dashed border-border bg-surface/40 px-[18px] py-[14px] cursor-text hover:border-[var(--color-brand-300)] hover:bg-[var(--color-brand-50)]/40 focus-within:border-[var(--color-brand-400)] focus-within:bg-base"
-            : "border-border bg-surface/40 px-[18px] py-[14px]")
-        }
-      >
-        <EditorContent editor={editor} />
-      </div>
+    <section className="mt-5">
+      <DescriptionEditor
+        value={description}
+        canEdit={canEdit}
+        placeholder="Describe this workspace…"
+        ariaLabel="Workspace description"
+        onSave={async (html) => {
+          const updated = await updateWorkspace(workspace.id, { description: html });
+          onSaved(updated);
+        }}
+      />
     </section>
   );
 }

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -9,7 +9,7 @@ import {
   getFolderContents,
   getWorkspaceSidebar,
   listMyWorkspaces,
-  uploadFile,
+  uploadFileOrPage,
   uploadTranscript,
 } from "../lib/api";
 
@@ -52,7 +52,7 @@ vi.mock("../lib/api", () => ({
   getFolderContents: vi.fn(),
   getWorkspaceSidebar: vi.fn(),
   listMyWorkspaces: vi.fn(),
-  uploadFile: vi.fn(),
+  uploadFileOrPage: vi.fn(),
   uploadTranscript: vi.fn(),
 }));
 
@@ -207,17 +207,20 @@ describe("AppSidebar tree expansion", () => {
       pages: [{ id: "page-child", name: "Roadmap" }],
       files: [],
     });
-    vi.mocked(uploadFile).mockResolvedValue({
-      id: "file-1",
-      workspace_id: "ws-1",
-      folder_id: null,
-      name: "brief.md",
-      content_type: "text/markdown",
-      size_bytes: 5,
-      url: "/files/file-1",
-      uploaded_by: "user-1",
-      created_at: "2026-05-11T00:00:00Z",
-      linked_table_id: null,
+    vi.mocked(uploadFileOrPage).mockResolvedValue({
+      kind: "file",
+      file: {
+        id: "file-1",
+        workspace_id: "ws-1",
+        folder_id: null,
+        name: "brief.md",
+        content_type: "text/markdown",
+        size_bytes: 5,
+        url: "/files/file-1",
+        uploaded_by: "user-1",
+        created_at: "2026-05-11T00:00:00Z",
+        linked_table_id: null,
+      },
     });
     vi.mocked(uploadTranscript).mockResolvedValue({
       session_id: "session-1",
@@ -529,7 +532,7 @@ describe("AppSidebar tree expansion", () => {
       dataTransfer: { types: ["Files"], files: [file] },
     });
 
-    await waitFor(() => expect(uploadFile).toHaveBeenCalledWith("ws-1", file));
+    await waitFor(() => expect(uploadFileOrPage).toHaveBeenCalledWith("ws-1", file));
     expect(await screen.findByText("1 file added.")).toBeTruthy();
   });
 });

--- a/frontend/src/components/DescriptionEditor.tsx
+++ b/frontend/src/components/DescriptionEditor.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Heading from "@tiptap/extension-heading";
+import Bold from "@tiptap/extension-bold";
+import Italic from "@tiptap/extension-italic";
+import TiptapLink from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+
+const AUTOSAVE_MS = 1500;
+
+type DescriptionEditorProps = {
+  value: string;
+  canEdit: boolean;
+  placeholder: string;
+  ariaLabel: string;
+  onSave: (html: string) => Promise<void> | void;
+};
+
+export function isBlankDescription(value: string): boolean {
+  return value.trim() === "" || value.trim() === "<p></p>";
+}
+
+export default function DescriptionEditor({
+  value,
+  canEdit,
+  placeholder,
+  ariaLabel,
+  onSave,
+}: DescriptionEditorProps) {
+  const canEditRef = useRef(canEdit);
+  const lastSaved = useRef(value);
+  const onSaveRef = useRef(onSave);
+  const pendingHtml = useRef<string | null>(null);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    canEditRef.current = canEdit;
+  }, [canEdit]);
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  const flushPendingSave = useCallback(async () => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+
+    const html = pendingHtml.current;
+    pendingHtml.current = null;
+    if (html === null || html === lastSaved.current) return;
+
+    lastSaved.current = html;
+    await onSaveRef.current(html);
+  }, []);
+
+  const queueSave = useCallback(
+    (html: string) => {
+      pendingHtml.current = html;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => {
+        void flushPendingSave();
+      }, AUTOSAVE_MS);
+    },
+    [flushPendingSave]
+  );
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    editable: canEdit,
+    content: value || "<p></p>",
+    extensions: [
+      StarterKit.configure({
+        blockquote: false,
+        codeBlock: false,
+        heading: false,
+        bold: false,
+        italic: false,
+        link: false,
+        underline: false,
+      }),
+      Heading.configure({ levels: [1, 2, 3] }),
+      Bold,
+      Italic,
+      TiptapLink.configure({
+        openOnClick: false,
+        autolink: true,
+        HTMLAttributes: { rel: "noopener noreferrer" },
+      }),
+      Placeholder.configure({ placeholder }),
+    ],
+    editorProps: {
+      attributes: {
+        "aria-label": ariaLabel,
+        class: "description-editor-content focus:outline-none file-page-body",
+      },
+      handleDOMEvents: {
+        blur: () => {
+          void flushPendingSave();
+          return false;
+        },
+        click: (_view, event) => {
+          const target = event.target as HTMLElement | null;
+          const anchor = target?.closest?.("a");
+          if (!anchor) return false;
+
+          const href = anchor.getAttribute("href");
+          if (!href) return false;
+
+          const shouldOpen = !canEditRef.current || event.metaKey || event.ctrlKey;
+          if (!shouldOpen) return false;
+
+          event.preventDefault();
+          openHref(href);
+          return true;
+        },
+      },
+    },
+    onUpdate: ({ editor: ed }) => {
+      const html = ed.isEmpty ? "" : ed.getHTML();
+      if (html === lastSaved.current) return;
+      queueSave(html);
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setEditable(canEdit);
+  }, [canEdit, editor]);
+
+  useEffect(() => {
+    lastSaved.current = value;
+    if (!editor || pendingHtml.current !== null) return;
+
+    const html = editor.isEmpty ? "" : editor.getHTML();
+    if (html === value) return;
+
+    editor.commands.setContent(value || "<p></p>", { emitUpdate: false });
+  }, [editor, value]);
+
+  useEffect(() => {
+    return () => {
+      void flushPendingSave();
+    };
+  }, [flushPendingSave]);
+
+  return (
+    <div
+      data-editable={canEdit ? "true" : "false"}
+      onClick={() => {
+        if (canEdit) editor?.commands.focus();
+      }}
+      className={
+        "description-editor -mx-1 rounded-md px-1 py-0.5 " +
+        (canEdit
+          ? "cursor-text transition-colors hover:bg-raised/45 focus-within:bg-raised/45"
+          : "")
+      }
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
+}
+
+function openHref(href: string) {
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(href);
+  if (href.startsWith("/")) {
+    window.location.href = href;
+    return;
+  }
+  if (hasScheme) {
+    window.open(href, "_blank", "noopener,noreferrer");
+    return;
+  }
+}

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -79,13 +79,13 @@ export default function HtmlPageView({
   // first `html` we see so saves (wrap, edit, unwrap) don't reload the iframe
   // and trash the user's caret. Switching pages remounts this component, so
   // a new page picks up its own initial html cleanly.
-  const initialHtmlRef = useRef(html);
+  const [initialHtml] = useState(html);
   const srcDoc = useMemo(
     () =>
       layout === "responsive"
-        ? injectResizeBootstrap(initialHtmlRef.current, channel)
-        : initialHtmlRef.current,
-    [layout, channel],
+        ? injectResizeBootstrap(initialHtml, channel)
+        : initialHtml,
+    [layout, channel, initialHtml],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Replaced the duplicated workspace/Stash description editors with a shared TipTap `DescriptionEditor`.
- Removed the dashed input-style chrome, fixed-height box, and section label so descriptions read as inline page content.
- Made ordinary link clicks keep focus in the editor, while read-only/Cmd-click behavior still opens links.
- Flushes pending autosaves on blur/unmount and moves the workspace description above Quick Add.

## Screenshots

Workspace description:

![Workspace description editor](https://files.catbox.moe/wbv4z2.png)

Stash description:

![Stash description editor](https://files.catbox.moe/82k6tk.png)

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- Playwright browser QA against local backend/frontend after rebasing onto `origin/main`: verified no visible editor border, plain link click does not navigate while editing, workspace autosave persists on blur, and Stash description renders with the new page-content styling.