### PR TITLE
[codex] Show generated session titles in lists

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -107,6 +107,7 @@ async def list_my_sessions(
           (ARRAY_AGG(NULLIF(u.display_name, '') ORDER BY he.created_at)
            FILTER (WHERE NULLIF(u.display_name, '') IS NOT NULL))[1] AS user_name,
           MAX(he.agent_name) AS agent_name,
+          COALESCE(MAX(s.summary), '') AS summary,
           COUNT(*)::INT AS event_count,
           MIN(he.created_at) AS started_at,
           MAX(he.created_at) AS last_event_at,
@@ -121,6 +122,9 @@ async def list_my_sessions(
         FROM history_events he
         LEFT JOIN workspaces w ON w.id = he.workspace_id
         LEFT JOIN users u ON u.id = he.created_by
+        LEFT JOIN sessions s ON s.workspace_id IS NOT DISTINCT FROM he.workspace_id
+          AND s.session_id = he.session_id
+          AND s.deleted_at IS NULL
         WHERE {' AND '.join(where)}
         GROUP BY he.session_id, he.workspace_id, w.name
         ORDER BY last_event_at DESC, user_name ASC, session_id ASC
@@ -132,6 +136,10 @@ async def list_my_sessions(
     for session in sessions:
         if not session["user_name"]:
             raise RuntimeError(f"Session {session['session_id']} has no author display_name")
+        session["title"] = session_title_service.title_from_summary(
+            session.pop("summary"),
+            session["session_id"],
+        )
     return {"sessions": sessions}
 
 

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -24,6 +24,8 @@ from ..services import (
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
+SIDEBAR_ETAG_VERSION = "sidebar-session-title-v2"
+
 
 # ---------------------------------------------------------------------------
 # Overview + Sidebar — the per-workspace view shapes
@@ -305,7 +307,11 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
           (SELECT MAX(created_at) FROM files
             WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS f,
           (SELECT MAX(updated_at) FROM folders WHERE workspace_id = $1)          AS d,
-          (SELECT MAX(GREATEST(finished_at, started_at)) FROM sessions
+          (SELECT MAX(GREATEST(
+            COALESCE(finished_at, started_at),
+            started_at,
+            COALESCE(summary_last_attempt_at, started_at)
+          )) FROM sessions
             WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS s,
           (SELECT MAX(updated_at) FROM stashes WHERE workspace_id = $1)            AS st,
           (SELECT MAX(sm.created_at) FROM stash_members sm
@@ -316,7 +322,10 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
         workspace_id,
         user_id,
     )
-    raw = "|".join(str(row[k] or "") for k in ("p", "f", "d", "s", "st", "sm", "w"))
+    raw = "|".join(
+        [SIDEBAR_ETAG_VERSION]
+        + [str(row[k] or "") for k in ("p", "f", "d", "s", "st", "sm", "w")]
+    )
     return f'W/"{_short_hash(raw)}"'
 
 

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -15,7 +15,13 @@ _GENERIC_PREFIXES = (
     "summary of changes",
     "summary",
     "what changed",
+    "what happened",
     "what the session accomplished",
+    "what was accomplished",
+    "accomplishment",
+    "accomplishments",
+    "status",
+    "session status",
     "key files modified or created",
     "key files",
     "important decisions made",
@@ -39,6 +45,10 @@ def _title_from_line(line: str) -> str:
         return ""
 
     text = _strip_generic_prefix(text)
+    if not text:
+        return ""
+
+    text = _strip_generic_lead_in(text)
     if not text:
         return ""
 
@@ -82,6 +92,22 @@ def _truncate(title: str) -> str:
     if len(title) <= MAX_TITLE_LENGTH:
         return title
     return title[:MAX_TITLE_LENGTH]
+
+
+def _strip_generic_lead_in(text: str) -> str:
+    lower = text.lower()
+    for phrase in ("this session just ", "this session is ", "this session was "):
+        if lower.startswith(phrase):
+            return ""
+    if lower.startswith("this session "):
+        return _capitalize_first(text[len("this session ") :].strip())
+    return text
+
+
+def _capitalize_first(text: str) -> str:
+    if not text:
+        return text
+    return text[0].upper() + text[1:]
 
 
 def _normalize(text: str) -> str:

--- a/backend/tests/test_session_title_service.py
+++ b/backend/tests/test_session_title_service.py
@@ -28,5 +28,41 @@ def test_title_from_summary_skips_generic_section_heading():
     assert title == "Added member invitation routes"
 
 
+def test_title_from_summary_skips_what_happened_heading():
+    title = title_from_summary(
+        "## What Happened?\n\nInvestigated API gateway latency and added tracing.",
+        "session-1",
+    )
+
+    assert title == "Investigated API gateway latency and added tracing"
+
+
+def test_title_from_summary_skips_empty_accomplishment_heading():
+    title = title_from_summary(
+        "Accomplishment:\nImplemented session title display in the sidebar.",
+        "session-1",
+    )
+
+    assert title == "Implemented session title display in the sidebar"
+
+
+def test_title_from_summary_skips_generic_status_line():
+    title = title_from_summary(
+        "Status: This session is waiting for tests.\nUpdated the session title parser.",
+        "session-1",
+    )
+
+    assert title == "Updated the session title parser"
+
+
+def test_title_from_summary_strips_this_session_lead_in():
+    title = title_from_summary(
+        "This session investigated API gateway latency and added tracing.",
+        "session-1",
+    )
+
+    assert title == "Investigated API gateway latency and added tracing"
+
+
 def test_title_from_summary_falls_back_to_session_id_for_empty_summary():
     assert title_from_summary("## Session Summary", "session-1") == "session-1"

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -423,10 +423,8 @@ function SessionTableRow({
 }
 
 function sessionTitle(s: SessionSummary): string {
-  const preview = (s.first_prompt_preview || "").trim().replace(/\s+/g, " ");
-  if (preview) return preview.length > 96 ? preview.slice(0, 96) + "…" : preview;
-  const id = s.session_id;
-  return id.replace(/^session[-_]/, "").replace(/[-_]+/g, " ") || id;
+  const title = s.title.trim().replace(/\s+/g, " ");
+  return title.length > 96 ? title.slice(0, 96) + "…" : title;
 }
 
 function sessionTime(session: SessionSummary): number {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -772,6 +772,7 @@ export async function updateFile(
 
 export interface SessionSummary {
   session_id: string;
+  title: string;
   workspace_id: string | null;
   workspace_name: string | null;
   user_name: string;

--- a/frontend/src/lib/sessionGrouping.test.ts
+++ b/frontend/src/lib/sessionGrouping.test.ts
@@ -10,6 +10,7 @@ import {
 function session(fields: Partial<SessionSummary> & { session_id: string }): SessionSummary {
   return {
     session_id: fields.session_id,
+    title: fields.title ?? fields.session_id,
     workspace_id: "ws-1",
     workspace_name: "Workspace",
     user_name: fields.user_name ?? "Test User",


### PR DESCRIPTION
## Summary
- return the derived session title from `/api/v1/me/sessions` so the Sessions page stops using first prompt previews as titles
- expand summary-to-title filtering for generic headings like `What Happened?`, `Accomplishment:`, and `Status:`
- bump the sidebar ETag key so cached sidebar payloads refetch with the new title logic

## Root Cause
PR #347 fixed title derivation for the session detail/sidebar path, but `/api/v1/me/sessions` still returned only `first_prompt_preview`, so the Sessions page kept displaying prompt text like “You are working on a Linear ticket...”. The “What happened?” label came from generated `sessions.summary` text, not from the chat transcript; the title parser did not treat that heading as boilerplate. Existing sidebar ETags also did not change when only title derivation logic changed, so clients could keep a cached old label.

## Validation
- `ruff check backend/services/session_title_service.py backend/routers/sessions.py backend/routers/workspace_knowledge.py backend/tests/test_session_title_service.py`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_title_fix PYTEST_ADDOPTS=--no-cov pytest backend/tests/test_session_title_service.py backend/tests/test_permissions.py::test_private_stash_hides_session_surfaces_until_user_is_added`
- `cd frontend && npm test -- sessionGrouping.test.ts`
- `cd frontend && npm run build`
- `cd frontend && npm run lint` (passes with 3 existing warnings in `ItemsColumns.tsx`)

## Screenshots
No screenshot attached: the changed UI surface is text label selection only, with no layout or visual styling change.