### PR TITLE
[codex] Make workspace sharing a dropdown

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -4,7 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppShell from "./AppShell";
 import { BreadcrumbProvider, useBreadcrumbs } from "./BreadcrumbContext";
 import { ShareModalProvider } from "../lib/shareModalContext";
-import { getSessionDetail, publishStash } from "../lib/api";
+import {
+  apiFetch,
+  createInviteToken,
+  getMe,
+  getSessionDetail,
+  getWorkspaceMembers,
+  publishStash,
+} from "../lib/api";
 import {
   getCachedWorkspaces,
   readCachedWorkspaces,
@@ -43,7 +50,11 @@ vi.mock("../lib/stashNavigationCache", () => ({
 }));
 
 vi.mock("../lib/api", () => ({
+  apiFetch: vi.fn(),
+  createInviteToken: vi.fn(),
+  getMe: vi.fn(),
   getSessionDetail: vi.fn(),
+  getWorkspaceMembers: vi.fn(),
   publishStash: vi.fn(),
 }));
 
@@ -66,17 +77,6 @@ vi.mock("./StashInviteCenter", () => ({
   default: () => <button aria-label="Stash invites">Invites</button>,
 }));
 
-vi.mock("./MembersModal", () => ({
-  default: ({
-    open,
-    title,
-  }: {
-    open: boolean;
-    title?: string;
-  }) => (open ? <div role="dialog" aria-label={title}>Invite modal</div> : null),
-}));
-
-
 const user = {
   id: "user-1",
   name: "Henry",
@@ -95,6 +95,14 @@ const workspace = {
   created_at: "2026-05-11T00:00:00Z",
   updated_at: "2026-05-11T00:00:00Z",
   member_count: 1,
+};
+
+const workspaceMember = {
+  user_id: user.id,
+  name: user.name,
+  display_name: user.display_name,
+  role: "owner",
+  joined_at: "2026-05-11T00:00:00Z",
 };
 
 function BreadcrumbPage() {
@@ -131,6 +139,15 @@ describe("AppShell sidebar collapse", () => {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
     vi.mocked(publishStash).mockResolvedValue(publishedStashResult("shared-link"));
+    vi.mocked(apiFetch).mockResolvedValue({});
+    vi.mocked(createInviteToken).mockResolvedValue({
+      id: "invite-1",
+      token: "invite-token",
+      workspace_id: "ws-1",
+      expires_at: "2026-05-18T00:00:00Z",
+    });
+    vi.mocked(getMe).mockResolvedValue(user);
+    vi.mocked(getWorkspaceMembers).mockResolvedValue([workspaceMember]);
     vi.mocked(readCachedWorkspaces).mockReturnValue({
       userId: user.id,
       all: [],
@@ -286,7 +303,7 @@ describe("AppShell sidebar collapse", () => {
     expect(screen.queryByRole("link", { name: "Demo Stash" })).not.toBeInTheDocument();
   });
 
-  it("opens workspace invites from Share on the workspace home route", async () => {
+  it("opens workspace sharing as a dropdown on the workspace home route", async () => {
     nav.pathname = "/workspaces/ws-1";
     mockWorkspaceCache();
 
@@ -300,8 +317,13 @@ describe("AppShell sidebar collapse", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Share" }));
 
+    const dialog = await screen.findByRole("dialog", { name: "Share Demo Stash" });
+    expect(dialog).toBeInTheDocument();
+    await within(dialog).findByText("Henry");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Generate invite link" }));
+    await waitFor(() => expect(createInviteToken).toHaveBeenCalledWith("ws-1", 5, 7));
     expect(
-      await screen.findByRole("dialog", { name: "Invite people to Workspace" })
+      within(dialog).getByDisplayValue(`${window.location.origin}/join/invite-token`)
     ).toBeInTheDocument();
     expect(publishStash).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -12,7 +12,7 @@ import { useShareModal } from "../lib/shareModalContext";
 import { type Crumb, useBreadcrumbsValue } from "./BreadcrumbContext";
 import { getCachedWorkspaces, readCachedWorkspaces } from "../lib/stashNavigationCache";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import MembersModal from "./MembersModal";
+import WorkspaceShareButton from "./WorkspaceShareButton";
 
 interface AppShellProps {
   user: User;
@@ -241,7 +241,6 @@ export default function AppShell({ user, onLogout, children, shareAction }: AppS
     () => readCachedWorkspaces(user.id)?.all ?? []
   );
   const [cmdkOpen, setCmdkOpen] = useState(false);
-  const [membersOpen, setMembersOpen] = useState(false);
   const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const [shareMessage, setShareMessage] = useState("");
 
@@ -283,11 +282,6 @@ export default function AppShell({ user, onLogout, children, shareAction }: AppS
 
   async function copyCurrentViewLink() {
     if (!activeWorkspaceId) return;
-
-    if (isWorkspaceHomePath(pathname)) {
-      setMembersOpen(true);
-      return;
-    }
 
     const target = directShareTarget;
     if (!target) {
@@ -347,13 +341,24 @@ export default function AppShell({ user, onLogout, children, shareAction }: AppS
           {shareMessage}
         </span>
       )}
-      <button
-        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
-        onClick={() => void copyCurrentViewLink()}
-        disabled={shareStatus === "creating"}
-      >
-        {shareStatus === "creating" ? "Creating..." : shareStatus === "copied" ? "Copied" : "Share"}
-      </button>
+      {isWorkspaceHomePath(pathname) ? (
+        <WorkspaceShareButton
+          workspaceId={activeWorkspaceId}
+          workspaceName={activeWorkspace?.name}
+        />
+      ) : (
+        <button
+          className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+          onClick={() => void copyCurrentViewLink()}
+          disabled={shareStatus === "creating"}
+        >
+          {shareStatus === "creating"
+            ? "Creating..."
+            : shareStatus === "copied"
+              ? "Copied"
+              : "Share"}
+        </button>
+      )}
     </div>
   ) : null;
 
@@ -421,15 +426,6 @@ export default function AppShell({ user, onLogout, children, shareAction }: AppS
         workspaceName={activeWorkspace?.name}
         searchScope={searchScope}
       />
-      {activeWorkspaceId && (
-        <MembersModal
-          workspaceId={activeWorkspaceId}
-          open={membersOpen}
-          onClose={() => setMembersOpen(false)}
-          title="Invite people to Workspace"
-          autoFocusInvite
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/WorkspaceShareButton.tsx
+++ b/frontend/src/components/WorkspaceShareButton.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import {
+  apiFetch,
+  createInviteToken,
+  getMe,
+  getWorkspaceMembers,
+} from "../lib/api";
+import type { WorkspaceMember } from "../lib/types";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+
+interface WorkspaceShareButtonProps {
+  workspaceId: string;
+  workspaceName?: string;
+}
+
+const PALETTE = [
+  { bg: "bg-rose-200", fg: "text-rose-800" },
+  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-emerald-200", fg: "text-emerald-800" },
+  { bg: "bg-amber-200", fg: "text-amber-900" },
+  { bg: "bg-sky-200", fg: "text-sky-800" },
+  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+];
+
+export default function WorkspaceShareButton({
+  workspaceId,
+  workspaceName = "Workspace",
+}: WorkspaceShareButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [members, setMembers] = useState<WorkspaceMember[]>([]);
+  const [meId, setMeId] = useState<string | null>(null);
+  const [username, setUsername] = useState("");
+  const [inviteLink, setInviteLink] = useState("");
+  const [msg, setMsg] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEscapeKey(open, () => setOpen(false));
+
+  const loadMembers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [nextMembers, me] = await Promise.all([
+        getWorkspaceMembers(workspaceId),
+        getMe(),
+      ]);
+      setMembers(nextMembers);
+      setMeId(me.id);
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Failed to load members.");
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onDown(e: globalThis.MouseEvent) {
+      if (!popoverRef.current) return;
+      if (!popoverRef.current.contains(e.target as Node)) setOpen(false);
+    }
+
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setMsg("");
+    setInviteLink("");
+    setUsername("");
+    setCopied(false);
+    void loadMembers();
+  }, [open, loadMembers]);
+
+  const myRole = members.find((m) => m.user_id === meId)?.role;
+  const canInvite = myRole === "owner";
+
+  async function addByUsername(e: FormEvent) {
+    e.preventDefault();
+    const nextUsername = username.trim();
+    if (!nextUsername) return;
+
+    setBusy(true);
+    setMsg("");
+    try {
+      await apiFetch(`/api/v1/workspaces/${workspaceId}/members`, {
+        method: "POST",
+        body: JSON.stringify({ username: nextUsername }),
+      });
+      setUsername("");
+      setMsg("Added.");
+      await loadMembers();
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Failed to add member.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function generateLink() {
+    setBusy(true);
+    setMsg("");
+    try {
+      const res = await createInviteToken(workspaceId, 5, 7);
+      setInviteLink(absoluteUrl(`/join/${res.token}`));
+      setCopied(false);
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Failed to create invite link.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyInviteLink() {
+    if (!inviteLink) return;
+
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      setMsg("Link copied.");
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setMsg("Failed to copy link.");
+    }
+  }
+
+  return (
+    <div ref={popoverRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+      >
+        Share
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={`Share ${workspaceName}`}
+          className="absolute right-0 top-full z-40 mt-1.5 w-[320px] rounded-lg border border-border bg-base p-3 shadow-lg"
+        >
+          <div className="sys-label mb-1">Invite link</div>
+          {inviteLink ? (
+            <div className="flex gap-1.5">
+              <input
+                readOnly
+                value={inviteLink}
+                className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[11.5px] font-mono text-foreground"
+              />
+              <button
+                type="button"
+                onClick={() => void copyInviteLink()}
+                className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void generateLink()}
+              disabled={busy || loading || !canInvite}
+              className="w-full rounded-md border border-border bg-base px-2 py-1.5 text-left text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-40"
+            >
+              Generate invite link
+            </button>
+          )}
+
+          <div className="sys-label mb-1 mt-3">Invite by username</div>
+          {canInvite ? (
+            <form onSubmit={addByUsername} className="flex gap-1.5">
+              <input
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="Username"
+                className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-400)] focus:outline-none"
+              />
+              <button
+                type="submit"
+                disabled={busy || !username.trim()}
+                className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised disabled:opacity-40"
+              >
+                Add
+              </button>
+            </form>
+          ) : (
+            <div className="rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-muted">
+              {loading
+                ? "Loading members..."
+                : "Only workspace admins can invite new people."}
+            </div>
+          )}
+
+          <div className="sys-label mb-1 mt-3">Members</div>
+          <ul className="max-h-44 overflow-y-auto">
+            {members.map((member) => (
+              <MemberRow
+                key={member.user_id}
+                member={member}
+                isMe={member.user_id === meId}
+              />
+            ))}
+            {members.length === 0 && (
+              <li className="py-2 text-[12px] text-muted">
+                {loading ? "Loading..." : "No members found."}
+              </li>
+            )}
+          </ul>
+
+          {msg && <div className="mt-2 text-[12px] text-muted">{msg}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  isMe,
+}: {
+  member: WorkspaceMember;
+  isMe: boolean;
+}) {
+  const label = member.display_name || member.name;
+  const color = colorFor(label);
+
+  return (
+    <li className="flex items-center gap-2.5 py-1 text-[13px]">
+      <span
+        className={
+          "inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-semibold " +
+          color.bg +
+          " " +
+          color.fg
+        }
+      >
+        {label.slice(0, 2).toUpperCase()}
+      </span>
+      <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+        {label}
+        {isMe ? <span className="ml-1 text-[10px] text-muted">(you)</span> : null}
+      </span>
+      <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted ring-1 ring-border">
+        {roleLabel(member.role)}
+      </span>
+    </li>
+  );
+}
+
+function colorFor(name: string) {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) h = (h * 33 + name.charCodeAt(i)) >>> 0;
+  return PALETTE[h % PALETTE.length];
+}
+
+function roleLabel(role: string): string {
+  if (role === "owner") return "admin";
+  return role;
+}
+
+function absoluteUrl(path: string): string {
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
+}


### PR DESCRIPTION
## Summary
- Replace the workspace-home Share modal path with a non-blocking dropdown that follows the Stash share popover pattern.
- Add workspace invite-link generation/copy, username invites, and a compact member list in the dropdown.
- Update AppShell coverage for the workspace Share dropdown and invite-link flow.

## Screenshots
- Workspace share dropdown screenshot attached in the PR thread.

## Validation
- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Playwright QA against the local dev app with mocked API responses, captured `/tmp/workspace-share-dropdown.png`.