### PR TITLE
Make stash titles editable inline

### DIFF
--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -17,6 +17,7 @@ import {
   getPublicStash,
   listStashMembers,
   searchUsers,
+  updateStash,
   type PublicStashDetail,
 } from "../../../lib/api";
 
@@ -267,6 +268,34 @@ describe("StashPageClient sharing", () => {
 
     expect(title).toHaveTextContent("Shared Stash");
     expect(title).not.toHaveTextContent("workspace");
+  });
+
+  it("lets writers rename the Stash title inline", async () => {
+    const editable = {
+      ...stashDetail({ access: "workspace" }),
+      can_write: true,
+    };
+    vi.mocked(getPublicStash).mockResolvedValueOnce(editable);
+    vi.mocked(updateStash).mockResolvedValueOnce({
+      ...editable.stash,
+      title: "Renamed Stash",
+    });
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    fireEvent.click(await screen.findByText("Shared Stash"));
+    const input = screen.getByDisplayValue("Shared Stash");
+    fireEvent.change(input, { target: { value: "Renamed Stash" } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(updateStash).toHaveBeenCalledWith("stash-1", {
+        title: "Renamed Stash",
+      }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Renamed Stash" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the stash author in the detail header", async () => {

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -19,6 +19,7 @@ import { PublicStashSkeleton, SkeletonBlock } from "../../../components/Skeleton
 import AddToStashModal from "../../../components/stash/AddToStashModal";
 import StashShareButton from "../../../components/stash/StashShareButton";
 import { SettingsIcon, StashIcon } from "../../../components/StashIcons";
+import EditableTitle from "../../../components/workspace/EditableTitle";
 import ContributorActivityTimeline from "../../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../../components/viz/EmbeddingSpaceExplorer";
 import { useAuth } from "../../../hooks/useAuth";
@@ -31,7 +32,9 @@ import {
   uploadFile,
   type PublicStashDetail,
   type PublicStashItem,
+  type WorkspaceStash,
 } from "../../../lib/api";
+import { resetStashNavigationCache } from "../../../lib/stashNavigationCache";
 import type { ActivityTimeline, EmbeddingProjection } from "../../../lib/types";
 import AddToWorkspaceButton from "./AddToWorkspaceButton";
 
@@ -137,7 +140,13 @@ export default function StashPageClient({ slug }: { slug: string }) {
         />
       }
     >
-      <StashPageBody data={data} onRefresh={load} />
+      <StashPageBody
+        data={data}
+        onRefresh={load}
+        onStashChanged={(stash) => {
+          setData((current) => (current ? { ...current, stash } : current));
+        }}
+      />
     </StashChrome>
   );
 }
@@ -163,9 +172,11 @@ const COVER_GRADIENTS = [
 function StashPageBody({
   data,
   onRefresh,
+  onStashChanged,
 }: {
   data: PublicStashDetail;
   onRefresh: () => Promise<void>;
+  onStashChanged: (stash: WorkspaceStash) => void;
 }) {
   const { stash, workspace_name, items, can_write } = data;
   const groups = groupStashItems(items);
@@ -208,6 +219,13 @@ function StashPageBody({
   }));
   const author = stash.owner_display_name || stash.owner_name;
 
+  async function renameStashTitle(nextTitle: string) {
+    const updated = await updateStash(stash.id, { title: nextTitle });
+    resetStashNavigationCache();
+    onStashChanged(updated);
+    return updated.title;
+  }
+
   return (
     <div className="scroll-thin min-h-screen bg-background">
       {/* Cover banner — click to upload (when can_write). Mirrors the
@@ -234,7 +252,13 @@ function StashPageBody({
             />
             <div className="min-w-0">
               <h1 className="m-0 truncate font-display text-[20px] font-bold leading-tight tracking-[-0.015em] text-foreground">
-                {stash.title}
+                <EditableTitle
+                  value={stash.title}
+                  onSave={renameStashTitle}
+                  disabled={!can_write}
+                  className="inline-block max-w-full truncate"
+                  title={stash.title}
+                />
               </h1>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-muted">
                 <span>by {author}</span>


### PR DESCRIPTION
## Summary

- Makes the stash detail title use the existing inline title editor for users with write access.
- Saves title changes through `updateStash`, updates the local page state, and resets the navigation cache so stale stash titles do not linger.
- Adds Vitest coverage for the inline title rename flow.

## Screenshot

![stash-not-editable-titles.png](https://github.com/user-attachments/assets/a684f80f-3fb7-4d27-ac9f-abef773f12b5)

## Validation

- `cd frontend && npm test -- StashPageClient.test.tsx`
- `cd frontend && npm test`
- `cd frontend && npm run lint` passes with existing warnings in `frontend/src/components/workspace/file-browser/ItemsColumns.tsx`