### PR TITLE
[codex] Fix session titles from summaries

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -20,6 +20,7 @@ from ..services import (
     memory_service,
     permission_service,
     session_service,
+    session_title_service,
     storage_service,
     workspace_service,
 )
@@ -45,6 +46,10 @@ def _session_response(row: dict) -> dict:
         "id": str(row["id"]),
         "workspace_id": str(row["workspace_id"]),
         "session_id": row["session_id"],
+        "title": session_title_service.title_from_summary(
+            row.get("summary"),
+            row["session_id"],
+        ),
         "agent_name": row.get("agent_name") or "",
         "cwd": row.get("cwd"),
         "summary": row.get("summary"),

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -16,6 +16,7 @@ from ..services import (
     ask_service,
     files_tree_service,
     memory_service,
+    session_title_service,
     skill_service,
     stash_service,
     workspace_service,
@@ -52,14 +53,10 @@ async def _list_sessions(workspace_id: UUID, user_id: UUID) -> list[dict]:
 
 
 def _auto_session_title(session: dict) -> str:
-    raw = (session.get("summary") or "").strip()
-    if not raw:
-        return session["session_id"]
-
-    first_sentence = raw.split(".")[0].strip()
-    if not first_sentence:
-        return session["session_id"]
-    return first_sentence[:80] if len(first_sentence) > 80 else first_sentence
+    return session_title_service.title_from_summary(
+        session.get("summary"),
+        session["session_id"],
+    )
 
 
 async def _files_tree(workspace_id: UUID, user_id: UUID) -> dict:

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -29,7 +29,8 @@ def render_session_summary_user(transcript: str, source_label: str = "transcript
         "3. Important decisions made\n"
         "4. Any unfinished work or known issues\n\n"
         "Keep the summary concise and useful for someone picking up "
-        "where this session left off.\n\n"
+        "where this session left off. Start with the concrete work, not a "
+        "generic heading. Do not include a markdown title like 'Session Summary'.\n\n"
         f"SESSION {source_label.upper()}:\n{transcript}"
     )
 

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -1,0 +1,88 @@
+"""Readable titles for sessions.
+
+Session summaries are longer prose. Navigation needs a short title, so derive
+one from the first useful summary line and ignore generic markdown wrappers.
+"""
+
+from __future__ import annotations
+
+import re
+
+MAX_TITLE_LENGTH = 80
+
+_GENERIC_PREFIXES = (
+    "session summary",
+    "summary of changes",
+    "summary",
+    "what changed",
+    "what the session accomplished",
+    "key files modified or created",
+    "key files",
+    "important decisions made",
+    "important decisions",
+    "unfinished work or known issues",
+    "known issues",
+)
+
+
+def title_from_summary(summary: str | None, session_id: str) -> str:
+    for line in (summary or "").splitlines():
+        title = _title_from_line(line)
+        if title:
+            return _truncate(title)
+    return session_id
+
+
+def _title_from_line(line: str) -> str:
+    text = _strip_markdown(line)
+    if not text:
+        return ""
+
+    text = _strip_generic_prefix(text)
+    if not text:
+        return ""
+
+    return _first_sentence(text)
+
+
+def _strip_markdown(line: str) -> str:
+    text = line.strip()
+    text = re.sub(r"^\s{0,3}#{1,6}\s*", "", text)
+    text = re.sub(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)", "", text)
+    text = text.replace("**", "").replace("__", "").replace("`", "")
+    return text.strip(" \t*_")
+
+
+def _strip_generic_prefix(text: str) -> str:
+    normalized = _normalize(text)
+    for prefix in _GENERIC_PREFIXES:
+        if normalized == prefix:
+            return ""
+
+    lower = text.lower()
+    for prefix in _GENERIC_PREFIXES:
+        if not lower.startswith(prefix):
+            continue
+
+        rest = text[len(prefix) :].lstrip(" :-–—")
+        return rest.strip()
+
+    return text
+
+
+def _first_sentence(text: str) -> str:
+    one_line = re.sub(r"\s+", " ", text).strip()
+    sentence, separator, _ = one_line.partition(".")
+    if separator:
+        return sentence.strip()
+    return one_line
+
+
+def _truncate(title: str) -> str:
+    if len(title) <= MAX_TITLE_LENGTH:
+        return title
+    return title[:MAX_TITLE_LENGTH]
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()

--- a/backend/tests/test_session_title_service.py
+++ b/backend/tests/test_session_title_service.py
@@ -1,0 +1,32 @@
+from backend.services.session_title_service import title_from_summary
+
+
+def test_title_from_summary_skips_generic_markdown_heading():
+    title = title_from_summary(
+        "## Session Summary\n\nAdded a new API route for members. Updated tests.",
+        "session-1",
+    )
+
+    assert title == "Added a new API route for members"
+
+
+def test_title_from_summary_strips_inline_generic_label():
+    title = title_from_summary(
+        "**Session Summary:** Added member invitations to the API. Documented the route.",
+        "session-1",
+    )
+
+    assert title == "Added member invitations to the API"
+
+
+def test_title_from_summary_skips_generic_section_heading():
+    title = title_from_summary(
+        "## Session Summary\n\n### What changed\n\n- Added member invitation routes.",
+        "session-1",
+    )
+
+    assert title == "Added member invitation routes"
+
+
+def test_title_from_summary_falls_back_to_session_id_for_empty_summary():
+    assert title_from_summary("## Session Summary", "session-1") == "session-1"

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -232,6 +232,7 @@ describe("AppShell sidebar collapse", () => {
       id: "session-row-uuid",
       workspace_id: "ws-1",
       session_id: "session-route-id",
+      title: "Debug auth flow",
       agent_name: "codex",
       cwd: null,
       summary: "Debug auth flow. Confirm token expiry.",

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -500,6 +500,9 @@ async function publishSessionStash(
 }
 
 function sessionShareTitle(session: SessionDetail): string {
+  const title = session.title?.trim();
+  if (title) return title;
+
   const summary = session.summary?.trim();
   if (summary) {
     const firstSentence = summary.split(".")[0]?.trim();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -814,6 +814,7 @@ export interface SessionDetail {
   id: string;
   workspace_id: string;
   session_id: string;
+  title: string;
   agent_name: string;
   cwd: string | null;
   summary: string | null;


### PR DESCRIPTION
## Summary
- derive session navigation titles through a shared summary-to-title helper that skips generic markdown headings like `## Session Summary`
- return the derived title from the session detail API and use it for session Stash publishing
- update the summarizer prompt so new summaries start with concrete work instead of a generic title

## Root Cause
The sidebar title came from the first sentence of raw `sessions.summary`. When the LLM returned a markdown heading such as `## Session Summary`, that boilerplate became the displayed session title.

## Validation
- `ruff check .`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_codex_title pytest --no-cov backend/tests/test_session_title_service.py backend/tests/test_session_summarizer.py`
- `cd frontend && npm test -- AppShell.test.tsx`
- `cd frontend && npm run lint`

## Screenshots
- UI text behavior only; no layout change. The visible session title now comes from the first useful summary line instead of the generic markdown heading.