### PR TITLE
Add agent-readable Stash links

### DIFF
--- a/backend/routers/skill.py
+++ b/backend/routers/skill.py
@@ -7,7 +7,42 @@ router = APIRouter(tags=["skill"])
 
 SKILL_PATH = Path(__file__).parent.parent / "static" / "SKILL.md"
 
+LLMS_TEXT = """# Stash
+
+Stash is shared memory for AI-agent work. Public Stash URLs are agent-readable.
+
+## Reading a public Stash
+
+Given a URL like:
+
+https://app.joinstash.ai/stashes/example
+
+Use these forms:
+
+- Markdown homepage: https://app.joinstash.ai/stashes/example.md
+- Structured JSON: https://app.joinstash.ai/stashes/example.json
+- CLI, if installed: stash read https://app.joinstash.ai/stashes/example
+
+The markdown homepage lists the Stash contents and links to item-level markdown
+and JSON views for progressive disclosure.
+
+## Connecting a repository
+
+If your human asks you to connect the current repository to Stash, run:
+
+```bash
+curl -fsSL https://joinstash.ai/install | bash
+```
+
+If Stash is already installed, run `stash login` and `stash connect`.
+"""
+
 
 @router.get("/skill/stash/SKILL.md", response_class=PlainTextResponse)
 async def get_skill_manifest():
     return SKILL_PATH.read_text()
+
+
+@router.get("/llms.txt", response_class=PlainTextResponse)
+async def get_llms_txt():
+    return LLMS_TEXT

--- a/backend/routers/stashes.py
+++ b/backend/routers/stashes.py
@@ -25,6 +25,8 @@ from ..services import permission_service, stash_service, workspace_service
 ws_router = APIRouter(prefix="/api/v1/workspaces", tags=["stashes"])
 public_router = APIRouter(prefix="/api/v1/stashes", tags=["stashes"])
 
