### PR TITLE
Fix activity timeline agent labels

### DIFF
--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -116,36 +116,62 @@ async def get_activity_timeline(
 
     rows = await pool.fetch(
         _accessible_events_cte(ws_idx=ws_idx) + """
-        , session_commits AS (
+        , timeline_events AS (
             SELECT
                 me.workspace_id,
                 me.session_id,
-                DATE_TRUNC($2, MIN(me.created_at)) AS bucket_date,
-                (
-                    ARRAY_AGG(me.agent_name ORDER BY me.created_at)
-                    FILTER (WHERE me.agent_name IS NOT NULL AND me.agent_name != '')
-                )[1] AS agent_name,
-                (
-                    ARRAY_AGG(me.created_by ORDER BY me.created_at)
-                    FILTER (WHERE me.created_by IS NOT NULL)
-                )[1] AS actor_id
+                me.created_at,
+                me.agent_name,
+                me.created_by,
+                CASE NULLIF(me.metadata->>'client', '')
+                    WHEN 'claude_code' THEN 'claude'
+                    WHEN 'codex_cli' THEN 'codex'
+                    WHEN 'gemini_cli' THEN 'gemini'
+                    ELSE NULLIF(me.metadata->>'client', '')
+                END AS client_name
             FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
             WHERE me.created_at >= $3
               AND me.session_id IS NOT NULL
-            GROUP BY me.workspace_id, me.session_id
+        )
+        , session_commits AS (
+            SELECT
+                timeline_events.workspace_id,
+                timeline_events.session_id,
+                DATE_TRUNC($2, MIN(timeline_events.created_at)) AS bucket_date,
+                (
+                    ARRAY_AGG(timeline_events.client_name ORDER BY timeline_events.created_at)
+                    FILTER (WHERE timeline_events.client_name IS NOT NULL)
+                )[1] AS client_name,
+                (
+                    ARRAY_AGG(timeline_events.agent_name ORDER BY timeline_events.created_at)
+                    FILTER (
+                        WHERE timeline_events.agent_name IS NOT NULL
+                          AND timeline_events.agent_name != ''
+                    )
+                )[1] AS agent_name,
+                (
+                    ARRAY_AGG(timeline_events.created_by ORDER BY timeline_events.created_at)
+                    FILTER (WHERE timeline_events.created_by IS NOT NULL)
+                )[1] AS actor_id
+            FROM timeline_events
+            GROUP BY timeline_events.workspace_id, timeline_events.session_id
         )
         SELECT
             sc.bucket_date,
             COALESCE(NULLIF(u.display_name, ''), u.name, 'Unknown human') AS human_name,
-            CASE
-                WHEN sc.agent_name = 'claude-subagent' THEN 'claude'
-                ELSE COALESCE(NULLIF(sc.agent_name, ''), 'unknown agent')
-            END AS agent_name,
+            COALESCE(
+                sc.client_name,
+                CASE
+                    WHEN sc.agent_name = 'claude-subagent' THEN 'claude'
+                    ELSE NULLIF(sc.agent_name, '')
+                END,
+                'unknown agent'
+            ) AS agent_name,
             COUNT(*) AS cnt
         FROM session_commits sc
         LEFT JOIN users u ON u.id = sc.actor_id
-        GROUP BY sc.bucket_date, human_name, agent_name
+        GROUP BY sc.bucket_date, human_name, sc.client_name, sc.agent_name
         ORDER BY bucket_date
         """,
         *args,

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -102,6 +102,44 @@ async def test_activity_timeline_pivots_on_human_and_agent_sessions(client: Asyn
 
 
 @pytest.mark.asyncio
+async def test_activity_timeline_uses_client_name_for_agent_label(client: AsyncClient):
+    register_resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": unique_name("activity_client_label"),
+            "display_name": "Client Human",
+            "password": "securepassword1",
+        },
+    )
+    assert register_resp.status_code == 201
+    api_key = register_resp.json()["api_key"]
+    workspace = await _workspace(client, api_key, "Client Label Workspace")
+
+    event_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/events",
+        json={
+            "agent_name": "user",
+            "event_type": "assistant_message",
+            "content": "done",
+            "session_id": "client-label-session",
+            "metadata": {"client": "codex_cli"},
+        },
+        headers=_auth(api_key),
+    )
+    assert event_resp.status_code == 201
+
+    resp = await client.get(
+        "/api/v1/me/activity-timeline",
+        params={"days": 365, "workspace_id": workspace["id"]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    timeline = resp.json()
+    assert timeline["contributors"] == ["Client Human / codex"]
+
+
+@pytest.mark.asyncio
 async def test_activity_timeline_counts_claude_subagents_as_claude(client: AsyncClient):
     register_resp = await client.post(
         "/api/v1/users/register",


### PR DESCRIPTION
## Summary
- Use session client metadata for the activity timeline's agent label, normalized to names like `codex`, `claude`, and `gemini`.
- Keep the existing `agent_name` path for events without client metadata and preserve `claude-subagent` grouping.
- Add a regression test for an event with `agent_name: "user"` and `metadata.client: "codex_cli"`.

Linear: https://linear.app/ferganalabs/issue/FER-103/what-is-user-here-in-henryuser

## Screenshot
![FER-103 after](https://gist.githubusercontent.com/henry-dowling/9e197044a2cd1feeb9c89aece839bad3/raw/fca09fa1bbf9e31951efe5968e2ca79bd63848d8/fer-103-after.png)

## Tests
- `TEST_DATABASE_URL='postgresql://stash:stash@localhost:5432/stash_test_fer103' pytest --no-cov backend/tests/test_activity.py`
- `ruff check backend/services/analytics_service.py backend/tests/test_activity.py`

Note: `pytest backend/tests/test_activity.py` against the default local `stash_test` database is blocked because that database is stamped with missing Alembic revision `0065` from another branch.
