### PR TITLE
fix sidebar session selection for stash items

### DIFF
--- a/frontend/src/app/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
+++ b/frontend/src/app/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
@@ -61,7 +61,11 @@ function Chrome({
   }
   if (user) {
     return (
-      <AppShell user={user} onLogout={logout}>
+      <AppShell
+        user={user}
+        onLogout={logout}
+        activeWorkspaceId={data?.stash.workspace_id ?? null}
+      >
         {children}
       </AppShell>
     );

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -853,6 +853,28 @@ describe("AppSidebar tree expansion", () => {
     expect(screen.queryByText("Handoff session")).toBeNull();
   });
 
+  it("opens and selects the active session on stash-scoped session item routes", async () => {
+    nav.pathname = "/stashes/project-alpha/items/session/session-row-1";
+    vi.mocked(getWorkspaceSidebar).mockResolvedValue(sidebarWithStash);
+
+    render(
+      <ShareModalProvider>
+        <AppSidebar
+          user={user}
+          activeWorkspaceId="ws-1"
+          onCmdkOpen={vi.fn()}
+        />
+      </ShareModalProvider>
+    );
+
+    const sessionLink = await screen.findByRole("link", {
+      name: /Planning session/,
+    });
+
+    expect(detailsFor("Henry")).toHaveAttribute("open");
+    expect(sessionLink).toHaveClass("bg-[var(--color-brand-50)]");
+  });
+
   it("rejects non-jsonl files dropped on the Sessions section", async () => {
     localStorage.setItem("stash_sidebar_open_workspaces", JSON.stringify({ "ws-1": true }));
     localStorage.setItem(

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -601,6 +601,58 @@ function searchSidebarSessions(
   });
 }
 
+type ActiveSessionRef = {
+  workspaceId: string | null;
+  sessionId: string | null;
+  objectId: string | null;
+};
+
+function activeSessionRef(pathname: string): ActiveSessionRef {
+  const workspaceMatch = pathname.match(
+    /^\/workspaces\/([^/]+)\/sessions\/([^/?#]+)/,
+  );
+  if (workspaceMatch) {
+    return {
+      workspaceId: workspaceMatch[1],
+      sessionId: decodeURIComponent(workspaceMatch[2]),
+      objectId: null,
+    };
+  }
+
+  const stashItemMatch = pathname.match(
+    /^\/stashes\/[^/]+\/items\/session\/([^/?#]+)/,
+  );
+  if (stashItemMatch) {
+    return {
+      workspaceId: null,
+      sessionId: null,
+      objectId: decodeURIComponent(stashItemMatch[1]),
+    };
+  }
+
+  return { workspaceId: null, sessionId: null, objectId: null };
+}
+
+function sessionMatchesActive(
+  active: ActiveSessionRef,
+  workspaceId: string,
+  session: Pick<WorkspaceSidebarSession, "id" | "session_id">
+): boolean {
+  if (active.workspaceId && active.workspaceId !== workspaceId) return false;
+  if (active.sessionId && active.sessionId === session.session_id) return true;
+  return !!active.objectId && active.objectId === session.id;
+}
+
+function sessionBucketHasActiveSession(
+  active: ActiveSessionRef,
+  workspaceId: string,
+  sessions: WorkspaceSidebarSession[]
+): boolean {
+  return sessions.some((session) =>
+    sessionMatchesActive(active, workspaceId, session)
+  );
+}
+
 type SessionTreeDayGroup = {
   dateKey: string;
   label: string;
@@ -789,20 +841,21 @@ function SidebarSearchField({
 function SessionNavRow({
   workspaceId,
   session,
+  activeSession,
   onPinMenu,
 }: {
   workspaceId: string;
   session: WorkspaceSidebarSession;
+  activeSession: ActiveSessionRef;
   onPinMenu?: (event: MouseEvent<HTMLAnchorElement>, session: WorkspaceSidebarSession) => void;
 }) {
-  const pathname = usePathname();
   const href = `/workspaces/${workspaceId}/sessions/${encodeURIComponent(session.session_id)}`;
   return (
     <NavRow
       href={href}
       icon={<span className="text-muted"><SessionsIcon /></span>}
       label={sessionLabelForSidebar(session)}
-      active={pathname === href}
+      active={sessionMatchesActive(activeSession, workspaceId, session)}
       onContextMenu={(event) => onPinMenu?.(event, session)}
     />
   );
@@ -838,6 +891,7 @@ function SessionsBlock({
   onAddSession: () => void;
 }) {
   const pathname = usePathname();
+  const activeSession = activeSessionRef(pathname);
   const [query, setQuery] = useState("");
   const [visiblePeriodCount, setVisiblePeriodCount] = useState(PREVIEW_ITEM_LIMIT);
   const [visibleSearchCount, setVisibleSearchCount] = useState(PREVIEW_ITEM_LIMIT);
@@ -859,7 +913,13 @@ function SessionsBlock({
     [sessions, query]
   );
   const queryActive = query.trim().length > 0;
-  const visibleGroups = groups.slice(0, visiblePeriodCount);
+  const activeGroupIndex = groups.findIndex((group) =>
+    group.users.some((bucket) =>
+      sessionBucketHasActiveSession(activeSession, workspace.id, bucket.sessions)
+    )
+  );
+  const visiblePeriodLimit = Math.max(visiblePeriodCount, activeGroupIndex + 1);
+  const visibleGroups = groups.slice(0, visiblePeriodLimit);
   const hiddenGroupCount = groups.length - visibleGroups.length;
   const visibleSearchResults = searchResults.slice(0, visibleSearchCount);
   const hiddenSearchCount = searchResults.length - visibleSearchResults.length;
@@ -867,6 +927,7 @@ function SessionsBlock({
     const session = sessionById.get(sessionId);
     return {
       id: sessionId,
+      objectId: session?.id ?? null,
       label: pinnedLabels.sessions[sessionId] ?? (session ? sessionLabelForSidebar(session) : "Session"),
       href: `/workspaces/${workspace.id}/sessions/${encodeURIComponent(sessionId)}`,
     };
@@ -968,6 +1029,7 @@ function SessionsBlock({
                 key={session.session_id}
                 workspaceId={workspace.id}
                 session={session}
+                activeSession={activeSession}
                 onPinMenu={(event, row) =>
                   showSessionPinMenu(
                     event,
@@ -1016,7 +1078,10 @@ function SessionsBlock({
                     href={session.href}
                     icon={<span className="text-muted"><SessionsIcon /></span>}
                     label={session.label}
-                    active={pathname === session.href}
+                    active={sessionMatchesActive(activeSession, workspace.id, {
+                      id: session.objectId,
+                      session_id: session.id,
+                    })}
                     onContextMenu={(event) =>
                       showSessionPinMenu(event, session.id, session.label)
                     }
@@ -1030,6 +1095,7 @@ function SessionsBlock({
                 workspaceId={workspace.id}
                 group={group}
                 initialOpen={index === 0}
+                activeSession={activeSession}
                 onSessionPinMenu={(event, session) =>
                   showSessionPinMenu(
                     event,
@@ -1074,17 +1140,31 @@ function SessionTreeDetails({
   workspaceId,
   group,
   initialOpen,
+  activeSession,
   onSessionPinMenu,
 }: {
   workspaceId: string;
   group: SessionTreeDayGroup;
   initialOpen?: boolean;
+  activeSession: ActiveSessionRef;
   onSessionPinMenu?: (event: MouseEvent<HTMLAnchorElement>, session: WorkspaceSidebarSession) => void;
 }) {
-  const [open, setOpen] = useState(!!initialOpen);
+  const hasActiveSession = group.users.some((bucket) =>
+    sessionBucketHasActiveSession(activeSession, workspaceId, bucket.sessions)
+  );
+  const [open, setOpen] = useState(!!initialOpen || hasActiveSession);
   const [visibleUserCount, setVisibleUserCount] = useState(PREVIEW_ITEM_LIMIT);
-  const visibleUsers = group.users.slice(0, visibleUserCount);
+  const activeUserIndex = group.users.findIndex((bucket) =>
+    sessionBucketHasActiveSession(activeSession, workspaceId, bucket.sessions)
+  );
+  const visibleUserLimit = Math.max(visibleUserCount, activeUserIndex + 1);
+  const visibleUsers = group.users.slice(0, visibleUserLimit);
   const hiddenUserCount = group.users.length - visibleUsers.length;
+
+  useEffect(() => {
+    if (hasActiveSession) setOpen(true);
+  }, [hasActiveSession]);
+
   return (
     <details open={open} className="text-[12.5px]">
       <summary
@@ -1111,6 +1191,7 @@ function SessionTreeDetails({
               key={`${group.dateKey}-${bucket.user}`}
               workspaceId={workspaceId}
               bucket={bucket}
+              activeSession={activeSession}
               onSessionPinMenu={onSessionPinMenu}
             />
           ))
@@ -1131,18 +1212,35 @@ function SessionTreeDetails({
 function SessionUserFolder({
   workspaceId,
   bucket,
+  activeSession,
   onSessionPinMenu,
 }: {
   workspaceId: string;
   bucket: { user: string; sessions: WorkspaceSidebarSession[] };
+  activeSession: ActiveSessionRef;
   onSessionPinMenu?: (event: MouseEvent<HTMLAnchorElement>, session: WorkspaceSidebarSession) => void;
 }) {
-  // Default collapsed — opening a date bucket already reveals N user rows,
-  // and auto-expanding each one explodes the whole tree on first paint.
-  const [open, setOpen] = useState(false);
+  const hasActiveSession = sessionBucketHasActiveSession(
+    activeSession,
+    workspaceId,
+    bucket.sessions
+  );
+  const [open, setOpen] = useState(hasActiveSession);
   const [visibleSessionCount, setVisibleSessionCount] = useState(PREVIEW_ITEM_LIMIT);
-  const visibleSessions = bucket.sessions.slice(0, visibleSessionCount);
+  const activeSessionIndex = bucket.sessions.findIndex((session) =>
+    sessionMatchesActive(activeSession, workspaceId, session)
+  );
+  const visibleSessionLimit = Math.max(
+    visibleSessionCount,
+    activeSessionIndex + 1
+  );
+  const visibleSessions = bucket.sessions.slice(0, visibleSessionLimit);
   const hiddenSessionCount = bucket.sessions.length - visibleSessions.length;
+
+  useEffect(() => {
+    if (hasActiveSession) setOpen(true);
+  }, [hasActiveSession]);
+
   return (
     <details open={open} className="text-[12px]">
       <summary
@@ -1166,6 +1264,7 @@ function SessionUserFolder({
             key={s.session_id}
             workspaceId={workspaceId}
             session={s}
+            activeSession={activeSession}
             onPinMenu={onSessionPinMenu}
           />
         ))}


### PR DESCRIPTION
## Summary
- Recognize stash-scoped session item URLs as active session routes in the sidebar.
- Auto-open the matching session period/user bucket and reveal the selected session row, even when it falls beyond the current preview limit.
- Pass the owning workspace into `AppShell` for stash item pages so the sidebar stays on the correct workspace context.

## Root Cause
Stash item pages use URLs like `/stashes/{slug}/items/session/{sessionUuid}` while the sidebar only selected rows for canonical workspace session URLs. The sidebar also reset nested session buckets to their collapsed defaults after navigation, so the selected row disappeared.

## Validation
- Reproduced locally in browser with a seeded Stash session item.
- Verified in browser that the session row is expanded and highlighted after navigating to the stash-scoped session page.
- `npm test -- AppSidebar.test.tsx`
- `npm run lint` (passes with existing warnings in `frontend/src/components/workspace/file-browser/ItemsColumns.tsx`)

## Screenshot
![Sidebar session selected on stash item route](https://gist.githubusercontent.com/henry-dowling/5b43411db922b62872522f16e8f9aa6a/raw/sidebar-selection-fixed.svg)