### PR TITLE
FER-83: Limit commit graph to recent activity

### DIFF
--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -325,8 +325,7 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
         user_id,
     )
     raw = "|".join(
-        [SIDEBAR_ETAG_VERSION]
-        + [str(row[k] or "") for k in ("p", "f", "d", "s", "st", "sm", "w")]
+        [SIDEBAR_ETAG_VERSION] + [str(row[k] or "") for k in ("p", "f", "d", "s", "st", "sm", "w")]
     )
     return f'W/"{_short_hash(raw)}"'
 

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -317,6 +317,21 @@ describe("StashPageClient sharing", () => {
     expect(title).not.toHaveTextContent("workspace");
   });
 
+  it("loads only recent activity for the commit graph", async () => {
+    render(<StashPageClient slug="shared-stash" />);
+
+    expect(
+      await screen.findByText("Human / agent commits — last 30 days"),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(getActivityTimeline).toHaveBeenCalledWith(
+        30,
+        "day",
+        "workspace-1",
+      ),
+    );
+  });
+
   it("shows the stash author in the detail header", async () => {
     vi.mocked(getPublicStash).mockResolvedValueOnce(
       stashDetail({ owner_name: "sam", owner_display_name: "Sam" })

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -183,7 +183,7 @@ function StashPageBody({
     let cancelled = false;
     setInsightsLoaded(false);
     Promise.allSettled([
-      getActivityTimeline(365, "day", stash.workspace_id),
+      getActivityTimeline(30, "day", stash.workspace_id),
       getEmbeddingProjection(500, undefined, stash.workspace_id),
     ]).then(([t, p]) => {
       if (cancelled) return;
@@ -340,7 +340,9 @@ function StashPageBody({
         {/* Visualizations: human/agent session activity + 3D embedding view of the
             owning workspace — same shape as workspace home. */}
         <section className="mt-8">
-          <div className="sys-label mb-1.5">Human / agent commits — past year</div>
+          <div className="sys-label mb-1.5">
+            Human / agent commits — last 30 days
+          </div>
           <div className="card-soft overflow-x-auto p-3">
             {!insightsLoaded ? (
               <SkeletonBlock className="h-40 w-full" />

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -62,10 +62,7 @@ export default function WorkspaceHomePage() {
     const [w, m, t, p] = await Promise.allSettled([
       getWorkspace(workspaceId),
       getWorkspaceMembers(workspaceId),
-      // 365 days because seeded dev data is dated; for production the
-      // visualization remains legible at this window (1 row per contributor × 365
-      // 14px cells = ~1.4kpx wide, fits with horizontal scroll).
-      getActivityTimeline(365, "day", workspaceId),
+      getActivityTimeline(30, "day", workspaceId),
       getEmbeddingProjection(500, undefined, workspaceId),
     ]);
     if (w.status === "fulfilled") setWorkspace(w.value);
@@ -215,7 +212,7 @@ export default function WorkspaceHomePage() {
               and know what's coming once data exists. */}
         <section className="mt-8">
           <div className="sys-label mb-1.5">
-            Human / agent commits — past year
+            Human / agent commits — last 30 days
           </div>
           <div className="card-soft overflow-x-auto p-3">
             {!insightsLoaded ? (


### PR DESCRIPTION
## Summary
- Limit workspace and stash commit activity graphs to the last 30 days instead of requesting a full year.
- Update the graph label to match the new recent window.
- Add a regression assertion for the stash detail analytics request.
- Apply Black formatting to `backend/routers/workspace_knowledge.py` so the repo-wide backend lint check passes.

## Screenshot
Product screenshot added in the PR thread: https://github.com/Fergana-Labs/stash/pull/358#issuecomment-4493445591

## Tests
- `npm test -- StashPageClient.test.tsx`
- `npm run lint` (passes with 3 existing unused-variable warnings in `ItemsColumns.tsx`)
- `npm run build`
- `ruff check backend/ cli/`
- `black --check backend/ cli/`
