### PR TITLE
[codex] Fix Render migration chain

### DIFF
--- a/backend/migrations/versions/0060_trash.py
+++ b/backend/migrations/versions/0060_trash.py
@@ -5,15 +5,15 @@ reads filter `deleted_at IS NULL`; the dedicated trash listing is the
 only query that intentionally inverts that. No auto-purge — items stay
 in trash until manually purged.
 
-Revision ID: 0061
-Revises: 0060
+Revision ID: 0060
+Revises: 0059
 Create Date: 2026-05-19 00:00:00.000000
 """
 
 from alembic import op
 
-revision = "0061"
-down_revision = "0060"
+revision = "0060"
+down_revision = "0059"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

Restores the Alembic migration chain after PR #346 renamed the trash migration to `0061`, colliding with `0061_require_user_display_names.py` and leaving no `0060` revision.

The trash migration is back to `0060` with `down_revision = "0059"`; display-name enforcement remains `0061` with `down_revision = "0060"`. This matches the chain Render successfully deployed before the later regression.

## Validation

- `python -m alembic heads` -> `0061 (head)`
- `black --check backend/ cli/`
- `ruff check backend/migrations/versions/0060_trash.py backend/migrations/versions/0061_require_user_display_names.py`
- Fresh pgvector Postgres: `python -m alembic upgrade head && python -m alembic current` -> `0061 (head)`
- Fresh pgvector Postgres: `pytest --no-cov backend/tests/test_migrations.py -q` -> `2 passed`

Note: `pytest backend/tests/test_migrations.py -q` without `--no-cov` runs the two tests successfully, then fails the repo-wide coverage gate at 29.08% because the targeted subset is too small.