### PR TITLE
[codex] fix migration head conflict

### DIFF
--- a/backend/migrations/versions/0061_require_user_display_names.py
+++ b/backend/migrations/versions/0061_require_user_display_names.py
@@ -1,13 +1,13 @@
 """Require user display names.
 
-Revision ID: 0060
-Revises: 0059
+Revision ID: 0061
+Revises: 0060
 """
 
 from alembic import op
 
-revision = "0060"
-down_revision = "0059"
+revision = "0061"
+down_revision = "0060"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

Fixes the Alembic migration graph by renumbering `0060_require_user_display_names.py` to `0061_require_user_display_names.py` and setting its `down_revision` to `0060`.

## Root Cause

Two migrations both declared `revision = "0060"` and both pointed at `0059`, so `alembic upgrade head` saw duplicate revision IDs and multiple heads.

## Validation

- `./.venv/bin/alembic heads` reports `0061 (head)`
- `./.venv/bin/alembic upgrade head` completes successfully
- `./.venv/bin/alembic current` reports `0061 (head)`