### PR TITLE
[codex] Remove description editor background

### DIFF
--- a/frontend/src/components/DescriptionEditor.tsx
+++ b/frontend/src/components/DescriptionEditor.tsx
@@ -162,10 +162,7 @@ export default function DescriptionEditor({
       data-editable={canEdit ? "true" : "false"}
       onClick={handleEditorFrameClick}
       className={
-        "description-editor -mx-1 rounded-md px-1 py-0.5 " +
-        (canEdit
-          ? "cursor-text transition-colors hover:bg-raised/45 focus-within:bg-raised/45"
-          : "")
+        "description-editor -mx-1 px-1 py-0.5 " + (canEdit ? "cursor-text" : "")
       }
     >
       <EditorContent editor={editor} />


### PR DESCRIPTION
## Summary

Remove the gray hover/focus background from the shared description editor so editing a Stash description feels like editing the page itself instead of a form field.

## Screenshot

![stash-description-editor-no-bg.png](https://github.com/user-attachments/assets/82bcbb16-e962-4f0f-a968-6dda0c444312)

## Validation

- `npm run lint`
- `npm test -- DescriptionEditor StashPageClient`
- Playwright visual check against a mocked writable Stash: editor background stayed transparent before hover, on hover, and while focused.