+_STASH_ITEM_TYPES = {"folder", "page", "table", "file", "session"}
+
 
 async def _require_can_share_item(workspace_id: UUID, item, user_id: UUID) -> None:
     item_workspace_id = await permission_service.resolve_workspace_id(
@@ -293,7 +295,12 @@ async def get_public_stash(
 
     if format == "text":
         return PlainTextResponse(
-            stash_service.items_to_text(stash["title"], items),
+            stash_service.stash_to_text(
+                stash,
+                stash.get("_workspace_name", ""),
+                items,
+                settings.PUBLIC_URL.rstrip(),
+            ),
             media_type="text/markdown",
         )
 
@@ -307,6 +314,53 @@ async def get_public_stash(
         items=items,
         can_write=can_write,
     )
+
+
+@public_router.get("/{slug}/items/{object_type}/{object_id}")
+async def get_public_stash_item(
+    slug: str,
+    object_type: str,
+    object_id: UUID,
+    format: str = Query(None, alias="format"),
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    if object_type not in _STASH_ITEM_TYPES:
+        raise HTTPException(status_code=404, detail="Stash item not found")
+
+    viewer_id = current_user["id"] if current_user else None
+    stash = await stash_service.get_public_stash(slug, viewer_id=viewer_id)
+    if not stash:
+        raise HTTPException(status_code=404, detail="Stash not found")
+
+    items = await stash_service.inline_items(stash, viewer_id=viewer_id)
+    item = next(
+        (
+            candidate
+            for candidate in items
+            if candidate["object_type"] == object_type
+            and str(candidate["object_id"]) == str(object_id)
+        ),
+        None,
+    )
+    if not item:
+        raise HTTPException(status_code=404, detail="Stash item not found")
+
+    if format == "text":
+        return PlainTextResponse(
+            stash_service.item_to_text(stash, item, settings.PUBLIC_URL.rstrip()),
+            media_type="text/markdown",
+        )
+
+    workspace_name = stash.pop("_workspace_name", "")
+    can_write = bool(
+        current_user and await stash_service.user_can_write(stash["id"], current_user["id"])
+    )
+    return {
+        "stash": StashResponse(**stash),
+        "workspace_name": workspace_name,
+        "item": item,
+        "can_write": can_write,
+    }
 
 
 @public_router.post("/{slug}/add-to-workspace", response_model=StashResponse, status_code=201)

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import html as html_lib
 import json
 import re
 import secrets
@@ -13,6 +14,11 @@ from . import files_tree_service, permission_service, storage_service, workspace
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_BREAK_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_HTML_BLOCK_END_RE = re.compile(
+    r"</(article|body|div|footer|h[1-6]|header|li|main|p|section|td|th|tr)>",
+    re.IGNORECASE,
+)
 
 
 def _slugify(title: str) -> str:
@@ -22,6 +28,24 @@ def _slugify(title: str) -> str:
 
 def _strip_html(html: str) -> str:
     return _HTML_TAG_RE.sub(" ", html)
+
+
+def _html_to_text(content_html: str) -> str:
+    with_breaks = _HTML_BREAK_RE.sub("\n", content_html)
+    with_blocks = _HTML_BLOCK_END_RE.sub("\n", with_breaks)
+    text = html_lib.unescape(_HTML_TAG_RE.sub(" ", with_blocks))
+    lines = [" ".join(line.split()) for line in text.splitlines()]
+    return "\n".join(line for line in lines if line).strip()
+
+
+def _page_text(page: dict) -> str:
+    content_markdown = page.get("content_markdown") or ""
+    if content_markdown.strip():
+        return content_markdown.strip()
+    content_html = page.get("content_html") or ""
+    if content_html.strip():
+        return _html_to_text(content_html)
+    return ""
 
 
 def _content_hash(content: str) -> str:
@@ -1204,6 +1228,186 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
     return out
 
 
+def _agent_item_url(base_url: str, stash: dict, item: dict, suffix: str) -> str:
+    return (
+        f"{base_url}/stashes/{stash['slug']}/items/"
+        f"{item['object_type']}/{item['object_id']}.{suffix}"
+    )
+
+
+def _preview(text: str, limit: int = 260) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 1].rstrip()}..."
+
+
+def _item_summary(item: dict) -> str:
+    obj_type = item["object_type"]
+    label = item.get("label", "Item")
+    inline = item.get("inline", {})
+    if obj_type == "folder":
+        pages = inline.get("pages", [])
+        files = inline.get("files", [])
+        return f"{len(pages)} pages, {len(files)} files"
+    if obj_type == "page":
+        page = inline.get("page", {})
+        text = _page_text(page)
+        return _preview(text) if text else "Page"
+    if obj_type == "table":
+        columns = inline.get("columns", [])
+        rows = inline.get("rows", [])
+        return f"{len(columns)} columns, {len(rows)} rows"
+    if obj_type == "file":
+        size = inline.get("size_bytes")
+        content_type = inline.get("content_type", "unknown")
+        return f"{content_type}, {size} bytes" if size is not None else str(content_type)
+    if obj_type == "session":
+        session = inline.get("session", {})
+        summary = session.get("summary")
+        if summary:
+            return _preview(str(summary))
+        events = session.get("events", [])
+        agent_name = session.get("agent_name") or "agent"
+        return f"{agent_name} session, {len(events)} events"
+    return label
+
+
+def stash_to_text(stash: dict, workspace_name: str, items: list[dict], base_url: str) -> str:
+    """Render a public Stash as a small agent-readable homepage."""
+    base_url = base_url.rstrip("/")
+    parts = [f"# {stash['title']}"]
+    if stash.get("description"):
+        parts.append(str(stash["description"]))
+    if workspace_name:
+        parts.append(f"Workspace: {workspace_name}")
+
+    item_count = len(items)
+    type_counts: dict[str, int] = {}
+    for item in items:
+        type_counts[item["object_type"]] = type_counts.get(item["object_type"], 0) + 1
+    counts = ", ".join(
+        f"{count} {kind}{'' if count == 1 else 's'}" for kind, count in type_counts.items()
+    )
+    plural = "" if item_count == 1 else "s"
+    count_detail = f": {counts}" if counts else ""
+    parts.append(f"This is a public Stash with {item_count} item{plural}{count_detail}.")
+
+    parts.append(
+        "## Agent Navigation\n\n"
+        "This page is the Stash homepage. Open only the deeper links you need.\n\n"
+        f"- Markdown homepage: {base_url}/stashes/{stash['slug']}.md\n"
+        f"- Structured JSON: {base_url}/stashes/{stash['slug']}.json\n"
+        "- Item links below expose their own markdown and JSON views."
+    )
+
+    if items:
+        lines = ["## Contents"]
+        for index, item in enumerate(items, start=1):
+            label = item.get("label") or item["object_type"].title()
+            md_url = _agent_item_url(base_url, stash, item, "md")
+            json_url = _agent_item_url(base_url, stash, item, "json")
+            lines.append(
+                f"{index}. [{label}]({md_url})\n"
+                f"   Type: {item['object_type']}\n"
+                f"   Preview: {_item_summary(item)}\n"
+                f"   JSON: {json_url}"
+            )
+        parts.append("\n\n".join(lines))
+
+    parts.append(
+        "## Using Stash\n\n"
+        "If your human wants this repository connected to Stash, run:\n\n"
+        "```bash\n"
+        "curl -fsSL https://joinstash.ai/install | bash\n"
+        "```\n\n"
+        "If Stash is already installed, run:\n\n"
+        "```bash\n"
+        f"stash read {base_url}/stashes/{stash['slug']}\n"
+        "```"
+    )
+    return "\n\n".join(part for part in parts if part).strip() + "\n"
+
+
+def item_to_text(stash: dict, item: dict, base_url: str) -> str:
+    base_url = base_url.rstrip("/")
+    label = item.get("label") or item["object_type"].title()
+    parts = [
+        f"# {label}",
+        f"Stash: [{stash['title']}]({base_url}/stashes/{stash['slug']}.md)",
+        "## Agent Navigation\n\n"
+        f"- Back to Stash homepage: {base_url}/stashes/{stash['slug']}.md\n"
+        f"- This item as JSON: {_agent_item_url(base_url, stash, item, 'json')}",
+    ]
+
+    obj_type = item["object_type"]
+    inline = item.get("inline", {})
+    if obj_type == "folder":
+        pages = inline.get("pages", [])
+        files = inline.get("files", [])
+        lines = [f"Folder with {len(pages)} pages and {len(files)} files."]
+        for page in pages:
+            page_text = _page_text(page)
+            lines.append(f"## {page.get('name', 'Page')}")
+            if page_text:
+                lines.append(page_text)
+        for file in files:
+            lines.append(
+                f"- Attached file: {file.get('name', 'file')} "
+                f"({file.get('content_type', 'unknown')})"
+            )
+        parts.append("\n\n".join(lines))
+    elif obj_type == "page":
+        page = inline.get("page", {})
+        page_text = _page_text(page)
+        if page_text:
+            parts.append(page_text)
+    elif obj_type == "table":
+        cols = inline.get("columns", [])
+        rows = inline.get("rows", [])
+        if inline.get("description"):
+            parts.append(str(inline["description"]))
+        if cols:
+            header = " | ".join(c["name"] for c in cols)
+            sep = " | ".join("---" for _ in cols)
+            table_lines = [f"| {header} |", f"| {sep} |"]
+            for row in rows[:100]:
+                vals = " | ".join(str(row["data"].get(c["name"], "")) for c in cols)
+                table_lines.append(f"| {vals} |")
+            parts.append("\n".join(table_lines))
+    elif obj_type == "file":
+        parts.append(
+            f"Content type: {inline.get('content_type', 'unknown')}\n\n"
+            f"Size: {inline.get('size_bytes', 'unknown')} bytes\n\n"
+            f"Download URL: {inline.get('url', '')}"
+        )
+    elif obj_type == "session":
+        session = inline.get("session", {})
+        lines = [
+            f"Session ID: {session.get('session_id', label)}",
+            f"Agent: {session.get('agent_name', 'agent')}",
+        ]
+        if session.get("summary"):
+            lines.extend(["## Summary", str(session["summary"])])
+        files_touched = session.get("files_touched") or []
+        if files_touched:
+            lines.append("## Files Touched")
+            lines.extend(f"- {path}" for path in files_touched)
+        events = session.get("events", [])
+        if events:
+            lines.append("## Events")
+            for event in events:
+                content = event.get("content")
+                if content:
+                    lines.append(
+                        f"### {event.get('event_type', 'event')} "
+                        f"({event.get('agent_name', 'agent')})\n\n{content}"
+                    )
+        parts.append("\n\n".join(lines))
+
+    return "\n\n".join(part for part in parts if part).strip() + "\n"
+
+
 def items_to_text(title: str, items: list[dict]) -> str:
     """Flatten a Stash's inlined items into readable markdown text."""
     parts = [f"# {title}\n"]
@@ -1216,16 +1420,18 @@ def items_to_text(title: str, items: list[dict]) -> str:
 
         if obj_type == "folder":
             for page in inline.get("pages", []):
-                if page.get("content_markdown"):
-                    parts.append(page["content_markdown"])
+                page_text = _page_text(page)
+                if page_text:
+                    parts.append(page_text)
             for file in inline.get("files", []):
                 parts.append(
                     f"*Attached file: {file.get('name', label)} ({file.get('content_type', 'unknown')})*\n"
                 )
         elif obj_type == "page":
             page = inline.get("page", {})
-            if page.get("content_markdown"):
-                parts.append(page["content_markdown"])
+            page_text = _page_text(page)
+            if page_text:
+                parts.append(page_text)
         elif obj_type == "table":
             cols = inline.get("columns", [])
             rows = inline.get("rows", [])

--- a/backend/tests/test_stash_agent_read.py
+++ b/backend/tests/test_stash_agent_read.py
@@ -1,0 +1,119 @@
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> tuple[str, dict]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("agent_read"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _create_workspace(client: AsyncClient, api_key: str) -> dict:
+    resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": unique_name("agent_read_workspace")},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def _create_page(
+    client: AsyncClient,
+    api_key: str,
+    workspace_id: str,
+    name: str,
+    content: str,
+) -> dict:
+    resp = await client.post(
+        f"/api/v1/workspaces/{workspace_id}/pages/new",
+        json={"name": name, "content": content},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_public_stash_text_is_agent_homepage(client: AsyncClient):
+    api_key, _ = await _register(client)
+    workspace = await _create_workspace(client, api_key)
+    page = await _create_page(client, api_key, workspace["id"], "Root cause", "# Finding")
+
+    published = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/stashes/publish",
+        json={
+            "title": "Auth 401 spike",
+            "description": "Clock skew investigation",
+            "workspace_permission": "read",
+            "public_permission": "read",
+            "items": [{"object_type": "page", "object_id": page["id"]}],
+        },
+        headers=_auth(api_key),
+    )
+    assert published.status_code == 201
+    slug = published.json()["stash"]["slug"]
+
+    resp = await client.get(f"/api/v1/stashes/{slug}?format=text")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    text = resp.text
+    assert "# Auth 401 spike" in text
+    assert "This page is the Stash homepage" in text
+    assert f"http://localhost:3457/stashes/{slug}.md" in text
+    assert f"http://localhost:3457/stashes/{slug}.json" in text
+    assert f"/stashes/{slug}/items/page/{page['id']}.md" in text
+    assert "Clock skew investigation" in text
+
+
+@pytest.mark.asyncio
+async def test_public_stash_item_text_strips_html_page_content(client: AsyncClient):
+    api_key, _ = await _register(client)
+    workspace = await _create_workspace(client, api_key)
+
+    published = await client.post(
+        "/api/v1/publish",
+        json={
+            "workspace_id": workspace["id"],
+            "title": "HTML strategy memo",
+            "content_type": "html",
+            "content": "<main><h1>Hello Agent</h1><p>Read this first.</p></main>",
+            "workspace_permission": "read",
+            "public_permission": "read",
+        },
+        headers=_auth(api_key),
+    )
+    assert published.status_code == 200
+    body = published.json()
+
+    resp = await client.get(
+        f"/api/v1/stashes/{body['stash_slug']}/items/page/{body['page_id']}?format=text"
+    )
+    assert resp.status_code == 200
+    assert "Hello Agent" in resp.text
+    assert "Read this first." in resp.text
+    assert "<h1>" not in resp.text
+
+    json_resp = await client.get(
+        f"/api/v1/stashes/{body['stash_slug']}/items/page/{body['page_id']}"
+    )
+    assert json_resp.status_code == 200
+    assert json_resp.json()["item"]["inline"]["page"]["content_type"] == "html"
+
+
+@pytest.mark.asyncio
+async def test_llms_txt_documents_agent_stash_reads(client: AsyncClient):
+    resp = await client.get("/llms.txt")
+    assert resp.status_code == 200
+    assert "Public Stash URLs are agent-readable" in resp.text
+    assert "/stashes/example.md" in resp.text

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,27 +3,100 @@ import type { NextConfig } from "next";
 const backend =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
+const acceptsJson = ".*application/json.*";
+const acceptsMarkdown = ".*(text/markdown|text/plain).*";
+const acceptsHtml = ".*text/html.*";
+const agentUserAgent = "^(?!.*[Mm]ozilla).+";
+
 const nextConfig: NextConfig = {
   output: "standalone",
   async rewrites() {
-    return [
-      {
-        source: "/api/v1/:path*",
-        destination: `${backend}/api/v1/:path*`,
-      },
-      {
-        source: "/skill/:path*",
-        destination: `${backend}/skill/:path*`,
-      },
-      {
-        source: "/health",
-        destination: `${backend}/health`,
-      },
-      {
-        source: "/llms.txt",
-        destination: `${backend}/llms.txt`,
-      },
-    ];
+    return {
+      // These run before App Router pages so `.md` and `.json` are content
+      // formats, not slug suffixes.
+      beforeFiles: [
+        {
+          source: "/stashes/:slug.md",
+          destination: `${backend}/api/v1/stashes/:slug?format=text`,
+        },
+        {
+          source: "/stashes/:slug.json",
+          destination: `${backend}/api/v1/stashes/:slug`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id.md",
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id?format=text`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id.json",
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id`,
+        },
+        {
+          source: "/stashes/:slug",
+          has: [{ type: "header", key: "accept", value: acceptsJson }],
+          destination: `${backend}/api/v1/stashes/:slug`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id",
+          has: [{ type: "header", key: "accept", value: acceptsJson }],
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id`,
+        },
+        {
+          source: "/stashes/:slug",
+          has: [{ type: "header", key: "accept", value: acceptsMarkdown }],
+          destination: `${backend}/api/v1/stashes/:slug?format=text`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id",
+          has: [{ type: "header", key: "accept", value: acceptsMarkdown }],
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id?format=text`,
+        },
+        {
+          source: "/stashes/:slug",
+          has: [{ type: "header", key: "user-agent", value: agentUserAgent }],
+          missing: [{ type: "header", key: "accept", value: acceptsHtml }],
+          destination: `${backend}/api/v1/stashes/:slug?format=text`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id",
+          has: [{ type: "header", key: "user-agent", value: agentUserAgent }],
+          missing: [{ type: "header", key: "accept", value: acceptsHtml }],
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id?format=text`,
+        },
+        {
+          source: "/stashes/:slug",
+          missing: [
+            { type: "header", key: "user-agent" },
+            { type: "header", key: "accept", value: acceptsHtml },
+          ],
+          destination: `${backend}/api/v1/stashes/:slug?format=text`,
+        },
+        {
+          source: "/stashes/:slug/items/:type/:id",
+          missing: [
+            { type: "header", key: "user-agent" },
+            { type: "header", key: "accept", value: acceptsHtml },
+          ],
+          destination: `${backend}/api/v1/stashes/:slug/items/:type/:id?format=text`,
+        },
+        {
+          source: "/api/v1/:path*",
+          destination: `${backend}/api/v1/:path*`,
+        },
+        {
+          source: "/skill/:path*",
+          destination: `${backend}/skill/:path*`,
+        },
+        {
+          source: "/health",
+          destination: `${backend}/health`,
+        },
+        {
+          source: "/llms.txt",
+          destination: `${backend}/llms.txt`,
+        },
+      ],
+    };
   },
   async headers() {
     return [

--- a/frontend/src/app/stashes/[slug]/items/[type]/[id]/page.tsx
+++ b/frontend/src/app/stashes/[slug]/items/[type]/[id]/page.tsx
@@ -24,7 +24,16 @@ export async function generateMetadata({
     (it) => it.object_type === type && it.object_id === id
   );
   const itemLabel = item?.label ?? "Item";
-  return { title: `${itemLabel} · ${data.stash.title} · Stash` };
+  return {
+    title: `${itemLabel} · ${data.stash.title} · Stash`,
+    alternates: {
+      canonical: `/stashes/${slug}/items/${type}/${id}`,
+      types: {
+        "text/markdown": `/stashes/${slug}/items/${type}/${id}.md`,
+        "application/json": `/stashes/${slug}/items/${type}/${id}.json`,
+      },
+    },
+  };
 }
 
 export default async function StashItemPage({

--- a/frontend/src/app/stashes/[slug]/page.tsx
+++ b/frontend/src/app/stashes/[slug]/page.tsx
@@ -19,6 +19,13 @@ export async function generateMetadata({
   return {
     title,
     description,
+    alternates: {
+      canonical: `/stashes/${slug}`,
+      types: {
+        "text/markdown": `/stashes/${slug}.md`,
+        "application/json": `/stashes/${slug}.json`,
+      },
+    },
     openGraph: {
       title,
       description,
@@ -44,5 +51,13 @@ export default async function StashPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  return <StashPageClient slug={slug} />;
+  return (
+    <>
+      <div className="sr-only">
+        Agent-readable Stash versions are available at {`/stashes/${slug}.md`} and{" "}
+        {`/stashes/${slug}.json`}.
+      </div>
+      <StashPageClient slug={slug} />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Adds markdown and JSON public Stash views for agents, including item-level progressive disclosure links.
- Uses frontend `beforeFiles` rewrites so `.md`/`.json` URLs and agent-style `Accept`/`User-Agent` requests reach the backend while browser HTML stays on the normal UI.
- Adds `/llms.txt` and metadata hints for agent-readable Stash URLs.

## Verification
- `black --check backend/routers/skill.py backend/routers/stashes.py backend/services/stash_service.py backend/tests/test_stash_agent_read.py`
- `ruff check backend/routers/stashes.py backend/routers/skill.py backend/services/stash_service.py backend/tests/test_stash_agent_read.py`
- `pytest backend/tests/test_stash_agent_read.py --no-cov`
- `pytest --no-cov`
- `pytest`
- `cd frontend && npx eslint next.config.ts 'src/app/stashes/[slug]/page.tsx' 'src/app/stashes/[slug]/items/[type]/[id]/page.tsx'`
- `cd frontend && npm run lint` (passes with existing warnings in `src/components/workspace/file-browser/ItemsColumns.tsx`)
- `cd frontend && npm run build`
- Next smoke test: curl-style `/stashes/not-a-real-stash` and explicit `/stashes/not-a-real-stash.md` returned backend 404s; browser-style `Accept: text/html` returned HTML.

## Known Existing Issue
- `cd frontend && npx tsc --noEmit --pretty false` still fails on pre-existing test fixture type drift in `AppShell.test.tsx`, `AppSidebar.test.tsx`, and `CommandPalette.test.tsx`.
