### PR TITLE
[codex] Add stash settings page

### DIFF
--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -174,13 +174,7 @@ async def update_stash(
         stash = await stash_service.update_stash(
             stash_id,
             current_user["id"],
-            title=req.title,
-            description=req.description,
-            access=req.access,
-            discoverable=req.discoverable,
-            cover_image_url=req.cover_image_url,
-            icon_url=req.icon_url,
-            items=req.items,
+            req.model_dump(exclude_unset=True),
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -470,17 +470,15 @@ async def _update_stash(args: dict) -> dict:
     if not await stash_service.user_can_manage(stash_id, user_id):
         return _text_result(json.dumps({"error": "not allowed"}))
 
-    items = None
+    updates = {
+        key: args[key] for key in ("title", "description", "access", "discoverable") if key in args
+    }
     if "items" in args:
-        items = await _parse_stash_items(args.get("items") or [], workspace_id)
+        updates["items"] = await _parse_stash_items(args.get("items") or [], workspace_id)
     stash = await stash_service.update_stash(
         stash_id,
         user_id,
-        title=args.get("title"),
-        description=args.get("description"),
-        access=args.get("access"),
-        discoverable=args.get("discoverable"),
-        items=items,
+        updates,
     )
     if not stash:
         return _text_result(json.dumps({"error": "not found"}))

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -254,14 +254,7 @@ async def _object_title(object_type: str, object_id: UUID) -> str:
 async def update_stash(
     stash_id: UUID,
     user_id: UUID,
-    *,
-    title: str | None = None,
-    description: str | None = None,
-    access: str | None = None,
-    discoverable: bool | None = None,
-    cover_image_url: str | None = None,
-    icon_url: str | None = None,
-    items: list | None = None,
+    updates: dict,
 ) -> dict | None:
     pool = get_pool()
     stash = await pool.fetchrow(
@@ -269,27 +262,35 @@ async def update_stash(
     )
     if not stash or not await user_can_manage(stash_id, user_id):
         return None
+    access = updates.get("access")
+    discoverable = updates.get("discoverable")
+    items = updates.get("items") if "items" in updates else None
     next_access = access or stash["access"]
     if next_access not in {"workspace", "private", "public"}:
         raise ValueError("Unsupported Stash access")
     if discoverable and next_access != "public":
         raise ValueError("Discover Stashes must be public")
-    if access and access != "public" and discoverable is None:
-        discoverable = False
+    if access and access != "public" and updates.get("discoverable") is None:
+        updates["discoverable"] = False
 
     sets, args, idx = [], [], 1
-    for col, val in (
-        ("title", title),
-        ("description", description),
-        ("access", access),
-        ("discoverable", discoverable),
-        ("cover_image_url", cover_image_url),
-        ("icon_url", icon_url),
+    clearable_fields = {"cover_image_url", "icon_url"}
+    for col in (
+        "title",
+        "description",
+        "access",
+        "discoverable",
+        "cover_image_url",
+        "icon_url",
     ):
-        if val is not None:
-            sets.append(f"{col} = ${idx}")
-            args.append(val)
-            idx += 1
+        if col not in updates:
+            continue
+        val = updates[col]
+        if val is None and col not in clearable_fields:
+            continue
+        sets.append(f"{col} = ${idx}")
+        args.append(val)
+        idx += 1
 
     async with pool.acquire() as conn:
         async with conn.transaction():

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -186,6 +186,10 @@ describe("StashPageClient sharing", () => {
     expect(
       await screen.findByRole("button", { name: "+ Add things" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Stash settings" })).toHaveAttribute(
+      "href",
+      "/stashes/shared-stash/settings",
+    );
     expect(
       screen.queryByPlaceholderText(
         "Paste a link, type a note, or drop a file",

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -17,7 +17,7 @@ import DescriptionEditor, {
 } from "../../../components/DescriptionEditor";
 import { PublicStashSkeleton, SkeletonBlock } from "../../../components/SkeletonStates";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
-import { StashIcon } from "../../../components/StashIcons";
+import { SettingsIcon, StashIcon } from "../../../components/StashIcons";
 import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
@@ -63,7 +63,12 @@ function StashChrome({
   }
   if (user) {
     return (
-      <AppShell user={user} onLogout={logout} shareAction={shareAction}>
+      <AppShell
+        user={user}
+        onLogout={logout}
+        shareAction={shareAction}
+        activeWorkspaceId={data?.stash.workspace_id ?? null}
+      >
         {children}
       </AppShell>
     );
@@ -254,13 +259,23 @@ function StashPageBody({
           </div>
           <div className="flex flex-shrink-0 items-center gap-1.5 pt-1">
             {can_write ? (
-              <button
-                type="button"
-                onClick={() => setAddOpen(true)}
-                className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-              >
-                + Add things
-              </button>
+              <>
+                <Link
+                  href={`/stashes/${stash.slug}/settings`}
+                  title="Stash settings"
+                  aria-label="Stash settings"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-raised hover:text-foreground"
+                >
+                  <SettingsIcon />
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => setAddOpen(true)}
+                  className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+                >
+                  + Add things
+                </button>
+              </>
             ) : (
               // Forking only makes sense when the viewer doesn't already have
               // write access to this stash in its own workspace.

--- a/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.test.tsx
@@ -1,0 +1,203 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StashSettingsPageClient from "./StashSettingsPageClient";
+import {
+  addStashMember,
+  getPublicStash,
+  listStashMembers,
+  searchUsers,
+  updateStash,
+  type PublicStashDetail,
+} from "../../../../lib/api";
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: "user-1",
+    name: "henry",
+    display_name: "Henry",
+    description: "",
+    created_at: "2026-05-11T00:00:00Z",
+    last_seen: "2026-05-11T00:00:00Z",
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+vi.mock("../../../../components/AppShell", () => ({
+  default: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("../../../../components/BreadcrumbContext", () => ({
+  useBreadcrumbs: vi.fn(),
+}));
+
+vi.mock("../../../../hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: authState.user,
+    loading: false,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../../lib/stashNavigationCache", () => ({
+  resetStashNavigationCache: vi.fn(),
+}));
+
+vi.mock("../../../../lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  addStashMember: vi.fn(),
+  deleteStash: vi.fn(),
+  getPublicStash: vi.fn(),
+  listStashMembers: vi.fn(),
+  removeStashMember: vi.fn(),
+  searchUsers: vi.fn(),
+  updateStash: vi.fn(),
+  uploadFile: vi.fn(),
+}));
+
+function stashDetail(
+  stash: Partial<PublicStashDetail["stash"]> = {},
+): PublicStashDetail {
+  return {
+    stash: {
+      id: "stash-1",
+      workspace_id: "workspace-1",
+      slug: "shared-stash",
+      title: "Shared Stash",
+      description: "",
+      owner_id: "user-1",
+      owner_name: "henry",
+      owner_display_name: "Henry",
+      access: "public",
+      discoverable: false,
+      cover_image_url: null,
+      icon_url: null,
+      view_count: 0,
+      items: [],
+      is_external: false,
+      added_to_workspace_id: null,
+      forked_from_stash_id: null,
+      created_at: "2026-05-11T00:00:00Z",
+      updated_at: "2026-05-11T00:00:00Z",
+      ...stash,
+    },
+    workspace_name: "Demo Workspace",
+    items: [],
+    can_write: true,
+  };
+}
+
+describe("StashSettingsPageClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getPublicStash).mockResolvedValue(stashDetail());
+    vi.mocked(listStashMembers).mockResolvedValue([
+      {
+        user_id: "user-2",
+        name: "sam",
+        display_name: "Sam",
+        permission: "write",
+        granted_by: "user-1",
+        created_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    vi.mocked(updateStash).mockImplementation(async (_stashId, updates) => ({
+      ...stashDetail().stash,
+      ...updates,
+    }));
+    vi.mocked(searchUsers).mockResolvedValue([
+      { id: "user-3", name: "alex", display_name: "Alex" },
+    ]);
+    vi.mocked(addStashMember).mockResolvedValue({
+      user_id: "user-3",
+      name: "alex",
+      display_name: "Alex",
+      permission: "read",
+      granted_by: "user-1",
+      created_at: "2026-05-13T00:00:00Z",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads editable stash settings and explicit members", async () => {
+    render(<StashSettingsPageClient slug="shared-stash" />);
+
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Shared Stash")).toBeInTheDocument();
+    expect(screen.getByText("@henry")).toBeInTheDocument();
+    expect(screen.getByText("@sam")).toBeInTheDocument();
+    expect(listStashMembers).toHaveBeenCalledWith("stash-1");
+  });
+
+  it("saves title and visibility changes", async () => {
+    render(<StashSettingsPageClient slug="shared-stash" />);
+
+    fireEvent.change(await screen.findByLabelText("Title"), {
+      target: { value: "Better Stash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(updateStash).toHaveBeenCalledWith("stash-1", {
+        title: "Better Stash",
+        access: "public",
+        discoverable: false,
+      }),
+    );
+    expect(await screen.findByText("Saved.")).toBeInTheDocument();
+  });
+
+  it("searches and adds a member", async () => {
+    render(<StashSettingsPageClient slug="shared-stash" />);
+
+    fireEvent.change(await screen.findByPlaceholderText("Search users"), {
+      target: { value: "alex" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    const addResult = await screen.findByRole("button", { name: /Alex/ });
+    fireEvent.click(addResult);
+
+    await waitFor(() =>
+      expect(addStashMember).toHaveBeenCalledWith("stash-1", "user-3", "read"),
+    );
+  });
+});

--- a/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.tsx
@@ -1,0 +1,678 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+import AppShell from "../../../../components/AppShell";
+import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
+import CustomSelect from "../../../../components/CustomSelect";
+import { StashIcon } from "../../../../components/StashIcons";
+import { useAuth } from "../../../../hooks/useAuth";
+import {
+  addStashMember,
+  ApiError,
+  deleteStash,
+  getPublicStash,
+  listStashMembers,
+  removeStashMember,
+  searchUsers,
+  updateStash,
+  uploadFile,
+  type PublicStashDetail,
+  type StashMember,
+  type StashMemberPermission,
+} from "../../../../lib/api";
+import { resetStashNavigationCache } from "../../../../lib/stashNavigationCache";
+import type { UserSearchResult } from "../../../../lib/types";
+
+type StashAccess = PublicStashDetail["stash"]["access"];
+
+const ACCESS_OPTIONS = [
+  { value: "workspace", label: "Workspace" },
+  { value: "private", label: "Private" },
+  { value: "public", label: "Public" },
+];
+
+const PERMISSION_OPTIONS = [
+  { value: "read", label: "Read" },
+  { value: "write", label: "Write" },
+  { value: "admin", label: "Admin" },
+];
+
+export default function StashSettingsPageClient({ slug }: { slug: string }) {
+  const router = useRouter();
+  const { user, loading: authLoading, logout } = useAuth();
+  const [data, setData] = useState<PublicStashDetail | null>(null);
+  const [members, setMembers] = useState<StashMember[]>([]);
+  const [canManageMembers, setCanManageMembers] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [title, setTitle] = useState("");
+  const [access, setAccess] = useState<StashAccess>("workspace");
+  const [discoverable, setDiscoverable] = useState(false);
+  const [userQuery, setUserQuery] = useState("");
+  const [userResults, setUserResults] = useState<UserSearchResult[]>([]);
+  const [newMemberPermission, setNewMemberPermission] =
+    useState<StashMemberPermission>("read");
+  const [memberMessage, setMemberMessage] = useState("");
+
+  const stash = data?.stash ?? null;
+
+  useBreadcrumbs(
+    [
+      { label: "Stashes", href: "/stashes" },
+      { label: stash?.title ?? "Stash", href: `/stashes/${slug}` },
+      { label: "Settings" },
+    ],
+    `stash-settings/${slug}/${stash?.id ?? "loading"}`
+  );
+
+  const load = useCallback(async () => {
+    if (!user) return;
+
+    setLoading(true);
+    setError("");
+    setMessage("");
+
+    try {
+      const nextData = await getPublicStash(slug);
+      setData(nextData);
+
+      if (!nextData.can_write) {
+        setMembers([]);
+        setCanManageMembers(false);
+        return;
+      }
+
+      try {
+        setMembers(await listStashMembers(nextData.stash.id));
+        setCanManageMembers(true);
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 403) {
+          setMembers([]);
+          setCanManageMembers(false);
+          return;
+        }
+        throw e;
+      }
+    } catch (e) {
+      setData(null);
+      setError(e instanceof Error ? e.message : "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [slug, user]);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace(`/login?next=${encodeURIComponent(`/stashes/${slug}/settings`)}`);
+    }
+  }, [authLoading, router, slug, user]);
+
+  useEffect(() => {
+    if (user) void load();
+  }, [load, user]);
+
+  useEffect(() => {
+    if (!stash) return;
+    setTitle(stash.title);
+    setAccess(stash.access);
+    setDiscoverable(stash.discoverable);
+  }, [stash]);
+
+  if (authLoading || !user) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-background text-muted">
+        Loading...
+      </main>
+    );
+  }
+
+  if (loading) {
+    return (
+      <AppShell user={user} onLogout={logout} activeWorkspaceId={stash?.workspace_id ?? null}>
+        <div className="flex min-h-[50vh] items-center justify-center text-muted">
+          Loading settings...
+        </div>
+      </AppShell>
+    );
+  }
+
+  if (!data || !stash) {
+    return (
+      <AppShell user={user} onLogout={logout}>
+        <div className="mx-auto max-w-md px-8 py-20 text-center">
+          <h1 className="font-display text-[26px] font-bold text-foreground">
+            Stash settings
+          </h1>
+          <p className="mt-2 text-[13px] text-muted">
+            {error || "This Stash is unavailable."}
+          </p>
+          <Link
+            href={`/stashes/${slug}`}
+            className="mt-4 inline-flex rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
+          >
+            Open Stash
+          </Link>
+        </div>
+      </AppShell>
+    );
+  }
+
+  if (!data.can_write) {
+    return (
+      <AppShell user={user} onLogout={logout} activeWorkspaceId={stash.workspace_id}>
+        <div className="mx-auto max-w-md px-8 py-20 text-center">
+          <h1 className="font-display text-[26px] font-bold text-foreground">
+            Stash settings
+          </h1>
+          <p className="mt-2 text-[13px] text-muted">
+            You do not have edit access to this Stash.
+          </p>
+          <Link
+            href={`/stashes/${stash.slug}`}
+            className="mt-4 inline-flex rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
+          >
+            Open Stash
+          </Link>
+        </div>
+      </AppShell>
+    );
+  }
+
+  async function saveGeneral(e: FormEvent) {
+    e.preventDefault();
+    if (!stash) return;
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setError("Title is required.");
+      return;
+    }
+
+    setSaving("general");
+    setError("");
+    setMessage("");
+    try {
+      const nextDiscoverable = access === "public" ? discoverable : false;
+      const updated = await updateStash(stash.id, {
+        title: trimmedTitle,
+        access,
+        discoverable: nextDiscoverable,
+      });
+      setData((current) => (current ? { ...current, stash: updated } : current));
+      setDiscoverable(updated.discoverable);
+      resetStashNavigationCache();
+      setMessage("Saved.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save settings");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function uploadAndSet(file: File, field: "cover_image_url" | "icon_url") {
+    if (!stash) return;
+
+    setSaving("branding");
+    setError("");
+    try {
+      const uploaded = await uploadFile(stash.workspace_id, file);
+      const updated = await updateStash(stash.id, { [field]: uploaded.url });
+      setData((current) => (current ? { ...current, stash: updated } : current));
+      resetStashNavigationCache();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not upload image");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function clearImage(field: "cover_image_url" | "icon_url") {
+    if (!stash) return;
+
+    setSaving("branding");
+    setError("");
+    try {
+      const updated = await updateStash(stash.id, { [field]: null });
+      setData((current) => (current ? { ...current, stash: updated } : current));
+      resetStashNavigationCache();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not clear image");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function searchForUsers(e: FormEvent) {
+    e.preventDefault();
+    if (!userQuery.trim()) return;
+
+    setSaving("members");
+    setMemberMessage("");
+    try {
+      setUserResults(await searchUsers(userQuery.trim()));
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not search users");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function refreshMembers() {
+    if (!stash) return;
+    setMembers(await listStashMembers(stash.id));
+  }
+
+  async function addMember(userId: string) {
+    if (!stash) return;
+
+    setSaving("members");
+    setMemberMessage("");
+    try {
+      await addStashMember(stash.id, userId, newMemberPermission);
+      await refreshMembers();
+      setUserQuery("");
+      setUserResults([]);
+      setMemberMessage("Added.");
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not add member");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function changeMemberPermission(
+    userId: string,
+    permission: StashMemberPermission
+  ) {
+    if (!stash) return;
+
+    setSaving("members");
+    setMemberMessage("");
+    try {
+      await addStashMember(stash.id, userId, permission);
+      await refreshMembers();
+      setMemberMessage("Updated.");
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not update member");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function removeMember(userId: string) {
+    if (!stash) return;
+    if (!confirm("Remove this member from the Stash?")) return;
+
+    setSaving("members");
+    setMemberMessage("");
+    try {
+      await removeStashMember(stash.id, userId);
+      await refreshMembers();
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not remove member");
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function handleDelete() {
+    if (!stash) return;
+    if (!confirm(`Delete "${stash.title}"? This cannot be undone.`)) return;
+
+    setSaving("delete");
+    setError("");
+    try {
+      await deleteStash(stash.id);
+      resetStashNavigationCache();
+      router.push(`/workspaces/${stash.workspace_id}/stashes`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete Stash");
+      setSaving("");
+    }
+  }
+
+  const ownerLabel = stash.owner_display_name || stash.owner_name;
+
+  return (
+    <AppShell user={user} onLogout={logout} activeWorkspaceId={stash.workspace_id}>
+      <div className="scroll-thin flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-2xl px-8 py-10">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
+                Settings
+              </h1>
+              <p className="mt-1 truncate text-[13px] text-muted">{stash.title}</p>
+            </div>
+            <Link
+              href={`/stashes/${stash.slug}`}
+              className="flex-shrink-0 rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
+            >
+              Open Stash
+            </Link>
+          </div>
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+              {error}
+            </div>
+          )}
+          {message && (
+            <div className="mt-4 rounded-lg border border-emerald-300/40 bg-emerald-500/10 px-4 py-2 text-[13px] text-emerald-700">
+              {message}
+            </div>
+          )}
+
+          <Section title="General">
+            <form
+              onSubmit={saveGeneral}
+              className="rounded-lg border border-border bg-base px-3 py-3"
+            >
+              <label className="block text-[12px] font-medium text-muted" htmlFor="stash-title">
+                Title
+              </label>
+              <input
+                id="stash-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-[13.5px] text-foreground outline-none focus:border-[var(--color-brand-400)]"
+              />
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-[160px_minmax(0,1fr)]">
+                <div>
+                  <label className="block text-[12px] font-medium text-muted">
+                    Visibility
+                  </label>
+                  <CustomSelect
+                    value={access}
+                    options={ACCESS_OPTIONS}
+                    onChange={(next) => setAccess(next as StashAccess)}
+                    ariaLabel="Stash visibility"
+                    className="mt-1 w-full rounded-md border border-border bg-surface px-2.5 py-2 text-[12.5px]"
+                  />
+                </div>
+                <label
+                  className={
+                    "mt-5 flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[12.5px] " +
+                    (access === "public"
+                      ? "cursor-pointer text-foreground"
+                      : "cursor-not-allowed text-muted")
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={access === "public" && discoverable}
+                    disabled={access !== "public"}
+                    onChange={(e) => setDiscoverable(e.target.checked)}
+                  />
+                  <span>List on Discover</span>
+                </label>
+              </div>
+
+              <div className="mt-4 flex items-center gap-3">
+                <button
+                  type="submit"
+                  disabled={saving === "general" || !title.trim()}
+                  className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                >
+                  {saving === "general" ? "Saving..." : "Save changes"}
+                </button>
+              </div>
+            </form>
+          </Section>
+
+          <Section title="Branding">
+            <ImageField
+              label="Banner"
+              sub="Wide image rendered above the Stash header."
+              url={stash.cover_image_url}
+              onUpload={(file) => uploadAndSet(file, "cover_image_url")}
+              onClear={() => clearImage("cover_image_url")}
+              previewClass="h-16 w-full rounded-md object-cover"
+            />
+            <ImageField
+              label="Icon"
+              sub="Square logo for this Stash."
+              url={stash.icon_url}
+              onUpload={(file) => uploadAndSet(file, "icon_url")}
+              onClear={() => clearImage("icon_url")}
+              previewClass="h-12 w-12 rounded-md object-cover"
+            />
+          </Section>
+
+          <Section title="Members">
+            <div className="rounded-lg border border-border bg-base px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[var(--color-brand-100)] text-[var(--color-brand-700)]">
+                    <StashIcon />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="truncate text-[13.5px] font-medium text-foreground">
+                      {ownerLabel}
+                    </div>
+                    <div className="truncate text-[11.5px] text-muted">
+                      @{stash.owner_name}
+                    </div>
+                  </div>
+                </div>
+                <span className="rounded bg-raised px-2 py-0.5 text-[11.5px] text-muted">
+                  admin
+                </span>
+              </div>
+            </div>
+
+            {canManageMembers ? (
+              <>
+                <ul className="flex flex-col gap-2">
+                  {members.map((member) => (
+                    <li
+                      key={member.user_id}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-border bg-base px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-[13.5px] font-medium text-foreground">
+                          {member.display_name || member.name}
+                        </div>
+                        <div className="truncate text-[11.5px] text-muted">
+                          @{member.name}
+                        </div>
+                      </div>
+                      <div className="flex flex-shrink-0 items-center gap-2">
+                        <CustomSelect
+                          value={member.permission}
+                          options={PERMISSION_OPTIONS}
+                          onChange={(next) =>
+                            changeMemberPermission(
+                              member.user_id,
+                              next as StashMemberPermission
+                            )
+                          }
+                          ariaLabel={`Permission for ${member.name}`}
+                          className="min-w-[82px] rounded border border-border bg-surface px-2 py-1 text-[12px]"
+                          align="right"
+                        />
+                        {member.user_id !== user.id && (
+                          <button
+                            type="button"
+                            onClick={() => removeMember(member.user_id)}
+                            className="text-[11.5px] text-red-500 hover:underline"
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+
+                <form
+                  onSubmit={searchForUsers}
+                  className="rounded-lg border border-border bg-base px-3 py-3"
+                >
+                  <label className="block text-[12px] font-medium text-muted" htmlFor="member-search">
+                    Add member
+                  </label>
+                  <div className="mt-1 flex gap-2">
+                    <input
+                      id="member-search"
+                      value={userQuery}
+                      onChange={(e) => setUserQuery(e.target.value)}
+                      placeholder="Search users"
+                      className="min-w-0 flex-1 rounded-md border border-border bg-surface px-3 py-2 text-[13px] text-foreground outline-none focus:border-[var(--color-brand-400)]"
+                    />
+                    <CustomSelect
+                      value={newMemberPermission}
+                      options={PERMISSION_OPTIONS}
+                      onChange={(next) =>
+                        setNewMemberPermission(next as StashMemberPermission)
+                      }
+                      ariaLabel="New member permission"
+                      className="min-w-[86px] rounded-md border border-border bg-surface px-2 py-2 text-[12px]"
+                      align="right"
+                    />
+                    <button
+                      type="submit"
+                      disabled={saving === "members" || !userQuery.trim()}
+                      className="rounded-md border border-border bg-base px-3 py-2 text-[12.5px] font-medium text-foreground hover:bg-raised disabled:opacity-50"
+                    >
+                      Search
+                    </button>
+                  </div>
+                  {userResults.length > 0 && (
+                    <div className="mt-3 flex flex-col gap-1">
+                      {userResults.map((result) => (
+                        <button
+                          key={result.id}
+                          type="button"
+                          onClick={() => addMember(result.id)}
+                          className="flex items-center justify-between rounded-md px-2 py-1.5 text-left hover:bg-raised"
+                        >
+                          <span className="min-w-0">
+                            <span className="block truncate text-[13px] font-medium text-foreground">
+                              {result.display_name || result.name}
+                            </span>
+                            <span className="block truncate text-[11.5px] text-muted">
+                              @{result.name}
+                            </span>
+                          </span>
+                          <span className="text-[11.5px] text-muted">Add</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {memberMessage && (
+                    <div className="mt-2 text-[12px] text-muted">{memberMessage}</div>
+                  )}
+                </form>
+              </>
+            ) : (
+              <div className="rounded-lg border border-border bg-base px-3 py-2 text-[13px] text-muted">
+                Only Stash admins can manage members.
+              </div>
+            )}
+          </Section>
+
+          <Section title="Danger zone">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={saving === "delete"}
+              className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-[13px] font-medium text-red-700 hover:bg-red-100 disabled:opacity-50"
+            >
+              {saving === "delete" ? "Deleting..." : "Delete this Stash"}
+            </button>
+          </Section>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-[12px] font-semibold uppercase tracking-wider text-muted">
+        {title}
+      </h2>
+      <div className="mt-3 flex flex-col gap-2">{children}</div>
+    </section>
+  );
+}
+
+function ImageField({
+  label,
+  sub,
+  url,
+  onUpload,
+  onClear,
+  previewClass,
+}: {
+  label: string;
+  sub: string;
+  url: string | null;
+  onUpload: (file: File) => Promise<void>;
+  onClear: () => Promise<void>;
+  previewClass: string;
+}) {
+  const inputId = `stash-${label.toLowerCase()}-upload`;
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (file) void onUpload(file);
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-base px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[13.5px] font-medium text-foreground">{label}</div>
+          <div className="text-[11.5px] text-muted">{sub}</div>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <label
+            htmlFor={inputId}
+            className="cursor-pointer rounded-md border border-border bg-surface px-2.5 py-1 text-[12px] text-foreground hover:bg-raised"
+          >
+            {url ? "Replace" : "Upload"}
+          </label>
+          <input
+            id={inputId}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleChange}
+          />
+          {url && (
+            <button
+              type="button"
+              onClick={() => void onClear()}
+              className="text-[11.5px] text-muted hover:text-foreground"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+      {url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={url} alt="" className={"mt-2 " + previewClass} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/stashes/[slug]/settings/page.tsx
+++ b/frontend/src/app/stashes/[slug]/settings/page.tsx
@@ -1,0 +1,10 @@
+import StashSettingsPageClient from "./StashSettingsPageClient";
+
+export default async function StashSettingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <StashSettingsPageClient slug={slug} />;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -19,6 +19,7 @@ interface AppShellProps {
   onLogout: () => void;
   children: ReactNode;
   shareAction?: ReactNode;
+  activeWorkspaceId?: string | null;
 }
 
 const SIDEBAR_KEY = "stash_sidebar_collapsed";
@@ -231,12 +232,20 @@ function TopSearchButton({
   );
 }
 
-export default function AppShell({ user, onLogout, children, shareAction }: AppShellProps) {
+export default function AppShell({
+  user,
+  onLogout,
+  children,
+  shareAction,
+  activeWorkspaceId: preferredWorkspaceId = null,
+}: AppShellProps) {
   const pathname = usePathname();
   const breadcrumbs = useBreadcrumbsValue();
   const shareModal = useShareModal();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
+    preferredWorkspaceId
+  );
   const [workspaces, setWorkspaces] = useState<Workspace[]>(
     () => readCachedWorkspaces(user.id)?.all ?? []
   );
@@ -251,6 +260,10 @@ export default function AppShell({ user, onLogout, children, shareAction }: AppS
       .then((r) => setWorkspaces(r.all))
       .catch(() => {});
   }, [user.id]);
+
+  useEffect(() => {
+    if (preferredWorkspaceId) setActiveWorkspaceId(preferredWorkspaceId);
+  }, [preferredWorkspaceId]);
 
   useEffect(() => {
     const m = pathname.match(/^\/workspaces\/([^/]+)/);

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -929,7 +929,7 @@ function StashSidebarRow({
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
   const href = `/stashes/${stash.slug}`;
-  const active = pathname === href;
+  const active = pathname === href || pathname.startsWith(`${href}/`);
   const children = buildStashTreeItems(
     workspaceId,
     stash.items ?? [],
@@ -2214,6 +2214,21 @@ export default function AppSidebar({
           : null))) ||
     mine[0] ||
     (shared[0] ? { ...shared[0], shared: true } : null);
+  const activeStashSlug = pathname.match(/^\/stashes\/([^/?#]+)/)?.[1] ?? null;
+  const activeStash =
+    activeWorkspace && activeStashSlug
+      ? spines[activeWorkspace.id]?.stashes?.find((stash) => stash.slug === activeStashSlug)
+      : null;
+  const settingsHref = activeStash
+    ? `/stashes/${activeStash.slug}/settings`
+    : activeWorkspace
+      ? `/workspaces/${activeWorkspace.id}/settings`
+      : "";
+  const settingsActive = activeStash
+    ? pathname === `/stashes/${activeStash.slug}/settings`
+    : activeWorkspace
+      ? pathname === `/workspaces/${activeWorkspace.id}/settings`
+      : false;
 
   return (
     <>
@@ -2285,10 +2300,10 @@ export default function AppSidebar({
         <NavRow href="/docs" icon={<HelpIcon />} label="Docs" active={pathname.startsWith("/docs")} />
         {activeWorkspace ? (
           <NavRow
-            href={`/workspaces/${activeWorkspace.id}/settings`}
+            href={settingsHref}
             icon={<SettingsIcon />}
             label="Settings"
-            active={pathname === `/workspaces/${activeWorkspace.id}/settings`}
+            active={settingsActive}
           />
         ) : (
           <DisabledNavRow icon={<SettingsIcon />} label="Settings" />


### PR DESCRIPTION
## Summary
- Add `/stashes/[slug]/settings` with editable title, visibility, Discover toggle, branding uploads, explicit member management, and deletion controls.
- Add a settings gear to writable stash detail pages and make stash routes keep the owning workspace context in the app shell/sidebar.
- Update stash patch handling so explicit `null` clears banner/icon images instead of being treated as an omitted field.

## Screenshot
- [Stash settings page screenshot](https://app.joinstash.ai/stashes/stash-settings-page-screenshot-fzcm4q)

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `ruff check .`
- `black --check backend/services/agent_runtime.py backend/services/stash_service.py backend/routers/stashes.py`
- `python -m py_compile backend/services/stash_service.py backend/routers/stashes.py backend/services/agent_runtime.py`
- GitHub Actions PR checks: passing

## Notes
- Local `pytest backend/tests/test_permissions.py -q` is still blocked by my local test database state: `_make_user` inserts `display_name = null` into the non-null `users.display_name` column. The remote backend pytest check passes on GitHub Actions.