### PR TITLE
Repair production trash schema migration

### DIFF
--- a/backend/migrations/versions/0062_repair_trash_schema.py
+++ b/backend/migrations/versions/0062_repair_trash_schema.py
@@ -1,0 +1,33 @@
+"""Repair trash schema for databases already stamped at 0061.
+
+Revision ID: 0062
+Revises: 0061
+"""
+
+from alembic import op
+
+revision = "0062"
+down_revision = "0061"
+branch_labels = None
+depends_on = None
+
+
+_TABLES = ("sessions", "pages", "files")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ")
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS deleted_by UUID")
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_trash "
+            f"ON {table} (workspace_id, deleted_at DESC) "
+            f"WHERE deleted_at IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"DROP INDEX IF EXISTS idx_{table}_trash")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS deleted_by")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS deleted_at")


### PR DESCRIPTION
## Summary
- Add migration `0062` to repair production databases already stamped at `0061` without the trash schema.
- Adds `deleted_at`, `deleted_by`, and the partial trash index for `sessions`, `pages`, and `files`.

## Root Cause
Production had `alembic_version=0061`, but the `0060` trash DDL never ran because the earlier duplicate revision conflict reused `0060` for a different migration. The backend is live, but endpoints that query `deleted_at` are returning 500 because those columns are missing in production.

## Validation
- `python -m alembic heads`
- `ruff check backend/migrations/versions/0062_repair_trash_schema.py`
- `black --check backend/migrations/versions/0062_repair_trash_schema.py`
- `pytest --no-cov backend/tests/test_migrations.py -q`
- Local PostgreSQL simulation:
  - fresh DB `alembic upgrade head` -> `0062` with trash columns/indexes
  - DB upgraded to `0059`, stamped to `0061`, then `upgrade head` -> `0062` with trash columns/indexes
