### PR TITLE
Trash + undelete across sessions, pages, files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from .routers import (
     stashes,
     tables,
     transcripts,
+    trash,
     users,
     workspace_knowledge,
     workspaces,
@@ -112,6 +113,7 @@ app.include_router(aggregate.router)
 app.include_router(skill.router)
 app.include_router(admin.router)
 app.include_router(sessions.router)
+app.include_router(trash.router)
 app.include_router(publish.router)
 
 if settings.AUTH0_ENABLED:

--- a/backend/migrations/versions/0060_trash.py
+++ b/backend/migrations/versions/0060_trash.py
@@ -1,0 +1,45 @@
+"""Add deleted_at + deleted_by to sessions, pages, files for soft delete.
+
+Soft-deleted rows live in the same tables with `deleted_at` stamped. All
+reads filter `deleted_at IS NULL`; the dedicated trash listing is the
+only query that intentionally inverts that. No auto-purge — items stay
+in trash until manually purged.
+
+Revision ID: 0060
+Revises: 0059
+Create Date: 2026-05-19 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = "0060"
+down_revision = "0059"
+branch_labels = None
+depends_on = None
+
+
+_TABLES = ("sessions", "pages", "files")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ"
+        )
+        op.execute(
+            f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS deleted_by UUID"
+        )
+        # Trash listing scans by workspace + deleted_at; partial index
+        # keeps the active-row hot path unaffected.
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_trash "
+            f"ON {table} (workspace_id, deleted_at DESC) "
+            f"WHERE deleted_at IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"DROP INDEX IF EXISTS idx_{table}_trash")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS deleted_by")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS deleted_at")

--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -100,6 +100,7 @@ async def list_activity(
           FROM pages p
           JOIN accessible_workspaces aw ON aw.id = p.workspace_id
           WHERE COALESCE(p.metadata->>'shared_in_stash_id', '') = ''
+            AND p.deleted_at IS NULL
             AND """
         + permission_service.readable_content_condition("page", "p", 1)
         + """
@@ -115,7 +116,8 @@ async def list_activity(
                  aw.name AS workspace_name
           FROM files f
           JOIN accessible_workspaces aw ON aw.id = f.workspace_id
-          WHERE """
+          WHERE f.deleted_at IS NULL
+            AND """
         + permission_service.readable_content_condition("file", "f", 1)
         + """
         )

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -20,6 +20,7 @@ from ..auth import get_current_user
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, FileUpdateRequest, TableResponse
 from ..services import (
+    files_service,
     permission_service,
     storage_service,
     table_service,
@@ -229,7 +230,7 @@ async def get_ws_file_text(
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT extracted_text, extraction_status, extraction_error "
-        "FROM files WHERE id = $1 AND workspace_id = $2",
+        "FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )
@@ -257,7 +258,7 @@ async def update_ws_file(
     await _check_write(workspace_id, current_user["id"])
     pool = get_pool()
     file_row = await pool.fetchrow(
-        "SELECT * FROM files WHERE id = $1 AND workspace_id = $2",
+        "SELECT * FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )
@@ -314,24 +315,48 @@ async def delete_ws_file(
     file_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
+    """Soft delete: stamps deleted_at + deleted_by. Object storage blob stays
+    so a restore is fully reversible. Use POST /restore to undo or DELETE
+    /purge to wipe permanently."""
     await _check_write(workspace_id, current_user["id"])
-    pool = get_pool()
-    row = await pool.fetchrow(
-        "SELECT storage_key FROM files WHERE id = $1 AND workspace_id = $2",
-        file_id,
-        workspace_id,
-    )
-    if not row:
-        raise HTTPException(status_code=404, detail="File not found")
     if not await _can_access_file(file_id, workspace_id, current_user["id"], require_write=True):
         raise HTTPException(status_code=404, detail="File not found")
-    try:
-        await storage_service.delete_file(row["storage_key"])
-    except Exception:
-        pass
-    await pool.execute(
-        "DELETE FROM files WHERE id = $1 AND workspace_id = $2", file_id, workspace_id
-    )
+    trashed = await files_service.delete_file(file_id, workspace_id, current_user["id"])
+    if not trashed:
+        raise HTTPException(status_code=404, detail="File not found")
+
+
+@ws_router.post("/{file_id}/restore", status_code=204)
+async def restore_ws_file(
+    workspace_id: UUID,
+    file_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_write(workspace_id, current_user["id"])
+    if not await _can_access_file(file_id, workspace_id, current_user["id"], require_write=True):
+        raise HTTPException(status_code=404, detail="File not found")
+    restored = await files_service.restore_file(file_id, workspace_id)
+    if not restored:
+        raise HTTPException(status_code=404, detail="File not in trash")
+
+
+@ws_router.delete("/{file_id}/purge", status_code=204)
+async def purge_ws_file(
+    workspace_id: UUID,
+    file_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Permanent delete — only callable on a file already in trash."""
+    await _check_write(workspace_id, current_user["id"])
+    if not await _can_access_file(file_id, workspace_id, current_user["id"], require_write=True):
+        raise HTTPException(status_code=404, detail="File not found")
+    row = await files_service.get_trashed_file(file_id, workspace_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="File not in trash")
+    await storage_service.delete_file(row["storage_key"])
+    purged = await files_service.purge_file(file_id, workspace_id)
+    if not purged:
+        raise HTTPException(status_code=404, detail="File not in trash")
 
 
 # ===== CSV → Table ingest =====
@@ -401,7 +426,7 @@ async def ingest_csv_file(
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, workspace_id, name, content_type, storage_key, linked_table_id "
-        "FROM files WHERE id = $1 AND workspace_id = $2",
+        "FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -161,7 +161,7 @@ async def list_ws_files(
     pool = get_pool()
     rows = await pool.fetch(
         "SELECT id, workspace_id, folder_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at, linked_table_id "
-        "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC",
+        "FROM files WHERE workspace_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC",
         workspace_id,
     )
     readable_rows = []
@@ -182,7 +182,7 @@ async def get_ws_file(
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, workspace_id, folder_id, name, content_type, size_bytes, storage_key, uploaded_by, created_at, linked_table_id "
-        "FROM files WHERE id = $1 AND workspace_id = $2",
+        "FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )
@@ -207,7 +207,7 @@ async def download_ws_file(
     await _check_member(workspace_id, current_user["id"])
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT storage_key FROM files WHERE id = $1 AND workspace_id = $2",
+        "SELECT storage_key FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -485,7 +485,7 @@ async def delete_page(
         current_user["id"],
         require_write=True,
     )
-    deleted = await files_tree_service.delete_page(page_id, workspace_id)
+    deleted = await files_tree_service.delete_page(page_id, workspace_id, current_user["id"])
     if not deleted:
         raise HTTPException(status_code=404, detail="Page not found")
 

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -186,19 +186,22 @@ async def get_folder_contents(
     subfolders = await pool.fetch(
         "SELECT id, name, "
         "       (SELECT COUNT(*) FROM pages p WHERE p.folder_id = f.id "
-        "        AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '') AS page_count, "
-        "       (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id) AS file_count "
+        "        AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '' "
+        "        AND p.deleted_at IS NULL) AS page_count, "
+        "       (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id "
+        "        AND fi.deleted_at IS NULL) AS file_count "
         "FROM folders f WHERE f.parent_folder_id = $1 ORDER BY name",
         folder_id,
     )
     pages = await pool.fetch(
         "SELECT id, name FROM pages WHERE folder_id = $1 "
-        "AND COALESCE(metadata->>'shared_in_stash_id', '') = '' ORDER BY name",
+        "AND COALESCE(metadata->>'shared_in_stash_id', '') = '' "
+        "AND deleted_at IS NULL ORDER BY name",
         folder_id,
     )
     files = await pool.fetch(
         "SELECT id, name, size_bytes, content_type, created_at, linked_table_id "
-        "FROM files WHERE folder_id = $1 ORDER BY created_at DESC",
+        "FROM files WHERE folder_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC",
         folder_id,
     )
     subfolders = await files_tree_service._filter_readable(
@@ -222,11 +225,13 @@ async def get_folder_contents(
     for folder_row in subfolders:
         child_pages = await pool.fetch(
             "SELECT id FROM pages WHERE folder_id = $1 "
-            "AND COALESCE(metadata->>'shared_in_stash_id', '') = ''",
+            "AND COALESCE(metadata->>'shared_in_stash_id', '') = '' "
+            "AND deleted_at IS NULL",
             folder_row["id"],
         )
         child_files = await pool.fetch(
-            "SELECT id FROM files WHERE folder_id = $1", folder_row["id"]
+            "SELECT id FROM files WHERE folder_id = $1 AND deleted_at IS NULL",
+            folder_row["id"],
         )
         folder_row["page_count"] = len(
             await files_tree_service._filter_readable(
@@ -490,13 +495,44 @@ async def delete_page(
         raise HTTPException(status_code=404, detail="Page not found")
 
 
+@router.post("/pages/{page_id}/restore", status_code=204)
+async def restore_page(
+    workspace_id: UUID,
+    page_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_ws_write(workspace_id, current_user["id"])
+    await _check_content_access(
+        "page", page_id, workspace_id, current_user["id"], require_write=True
+    )
+    restored = await files_tree_service.restore_page(page_id, workspace_id)
+    if not restored:
+        raise HTTPException(status_code=404, detail="Page not in trash")
+
+
+@router.delete("/pages/{page_id}/purge", status_code=204)
+async def purge_page(
+    workspace_id: UUID,
+    page_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Permanent delete — only callable on a page already in trash."""
+    await _check_ws_write(workspace_id, current_user["id"])
+    await _check_content_access(
+        "page", page_id, workspace_id, current_user["id"], require_write=True
+    )
+    purged = await files_tree_service.purge_page(page_id, workspace_id)
+    if not purged:
+        raise HTTPException(status_code=404, detail="Page not in trash")
+
+
 # --- Page comments ---
 
 
 async def _check_page_in_workspace(workspace_id: UUID, page_id: UUID) -> None:
     pool = get_pool()
     found = await pool.fetchval(
-        "SELECT 1 FROM pages WHERE id = $1 AND workspace_id = $2",
+        "SELECT 1 FROM pages WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         page_id,
         workspace_id,
     )

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -171,6 +171,79 @@ async def get_workspace_session(
     return payload
 
 
+async def _check_session_write(
+    workspace_id: UUID,
+    session_row_id: UUID,
+    user_id: UUID,
+) -> dict:
+    """Resolve a session row that the user is allowed to mutate.
+
+    Returns the raw row (including trashed). The trash flows need to
+    operate on rows the live-only `get_session_by_id` won't return.
+    """
+    if not await workspace_service.can_write(workspace_id, user_id):
+        raise HTTPException(
+            status_code=403, detail="Viewers can read but not modify sessions"
+        )
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id FROM sessions WHERE id = $1",
+        session_row_id,
+    )
+    if not row or row["workspace_id"] != workspace_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+    can_write = await permission_service.check_access(
+        "session",
+        session_row_id,
+        user_id,
+        workspace_id=workspace_id,
+        require_write=True,
+    )
+    if not can_write:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return dict(row)
+
+
+@router.delete("/workspaces/{workspace_id}/sessions/{session_row_id}", status_code=204)
+async def delete_workspace_session(
+    workspace_id: UUID,
+    session_row_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Soft delete: stamps deleted_at + deleted_by."""
+    await _check_session_write(workspace_id, session_row_id, current_user["id"])
+    deleted = await session_service.delete_session(
+        session_row_id, workspace_id, current_user["id"]
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+
+@router.post("/workspaces/{workspace_id}/sessions/{session_row_id}/restore", status_code=204)
+async def restore_workspace_session(
+    workspace_id: UUID,
+    session_row_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_session_write(workspace_id, session_row_id, current_user["id"])
+    restored = await session_service.restore_session(session_row_id, workspace_id)
+    if not restored:
+        raise HTTPException(status_code=404, detail="Session not in trash")
+
+
+@router.delete("/workspaces/{workspace_id}/sessions/{session_row_id}/purge", status_code=204)
+async def purge_workspace_session(
+    workspace_id: UUID,
+    session_row_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Permanent delete — only callable on a session already in trash."""
+    await _check_session_write(workspace_id, session_row_id, current_user["id"])
+    purged = await session_service.purge_session(session_row_id, workspace_id)
+    if not purged:
+        raise HTTPException(status_code=404, detail="Session not in trash")
+
+
 @router.post("/workspaces/{workspace_id}/sessions/{session_row_id}/artifacts", status_code=201)
 async def upload_session_artifact(
     workspace_id: UUID,
@@ -286,7 +359,8 @@ async def materialize_session(
     # the display name format without orphaning previously-materialized pages.
     existing = await pool.fetchrow(
         "SELECT id FROM pages "
-        "WHERE workspace_id = $1 AND folder_id = $2 AND metadata->>'session_id' = $3 LIMIT 1",
+        "WHERE workspace_id = $1 AND folder_id = $2 AND metadata->>'session_id' = $3 "
+        "AND deleted_at IS NULL LIMIT 1",
         workspace_id,
         folder["id"],
         session_id,

--- a/backend/routers/trash.py
+++ b/backend/routers/trash.py
@@ -1,0 +1,76 @@
+"""Trash router: aggregate listing of soft-deleted pages, files, and sessions."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user
+from ..database import get_pool
+from ..services import (
+    files_service,
+    files_tree_service,
+    session_service,
+    workspace_service,
+)
+
+router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}", tags=["trash"])
+
+
+async def _check_write(workspace_id: UUID, user_id: UUID) -> None:
+    if not await workspace_service.can_write(workspace_id, user_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Viewers can read but not modify trash",
+        )
+
+
+@router.get("/trash")
+async def list_trash(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Trash listing: pages + files + sessions, each sorted by deleted_at DESC.
+
+    Includes deleted_by display name so the UI can show "Deleted by Alice"
+    without a second round-trip.
+    """
+    await _check_write(workspace_id, current_user["id"])
+
+    pages = await files_tree_service.list_trashed_pages(workspace_id)
+    files = await files_service.list_trashed_files(workspace_id)
+    sessions = await session_service.list_trashed_sessions(workspace_id)
+
+    actor_ids = {
+        row["deleted_by"]
+        for row in pages + files + sessions
+        if row.get("deleted_by")
+    }
+    actors: dict[UUID, dict] = {}
+    if actor_ids:
+        pool = get_pool()
+        actor_rows = await pool.fetch(
+            "SELECT id, name, display_name FROM users WHERE id = ANY($1::uuid[])",
+            list(actor_ids),
+        )
+        actors = {
+            r["id"]: {"name": r["name"], "display_name": r["display_name"]}
+            for r in actor_rows
+        }
+
+    def _render(row: dict, name_key: str) -> dict:
+        actor = actors.get(row.get("deleted_by")) if row.get("deleted_by") else None
+        return {
+            "id": str(row["id"]),
+            "name": row[name_key],
+            "deleted_at": row["deleted_at"],
+            "deleted_by": str(row["deleted_by"]) if row.get("deleted_by") else None,
+            "deleted_by_name": (
+                actor["display_name"] or actor["name"] if actor else None
+            ),
+        }
+
+    return {
+        "pages": [_render(p, "name") for p in pages],
+        "files": [_render(f, "name") for f in files],
+        "sessions": [_render(s, "session_id") for s in sessions],
+    }

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -69,22 +69,27 @@ async def _files_tree(workspace_id: UUID, user_id: UUID) -> dict:
         pool.fetch(
             "SELECT f.id, f.name, f.parent_folder_id, "
             "       (SELECT COUNT(*) FROM pages p WHERE p.folder_id = f.id "
-            "        AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '') AS page_count, "
-            "       (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id) AS file_count, "
+            "        AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '' "
+            "        AND p.deleted_at IS NULL) AS page_count, "
+            "       (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id "
+            "        AND fi.deleted_at IS NULL) AS file_count, "
             "       EXISTS(SELECT 1 FROM pages p WHERE p.folder_id = f.id AND p.name = 'SKILL.md' "
-            "              AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '') AS has_skill "
+            "              AND COALESCE(p.metadata->>'shared_in_stash_id', '') = '' "
+            "              AND p.deleted_at IS NULL) AS has_skill "
             "FROM folders f WHERE f.workspace_id = $1 ORDER BY f.name",
             workspace_id,
         ),
         pool.fetch(
             "SELECT id, name, folder_id FROM pages WHERE workspace_id = $1 "
-            "AND COALESCE(metadata->>'shared_in_stash_id', '') = '' ORDER BY name",
+            "AND COALESCE(metadata->>'shared_in_stash_id', '') = '' "
+            "AND deleted_at IS NULL ORDER BY name",
             workspace_id,
         ),
         pool.fetch(
             "SELECT id, name, folder_id, size_bytes, content_type, "
             "       created_at, linked_table_id "
-            "FROM files WHERE workspace_id = $1 ORDER BY created_at DESC",
+            "FROM files WHERE workspace_id = $1 AND deleted_at IS NULL "
+            "ORDER BY created_at DESC",
             workspace_id,
         ),
     )
@@ -297,11 +302,13 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
         """
         SELECT
           (SELECT MAX(updated_at) FROM pages
-            WHERE workspace_id = $1 AND COALESCE(metadata->>'shared_in_stash_id', '') = '') AS p,
-          (SELECT MAX(created_at) FROM files WHERE workspace_id = $1)            AS f,
+            WHERE workspace_id = $1 AND COALESCE(metadata->>'shared_in_stash_id', '') = ''
+            AND deleted_at IS NULL) AS p,
+          (SELECT MAX(created_at) FROM files
+            WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS f,
           (SELECT MAX(updated_at) FROM folders WHERE workspace_id = $1)          AS d,
           (SELECT MAX(GREATEST(finished_at, started_at)) FROM sessions
-            WHERE workspace_id = $1)                                              AS s,
+            WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS s,
           (SELECT MAX(updated_at) FROM stashes WHERE workspace_id = $1)            AS st,
           (SELECT MAX(sm.created_at) FROM stash_members sm
            JOIN stashes s ON s.id = sm.stash_id

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -236,6 +236,7 @@ async def _list_files(args: dict) -> dict:
     user_id = _current_user()
     rows = await get_pool().fetch(
         "SELECT id, name, content_type, size_bytes FROM files WHERE workspace_id = $1 "
+        "AND deleted_at IS NULL "
         "ORDER BY created_at DESC LIMIT 50",
         workspace_id,
     )
@@ -276,7 +277,8 @@ async def _read_file(args: dict) -> dict:
     user_id = _current_user()
     file_id = UUID(args["file_id"])
     row = await get_pool().fetchrow(
-        "SELECT name, extracted_text FROM files WHERE id = $1 AND workspace_id = $2",
+        "SELECT name, extracted_text FROM files "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
         file_id,
         workspace_id,
     )

--- a/backend/services/files_service.py
+++ b/backend/services/files_service.py
@@ -1,0 +1,66 @@
+"""Files (uploaded blobs) soft-delete service.
+
+Mirrors files_tree_service for pages. Hard deletes (purge) also drop the
+S3 blob; soft deletes leave it intact so restore is fully reversible.
+"""
+
+from uuid import UUID
+
+from ..database import get_pool
+
+
+async def delete_file(file_id: UUID, workspace_id: UUID, deleted_by: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE files SET deleted_at = NOW(), deleted_by = $3 "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+        file_id,
+        workspace_id,
+        deleted_by,
+    )
+    return result == "UPDATE 1"
+
+
+async def restore_file(file_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE files SET deleted_at = NULL, deleted_by = NULL "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        file_id,
+        workspace_id,
+    )
+    return result == "UPDATE 1"
+
+
+async def get_trashed_file(file_id: UUID, workspace_id: UUID) -> dict | None:
+    """Return the trashed row (or None). Used by purge to grab storage_key."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, storage_key FROM files "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        file_id,
+        workspace_id,
+    )
+    return dict(row) if row else None
+
+
+async def purge_file(file_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "DELETE FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        file_id,
+        workspace_id,
+    )
+    return result == "DELETE 1"
+
+
+async def list_trashed_files(workspace_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, folder_id, name, content_type, size_bytes, "
+        "deleted_at, deleted_by "
+        "FROM files WHERE workspace_id = $1 AND deleted_at IS NOT NULL "
+        "ORDER BY deleted_at DESC",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -18,7 +18,11 @@ from . import permission_service
 
 logger = logging.getLogger(__name__)
 
-_WORKSPACE_PAGE_FILTER = "COALESCE(metadata->>'shared_in_stash_id', '') = ''"
+# Workspace-owned page (excludes the read-only stash mirror rows).
+_OWNED_PAGE_PRED = "COALESCE(metadata->>'shared_in_stash_id', '') = ''"
+# All "live" reads filter both stash-mirror and trash. Every SELECT on
+# pages that wants the active set uses this.
+_WORKSPACE_PAGE_FILTER = f"{_OWNED_PAGE_PRED} AND deleted_at IS NULL"
 
 
 async def _filter_readable(
@@ -479,14 +483,54 @@ async def update_page(
     raise ConcurrentEditError(dict(fresh))
 
 
-async def delete_page(page_id: UUID, workspace_id: UUID) -> bool:
+async def delete_page(page_id: UUID, workspace_id: UUID, deleted_by: UUID) -> bool:
+    """Soft delete: stamps deleted_at + deleted_by. Restore via restore_page."""
     pool = get_pool()
     result = await pool.execute(
-        f"DELETE FROM pages WHERE id = $1 AND workspace_id = $2 AND {_WORKSPACE_PAGE_FILTER}",
+        "UPDATE pages SET deleted_at = NOW(), deleted_by = $3 "
+        f"WHERE id = $1 AND workspace_id = $2 AND {_OWNED_PAGE_PRED} "
+        "AND deleted_at IS NULL",
+        page_id,
+        workspace_id,
+        deleted_by,
+    )
+    return result == "UPDATE 1"
+
+
+async def restore_page(page_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE pages SET deleted_at = NULL, deleted_by = NULL "
+        f"WHERE id = $1 AND workspace_id = $2 AND {_OWNED_PAGE_PRED} "
+        "AND deleted_at IS NOT NULL",
+        page_id,
+        workspace_id,
+    )
+    return result == "UPDATE 1"
+
+
+async def purge_page(page_id: UUID, workspace_id: UUID) -> bool:
+    """Permanent delete — only callable on a page already in trash."""
+    pool = get_pool()
+    result = await pool.execute(
+        f"DELETE FROM pages WHERE id = $1 AND workspace_id = $2 AND {_OWNED_PAGE_PRED} "
+        "AND deleted_at IS NOT NULL",
         page_id,
         workspace_id,
     )
     return result == "DELETE 1"
+
+
+async def list_trashed_pages(workspace_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, folder_id, name, content_type, deleted_at, deleted_by "
+        f"FROM pages WHERE workspace_id = $1 AND {_OWNED_PAGE_PRED} "
+        "AND deleted_at IS NOT NULL "
+        "ORDER BY deleted_at DESC",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]
 
 
 # --- Listings ---

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -242,6 +242,7 @@ def readable_session_event_condition(event_alias: str, user_arg: int) -> str:
             FROM sessions readable_session
             WHERE readable_session.workspace_id = {event_alias}.workspace_id
               AND readable_session.session_id = {event_alias}.session_id
+              AND readable_session.deleted_at IS NULL
               AND (
                 NOT EXISTS (
                   SELECT 1

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -91,3 +91,59 @@ async def set_files_touched(session_row_id: UUID, files: list[str]) -> None:
         json.dumps(files),
         session_row_id,
     )
+
+
+async def delete_session(session_row_id: UUID, workspace_id: UUID, deleted_by: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE sessions SET deleted_at = NOW(), deleted_by = $3 "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+        session_row_id,
+        workspace_id,
+        deleted_by,
+    )
+    return result == "UPDATE 1"
+
+
+async def restore_session(session_row_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE sessions SET deleted_at = NULL, deleted_by = NULL "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        session_row_id,
+        workspace_id,
+    )
+    return result == "UPDATE 1"
+
+
+async def purge_session(session_row_id: UUID, workspace_id: UUID) -> bool:
+    pool = get_pool()
+    result = await pool.execute(
+        "DELETE FROM sessions WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        session_row_id,
+        workspace_id,
+    )
+    return result == "DELETE 1"
+
+
+async def list_trashed_sessions(workspace_id: UUID) -> list[dict]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, workspace_id, session_id, agent_name, summary, "
+        "started_at, finished_at, deleted_at, deleted_by "
+        "FROM sessions WHERE workspace_id = $1 AND deleted_at IS NOT NULL "
+        "ORDER BY deleted_at DESC",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def get_trashed_session(session_row_id: UUID, workspace_id: UUID) -> dict | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        f"SELECT {_SELECT_COLS} FROM sessions "
+        "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NOT NULL",
+        session_row_id,
+        workspace_id,
+    )
+    return dict(row) if row else None

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -54,7 +54,8 @@ async def upsert_session(
 async def get_session(workspace_id: UUID, session_id: str) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        f"SELECT {_SELECT_COLS} " "FROM sessions WHERE workspace_id = $1 AND session_id = $2",
+        f"SELECT {_SELECT_COLS} FROM sessions "
+        "WHERE workspace_id = $1 AND session_id = $2 AND deleted_at IS NULL",
         workspace_id,
         session_id,
     )
@@ -64,7 +65,7 @@ async def get_session(workspace_id: UUID, session_id: str) -> dict | None:
 async def get_session_by_id(session_row_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        f"SELECT {_SELECT_COLS} FROM sessions WHERE id = $1",
+        f"SELECT {_SELECT_COLS} FROM sessions WHERE id = $1 AND deleted_at IS NULL",
         session_row_id,
     )
     return dict(row) if row else None

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -51,9 +51,10 @@ async def list_skills(workspace_id: UUID, user_id: UUID) -> list[dict]:
     rows = await pool.fetch(
         "SELECT f.id AS folder_id, f.name AS folder_name, "
         "  p.id AS skill_md_id, p.content_markdown AS skill_md, p.updated_at, "
-        "  (SELECT COUNT(*) FROM pages p2 WHERE p2.folder_id = f.id) AS file_count "
+        "  (SELECT COUNT(*) FROM pages p2 WHERE p2.folder_id = f.id "
+        "   AND p2.deleted_at IS NULL) AS file_count "
         "FROM folders f "
-        "JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' "
+        "JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL "
         "WHERE f.workspace_id = $1 "
         "ORDER BY f.name",
         workspace_id,
@@ -112,7 +113,7 @@ async def read_skill(workspace_id: UUID, name: str, user_id: UUID) -> dict | Non
     folder_id = match["folder_id"]
     pages = await pool.fetch(
         "SELECT id, name, content_markdown, updated_at "
-        "FROM pages WHERE folder_id = $1 ORDER BY name",
+        "FROM pages WHERE folder_id = $1 AND deleted_at IS NULL ORDER BY name",
         UUID(folder_id),
     )
     readable_pages = []

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -126,10 +126,10 @@ async def _partition_targets(conn, object_type: str, object_id: UUID) -> list[tu
             "SELECT 'folder' AS object_type, id AS object_id FROM subtree "
             "UNION ALL "
             "SELECT 'page' AS object_type, p.id AS object_id FROM pages p "
-            "WHERE p.folder_id IN (SELECT id FROM subtree) "
+            "WHERE p.folder_id IN (SELECT id FROM subtree) AND p.deleted_at IS NULL "
             "UNION ALL "
             "SELECT 'file' AS object_type, f.id AS object_id FROM files f "
-            "WHERE f.folder_id IN (SELECT id FROM subtree)",
+            "WHERE f.folder_id IN (SELECT id FROM subtree) AND f.deleted_at IS NULL",
             object_id,
         )
         targets.extend((row["object_type"], row["object_id"]) for row in rows)
@@ -237,14 +237,20 @@ async def _object_title(object_type: str, object_id: UUID) -> str:
     if object_type == "folder":
         row = await pool.fetchrow("SELECT name FROM folders WHERE id = $1", object_id)
     elif object_type == "page":
-        row = await pool.fetchrow("SELECT name FROM pages WHERE id = $1", object_id)
+        row = await pool.fetchrow(
+            "SELECT name FROM pages WHERE id = $1 AND deleted_at IS NULL", object_id
+        )
     elif object_type == "table":
         row = await pool.fetchrow("SELECT name FROM tables WHERE id = $1", object_id)
     elif object_type == "file":
-        row = await pool.fetchrow("SELECT name FROM files WHERE id = $1", object_id)
+        row = await pool.fetchrow(
+            "SELECT name FROM files WHERE id = $1 AND deleted_at IS NULL", object_id
+        )
     elif object_type == "session":
         row = await pool.fetchrow(
-            "SELECT session_id AS name FROM sessions WHERE id = $1", object_id
+            "SELECT session_id AS name FROM sessions "
+            "WHERE id = $1 AND deleted_at IS NULL",
+            object_id,
         )
     else:
         row = None
@@ -338,7 +344,8 @@ async def add_sessions_to_stash(
 
     rows = await pool.fetch(
         "SELECT id, session_id FROM sessions "
-        "WHERE workspace_id = $1 AND session_id = ANY($2::varchar[])",
+        "WHERE workspace_id = $1 AND session_id = ANY($2::varchar[]) "
+        "AND deleted_at IS NULL",
         workspace_id,
         session_ids,
     )
@@ -972,6 +979,7 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                     "SELECT p.id, p.name, p.content_markdown, p.content_html, p.content_type, "
                     "p.html_layout, p.updated_at FROM pages p "
                     "WHERE p.folder_id IN (SELECT id FROM subtree) "
+                    "AND p.deleted_at IS NULL "
                     "ORDER BY p.created_at, p.name",
                     obj_id,
                 )
@@ -989,6 +997,7 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                     ") "
                     "SELECT f.id, f.name, f.content_type, f.size_bytes, f.storage_key, f.created_at "
                     "FROM files f WHERE f.folder_id IN (SELECT id FROM subtree) "
+                    "AND f.deleted_at IS NULL "
                     "ORDER BY f.created_at, f.name",
                     obj_id,
                 )
@@ -1026,7 +1035,7 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
         elif obj_type == "page":
             p = await pool.fetchrow(
                 "SELECT id, name, content_markdown, content_html, content_type, "
-                "html_layout, updated_at FROM pages WHERE id = $1",
+                "html_layout, updated_at FROM pages WHERE id = $1 AND deleted_at IS NULL",
                 obj_id,
             )
             if p:
@@ -1060,7 +1069,8 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                 }
         elif obj_type == "file":
             f = await pool.fetchrow(
-                "SELECT name, content_type, size_bytes, storage_key, created_at FROM files WHERE id = $1",
+                "SELECT name, content_type, size_bytes, storage_key, created_at "
+                "FROM files WHERE id = $1 AND deleted_at IS NULL",
                 obj_id,
             )
             if f:
@@ -1075,7 +1085,7 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
         elif obj_type == "session":
             s = await pool.fetchrow(
                 "SELECT id, session_id, agent_name, summary, summary_status, files_touched, started_at, "
-                "finished_at FROM sessions WHERE id = $1",
+                "finished_at FROM sessions WHERE id = $1 AND deleted_at IS NULL",
                 obj_id,
             )
             if s:

--- a/backend/workers/embedding_reconciler.py
+++ b/backend/workers/embedding_reconciler.py
@@ -33,7 +33,8 @@ def _text_hash(text: str) -> str:
 async def _reconcile_pages() -> int:
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT id, content_markdown FROM pages WHERE embed_stale LIMIT $1",
+        "SELECT id, content_markdown FROM pages "
+        "WHERE embed_stale AND deleted_at IS NULL LIMIT $1",
         BATCH_SIZE,
     )
     if not rows:

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -55,7 +55,8 @@ async def _run(file_id: UUID) -> int:
     conn = await asyncpg.connect(settings.DATABASE_URL)
     try:
         row = await conn.fetchrow(
-            "SELECT id, storage_key, content_type, extraction_attempts " "FROM files WHERE id = $1",
+            "SELECT id, storage_key, content_type, extraction_attempts "
+            "FROM files WHERE id = $1 AND deleted_at IS NULL",
             file_id,
         )
         if not row:

--- a/backend/workers/session_summarizer.py
+++ b/backend/workers/session_summarizer.py
@@ -187,6 +187,7 @@ async def _tick() -> int:
             SELECT id FROM sessions
             WHERE summary IS NULL
               AND summary_status = 'need_summary'
+              AND deleted_at IS NULL
               AND summary_attempts < $1
               AND (
                     summary_last_attempt_at IS NULL

--- a/cli/client.py
+++ b/cli/client.py
@@ -333,6 +333,12 @@ class StashClient:
     def delete_page(self, workspace_id: str, page_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}")
 
+    def restore_page(self, workspace_id: str, page_id: str) -> None:
+        self._post(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/restore")
+
+    def purge_page(self, workspace_id: str, page_id: str) -> None:
+        self._delete(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/purge")
+
     # --- Session events ---
 
     def list_agent_names(self, workspace_id: str) -> list:
@@ -475,6 +481,12 @@ class StashClient:
     def delete_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/files/{file_id}")
 
+    def restore_ws_file(self, workspace_id: str, file_id: str) -> None:
+        self._post(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/restore")
+
+    def purge_ws_file(self, workspace_id: str, file_id: str) -> None:
+        self._delete(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/purge")
+
     def update_ws_file(
         self,
         workspace_id: str,
@@ -575,6 +587,23 @@ class StashClient:
     def delete_table_column(self, workspace_id: str, table_id: str, column_id: str) -> dict:
         base = f"/api/v1/workspaces/{workspace_id}/tables"
         return self._request("DELETE", f"{base}/{table_id}/columns/{column_id}").json()
+
+    # --- Sessions ---
+
+    def delete_session(self, workspace_id: str, session_row_id: str) -> None:
+        self._delete(f"/api/v1/workspaces/{workspace_id}/sessions/{session_row_id}")
+
+    def restore_session(self, workspace_id: str, session_row_id: str) -> None:
+        self._post(f"/api/v1/workspaces/{workspace_id}/sessions/{session_row_id}/restore")
+
+    def purge_session(self, workspace_id: str, session_row_id: str) -> None:
+        self._delete(f"/api/v1/workspaces/{workspace_id}/sessions/{session_row_id}/purge")
+
+    # --- Trash ---
+
+    def get_trash(self, workspace_id: str) -> dict:
+        data = self._get(f"/api/v1/workspaces/{workspace_id}/trash")
+        return data if isinstance(data, dict) else {}
 
     def publish(
         self,

--- a/cli/main.py
+++ b/cli/main.py
@@ -2343,6 +2343,93 @@ def hist_import(
             )
 
 
+@hist_app.command("delete")
+def hist_delete(
+    session_row_id: str = typer.Argument(..., help="Session row id (UUID), not session_id."),
+    workspace_id: str = typer.Option(None, "--ws"),
+    permanent: bool = typer.Option(False, "--permanent"),
+):
+    """Move a session to trash. Pass --permanent to wipe it without going through trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.delete_session(ws, session_row_id)
+            if permanent:
+                c.purge_session(ws, session_row_id)
+        except StashError as e:
+            _err(e)
+    console.print(
+        "[green]Session permanently deleted.[/green]" if permanent
+        else "[green]Session moved to trash.[/green]"
+    )
+
+
+@hist_app.command("restore")
+def hist_restore(
+    session_row_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Restore a session from trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.restore_session(ws, session_row_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]Session restored.[/green]")
+
+
+@hist_app.command("purge")
+def hist_purge(
+    session_row_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Permanently delete a session already in trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.purge_session(ws, session_row_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]Session permanently deleted.[/green]")
+
+
+# ===========================================================================
+# Trash
+# ===========================================================================
+
+trash_app = typer.Typer(help="Trash — soft-deleted pages, files, and sessions.")
+app.add_typer(trash_app, name="trash")
+
+
+@trash_app.command("list")
+def trash_list(
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """List trashed pages, files, and sessions in this workspace."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            data = c.get_trash(ws)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+        return
+    for kind in ("pages", "files", "sessions"):
+        items = data.get(kind, [])
+        console.print(f"\n[bold]{kind.capitalize()} ({len(items)})[/bold]")
+        if not items:
+            console.print("  [dim]empty[/dim]")
+            continue
+        for item in items:
+            who = item.get("deleted_by_name") or "unknown"
+            console.print(
+                f"  {item['id']}  {item['name']}  [dim](deleted {item['deleted_at'][:19]} by {who})[/dim]"
+            )
+
+
 # ===========================================================================
 # Tables
 # ===========================================================================
@@ -2963,15 +3050,106 @@ def files_edit_file(
 def files_rm(
     file_id: str = typer.Argument(...),
     workspace_id: str = typer.Option(None, "--ws"),
+    permanent: bool = typer.Option(
+        False,
+        "--permanent",
+        help="Trash and then immediately purge — skips the recoverable trash window.",
+    ),
 ):
-    """Delete a file."""
+    """Move a file to trash. Pass --permanent to wipe it without going through trash."""
     ws = workspace_id or _resolve_workspace()
     with _client() as c:
         try:
             c.delete_ws_file(ws, file_id)
+            if permanent:
+                c.purge_ws_file(ws, file_id)
         except StashError as e:
             _err(e)
-    console.print("[green]File deleted.[/green]")
+    console.print(
+        "[green]File permanently deleted.[/green]" if permanent
+        else "[green]File moved to trash.[/green]"
+    )
+
+
+@files_app.command("restore")
+def files_restore(
+    file_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Restore a file from trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.restore_ws_file(ws, file_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]File restored.[/green]")
+
+
+@files_app.command("purge")
+def files_purge(
+    file_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Permanently delete a file already in trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.purge_ws_file(ws, file_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]File permanently deleted.[/green]")
+
+
+@files_app.command("rm-page")
+def files_rm_page(
+    page_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    permanent: bool = typer.Option(False, "--permanent"),
+):
+    """Move a page to trash. Pass --permanent to wipe it without going through trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.delete_page(ws, page_id)
+            if permanent:
+                c.purge_page(ws, page_id)
+        except StashError as e:
+            _err(e)
+    console.print(
+        "[green]Page permanently deleted.[/green]" if permanent
+        else "[green]Page moved to trash.[/green]"
+    )
+
+
+@files_app.command("restore-page")
+def files_restore_page(
+    page_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Restore a page from trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.restore_page(ws, page_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]Page restored.[/green]")
+
+
+@files_app.command("purge-page")
+def files_purge_page(
+    page_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Permanently delete a page already in trash."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            c.purge_page(ws, page_id)
+        except StashError as e:
+            _err(e)
+    console.print("[green]Page permanently deleted.[/green]")
 
 
 @files_app.command("text")

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -619,6 +619,52 @@ def stash_publish_markdown(
     )
 
 
+# ── Trash ─────────────────────────────────────────────────────────
+
+
+_TRASH_KINDS = {"page", "file", "session"}
+
+
+@mcp.tool()
+def list_trash(workspace_id: str = "") -> str:
+    """List soft-deleted pages, files, and sessions. Items can be restored or purged."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.get_trash(ws))
+
+
+@mcp.tool()
+def restore_object(kind: str, id: str, workspace_id: str = "") -> str:
+    """Restore a trashed page/file/session. `kind` is one of: page, file, session."""
+    if kind not in _TRASH_KINDS:
+        raise ValueError(f"kind must be one of {sorted(_TRASH_KINDS)}")
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    if kind == "page":
+        client.restore_page(ws, id)
+    elif kind == "file":
+        client.restore_ws_file(ws, id)
+    else:
+        client.restore_session(ws, id)
+    return _json({"ok": True, "kind": kind, "id": id})
+
+
+@mcp.tool()
+def purge_object(kind: str, id: str, workspace_id: str = "") -> str:
+    """Permanently delete a trashed page/file/session. Not reversible."""
+    if kind not in _TRASH_KINDS:
+        raise ValueError(f"kind must be one of {sorted(_TRASH_KINDS)}")
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    if kind == "page":
+        client.purge_page(ws, id)
+    elif kind == "file":
+        client.purge_ws_file(ws, id)
+    else:
+        client.purge_session(ws, id)
+    return _json({"ok": True, "kind": kind, "id": id})
+
+
 # ── Entry point ───────────────────────────────────────────────────
 
 

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -214,7 +214,7 @@ function FileViewerPageInner() {
         downloadOptions={
           file?.url
             ? [
-                { label: `Download ${file.name}`, onSelect: () => triggerDownload(file.url, file.name) },
+                { label: "Download", onSelect: () => triggerDownload(file.url, file.name) },
                 ...(readOnly
                   ? []
                   : [

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -11,6 +11,7 @@ import {
   getFolderContents,
   getPublicStash,
   ingestCsvFile,
+  trashItem,
   updateFile,
   type FolderBreadcrumb,
 } from "../../../../../lib/api";
@@ -212,7 +213,26 @@ function FileViewerPageInner() {
         meta={meta}
         downloadOptions={
           file?.url
-            ? [{ label: `Download ${file.name}`, onSelect: () => triggerDownload(file.url, file.name) }]
+            ? [
+                { label: `Download ${file.name}`, onSelect: () => triggerDownload(file.url, file.name) },
+                ...(readOnly
+                  ? []
+                  : [
+                      {
+                        label: "Delete",
+                        destructive: true,
+                        onSelect: async () => {
+                          if (!window.confirm(`Move "${file.name}" to trash?`)) return;
+                          try {
+                            await trashItem(workspaceId, "file", fileId);
+                            router.push(`/workspaces/${workspaceId}`);
+                          } catch (e) {
+                            setError(e instanceof Error ? e.message : "Delete failed");
+                          }
+                        },
+                      },
+                    ]),
+              ]
             : undefined
         }
       />

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -331,7 +331,7 @@ export default function StashPageView() {
           page
             ? [
                 {
-                  label: "Markdown (.md)",
+                  label: "Download as Markdown",
                   onSelect: () =>
                     downloadBlob(
                       page.content_markdown ?? "",
@@ -340,7 +340,7 @@ export default function StashPageView() {
                     ),
                 },
                 {
-                  label: "HTML (.html)",
+                  label: "Download as HTML",
                   onSelect: () =>
                     downloadBlob(
                       wrapHtml(page.name, page.content_html ?? ""),
@@ -348,7 +348,7 @@ export default function StashPageView() {
                       `${baseName}.html`
                     ),
                 },
-                { label: "PDF (print)", onSelect: () => window.print() },
+                { label: "Print as PDF", onSelect: () => window.print() },
                 {
                   label: "Delete",
                   destructive: true,

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -29,6 +29,7 @@ import {
   reconcileCommentAnchors,
   replyToCommentThread,
   setCommentResolved,
+  trashItem,
   updatePage,
   type FolderBreadcrumb,
   type WorkspaceStash,
@@ -348,6 +349,19 @@ export default function StashPageView() {
                     ),
                 },
                 { label: "PDF (print)", onSelect: () => window.print() },
+                {
+                  label: "Delete",
+                  destructive: true,
+                  onSelect: async () => {
+                    if (!window.confirm(`Move "${page.name}" to trash?`)) return;
+                    try {
+                      await trashItem(workspaceId, "page", pageId);
+                      router.push(`/workspaces/${workspaceId}`);
+                    } catch (e) {
+                      setError(e instanceof Error ? e.message : "Delete failed");
+                    }
+                  },
+                },
               ]
             : undefined
         }

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -173,7 +173,7 @@ export default function SessionViewerPage() {
               <DownloadMenu
                 options={[
                   {
-                    label: "JSONL transcript",
+                    label: "Download transcript (.jsonl)",
                     onSelect: async () => {
                       const path = `/api/v1/workspaces/${workspaceId}/transcripts/${encodeURIComponent(
                         sessionId

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -12,6 +12,7 @@ import {
   getSessionEvents,
   getWorkspaceSidebar,
   listObjectStashes,
+  trashItem,
   type SessionDetail,
   type SessionEvent,
   type WorkspaceStash,
@@ -190,6 +191,30 @@ export default function SessionViewerPage() {
                       URL.revokeObjectURL(url);
                     },
                   },
+                  ...(sessionDetail
+                    ? [
+                        {
+                          label: "Delete",
+                          destructive: true,
+                          onSelect: async () => {
+                            if (
+                              !window.confirm(
+                                `Move session "${sessionId}" to trash?`
+                              )
+                            )
+                              return;
+                            try {
+                              await trashItem(workspaceId, "session", sessionDetail.id);
+                              router.push(`/workspaces/${workspaceId}/sessions`);
+                            } catch (e) {
+                              setError(
+                                e instanceof Error ? e.message : "Delete failed"
+                              );
+                            }
+                          },
+                        },
+                      ]
+                    : []),
                 ]}
               />
             </div>

--- a/frontend/src/app/workspaces/[workspaceId]/trash/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/trash/page.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
+import { useAuth } from "../../../../hooks/useAuth";
+import { getTrash, purgeItem, restoreItem } from "../../../../lib/api";
+import type { TrashEntry, TrashKind, TrashListing } from "../../../../lib/types";
+
+type RowKind = TrashKind;
+
+const SECTION_TITLES: Record<RowKind, string> = {
+  page: "Pages",
+  file: "Files",
+  session: "Sessions",
+};
+
+export default function TrashPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+  const { user, loading } = useAuth();
+
+  const [data, setData] = useState<TrashListing | null>(null);
+  const [error, setError] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useBreadcrumbs([{ label: "Trash" }], `${workspaceId}/trash`);
+
+  const load = useCallback(async () => {
+    try {
+      setData(await getTrash(workspaceId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load trash");
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (user) load();
+  }, [user, load]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  async function handleRestore(kind: RowKind, id: string) {
+    setBusyId(id);
+    setError("");
+    try {
+      await restoreItem(workspaceId, kind, id);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Restore failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handlePurge(kind: RowKind, id: string, name: string) {
+    if (!window.confirm(`Permanently delete "${name}"? This cannot be undone.`)) return;
+    setBusyId(id);
+    setError("");
+    try {
+      await purgeItem(workspaceId, kind, id);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Permanent delete failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (loading || !data)
+    return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
+  if (!user) return null;
+
+  const total = data.pages.length + data.files.length + data.sessions.length;
+
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-12 py-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
+            Trash
+          </h1>
+          <span className="sys-label" style={{ fontSize: 10.5 }}>
+            {total} item{total === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        <p className="mt-2 text-[13px] text-muted">
+          Items here are recoverable. Permanent delete cannot be undone.
+        </p>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col gap-6">
+          {(["page", "file", "session"] as const).map((kind) => (
+            <TrashSection
+              key={kind}
+              title={SECTION_TITLES[kind]}
+              kind={kind}
+              entries={data[`${kind}s`]}
+              busyId={busyId}
+              onRestore={handleRestore}
+              onPurge={handlePurge}
+            />
+          ))}
+          {total === 0 && (
+            <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-8 text-center text-[12.5px] text-muted">
+              Nothing in trash.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TrashSection({
+  title,
+  kind,
+  entries,
+  busyId,
+  onRestore,
+  onPurge,
+}: {
+  title: string;
+  kind: RowKind;
+  entries: TrashEntry[];
+  busyId: string | null;
+  onRestore: (kind: RowKind, id: string) => void;
+  onPurge: (kind: RowKind, id: string, name: string) => void;
+}) {
+  if (entries.length === 0) return null;
+  return (
+    <section>
+      <h2 className="mb-2 font-display text-[15px] font-semibold text-foreground">
+        {title} <span className="text-muted">({entries.length})</span>
+      </h2>
+      <div className="overflow-hidden rounded-lg border border-border bg-surface">
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className="flex items-center gap-3 border-b border-border px-4 py-2.5 text-[13px] last:border-b-0"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-medium text-foreground">{entry.name}</div>
+              <div className="mt-0.5 truncate text-[11.5px] text-muted">
+                Deleted {formatRelative(entry.deleted_at)}
+                {entry.deleted_by_name ? ` by ${entry.deleted_by_name}` : ""}
+              </div>
+            </div>
+            <button
+              type="button"
+              disabled={busyId === entry.id}
+              onClick={() => onRestore(kind, entry.id)}
+              className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+            >
+              Restore
+            </button>
+            <button
+              type="button"
+              disabled={busyId === entry.id}
+              onClick={() => onPurge(kind, entry.id, entry.name)}
+              className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+            >
+              Delete forever
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 7) return `${diffD}d ago`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/frontend/src/app/workspaces/[workspaceId]/trash/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/trash/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import { useAuth } from "../../../../hooks/useAuth";
 import { getTrash, purgeItem, restoreItem } from "../../../../lib/api";
@@ -15,6 +15,12 @@ const SECTION_TITLES: Record<RowKind, string> = {
   session: "Sessions",
 };
 
+// Selection keys are kind-namespaced because page + file UUIDs can collide
+// in trash listings.
+function key(kind: RowKind, id: string) {
+  return `${kind}:${id}`;
+}
+
 export default function TrashPage() {
   const params = useParams();
   const router = useRouter();
@@ -24,6 +30,8 @@ export default function TrashPage() {
   const [data, setData] = useState<TrashListing | null>(null);
   const [error, setError] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   useBreadcrumbs([{ label: "Trash" }], `${workspaceId}/trash`);
 
@@ -42,6 +50,51 @@ export default function TrashPage() {
   useEffect(() => {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
+
+  // Drop stale selections when the trash listing changes (item restored
+  // by someone else, list refreshed, etc.).
+  useEffect(() => {
+    if (!data) return;
+    const live = new Set<string>();
+    for (const k of ["page", "file", "session"] as const) {
+      for (const e of data[`${k}s`]) live.add(key(k, e.id));
+    }
+    setSelected((cur) => {
+      const next = new Set<string>();
+      cur.forEach((k) => {
+        if (live.has(k)) next.add(k);
+      });
+      return next.size === cur.size ? cur : next;
+    });
+  }, [data]);
+
+  function toggleOne(kind: RowKind, id: string) {
+    setSelected((cur) => {
+      const next = new Set(cur);
+      const k = key(kind, id);
+      if (next.has(k)) next.delete(k);
+      else next.add(k);
+      return next;
+    });
+  }
+
+  function toggleSection(kind: RowKind, entries: TrashEntry[]) {
+    const ids = entries.map((e) => key(kind, e.id));
+    setSelected((cur) => {
+      const next = new Set(cur);
+      const allSelected = ids.every((k) => next.has(k));
+      if (allSelected) ids.forEach((k) => next.delete(k));
+      else ids.forEach((k) => next.add(k));
+      return next;
+    });
+  }
+
+  function toggleAll(all: { kind: RowKind; id: string }[]) {
+    setSelected((cur) => {
+      if (cur.size === all.length) return new Set();
+      return new Set(all.map((x) => key(x.kind, x.id)));
+    });
+  }
 
   async function handleRestore(kind: RowKind, id: string) {
     setBusyId(id);
@@ -70,11 +123,76 @@ export default function TrashPage() {
     }
   }
 
+  // Parse each "kind:id" selection back into a typed call. Bulk ops are
+  // a simple Promise.all — if anything fails we surface the first error
+  // and reload to show the consistent post-operation state.
+  function parseSelection(): { kind: RowKind; id: string }[] {
+    const out: { kind: RowKind; id: string }[] = [];
+    selected.forEach((k) => {
+      const [kind, id] = k.split(":") as [RowKind, string];
+      if (kind === "page" || kind === "file" || kind === "session") {
+        out.push({ kind, id });
+      }
+    });
+    return out;
+  }
+
+  async function handleBulkRestore() {
+    const items = parseSelection();
+    if (items.length === 0) return;
+    setBulkBusy(true);
+    setError("");
+    try {
+      await Promise.all(items.map((it) => restoreItem(workspaceId, it.kind, it.id)));
+      setSelected(new Set());
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Bulk restore failed");
+      await load();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function handleBulkPurge() {
+    const items = parseSelection();
+    if (items.length === 0) return;
+    if (
+      !window.confirm(
+        `Permanently delete ${items.length} item${items.length === 1 ? "" : "s"}? This cannot be undone.`
+      )
+    )
+      return;
+    setBulkBusy(true);
+    setError("");
+    try {
+      await Promise.all(items.map((it) => purgeItem(workspaceId, it.kind, it.id)));
+      setSelected(new Set());
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Bulk delete failed");
+      await load();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  const allItems = useMemo(() => {
+    if (!data) return [];
+    return [
+      ...data.pages.map((e) => ({ kind: "page" as const, id: e.id })),
+      ...data.files.map((e) => ({ kind: "file" as const, id: e.id })),
+      ...data.sessions.map((e) => ({ kind: "session" as const, id: e.id })),
+    ];
+  }, [data]);
+
   if (loading || !data)
     return <div className="flex h-screen items-center justify-center text-muted">Loading…</div>;
   if (!user) return null;
 
-  const total = data.pages.length + data.files.length + data.sessions.length;
+  const total = allItems.length;
+  const allChecked = total > 0 && selected.size === total;
+  const someChecked = selected.size > 0 && !allChecked;
 
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
@@ -98,7 +216,46 @@ export default function TrashPage() {
           </div>
         )}
 
-        <div className="mt-6 flex flex-col gap-6">
+        {total > 0 && (
+          <div className="mt-6 flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-2.5 text-[13px]">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-foreground">
+              <input
+                ref={(el) => {
+                  if (el) el.indeterminate = someChecked;
+                }}
+                type="checkbox"
+                checked={allChecked}
+                onChange={() => toggleAll(allItems)}
+                className="h-4 w-4 rounded border-border accent-[var(--color-brand-600)]"
+                aria-label="Select all trashed items"
+              />
+              <span className="text-muted">
+                {selected.size === 0
+                  ? "Select all"
+                  : `${selected.size} of ${total} selected`}
+              </span>
+            </label>
+            <span className="flex-1" />
+            <button
+              type="button"
+              disabled={bulkBusy || selected.size === 0}
+              onClick={handleBulkRestore}
+              className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+            >
+              Restore {selected.size > 0 ? `(${selected.size})` : ""}
+            </button>
+            <button
+              type="button"
+              disabled={bulkBusy || selected.size === 0}
+              onClick={handleBulkPurge}
+              className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+            >
+              Delete forever {selected.size > 0 ? `(${selected.size})` : ""}
+            </button>
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-col gap-6">
           {(["page", "file", "session"] as const).map((kind) => (
             <TrashSection
               key={kind}
@@ -106,6 +263,10 @@ export default function TrashPage() {
               kind={kind}
               entries={data[`${kind}s`]}
               busyId={busyId}
+              bulkBusy={bulkBusy}
+              selected={selected}
+              onToggle={toggleOne}
+              onToggleSection={toggleSection}
               onRestore={handleRestore}
               onPurge={handlePurge}
             />
@@ -126,6 +287,10 @@ function TrashSection({
   kind,
   entries,
   busyId,
+  bulkBusy,
+  selected,
+  onToggle,
+  onToggleSection,
   onRestore,
   onPurge,
 }: {
@@ -133,46 +298,76 @@ function TrashSection({
   kind: RowKind;
   entries: TrashEntry[];
   busyId: string | null;
+  bulkBusy: boolean;
+  selected: Set<string>;
+  onToggle: (kind: RowKind, id: string) => void;
+  onToggleSection: (kind: RowKind, entries: TrashEntry[]) => void;
   onRestore: (kind: RowKind, id: string) => void;
   onPurge: (kind: RowKind, id: string, name: string) => void;
 }) {
   if (entries.length === 0) return null;
+  const sectionSelected = entries.filter((e) => selected.has(key(kind, e.id))).length;
+  const allSel = sectionSelected === entries.length;
+  const someSel = sectionSelected > 0 && !allSel;
   return (
     <section>
-      <h2 className="mb-2 font-display text-[15px] font-semibold text-foreground">
+      <h2 className="mb-2 flex items-center gap-2 font-display text-[15px] font-semibold text-foreground">
+        <input
+          ref={(el) => {
+            if (el) el.indeterminate = someSel;
+          }}
+          type="checkbox"
+          checked={allSel}
+          onChange={() => onToggleSection(kind, entries)}
+          className="h-4 w-4 rounded border-border accent-[var(--color-brand-600)]"
+          aria-label={`Select all ${title.toLowerCase()}`}
+        />
         {title} <span className="text-muted">({entries.length})</span>
       </h2>
       <div className="overflow-hidden rounded-lg border border-border bg-surface">
-        {entries.map((entry) => (
-          <div
-            key={entry.id}
-            className="flex items-center gap-3 border-b border-border px-4 py-2.5 text-[13px] last:border-b-0"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="truncate font-medium text-foreground">{entry.name}</div>
-              <div className="mt-0.5 truncate text-[11.5px] text-muted">
-                Deleted {formatRelative(entry.deleted_at)}
-                {entry.deleted_by_name ? ` by ${entry.deleted_by_name}` : ""}
+        {entries.map((entry) => {
+          const isSel = selected.has(key(kind, entry.id));
+          return (
+            <div
+              key={entry.id}
+              className={
+                "flex items-center gap-3 border-b border-border px-4 py-2.5 text-[13px] last:border-b-0 " +
+                (isSel ? "bg-[var(--color-brand-50)]/40" : "")
+              }
+            >
+              <input
+                type="checkbox"
+                checked={isSel}
+                onChange={() => onToggle(kind, entry.id)}
+                className="h-4 w-4 rounded border-border accent-[var(--color-brand-600)]"
+                aria-label={`Select ${entry.name}`}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium text-foreground">{entry.name}</div>
+                <div className="mt-0.5 truncate text-[11.5px] text-muted">
+                  Deleted {formatRelative(entry.deleted_at)}
+                  {entry.deleted_by_name ? ` by ${entry.deleted_by_name}` : ""}
+                </div>
               </div>
+              <button
+                type="button"
+                disabled={busyId === entry.id || bulkBusy}
+                onClick={() => onRestore(kind, entry.id)}
+                className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+              >
+                Restore
+              </button>
+              <button
+                type="button"
+                disabled={busyId === entry.id || bulkBusy}
+                onClick={() => onPurge(kind, entry.id, entry.name)}
+                className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+              >
+                Delete forever
+              </button>
             </div>
-            <button
-              type="button"
-              disabled={busyId === entry.id}
-              onClick={() => onRestore(kind, entry.id)}
-              className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
-            >
-              Restore
-            </button>
-            <button
-              type="button"
-              disabled={busyId === entry.id}
-              onClick={() => onPurge(kind, entry.id, entry.name)}
-              className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
-            >
-              Delete forever
-            </button>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -41,6 +41,7 @@ import {
   SettingsIcon,
   StashIcon,
   TableIcon,
+  TrashIcon,
   WorkspaceIcon,
 } from "./StashIcons";
 
@@ -549,6 +550,14 @@ function WorkspaceTree({
           onUnpinAll={() => onUnpinAll(workspace.id)}
           onAddPage={() => onAddPage(workspace.id)}
         />
+
+        <Link
+          href={`/workspaces/${workspace.id}/trash`}
+          className="page-row flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] text-muted hover:bg-raised hover:text-foreground"
+        >
+          <span className="text-muted"><TrashIcon /></span>
+          <span className="flex-1 truncate">Trash</span>
+        </Link>
     </div>
   );
 }

--- a/frontend/src/components/DownloadMenu.tsx
+++ b/frontend/src/components/DownloadMenu.tsx
@@ -3,9 +3,12 @@
 import { useEffect, useRef, useState } from "react";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 
-interface DownloadOption {
+export interface DownloadOption {
   label: string;
   onSelect: () => void;
+  // Destructive options render below a divider in red so a misplaced
+  // click on "Delete" doesn't land inside the routine download formats.
+  destructive?: boolean;
 }
 
 export default function DownloadMenu({ options }: { options: DownloadOption[] }) {
@@ -25,6 +28,9 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
     };
   }, [open]);
 
+  const safe = options.filter((o) => !o.destructive);
+  const destructive = options.filter((o) => o.destructive);
+
   return (
     <div ref={ref} className="relative inline-block">
       <button
@@ -35,8 +41,8 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
         Download ▾
       </button>
       {open && (
-        <div className="absolute right-0 top-full z-30 mt-1 w-40 overflow-hidden rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg">
-          {options.map((o) => (
+        <div className="absolute right-0 top-full z-30 mt-1 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg">
+          {safe.map((o) => (
             <button
               key={o.label}
               onClick={() => {
@@ -44,6 +50,21 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
                 o.onSelect();
               }}
               className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+            >
+              {o.label}
+            </button>
+          ))}
+          {destructive.length > 0 && safe.length > 0 && (
+            <div className="my-1 border-t border-border" />
+          )}
+          {destructive.map((o) => (
+            <button
+              key={o.label}
+              onClick={() => {
+                setOpen(false);
+                o.onSelect();
+              }}
+              className="block w-full px-3 py-1.5 text-left text-red-600 hover:bg-red-500/10"
             >
               {o.label}
             </button>

--- a/frontend/src/components/DownloadMenu.tsx
+++ b/frontend/src/components/DownloadMenu.tsx
@@ -36,9 +36,15 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-muted hover:bg-raised hover:text-foreground"
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-base text-muted hover:bg-raised hover:text-foreground"
+        aria-label="More actions"
+        title="More actions"
       >
-        Download ▾
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+          <circle cx="5" cy="12" r="1.7" />
+          <circle cx="12" cy="12" r="1.7" />
+          <circle cx="19" cy="12" r="1.7" />
+        </svg>
       </button>
       {open && (
         <div className="absolute right-0 top-full z-30 mt-1 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg">

--- a/frontend/src/components/StashIcons.tsx
+++ b/frontend/src/components/StashIcons.tsx
@@ -1,3 +1,4 @@
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import ExploreOutlinedIcon from "@mui/icons-material/ExploreOutlined";
 import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
@@ -113,4 +114,8 @@ export function NotificationsIcon(props: IconProps) {
 
 export function PersonIcon(props: IconProps) {
   return <MaterialIcon icon={PersonOutlineOutlinedIcon} {...props} />;
+}
+
+export function TrashIcon(props: IconProps) {
+  return <MaterialIcon icon={DeleteOutlineOutlinedIcon} {...props} />;
 }

--- a/frontend/src/components/workspace/FileViewerHeader.tsx
+++ b/frontend/src/components/workspace/FileViewerHeader.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import type { CSSProperties, ReactNode } from "react";
 
-import DownloadMenu from "../DownloadMenu";
+import DownloadMenu, { type DownloadOption } from "../DownloadMenu";
 import EditableTitle from "./EditableTitle";
 
 export type FileViewerSaveStatus = "saved" | "dirty" | "saving";
@@ -43,7 +43,7 @@ interface FileViewerHeaderProps {
   /** "saved" | "dirty" | "saving" — colored save-status text. Hidden in read-only mode. */
   saveStatus?: FileViewerSaveStatus | null;
   /** Right-aligned download menu options. Omit to hide. */
-  downloadOptions?: { label: string; onSelect: () => void }[];
+  downloadOptions?: DownloadOption[];
   /** Anything that should sit between the save-status and the download menu. */
   rightExtras?: ReactNode;
 }

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSelect: (item: GridItem) => void;
   onNavigate: (item: GridItem) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
 }
 
 export default function FolderItemGrid({
@@ -30,6 +31,7 @@ export default function FolderItemGrid({
   onSelect,
   onNavigate,
   onReparent,
+  onDelete,
 }: Props) {
   if (items.length === 0) {
     return (
@@ -52,6 +54,7 @@ export default function FolderItemGrid({
             onSelect={() => onSelect(item)}
             onNavigate={() => onNavigate(item)}
             onReparent={onReparent}
+            onDelete={onDelete}
           />
         ))}
       </div>
@@ -65,12 +68,14 @@ function Tile({
   onSelect,
   onNavigate,
   onReparent,
+  onDelete,
 }: {
   item: GridItem;
   selected: boolean;
   onSelect: () => void;
   onNavigate: () => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
 }) {
   const [over, setOver] = useState(false);
   const isFolder = item.kind === "folder";
@@ -131,6 +136,26 @@ function Tile({
         <div className="truncate text-[13.5px] font-semibold text-foreground">{item.name}</div>
         <div className="mt-0.5 truncate text-[11.5px] text-muted">{item.subtitle}</div>
       </div>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void onDelete(item);
+          }}
+          className="rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+          title="Delete"
+          aria-label="Delete"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="3 6 5 6 21 6" />
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+            <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -14,6 +14,9 @@ export interface GridItem {
   sizeBytes?: number;
   contentType?: string;
   linkedTableId?: string;
+  /** ISO timestamp. Renders as "Modified" in the Drive-style List view.
+   *  Not all rows have one — FolderContents.pages currently omits it. */
+  updatedAt?: string;
 }
 
 interface Props {

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -17,6 +17,7 @@ interface Props {
   currentItems: GridItem[];
   onNavigate: (item: GridItem) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
 }
 
 // Column view: left column is the workspace folder tree (Finder's sidebar),
@@ -29,6 +30,7 @@ export default function ItemsColumns({
   activeFolderId,
   onNavigate,
   onReparent,
+  onDelete,
   currentItems,
 }: Props) {
   return (
@@ -68,6 +70,7 @@ export default function ItemsColumns({
                 item={item}
                 onNavigate={onNavigate}
                 onReparent={onReparent}
+                onDelete={onDelete}
               />
             ))}
           </div>
@@ -230,10 +233,12 @@ function ItemRow({
   item,
   onNavigate,
   onReparent,
+  onDelete,
 }: {
   item: GridItem;
   onNavigate: (item: GridItem) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
 }) {
   const [over, setOver] = useState(false);
   const isFolder = item.kind === "folder";
@@ -274,7 +279,7 @@ function ItemRow({
         }
       }}
       className={
-        "flex cursor-pointer select-none items-center gap-3 px-3 py-2 text-[13px] hover:bg-[var(--color-brand-50)]/30 " +
+        "group flex cursor-pointer select-none items-center gap-3 px-3 py-2 text-[13px] hover:bg-[var(--color-brand-50)]/30 " +
         (over ? "ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
     >
@@ -283,6 +288,26 @@ function ItemRow({
       </span>
       <span className="min-w-0 flex-1 truncate font-medium text-foreground">{item.name}</span>
       <span className="hidden text-[11.5px] text-muted sm:inline">{item.subtitle}</span>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void onDelete(item);
+          }}
+          className="rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+          title="Delete"
+          aria-label="Delete"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="3 6 5 6 21 6" />
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+            <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -1,105 +1,167 @@
 "use client";
 
-import Link from "next/link";
-import { useState, type DragEvent } from "react";
-import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
-import type { FolderContents } from "../../../lib/api";
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import { getFolderContents, type FolderContents } from "../../../lib/api";
 import type { FolderTreeNode, WorkspaceTree } from "../../../lib/types";
-import { FB_DRAG_MIME, type FBDragPayload } from "./WorkspaceFileBrowser";
+import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
 import type { GridItem, ItemKind } from "./FolderItemGrid";
-import { useParams } from "next/navigation";
+import { FB_DRAG_MIME, type FBDragPayload } from "./WorkspaceFileBrowser";
 
 interface Props {
   workspaceId: string;
   tree: WorkspaceTree | null;
-  activeFolderId: string | null;
-  currentContents: FolderContents | null;
-  currentItems: GridItem[];
+  rootItems: GridItem[];
   onNavigate: (item: GridItem) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
 }
 
-// Column view: left column is the workspace folder tree (Finder's sidebar),
-// right column is the contents of the currently selected folder. Drag-drop
-// works in both — drop on a tree node to reparent, drop on a folder tile in
-// the right column to nest into it.
+// Finder-style column view: a stack of identical folder columns that grow
+// to the right as the user drills, plus a metadata-only preview panel for
+// the rightmost selected leaf. Each column has the same shape and behavior;
+// clicking a folder in column N opens its contents in column N+1, clicking
+// a non-folder selects it for the preview.
 export default function ItemsColumns({
   workspaceId,
   tree,
-  activeFolderId,
+  rootItems,
   onNavigate,
   onReparent,
   onDelete,
-  currentItems,
 }: Props) {
+  // path: folder IDs of the drill trail. Empty array = root only.
+  const [path, setPath] = useState<string[]>([]);
+  const [cache, setCache] = useState<Map<string, FolderContents | null>>(new Map());
+  const [selected, setSelected] = useState<{ columnIdx: number; item: GridItem } | null>(
+    null
+  );
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Fetch any missing folder contents along the current path.
+  useEffect(() => {
+    let cancelled = false;
+    async function ensure() {
+      const missing = path.filter((id) => !cache.has(id));
+      if (missing.length === 0) return;
+      const fetched = await Promise.all(
+        missing.map(async (id) => [id, await getFolderContents(workspaceId, id)] as const)
+      );
+      if (cancelled) return;
+      setCache((cur) => {
+        const next = new Map(cur);
+        for (const [id, contents] of fetched) next.set(id, contents);
+        return next;
+      });
+    }
+    void ensure();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, cache, workspaceId]);
+
+  // Keep the rightmost column visible as the user drills.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) el.scrollLeft = el.scrollWidth;
+  }, [path]);
+
+  function columnItemsAt(idx: number): GridItem[] {
+    if (idx === 0) return rootItems;
+    const folderId = path[idx - 1];
+    const contents = cache.get(folderId);
+    if (!contents) return [];
+    return folderContentsToItems(contents);
+  }
+
+  function handlePick(columnIdx: number, item: GridItem) {
+    if (item.kind === "folder") {
+      // Drill into folder: truncate path at this column and append.
+      setPath((cur) => [...cur.slice(0, columnIdx), item.id]);
+      setSelected({ columnIdx, item });
+      return;
+    }
+    // Leaf click: trim any deeper columns and surface in the preview panel.
+    setPath((cur) => cur.slice(0, columnIdx));
+    setSelected({ columnIdx, item });
+  }
+
+  function handleOpen(item: GridItem) {
+    if (item.kind === "folder") return; // drilling handled above
+    onNavigate(item);
+  }
+
+  // Build column data: root + one per element of path.
+  const columns = useMemo(() => {
+    const out: { idx: number; folderId: string | null; items: GridItem[] }[] = [
+      { idx: 0, folderId: null, items: columnItemsAt(0) },
+    ];
+    for (let i = 0; i < path.length; i++) {
+      out.push({ idx: i + 1, folderId: path[i], items: columnItemsAt(i + 1) });
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path, cache, rootItems]);
+
+  // The active id per column so each column highlights the drilled-into
+  // folder (or the previewed leaf).
+  function activeIdInColumn(columnIdx: number): string | null {
+    if (columnIdx < path.length) return path[columnIdx];
+    if (selected && selected.columnIdx === columnIdx) return selected.item.id;
+    return null;
+  }
+
   return (
-    <div className="grid min-h-0 flex-1 grid-cols-[260px_minmax(0,1fr)] divide-x divide-border">
-      <nav className="scroll-thin overflow-y-auto bg-surface/40 px-2 py-3 text-[13px]">
-        <RootRow
-          workspaceId={workspaceId}
-          active={activeFolderId === null}
-          onReparent={onReparent}
-        />
-        {tree?.folders.map((node) => (
-          <TreeRow
-            key={node.id}
-            node={node}
-            depth={0}
-            workspaceId={workspaceId}
-            activeFolderId={activeFolderId}
+    <div className="flex min-h-0 flex-1">
+      <div
+        ref={containerRef}
+        className="scroll-thin flex min-h-0 flex-1 overflow-x-auto"
+      >
+        {columns.map((col) => (
+          <Column
+            key={`${col.idx}-${col.folderId ?? "root"}`}
+            items={col.items}
+            activeId={activeIdInColumn(col.idx)}
+            onPick={(item) => handlePick(col.idx, item)}
+            onOpen={handleOpen}
             onReparent={onReparent}
+            onDelete={onDelete}
+            folderIdForDrop={col.folderId}
+            loading={col.idx > 0 && !cache.get(col.folderId!) }
           />
         ))}
-        {tree && tree.folders.length === 0 && (
-          <div className="px-2 py-2 text-[11.5px] italic text-muted">No folders yet.</div>
-        )}
-      </nav>
-      <div className="scroll-thin overflow-y-auto bg-base">
-        {currentItems.length === 0 ? (
-          <div className="flex items-center justify-center p-12">
-            <div className="rounded-lg border border-dashed border-border bg-surface/30 px-6 py-10 text-center text-[12.5px] text-muted">
-              Empty folder.
-            </div>
-          </div>
-        ) : (
-          <div className="divide-y divide-border-subtle">
-            {currentItems.map((item) => (
-              <ItemRow
-                key={`${item.kind}-${item.id}`}
-                item={item}
-                onNavigate={onNavigate}
-                onReparent={onReparent}
-                onDelete={onDelete}
-              />
-            ))}
-          </div>
-        )}
       </div>
+      <PreviewPanel
+        selected={selected?.item ?? null}
+        tree={tree}
+        onOpen={() => selected && handleOpen(selected.item)}
+        onDelete={onDelete ? () => selected && onDelete(selected.item) : undefined}
+      />
     </div>
   );
 }
 
-function RootRow({
-  workspaceId,
-  active,
+function Column({
+  items,
+  activeId,
+  onPick,
+  onOpen,
   onReparent,
+  onDelete,
+  folderIdForDrop,
+  loading,
 }: {
-  workspaceId: string;
-  active: boolean;
+  items: GridItem[];
+  activeId: string | null;
+  onPick: (item: GridItem) => void;
+  onOpen: (item: GridItem) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
+  folderIdForDrop: string | null;
+  loading: boolean;
 }) {
   const [over, setOver] = useState(false);
   return (
-    <Link
-      href={`/workspaces/${workspaceId}/files`}
-      className={
-        "mb-1 flex items-center gap-2 rounded-md px-2 py-1 " +
-        (active
-          ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
-          : "text-dim hover:bg-raised hover:text-foreground") +
-        (over ? " ring-2 ring-[var(--color-brand-300)]" : "")
-      }
+    <div
       onDragOver={(e) => {
         if (!e.dataTransfer.types.includes(FB_DRAG_MIME)) return;
         e.preventDefault();
@@ -113,130 +175,51 @@ function RootRow({
         if (!raw) return;
         e.preventDefault();
         try {
-          onReparent(JSON.parse(raw) as FBDragPayload, null);
+          const payload = JSON.parse(raw) as FBDragPayload;
+          if (payload.kind === "folder" && payload.id === folderIdForDrop) return;
+          onReparent(payload, folderIdForDrop);
         } catch {
           /* malformed */
         }
       }}
+      className={
+        "scroll-thin flex h-full w-[240px] flex-shrink-0 flex-col overflow-y-auto border-r border-border bg-base " +
+        (over ? "bg-[var(--color-brand-50)]/40" : "")
+      }
     >
-      <FolderIcon />
-      <span className="font-medium">Files</span>
-    </Link>
-  );
-}
-
-function TreeRow({
-  node,
-  depth,
-  workspaceId,
-  activeFolderId,
-  onReparent,
-}: {
-  node: FolderTreeNode;
-  depth: number;
-  workspaceId: string;
-  activeFolderId: string | null;
-  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-}) {
-  const [open, setOpen] = useState(activeFolderId === node.id || depth === 0);
-  const [over, setOver] = useState(false);
-  const active = activeFolderId === node.id;
-  return (
-    <div>
-      <div
-        className={
-          "flex items-center gap-1 rounded-md px-1 py-0.5 " +
-          (active ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]" : "hover:bg-raised") +
-          (over ? " ring-2 ring-[var(--color-brand-300)]" : "")
-        }
-        style={{ paddingLeft: 4 + depth * 12 }}
-        draggable
-        onDragStart={(e: DragEvent<HTMLDivElement>) => {
-          const payload: FBDragPayload = { kind: "folder", id: node.id };
-          e.dataTransfer.setData(FB_DRAG_MIME, JSON.stringify(payload));
-          e.dataTransfer.effectAllowed = "move";
-        }}
-        onDragOver={(e) => {
-          if (!e.dataTransfer.types.includes(FB_DRAG_MIME)) return;
-          e.preventDefault();
-          e.dataTransfer.dropEffect = "move";
-          setOver(true);
-        }}
-        onDragLeave={() => setOver(false)}
-        onDrop={(e) => {
-          const raw = e.dataTransfer.getData(FB_DRAG_MIME);
-          setOver(false);
-          if (!raw) return;
-          e.preventDefault();
-          try {
-            const p = JSON.parse(raw) as FBDragPayload;
-            if (p.kind === "folder" && p.id === node.id) return;
-            onReparent(p, node.id);
-          } catch {
-            /* malformed */
-          }
-        }}
-      >
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            setOpen((o) => !o);
-          }}
-          className="flex h-4 w-4 items-center justify-center rounded text-muted hover:bg-base/60 hover:text-foreground"
-          aria-expanded={open}
-          aria-label={open ? "Collapse" : "Expand"}
-        >
-          {node.folders.length > 0 ? (
-            <svg
-              className={"h-3 w-3 transition-transform " + (open ? "rotate-90" : "")}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          ) : (
-            <span className="block h-1 w-1 rounded-full bg-muted/40" />
-          )}
-        </button>
-        <Link
-          href={`/workspaces/${workspaceId}/folders/${node.id}`}
-          className={
-            "flex min-w-0 flex-1 items-center gap-1.5 truncate " +
-            (active ? "font-medium" : "text-foreground")
-          }
-        >
-          <FolderIcon />
-          <span className="truncate">{node.name}</span>
-        </Link>
-      </div>
-      {open &&
-        node.folders.map((child) => (
-          <TreeRow
-            key={child.id}
-            node={child}
-            depth={depth + 1}
-            workspaceId={workspaceId}
-            activeFolderId={activeFolderId}
-            onReparent={onReparent}
-          />
-        ))}
+      {loading && (
+        <div className="px-3 py-2 text-[12px] text-muted">Loading…</div>
+      )}
+      {!loading && items.length === 0 && (
+        <div className="px-3 py-2 text-[12px] italic text-muted">Empty</div>
+      )}
+      {items.map((item) => (
+        <ColumnRow
+          key={`${item.kind}-${item.id}`}
+          item={item}
+          active={item.id === activeId}
+          onPick={() => onPick(item)}
+          onOpen={() => onOpen(item)}
+          onReparent={onReparent}
+          onDelete={onDelete}
+        />
+      ))}
     </div>
   );
 }
 
-function ItemRow({
+function ColumnRow({
   item,
-  onNavigate,
+  active,
+  onPick,
+  onOpen,
   onReparent,
   onDelete,
 }: {
   item: GridItem;
-  onNavigate: (item: GridItem) => void;
+  active: boolean;
+  onPick: () => void;
+  onOpen: () => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
 }) {
@@ -244,11 +227,12 @@ function ItemRow({
   const isFolder = item.kind === "folder";
   return (
     <div
-      onClick={() => onNavigate(item)}
+      onClick={onPick}
+      onDoubleClick={onOpen}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === "Enter") onNavigate(item);
+        if (e.key === "Enter") onOpen();
       }}
       draggable
       onDragStart={(e: DragEvent<HTMLDivElement>) => {
@@ -279,37 +263,144 @@ function ItemRow({
         }
       }}
       className={
-        "group flex cursor-pointer select-none items-center gap-3 px-3 py-2 text-[13px] hover:bg-[var(--color-brand-50)]/30 " +
-        (over ? "ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
+        "group flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 text-[13px] " +
+        (active
+          ? "bg-[var(--color-brand-600)] text-white"
+          : "text-foreground hover:bg-[var(--color-brand-50)]/40") +
+        (over ? " ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
     >
-      <span className={tintFor(item)}>
+      <span className={"flex h-4 w-4 flex-shrink-0 items-center justify-center " + (active ? "" : tintFor(item))}>
         <KindIcon kind={item.kind} />
       </span>
-      <span className="min-w-0 flex-1 truncate font-medium text-foreground">{item.name}</span>
-      <span className="hidden text-[11.5px] text-muted sm:inline">{item.subtitle}</span>
-      {onDelete && (
+      <span className="min-w-0 flex-1 truncate font-medium">{item.name}</span>
+      {isFolder && (
+        <span className={"flex-shrink-0 text-[12px] " + (active ? "text-white/80" : "text-muted")}>›</span>
+      )}
+      {!isFolder && onDelete && (
         <button
           type="button"
           onClick={(e) => {
             e.stopPropagation();
             void onDelete(item);
           }}
-          className="rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+          className={
+            "flex-shrink-0 rounded p-0.5 opacity-0 transition focus-visible:opacity-100 group-hover:opacity-100 " +
+            (active ? "text-white hover:bg-white/10" : "text-muted hover:bg-raised hover:text-red-600")
+          }
           title="Delete"
           aria-label="Delete"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="3 6 5 6 21 6" />
             <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-            <path d="M10 11v6" />
-            <path d="M14 11v6" />
-            <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
           </svg>
         </button>
       )}
     </div>
   );
+}
+
+function PreviewPanel({
+  selected,
+  tree: _tree,
+  onOpen,
+  onDelete,
+}: {
+  selected: GridItem | null;
+  tree: WorkspaceTree | null;
+  onOpen: () => void;
+  onDelete?: () => void;
+}) {
+  if (!selected || selected.kind === "folder") {
+    return (
+      <aside className="hidden w-[280px] flex-shrink-0 flex-col border-l border-border bg-surface/40 p-4 text-[12.5px] text-muted lg:flex">
+        <div className="flex h-full items-center justify-center text-center">
+          Select an item to preview its details.
+        </div>
+      </aside>
+    );
+  }
+  return (
+    <aside className="hidden w-[280px] flex-shrink-0 flex-col border-l border-border bg-surface/40 lg:flex">
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-5">
+        <div className={"inline-flex h-12 w-12 items-center justify-center rounded-md border border-border bg-base " + tintFor(selected)}>
+          <KindIcon kind={selected.kind} />
+        </div>
+        <div>
+          <h3 className="break-words font-display text-[16px] font-semibold leading-snug text-foreground">
+            {selected.name}
+          </h3>
+          <p className="mt-0.5 text-[12px] text-muted">{kindLabel(selected)}</p>
+        </div>
+        <dl className="grid grid-cols-[80px_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-[12px]">
+          {selected.sizeBytes != null && (
+            <>
+              <dt className="text-muted">Size</dt>
+              <dd className="text-foreground">{formatBytes(selected.sizeBytes)}</dd>
+            </>
+          )}
+          <dt className="text-muted">Modified</dt>
+          <dd className="text-foreground">{formatAbsolute(selected.updatedAt)}</dd>
+          {selected.contentType && (
+            <>
+              <dt className="text-muted">Type</dt>
+              <dd className="break-all text-foreground">{selected.contentType}</dd>
+            </>
+          )}
+        </dl>
+      </div>
+      <div className="flex items-center gap-2 border-t border-border bg-base/60 px-4 py-2.5">
+        <button
+          type="button"
+          onClick={onOpen}
+          className="flex-1 rounded-md border border-border bg-base px-3 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
+        >
+          Open
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10"
+            title="Move to trash"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function folderContentsToItems(contents: FolderContents): GridItem[] {
+  return [
+    ...contents.subfolders.map<GridItem>((sub) => ({
+      kind: "folder",
+      id: sub.id,
+      name: sub.name,
+      subtitle: `${sub.page_count + sub.file_count} item${sub.page_count + sub.file_count === 1 ? "" : "s"}`,
+    })),
+    ...contents.pages.map<GridItem>((p) => ({
+      kind: "page",
+      id: p.id,
+      name: p.name.replace(/\.md$/, ""),
+      subtitle: p.name.toLowerCase().endsWith(".html") ? "html page" : "page",
+    })),
+    ...contents.files.map<GridItem>((f) => {
+      const isCsvLinked = !!(f.content_type.includes("csv") && f.linked_table_id);
+      return {
+        kind: isCsvLinked ? "table" : "file",
+        id: f.id,
+        name: f.name,
+        subtitle: `${f.content_type || "file"} · ${formatBytes(f.size_bytes)}`,
+        sizeBytes: f.size_bytes,
+        contentType: f.content_type,
+        linkedTableId: f.linked_table_id ?? undefined,
+        updatedAt: f.created_at,
+      };
+    }),
+  ];
 }
 
 function KindIcon({ kind }: { kind: ItemKind }) {
@@ -324,10 +415,38 @@ function tintFor(item: GridItem): string {
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.includes("image")) return "text-violet-600";
+  if (item.contentType?.startsWith("image/")) return "text-violet-500";
+  if (item.kind === "page") return "text-[var(--color-brand-600)]";
   return "text-muted";
 }
 
-// Suppress unused-import warning in some build configs (useParams reserved for
-// future deep-link behavior — keep import while not actively used).
-void useParams;
+function kindLabel(item: GridItem): string {
+  if (item.kind === "folder") return "Folder";
+  if (item.kind === "table") return "Table";
+  if (item.kind === "html") return "HTML page";
+  if (item.kind === "page") return "Page";
+  if (item.contentType?.includes("pdf")) return "PDF";
+  if (item.contentType?.includes("csv")) return "CSV";
+  if (item.contentType?.startsWith("image/")) {
+    return `Image · ${item.contentType.replace("image/", "").toUpperCase()}`;
+  }
+  return item.contentType || "File";
+}
+
+function formatBytes(bytes: number | undefined): string {
+  if (bytes == null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatAbsolute(iso: string | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -112,7 +112,7 @@ function Row({
           e.stopPropagation();
           void onDelete(item);
         }}
-        className="rounded p-1 text-muted opacity-0 hover:bg-raised hover:text-red-600 group-hover:opacity-100"
+        className="rounded p-1 text-muted opacity-0 hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
         title="Delete"
         aria-label="Delete"
       >

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useState, type DragEvent } from "react";
+import {
+  FB_DRAG_MIME,
+  type FBDragPayload,
+} from "./WorkspaceFileBrowser";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
-import { FB_DRAG_MIME, type FBDragPayload } from "./WorkspaceFileBrowser";
 import type { GridItem, ItemKind } from "./FolderItemGrid";
 
 interface Props {
@@ -12,36 +15,40 @@ interface Props {
   onDelete: (item: GridItem) => Promise<void>;
 }
 
-// Dense list view: one item per row with kind icon, name, subtitle, and
-// a hover-only delete affordance. Same drag-drop semantics as Grid.
-export default function ItemsList({ items, onNavigate, onReparent, onDelete }: Props) {
-  if (items.length === 0) {
-    return (
-      <div className="flex items-center justify-center bg-base p-12">
-        <div className="rounded-lg border border-dashed border-border bg-surface/30 px-6 py-10 text-center text-[12.5px] text-muted">
-          Empty folder.
-        </div>
-      </div>
-    );
-  }
-
+// Google-Drive-style list: Name / Modified / Type / overflow.
+// Hover reveals a trash button in the overflow column. Folders + files +
+// pages all live in the same grid; folders surface their child-count in the
+// Type column instead of a modified date.
+export default function ItemsList({
+  items,
+  onNavigate,
+  onReparent,
+  onDelete,
+}: Props) {
   return (
-    <div className="scroll-thin overflow-y-auto bg-base">
-      <div className="grid grid-cols-[20px_minmax(0,1fr)_minmax(0,1fr)_28px] gap-3 border-b border-border bg-surface px-4 py-2 text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
-        <span />
+    <div className="scroll-thin overflow-y-auto">
+      <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_36px] items-center gap-3 border-b border-border-subtle bg-surface/40 px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-muted">
         <span>Name</span>
-        <span>Type / size</span>
+        <span>Modified</span>
+        <span>Type</span>
         <span />
       </div>
-      {items.map((item) => (
-        <Row
-          key={`${item.kind}-${item.id}`}
-          item={item}
-          onNavigate={onNavigate}
-          onReparent={onReparent}
-          onDelete={onDelete}
-        />
-      ))}
+      <div>
+        {items.map((item) => (
+          <Row
+            key={`${item.kind}-${item.id}`}
+            item={item}
+            onNavigate={onNavigate}
+            onReparent={onReparent}
+            onDelete={onDelete}
+          />
+        ))}
+        {items.length === 0 && (
+          <div className="px-4 py-8 text-center text-[12.5px] text-muted">
+            Empty folder.
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -97,27 +104,34 @@ function Row({
         }
       }}
       className={
-        "group grid cursor-pointer select-none grid-cols-[20px_minmax(0,1fr)_minmax(0,1fr)_28px] items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] hover:bg-[var(--color-brand-50)]/30 " +
+        "group grid cursor-pointer select-none grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_36px] items-center gap-3 border-b border-border-subtle px-4 py-1.5 text-[13px] hover:bg-[var(--color-brand-50)]/40 " +
         (over ? "ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
     >
-      <span className={tintFor(item)}>
-        <KindIcon kind={item.kind} />
-      </span>
-      <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
-      <span className="min-w-0 truncate text-[12px] text-muted">{item.subtitle}</span>
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span className={"flex h-4 w-4 flex-shrink-0 items-center justify-center " + tintFor(item)}>
+          <KindIcon kind={item.kind} />
+        </span>
+        <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
+      </div>
+      <span className="truncate text-[12px] text-muted">{formatRelative(item.updatedAt)}</span>
+      <span className="truncate text-[12px] text-muted">{typeFor(item)}</span>
       <button
         type="button"
         onClick={(e) => {
           e.stopPropagation();
           void onDelete(item);
         }}
-        className="rounded p-1 text-muted opacity-0 hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+        className="ml-auto rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
         title="Delete"
         aria-label="Delete"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+          <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
         </svg>
       </button>
     </div>
@@ -136,6 +150,39 @@ function tintFor(item: GridItem): string {
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.includes("image")) return "text-violet-600";
+  if (item.contentType?.startsWith("image/")) return "text-violet-500";
+  if (item.kind === "page") return "text-[var(--color-brand-600)]";
   return "text-muted";
+}
+
+function typeFor(item: GridItem): string {
+  if (item.kind === "folder") return item.subtitle;
+  if (item.kind === "table") return "Table";
+  if (item.kind === "html") return "HTML page";
+  if (item.kind === "page") return "Page";
+  if (item.contentType?.includes("pdf")) return "PDF";
+  if (item.contentType?.includes("csv")) return "CSV";
+  if (item.contentType?.startsWith("image/")) {
+    return item.contentType.replace("image/", "").toUpperCase();
+  }
+  return item.contentType || "File";
+}
+
+function formatRelative(iso: string | undefined): string {
+  if (!iso) return "—";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "—";
+  const diffMs = Date.now() - then;
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 7) return `${diffD}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: new Date(iso).getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+  });
 }

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -129,6 +129,30 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     loadContents();
   }, [loadContents]);
 
+  // Always-root projection of folders + pages + rootFiles. The Column view
+  // manages its own drill state, so it needs root regardless of the current
+  // folderId.
+  const rootItems: GridItem[] = useMemo(() => {
+    if (!tree) return [];
+    return [
+      ...tree.folders.map((sub) => ({
+        kind: "folder" as const,
+        id: sub.id,
+        name: sub.name,
+        subtitle: subtitleForFolder(sub.pages?.length ?? 0, 0),
+        updatedAt: sub.updated_at,
+      })),
+      ...tree.pages.map((p: PageSummary) => ({
+        kind: "page" as const,
+        id: p.id,
+        name: p.name.replace(/\.md$/, ""),
+        subtitle: p.name.toLowerCase().endsWith(".html") ? "html page" : "page",
+        updatedAt: p.updated_at,
+      })),
+      ...rootFiles,
+    ];
+  }, [tree, rootFiles]);
+
   const items: GridItem[] = useMemo(() => {
     if (folderId) {
       if (!contents) return [];
@@ -152,6 +176,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
             content_type: f.content_type,
             size_bytes: f.size_bytes,
             linked_table_id: f.linked_table_id ?? null,
+            created_at: f.created_at,
           })
         ),
       ];
@@ -167,12 +192,14 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           // file count isn't returned in the tree; approximate as 0
           0
         ),
+        updatedAt: sub.updated_at,
       })),
       ...tree.pages.map((p: PageSummary) => ({
         kind: "page" as const,
         id: p.id,
         name: p.name.replace(/\.md$/, ""),
         subtitle: p.name.toLowerCase().endsWith(".html") ? "html page" : "page",
+        updatedAt: p.updated_at,
       })),
       ...rootFiles,
     ];
@@ -396,9 +423,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           <ItemsColumns
             workspaceId={workspaceId}
             tree={tree}
-            activeFolderId={folderId}
-            currentContents={contents}
-            currentItems={items}
+            rootItems={rootItems}
             onNavigate={navigateTo}
             onReparent={reparent}
             onDelete={handleDelete}
@@ -465,6 +490,7 @@ function fileToGridItem(file: {
   content_type: string;
   size_bytes: number;
   linked_table_id?: string | null;
+  created_at?: string;
 }): GridItem {
   const isCsvLinked = !!(file.content_type.includes("csv") && file.linked_table_id);
   return {
@@ -475,6 +501,7 @@ function fileToGridItem(file: {
     sizeBytes: file.size_bytes,
     linkedTableId: file.linked_table_id ?? undefined,
     contentType: file.content_type,
+    updatedAt: file.created_at,
   };
 }
 

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -389,6 +389,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
             onSelect={navigateTo}
             onNavigate={navigateTo}
             onReparent={reparent}
+            onDelete={handleDelete}
           />
         )}
         {view === "column" && (
@@ -400,6 +401,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
             currentItems={items}
             onNavigate={navigateTo}
             onReparent={reparent}
+            onDelete={handleDelete}
           />
         )}
       </div>

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -5,12 +5,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createFolder,
   createPage,
-  deleteFile,
-  deletePage,
   deleteFolder,
   getFolderContents,
   getWorkspaceTree,
   listFiles,
+  restoreItem,
+  trashItem,
   updateFile,
   updateFolder,
   updatePage,
@@ -70,6 +70,16 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     }
   }
   const [error, setError] = useState("");
+  const [undo, setUndo] = useState<{ kind: "page" | "file"; id: string; name: string } | null>(
+    null,
+  );
+
+  // Auto-dismiss the Undo toast after 10s. Matches the gmail-style window.
+  useEffect(() => {
+    if (!undo) return;
+    const t = window.setTimeout(() => setUndo(null), 10000);
+    return () => window.clearTimeout(t);
+  }, [undo]);
 
   // Load workspace tree once per workspace; powers the Column view.
   const loadTree = useCallback(async () => {
@@ -261,15 +271,36 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
   }
 
   async function handleDelete(item: GridItem) {
-    const yes = window.confirm(`Delete "${item.name}"? This can't be undone.`);
-    if (!yes) return;
+    if (item.kind === "folder") {
+      const yes = window.confirm(`Delete folder "${item.name}"? This can't be undone.`);
+      if (!yes) return;
+      try {
+        await deleteFolder(workspaceId, item.id);
+        await refreshAll();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Delete failed");
+      }
+      return;
+    }
+    const kind = item.kind === "page" || item.kind === "html" ? "page" : "file";
     try {
-      if (item.kind === "folder") await deleteFolder(workspaceId, item.id);
-      else if (item.kind === "page" || item.kind === "html") await deletePage(workspaceId, item.id);
-      else await deleteFile(workspaceId, item.id);
+      await trashItem(workspaceId, kind, item.id);
       await refreshAll();
+      setUndo({ kind, id: item.id, name: item.name });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Delete failed");
+    }
+  }
+
+  async function handleUndoDelete() {
+    if (!undo) return;
+    const { kind, id } = undo;
+    setUndo(null);
+    try {
+      await restoreItem(workspaceId, kind, id);
+      await refreshAll();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Restore failed");
     }
   }
 
@@ -372,6 +403,28 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           />
         )}
       </div>
+      {undo && (
+        <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center">
+          <div className="pointer-events-auto flex items-center gap-3 rounded-lg border border-border bg-foreground px-4 py-2 text-[13px] text-background shadow-lg">
+            <span>Moved &ldquo;{undo.name}&rdquo; to trash.</span>
+            <button
+              type="button"
+              onClick={handleUndoDelete}
+              className="rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={() => setUndo(null)}
+              className="ml-1 text-[18px] leading-none text-background/70 hover:text-background"
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,8 @@ import {
   FileInfo,
   Folder,
   Page,
+  TrashKind,
+  TrashListing,
   WorkspaceTree,
   RegisterResponse,
   User,
@@ -353,10 +355,6 @@ export async function updatePage(
     method: "PATCH",
     body: JSON.stringify(data),
   });
-}
-
-export async function deletePage(workspaceId: string, pageId: string): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/pages/${pageId}`, { method: "DELETE" });
 }
 
 // --- Page comments ---
@@ -755,10 +753,6 @@ export async function ingestCsvFile(workspaceId: string, fileId: string): Promis
   return apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}/ingest-csv`, {
     method: "POST",
   });
-}
-
-export async function deleteFile(workspaceId: string, fileId: string): Promise<void> {
-  await apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}`, { method: "DELETE" });
 }
 
 export async function updateFile(
@@ -1457,4 +1451,51 @@ export async function getFolderContents(
   return apiFetch(
     `/api/v1/workspaces/${workspaceId}/folders/${folderId}/contents`
   );
+}
+
+// --- Trash ---
+
+// All three flavors share the same URL shape (`/{kind}s/{id}`), so a single
+// helper covers trash/restore/purge instead of three near-identical pairs.
+const TRASH_KIND_PATH: Record<TrashKind, string> = {
+  page: "pages",
+  file: "files",
+  session: "sessions",
+};
+
+export async function trashItem(
+  workspaceId: string,
+  kind: TrashKind,
+  id: string,
+): Promise<void> {
+  await apiFetch(
+    `/api/v1/workspaces/${workspaceId}/${TRASH_KIND_PATH[kind]}/${id}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function restoreItem(
+  workspaceId: string,
+  kind: TrashKind,
+  id: string,
+): Promise<void> {
+  await apiFetch(
+    `/api/v1/workspaces/${workspaceId}/${TRASH_KIND_PATH[kind]}/${id}/restore`,
+    { method: "POST" },
+  );
+}
+
+export async function purgeItem(
+  workspaceId: string,
+  kind: TrashKind,
+  id: string,
+): Promise<void> {
+  await apiFetch(
+    `/api/v1/workspaces/${workspaceId}/${TRASH_KIND_PATH[kind]}/${id}/purge`,
+    { method: "DELETE" },
+  );
+}
+
+export async function getTrash(workspaceId: string): Promise<TrashListing> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/trash`);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -241,3 +241,21 @@ export interface UserSearchResult {
   name: string;
   display_name: string | null;
 }
+
+// --- Trash ---
+
+export type TrashKind = "page" | "file" | "session";
+
+export interface TrashEntry {
+  id: string;
+  name: string;
+  deleted_at: string;
+  deleted_by: string | null;
+  deleted_by_name: string | null;
+}
+
+export interface TrashListing {
+  pages: TrashEntry[];
+  files: TrashEntry[];
+  sessions: TrashEntry[];
+}


### PR DESCRIPTION
## Summary

Adds soft-delete + restore + purge across **sessions, pages, and files** with matching surfaces in the UI, CLI, MCP, and API. No auto-purge — items stay in trash forever until manually purged.

- **DB**: migration `0060_trash.py` adds `deleted_at TIMESTAMPTZ NULL` + `deleted_by UUID NULL` to `sessions`, `pages`, `files`, with a partial index on `(workspace_id, deleted_at DESC) WHERE deleted_at IS NOT NULL` for fast trash listing.
- **Backend reads**: every live `SELECT` on these tables now filters `deleted_at IS NULL`. Pages route through `_WORKSPACE_PAGE_FILTER`, files/sessions are filtered inline.
- **Existing DELETE endpoints become soft**. `DELETE /files/{id}` and `DELETE /pages/{id}` now stamp `deleted_at` instead of removing rows. Sessions gained a `DELETE` endpoint (it didn't exist before).
- **New endpoints**:
  - `GET /workspaces/{id}/trash` — returns `{pages, files, sessions}` lists with `deleted_at` + `deleted_by`
  - `POST /workspaces/{id}/{pages|files|sessions}/{id}/restore`
  - `DELETE /workspaces/{id}/{pages|files|sessions}/{id}/purge` (the actual hard-delete; for files, also removes the S3 blob)
- **Frontend**: new `/workspaces/<id>/trash` page with three sections (Pages / Files / Sessions), Restore + Purge actions on each row. Trash entry under each workspace in `AppSidebar`. Existing delete actions now show a "Moved to trash · Undo" toast; clicking Undo within 10s restores. `deletePage` / `deleteFile` helpers removed (replaced by `trashItem` / `restoreItem` / `purgeItem`).
- **CLI**: existing delete commands are now soft. New `--permanent` flag (two-call: trash then purge). New commands: `stash trash list`, `stash files restore`, `stash files purge`, `stash pages restore`, `stash pages purge`, `stash sessions delete | restore | purge`.
- **MCP**: three new tools — `list_trash`, `restore_object`, `purge_object` (kind = page | file | session).

## Folders are out of scope

Folders don't have `deleted_at` and existing folder delete keeps hard-delete semantics. Trash + restore are limited to leaf items.

## Verification

- `ruff check backend/ cli/` — clean
- `alembic upgrade head` — applied 0060, dev server restarted, all 7 new endpoints live in OpenAPI
- `npx tsc --noEmit` (frontend) — no new errors in touched files
- `pytest backend/tests` — 98 passing (auth-only pre-existing failures unrelated)
- OpenAPI lists the new endpoints; backend serving cleanly on :3456

## Out-of-scope follow-ups flagged in the diff

- `backend/services/analytics_service.py` page selects not filtered — visualizations may still surface trashed pages until follow-up.
- Stash fork SQL (`_fork_page`, `_fork_file`, etc.) not filtered inside the transaction — entry points already filter, so this is defense-in-depth only.
- The next planned PR (pinned + recent-N in the sidebar) intentionally builds on this — recent-N reads need to skip trashed items, which works for free now.

## Test plan

- [ ] Soft-delete a page from the file browser → toast appears → confirm page disappears from listings → undo within 10s → page returns
- [ ] Same for a file
- [ ] Open `/workspaces/<id>/trash` → see deleted items → Restore one → confirm it reappears in the file browser
- [ ] Purge a trashed file → confirm S3 blob is also deleted (storage tab in dev DB or `psql`)
- [ ] CLI: `stash trash list` → `stash files restore <id>` → confirm via UI
- [ ] MCP: call `list_trash`, `restore_object`, `purge_object` from a connected agent
- [ ] Sessions: delete a session via the new endpoint, confirm it disappears from sidebar + sessions list, restore via trash UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)