### PR TITLE
[codex] Fix description editor focus stealing

### DIFF
--- a/frontend/src/components/DescriptionEditor.tsx
+++ b/frontend/src/components/DescriptionEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, type MouseEvent } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Heading from "@tiptap/extension-heading";
@@ -8,6 +8,7 @@ import Bold from "@tiptap/extension-bold";
 import Italic from "@tiptap/extension-italic";
 import TiptapLink from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
+import { shouldFocusEditorFrame } from "../lib/editorClick";
 
 const AUTOSAVE_MS = 1500;
 
@@ -148,12 +149,18 @@ export default function DescriptionEditor({
     };
   }, [flushPendingSave]);
 
+  function handleEditorFrameClick(event: MouseEvent<HTMLDivElement>) {
+    if (!editor) return;
+    if (!canEdit) return;
+    if (!shouldFocusEditorFrame(editor.view.dom, event.target)) return;
+
+    editor.commands.focus();
+  }
+
   return (
     <div
       data-editable={canEdit ? "true" : "false"}
-      onClick={() => {
-        if (canEdit) editor?.commands.focus();
-      }}
+      onClick={handleEditorFrameClick}
       className={
         "description-editor -mx-1 rounded-md px-1 py-0.5 " +
         (canEdit

--- a/frontend/src/lib/editorClick.test.ts
+++ b/frontend/src/lib/editorClick.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { shouldFocusEditorFrame } from "./editorClick";
+
+describe("shouldFocusEditorFrame", () => {
+  it("does not focus the frame for clicks inside editor content", () => {
+    const editorElement = document.createElement("div");
+    const paragraph = document.createElement("p");
+    editorElement.append(paragraph);
+
+    expect(shouldFocusEditorFrame(editorElement, paragraph)).toBe(false);
+  });
+
+  it("focuses the editor for clicks on surrounding frame chrome", () => {
+    const editorElement = document.createElement("div");
+    const frameElement = document.createElement("div");
+    frameElement.append(editorElement);
+
+    expect(shouldFocusEditorFrame(editorElement, frameElement)).toBe(true);
+  });
+
+  it("ignores targets that cannot contain a cursor position", () => {
+    expect(
+      shouldFocusEditorFrame(document.createElement("div"), new EventTarget()),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/editorClick.ts
+++ b/frontend/src/lib/editorClick.ts
@@ -1,0 +1,8 @@
+export function shouldFocusEditorFrame(
+  editorElement: HTMLElement,
+  target: EventTarget | null,
+): boolean {
+  if (!(target instanceof Node)) return false;
+
+  return !editorElement.contains(target);
+}


### PR DESCRIPTION
## Summary
- Prevent the shared description editor frame from refocusing Tiptap when a click already landed inside the editable ProseMirror content.
- Keep frame/background clicks focusing the editor for the intended large-click-target behavior.
- Add focused regression coverage for the click-target guard.

## Root cause
The editor frame handled every bubbled click by calling `editor.commands.focus()`. During rapid blur/refocus cycles, that focus command could restore a stale editor selection after ProseMirror had placed the cursor at the clicked text position, which made the cursor jump away from the click target.

## Validation
- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Headless Playwright check against the local workspace page: repeated blur/click cycles kept the selection in the clicked paragraph at offset `0` with no console errors.

Product screenshot attached in the PR thread.