### PR TITLE
[codex] Add stash agent handoff button

### DIFF
--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -30,12 +30,12 @@ const FILTERS: { key: FilterKey; label: string }[] = [
 
 const AVATAR_CLASSES = [
   "av-rose",
-  "av-indigo",
+  "av-orange",
   "av-emerald",
   "av-amber",
   "av-sky",
-  "av-fuchsia",
-  "av-violet",
+  "av-teal",
+  "av-lime",
 ];
 
 function avatarClassFor(name: string): string {

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -16,8 +16,8 @@ const PILLARS = [
   },
   {
     label: "Connect",
-    color: "bg-violet-500/8 border-violet-500/20 text-violet-600",
-    dot: "bg-violet-500",
+    color: "bg-sky-500/8 border-sky-500/20 text-sky-700",
+    dot: "bg-sky-500",
     description: "Publish Stashes so teammates and collaborators can reuse curated context.",
   },
 ];

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -58,9 +58,9 @@
   --color-brand-muted: #FFF7ED;
   --color-brand-deep: #C2410C;
 
-  /* Agent (violet) */
-  --color-agent: #8B5CF6;
-  --color-agent-muted: oklch(0.6 0.18 290 / 0.15);
+  /* Agent/session accent */
+  --color-agent: #EA580C;
+  --color-agent-muted: rgba(249, 115, 22, 0.12);
 
   /* Human (blue) */
   --color-human: #3B82F6;
@@ -673,7 +673,7 @@ details > summary::-webkit-details-marker {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.tag-agent { background: #EDE9FE; color: #6D28D9; }
+.tag-agent { background: #FFEDD5; color: #C2410C; }
 .tag-human { background: #DBEAFE; color: #1D4ED8; }
 .tag-brand { background: #FFEDD5; color: #C2410C; }
 .tag-success { background: rgba(34,197,94,0.12); color: #15803D; }
@@ -719,19 +719,19 @@ details > summary::-webkit-details-marker {
   flex-shrink: 0;
 }
 .av-rose { background: #FECDD3; color: #9F1239; }
-.av-indigo { background: #C7D2FE; color: #3730A3; }
+.av-orange { background: #FED7AA; color: #9A3412; }
 .av-emerald { background: #A7F3D0; color: #065F46; }
 .av-amber { background: #FDE68A; color: #78350F; }
 .av-sky { background: #BAE6FD; color: #075985; }
-.av-fuchsia { background: #F5D0FE; color: #86198F; }
-.av-violet { background: #DDD6FE; color: #5B21B6; }
+.av-teal { background: #99F6E4; color: #115E59; }
+.av-lime { background: #D9F99D; color: #3F6212; }
 
 /* Discover/stash cover gradients */
 .cover-1 { background: linear-gradient(135deg, #FED7AA, #FCA5A5); }
-.cover-2 { background: linear-gradient(135deg, #DDD6FE, #BFDBFE); }
+.cover-2 { background: linear-gradient(135deg, #BFDBFE, #A7F3D0); }
 .cover-3 { background: linear-gradient(135deg, #A7F3D0, #BAE6FD); }
 .cover-4 { background: linear-gradient(135deg, #FDE68A, #FECACA); }
-.cover-5 { background: linear-gradient(135deg, #C7D2FE, #FBCFE8); }
+.cover-5 { background: linear-gradient(135deg, #BAE6FD, #FED7AA); }
 .cover-6 { background: linear-gradient(135deg, #FECDD3, #FEF3C7); }
 
 /* Diagonal-stripe image placeholder */

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -199,6 +199,9 @@ describe("StashPageClient sharing", () => {
     render(<StashPageClient slug="shared-stash" />);
 
     const shareButton = await screen.findByRole("button", { name: "Share" });
+    expect(
+      screen.getByRole("button", { name: "Copy agent handoff link" }),
+    ).toBeInTheDocument();
     expect(shareButton.closest("header")).not.toBeNull();
     expect(screen.getAllByRole("button", { name: "Share" })).toHaveLength(1);
 
@@ -212,6 +215,56 @@ describe("StashPageClient sharing", () => {
       ),
     );
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("copies an agent-readable handoff link from the app header", async () => {
+    render(<StashPageClient slug="shared-stash" />);
+
+    const handoffButton = await screen.findByRole("button", {
+      name: "Copy agent handoff link",
+    });
+    fireEvent.click(handoffButton);
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/api/v1/stashes/shared-stash?format=text`,
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Copy agent handoff link" }),
+    ).toHaveTextContent("Copied");
+  });
+
+  it("makes private Stashes public and unlisted before copying an agent link", async () => {
+    vi.mocked(getPublicStash).mockResolvedValueOnce({
+      ...stashDetail({
+        access: "private",
+        workspace_permission: "none",
+        public_permission: "none",
+        discoverable: false,
+      }),
+      can_write: true,
+    });
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Copy agent handoff link" }),
+    );
+
+    await waitFor(() =>
+      expect(updateStash).toHaveBeenCalledWith("stash-1", {
+        workspace_permission: "read",
+        public_permission: "read",
+        discoverable: false,
+      }),
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/api/v1/stashes/shared-stash?format=text`,
+    );
+    expect(
+      screen.getByRole("button", { name: "Copy agent handoff link" }),
+    ).toHaveTextContent("Copied");
   });
 
   it("can make the Stash private from the Share dropdown", async () => {

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -153,10 +153,10 @@ function coverIndexFor(id: string): number {
 
 const COVER_GRADIENTS = [
   "linear-gradient(135deg, #FED7AA, #FCA5A5)",
-  "linear-gradient(135deg, #DDD6FE, #BFDBFE)",
+  "linear-gradient(135deg, #BFDBFE, #A7F3D0)",
   "linear-gradient(135deg, #A7F3D0, #BAE6FD)",
   "linear-gradient(135deg, #FDE68A, #FECACA)",
-  "linear-gradient(135deg, #C7D2FE, #FBCFE8)",
+  "linear-gradient(135deg, #BAE6FD, #FED7AA)",
   "linear-gradient(135deg, #FECDD3, #FEF3C7)",
 ];
 

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -324,7 +324,7 @@ function kindLabel(contentType: string, name: string): string {
 
 function kindIconColor(contentType: string): string {
   if (isPdf(contentType)) return "#E11D48";
-  if (isImage(contentType)) return "#7C3AED";
+  if (isImage(contentType)) return "#EA580C";
   return "var(--text-muted)";
 }
 

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -69,11 +69,11 @@ function eventToTurn(ev: SessionEvent): MessageTurn {
 
 const AVATAR_PALETTE: { bg: string; fg: string }[] = [
   { bg: "bg-rose-200", fg: "text-rose-800" },
-  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-orange-200", fg: "text-orange-800" },
   { bg: "bg-emerald-200", fg: "text-emerald-800" },
   { bg: "bg-amber-200", fg: "text-amber-900" },
   { bg: "bg-sky-200", fg: "text-sky-800" },
-  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+  { bg: "bg-teal-200", fg: "text-teal-800" },
 ];
 
 function avatarFor(name: string) {
@@ -404,7 +404,7 @@ function MessageRow({ turn, index }: { turn: MessageTurn; index: number }) {
               <span className="tag tag-human">human</span>
             )}
             {turn.toolName && (
-              <span className="rounded bg-indigo-50 px-1.5 py-0 font-mono text-[10.5px] text-indigo-700 ring-1 ring-indigo-200">
+              <span className="rounded bg-surface px-1.5 py-0 font-mono text-[10.5px] text-dim ring-1 ring-border">
                 {turn.toolName}
               </span>
             )}

--- a/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/sessions/page.tsx
@@ -434,11 +434,11 @@ function sessionTime(session: SessionSummary): number {
 
 const AVATAR_PALETTE: { bg: string; fg: string }[] = [
   { bg: "bg-rose-200", fg: "text-rose-800" },
-  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-orange-200", fg: "text-orange-800" },
   { bg: "bg-emerald-200", fg: "text-emerald-800" },
   { bg: "bg-amber-200", fg: "text-amber-900" },
   { bg: "bg-sky-200", fg: "text-sky-800" },
-  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+  { bg: "bg-teal-200", fg: "text-teal-800" },
 ];
 
 function avatarFor(name: string) {

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -13,11 +13,11 @@ const VERB: Record<string, string> = {
 
 const PALETTE = [
   { bg: "bg-rose-200", fg: "text-rose-800" },
-  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-orange-200", fg: "text-orange-800" },
   { bg: "bg-emerald-200", fg: "text-emerald-800" },
   { bg: "bg-amber-200", fg: "text-amber-900" },
   { bg: "bg-sky-200", fg: "text-sky-800" },
-  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+  { bg: "bg-teal-200", fg: "text-teal-800" },
 ];
 
 function colorFor(name: string) {

--- a/frontend/src/components/stash/StashShareButton.tsx
+++ b/frontend/src/components/stash/StashShareButton.tsx
@@ -48,11 +48,11 @@ const PUBLIC_PERMISSION_OPTIONS: { value: StashGeneralPermission; label: string 
 
 const PALETTE = [
   { bg: "bg-rose-200", fg: "text-rose-800" },
-  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-orange-200", fg: "text-orange-800" },
   { bg: "bg-emerald-200", fg: "text-emerald-800" },
   { bg: "bg-amber-200", fg: "text-amber-900" },
   { bg: "bg-sky-200", fg: "text-sky-800" },
-  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+  { bg: "bg-teal-200", fg: "text-teal-800" },
 ];
 
 function visibilityForPermissions(
@@ -351,7 +351,7 @@ export default function StashShareButton({
         disabled={handoffStatus === "copying"}
         aria-label="Copy agent handoff link"
         title="Copy an agent-readable public link"
-        className="inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-md border border-[var(--color-agent)] bg-[var(--color-agent-muted)] px-2.5 py-1 text-[12.5px] font-medium text-[var(--color-agent)] hover:bg-raised disabled:opacity-50"
+        className="inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim hover:bg-raised hover:text-foreground disabled:opacity-50"
       >
         <TerminalOutlinedIcon aria-hidden="true" className="text-[14px]" />
         {handoffStatus === "copying"

--- a/frontend/src/components/stash/StashShareButton.tsx
+++ b/frontend/src/components/stash/StashShareButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import TerminalOutlinedIcon from "@mui/icons-material/TerminalOutlined";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import {
   addStashMember,
@@ -19,6 +20,7 @@ import { resetStashNavigationCache } from "../../lib/stashNavigationCache";
 import type { UserSearchResult } from "../../lib/types";
 
 type StashVisibility = "private" | "workspace" | "public";
+type HandoffStatus = "idle" | "copying" | "copied" | "error";
 
 const PERMISSION_OPTIONS: { value: StashMemberPermission; label: string }[] = [
   { value: "read", label: "Read" },
@@ -103,6 +105,8 @@ export default function StashShareButton({
   const [discoverable, setDiscoverable] = useState(stash.discoverable);
   const [saving, setSaving] = useState(false);
   const [shareMessage, setShareMessage] = useState("");
+  const [handoffStatus, setHandoffStatus] = useState<HandoffStatus>("idle");
+  const [handoffMessage, setHandoffMessage] = useState("");
   const [members, setMembers] = useState<StashMember[]>([]);
   const [meId, setMeId] = useState<string | null>(null);
   const [membersLoading, setMembersLoading] = useState(false);
@@ -177,6 +181,40 @@ export default function StashShareButton({
       window.setTimeout(() => setCopied(false), 1600);
     } catch {
       setShareMessage("Failed to copy link.");
+    }
+  }
+
+  async function copyAgentHandoffLink() {
+    setOpen(false);
+    setHandoffStatus("copying");
+    setHandoffMessage("");
+    try {
+      if (publicPermission === "none") {
+        if (!canWrite) {
+          throw new Error("Only Stash editors can create public agent links.");
+        }
+        const updated = await updateStash(stash.id, {
+          workspace_permission:
+            workspacePermission === "none" ? "read" : workspacePermission,
+          public_permission: "read",
+          discoverable: false,
+        });
+        setWorkspacePermission(updated.workspace_permission);
+        setPublicPermission(updated.public_permission);
+        setDiscoverable(updated.discoverable);
+        resetStashNavigationCache();
+      }
+
+      await navigator.clipboard.writeText(agentHandoffUrl(stash.slug));
+      setHandoffStatus("copied");
+      window.setTimeout(() => setHandoffStatus("idle"), 1600);
+    } catch (e) {
+      setHandoffStatus("error");
+      setHandoffMessage(e instanceof Error ? e.message : "Could not copy agent link.");
+      window.setTimeout(() => {
+        setHandoffStatus("idle");
+        setHandoffMessage("");
+      }, 3000);
     }
   }
 
@@ -306,7 +344,22 @@ export default function StashShareButton({
   }
 
   return (
-    <div ref={popoverRef} className="relative">
+    <div ref={popoverRef} className="relative flex items-center gap-1.5">
+      <button
+        type="button"
+        onClick={() => void copyAgentHandoffLink()}
+        disabled={handoffStatus === "copying"}
+        aria-label="Copy agent handoff link"
+        title="Copy an agent-readable public link"
+        className="inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-md border border-[var(--color-agent)] bg-[var(--color-agent-muted)] px-2.5 py-1 text-[12.5px] font-medium text-[var(--color-agent)] hover:bg-raised disabled:opacity-50"
+      >
+        <TerminalOutlinedIcon aria-hidden="true" className="text-[14px]" />
+        {handoffStatus === "copying"
+          ? "Copying"
+          : handoffStatus === "copied"
+            ? "Copied"
+            : "Hand off"}
+      </button>
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -316,6 +369,11 @@ export default function StashShareButton({
       >
         Share
       </button>
+      {handoffMessage && !open && (
+        <div className="absolute right-0 top-full z-40 mt-1.5 max-w-[280px] rounded-md border border-border bg-base px-2 py-1.5 text-[12px] text-muted shadow-lg">
+          {handoffMessage}
+        </div>
+      )}
       {open && (
         <div
           role="dialog"
@@ -684,4 +742,8 @@ function initials(label: string): string {
 function absoluteUrl(path: string): string {
   if (typeof window === "undefined") return path;
   return `${window.location.origin}${path}`;
+}
+
+function agentHandoffUrl(slug: string): string {
+  return absoluteUrl(`/api/v1/stashes/${slug}?format=text`);
 }

--- a/frontend/src/components/stash/StashShareButton.tsx
+++ b/frontend/src/components/stash/StashShareButton.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
-import TerminalOutlinedIcon from "@mui/icons-material/TerminalOutlined";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import {
   addStashMember,
@@ -351,9 +350,8 @@ export default function StashShareButton({
         disabled={handoffStatus === "copying"}
         aria-label="Copy agent handoff link"
         title="Copy an agent-readable public link"
-        className="inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim hover:bg-raised hover:text-foreground disabled:opacity-50"
+        className="inline-flex min-w-[72px] items-center justify-center rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground disabled:opacity-50"
       >
-        <TerminalOutlinedIcon aria-hidden="true" className="text-[14px]" />
         {handoffStatus === "copying"
           ? "Copying"
           : handoffStatus === "copied"

--- a/frontend/src/components/stash/StashShareButton.tsx
+++ b/frontend/src/components/stash/StashShareButton.tsx
@@ -356,7 +356,7 @@ export default function StashShareButton({
           ? "Copying"
           : handoffStatus === "copied"
             ? "Copied"
-            : "Hand off"}
+            : "Agent Handoff"}
       </button>
       <button
         type="button"

--- a/frontend/src/components/viz/ContributorActivityTimeline.tsx
+++ b/frontend/src/components/viz/ContributorActivityTimeline.tsx
@@ -86,7 +86,7 @@ export default function ContributorActivityTimeline({
     ctx.font = "500 11px 'JetBrains Mono', monospace";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
-    ctx.fillStyle = "#8B5CF6";
+    ctx.fillStyle = "#C2410C";
 
     for (let i = 0; i < contributors.length; i++) {
       const y = PADDING + i * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2;
@@ -204,7 +204,7 @@ export default function ContributorActivityTimeline({
           style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
         >
           <div className="text-xs font-medium text-foreground">
-            <span className="text-violet-400">{tooltip.contributor}</span>
+            <span className="text-[var(--color-brand-600)]">{tooltip.contributor}</span>
             <span className="text-muted mx-1">&middot;</span>
             <span className="text-muted font-mono">{tooltip.date}</span>
           </div>

--- a/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
+++ b/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const SOURCE_COLORS: Record<string, string> = {
-  history_events: "#8B5CF6",  // violet — agent
+  history_events: "#F97316",  // orange — sessions
   pages: "#22C55E",           // green — files
   table_rows: "#3B82F6",      // blue
 };

--- a/frontend/src/components/workspace/WorkspaceMembersPanel.tsx
+++ b/frontend/src/components/workspace/WorkspaceMembersPanel.tsx
@@ -27,11 +27,11 @@ const MEMBER_ROLE_OPTIONS = [
 
 const PALETTE = [
   { bg: "bg-rose-200", fg: "text-rose-800" },
-  { bg: "bg-indigo-200", fg: "text-indigo-800" },
+  { bg: "bg-orange-200", fg: "text-orange-800" },
   { bg: "bg-emerald-200", fg: "text-emerald-800" },
   { bg: "bg-amber-200", fg: "text-amber-900" },
   { bg: "bg-sky-200", fg: "text-sky-800" },
-  { bg: "bg-fuchsia-200", fg: "text-fuchsia-800" },
+  { bg: "bg-teal-200", fg: "text-teal-800" },
 ];
 
 export default function WorkspaceMembersPanel({

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -175,6 +175,6 @@ function tintFor(item: GridItem): string {
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.includes("image")) return "text-violet-600";
+  if (item.contentType?.includes("image")) return "text-[var(--color-brand-600)]";
   return "text-muted";
 }

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -415,7 +415,7 @@ function tintFor(item: GridItem): string {
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.startsWith("image/")) return "text-violet-500";
+  if (item.contentType?.startsWith("image/")) return "text-[var(--color-brand-600)]";
   if (item.kind === "page") return "text-[var(--color-brand-600)]";
   return "text-muted";
 }

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -160,7 +160,7 @@ function tintFor(item: GridItem): string {
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.startsWith("image/")) return "text-violet-500";
+  if (item.contentType?.startsWith("image/")) return "text-[var(--color-brand-600)]";
   if (item.kind === "page") return "text-[var(--color-brand-600)]";
   return "text-muted";
 }

--- a/www/app/_components/EmbeddingProjection3D.tsx
+++ b/www/app/_components/EmbeddingProjection3D.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 const SOURCE_COLORS: Record<string, string> = {
-  sessions: "#8B5CF6",
+  sessions: "#F97316",
   files: "#22C55E",
   table: "#3B82F6",
 };
@@ -143,7 +143,7 @@ export default function EmbeddingProjection3D() {
     >
       <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-4 py-3">
         <div className="flex items-center gap-2.5">
-          <span className="h-2 w-2 rounded-full bg-[#8B5CF6]" />
+          <span className="h-2 w-2 rounded-full bg-[#F97316]" />
           <span className="text-[13px] font-semibold text-ink">
             embedding projection
           </span>

--- a/www/app/_components/VisualizationsShowcase.tsx
+++ b/www/app/_components/VisualizationsShowcase.tsx
@@ -56,7 +56,7 @@ function PageGraphMock() {
   const nodeColor = (degree: number) => {
     if (degree >= 5) return "#F97316";
     if (degree >= 3) return "#EA7C1F";
-    if (degree === 0) return "#8B5CF6";
+    if (degree === 0) return "#F97316";
     return "#64748B";
   };
 

--- a/www/app/globals.css
+++ b/www/app/globals.css
@@ -21,8 +21,8 @@
   --brand-ink: #7C2D12;
   --brand-soft: rgba(249, 115, 22, 0.12);
 
-  --agent: #8B5CF6;
-  --agent-soft: rgba(139, 92, 246, 0.14);
+  --agent: #EA580C;
+  --agent-soft: rgba(249, 115, 22, 0.14);
   --human: #3B82F6;
   --human-soft: rgba(59, 130, 246, 0.14);
 


### PR DESCRIPTION
## Summary
- Adds a separate neutral, iconless `Agent Handoff` action next to `Share` on Stash pages.
- Copies the agent-readable markdown export URL at `/api/v1/stashes/{slug}?format=text`.
- Makes editor-owned private/workspace stashes public read and unlisted before copying, so the agent link works for anyone with the URL.
- Removes purple from active product and marketing UI accents: agent/session tokens, tags, charts, docs pills, image-file icons, avatars, and stash cover gradients now use brand-orange, blue, green, or neutral treatments.

## Screenshot
![Stash header with iconless neutral Agent Handoff and orange Share buttons](https://gist.githubusercontent.com/henry-dowling/d1c6906447331500e6a70e8eedf49509/raw/stash-handoff-header-agent-handoff.svg)

## Validation
- `npm test -- --run 'src/app/stashes/[slug]/StashPageClient.test.tsx'`
- `npm run lint` in `frontend/` (passes with existing unrelated warnings in `ItemsColumns.tsx`)
- `npm run build` in `frontend/`
- `npm run lint` in `www/` (passes with existing unrelated unused-import warnings)
- `npm run build` in `www/`
- Browser QA on local Stash page: verified the header renders both buttons, no console errors, and `Agent Handoff`/`Share` both measure `26.75px` tall.

## Purple Sweep
- Active `frontend/src`, `www/app`, and `www/public` are clean for purple/violet/indigo/fuchsia literals from the audit search.
- Remaining purple references are in `frontend/public/design`, which is static design-canvas/mockup material and not part of the active app surfaces changed here.