### PR TITLE
[codex] Add app loading skeleton states

### DIFF
--- a/frontend/src/app/activity/loading.tsx
+++ b/frontend/src/app/activity/loading.tsx
@@ -1,0 +1,5 @@
+import { ActivitySkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <ActivitySkeleton />;
+}

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import AppShell from "../../components/AppShell";
+import { ActivitySkeleton, BasicPageSkeleton } from "../../components/SkeletonStates";
 import {
   FileIcon,
   PageIcon,
@@ -57,7 +58,7 @@ function relativeTime(iso: string): string {
 
 export default function ActivityPage() {
   return (
-    <Suspense fallback={<div className="flex h-screen items-center justify-center text-muted">Loading…</div>}>
+    <Suspense fallback={<BasicPageSkeleton />}>
       <ActivityPageInner />
     </Suspense>
   );
@@ -128,8 +129,15 @@ function ActivityPageInner() {
     return events;
   }, [events, filter]);
 
-  if (loading) return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <BasicPageSkeleton />;
   if (!user) return null;
+  if (fetching) {
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <ActivitySkeleton />
+      </AppShell>
+    );
+  }
 
   return (
     <AppShell user={user} onLogout={logout}>
@@ -142,9 +150,7 @@ function ActivityPageInner() {
             : "Recent work across your workspaces."}
         </h1>
         <p className="mt-1 max-w-[620px] text-[14.5px] text-dim">
-          {fetching
-            ? "Loading…"
-            : `${stats.sessions24h} session${stats.sessions24h === 1 ? "" : "s"}, ${stats.pages24h} page edit${stats.pages24h === 1 ? "" : "s"}, and ${stats.files24h} file upload${stats.files24h === 1 ? "" : "s"} in the last 24 hours.`}
+          {`${stats.sessions24h} session${stats.sessions24h === 1 ? "" : "s"}, ${stats.pages24h} page edit${stats.pages24h === 1 ? "" : "s"}, and ${stats.files24h} file upload${stats.files24h === 1 ? "" : "s"} in the last 24 hours.`}
         </p>
 
         {/* Stat strip */}
@@ -181,11 +187,7 @@ function ActivityPageInner() {
 
         {/* Feed */}
         <div className="mt-3.5 flex flex-col gap-2.5">
-          {fetching ? (
-            <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
-              Loading…
-            </div>
-          ) : filtered.length === 0 ? (
+          {filtered.length === 0 ? (
             <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
               {events.length === 0
                 ? "No activity yet. Push a transcript, edit a page, or upload a file."

--- a/frontend/src/app/discover/loading.tsx
+++ b/frontend/src/app/discover/loading.tsx
@@ -1,0 +1,5 @@
+import { DiscoverSkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <DiscoverSkeleton />;
+}

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import AppShell from "../../components/AppShell";
 import { useBreadcrumbs } from "../../components/BreadcrumbContext";
+import { BasicPageSkeleton, CardGridSkeleton } from "../../components/SkeletonStates";
 import StashCard from "../../components/stash/StashCard";
 import { useAuth } from "../../hooks/useAuth";
 import type { PublicStashCard } from "../../lib/api";
@@ -85,7 +86,7 @@ export default function DiscoverPage() {
       </div>
 
       {fetching ? (
-        <p className="mt-12 text-center text-[13px] text-muted">Loading…</p>
+        <CardGridLoading />
       ) : stashes.length === 0 ? (
         <EmptyState />
       ) : (
@@ -95,11 +96,7 @@ export default function DiscoverPage() {
   );
 
   if (loading) {
-    return (
-      <div className="flex h-screen items-center justify-center text-muted">
-        Loading…
-      </div>
-    );
+    return <BasicPageSkeleton />;
   }
 
   if (user) {
@@ -111,6 +108,10 @@ export default function DiscoverPage() {
   }
 
   return <main>{content}</main>;
+}
+
+function CardGridLoading() {
+  return <CardGridSkeleton className="mt-6" />;
 }
 
 function DiscoverGrid({

--- a/frontend/src/app/docs/loading.tsx
+++ b/frontend/src/app/docs/loading.tsx
@@ -1,0 +1,5 @@
+import { DocsPageSkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <DocsPageSkeleton />;
+}

--- a/frontend/src/app/join/[code]/loading.tsx
+++ b/frontend/src/app/join/[code]/loading.tsx
@@ -1,0 +1,5 @@
+import { JoinWorkspaceSkeleton } from "../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <JoinWorkspaceSkeleton />;
+}

--- a/frontend/src/app/join/[code]/page.tsx
+++ b/frontend/src/app/join/[code]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Header from "../../../components/Header";
+import { JoinWorkspaceSkeleton } from "../../../components/SkeletonStates";
 import { useAuth } from "../../../hooks/useAuth";
 import { joinWorkspace } from "../../../lib/api";
 
@@ -31,11 +32,7 @@ export default function JoinPage() {
   }, [code, user, loading, status, router]);
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center text-muted">
-        Loading...
-      </div>
-    );
+    return <JoinWorkspaceSkeleton />;
   }
 
   return (
@@ -56,7 +53,7 @@ export default function JoinPage() {
               </a>
             </div>
           ) : status === "joining" ? (
-            <p className="text-dim">Joining workspace...</p>
+            <JoinProgress />
           ) : status === "error" ? (
             <div>
               <p className="text-red-400 mb-4">{error}</p>
@@ -70,6 +67,16 @@ export default function JoinPage() {
           ) : null}
         </div>
       </main>
+    </div>
+  );
+}
+
+function JoinProgress() {
+  return (
+    <div className="w-[320px] rounded-lg border border-border bg-surface p-5">
+      <div className="mx-auto h-10 w-10 animate-pulse rounded-lg bg-raised" />
+      <div className="mx-auto mt-4 h-4 w-44 animate-pulse rounded bg-raised" />
+      <div className="mx-auto mt-3 h-3 w-56 animate-pulse rounded bg-raised" />
     </div>
   );
 }

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { AppRouteSkeleton } from "../components/SkeletonStates";
+
+export default function Loading() {
+  return <AppRouteSkeleton />;
+}

--- a/frontend/src/app/login/loading.tsx
+++ b/frontend/src/app/login/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthPageSkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <AuthPageSkeleton />;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../../components/Header";
+import { AuthPageSkeleton, SkeletonBlock } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import { getToken, setToken, listMyWorkspaces } from "../../lib/api";
 
@@ -24,7 +25,7 @@ function formatApiError(detail: unknown, fallback: string): string {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>}>
+    <Suspense fallback={<AuthPageSkeleton />}>
       <LoginPageInner />
     </Suspense>
   );
@@ -66,7 +67,7 @@ function LoginPageInner() {
   // Wait for useAuth to load before rendering — otherwise the signed-out form
   // flashes on every /login hit even for already-signed-in users.
   if (loading) {
-    return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
+    return <AuthPageSkeleton />;
   }
 
   if (cliApproved) {
@@ -318,7 +319,10 @@ function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0Panel
 
   const body =
     hasSession === null ? (
-      <p className="text-sm text-muted text-center py-2">Loading…</p>
+      <div className="space-y-3">
+        <SkeletonBlock className="h-10 w-full rounded-lg" />
+        <SkeletonBlock className="h-10 w-full rounded-xl" />
+      </div>
     ) : hasSession ? (
       <Auth0Exchange cliSession={cliSession} onCliApproved={onCliApproved} />
     ) : (
@@ -358,7 +362,7 @@ function Auth0LoginButton(props: { cliSession: string | null }) {
   useEffect(() => {
     import("@managed/auth0/LoginButton").then((m) => setComp(() => m.default));
   }, []);
-  if (!Comp) return null;
+  if (!Comp) return <SkeletonBlock className="h-10 w-full rounded-xl" />;
   return <Comp cliSession={props.cliSession} />;
 }
 
@@ -370,7 +374,7 @@ function Auth0Exchange(props: { cliSession: string | null; onCliApproved: () => 
   useEffect(() => {
     import("@managed/auth0/ExchangeAndRedirect").then((m) => setComp(() => m.default));
   }, []);
-  if (!Comp) return null;
+  if (!Comp) return <SkeletonBlock className="h-10 w-full rounded-xl" />;
   return <Comp cliSession={props.cliSession} onCliApproved={props.onCliApproved} />;
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { type FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AppShell from "../components/AppShell";
+import { BasicPageSkeleton, HomeSkeleton } from "../components/SkeletonStates";
 import { useAuth } from "../hooks/useAuth";
 import { joinWorkspace, listMyWorkspaces } from "../lib/api";
 import { resetStashNavigationCache } from "../lib/stashNavigationCache";
@@ -86,7 +87,7 @@ export default function Home() {
   }, [loading, router, user]);
 
   if (loading || !user) {
-    return <div className="flex min-h-screen items-center justify-center text-muted">Loading...</div>;
+    return <BasicPageSkeleton />;
   }
 
   return <LoggedInHome user={user} logout={logout} />;
@@ -143,11 +144,19 @@ function LoggedInHome({
   }, [router]);
 
   if (loading) {
-    return <div className="flex min-h-screen items-center justify-center text-muted">Loading…</div>;
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <HomeSkeleton />
+      </AppShell>
+    );
   }
 
   if (workspaces.length > 0) {
-    return <div className="flex min-h-screen items-center justify-center text-muted">Opening home...</div>;
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <HomeSkeleton />
+      </AppShell>
+    );
   }
 
   async function handleJoin(event: FormEvent) {

--- a/frontend/src/app/search/loading.tsx
+++ b/frontend/src/app/search/loading.tsx
@@ -1,0 +1,5 @@
+import { SearchSkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <SearchSkeleton />;
+}

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import AppShell from "../../components/AppShell";
 import CustomSelect from "../../components/CustomSelect";
+import { BasicPageSkeleton, SearchResultsSkeleton, SearchSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import {
   getWorkspaceSidebar,
@@ -56,7 +57,7 @@ function initialContentScope(value: string | null, sessionId: string): ContentSc
 export default function SearchPage() {
   return (
     <Suspense
-      fallback={<div className="flex min-h-screen items-center justify-center text-muted">Loading...</div>}
+      fallback={<BasicPageSkeleton />}
     >
       <SearchPageInner />
     </Suspense>
@@ -308,9 +309,16 @@ function SearchPageInner() {
   }, [fetching, handleSearch, searchParams]);
 
   if (loading) {
-    return <div className="flex min-h-screen items-center justify-center text-muted">Loading...</div>;
+    return <BasicPageSkeleton />;
   }
   if (!user) return null;
+  if (fetching) {
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <SearchSkeleton />
+      </AppShell>
+    );
+  }
 
   return (
     <AppShell user={user} onLogout={logout}>
@@ -505,11 +513,7 @@ function SearchPageInner() {
               </div>
             )}
 
-            {searching && (
-              <p className="py-10 text-center text-[13px] text-muted">
-                Searching selected knowledge...
-              </p>
-            )}
+            {searching && <SearchResultsSkeleton />}
 
             {!searching && searchedQuery && results.length === 0 && !error && (
               <p className="py-10 text-center text-[13px] text-muted">

--- a/frontend/src/app/settings/loading.tsx
+++ b/frontend/src/app/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { AccountSettingsSkeleton } from "../../components/SkeletonStates";
+
+export default function Loading() {
+  return <AccountSettingsSkeleton />;
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Header from "../../components/Header";
+import { AccountSettingsSkeleton, ApiKeysSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import {
   ApiError,
@@ -26,9 +27,7 @@ export default function SettingsPage() {
   }, [loading, user, router]);
 
   if (loading || !user) {
-    return (
-      <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>
-    );
+    return <AccountSettingsSkeleton />;
   }
 
   return (
@@ -237,7 +236,7 @@ function ActiveSessions() {
 
       {error && <p className="text-xs text-error">{error}</p>}
       {keys === null ? (
-        <p className="text-sm text-muted">Loading…</p>
+        <ApiKeysSkeleton />
       ) : keys.length === 0 ? (
         <p className="text-sm text-muted">No active sessions.</p>
       ) : (

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -19,6 +19,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 
 import AppShell from "../../../components/AppShell";
 import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
+import { PublicStashSkeleton, SkeletonBlock } from "../../../components/SkeletonStates";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
 import { StashIcon } from "../../../components/StashIcons";
 import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
@@ -66,11 +67,7 @@ function StashChrome({
     `stash/${data?.stash.id ?? "loading"}`,
   );
   if (loading) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-background text-muted">
-        Loading Stash...
-      </main>
-    );
+    return <PublicStashSkeleton />;
   }
   if (user) {
     return (
@@ -111,9 +108,7 @@ export default function StashPageClient({ slug }: { slug: string }) {
   if (loading) {
     return (
       <StashChrome data={data}>
-        <div className="flex min-h-[50vh] items-center justify-center text-muted">
-          Loading Stash...
-        </div>
+        <PublicStashSkeleton />
       </StashChrome>
     );
   }
@@ -182,12 +177,14 @@ function StashPageBody({
   const [projection, setProjection] = useState<EmbeddingProjection | null>(
     null,
   );
+  const [insightsLoaded, setInsightsLoaded] = useState(false);
 
   useEffect(() => {
     // Visualizations are workspace-scoped — they show the owning workspace's
     // activity so the stash detail page has the same "knowledge map" feel
     // as the workspace home.
     let cancelled = false;
+    setInsightsLoaded(false);
     Promise.allSettled([
       getActivityTimeline(365, "day", stash.workspace_id),
       getEmbeddingProjection(500, undefined, stash.workspace_id),
@@ -195,6 +192,7 @@ function StashPageBody({
       if (cancelled) return;
       if (t.status === "fulfilled") setTimeline(t.value);
       if (p.status === "fulfilled") setProjection(p.value);
+      setInsightsLoaded(true);
     });
     return () => {
       cancelled = true;
@@ -338,7 +336,9 @@ function StashPageBody({
         <section className="mt-8">
           <div className="sys-label mb-1.5">Human / agent commits — past year</div>
           <div className="card-soft overflow-x-auto p-3">
-            {timeline && timeline.contributors.length > 0 ? (
+            {!insightsLoaded ? (
+              <SkeletonBlock className="h-40 w-full" />
+            ) : timeline && timeline.contributors.length > 0 ? (
               <ContributorActivityTimeline data={timeline} />
             ) : (
               <div className="px-2 py-6 text-center text-[12.5px] text-muted">
@@ -354,7 +354,9 @@ function StashPageBody({
             Embedding space — workspace knowledge map
           </div>
           <div className="card-soft p-3">
-            {projection && projection.points.length > 0 ? (
+            {!insightsLoaded ? (
+              <SkeletonBlock className="h-40 w-full" />
+            ) : projection && projection.points.length > 0 ? (
               <EmbeddingSpaceExplorer data={projection} />
             ) : (
               <div className="px-2 py-6 text-center text-[12.5px] text-muted">

--- a/frontend/src/app/stashes/[slug]/embed/loading.tsx
+++ b/frontend/src/app/stashes/[slug]/embed/loading.tsx
@@ -1,0 +1,5 @@
+import { PublicStashSkeleton } from "../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <PublicStashSkeleton />;
+}

--- a/frontend/src/app/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
+++ b/frontend/src/app/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 
 import AppShell from "../../../../../../components/AppShell";
 import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
+import { StashItemSkeleton } from "../../../../../../components/SkeletonStates";
 import HtmlPageView from "../../../../../../components/workspace/HtmlPageView";
 import { useAuth } from "../../../../../../hooks/useAuth";
 import {
@@ -56,11 +57,7 @@ function Chrome({
     `stash-item/${data?.stash.id ?? "loading"}/${item?.object_id ?? "loading"}`
   );
   if (loading) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-background text-muted">
-        Loading…
-      </main>
-    );
+    return <StashItemSkeleton />;
   }
   if (user) {
     return (
@@ -100,9 +97,7 @@ export default function StashItemClient({ slug, type, itemId }: Props) {
   if (loading) {
     return (
       <Chrome data={data} item={null}>
-        <div className="flex min-h-[50vh] items-center justify-center text-muted">
-          Loading…
-        </div>
+        <StashItemSkeleton />
       </Chrome>
     );
   }

--- a/frontend/src/app/stashes/[slug]/items/[type]/[id]/loading.tsx
+++ b/frontend/src/app/stashes/[slug]/items/[type]/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { StashItemSkeleton } from "../../../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <StashItemSkeleton />;
+}

--- a/frontend/src/app/stashes/[slug]/loading.tsx
+++ b/frontend/src/app/stashes/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PublicStashSkeleton } from "../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <PublicStashSkeleton />;
+}

--- a/frontend/src/app/tables/[tableId]/loading.tsx
+++ b/frontend/src/app/tables/[tableId]/loading.tsx
@@ -1,0 +1,5 @@
+import { TableEditorSkeleton } from "../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <TableEditorSkeleton />;
+}

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -7,6 +7,7 @@ import CustomSelect from "../../../components/CustomSelect";
 import { useAuth } from "../../../hooks/useAuth";
 import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import { useShareModal } from "../../../lib/shareModalContext";
+import { SkeletonBlock, TableEditorSkeleton } from "../../../components/SkeletonStates";
 import {
   getPublicStash,
   getTable, updateTable,
@@ -36,7 +37,7 @@ type SummaryData = { total_rows: number; columns: Record<string, { name: string;
 
 export default function TableEditorPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>}>
+    <Suspense fallback={<TableEditorSkeleton />}>
       <TableEditorPageInner />
     </Suspense>
   );
@@ -499,8 +500,22 @@ function TableEditorPageInner() {
   // Stash-scoped readers can be anonymous when the stash is public; only
   // redirect to /login in workspace mode.
   useEffect(() => { if (!readOnly && !loading && !user) router.push("/login"); }, [readOnly, user, loading, router]);
-  if (loading && !readOnly) return <div className="min-h-screen flex items-center justify-center text-muted">Loading...</div>;
+  if (loading && !readOnly) return <TableEditorSkeleton />;
   if (!user && !readOnly) return null;
+  if (!table && !error) {
+    if (!user) {
+      return (
+        <main className="flex min-h-screen flex-col bg-background">
+          <TableEditorSkeleton />
+        </main>
+      );
+    }
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <TableEditorSkeleton />
+      </AppShell>
+    );
+  }
 
   // --- Render row ---
   const renderRow = (row: TableRow, idx: number) => (
@@ -567,7 +582,7 @@ function TableEditorPageInner() {
         <FileViewerHeader
           icon={<TableGlyph />}
           iconColor="#059669"
-          title={table?.name ?? "Loading…"}
+          title={table?.name ?? "Table"}
           onRenameTitle={
             table && !readOnly
               ? async (next) => {
@@ -841,7 +856,15 @@ function TableEditorPageInner() {
 
             {/* Add row + infinite scroll sentinel */}
             {!readOnly && <button onClick={handleAddRow} className="w-full py-2 text-sm text-muted hover:text-foreground hover:bg-raised border-b border-border/50 transition-colors text-left px-4">+ New row</button>}
-            {hasMore && <div ref={sentinelRef} className="py-4 text-center text-xs text-muted">{loadingMore ? "Loading..." : `${totalCount - offset} more rows`}</div>}
+            {hasMore && (
+              <div ref={sentinelRef} className="py-4 text-center text-xs text-muted">
+                {loadingMore ? (
+                  <SkeletonBlock className="mx-auto h-4 w-32" />
+                ) : (
+                  `${totalCount - offset} more rows`
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/loading.tsx
@@ -1,0 +1,5 @@
+import { FileViewerSkeleton } from "../../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <FileViewerSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -5,6 +5,11 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
+import {
+  DocumentBodySkeleton,
+  FileViewerSkeleton,
+  SkeletonBlock,
+} from "../../../../../components/SkeletonStates";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
   getFile,
@@ -38,7 +43,7 @@ function isText(ct: string) {
 
 export default function FileViewerPage() {
   return (
-    <Suspense fallback={<div className="flex h-screen items-center justify-center text-muted">Loading…</div>}>
+    <Suspense fallback={<FileViewerSkeleton />}>
       <FileViewerPageInner />
     </Suspense>
   );
@@ -175,9 +180,9 @@ function FileViewerPageInner() {
     if (!readOnly && !loading && !user) router.push("/login");
   }, [readOnly, user, loading, router]);
 
-  if (loading && !readOnly)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading && !readOnly) return <FileViewerSkeleton />;
   if (!user && !readOnly) return null;
+  if (!file && !error) return <FileViewerSkeleton />;
 
   const fileKindLabel = file ? kindLabel(file.content_type, file.name) : "";
   const updatedAt = file?.created_at
@@ -257,6 +262,7 @@ function FileBody({ file, text }: { file: FileInfo; text: string | null }) {
     );
   }
   if (isMarkdown(file.content_type, file.name)) {
+    if (text === null) return <DocumentBodySkeleton className="mx-auto mt-8 max-w-3xl" />;
     return (
       <article className="markdown-content mx-auto max-w-3xl px-12 py-8 text-[15px] leading-relaxed text-foreground">
         <Markdown remarkPlugins={[remarkGfm]}>{text || ""}</Markdown>
@@ -264,9 +270,18 @@ function FileBody({ file, text }: { file: FileInfo; text: string | null }) {
     );
   }
   if (isText(file.content_type)) {
+    if (text === null) {
+      return (
+        <div className="space-y-2 px-5 py-4">
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((row) => (
+            <SkeletonBlock key={row} className="h-4 w-full max-w-4xl" />
+          ))}
+        </div>
+      );
+    }
     return (
       <pre className="scroll-thin h-full overflow-auto px-5 py-4 font-mono text-[12.5px] text-foreground">
-        {text || "Loading…"}
+        {text || ""}
       </pre>
     );
   }

--- a/frontend/src/app/workspaces/[workspaceId]/files/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/files/loading.tsx
@@ -1,0 +1,5 @@
+import { FileBrowserSkeleton } from "../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <FileBrowserSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/files/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/files/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
+import { FileBrowserSkeleton } from "../../../../components/SkeletonStates";
 import WorkspaceFileBrowser from "../../../../components/workspace/file-browser/WorkspaceFileBrowser";
 import { useAuth } from "../../../../hooks/useAuth";
 
@@ -18,8 +19,7 @@ export default function WorkspaceFilesPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <FileBrowserSkeleton />;
   if (!user) return null;
 
   return <WorkspaceFileBrowser workspaceId={workspaceId} folderId={null} />;

--- a/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/loading.tsx
@@ -1,0 +1,5 @@
+import { FileBrowserSkeleton } from "../../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <FileBrowserSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/folders/[folderId]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
+import { FileBrowserSkeleton } from "../../../../../components/SkeletonStates";
 import WorkspaceFileBrowser from "../../../../../components/workspace/file-browser/WorkspaceFileBrowser";
 import { useAuth } from "../../../../../hooks/useAuth";
 import { getFolderContents } from "../../../../../lib/api";
@@ -52,8 +53,7 @@ export default function FolderDetailPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <FileBrowserSkeleton />;
   if (!user) return null;
 
   return <WorkspaceFileBrowser workspaceId={workspaceId} folderId={folderId} />;

--- a/frontend/src/app/workspaces/[workspaceId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/layout.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { ReactNode, useEffect } from "react";
 import AppShell from "../../../components/AppShell";
+import { AppShellSkeleton } from "../../../components/SkeletonStates";
 import { useAuth } from "../../../hooks/useAuth";
 
 export default function StashLayout({ children }: { children: ReactNode }) {
@@ -13,8 +14,7 @@ export default function StashLayout({ children }: { children: ReactNode }) {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <AppShellSkeleton />;
   if (!user) return null;
 
   return (

--- a/frontend/src/app/workspaces/[workspaceId]/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/loading.tsx
@@ -1,0 +1,5 @@
+import { WorkspaceHomeSkeleton } from "../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <WorkspaceHomeSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/loading.tsx
@@ -1,0 +1,5 @@
+import { DocumentPageSkeleton } from "../../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <DocumentPageSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import { downloadBlob } from "../../../../../components/DownloadMenu";
+import { DocumentPageSkeleton } from "../../../../../components/SkeletonStates";
 import { StashIcon } from "../../../../../components/StashIcons";
 import HtmlPageView from "../../../../../components/workspace/HtmlPageView";
 import FileViewerHeader from "../../../../../components/workspace/FileViewerHeader";
@@ -92,9 +93,9 @@ export default function StashPageView() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <DocumentPageSkeleton />;
   if (!user) return null;
+  if (!page && !error) return <DocumentPageSkeleton />;
 
   const isHtml = page?.content_type === "html";
   const updatedAt = page?.updated_at
@@ -181,9 +182,7 @@ export default function StashPageView() {
                   onNavigateInternal={(href) => router.push(href)}
                 />
               )
-            ) : (
-              <p className="text-muted">Loading…</p>
-            )}
+            ) : null}
           </article>
 
           {page && !isHtml && (

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -11,6 +11,7 @@ import Italic from "@tiptap/extension-italic";
 import TiptapLink from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import MembersModal from "../../../components/MembersModal";
+import { SkeletonBlock, WorkspaceHomeSkeleton } from "../../../components/SkeletonStates";
 import StashQuickAdd from "../../../components/StashQuickAdd";
 import { WorkspaceIcon } from "../../../components/StashIcons";
 import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
@@ -57,10 +58,12 @@ export default function WorkspaceHomePage() {
   const [projection, setProjection] = useState<EmbeddingProjection | null>(
     null,
   );
+  const [insightsLoaded, setInsightsLoaded] = useState(false);
   const [error, setError] = useState("");
   const [membersOpen, setMembersOpen] = useState(false);
 
   const load = useCallback(async () => {
+    setInsightsLoaded(false);
     const [w, m, t, p] = await Promise.allSettled([
       getWorkspace(workspaceId),
       getWorkspaceMembers(workspaceId),
@@ -75,6 +78,7 @@ export default function WorkspaceHomePage() {
     if (m.status === "fulfilled") setMembers(m.value);
     if (t.status === "fulfilled") setTimeline(t.value);
     if (p.status === "fulfilled") setProjection(p.value);
+    setInsightsLoaded(true);
   }, [workspaceId]);
 
   useEffect(() => {
@@ -98,13 +102,9 @@ export default function WorkspaceHomePage() {
     }
   }
 
-  if (loading)
-    return (
-      <div className="flex h-screen items-center justify-center text-muted">
-        Loading…
-      </div>
-    );
+  if (loading) return <WorkspaceHomeSkeleton />;
   if (!user) return null;
+  if (!workspace && !error) return <WorkspaceHomeSkeleton />;
 
   return (
     <>
@@ -216,7 +216,9 @@ export default function WorkspaceHomePage() {
           <section className="mt-8">
             <div className="sys-label mb-1.5">Human / agent commits — past year</div>
             <div className="card-soft overflow-x-auto p-3">
-              {timeline && timeline.contributors.length > 0 ? (
+              {!insightsLoaded ? (
+                <SkeletonBlock className="h-40 w-full" />
+              ) : timeline && timeline.contributors.length > 0 ? (
                 <ContributorActivityTimeline data={timeline} />
               ) : (
                 <div className="px-2 py-6 text-center text-[12.5px] text-muted">
@@ -232,7 +234,9 @@ export default function WorkspaceHomePage() {
               Embedding space — workspace knowledge map
             </div>
             <div className="card-soft p-3">
-              {projection && projection.points.length > 0 ? (
+              {!insightsLoaded ? (
+                <SkeletonBlock className="h-40 w-full" />
+              ) : projection && projection.points.length > 0 ? (
                 <EmbeddingSpaceExplorer data={projection} />
               ) : (
                 <div className="px-2 py-6 text-center text-[12.5px] text-muted">

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/loading.tsx
@@ -1,0 +1,5 @@
+import { SessionDetailSkeleton } from "../../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <SessionDetailSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import DownloadMenu from "../../../../../components/DownloadMenu";
+import { SessionDetailSkeleton } from "../../../../../components/SkeletonStates";
 import { StashIcon } from "../../../../../components/StashIcons";
 import { useAuth } from "../../../../../hooks/useAuth";
 import {
@@ -135,9 +136,9 @@ export default function SessionViewerPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <SessionDetailSkeleton />;
   if (!user) return null;
+  if (!sessionDetail && turns.length === 0 && !error) return <SessionDetailSkeleton />;
 
   const sessionDate = turns.find((turn) => turn.dateLabel)?.dateLabel;
 
@@ -218,7 +219,7 @@ export default function SessionViewerPage() {
             })}
             {!error && turns.length === 0 && (
               <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
-                Loading transcript…
+                No transcript events yet.
               </div>
             )}
           </div>

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/loading.tsx
@@ -1,0 +1,5 @@
+import { SessionsListSkeleton } from "../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <SessionsListSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import SessionUpload from "../../../../components/SessionUpload";
+import { SessionsListSkeleton } from "../../../../components/SkeletonStates";
 import { SettingsIcon } from "../../../../components/StashIcons";
 import { useAuth } from "../../../../hooks/useAuth";
 import { listMySessions, type SessionSummary } from "../../../../lib/api";
@@ -85,9 +86,9 @@ export default function StashSessionsPage() {
     return copy;
   }, [sessions, sort]);
 
-  if (loading)
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <SessionsListSkeleton />;
   if (!user) return null;
+  if (sorted === null) return <SessionsListSkeleton />;
 
   const total = sessions?.length ?? 0;
 

--- a/frontend/src/app/workspaces/[workspaceId]/settings/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { WorkspaceSettingsSkeleton } from "../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <WorkspaceSettingsSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/settings/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import CustomSelect from "../../../../components/CustomSelect";
+import { WorkspaceSettingsSkeleton } from "../../../../components/SkeletonStates";
 import { useAuth } from "../../../../hooks/useAuth";
 import {
   deleteWorkspace,
@@ -59,11 +60,8 @@ export default function StashSettingsPage() {
 
   if (!user) return null;
   if (!workspace) {
-    return (
-      <div className="mx-auto max-w-2xl px-8 py-12 text-muted">
-        {error || "Loading…"}
-      </div>
-    );
+    if (error) return <div className="mx-auto max-w-2xl px-8 py-12 text-muted">{error}</div>;
+    return <WorkspaceSettingsSkeleton />;
   }
 
   const myRole = members.find((m) => m.user_id === user.id)?.role;

--- a/frontend/src/app/workspaces/[workspaceId]/stashes/loading.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/stashes/loading.tsx
@@ -1,0 +1,5 @@
+import { StashesGridSkeleton } from "../../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <StashesGridSkeleton />;
+}

--- a/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/stashes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { StashesGridSkeleton } from "../../../../components/SkeletonStates";
 import StashCard from "../../../../components/stash/StashCard";
 import { useShareModal } from "../../../../lib/shareModalContext";
 import { addExternalStash, ApiError, listStashes, type WorkspaceStash } from "../../../../lib/api";
@@ -73,7 +74,7 @@ export default function WorkspaceStashesPage() {
   );
 
   if (stashes === null) {
-    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+    return <StashesGridSkeleton />;
   }
 
   return (

--- a/frontend/src/app/workspaces/new/loading.tsx
+++ b/frontend/src/app/workspaces/new/loading.tsx
@@ -1,0 +1,5 @@
+import { WorkspaceFormSkeleton } from "../../../components/SkeletonStates";
+
+export default function Loading() {
+  return <WorkspaceFormSkeleton />;
+}

--- a/frontend/src/app/workspaces/new/page.tsx
+++ b/frontend/src/app/workspaces/new/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import AppShell from "../../../components/AppShell";
+import { BasicPageSkeleton } from "../../../components/SkeletonStates";
 import { useAuth } from "../../../hooks/useAuth";
 import { createWorkspace } from "../../../lib/api";
 import { resetStashNavigationCache } from "../../../lib/stashNavigationCache";
@@ -15,7 +16,7 @@ export default function NewWorkspacePage() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
-  if (loading) return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (loading) return <BasicPageSkeleton />;
   if (!user) {
     if (typeof window !== "undefined") router.push("/login");
     return null;

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/api";
 import { useShareModal } from "../lib/shareModalContext";
 import { useEscapeKey } from "../hooks/useEscapeKey";
+import { SkeletonBlock } from "./SkeletonStates";
 import { displaySessionUserName } from "../lib/sessionGrouping";
 import {
   getCachedFolderContents,
@@ -1167,9 +1168,7 @@ function FolderTreeNode({
         </Link>
       </summary>
       <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
-        {contents === null && loaded && (
-          <div className="px-2 py-1 text-[11px] italic text-muted">loading…</div>
-        )}
+        {contents === null && loaded && <SkeletonBlock className="my-1 h-5 w-28" />}
         {contents?.subfolders
           .filter((sub) => !isFolderPinned(sub.id))
           .map((sub) => (

--- a/frontend/src/components/SkeletonStates.tsx
+++ b/frontend/src/components/SkeletonStates.tsx
@@ -1,0 +1,713 @@
+import type { ReactNode } from "react";
+
+type SkeletonProps = {
+  className?: string;
+};
+
+function cx(...parts: Array<string | false | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+export function SkeletonBlock({ className }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cx("animate-pulse rounded-md bg-raised", className)}
+    />
+  );
+}
+
+function SkeletonLine({ className }: SkeletonProps) {
+  return <SkeletonBlock className={cx("h-3", className)} />;
+}
+
+function SkeletonCard({
+  className,
+  children,
+}: SkeletonProps & {
+  children?: ReactNode;
+}) {
+  return (
+    <div className={cx("rounded-lg border border-border bg-surface p-4", className)}>
+      {children}
+    </div>
+  );
+}
+
+function HeaderSkeleton() {
+  return (
+    <header className="sticky top-0 z-30 grid h-11 flex-shrink-0 grid-cols-[minmax(0,1fr)_minmax(220px,460px)_minmax(0,1fr)] items-center gap-3 border-b border-border bg-base/85 px-3 backdrop-blur-md">
+      <div className="flex items-center gap-2">
+        <SkeletonBlock className="h-6 w-6 rounded" />
+        <SkeletonLine className="h-3 w-36" />
+      </div>
+      <SkeletonBlock className="h-7 w-full" />
+      <div className="flex justify-end gap-2">
+        <SkeletonBlock className="h-6 w-16" />
+        <SkeletonBlock className="h-6 w-6 rounded-full" />
+      </div>
+    </header>
+  );
+}
+
+function SidebarSkeleton() {
+  return (
+    <aside className="hidden min-h-0 border-r border-border bg-surface px-3 py-3 md:block">
+      <SkeletonBlock className="mb-4 h-8 w-full" />
+      <div className="space-y-5">
+        {[0, 1, 2].map((section) => (
+          <div key={section} className="space-y-2">
+            <SkeletonLine className="h-2.5 w-16" />
+            {[0, 1, 2, 3].map((row) => (
+              <div key={row} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+                <SkeletonBlock className="h-4 w-4 rounded" />
+                <SkeletonLine className={row % 2 === 0 ? "w-36" : "w-24"} />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export function AppShellSkeleton({
+  children,
+  sidebar = true,
+}: {
+  children?: ReactNode;
+  sidebar?: boolean;
+}) {
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-base text-foreground">
+      <HeaderSkeleton />
+      <div
+        className="grid min-h-0 flex-1 overflow-hidden"
+        style={{ gridTemplateColumns: sidebar ? "260px minmax(0, 1fr)" : "minmax(0, 1fr)" }}
+      >
+        {sidebar && <SidebarSkeleton />}
+        <main className="min-w-0 overflow-y-auto bg-base">
+          {children ?? <WorkspaceHomeSkeleton />}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export function AppRouteSkeleton() {
+  return (
+    <AppShellSkeleton>
+      <WorkspaceHomeSkeleton />
+    </AppShellSkeleton>
+  );
+}
+
+export function BasicPageSkeleton() {
+  return (
+    <main className="min-h-screen bg-base px-6 py-8 text-foreground">
+      <div className="mx-auto max-w-[920px]">
+        <SkeletonLine className="h-2.5 w-20" />
+        <SkeletonLine className="mt-4 h-8 w-72 max-w-full" />
+        <SkeletonLine className="mt-3 h-4 w-[520px] max-w-full" />
+        <div className="mt-8 grid gap-3 sm:grid-cols-2">
+          {[0, 1, 2, 3].map((i) => (
+            <SkeletonCard key={i}>
+              <SkeletonLine className="h-4 w-36" />
+              <SkeletonLine className="mt-3 w-full" />
+              <SkeletonLine className="mt-2 w-2/3" />
+            </SkeletonCard>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export function AuthPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col bg-base text-foreground">
+      <div className="border-b border-border bg-surface px-4 py-2">
+        <div className="flex justify-end">
+          <SkeletonBlock className="h-7 w-24" />
+        </div>
+      </div>
+      <main className="flex flex-1 items-center justify-center px-4 py-12">
+        <SkeletonCard className="w-full max-w-sm rounded-2xl p-6">
+          <SkeletonLine className="h-5 w-28" />
+          <SkeletonBlock className="mt-4 h-10 w-full rounded-lg" />
+          <SkeletonBlock className="mt-3 h-10 w-full rounded-lg" />
+          <SkeletonBlock className="mt-3 h-10 w-full rounded-xl" />
+          <SkeletonLine className="mx-auto mt-4 w-40" />
+        </SkeletonCard>
+      </main>
+    </div>
+  );
+}
+
+export function AccountSettingsSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col bg-base text-foreground">
+      <div className="border-b border-border bg-surface px-4 py-2">
+        <div className="flex justify-end">
+          <SkeletonBlock className="h-7 w-7 rounded-full" />
+        </div>
+      </div>
+      <main className="flex-1 px-4 py-10">
+        <div className="mx-auto w-full max-w-2xl space-y-8">
+          <SkeletonLine className="h-4 w-16" />
+          <div>
+            <SkeletonLine className="h-7 w-56" />
+            <SkeletonLine className="mt-3 h-4 w-96 max-w-full" />
+          </div>
+          {[0, 1, 2].map((i) => (
+            <SettingsSectionSkeleton key={i} />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export function ApiKeysSkeleton() {
+  return (
+    <div className="space-y-2">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex items-center gap-3 rounded-lg border border-border bg-base p-3">
+          <div className="min-w-0 flex-1">
+            <SkeletonLine className="h-4 w-40" />
+            <SkeletonLine className="mt-2 h-3 w-56 max-w-full" />
+          </div>
+          <SkeletonBlock className="h-7 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SettingsSectionSkeleton() {
+  return (
+    <SkeletonCard className="rounded-2xl p-6">
+      <SkeletonLine className="h-5 w-32" />
+      <SkeletonLine className="mt-2 h-3 w-80 max-w-full" />
+      <SkeletonBlock className="mt-5 h-10 w-full rounded-lg" />
+      <SkeletonBlock className="mt-3 h-10 w-full rounded-lg" />
+      <SkeletonBlock className="mt-4 h-9 w-32 rounded-lg" />
+    </SkeletonCard>
+  );
+}
+
+export function HomeSkeleton() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-12">
+      <SkeletonLine className="h-3 w-20" />
+      <SkeletonLine className="h-9 w-80 max-w-full" />
+      <div className="space-y-2">
+        <SkeletonLine className="h-4 w-full" />
+        <SkeletonLine className="h-4 w-4/5" />
+      </div>
+      <SkeletonCard className="border-dashed p-4">
+        <SkeletonLine className="h-5 w-32" />
+        <SkeletonBlock className="mt-4 h-9 w-36" />
+      </SkeletonCard>
+      <SkeletonCard className="p-4">
+        <SkeletonLine className="h-5 w-40" />
+        <SkeletonLine className="mt-2 w-64 max-w-full" />
+        <div className="mt-4 flex gap-2">
+          <SkeletonBlock className="h-9 flex-1" />
+          <SkeletonBlock className="h-9 w-20" />
+        </div>
+      </SkeletonCard>
+    </div>
+  );
+}
+
+export function DiscoverSkeleton() {
+  return (
+    <div className="mx-auto max-w-[1180px] px-12 pb-20 pt-9">
+      <div className="flex items-center gap-3">
+        <SkeletonBlock className="h-9 max-w-[460px] flex-1 rounded-lg" />
+        <SkeletonBlock className="h-8 w-56 rounded-lg" />
+        <span className="flex-1" />
+        <SkeletonLine className="w-20" />
+      </div>
+      <CardGridSkeleton className="mt-6" />
+    </div>
+  );
+}
+
+export function ActivitySkeleton() {
+  return (
+    <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
+      <SkeletonLine className="h-3 w-20" />
+      <SkeletonLine className="mt-3 h-8 w-[520px] max-w-full" />
+      <SkeletonLine className="mt-3 h-4 w-[620px] max-w-full" />
+      <div className="mt-5 grid grid-cols-2 gap-2.5 md:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <SkeletonCard key={i} className="p-3.5">
+            <SkeletonLine className="h-7 w-12" />
+            <SkeletonLine className="mt-2 h-3 w-24" />
+          </SkeletonCard>
+        ))}
+      </div>
+      <SkeletonBlock className="mt-8 h-px w-full rounded-none" />
+      <ActivityFeedSkeleton />
+    </div>
+  );
+}
+
+export function ActivityFeedSkeleton() {
+  return (
+    <div className="mt-3.5 flex flex-col gap-2.5">
+      {[0, 1, 2, 3, 4].map((i) => (
+        <SkeletonCard key={i} className="flex items-start gap-3 px-4 py-3.5">
+          <SkeletonBlock className="h-7 w-7 rounded-full" />
+          <div className="min-w-0 flex-1">
+            <SkeletonLine className="h-3 w-64 max-w-full" />
+            <SkeletonLine className="mt-3 h-5 w-80 max-w-full" />
+            <SkeletonLine className="mt-2 h-3 w-full" />
+          </div>
+        </SkeletonCard>
+      ))}
+    </div>
+  );
+}
+
+export function WorkspaceHomeSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <SkeletonBlock className="h-[72px] w-full rounded-none bg-brand-100" />
+      <div className="mx-auto max-w-[920px] px-12 pb-20">
+        <div className="flex items-start justify-between gap-3 pt-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <SkeletonBlock className="-mt-9 h-12 w-12 rounded-[10px] border-2 border-base" />
+            <div className="min-w-0">
+              <SkeletonLine className="h-6 w-56 max-w-full" />
+              <SkeletonLine className="mt-2 h-3 w-44" />
+            </div>
+          </div>
+          <SkeletonBlock className="h-7 w-7" />
+        </div>
+        <SkeletonCard className="mt-6 p-3">
+          <SkeletonLine className="h-3 w-56" />
+          <SkeletonBlock className="mt-2 h-10 w-full" />
+        </SkeletonCard>
+        <DocumentBodySkeleton className="mt-6" />
+        <VisualizationSkeleton className="mt-8" />
+        <VisualizationSkeleton className="mt-6" />
+      </div>
+    </div>
+  );
+}
+
+export function VisualizationSkeleton({ className }: SkeletonProps) {
+  return (
+    <section className={className}>
+      <SkeletonLine className="mb-1.5 h-3 w-56" />
+      <SkeletonCard className="p-3">
+        <SkeletonBlock className="h-40 w-full" />
+      </SkeletonCard>
+    </section>
+  );
+}
+
+export function WorkspaceFormSkeleton() {
+  return (
+    <div className="mx-auto max-w-2xl px-8 py-12">
+      <SkeletonLine className="h-3 w-28" />
+      <SkeletonLine className="mt-3 h-9 w-72 max-w-full" />
+      <SkeletonLine className="mt-4 h-4 w-full" />
+      <SkeletonLine className="mt-2 h-4 w-4/5" />
+      <div className="mt-8 space-y-4">
+        <SkeletonBlock className="h-16 w-full rounded-lg" />
+        <SkeletonBlock className="h-28 w-full rounded-lg" />
+        <div className="flex justify-between">
+          <SkeletonBlock className="h-8 w-16" />
+          <SkeletonBlock className="h-9 w-36" />
+        </div>
+      </div>
+      <SkeletonCard className="mt-12 rounded-2xl p-5">
+        <SkeletonLine className="h-3 w-48" />
+        <div className="mt-4 space-y-3">
+          <SkeletonLine className="w-full" />
+          <SkeletonLine className="w-5/6" />
+          <SkeletonLine className="w-2/3" />
+        </div>
+      </SkeletonCard>
+    </div>
+  );
+}
+
+export function WorkspaceSettingsSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-2xl px-8 py-10">
+        <SkeletonLine className="h-8 w-36" />
+        <SkeletonLine className="mt-3 h-3 w-40" />
+        {[0, 1, 2].map((i) => (
+          <SkeletonCard key={i} className="mt-6 p-4">
+            <SkeletonLine className="h-5 w-28" />
+            <div className="mt-4 space-y-2">
+              {[0, 1, 2].map((row) => (
+                <SkeletonBlock key={row} className="h-12 w-full rounded-lg" />
+              ))}
+            </div>
+          </SkeletonCard>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SessionsListSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-12 py-8">
+        <div className="flex items-baseline justify-between">
+          <SkeletonLine className="h-8 w-32" />
+          <SkeletonLine className="h-3 w-20" />
+        </div>
+        <SkeletonBlock className="mt-5 h-24 w-full rounded-lg" />
+        <SkeletonBlock className="mb-3 mt-4 h-px w-full rounded-none" />
+        <div className="space-y-2">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <SkeletonBlock key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FileBrowserSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-3 border-b border-border bg-surface px-4 py-2.5">
+        <SkeletonLine className="h-4 w-24" />
+        <span className="flex-1" />
+        <SkeletonBlock className="h-7 w-40" />
+        <SkeletonBlock className="h-7 w-20" />
+        <SkeletonBlock className="h-7 w-24" />
+      </div>
+      <div className="grid gap-3 p-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+          <SkeletonCard key={i} className="p-3">
+            <SkeletonBlock className="h-8 w-8 rounded" />
+            <SkeletonLine className="mt-4 h-4 w-36" />
+            <SkeletonLine className="mt-2 h-3 w-24" />
+          </SkeletonCard>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function StashesGridSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-[1120px] px-12 pb-20 pt-8">
+        <div className="flex items-center justify-between gap-4">
+          <SkeletonLine className="h-9 w-36" />
+          <SkeletonBlock className="h-8 w-24" />
+        </div>
+        <SkeletonBlock className="mt-5 h-10 w-full rounded-lg" />
+        <SkeletonBlock className="mt-4 h-24 w-full rounded-lg" />
+        <CardGridSkeleton className="mt-4" />
+      </div>
+    </div>
+  );
+}
+
+export function CardGridSkeleton({ className }: SkeletonProps) {
+  return (
+    <div className={cx("grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3", className)}>
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <SkeletonCard key={i} className="overflow-hidden p-0">
+          <SkeletonBlock className="h-28 w-full rounded-none" />
+          <div className="p-4">
+            <SkeletonLine className="h-5 w-3/4" />
+            <SkeletonLine className="mt-3 w-full" />
+            <SkeletonLine className="mt-2 w-2/3" />
+            <div className="mt-4 flex justify-between">
+              <SkeletonLine className="w-24" />
+              <SkeletonBlock className="h-6 w-16" />
+            </div>
+          </div>
+        </SkeletonCard>
+      ))}
+    </div>
+  );
+}
+
+export function DocumentPageSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <ViewerHeaderSkeleton />
+      <div className="mx-auto mt-6 grid max-w-[1100px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <main className="min-w-0">
+          <DocumentBodySkeleton />
+        </main>
+        <aside className="mt-20 hidden lg:block">
+          <SkeletonCard className="sticky top-16 p-3.5">
+            <SkeletonLine className="h-3 w-20" />
+            <SkeletonLine className="mt-4 w-full" />
+            <SkeletonLine className="mt-2 w-2/3" />
+          </SkeletonCard>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export function DocumentBodySkeleton({ className }: SkeletonProps) {
+  return (
+    <article className={cx("rounded-lg border border-border bg-base px-5 py-5", className)}>
+      <SkeletonLine className="h-8 w-2/3" />
+      <SkeletonLine className="mt-6 w-full" />
+      <SkeletonLine className="mt-3 w-11/12" />
+      <SkeletonLine className="mt-3 w-10/12" />
+      <SkeletonLine className="mt-8 h-6 w-1/2" />
+      <SkeletonLine className="mt-4 w-full" />
+      <SkeletonLine className="mt-3 w-4/5" />
+      <SkeletonBlock className="mt-6 h-32 w-full rounded-lg" />
+    </article>
+  );
+}
+
+export function FileViewerSkeleton() {
+  return (
+    <div className="scroll-thin flex min-h-0 flex-1 flex-col overflow-hidden">
+      <ViewerHeaderSkeleton />
+      <div className="flex-1 overflow-auto bg-base p-8">
+        <SkeletonBlock className="h-full min-h-[420px] w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+function ViewerHeaderSkeleton() {
+  return (
+    <div className="border-b border-border bg-surface px-5 py-4">
+      <div className="flex items-center gap-3">
+        <SkeletonBlock className="h-10 w-10 rounded-lg" />
+        <div className="min-w-0 flex-1">
+          <SkeletonLine className="h-5 w-64 max-w-full" />
+          <SkeletonLine className="mt-2 h-3 w-40" />
+        </div>
+        <SkeletonBlock className="h-8 w-24" />
+      </div>
+    </div>
+  );
+}
+
+export function SessionDetailSkeleton() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto grid max-w-[1100px] gap-7 px-12 pb-20 pt-7 lg:grid-cols-[minmax(0,1fr)_260px]">
+        <main className="min-w-0">
+          <div className="mb-2 border-b border-border pb-3.5">
+            <SkeletonBlock className="h-5 w-36" />
+            <SkeletonLine className="mt-3 h-8 w-60" />
+            <SkeletonLine className="mt-3 h-3 w-48" />
+          </div>
+          <TranscriptSkeleton />
+        </main>
+        <aside className="hidden lg:block">
+          <SkeletonCard className="sticky top-16 p-3.5">
+            <SkeletonLine className="h-3 w-20" />
+            <SkeletonLine className="mt-4 w-full" />
+            <SkeletonLine className="mt-2 w-2/3" />
+          </SkeletonCard>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function TranscriptSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="flex gap-3 border-b border-border-subtle py-4">
+          <SkeletonBlock className="h-8 w-8 rounded-full" />
+          <div className="min-w-0 flex-1">
+            <SkeletonLine className="h-3 w-32" />
+            <SkeletonLine className="mt-3 w-full" />
+            <SkeletonLine className="mt-2 w-11/12" />
+            <SkeletonLine className="mt-2 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function SearchSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-[1180px] px-6 py-8">
+      <header className="border-b border-border-subtle pb-6">
+        <SkeletonLine className="h-3 w-20" />
+        <SkeletonLine className="mt-4 h-9 w-[520px] max-w-full" />
+        <SkeletonLine className="mt-4 h-4 w-[700px] max-w-full" />
+        <SkeletonLine className="mt-2 h-4 w-[520px] max-w-full" />
+      </header>
+      <div className="mt-6 grid gap-5 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <SkeletonCard className="p-4">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="mb-4 last:mb-0">
+              <SkeletonLine className="h-3 w-20" />
+              <SkeletonBlock className="mt-2 h-9 w-full" />
+            </div>
+          ))}
+        </SkeletonCard>
+        <main>
+          <SkeletonBlock className="h-12 w-full rounded-lg" />
+          <SearchResultsSkeleton />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export function SearchResultsSkeleton() {
+  return (
+    <div className="mt-5 flex flex-col gap-2">
+      {[0, 1, 2, 3].map((i) => (
+        <SkeletonCard key={i} className="px-4 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <SkeletonBlock className="h-5 w-14" />
+                <SkeletonLine className="h-4 w-56 max-w-full" />
+              </div>
+              <SkeletonLine className="mt-3 w-full" />
+              <SkeletonLine className="mt-2 w-2/3" />
+            </div>
+            <SkeletonLine className="w-20" />
+          </div>
+        </SkeletonCard>
+      ))}
+    </div>
+  );
+}
+
+export function TableEditorSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <ViewerHeaderSkeleton />
+      <div className="mt-2 flex items-center gap-2 border-y border-border bg-surface px-4 py-2.5">
+        <SkeletonBlock className="h-8 w-72 max-w-full" />
+        <span className="flex-1" />
+        {[0, 1, 2, 3, 4].map((i) => (
+          <SkeletonBlock key={i} className="h-7 w-20" />
+        ))}
+      </div>
+      <div className="flex-1 overflow-auto">
+        <div className="min-w-[900px]">
+          <div className="grid grid-cols-[48px_56px_repeat(6,160px)] border-b border-border bg-surface">
+            {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+              <div key={i} className="border-r border-border p-2">
+                <SkeletonLine className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+          {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((row) => (
+            <div key={row} className="grid grid-cols-[48px_56px_repeat(6,160px)] border-b border-border/50">
+              {[0, 1, 2, 3, 4, 5, 6, 7].map((col) => (
+                <div key={col} className="border-r border-border/50 p-2">
+                  <SkeletonLine className={col < 2 ? "h-4 w-5" : "h-4 w-full"} />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PublicStashSkeleton() {
+  return (
+    <div className="scroll-thin min-h-screen bg-background">
+      <SkeletonBlock className="h-[72px] w-full rounded-none bg-brand-100" />
+      <div className="mx-auto max-w-[920px] px-12 pb-20">
+        <div className="flex items-start justify-between gap-3 pt-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <SkeletonBlock className="-mt-9 h-12 w-12 rounded-[10px] border-2 border-base" />
+            <div className="min-w-0">
+              <SkeletonLine className="h-6 w-56 max-w-full" />
+              <SkeletonLine className="mt-2 h-3 w-64 max-w-full" />
+            </div>
+          </div>
+          <SkeletonBlock className="h-8 w-24" />
+        </div>
+        <DocumentBodySkeleton className="mt-6" />
+        <div className="mt-6 flex flex-col gap-3">
+          {[0, 1, 2, 3].map((i) => (
+            <SkeletonBlock key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </div>
+        <VisualizationSkeleton className="mt-8" />
+      </div>
+    </div>
+  );
+}
+
+export function StashItemSkeleton() {
+  return (
+    <div className="scroll-thin min-h-screen bg-background">
+      <div className="mx-auto max-w-[920px] px-12 pb-20 pt-6">
+        <SkeletonLine className="h-4 w-32" />
+        <SkeletonLine className="mt-4 h-7 w-72 max-w-full" />
+        <SkeletonLine className="mt-2 h-3 w-20" />
+        <DocumentBodySkeleton className="mt-6" />
+      </div>
+    </div>
+  );
+}
+
+export function JoinWorkspaceSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col bg-base text-foreground">
+      <div className="border-b border-border bg-surface px-4 py-2">
+        <div className="flex justify-end">
+          <SkeletonBlock className="h-7 w-24" />
+        </div>
+      </div>
+      <main className="flex flex-1 items-center justify-center px-4">
+        <SkeletonCard className="w-full max-w-sm p-6 text-center">
+          <SkeletonLine className="mx-auto h-5 w-48" />
+          <SkeletonLine className="mx-auto mt-3 w-64 max-w-full" />
+          <SkeletonBlock className="mx-auto mt-5 h-9 w-36" />
+        </SkeletonCard>
+      </main>
+    </div>
+  );
+}
+
+export function DocsPageSkeleton() {
+  return (
+    <div className="min-h-screen bg-base text-foreground">
+      <header className="sticky top-0 z-30 border-b border-border bg-base/95">
+        <div className="mx-auto flex h-14 max-w-[1440px] items-center justify-between px-6 lg:px-8">
+          <SkeletonLine className="h-5 w-40" />
+          <SkeletonLine className="h-4 w-28" />
+        </div>
+      </header>
+      <div className="mx-auto max-w-[1440px] px-6 py-8 lg:px-8">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px]">
+          <SkeletonCard className="hidden p-4 lg:block">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <SkeletonLine key={i} className="mb-4 w-32" />
+            ))}
+          </SkeletonCard>
+          <DocumentBodySkeleton />
+          <SkeletonCard className="hidden p-4 xl:block">
+            {[0, 1, 2, 3].map((i) => (
+              <SkeletonLine key={i} className="mb-4 w-28" />
+            ))}
+          </SkeletonCard>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StashInviteCenter.tsx
+++ b/frontend/src/components/StashInviteCenter.tsx
@@ -7,6 +7,7 @@ import {
   listStashInvites,
   type StashInvite,
 } from "../lib/api";
+import { SkeletonBlock } from "./SkeletonStates";
 import { NotificationsIcon } from "./StashIcons";
 
 export default function StashInviteCenter() {
@@ -127,7 +128,15 @@ export default function StashInviteCenter() {
             ) : null}
 
             {loading ? (
-              <p className="px-2 py-8 text-center text-[12.5px] text-muted">Loading…</p>
+              <div className="space-y-2 px-1 py-1">
+                {[0, 1, 2].map((row) => (
+                  <div key={row} className="rounded-lg border border-border-subtle bg-surface p-3">
+                    <SkeletonBlock className="h-4 w-44" />
+                    <SkeletonBlock className="mt-2 h-3 w-full" />
+                    <SkeletonBlock className="mt-3 h-7 w-24" />
+                  </div>
+                ))}
+              </div>
             ) : invites.length === 0 ? (
               <p className="px-2 py-8 text-center text-[12.5px] text-muted">
                 No new Stash access.

--- a/frontend/src/components/stash/AddToStashModal.tsx
+++ b/frontend/src/components/stash/AddToStashModal.tsx
@@ -19,6 +19,7 @@ import {
 import type { TableWithWorkspace } from "../../lib/types";
 import { stashSlugFromInput } from "../../lib/stashLinks";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
+import { SkeletonBlock } from "../SkeletonStates";
 
 interface Props {
   open: boolean;
@@ -336,7 +337,14 @@ export default function AddToStashModal({
             </div>
             <div className="scroll-thin max-h-[420px] overflow-y-auto px-2 py-2">
               {loading ? (
-                <div className="px-2 py-6 text-center text-[12.5px] text-muted">Loading…</div>
+                <div className="space-y-1.5 px-1 py-1">
+                  {[0, 1, 2, 3, 4].map((row) => (
+                    <div key={row} className="rounded-md border border-border-subtle bg-surface px-2.5 py-2">
+                      <SkeletonBlock className="h-4 w-48 max-w-full" />
+                      <SkeletonBlock className="mt-2 h-3 w-32" />
+                    </div>
+                  ))}
+                </div>
               ) : rows.length === 0 ? (
                 <div className="px-2 py-6 text-center text-[12.5px] text-muted">
                   {query.trim() ? "Nothing matches." : "No items in this workspace yet."}

--- a/frontend/src/components/viz/DashboardSection.tsx
+++ b/frontend/src/components/viz/DashboardSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
+import { SkeletonBlock } from "../SkeletonStates";
 
 interface DashboardSectionProps {
   title: string;
@@ -25,8 +26,8 @@ export default function DashboardSection({
         </span>
       </div>
       {loading ? (
-        <div className="h-[200px] flex items-center justify-center">
-          <span className="text-xs text-muted">Loading...</span>
+        <div className="h-[200px] p-4">
+          <SkeletonBlock className="h-full w-full" />
         </div>
       ) : empty ? (
         <div className="h-[200px] flex items-center justify-center px-6">

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -22,6 +22,7 @@ import type {
   PageSummary,
   WorkspaceTree,
 } from "../../../lib/types";
+import { FileBrowserSkeleton } from "../../SkeletonStates";
 import EditableTitle from "../EditableTitle";
 import FolderItemGrid, { type GridItem, type ItemKind } from "./FolderItemGrid";
 import ItemsList from "./ItemsList";
@@ -51,6 +52,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
 
   const [tree, setTree] = useState<WorkspaceTree | null>(null);
   const [contents, setContents] = useState<FolderContents | null>(null);
+  const [contentsLoaded, setContentsLoaded] = useState(false);
   const [rootFiles, setRootFiles] = useState<GridItem[]>([]);
   const [view, setView] = useState<View>("grid");
 
@@ -85,6 +87,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
   // /folders/{id}/contents. For the root view there's no such endpoint, so we
   // synthesize the contents from the tree + a list-files call.
   const loadContents = useCallback(async () => {
+    setContentsLoaded(false);
     if (folderId) {
       try {
         const c = await getFolderContents(workspaceId, folderId);
@@ -92,6 +95,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
         setRootFiles([]);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load folder");
+      } finally {
+        setContentsLoaded(true);
       }
     } else {
       try {
@@ -107,6 +112,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
         setRootFiles(roots);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load root");
+      } finally {
+        setContentsLoaded(true);
       }
     }
   }, [workspaceId, folderId]);
@@ -167,6 +174,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
       ...rootFiles,
     ];
   }, [folderId, contents, tree, rootFiles]);
+
+  const loadingItems = folderId ? contents === null : !contentsLoaded;
 
   async function refreshAll() {
     await Promise.all([loadTree(), loadContents()]);
@@ -290,6 +299,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     await refreshAll();
     return updated.name;
   }
+
+  if (loadingItems && !error) return <FileBrowserSkeleton />;
 
   return (
     <div className="flex h-full min-h-0 flex-col">


### PR DESCRIPTION
## Summary
- Added a shared skeleton-state component set and route-level `loading.tsx` fallbacks for the frontend app routes.
- Replaced text-only loading states across auth, search, activity, workspaces, files, sessions, pages, tables, Stashes, and supporting modal/sidebar surfaces.
- Kept data-heavy surfaces such as visualizations, file text previews, table pagination, and the file browser in skeleton states while their primary data is still pending.

## Screenshots
Screenshots are attached in the PR thread for representative loading states: auth/home, workspace files, public Stash, and table editor.

## Validation
- `npm run lint`
- `npm test` (52 tests)
- `npm run build`
- Playwright smoke check with delayed API responses verified skeleton elements on auth/home, workspace files, public Stash, and table editor loading states.