### PR TITLE
[codex] Add Yjs page collaboration service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,15 @@ DB_POOL_MAX=20
 PUBLIC_URL=http://localhost:3457
 CORS_ORIGINS=http://localhost:3457,http://localhost:3456
 
+# ── Live Collaboration ───────────────────────
+# The frontend defaults to ws://localhost:3458 in local dev and /collab on
+# deployed same-origin installs. Set this when the collab service has its own
+# public host, e.g. wss://stash-collab.onrender.com.
+# COLLAB_PUBLIC_URL=ws://localhost:3458
+
+# Used by the collab sidecar to authorize users through FastAPI.
+BACKEND_URL=http://localhost:3456
+
 # ── Embeddings ──────────────────────────────────────────────────
 # Provider: openai | huggingface | local | auto (default).
 # "auto" detects from available keys: OPENAI_API_KEY → openai, HF_TOKEN → huggingface, else → local.

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,9 +4,6 @@
 # Caddy automatically provisions and renews TLS certificates via Let's Encrypt.
 
 app.example.com {
-    # Frontend
-    reverse_proxy frontend:3457
-
     # Backend API
     handle /api/* {
         reverse_proxy backend:3456
@@ -14,5 +11,15 @@ app.example.com {
 
     handle /health {
         reverse_proxy backend:3456
+    }
+
+    # Yjs collaboration WebSocket
+    handle /collab* {
+        reverse_proxy collab:3458
+    }
+
+    # Frontend
+    handle {
+        reverse_proxy frontend:3457
     }
 }

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from .middleware import limiter
 from .routers import (
     admin,
     aggregate,
+    collab,
     discover,
     files,
     files_tree,
@@ -98,6 +99,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.include_router(users.router)
+app.include_router(collab.router)
 app.include_router(workspaces.router)
 app.include_router(workspace_knowledge.router)
 app.include_router(discover.router)

--- a/backend/migrations/versions/0064_page_collab_documents.py
+++ b/backend/migrations/versions/0064_page_collab_documents.py
@@ -1,0 +1,35 @@
+"""Add persisted Yjs state for collaborative page editing.
+
+Revision ID: 0064
+Revises: 0063
+"""
+
+from alembic import op
+
+revision = "0064"
+down_revision = "0063"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS page_collab_documents (
+            page_id UUID PRIMARY KEY REFERENCES pages(id) ON DELETE CASCADE,
+            workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            yjs_state BYTEA NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_page_collab_documents_workspace "
+        "ON page_collab_documents(workspace_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_page_collab_documents_workspace")
+    op.execute("DROP TABLE IF EXISTS page_collab_documents")

--- a/backend/migrations/versions/0064_page_collab_documents.py
+++ b/backend/migrations/versions/0064_page_collab_documents.py
@@ -13,8 +13,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         CREATE TABLE IF NOT EXISTS page_collab_documents (
             page_id UUID PRIMARY KEY REFERENCES pages(id) ON DELETE CASCADE,
             workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -22,8 +21,7 @@ def upgrade() -> None:
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
         )
-        """
-    )
+        """)
     op.execute(
         "CREATE INDEX IF NOT EXISTS idx_page_collab_documents_workspace "
         "ON page_collab_documents(workspace_id)"

--- a/backend/models.py
+++ b/backend/models.py
@@ -330,6 +330,7 @@ class PageUpdateRequest(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=255)
     folder_id: UUID | None = None
     content: str | None = None
+    collab_projection: bool = False
     content_type: str | None = Field(None, pattern=r"^(markdown|html)$")
     content_html: str | None = None
     html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect)$")

--- a/backend/routers/collab.py
+++ b/backend/routers/collab.py
@@ -1,0 +1,68 @@
+"""Collaboration auth endpoints used by the Yjs sidecar."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..auth import get_current_user
+from ..services import files_tree_service, permission_service, workspace_service
+
+router = APIRouter(prefix="/api/v1/collab", tags=["collaboration"])
+
+
+class CollabAuthorizeRequest(BaseModel):
+    document_name: str = Field(..., min_length=1, max_length=256)
+
+
+class CollabUser(BaseModel):
+    id: UUID
+    name: str
+    display_name: str
+
+
+class CollabAuthorizeResponse(BaseModel):
+    user: CollabUser
+    can_write: bool
+
+
+def _parse_page_document_name(document_name: str) -> tuple[UUID, UUID]:
+    parts = document_name.split(":")
+    if len(parts) != 4 or parts[0] != "workspace" or parts[2] != "page":
+        raise HTTPException(status_code=400, detail="Unsupported collaboration document")
+    try:
+        return UUID(parts[1]), UUID(parts[3])
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Invalid collaboration document") from e
+
+
+@router.post("/authorize", response_model=CollabAuthorizeResponse)
+async def authorize_collab_document(
+    req: CollabAuthorizeRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    workspace_id, page_id = _parse_page_document_name(req.document_name)
+    if not await workspace_service.is_member(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+    page = await files_tree_service.get_page(page_id, workspace_id, current_user["id"])
+    if not page:
+        raise HTTPException(status_code=404, detail="Page not found")
+    if page["content_type"] != "markdown":
+        raise HTTPException(status_code=400, detail="Only markdown pages support live editing")
+
+    can_write = await permission_service.check_access(
+        "page",
+        page_id,
+        current_user["id"],
+        workspace_id=workspace_id,
+        require_write=True,
+    )
+    return CollabAuthorizeResponse(
+        user=CollabUser(
+            id=current_user["id"],
+            name=current_user["name"],
+            display_name=current_user["display_name"],
+        ),
+        can_write=can_write,
+    )

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -459,6 +459,7 @@ async def update_page(
             current_user["id"],
             require_write=True,
         )
+
     try:
         page = await files_tree_service.update_page(
             page_id,
@@ -471,6 +472,7 @@ async def update_page(
             content_html=req.content_html,
             html_layout=req.html_layout,
             move_to_root=req.move_to_root,
+            guard_content_hash=not (req.collab_projection and req.content is not None),
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -476,6 +476,8 @@ async def update_page(
         raise HTTPException(status_code=409, detail=str(e))
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    if req.content is not None and not req.collab_projection:
+        await files_tree_service.delete_page_collab_state(page_id, workspace_id)
     return PageResponse(**page)
 
 

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -521,6 +521,15 @@ async def purge_page(page_id: UUID, workspace_id: UUID) -> bool:
     return result == "DELETE 1"
 
 
+async def delete_page_collab_state(page_id: UUID, workspace_id: UUID) -> None:
+    pool = get_pool()
+    await pool.execute(
+        "DELETE FROM page_collab_documents WHERE page_id = $1 AND workspace_id = $2",
+        page_id,
+        workspace_id,
+    )
+
+
 async def list_trashed_pages(workspace_id: UUID) -> list[dict]:
     pool = get_pool()
     rows = await pool.fetch(

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -343,6 +343,7 @@ async def update_page(
     html_layout: str | None = None,
     move_to_root: bool = False,
     metadata: dict | None = None,
+    guard_content_hash: bool = True,
     on_conflict: Callable[[dict], Awaitable[str]] | None = None,
 ) -> dict | None:
     """Update a page with optimistic concurrency on content_hash."""
@@ -421,7 +422,7 @@ async def update_page(
         args.append(page_id)
         args.append(workspace_id)
         where = f"id = ${idx} AND workspace_id = ${idx + 1} AND {_WORKSPACE_PAGE_FILTER}"
-        if expected_hash is not None:
+        if expected_hash is not None and guard_content_hash:
             args.append(expected_hash)
             where += f" AND content_hash = ${idx + 2}"
 
@@ -444,7 +445,7 @@ async def update_page(
                 _schedule_embed(page["id"], active)
             return page
 
-        if expected_hash is None:
+        if expected_hash is None or not guard_content_hash:
             return None
 
         fresh = await pool.fetchrow(

--- a/backend/tests/test_collab.py
+++ b/backend/tests/test_collab.py
@@ -1,0 +1,115 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+def _auth(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient) -> tuple[str, dict]:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    response = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    return body["api_key"], body
+
+
+@pytest.mark.asyncio
+async def test_collab_authorizes_markdown_page_writer(client: AsyncClient):
+    api_key, _user = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(api_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(api_key),
+        )
+    ).json()
+
+    response = await client.post(
+        "/api/v1/collab/authorize",
+        json={"document_name": f"workspace:{workspace['id']}:page:{page['id']}"},
+        headers=_auth(api_key),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["can_write"] is True
+
+
+@pytest.mark.asyncio
+async def test_collab_authorizes_workspace_viewer_as_read_only(
+    client: AsyncClient,
+    pool,
+):
+    owner_key, _owner = await _register(client)
+    viewer_key, viewer = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    await pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'viewer')",
+        uuid.UUID(workspace["id"]),
+        uuid.UUID(viewer["id"]),
+    )
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+
+    response = await client.post(
+        "/api/v1/collab/authorize",
+        json={"document_name": f"workspace:{workspace['id']}:page:{page['id']}"},
+        headers=_auth(viewer_key),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["can_write"] is False
+
+
+@pytest.mark.asyncio
+async def test_collab_rejects_html_pages(client: AsyncClient):
+    api_key, _user = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(api_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={
+                "name": "Demo",
+                "content_type": "html",
+                "content_html": "<h1>Demo</h1>",
+            },
+            headers=_auth(api_key),
+        )
+    ).json()
+
+    response = await client.post(
+        "/api/v1/collab/authorize",
+        json={"document_name": f"workspace:{workspace['id']}:page:{page['id']}"},
+        headers=_auth(api_key),
+    )
+
+    assert response.status_code == 400

--- a/backend/tests/test_collab.py
+++ b/backend/tests/test_collab.py
@@ -1,7 +1,10 @@
+import asyncio
 import uuid
 
 import pytest
 from httpx import AsyncClient
+
+from backend.services import files_tree_service
 
 
 def _auth(api_key: str) -> dict[str, str]:
@@ -113,3 +116,70 @@ async def test_collab_rejects_html_pages(client: AsyncClient):
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_collab_projection_save_disables_content_hash_guard(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    api_key, _user = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(api_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(api_key),
+        )
+    ).json()
+
+    async def update_page_with_conflict(*args, **kwargs):
+        assert kwargs["guard_content_hash"] is False
+        return {**page, "content_markdown": kwargs["content"]}
+
+    monkeypatch.setattr(files_tree_service, "update_page", update_page_with_conflict)
+
+    response = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/pages/{page['id']}",
+        json={"content": "CRDT projection", "collab_projection": True},
+        headers=_auth(api_key),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content_markdown"] == "CRDT projection"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_collab_projection_saves_do_not_500(client: AsyncClient):
+    api_key, _user = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(api_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(api_key),
+        )
+    ).json()
+
+    async def save_projection(index: int):
+        return await client.patch(
+            f"/api/v1/workspaces/{workspace['id']}/pages/{page['id']}",
+            json={"content": f"CRDT projection {index}", "collab_projection": True},
+            headers=_auth(api_key),
+        )
+
+    responses = await asyncio.gather(*(save_projection(i) for i in range(12)))
+
+    assert [response.status_code for response in responses] == [200] * 12

--- a/collab/.gitignore
+++ b/collab/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/collab/Dockerfile
+++ b/collab/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3458
+
+ENV PORT=3458
+
+CMD ["node", "dist/server.js"]

--- a/collab/package-lock.json
+++ b/collab/package-lock.json
@@ -1,0 +1,1840 @@
+{
+  "name": "stash-collab",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stash-collab",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hocuspocus/server": "4.0.0",
+        "@hocuspocus/transformer": "4.0.0",
+        "@tiptap/core": "3.23.5",
+        "@tiptap/extension-bold": "3.23.5",
+        "@tiptap/extension-heading": "3.23.5",
+        "@tiptap/extension-image": "3.23.5",
+        "@tiptap/extension-italic": "3.23.5",
+        "@tiptap/extension-link": "3.23.5",
+        "@tiptap/extension-subscript": "3.23.5",
+        "@tiptap/extension-superscript": "3.23.5",
+        "@tiptap/extension-table": "3.23.5",
+        "@tiptap/extension-table-cell": "3.23.5",
+        "@tiptap/extension-table-header": "3.23.5",
+        "@tiptap/extension-table-row": "3.23.5",
+        "@tiptap/extension-typography": "3.23.5",
+        "@tiptap/extension-underline": "3.23.5",
+        "@tiptap/html": "3.23.5",
+        "@tiptap/starter-kit": "3.23.5",
+        "happy-dom": "20.8.9",
+        "markdown-it": "14.1.0",
+        "pg": "8.13.3",
+        "yjs": "13.6.23"
+      },
+      "devDependencies": {
+        "@types/markdown-it": "14.1.2",
+        "@types/node": "20.19.1",
+        "@types/pg": "8.11.11",
+        "tsx": "4.20.3",
+        "typescript": "5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hocuspocus/common": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.0.0.tgz",
+      "integrity": "sha512-7BE8TsKBkdiOZO6tfm3ny6bIHPbxkIZb3hsYdVn/X5xbXI8n8w9pnE6pXgEMKQhJm6zsWsa9IDRJIp/c9u+DmA==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
+    "node_modules/@hocuspocus/server": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.0.0.tgz",
+      "integrity": "sha512-Pgm+kVtTrVvybIJUVot5XumSzD8rPLQglUV0QAAiN6J64dkYc2wWNdGcMwJz3q3yJPV0dO+eRU9JEck+iVdgzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^4.0.0",
+        "async-mutex": "^0.5.0",
+        "crossws": "^0.4.4",
+        "kleur": "^4.1.4",
+        "lib0": "^0.2.47"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@hocuspocus/transformer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/transformer/-/transformer-4.0.0.tgz",
+      "integrity": "sha512-neyV/DXaWyIYRV6TZ3WvntZzmh1kM+iGq3fHajtmUGyhp3EID+lmeCVY1Q2V6ZXD+fVw+S0i4pUzeWFe35A5mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/starter-kit": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1",
+        "@tiptap/pm": "^3.0.1",
+        "y-prosemirror": "^1.2.1",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.5.tgz",
+      "integrity": "sha512-657Xqcgf1IYWLkAmRDJKNSGdoS1AHJEgK6zHWHFJERQGIqHnwC7Fz7nvWs/NQhQVBkclQd0ERRdTCZ3XwRc1+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.5.tgz",
+      "integrity": "sha512-DZsDCCf53fA9HmsFzfUHl5jLOwDYf+XzfP+QJjJ4cK23SsxDirameTjgnwi4l1EgEPLWunMZQjU+wHmh7vvX6Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.5.tgz",
+      "integrity": "sha512-tFI+iYk34geacVOGqYgyoC8siQjdGn605XaYSZcGRFF8NY+HrGlLkQi2QRRCeLaUhxoctONmWc8USn3H5U7wLQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.23.5.tgz",
+      "integrity": "sha512-v6u9zbJSKLjml6DDn1/1WOOIzVxz3K5Idl1EgUl+IpJH7kR1HLRJ3TaSgF7z2RRQmqyHlmtdCzdaKoe0jCIyqQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.5.tgz",
+      "integrity": "sha512-XjRSPr6j4mz+8O5j5KNfxVb+1fGNt0wr+js6MLxxGdU7M+PoDPdVY6fARbmBazv4ERlZ5PNS9m35Vo5xDjDfrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.5.tgz",
+      "integrity": "sha512-FEI58NAPnauBbs4nw1dkgRyEhcWnure0vIlStfQoQGXxj3xSRvxKH2lOkz54fGzuzRJAoudyLU65HW6D7kc+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-subscript": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.23.5.tgz",
+      "integrity": "sha512-q4O6qmrh6aD2Nt+voLJ4uICEexjF6LBvxf7psYMI4bYII7vDJaFZ+8XR6pDOl5JCJCwl1WYboxF2a4U2XrMAxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-superscript": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.23.5.tgz",
+      "integrity": "sha512-TLCvZ/38lkx0jcVPMm6L2p0wWn8uziJKQPQp/rgR3Cfkn4jzL1Y/Vmq5JpN2NoX69XdusdtGlh4tl594BT0FLQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-table": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.23.5.tgz",
+      "integrity": "sha512-3uTaC+LsilQHaMGTW6vK4fXHsTYL/TPGM0mxoBz8UvMl+G/uzL149RcMC0d0qKvYPxInFQ2rFzxPTpnY3Rg3UA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-table-cell": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.23.5.tgz",
+      "integrity": "sha512-P8agH3q1EDEGTcs9+BXqIv/2weUkJfy63SIQetU28egtNRJt1L+rhnrkwzd95f01TNN/TRSyW01OAZ3tj8tHKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-table-header": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.23.5.tgz",
+      "integrity": "sha512-CeEiMwEg4L38e8c4qJovasKaaSkcAUrMNNfvF/qE8WogSYfke2/OAy4cZ47bhzd5oauSUjiIUnmsY11Q0jdX/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-table-row": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.23.5.tgz",
+      "integrity": "sha512-tbpl+kSHeuPIqwgPw3SuQXS/rzdzRYigxXY1fCeWea20wONMQhLHyaL710vFcugIW6d9aSgmvdiwcGS/MneL0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-typography": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-3.23.5.tgz",
+      "integrity": "sha512-bPeLGAuqUh9t9gfVik9eHEXU+tQA+24cQj+YexK8pZivNEDi7ED3RCbR01t5SlUqSEDEK+cssVPmmz6d/hPDeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.5.tgz",
+      "integrity": "sha512-fyxthzE6CNCi9a9OVAwXs1sSyJ7jlrzT3aP2KhYLQCsJABHaPJgJA7k52/CRuKqCW3WbxU1ULH9LGuGtBbhEyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/html": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-3.23.5.tgz",
+      "integrity": "sha512-lFJbuL3mFHvqe9BaFbEd43cb/lHKAoM0O69opFJLlIYn3dre6kt64Qr7UOXQ3dp6mRU0ptVUwBV3R1eG9EPpUQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5",
+        "happy-dom": "^20.8.9"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.5.tgz",
+      "integrity": "sha512-9tgLdpTvNN0/fLP4RcNzbyQ0qjg9J2ahaFbQzgV5uvd+QMy8Xkg2IqKKnOoJJUAV3FDjGq3Yx0WrV2BGro9pfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.5.tgz",
+      "integrity": "sha512-ac0edQ1a1nYkNAzOgdqIBKGdrOlNQpPP9wGAG3Q9EgTq4+C4/EftJZZJmUn3KzaSOUv4cLEDo0z0jurJvZPkaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.23.5",
+        "@tiptap/extension-blockquote": "^3.23.5",
+        "@tiptap/extension-bold": "^3.23.5",
+        "@tiptap/extension-bullet-list": "^3.23.5",
+        "@tiptap/extension-code": "^3.23.5",
+        "@tiptap/extension-code-block": "^3.23.5",
+        "@tiptap/extension-document": "^3.23.5",
+        "@tiptap/extension-dropcursor": "^3.23.5",
+        "@tiptap/extension-gapcursor": "^3.23.5",
+        "@tiptap/extension-hard-break": "^3.23.5",
+        "@tiptap/extension-heading": "^3.23.5",
+        "@tiptap/extension-horizontal-rule": "^3.23.5",
+        "@tiptap/extension-italic": "^3.23.5",
+        "@tiptap/extension-link": "^3.23.5",
+        "@tiptap/extension-list": "^3.23.5",
+        "@tiptap/extension-list-item": "^3.23.5",
+        "@tiptap/extension-list-keymap": "^3.23.5",
+        "@tiptap/extension-ordered-list": "^3.23.5",
+        "@tiptap/extension-paragraph": "^3.23.5",
+        "@tiptap/extension-strike": "^3.23.5",
+        "@tiptap/extension-text": "^3.23.5",
+        "@tiptap/extension-underline": "^3.23.5",
+        "@tiptap/extensions": "^3.23.5",
+        "@tiptap/pm": "^3.23.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-blockquote": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.5.tgz",
+      "integrity": "sha512-PBQRoGfSWfIY7HmGbS5PTHEBQl5nKbild5J5phPLFF+O3aOBQ0d49AC9cxbaou/6FRCtq6g4Uqse9rRTKJRM0w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.5.tgz",
+      "integrity": "sha512-o0bzZbFvOPhPX6+RAhIFPKMIN3jIenY6Ib3FJ6ZqxTdVcjuV2mIXUmJU0uV2BwKtz73GmKSRKRKia6KJ0ml8qA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.5.tgz",
+      "integrity": "sha512-NOJUD2Z0hrtBWnovXiiH1XtOjEQePOfIG3bNJgXSs1bWxPVhqp6KjVd8mUJNra974hxbml3tC97sL9QqjpAWFg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code-block": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.5.tgz",
+      "integrity": "sha512-P2XH8WPM4UahavcWoQgAwNAKQCbF/JWi6ZqgsQmVBfAqQ3mf8gMxB7HnciMq1DlyI9EfjXoJH11yUqldF/6AaQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-document": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.5.tgz",
+      "integrity": "sha512-Y7uPjEM1xIK4Spcdk/kp/vZ/Az3cEaglTCk6uHrWvNFVglEoGehNb6IQbQFZW0wjE19YoMIiLBLtG6V9dqrpBw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.5.tgz",
+      "integrity": "sha512-l72R798Q69D6f89Vp9xreoRnPcpK0LHPKLZIc6pvqBC2iOjx5wLKtW0uP1uqVWdQtvF5AUYBRNIGAQ5Gel9XEg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.5.tgz",
+      "integrity": "sha512-x9XlYG26TowX0Ly1w0ZV2D8qliyQy9fTmMY4suI6B/6o6m/sXHGTAJMmJqwP66sZKF6cMLU3HECumhtyQxPT2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-hard-break": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.5.tgz",
+      "integrity": "sha512-j/BDBMOA1mA+RhCx622SRPBhpp2XWNFYz9asbg8T3yk8v9WI3Vjo6IDlfTp6fwsR2LGE7Pek3R0xDAjW6yVG3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.5.tgz",
+      "integrity": "sha512-9XkRYc4XE0stERZB3y8bsJd32Jw9UZfMwZXo1GLNYRHFr7dmhSGUj0IzgofqOVmLDcOMW6XcCk54TBYw6BCrWA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.5.tgz",
+      "integrity": "sha512-nzZXpVwnyKwTj4TVyPyu1bCUFjJCsaXnhAthmvJDnX3RBtemNG9Ka07xGR2NIspzumSbQSMFtDxjmxv3W5dEtg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-item": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.5.tgz",
+      "integrity": "sha512-l7Hb4rfNIkO6JrNJYkdXap6QYXCz4XeeFmI1bfQgEiwPGs+RAn/+0cOdg7q+6MmtZFac5uSXV0PftPk6A0GsEA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.5.tgz",
+      "integrity": "sha512-Hz8jRA51VSiHezEkwqwaMYbTEYcR/5Aq3UgCgDlNPlE6k1OZrvRtV/4s3AOO0RRgzyVLKv7yv7KuOJN/OLGErw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.5.tgz",
+      "integrity": "sha512-qQeU71ij0cAAD9bbGqot5T5bpR3dysgQ+W67quRs6VDyusU89EYaJHKn/qWU6a1XOEQ4sL+5GNw52FYQVHUxbA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-paragraph": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.5.tgz",
+      "integrity": "sha512-LtgMcR1rvWnZDtphFJ/LBltlC0+6HGA07k7vhy+U7P/zIg/V3Fb4RD6YDuAo0cPfBsLm8p1WYJV92WpAsGgtlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-strike": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.5.tgz",
+      "integrity": "sha512-PMB9lpQGOJGuRTIS9rBw8UZtHQwmsiJbWKjcBr5z20MluaJQ3ZCHFhDYG6ncIDRz+0ny4ZvoJ7cKGpI+NTvXMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-text": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.5.tgz",
+      "integrity": "sha512-GLa+AaA2NC5XYRZad/Qq/oH5Pa95s+uA17J7+RCkF8j1RNREUBkYQ5CD5MT8kT+D3DHgU8MRyYdTd28I46HBDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5"
+      }
+    },
+    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extensions": {
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.5.tgz",
+      "integrity": "sha512-ROcdNPV+buzldEFKvD3o29P7H7zpAf2lnLfndO2LHSToWyHw4hlzVPCeAU8uAvhl/jyfeUoFLrBwxphMX/KG6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.5",
+        "@tiptap/pm": "3.23.5"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
+      "integrity": "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.5.tgz",
+      "integrity": "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.13.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.3.tgz",
+      "integrity": "sha512-P6tPt9jXbL9HVu/SSRERNYaYG++MjnscnegFh9pPHihfoBSujsrka0hyuymMzeJKFWrcG8wvCKy8rCe8e5nDUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.1",
+        "pg-protocol": "^1.7.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
+      "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y-prosemirror": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.109"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.23",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/collab/package.json
+++ b/collab/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "stash-collab",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@hocuspocus/server": "4.0.0",
+    "@hocuspocus/transformer": "4.0.0",
+    "@tiptap/core": "3.23.5",
+    "@tiptap/extension-bold": "3.23.5",
+    "@tiptap/extension-heading": "3.23.5",
+    "@tiptap/extension-image": "3.23.5",
+    "@tiptap/extension-italic": "3.23.5",
+    "@tiptap/extension-link": "3.23.5",
+    "@tiptap/extension-subscript": "3.23.5",
+    "@tiptap/extension-superscript": "3.23.5",
+    "@tiptap/extension-table": "3.23.5",
+    "@tiptap/extension-table-cell": "3.23.5",
+    "@tiptap/extension-table-header": "3.23.5",
+    "@tiptap/extension-table-row": "3.23.5",
+    "@tiptap/extension-typography": "3.23.5",
+    "@tiptap/extension-underline": "3.23.5",
+    "@tiptap/html": "3.23.5",
+    "@tiptap/starter-kit": "3.23.5",
+    "happy-dom": "20.8.9",
+    "markdown-it": "14.1.0",
+    "pg": "8.13.3",
+    "yjs": "13.6.23"
+  },
+  "devDependencies": {
+    "@types/markdown-it": "14.1.2",
+    "@types/node": "20.19.1",
+    "@types/pg": "8.11.11",
+    "tsx": "4.20.3",
+    "typescript": "5.8.3"
+  }
+}

--- a/collab/src/server.ts
+++ b/collab/src/server.ts
@@ -1,0 +1,250 @@
+import { Mark, type Extensions } from "@tiptap/core";
+import Bold from "@tiptap/extension-bold";
+import Heading from "@tiptap/extension-heading";
+import Image from "@tiptap/extension-image";
+import Italic from "@tiptap/extension-italic";
+import Link from "@tiptap/extension-link";
+import Subscript from "@tiptap/extension-subscript";
+import Superscript from "@tiptap/extension-superscript";
+import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
+import Typography from "@tiptap/extension-typography";
+import Underline from "@tiptap/extension-underline";
+import { generateJSON } from "@tiptap/html/server";
+import StarterKit from "@tiptap/starter-kit";
+import { Server } from "@hocuspocus/server";
+import { TiptapTransformer } from "@hocuspocus/transformer";
+import MarkdownIt from "markdown-it";
+import pg from "pg";
+import * as Y from "yjs";
+
+type CollabAuth = {
+  user: {
+    id: string;
+    name: string;
+    display_name: string;
+  };
+  can_write: boolean;
+};
+
+type PageDocument = {
+  workspaceId: string;
+  pageId: string;
+};
+
+type CollabContext = {
+  userId?: string;
+  canWrite?: boolean;
+};
+
+const { Pool } = pg;
+
+const port = Number(process.env.PORT || "3458");
+const backendUrl = requiredEnv("BACKEND_URL").replace(/\/$/, "");
+const databaseUrl = requiredEnv("DATABASE_URL");
+const databaseSsl = process.env.DATABASE_SSL === "true";
+const debugEnabled = process.env.COLLAB_DEBUG === "true";
+
+const pool = new Pool({
+  connectionString: databaseUrl,
+  ssl: databaseSsl ? { rejectUnauthorized: false } : undefined,
+});
+
+const markdown = new MarkdownIt({ html: true, linkify: true, typographer: false });
+
+const CommentMark = Mark.create({
+  name: "comment",
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-comment-id"),
+        renderHTML: (attributes) =>
+          attributes.id ? { "data-comment-id": attributes.id } : {},
+      },
+    };
+  },
+  parseHTML() {
+    return [{ tag: "span[data-comment-id]" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["span", HTMLAttributes, 0];
+  },
+});
+
+const editorExtensions: Extensions = [
+  StarterKit.configure({
+    blockquote: false,
+    codeBlock: false,
+    heading: false,
+    bold: false,
+    italic: false,
+    link: false,
+    underline: false,
+  }),
+  Heading.configure({ levels: [1, 2, 3] }),
+  Bold,
+  Italic,
+  Underline,
+  Subscript,
+  Superscript,
+  Typography,
+  Link.configure({ openOnClick: false, autolink: true }),
+  Image,
+  Table,
+  TableRow,
+  TableHeader,
+  TableCell,
+  CommentMark,
+];
+
+const server = new Server<CollabContext>({
+  port,
+  address: "0.0.0.0",
+  debounce: 1500,
+  maxDebounce: 10000,
+  quiet: process.env.COLLAB_QUIET !== "false",
+
+  async onAuthenticate(data) {
+    const page = parsePageDocument(data.documentName);
+    const auth = await authorize(data.documentName, data.token);
+    if (!auth.can_write) {
+      data.connectionConfig.readOnly = true;
+    }
+    debug("authenticated", {
+      documentName: data.documentName,
+      userId: auth.user.id,
+      canWrite: auth.can_write,
+    });
+    return {
+      userId: auth.user.id,
+      canWrite: auth.can_write,
+      pageId: page.pageId,
+    };
+  },
+
+  async onLoadDocument({ documentName }) {
+    const page = parsePageDocument(documentName);
+    const persisted = await loadPersistedState(page.pageId);
+    if (persisted) {
+      debug("loaded persisted document", {
+        documentName,
+        bytes: persisted.byteLength,
+      });
+      return persisted;
+    }
+    const document = await bootstrapPageDocument(page);
+    debug("bootstrapped document", {
+      documentName,
+      fields: Array.from(document.share.keys()),
+      bytes: Y.encodeStateAsUpdate(document).byteLength,
+    });
+    return document;
+  },
+
+  async onStoreDocument({ document, documentName }) {
+    const page = parsePageDocument(documentName);
+    const state = Buffer.from(Y.encodeStateAsUpdate(document));
+    debug("stored document", {
+      documentName,
+      bytes: state.byteLength,
+    });
+    await pool.query(
+      `
+      INSERT INTO page_collab_documents (page_id, workspace_id, yjs_state)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (page_id)
+      DO UPDATE SET yjs_state = EXCLUDED.yjs_state, updated_at = now()
+      `,
+      [page.pageId, page.workspaceId, state],
+    );
+  },
+});
+
+await server.listen();
+console.log(`Stash collaboration server listening on ${server.webSocketURL}`);
+
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+process.on("SIGINT", () => {
+  void shutdown();
+});
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function debug(message: string, data: Record<string, unknown>): void {
+  if (!debugEnabled) return;
+  console.log(`[collab] ${message}`, JSON.stringify(data));
+}
+
+function parsePageDocument(documentName: string): PageDocument {
+  const parts = documentName.split(":");
+  if (parts.length !== 4 || parts[0] !== "workspace" || parts[2] !== "page") {
+    throw new Error("Unsupported collaboration document");
+  }
+  return {
+    workspaceId: parts[1],
+    pageId: parts[3],
+  };
+}
+
+async function authorize(documentName: string, token: string): Promise<CollabAuth> {
+  if (!token) {
+    throw new Error("Authentication token is required");
+  }
+  const response = await fetch(`${backendUrl}/api/v1/collab/authorize`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ document_name: documentName }),
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  return (await response.json()) as CollabAuth;
+}
+
+async function loadPersistedState(pageId: string): Promise<Uint8Array | null> {
+  const result = await pool.query<{ yjs_state: Buffer }>(
+    "SELECT yjs_state FROM page_collab_documents WHERE page_id = $1",
+    [pageId],
+  );
+  const state = result.rows[0]?.yjs_state;
+  return state ? new Uint8Array(state) : null;
+}
+
+async function bootstrapPageDocument(page: PageDocument): Promise<Y.Doc> {
+  const result = await pool.query<{ content_markdown: string }>(
+    `
+    SELECT content_markdown
+    FROM pages
+    WHERE id = $1
+      AND workspace_id = $2
+      AND content_type = 'markdown'
+      AND deleted_at IS NULL
+    `,
+    [page.pageId, page.workspaceId],
+  );
+  const markdownSource = result.rows[0]?.content_markdown;
+  if (markdownSource === undefined) {
+    throw new Error("Page not found");
+  }
+  const html = markdown.render(markdownSource);
+  const json = generateJSON(html, editorExtensions);
+  return TiptapTransformer.toYdoc(json, "default", editorExtensions);
+}
+
+async function shutdown(): Promise<void> {
+  await server.hocuspocus.flushPendingStores();
+  await server.destroy();
+  await pool.end();
+  process.exit(0);
+}

--- a/collab/tsconfig.json
+++ b/collab/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,7 @@ version: "3.9"
 # Optional (embeddings default to local sentence-transformers — no key needed):
 #   OPENAI_API_KEY or HF_TOKEN  (use hosted embedding provider instead of local)
 #   S3_ENDPOINT / S3_BUCKET / …  (enable file uploads)
+#   COLLAB_PUBLIC_URL           (WebSocket URL if collab is not routed under /collab)
 
 services:
   postgres:
@@ -59,6 +60,22 @@ services:
       - backend
     environment:
       NEXT_PUBLIC_API_URL: ${PUBLIC_URL}
+      NEXT_PUBLIC_COLLAB_URL: ${COLLAB_PUBLIC_URL:-}
+
+  collab:
+    image: ghcr.io/Fergana-Labs/stash-collab:latest
+    restart: always
+    expose:
+      - "3458"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      backend:
+        condition: service_started
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      BACKEND_URL: http://backend:3456
 
   caddy:
     image: caddy:2-alpine
@@ -73,6 +90,7 @@ services:
     depends_on:
       - backend
       - frontend
+      - collab
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,21 @@ services:
     depends_on:
       - backend
 
+  collab:
+    build:
+      context: ./collab
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "3458:3458"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      backend:
+        condition: service_started
+    environment:
+      DATABASE_URL: postgresql://stash:stash@postgres:5432/stash
+      BACKEND_URL: http://backend:3456
+
 volumes:
   postgres_data:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,8 +11,11 @@
         "@auth0/nextjs-auth0": "^4.17.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hocuspocus/provider": "^4.0.0",
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
+        "@tiptap/extension-collaboration": "^3.6.6",
+        "@tiptap/extension-collaboration-caret": "^3.6.6",
         "@tiptap/extension-image": "^3.22.2",
         "@tiptap/extension-link": "3.6.6",
         "@tiptap/extension-placeholder": "3.6.6",
@@ -28,6 +31,7 @@
         "@tiptap/react": "3.6.6",
         "@tiptap/starter-kit": "3.6.6",
         "@tiptap/suggestion": "^3.22.2",
+        "@tiptap/y-tiptap": "^3.0.3",
         "d3-drag": "^3.0.0",
         "d3-force": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -38,7 +42,9 @@
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
-        "tippy.js": "^6.3.7"
+        "tippy.js": "^6.3.7",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.23"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -939,6 +945,31 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@hocuspocus/common": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.0.0.tgz",
+      "integrity": "sha512-7BE8TsKBkdiOZO6tfm3ny6bIHPbxkIZb3hsYdVn/X5xbXI8n8w9pnE6pXgEMKQhJm6zsWsa9IDRJIp/c9u+DmA==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
+    "node_modules/@hocuspocus/provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-4.0.0.tgz",
+      "integrity": "sha512-08gpeNZ6x2pmRD6m4XwRD52yQKnTl32a0HS9VSXZ5A1dIBVqxMz/x8Z06XbkKM2X8sp6vWEUCZCtzAGFSsofgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^4.0.0",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.87",
+        "ws": "^8.17.1"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1502,6 +1533,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lifeomic/attempt": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.1.0.tgz",
+      "integrity": "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "9.0.1",
@@ -2832,6 +2869,37 @@
         "@tiptap/pm": "^3.19.0"
       }
     },
+    "node_modules/@tiptap/extension-collaboration": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.6.6.tgz",
+      "integrity": "sha512-yUyUs4DBgDRrsWTOK3wxkqSZDLLsG2tWZk6BRqSN55rkIxHPkuvuYHJt8vC+926vSYoVYOZOWFnS9Nl1YUyKvw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.6",
+        "@tiptap/pm": "^3.6.6",
+        "@tiptap/y-tiptap": "^3.0.0-beta.3",
+        "yjs": "^13"
+      }
+    },
+    "node_modules/@tiptap/extension-collaboration-caret": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration-caret/-/extension-collaboration-caret-3.6.6.tgz",
+      "integrity": "sha512-tjgIYTq5efMplaAK2bzv315268Tl4g3oLi64ydEy6OhF4JMC4rI8uhpKTccJH6YMMFCRWneXWR7uAq3TwBQUHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.6",
+        "@tiptap/pm": "^3.6.6",
+        "@tiptap/y-tiptap": "^3.0.0-beta.3"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.19.0.tgz",
@@ -3301,6 +3369,26 @@
       "peerDependencies": {
         "@tiptap/core": "^3.22.2",
         "@tiptap/pm": "^3.22.2"
+      }
+    },
+    "node_modules/@tiptap/y-tiptap": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.3.tgz",
+      "integrity": "sha512-8UvuV4lTisCE9cMTc/X8kRyTn9edUO7Kball0I6wb17VwZSjNDfh/YKtP4O5vcPawEzFHQIvZGq/k1h37kAf0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.100"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -7248,6 +7336,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7465,6 +7563,27 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -11884,6 +12003,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -11901,6 +12041,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -11915,6 +12075,23 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.23",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,11 @@
     "@auth0/nextjs-auth0": "^4.17.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hocuspocus/provider": "^4.0.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
+    "@tiptap/extension-collaboration": "^3.6.6",
+    "@tiptap/extension-collaboration-caret": "^3.6.6",
     "@tiptap/extension-image": "^3.22.2",
     "@tiptap/extension-link": "3.6.6",
     "@tiptap/extension-placeholder": "3.6.6",
@@ -31,6 +34,7 @@
     "@tiptap/react": "3.6.6",
     "@tiptap/starter-kit": "3.6.6",
     "@tiptap/suggestion": "^3.22.2",
+    "@tiptap/y-tiptap": "^3.0.3",
     "d3-drag": "^3.0.0",
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",
@@ -41,7 +45,9 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.23"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -391,6 +391,10 @@ details > summary::-webkit-details-marker {
   font-family: var(--font-mono), monospace;
 }
 
+.collaboration-selection {
+  border-radius: 2px;
+}
+
 /* Task list checkbox styles */
 .tiptap ul[data-type="taskList"] {
   list-style: none;

--- a/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -153,7 +153,10 @@ export default function StashPageView() {
       const seq = saveSeq.current + 1;
       saveSeq.current = seq;
       try {
-        const updated = await updatePage(workspaceId, pageId, { content });
+        const updated = await updatePage(workspaceId, pageId, {
+          content,
+          collab_projection: true,
+        });
         if (saveSeq.current === seq) setPage(updated);
         reconcileAfterSave(content, "markdown");
       } catch (e) {
@@ -466,6 +469,10 @@ export default function StashPageView() {
                   workspaceId={workspaceId}
                   file={page}
                   onSave={handleSave}
+                  collaborationUser={{
+                    id: user.id,
+                    name: user.display_name || user.name,
+                  }}
                   onSaveStatusChange={setSaveStatus}
                   onNavigateInternal={(href) => router.push(href)}
                   onAddComment={handleAddCommentMarkdown}

--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
+import Collaboration from "@tiptap/extension-collaboration";
+import CollaborationCaret from "@tiptap/extension-collaboration-caret";
 import StarterKit from "@tiptap/starter-kit";
 import Heading from "@tiptap/extension-heading";
 import Bold from "@tiptap/extension-bold";
@@ -14,11 +16,13 @@ import Typography from "@tiptap/extension-typography";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import * as Y from "yjs";
 import EditorToolbar from "./EditorToolbar";
 import CommentMark from "./CommentMark";
 import CommentComposerPopover from "./CommentComposerPopover";
-import { Page, FileInfo } from "../../lib/types";
-import { listFiles, uploadFile } from "../../lib/api";
+import { Page } from "../../lib/types";
+import { getCollabUrl, getToken, uploadFile } from "../../lib/api";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 const ANCHOR_CONTEXT_CHARS = 32;
@@ -32,10 +36,21 @@ export type AddCommentArgs = {
   body: string;
 };
 
+type CollaborationUser = {
+  id: string;
+  name: string;
+};
+
+type CollaborationState = {
+  document: Y.Doc;
+  provider: HocuspocusProvider;
+};
+
 interface MarkdownEditorProps {
   workspaceId: string | null;
   file: Page;
   onSave: (content: string) => void | Promise<void>;
+  collaborationUser: CollaborationUser;
   confirmSave?: () => boolean;
   onSaveStatusChange?: (status: SaveStatus) => void;
   /** Called on clicks to same-origin stash routes so the page
@@ -60,6 +75,7 @@ export default function MarkdownEditor({
   workspaceId,
   file,
   onSave,
+  collaborationUser,
   confirmSave,
   onSaveStatusChange,
   onNavigateInternal,
@@ -72,11 +88,8 @@ export default function MarkdownEditor({
   const [saving, setSaving] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSaved = useRef<string>(file.content_markdown);
-  // Distinct from `lastSaved`: the markdown most recently *applied* to the
-  // editor (after resolvedMarkdown rehydration). Used to detect "user has
-  // typed since we loaded" so we don't blow away in-flight edits.
-  const appliedMarkdown = useRef<string>(file.content_markdown);
-  const loadedFileId = useRef<string>(file.id);
+  const [collabError, setCollabError] = useState("");
+  const [readOnly, setReadOnly] = useState(false);
   // Refs that closures inside `useEditor` / window listeners can call
   // without re-creating the editor every render.
   const saveMarkdownRef = useRef<(md: string) => void>(() => {});
@@ -95,45 +108,56 @@ export default function MarkdownEditor({
     suffix: string;
   } | null>(null);
 
-  // `sourceMarkdown` is the markdown we're currently resolving / showing.
-  // It diverges from `file.content_markdown` once the user types — the
-  // parent re-rendering with a stale prop must not yank the editor back.
-  const [sourceMarkdown, setSourceMarkdown] = useState<string>(file.content_markdown);
-  // Resolved markdown — relative image refs like ![](a69cb715b010.jpg) get
-  // rewritten to signed URLs if a matching workspace file exists.
-  // While the lookup is in-flight, show the raw markdown so the page never
-  // flashes empty.
-  const [resolvedMarkdown, setResolvedMarkdown] = useState<string>(file.content_markdown);
+  const [collaboration, setCollaboration] = useState<CollaborationState | null>(
+    null
+  );
 
   useEffect(() => {
-    let cancelled = false;
-    setResolvedMarkdown(sourceMarkdown);
-    if (!workspaceId) return;
-    const relativeNames = extractRelativeImageNames(sourceMarkdown);
-    if (relativeNames.size === 0) return;
-    listFiles(workspaceId)
-      .then((files) => {
-        if (cancelled) return;
-        const map = buildFileNameMap(files, relativeNames);
-        if (map.size === 0) return;
-        setResolvedMarkdown(rewriteRelativeImages(sourceMarkdown, map));
-      })
-      .catch(() => {
-        // Network flake is non-fatal — the raw markdown is still visible.
-      });
+    if (!workspaceId || typeof window === "undefined") {
+      setCollaboration(null);
+      return;
+    }
+    let active = true;
+    setCollabError("");
+    setReadOnly(false);
+    const document = new Y.Doc();
+    const provider = new HocuspocusProvider({
+      url: getCollabUrl(),
+      name: `workspace:${workspaceId}:page:${file.id}`,
+      document,
+      sessionAwareness: true,
+      token: () => getToken() ?? "",
+      onAuthenticated: ({ scope }) => {
+        if (!active) return;
+        setReadOnly(scope === "readonly");
+        setCollabError("");
+      },
+      onAuthenticationFailed: ({ reason }) => {
+        if (!active) return;
+        setCollabError(reason || "Live editing authentication failed");
+      },
+      onClose: ({ event }) => {
+        if (!active) return;
+        if (event.code === 1000) return;
+        setCollabError("Live editing connection closed");
+      },
+    });
+    setCollaboration({ document, provider });
     return () => {
-      cancelled = true;
+      active = false;
+      provider.destroy();
+      document.destroy();
     };
-  }, [workspaceId, sourceMarkdown]);
+  }, [file.id, workspaceId]);
 
-  const initialContent = useMemo(
-    () => markdownToInitialJSON(resolvedMarkdown),
-    [resolvedMarkdown]
+  const collaborationUserColor = useMemo(
+    () => colorFromId(collaborationUser.id),
+    [collaborationUser.id],
   );
 
   const editor = useEditor({
     immediatelyRender: false,
-    content: initialContent,
+    editable: !!collaboration && !readOnly,
     extensions: [
       StarterKit.configure({
         blockquote: false,
@@ -146,6 +170,7 @@ export default function MarkdownEditor({
         // avoid the "Duplicate extension names" warning + drift.
         link: false,
         underline: false,
+        undoRedo: false,
       }),
       Heading.configure({ levels: [1, 2, 3] }),
       Bold,
@@ -180,6 +205,39 @@ export default function MarkdownEditor({
       TableCell,
       Placeholder.configure({ placeholder: "Start typing..." }),
       CommentMark,
+      ...(collaboration
+        ? [
+            Collaboration.configure({
+              document: collaboration.document,
+              provider: collaboration.provider,
+            }),
+            CollaborationCaret.configure({
+              provider: collaboration.provider,
+              user: {
+                name: collaborationUser.name,
+                color: collaborationUserColor,
+              },
+              render: (user) => {
+                const cursor = document.createElement("span");
+                cursor.classList.add("collaboration-cursor__caret");
+                cursor.style.borderColor = user.color;
+
+                const label = document.createElement("span");
+                label.classList.add("collaboration-cursor__label");
+                label.style.backgroundColor = user.color;
+                label.textContent = user.name;
+
+                cursor.append(label);
+                return cursor;
+              },
+              selectionRender: (user) => ({
+                nodeName: "span",
+                class: "collaboration-selection",
+                style: `background-color: ${user.color}33`,
+              }),
+            }),
+          ]
+        : []),
     ],
     editorProps: {
       attributes: {
@@ -248,6 +306,7 @@ export default function MarkdownEditor({
       },
     },
     onUpdate: ({ editor }) => {
+      if (readOnly) return;
       const md = serializeMarkdown(editor.getJSON(), lastSaved.current);
       if (md === lastSaved.current) return;
       setDirty(true);
@@ -257,24 +316,27 @@ export default function MarkdownEditor({
         saveMarkdownRef.current(md);
       }, AUTOSAVE_DEBOUNCE_MS);
     },
-  });
+  }, [collaboration, collaborationUser.name, collaborationUserColor, readOnly]);
 
   const saveMarkdown = useCallback(
     async (md: string) => {
-      if (confirmSave && !confirmSave()) return;
+      if (readOnly || (confirmSave && !confirmSave())) return;
       setSaving(true);
-      await onSave(md);
-      // If the doc changed during the save (user kept typing), leave the
-      // dirty flag alone so the next debounce flushes — only clear it when
-      // what we saved is still what's on screen.
-      const currentMd = editor ? serializeMarkdown(editor.getJSON(), md) : md;
-      if (currentMd === md) {
-        lastSaved.current = md;
-        setDirty(false);
+      try {
+        await onSave(md);
+        // If the doc changed during the save (user kept typing), leave the
+        // dirty flag alone so the next debounce flushes — only clear it when
+        // what we saved is still what's on screen.
+        const currentMd = editor ? serializeMarkdown(editor.getJSON(), md) : md;
+        if (currentMd === md) {
+          lastSaved.current = md;
+          setDirty(false);
+        }
+      } finally {
+        setSaving(false);
       }
-      setSaving(false);
     },
-    [confirmSave, editor, onSave]
+    [confirmSave, editor, onSave, readOnly]
   );
 
   const insertUploadedFiles = useCallback(
@@ -282,13 +344,9 @@ export default function MarkdownEditor({
       if (!workspaceId || !editor) return;
       for (const fileToUpload of Array.from(files)) {
         const result = await uploadFile(workspaceId, fileToUpload);
-        // During the upload await, the resolvedMarkdown effect higher up
-        // can rehydrate the editor via `setContent(initialContent)`. A
-        // chain() built against the pre-rehydrate state would then throw
-        // "Applying a mismatched transaction" on .run(). Use
-        // `editor.commands.X` — each command builds a fresh transaction
-        // from the current state at dispatch time — and bail cleanly if
-        // the editor was destroyed mid-flight.
+        // Build each insertion from the current editor state. Uploads can
+        // overlap with remote Yjs updates, so old transactions may no longer
+        // match the document by the time the upload finishes.
         if (editor.isDestroyed) return;
         if (result.content_type.startsWith("image/")) {
           editor.commands.setImage({ src: result.url, alt: result.name });
@@ -316,32 +374,11 @@ export default function MarkdownEditor({
     };
   }, [insertUploadedFiles]);
 
-  // Switching to a different page id: reset the editor's notion of what
-  // it has loaded. (Re-renders with the SAME id and same content_markdown
-  // are no-ops; we don't yank the editor out from under the user.)
   useEffect(() => {
-    if (!editor) return;
-    if (loadedFileId.current === file.id) return;
-    loadedFileId.current = file.id;
     lastSaved.current = file.content_markdown;
-    appliedMarkdown.current = file.content_markdown;
-    setSourceMarkdown(file.content_markdown);
-    editor.commands.setContent(markdownToInitialJSON(file.content_markdown));
     setDirty(false);
     setSaving(false);
-  }, [editor, file.content_markdown, file.id]);
-
-  // Parent save responses for the same page are intentionally ignored —
-  // the editor is the local source of truth after mount. This avoids
-  // older save responses replacing newer in-progress typing.
-  useEffect(() => {
-    if (!editor) return;
-    const currentMd = serializeMarkdown(editor.getJSON(), appliedMarkdown.current);
-    if (currentMd !== appliedMarkdown.current) return;
-    editor.commands.setContent(initialContent);
-    appliedMarkdown.current = resolvedMarkdown;
-    lastSaved.current = resolvedMarkdown;
-  }, [editor, initialContent, resolvedMarkdown]);
+  }, [file.content_markdown, file.id]);
 
   // Bubble save status to parent
   useEffect(() => {
@@ -378,7 +415,7 @@ export default function MarkdownEditor({
         !!activeThreadId && el.getAttribute("data-comment-id") === activeThreadId,
       );
     });
-  }, [activeThreadId, resolvedMarkdown]);
+  }, [activeThreadId, file.id]);
 
   // When the parent reports a deleted thread, walk the doc and strip the
   // `comment` mark from every text node that carried this id. Dispatching
@@ -458,7 +495,7 @@ export default function MarkdownEditor({
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "s") {
         e.preventDefault();
-        if (!editor) return;
+        if (!editor || readOnly) return;
         if (saveTimer.current) {
           clearTimeout(saveTimer.current);
           saveTimer.current = null;
@@ -469,15 +506,25 @@ export default function MarkdownEditor({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [editor]);
+  }, [editor, readOnly]);
 
   return (
     <div className="flex h-full flex-col">
       <EditorToolbar
         editor={editor}
         workspaceId={workspaceId}
-        onStartComment={onAddComment ? openComposer : undefined}
+        onStartComment={!readOnly && onAddComment ? openComposer : undefined}
       />
+      {collabError && (
+        <div className="border-b border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+          {collabError}
+        </div>
+      )}
+      {readOnly && !collabError && (
+        <div className="border-b border-border-subtle bg-raised px-4 py-2 text-[12px] text-muted">
+          Read-only live view
+        </div>
+      )}
       <div
         ref={scrollContainerRef}
         className="relative flex-1 overflow-y-auto bg-background"
@@ -496,6 +543,21 @@ export default function MarkdownEditor({
       </div>
     </div>
   );
+}
+
+const CARET_COLORS = [
+  "#2563eb",
+  "#059669",
+  "#dc2626",
+  "#7c3aed",
+  "#c2410c",
+  "#0891b2",
+];
+
+function colorFromId(id: string): string {
+  let hash = 0;
+  for (const char of id) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  return CARET_COLORS[hash % CARET_COLORS.length];
 }
 
 type JSONNode = {
@@ -750,42 +812,6 @@ function parseTableBlock(block: string): JSONNode | null {
     });
 
   return { type: "table", content: [headerRow, ...bodyRows] };
-}
-
-// --- Relative image resolution ---
-
-function extractRelativeImageNames(markdown: string): Set<string> {
-  const names = new Set<string>();
-  const re = /!\[[^\]]*\]\(([^)]+)\)/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(markdown)) !== null) {
-    const src = m[1].trim();
-    if (/^https?:\/\//i.test(src) || src.startsWith("/") || src.startsWith("data:")) continue;
-    // Strip any fragment / querystring — storage keys are filename-only.
-    const cleaned = src.split(/[?#]/)[0];
-    if (cleaned) names.add(cleaned);
-  }
-  return names;
-}
-
-function buildFileNameMap(files: FileInfo[], wanted: Set<string>): Map<string, string> {
-  const map = new Map<string, string>();
-  const byName = new Map<string, string>();
-  for (const f of files) byName.set(f.name, f.url);
-  for (const want of wanted) {
-    const url = byName.get(want) ?? byName.get(want.split("/").pop() || want);
-    if (url) map.set(want, url);
-  }
-  return map;
-}
-
-function rewriteRelativeImages(markdown: string, urls: Map<string, string>): string {
-  return markdown.replace(/(!\[[^\]]*\]\()([^)]+)(\))/g, (full, pre, src, post) => {
-    const trimmed = src.trim();
-    const cleaned = trimmed.split(/[?#]/)[0];
-    const url = urls.get(cleaned);
-    return url ? `${pre}${url}${post}` : full;
-  });
 }
 
 export function serializeMarkdown(doc: JSONNode | null | undefined, fallback: string): string {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,6 +21,7 @@ import {
 
 const TOKEN_KEY = "stash_token";
 const API_BASE = "";
+const DEFAULT_LOCAL_COLLAB_URL = "ws://localhost:3458";
 
 // --- Token management (for CLI API key fallback) ---
 
@@ -35,6 +36,17 @@ export function setToken(token: string) {
 
 export function clearToken() {
   localStorage.removeItem(TOKEN_KEY);
+}
+
+export function getCollabUrl(): string {
+  const configured = process.env.NEXT_PUBLIC_COLLAB_URL?.trim();
+  if (configured) return configured.replace(/\/$/, "");
+  if (typeof window === "undefined") return DEFAULT_LOCAL_COLLAB_URL;
+  if (["localhost", "127.0.0.1"].includes(window.location.hostname)) {
+    return DEFAULT_LOCAL_COLLAB_URL;
+  }
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}/collab`;
 }
 
 export class ApiError extends Error {
@@ -348,6 +360,7 @@ export async function updatePage(
     name?: string;
     folder_id?: string | null;
     content?: string;
+    collab_projection?: boolean;
     content_type?: "markdown" | "html";
     content_html?: string;
     html_layout?: "responsive" | "fixed-aspect";


### PR DESCRIPTION
## Summary

- Adds a Hocuspocus/Yjs collaboration sidecar that authenticates against the FastAPI backend, bootstraps markdown pages into Yjs documents, and persists document updates in Postgres.
- Adds `POST /api/v1/collab/authorize`, a `page_collab_documents` migration, and invalidates persisted collab state when non-collab REST writes update page markdown.
- Wires the markdown editor to Hocuspocus/Yjs with collaborative cursors, read-only live views for viewers, debounced markdown projection saves, and session-aware provider lifecycle handling.
- Updates Docker Compose, prod compose, Caddy routing, and env docs for the new `/collab` websocket service.

## Deployment Notes

The collab service needs `DATABASE_URL` and `BACKEND_URL`; set `DATABASE_SSL=true` where Postgres requires SSL. Frontend can use `NEXT_PUBLIC_COLLAB_URL` explicitly, otherwise local dev defaults to `ws://localhost:3458` and production uses same-origin `/collab`.

## Screenshots

Local browser QA screenshot captured at `/tmp/stash-live-collaboration-editor.png` after verifying two editor sessions synced through Hocuspocus/Yjs.

## Validation

- `ruff check .`
- `pytest backend/tests/test_collab.py backend/tests/test_migrations.py backend/tests/test_permissions.py --no-cov` (31 passed, 1 Alembic deprecation warning)
- `cd collab && npm run build`
- `cd frontend && npm test` (15 files, 82 tests)
- `cd frontend && npm run build`
- Playwright local QA: opened two sessions on the same markdown page, typed in one, verified the text appeared in the other, and captured `/tmp/stash-live-collaboration-editor.png`.

## Follow-up

External REST/CLI markdown writes invalidate persisted Yjs state. If a page is actively loaded in the collab sidecar at the same time, the in-memory document remains authoritative until it unloads; handling live external overwrite broadcasts should be a separate product decision.