### PR TITLE
[codex] Move Stash members into share dropdown

### DIFF
--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -4,14 +4,19 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StashPageClient from "./StashPageClient";
 import {
+  addStashMember,
   getActivityTimeline,
   getEmbeddingProjection,
+  getMe,
   getPublicStash,
+  listStashMembers,
+  searchUsers,
   type PublicStashDetail,
 } from "../../../lib/api";
 
@@ -65,12 +70,17 @@ vi.mock("../../../lib/api", () => ({
     }
   },
   addExternalStash: vi.fn(),
+  addStashMember: vi.fn(),
   createPage: vi.fn(),
+  getMe: vi.fn(),
   getPublicStash: vi.fn(),
   listAllPages: vi.fn(),
   listAllTables: vi.fn(),
   listFiles: vi.fn(),
   listMySessions: vi.fn(),
+  listStashMembers: vi.fn(),
+  removeStashMember: vi.fn(),
+  searchUsers: vi.fn(),
   updateStash: vi.fn(),
   uploadFile: vi.fn(),
   getActivityTimeline: vi.fn(),
@@ -149,7 +159,29 @@ describe("StashPageClient sharing", () => {
       stats: { total_embeddings: 0, projected: 0 },
       cached: false,
     });
+    vi.mocked(getMe).mockResolvedValue(authState.user!);
     vi.mocked(getPublicStash).mockResolvedValue(stashDetail());
+    vi.mocked(listStashMembers).mockResolvedValue([
+      {
+        user_id: "user-2",
+        name: "sam",
+        display_name: "Sam",
+        permission: "write",
+        granted_by: "user-1",
+        created_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    vi.mocked(searchUsers).mockResolvedValue([
+      { id: "user-3", name: "alex", display_name: "Alex" },
+    ]);
+    vi.mocked(addStashMember).mockResolvedValue({
+      user_id: "user-3",
+      name: "alex",
+      display_name: "Alex",
+      permission: "read",
+      granted_by: "user-1",
+      created_at: "2026-05-13T00:00:00Z",
+    });
   });
 
   afterEach(() => {
@@ -173,6 +205,33 @@ describe("StashPageClient sharing", () => {
       ),
     );
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("manages explicit Stash members from the Share dropdown", async () => {
+    vi.mocked(getPublicStash).mockResolvedValueOnce({
+      ...stashDetail({ access: "private" }),
+      can_write: true,
+    });
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Share Shared Stash",
+    });
+
+    expect(await within(dialog).findByText("@sam")).toBeInTheDocument();
+    expect(listStashMembers).toHaveBeenCalledWith("stash-1");
+
+    fireEvent.change(within(dialog).getByPlaceholderText("Search users"), {
+      target: { value: "alex" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Search" }));
+    fireEvent.click(await within(dialog).findByRole("button", { name: /Alex/ }));
+
+    await waitFor(() =>
+      expect(addStashMember).toHaveBeenCalledWith("stash-1", "user-3", "read"),
+    );
   });
 
   it("keeps add/create flows behind the single Add things button", async () => {

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -17,11 +17,11 @@ import DescriptionEditor, {
 } from "../../../components/DescriptionEditor";
 import { PublicStashSkeleton, SkeletonBlock } from "../../../components/SkeletonStates";
 import AddToStashModal from "../../../components/stash/AddToStashModal";
+import StashShareButton from "../../../components/stash/StashShareButton";
 import { SettingsIcon, StashIcon } from "../../../components/StashIcons";
 import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
-import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import {
   ApiError,
   getActivityTimeline,
@@ -130,7 +130,7 @@ export default function StashPageClient({ slug }: { slug: string }) {
     <StashChrome
       data={data}
       shareAction={
-        <ShareStashButton
+        <StashShareButton
           stash={data.stash}
           canWrite={data.can_write}
           onChanged={load}
@@ -565,201 +565,6 @@ function relativeTime(iso: string): string {
   const d = Math.floor(h / 24);
   if (d < 30) return `${d} d ago`;
   return new Date(iso).toLocaleDateString();
-}
-
-// Header-level Stash share popover: copy public URL, choose visibility,
-// toggle discoverability. Non-writers only see the "Copy link" path.
-function ShareStashButton({
-  stash,
-  canWrite,
-  onChanged,
-}: {
-  stash: PublicStashDetail["stash"];
-  canWrite: boolean;
-  onChanged: () => Promise<void>;
-}) {
-  const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [vis, setVis] = useState(stash.access);
-  const [discoverable, setDiscoverable] = useState(stash.discoverable);
-  const [saving, setSaving] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
-
-  useEscapeKey(open, () => setOpen(false));
-
-  useEffect(() => {
-    if (!open) return;
-    function onDown(e: globalThis.MouseEvent) {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
-
-  async function copyLink() {
-    try {
-      await navigator.clipboard.writeText(
-        absoluteUrl(`/stashes/${stash.slug}`),
-      );
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1600);
-    } catch {
-      /* ignore */
-    }
-  }
-
-  async function applyChanges(
-    next: Partial<{ access: typeof vis; discoverable: boolean }>,
-  ) {
-    setSaving(true);
-    try {
-      await updateStash(stash.id, next);
-      await onChanged();
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-      >
-        Share
-      </button>
-      {open && (
-        <div
-          ref={popoverRef}
-          className="absolute right-0 top-full z-40 mt-1.5 w-[300px] rounded-lg border border-border bg-base p-3 shadow-lg"
-        >
-          <div className="sys-label mb-1">Public URL</div>
-          <div className="flex gap-1.5">
-            <input
-              readOnly
-              value={absoluteUrl(`/stashes/${stash.slug}`)}
-              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[11.5px] font-mono text-foreground"
-            />
-            <button
-              type="button"
-              onClick={() => void copyLink()}
-              className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
-            >
-              {copied ? "Copied" : "Copy"}
-            </button>
-          </div>
-
-          {canWrite && (
-            <>
-              <div className="sys-label mb-1 mt-3">Visibility</div>
-              <div className="flex flex-col gap-1">
-                <VisOption
-                  label="Workspace"
-                  hint="Anyone in the owning workspace can view"
-                  value="workspace"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-                <VisOption
-                  label="Private"
-                  hint="Only the owner and explicit members"
-                  value="private"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-                <VisOption
-                  label="Public"
-                  hint="Anyone with the URL can view"
-                  value="public"
-                  current={vis}
-                  onChange={(v) => {
-                    setVis(v);
-                    void applyChanges({ access: v });
-                  }}
-                />
-              </div>
-
-              {vis === "public" && (
-                <label className="mt-3 flex cursor-pointer items-center gap-2 rounded-md border border-border bg-surface px-2 py-1.5">
-                  <input
-                    type="checkbox"
-                    checked={discoverable}
-                    onChange={(e) => {
-                      setDiscoverable(e.target.checked);
-                      void applyChanges({ discoverable: e.target.checked });
-                    }}
-                  />
-                  <span className="text-[12px] text-foreground">
-                    List on Discover
-                  </span>
-                </label>
-              )}
-
-              {saving && (
-                <div className="mt-2 text-[11px] text-muted">Saving…</div>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function VisOption({
-  label,
-  hint,
-  value,
-  current,
-  onChange,
-}: {
-  label: string;
-  hint: string;
-  value: "workspace" | "private" | "public";
-  current: "workspace" | "private" | "public";
-  onChange: (next: "workspace" | "private" | "public") => void;
-}) {
-  const active = value === current;
-  return (
-    <button
-      type="button"
-      onClick={() => onChange(value)}
-      className={
-        "flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[12px] " +
-        (active ? "bg-[var(--color-brand-50)]" : "hover:bg-raised")
-      }
-    >
-      <span
-        className={
-          "mt-[3px] inline-block h-3 w-3 flex-shrink-0 rounded-full border-2 " +
-          (active
-            ? "border-[var(--color-brand-600)] bg-[var(--color-brand-500)]"
-            : "border-border bg-base")
-        }
-      />
-      <span className="min-w-0">
-        <span className="block font-medium text-foreground">{label}</span>
-        <span className="block text-[11px] text-muted">{hint}</span>
-      </span>
-    </button>
-  );
-}
-
-function absoluteUrl(path: string): string {
-  if (typeof window === "undefined") return path;
-  return `${window.location.origin}${path}`;
 }
 
 function groupStashItems(items: PublicStashItem[]): StashItemGroup {

--- a/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.test.tsx
@@ -9,10 +9,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StashSettingsPageClient from "./StashSettingsPageClient";
 import {
-  addStashMember,
   getPublicStash,
-  listStashMembers,
-  searchUsers,
   updateStash,
   type PublicStashDetail,
 } from "../../../../lib/api";
@@ -73,19 +70,8 @@ vi.mock("../../../../lib/stashNavigationCache", () => ({
 }));
 
 vi.mock("../../../../lib/api", () => ({
-  ApiError: class ApiError extends Error {
-    status: number;
-    constructor(status: number, message: string) {
-      super(message);
-      this.status = status;
-    }
-  },
-  addStashMember: vi.fn(),
   deleteStash: vi.fn(),
   getPublicStash: vi.fn(),
-  listStashMembers: vi.fn(),
-  removeStashMember: vi.fn(),
-  searchUsers: vi.fn(),
   updateStash: vi.fn(),
   uploadFile: vi.fn(),
 }));
@@ -126,45 +112,22 @@ describe("StashSettingsPageClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getPublicStash).mockResolvedValue(stashDetail());
-    vi.mocked(listStashMembers).mockResolvedValue([
-      {
-        user_id: "user-2",
-        name: "sam",
-        display_name: "Sam",
-        permission: "write",
-        granted_by: "user-1",
-        created_at: "2026-05-12T00:00:00Z",
-      },
-    ]);
     vi.mocked(updateStash).mockImplementation(async (_stashId, updates) => ({
       ...stashDetail().stash,
       ...updates,
     }));
-    vi.mocked(searchUsers).mockResolvedValue([
-      { id: "user-3", name: "alex", display_name: "Alex" },
-    ]);
-    vi.mocked(addStashMember).mockResolvedValue({
-      user_id: "user-3",
-      name: "alex",
-      display_name: "Alex",
-      permission: "read",
-      granted_by: "user-1",
-      created_at: "2026-05-13T00:00:00Z",
-    });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("loads editable stash settings and explicit members", async () => {
+  it("loads editable stash settings", async () => {
     render(<StashSettingsPageClient slug="shared-stash" />);
 
     expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument();
     expect(await screen.findByDisplayValue("Shared Stash")).toBeInTheDocument();
-    expect(screen.getByText("@henry")).toBeInTheDocument();
-    expect(screen.getByText("@sam")).toBeInTheDocument();
-    expect(listStashMembers).toHaveBeenCalledWith("stash-1");
+    expect(screen.queryByText("Members")).not.toBeInTheDocument();
   });
 
   it("saves title and visibility changes", async () => {
@@ -185,19 +148,4 @@ describe("StashSettingsPageClient", () => {
     expect(await screen.findByText("Saved.")).toBeInTheDocument();
   });
 
-  it("searches and adds a member", async () => {
-    render(<StashSettingsPageClient slug="shared-stash" />);
-
-    fireEvent.change(await screen.findByPlaceholderText("Search users"), {
-      target: { value: "alex" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-
-    const addResult = await screen.findByRole("button", { name: /Alex/ });
-    fireEvent.click(addResult);
-
-    await waitFor(() =>
-      expect(addStashMember).toHaveBeenCalledWith("stash-1", "user-3", "read"),
-    );
-  });
 });

--- a/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/settings/StashSettingsPageClient.tsx
@@ -13,24 +13,15 @@ import {
 import AppShell from "../../../../components/AppShell";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import CustomSelect from "../../../../components/CustomSelect";
-import { StashIcon } from "../../../../components/StashIcons";
 import { useAuth } from "../../../../hooks/useAuth";
 import {
-  addStashMember,
-  ApiError,
   deleteStash,
   getPublicStash,
-  listStashMembers,
-  removeStashMember,
-  searchUsers,
   updateStash,
   uploadFile,
   type PublicStashDetail,
-  type StashMember,
-  type StashMemberPermission,
 } from "../../../../lib/api";
 import { resetStashNavigationCache } from "../../../../lib/stashNavigationCache";
-import type { UserSearchResult } from "../../../../lib/types";
 
 type StashAccess = PublicStashDetail["stash"]["access"];
 
@@ -40,18 +31,10 @@ const ACCESS_OPTIONS = [
   { value: "public", label: "Public" },
 ];
 
-const PERMISSION_OPTIONS = [
-  { value: "read", label: "Read" },
-  { value: "write", label: "Write" },
-  { value: "admin", label: "Admin" },
-];
-
 export default function StashSettingsPageClient({ slug }: { slug: string }) {
   const router = useRouter();
   const { user, loading: authLoading, logout } = useAuth();
   const [data, setData] = useState<PublicStashDetail | null>(null);
-  const [members, setMembers] = useState<StashMember[]>([]);
-  const [canManageMembers, setCanManageMembers] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState("");
   const [error, setError] = useState("");
@@ -59,11 +42,6 @@ export default function StashSettingsPageClient({ slug }: { slug: string }) {
   const [title, setTitle] = useState("");
   const [access, setAccess] = useState<StashAccess>("workspace");
   const [discoverable, setDiscoverable] = useState(false);
-  const [userQuery, setUserQuery] = useState("");
-  const [userResults, setUserResults] = useState<UserSearchResult[]>([]);
-  const [newMemberPermission, setNewMemberPermission] =
-    useState<StashMemberPermission>("read");
-  const [memberMessage, setMemberMessage] = useState("");
 
   const stash = data?.stash ?? null;
 
@@ -86,24 +64,6 @@ export default function StashSettingsPageClient({ slug }: { slug: string }) {
     try {
       const nextData = await getPublicStash(slug);
       setData(nextData);
-
-      if (!nextData.can_write) {
-        setMembers([]);
-        setCanManageMembers(false);
-        return;
-      }
-
-      try {
-        setMembers(await listStashMembers(nextData.stash.id));
-        setCanManageMembers(true);
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 403) {
-          setMembers([]);
-          setCanManageMembers(false);
-          return;
-        }
-        throw e;
-      }
     } catch (e) {
       setData(null);
       setError(e instanceof Error ? e.message : "Failed to load settings");
@@ -253,82 +213,6 @@ export default function StashSettingsPageClient({ slug }: { slug: string }) {
     }
   }
 
-  async function searchForUsers(e: FormEvent) {
-    e.preventDefault();
-    if (!userQuery.trim()) return;
-
-    setSaving("members");
-    setMemberMessage("");
-    try {
-      setUserResults(await searchUsers(userQuery.trim()));
-    } catch (e) {
-      setMemberMessage(e instanceof Error ? e.message : "Could not search users");
-    } finally {
-      setSaving("");
-    }
-  }
-
-  async function refreshMembers() {
-    if (!stash) return;
-    setMembers(await listStashMembers(stash.id));
-  }
-
-  async function addMember(userId: string) {
-    if (!stash) return;
-
-    setSaving("members");
-    setMemberMessage("");
-    try {
-      await addStashMember(stash.id, userId, newMemberPermission);
-      await refreshMembers();
-      setUserQuery("");
-      setUserResults([]);
-      setMemberMessage("Added.");
-      resetStashNavigationCache();
-    } catch (e) {
-      setMemberMessage(e instanceof Error ? e.message : "Could not add member");
-    } finally {
-      setSaving("");
-    }
-  }
-
-  async function changeMemberPermission(
-    userId: string,
-    permission: StashMemberPermission
-  ) {
-    if (!stash) return;
-
-    setSaving("members");
-    setMemberMessage("");
-    try {
-      await addStashMember(stash.id, userId, permission);
-      await refreshMembers();
-      setMemberMessage("Updated.");
-      resetStashNavigationCache();
-    } catch (e) {
-      setMemberMessage(e instanceof Error ? e.message : "Could not update member");
-    } finally {
-      setSaving("");
-    }
-  }
-
-  async function removeMember(userId: string) {
-    if (!stash) return;
-    if (!confirm("Remove this member from the Stash?")) return;
-
-    setSaving("members");
-    setMemberMessage("");
-    try {
-      await removeStashMember(stash.id, userId);
-      await refreshMembers();
-      resetStashNavigationCache();
-    } catch (e) {
-      setMemberMessage(e instanceof Error ? e.message : "Could not remove member");
-    } finally {
-      setSaving("");
-    }
-  }
-
   async function handleDelete() {
     if (!stash) return;
     if (!confirm(`Delete "${stash.title}"? This cannot be undone.`)) return;
@@ -344,8 +228,6 @@ export default function StashSettingsPageClient({ slug }: { slug: string }) {
       setSaving("");
     }
   }
-
-  const ownerLabel = stash.owner_display_name || stash.owner_name;
 
   return (
     <AppShell user={user} onLogout={logout} activeWorkspaceId={stash.workspace_id}>
@@ -452,139 +334,6 @@ export default function StashSettingsPageClient({ slug }: { slug: string }) {
               onClear={() => clearImage("icon_url")}
               previewClass="h-12 w-12 rounded-md object-cover"
             />
-          </Section>
-
-          <Section title="Members">
-            <div className="rounded-lg border border-border bg-base px-3 py-2">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[var(--color-brand-100)] text-[var(--color-brand-700)]">
-                    <StashIcon />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="truncate text-[13.5px] font-medium text-foreground">
-                      {ownerLabel}
-                    </div>
-                    <div className="truncate text-[11.5px] text-muted">
-                      @{stash.owner_name}
-                    </div>
-                  </div>
-                </div>
-                <span className="rounded bg-raised px-2 py-0.5 text-[11.5px] text-muted">
-                  admin
-                </span>
-              </div>
-            </div>
-
-            {canManageMembers ? (
-              <>
-                <ul className="flex flex-col gap-2">
-                  {members.map((member) => (
-                    <li
-                      key={member.user_id}
-                      className="flex items-center justify-between gap-3 rounded-lg border border-border bg-base px-3 py-2"
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate text-[13.5px] font-medium text-foreground">
-                          {member.display_name || member.name}
-                        </div>
-                        <div className="truncate text-[11.5px] text-muted">
-                          @{member.name}
-                        </div>
-                      </div>
-                      <div className="flex flex-shrink-0 items-center gap-2">
-                        <CustomSelect
-                          value={member.permission}
-                          options={PERMISSION_OPTIONS}
-                          onChange={(next) =>
-                            changeMemberPermission(
-                              member.user_id,
-                              next as StashMemberPermission
-                            )
-                          }
-                          ariaLabel={`Permission for ${member.name}`}
-                          className="min-w-[82px] rounded border border-border bg-surface px-2 py-1 text-[12px]"
-                          align="right"
-                        />
-                        {member.user_id !== user.id && (
-                          <button
-                            type="button"
-                            onClick={() => removeMember(member.user_id)}
-                            className="text-[11.5px] text-red-500 hover:underline"
-                          >
-                            Remove
-                          </button>
-                        )}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-
-                <form
-                  onSubmit={searchForUsers}
-                  className="rounded-lg border border-border bg-base px-3 py-3"
-                >
-                  <label className="block text-[12px] font-medium text-muted" htmlFor="member-search">
-                    Add member
-                  </label>
-                  <div className="mt-1 flex gap-2">
-                    <input
-                      id="member-search"
-                      value={userQuery}
-                      onChange={(e) => setUserQuery(e.target.value)}
-                      placeholder="Search users"
-                      className="min-w-0 flex-1 rounded-md border border-border bg-surface px-3 py-2 text-[13px] text-foreground outline-none focus:border-[var(--color-brand-400)]"
-                    />
-                    <CustomSelect
-                      value={newMemberPermission}
-                      options={PERMISSION_OPTIONS}
-                      onChange={(next) =>
-                        setNewMemberPermission(next as StashMemberPermission)
-                      }
-                      ariaLabel="New member permission"
-                      className="min-w-[86px] rounded-md border border-border bg-surface px-2 py-2 text-[12px]"
-                      align="right"
-                    />
-                    <button
-                      type="submit"
-                      disabled={saving === "members" || !userQuery.trim()}
-                      className="rounded-md border border-border bg-base px-3 py-2 text-[12.5px] font-medium text-foreground hover:bg-raised disabled:opacity-50"
-                    >
-                      Search
-                    </button>
-                  </div>
-                  {userResults.length > 0 && (
-                    <div className="mt-3 flex flex-col gap-1">
-                      {userResults.map((result) => (
-                        <button
-                          key={result.id}
-                          type="button"
-                          onClick={() => addMember(result.id)}
-                          className="flex items-center justify-between rounded-md px-2 py-1.5 text-left hover:bg-raised"
-                        >
-                          <span className="min-w-0">
-                            <span className="block truncate text-[13px] font-medium text-foreground">
-                              {result.display_name || result.name}
-                            </span>
-                            <span className="block truncate text-[11.5px] text-muted">
-                              @{result.name}
-                            </span>
-                          </span>
-                          <span className="text-[11.5px] text-muted">Add</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  {memberMessage && (
-                    <div className="mt-2 text-[12px] text-muted">{memberMessage}</div>
-                  )}
-                </form>
-              </>
-            ) : (
-              <div className="rounded-lg border border-border bg-base px-3 py-2 text-[13px] text-muted">
-                Only Stash admins can manage members.
-              </div>
-            )}
           </Section>
 
           <Section title="Danger zone">

--- a/frontend/src/components/stash/StashShareButton.tsx
+++ b/frontend/src/components/stash/StashShareButton.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
+import {
+  addStashMember,
+  ApiError,
+  getMe,
+  listStashMembers,
+  removeStashMember,
+  searchUsers,
+  updateStash,
+  type PublicStashDetail,
+  type StashMember,
+  type StashMemberPermission,
+} from "../../lib/api";
+import { resetStashNavigationCache } from "../../lib/stashNavigationCache";
+import type { UserSearchResult } from "../../lib/types";
+
+type StashAccess = PublicStashDetail["stash"]["access"];
+
+const PERMISSION_OPTIONS: { value: StashMemberPermission; label: string }[] = [
+  { value: "read", label: "Read" },
+  { value: "write", label: "Write" },
+  { value: "admin", label: "Admin" },
+];
+
+const PALETTE = [
+  { bg: "bg-rose-200", fg: "text-rose-800" },
+  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-emerald-200", fg: "text-emerald-800" },
+  { bg: "bg-amber-200", fg: "text-amber-900" },
+  { bg: "bg-sky-200", fg: "text-sky-800" },
+  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+];
+
+export default function StashShareButton({
+  stash,
+  canWrite,
+  onChanged,
+}: {
+  stash: PublicStashDetail["stash"];
+  canWrite: boolean;
+  onChanged: () => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [vis, setVis] = useState<StashAccess>(stash.access);
+  const [discoverable, setDiscoverable] = useState(stash.discoverable);
+  const [saving, setSaving] = useState(false);
+  const [shareMessage, setShareMessage] = useState("");
+  const [members, setMembers] = useState<StashMember[]>([]);
+  const [meId, setMeId] = useState<string | null>(null);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [canManageMembers, setCanManageMembers] = useState(false);
+  const [memberBusy, setMemberBusy] = useState(false);
+  const [memberMessage, setMemberMessage] = useState("");
+  const [userQuery, setUserQuery] = useState("");
+  const [userResults, setUserResults] = useState<UserSearchResult[]>([]);
+  const [newMemberPermission, setNewMemberPermission] =
+    useState<StashMemberPermission>("read");
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEscapeKey(open, () => setOpen(false));
+
+  useEffect(() => {
+    setVis(stash.access);
+    setDiscoverable(stash.discoverable);
+  }, [stash.access, stash.discoverable]);
+
+  const loadMembers = useCallback(async () => {
+    setMembersLoading(true);
+    setMemberMessage("");
+    try {
+      const [nextMembers, me] = await Promise.all([
+        listStashMembers(stash.id),
+        getMe(),
+      ]);
+      setMembers(nextMembers);
+      setMeId(me.id);
+      setCanManageMembers(true);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 403) {
+        setMembers([]);
+        setCanManageMembers(false);
+        return;
+      }
+      setMemberMessage(e instanceof Error ? e.message : "Failed to load members.");
+    } finally {
+      setMembersLoading(false);
+    }
+  }, [stash.id]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onDown(e: globalThis.MouseEvent) {
+      if (!popoverRef.current) return;
+      if (!popoverRef.current.contains(e.target as Node)) setOpen(false);
+    }
+
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !canWrite) return;
+
+    setShareMessage("");
+    setMemberMessage("");
+    setUserQuery("");
+    setUserResults([]);
+    setCopied(false);
+    void loadMembers();
+  }, [open, canWrite, loadMembers]);
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(absoluteUrl(`/stashes/${stash.slug}`));
+      setCopied(true);
+      setShareMessage("Link copied.");
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setShareMessage("Failed to copy link.");
+    }
+  }
+
+  async function applyVisibility(nextAccess: StashAccess) {
+    const nextDiscoverable = nextAccess === "public" ? discoverable : false;
+
+    setSaving(true);
+    setShareMessage("");
+    try {
+      const updated = await updateStash(stash.id, {
+        access: nextAccess,
+        discoverable: nextDiscoverable,
+      });
+      setVis(updated.access);
+      setDiscoverable(updated.discoverable);
+      resetStashNavigationCache();
+      await onChanged();
+    } catch (e) {
+      setShareMessage(e instanceof Error ? e.message : "Could not update visibility.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleDiscoverable(nextDiscoverable: boolean) {
+    setSaving(true);
+    setShareMessage("");
+    try {
+      const updated = await updateStash(stash.id, {
+        access: "public",
+        discoverable: nextDiscoverable,
+      });
+      setVis(updated.access);
+      setDiscoverable(updated.discoverable);
+      resetStashNavigationCache();
+      await onChanged();
+    } catch (e) {
+      setShareMessage(e instanceof Error ? e.message : "Could not update Discover.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function searchForUsers(e: FormEvent) {
+    e.preventDefault();
+    const query = userQuery.trim();
+    if (!query) return;
+
+    setMemberBusy(true);
+    setMemberMessage("");
+    try {
+      setUserResults(await searchUsers(query));
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not search users.");
+    } finally {
+      setMemberBusy(false);
+    }
+  }
+
+  async function addMember(userId: string) {
+    setMemberBusy(true);
+    setMemberMessage("");
+    try {
+      await addStashMember(stash.id, userId, newMemberPermission);
+      await loadMembers();
+      setUserQuery("");
+      setUserResults([]);
+      setMemberMessage("Added.");
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not add member.");
+    } finally {
+      setMemberBusy(false);
+    }
+  }
+
+  async function changeMemberPermission(
+    userId: string,
+    permission: StashMemberPermission,
+  ) {
+    setMemberBusy(true);
+    setMemberMessage("");
+    try {
+      await addStashMember(stash.id, userId, permission);
+      await loadMembers();
+      setMemberMessage("Updated.");
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not update member.");
+    } finally {
+      setMemberBusy(false);
+    }
+  }
+
+  async function deleteMember(userId: string) {
+    if (!confirm("Remove this member from the Stash?")) return;
+
+    setMemberBusy(true);
+    setMemberMessage("");
+    try {
+      await removeStashMember(stash.id, userId);
+      await loadMembers();
+      resetStashNavigationCache();
+    } catch (e) {
+      setMemberMessage(e instanceof Error ? e.message : "Could not remove member.");
+    } finally {
+      setMemberBusy(false);
+    }
+  }
+
+  const ownerLabel = stash.owner_display_name || stash.owner_name;
+
+  return (
+    <div ref={popoverRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+      >
+        Share
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={`Share ${stash.title}`}
+          className="absolute right-0 top-full z-40 mt-1.5 w-[360px] rounded-lg border border-border bg-base p-3 shadow-lg"
+        >
+          <div className="sys-label mb-1">Public URL</div>
+          <div className="flex gap-1.5">
+            <input
+              readOnly
+              value={absoluteUrl(`/stashes/${stash.slug}`)}
+              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[11.5px] font-mono text-foreground"
+            />
+            <button
+              type="button"
+              onClick={() => void copyLink()}
+              className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+
+          {canWrite && (
+            <>
+              <div className="sys-label mb-1 mt-3">Visibility</div>
+              <div className="flex flex-col gap-1">
+                <VisOption
+                  label="Workspace"
+                  hint="Anyone in the owning workspace can view"
+                  value="workspace"
+                  current={vis}
+                  onChange={(v) => void applyVisibility(v)}
+                />
+                <VisOption
+                  label="Private"
+                  hint="Only the owner and explicit members"
+                  value="private"
+                  current={vis}
+                  onChange={(v) => void applyVisibility(v)}
+                />
+                <VisOption
+                  label="Public"
+                  hint="Anyone with the URL can view"
+                  value="public"
+                  current={vis}
+                  onChange={(v) => void applyVisibility(v)}
+                />
+              </div>
+
+              {vis === "public" && (
+                <label className="mt-3 flex cursor-pointer items-center gap-2 rounded-md border border-border bg-surface px-2 py-1.5">
+                  <input
+                    type="checkbox"
+                    checked={discoverable}
+                    onChange={(e) => void toggleDiscoverable(e.target.checked)}
+                  />
+                  <span className="text-[12px] text-foreground">
+                    List on Discover
+                  </span>
+                </label>
+              )}
+
+              <div className="mt-4 border-t border-border pt-3">
+                <div className="sys-label mb-2">Members</div>
+                <OwnerRow label={ownerLabel} username={stash.owner_name} />
+
+                {membersLoading && (
+                  <div className="mt-2 rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-muted">
+                    Loading members...
+                  </div>
+                )}
+
+                {!membersLoading && canManageMembers && (
+                  <>
+                    <ul className="mt-2 max-h-44 overflow-y-auto pr-1">
+                      {members.map((member) => (
+                        <MemberRow
+                          key={member.user_id}
+                          member={member}
+                          isMe={member.user_id === meId}
+                          busy={memberBusy}
+                          onPermissionChange={(permission) =>
+                            void changeMemberPermission(member.user_id, permission)
+                          }
+                          onRemove={
+                            meId && member.user_id !== meId
+                              ? () => void deleteMember(member.user_id)
+                              : null
+                          }
+                        />
+                      ))}
+                      {members.length === 0 && (
+                        <li className="py-2 text-[12px] text-muted">
+                          No explicit members yet.
+                        </li>
+                      )}
+                    </ul>
+
+                    <form onSubmit={searchForUsers} className="mt-3">
+                      <div className="sys-label mb-1">Add member</div>
+                      <div className="flex gap-1.5">
+                        <input
+                          value={userQuery}
+                          onChange={(e) => setUserQuery(e.target.value)}
+                          placeholder="Search users"
+                          className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-[var(--color-brand-400)] focus:outline-none"
+                        />
+                        <PermissionSelect
+                          value={newMemberPermission}
+                          onChange={setNewMemberPermission}
+                          ariaLabel="New member permission"
+                          disabled={memberBusy}
+                        />
+                        <button
+                          type="submit"
+                          disabled={memberBusy || !userQuery.trim()}
+                          className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised disabled:opacity-40"
+                        >
+                          Search
+                        </button>
+                      </div>
+                      {userResults.length > 0 && (
+                        <div className="mt-2 flex flex-col gap-1">
+                          {userResults.map((result) => (
+                            <button
+                              key={result.id}
+                              type="button"
+                              onClick={() => void addMember(result.id)}
+                              className="flex items-center justify-between rounded-md px-2 py-1.5 text-left hover:bg-raised"
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-[13px] font-medium text-foreground">
+                                  {result.display_name || result.name}
+                                </span>
+                                <span className="block truncate text-[11.5px] text-muted">
+                                  @{result.name}
+                                </span>
+                              </span>
+                              <span className="text-[11.5px] text-muted">Add</span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </form>
+                  </>
+                )}
+
+                {!membersLoading && !canManageMembers && (
+                  <div className="mt-2 rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-muted">
+                    Only Stash admins can manage members.
+                  </div>
+                )}
+              </div>
+
+              {saving && (
+                <div className="mt-2 text-[11px] text-muted">Saving...</div>
+              )}
+            </>
+          )}
+
+          {(shareMessage || memberMessage) && (
+            <div className="mt-2 text-[12px] text-muted">
+              {memberMessage || shareMessage}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OwnerRow({ label, username }: { label: string; username: string }) {
+  return (
+    <div className="flex items-center gap-2.5 rounded-md border border-border bg-surface px-2 py-1.5 text-[13px]">
+      <Avatar label={label} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">{label}</span>
+        <span className="block truncate text-[11.5px] text-muted">@{username}</span>
+      </span>
+      <span className="rounded bg-base px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted ring-1 ring-border">
+        admin
+      </span>
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  isMe,
+  busy,
+  onPermissionChange,
+  onRemove,
+}: {
+  member: StashMember;
+  isMe: boolean;
+  busy: boolean;
+  onPermissionChange: (permission: StashMemberPermission) => void;
+  onRemove: (() => void) | null;
+}) {
+  const label = member.display_name || member.name;
+
+  return (
+    <li className="flex items-center gap-2.5 py-1 text-[13px]">
+      <Avatar label={label} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">
+          {label}
+          {isMe ? <span className="ml-1 text-[10px] text-muted">(you)</span> : null}
+        </span>
+        <span className="block truncate text-[11.5px] text-muted">@{member.name}</span>
+      </span>
+      <PermissionSelect
+        value={member.permission}
+        onChange={onPermissionChange}
+        ariaLabel={`Permission for ${member.name}`}
+        disabled={busy}
+      />
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={busy}
+          className="text-[11.5px] text-red-500 hover:underline disabled:opacity-40"
+        >
+          Remove
+        </button>
+      )}
+    </li>
+  );
+}
+
+function PermissionSelect({
+  value,
+  onChange,
+  ariaLabel,
+  disabled,
+}: {
+  value: StashMemberPermission;
+  onChange: (value: StashMemberPermission) => void;
+  ariaLabel: string;
+  disabled: boolean;
+}) {
+  return (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value as StashMemberPermission)}
+      className="h-7 rounded border border-border bg-base px-1.5 text-[11.5px] text-foreground outline-none focus:border-[var(--color-brand-400)] disabled:opacity-40"
+    >
+      {PERMISSION_OPTIONS.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function Avatar({ label }: { label: string }) {
+  const color = colorFor(label);
+  return (
+    <span
+      className={
+        "inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-semibold " +
+        color.bg +
+        " " +
+        color.fg
+      }
+    >
+      {initials(label)}
+    </span>
+  );
+}
+
+function VisOption({
+  label,
+  hint,
+  value,
+  current,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  value: StashAccess;
+  current: StashAccess;
+  onChange: (next: StashAccess) => void;
+}) {
+  const active = value === current;
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(value)}
+      className={
+        "flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[12px] " +
+        (active ? "bg-[var(--color-brand-50)]" : "hover:bg-raised")
+      }
+    >
+      <span
+        className={
+          "mt-[3px] inline-block h-3 w-3 flex-shrink-0 rounded-full border-2 " +
+          (active
+            ? "border-[var(--color-brand-600)] bg-[var(--color-brand-500)]"
+            : "border-border bg-base")
+        }
+      />
+      <span className="min-w-0">
+        <span className="block font-medium text-foreground">{label}</span>
+        <span className="block text-[11px] text-muted">{hint}</span>
+      </span>
+    </button>
+  );
+}
+
+function colorFor(name: string) {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) h = (h * 33 + name.charCodeAt(i)) >>> 0;
+  return PALETTE[h % PALETTE.length];
+}
+
+function initials(label: string): string {
+  return label
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+function absoluteUrl(path: string): string {
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
+}


### PR DESCRIPTION
## Summary
- Moved the Stash detail Share dropdown into a reusable Stash share component.
- Added explicit Stash member management to that dropdown: owner display, member permissions, remove, search, and add.
- Removed Stash member management from the settings page so settings stays focused on general, branding, and delete controls.

## Screenshots
- Stash detail page with Share dropdown open, showing visibility and members together. Captured during validation at `/tmp/stash-members-share-dropdown.png`.

## Validation
- `npm test -- StashPageClient.test.tsx StashSettingsPageClient.test.tsx`
- `npm run lint`
- `npm run build`
- Playwright smoke check against `http://localhost:3457/stashes/shared-stash` with mocked API responses and the Share dropdown open.