### PR TITLE
Onboarding wizard: signup → share, templates, imports, invite

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -47,19 +47,20 @@ def _get_state_fernet() -> Fernet:
     return Fernet(settings.INTEGRATIONS_ENCRYPTION_KEY.encode())
 
 
-def _encode_state(user_id: UUID, provider: str) -> str:
+def _encode_state(user_id: UUID, provider: str, return_to: str | None = None) -> str:
     payload = json.dumps(
         {
             "u": str(user_id),
             "p": provider,
             "n": secrets.token_urlsafe(16),
             "t": datetime.now(UTC).isoformat(),
+            "r": return_to,
         }
     )
     return _get_state_fernet().encrypt(payload.encode()).decode()
 
 
-def _decode_state(state: str, expected_provider: str) -> UUID:
+def _decode_state(state: str, expected_provider: str) -> tuple[UUID, str | None]:
     try:
         raw = _get_state_fernet().decrypt(state.encode(), ttl=int(STATE_TTL.total_seconds()))
     except InvalidToken:
@@ -67,7 +68,14 @@ def _decode_state(state: str, expected_provider: str) -> UUID:
     payload = json.loads(raw)
     if payload.get("p") != expected_provider:
         raise HTTPException(status_code=400, detail="provider mismatch in state")
-    return UUID(payload["u"])
+    return UUID(payload["u"]), payload.get("r")
+
+
+def _safe_return_to(return_to: str | None) -> str | None:
+    """Only honor relative same-origin paths; blocks open-redirect."""
+    if not return_to or not return_to.startswith("/") or return_to.startswith("//"):
+        return None
+    return return_to
 
 
 class ProviderListItem(BaseModel):
@@ -124,6 +132,7 @@ class ConnectStartResponse(BaseModel):
 @router.get("/{provider}/connect", response_model=ConnectStartResponse)
 async def integration_connect(
     provider: str,
+    return_to: str | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
     """Return the provider's OAuth authorize URL.
@@ -132,9 +141,13 @@ async def integration_connect(
     navigation can't carry that header, so we can't 302 here. Instead
     the frontend fetches this with the Bearer, gets the URL, and does
     the navigation itself.
+
+    `return_to`, if a relative same-origin path, is round-tripped through
+    the encrypted state so the callback can land the user back where they
+    started (e.g. /onboarding) instead of /settings.
     """
     p = get_provider(provider)
-    state = _encode_state(current_user["id"], provider)
+    state = _encode_state(current_user["id"], provider, _safe_return_to(return_to))
     return ConnectStartResponse(authorize_url=p.authorize_url(state))
 
 
@@ -145,18 +158,19 @@ async def integration_callback(
     state: str = Query(...),
 ):
     p = get_provider(provider)
-    user_id = _decode_state(state, expected_provider=provider)
+    user_id, return_to = _decode_state(state, expected_provider=provider)
 
     token = await p.exchange_code(code)
     account = await p.fetch_account(token.access_token)
     await storage.store_token(user_id, provider, token, account)
 
-    # Send the user back to /settings — the Integrations section is
-    # embedded there. The query param triggers the panel to re-fetch
-    # connection state.
-    redirect_target = f"{settings.PUBLIC_URL.rstrip('/')}/settings"
-    query = urlencode({"connected": provider})
-    return RedirectResponse(url=f"{redirect_target}?{query}", status_code=302)
+    base = settings.PUBLIC_URL.rstrip("/")
+    target = _safe_return_to(return_to) or "/settings"
+    sep = "&" if "?" in target else "?"
+    return RedirectResponse(
+        url=f"{base}{target}{sep}{urlencode({'connected': provider})}",
+        status_code=302,
+    )
 
 
 @router.post("/{provider}/disconnect")

--- a/backend/migrations/versions/0067_workspace_member_is_primary.py
+++ b/backend/migrations/versions/0067_workspace_member_is_primary.py
@@ -1,0 +1,44 @@
+"""Mark each user's primary workspace.
+
+The auto-provisioned workspace created at signup is the user's "primary" — the
+fallback target when an agent calls /publish without a workspace_id. A partial
+unique index enforces at most one primary per user.
+
+Backfills existing users by marking their earliest membership primary so the
+fallback works for accounts created before this column existed.
+
+Revision ID: 0067
+Revises: 0066
+"""
+
+from alembic import op
+
+revision = "0067"
+down_revision = "0066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE workspace_members "
+        "ADD COLUMN IF NOT EXISTS is_primary BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS workspace_members_one_primary_per_user "
+        "ON workspace_members (user_id) WHERE is_primary"
+    )
+    op.execute(
+        "UPDATE workspace_members wm SET is_primary = TRUE "
+        "FROM ("
+        "  SELECT DISTINCT ON (user_id) user_id, workspace_id "
+        "  FROM workspace_members "
+        "  ORDER BY user_id, joined_at ASC"
+        ") earliest "
+        "WHERE wm.user_id = earliest.user_id AND wm.workspace_id = earliest.workspace_id"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS workspace_members_one_primary_per_user")
+    op.execute("ALTER TABLE workspace_members DROP COLUMN IF EXISTS is_primary")

--- a/backend/models.py
+++ b/backend/models.py
@@ -637,7 +637,7 @@ class PublishRequest(BaseModel):
     Stash, and return the Stash URL. Folder is optional; defaults to a
     workspace's "AI Drafts" folder that's auto-created on first use."""
 
-    workspace_id: UUID
+    workspace_id: UUID | None = None
     title: str = Field(..., min_length=1, max_length=255)
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -17,21 +17,30 @@ async def publish(
     req: PublishRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    if not await workspace_service.is_member(req.workspace_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Not a workspace member")
+    if req.workspace_id is None:
+        workspace_id = await workspace_service.get_primary_for_user(current_user["id"])
+        if workspace_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="No primary workspace; pass workspace_id explicitly",
+            )
+    else:
+        workspace_id = req.workspace_id
+        if not await workspace_service.is_member(workspace_id, current_user["id"]):
+            raise HTTPException(status_code=403, detail="Not a workspace member")
 
     if req.folder_id is not None:
         folder = await files_tree_service.get_folder(req.folder_id)
-        if not folder or folder["workspace_id"] != req.workspace_id:
+        if not folder or folder["workspace_id"] != workspace_id:
             raise HTTPException(status_code=404, detail="Folder not found in this workspace")
         target_folder = folder
     else:
         target_folder = await files_tree_service.find_or_create_root_folder(
-            req.workspace_id, AI_DRAFTS_FOLDER_NAME, current_user["id"]
+            workspace_id, AI_DRAFTS_FOLDER_NAME, current_user["id"]
         )
 
     page = await files_tree_service.create_page(
-        workspace_id=req.workspace_id,
+        workspace_id=workspace_id,
         name=req.title,
         created_by=current_user["id"],
         folder_id=target_folder["id"],
@@ -43,7 +52,7 @@ async def publish(
 
     try:
         stash = await stash_service.create_stash(
-            workspace_id=req.workspace_id,
+            workspace_id=workspace_id,
             owner_id=current_user["id"],
             title=req.title,
             description="",
@@ -60,7 +69,7 @@ async def publish(
     return PublishResponse(
         page_id=page["id"],
         folder_id=target_folder["id"],
-        workspace_id=req.workspace_id,
+        workspace_id=workspace_id,
         visibility=stash["access"],
         workspace_permission=stash["workspace_permission"],
         public_permission=stash["public_permission"],

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -42,6 +42,7 @@ async def register_user(
         name=ws_name,
         description="",
         creator_id=user["id"],
+        is_primary=True,
     )
     return user, api_key
 

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -55,8 +55,7 @@ async def get_primary_for_user(user_id: UUID) -> UUID | None:
     """Return the workspace id the user has marked primary, or None."""
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT workspace_id FROM workspace_members "
-        "WHERE user_id = $1 AND is_primary LIMIT 1",
+        "SELECT workspace_id FROM workspace_members " "WHERE user_id = $1 AND is_primary LIMIT 1",
         user_id,
     )
     return row["workspace_id"] if row else None

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -10,8 +10,14 @@ async def create_workspace(
     name: str,
     description: str,
     creator_id: UUID,
+    is_primary: bool = False,
 ) -> dict:
-    """Create a workspace with the creator as owner."""
+    """Create a workspace with the creator as owner.
+
+    Pass is_primary=True to mark the creator's membership as their primary
+    workspace — used by /publish as the fallback target when no workspace_id
+    is supplied. Only the auto-provisioned signup workspace should pass this.
+    """
     pool = get_pool()
     invite_code = ""
     for _ in range(5):
@@ -35,12 +41,25 @@ async def create_workspace(
     )
     ws = dict(row)
     await pool.execute(
-        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        "INSERT INTO workspace_members (workspace_id, user_id, role, is_primary) "
+        "VALUES ($1, $2, 'owner', $3)",
         ws["id"],
         creator_id,
+        is_primary,
     )
     ws["member_count"] = 1
     return ws
+
+
+async def get_primary_for_user(user_id: UUID) -> UUID | None:
+    """Return the workspace id the user has marked primary, or None."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT workspace_id FROM workspace_members "
+        "WHERE user_id = $1 AND is_primary LIMIT 1",
+        user_id,
+    )
+    return row["workspace_id"] if row else None
 
 
 async def get_workspace(workspace_id: UUID) -> dict | None:

--- a/backend/tests/test_publish.py
+++ b/backend/tests/test_publish.py
@@ -1,0 +1,92 @@
+"""Tests for the /api/v1/publish single-call publish endpoint.
+
+The interesting behaviour is the workspace_id fallback: a brand-new user can
+publish without first looking up their workspace, because register_user marks
+the auto-provisioned signup workspace primary.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+@pytest.mark.asyncio
+async def test_publish_falls_back_to_primary_workspace(client: AsyncClient):
+    """A new user can call /publish without supplying workspace_id."""
+    key = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "title": "Untitled HTML",
+            "content_type": "html",
+            "content": "<h1>hi</h1>",
+            "public_permission": "read",
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["page_id"]
+    assert body["workspace_id"]
+    assert body["url"].endswith(f"/stashes/{body['stash_slug']}")
+
+
+@pytest.mark.asyncio
+async def test_publish_with_explicit_workspace(client: AsyncClient):
+    """Explicit workspace_id works the same as before for members."""
+    key = await _register(client)
+
+    mine = await client.get("/api/v1/workspaces/mine", headers=_auth(key))
+    workspace_id = mine.json()["workspaces"][0]["id"]
+
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "workspace_id": workspace_id,
+            "title": "Explicit-WS publish",
+            "content_type": "markdown",
+            "content": "# hello",
+            "public_permission": "read",
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["workspace_id"] == workspace_id
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_non_member_workspace(client: AsyncClient):
+    """If the user passes a workspace_id they don't belong to, return 403."""
+    key_a = await _register(client)
+    key_b = await _register(client)
+
+    mine_b = await client.get("/api/v1/workspaces/mine", headers=_auth(key_b))
+    foreign_workspace = mine_b.json()["workspaces"][0]["id"]
+
+    resp = await client.post(
+        "/api/v1/publish",
+        json={
+            "workspace_id": foreign_workspace,
+            "title": "Foreign publish",
+            "content_type": "markdown",
+            "content": "# nope",
+            "public_permission": "read",
+        },
+        headers=_auth(key_a),
+    )
+    assert resp.status_code == 403

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -43,10 +43,16 @@ function LoginPageInner() {
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [cliApproved, setCliApproved] = useState(false);
+  const [justRegistered, setJustRegistered] = useState(false);
 
   // Normal redirect for non-CLI logins
   useEffect(() => {
     if (loading || !user || cliSession) return;
+
+    if (justRegistered) {
+      router.push("/onboarding");
+      return;
+    }
 
     if (nextPath) {
       router.push(nextPath);
@@ -62,7 +68,7 @@ function LoginPageInner() {
     }).catch(() => {
       router.push("/");
     });
-  }, [user, loading, cliSession, nextPath, router]);
+  }, [user, loading, cliSession, nextPath, router, justRegistered]);
 
   // Wait for useAuth to load before rendering — otherwise the signed-out form
   // flashes on every /login hit even for already-signed-in users.
@@ -111,6 +117,9 @@ function LoginPageInner() {
 
       const data = await res.json();
       setToken(data.api_key);
+      if (mode === "register" && !cliSession) {
+        setJustRegistered(true);
+      }
 
       if (cliSession) {
         const approveRes = await fetch(

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { Suspense, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import Header from "../../components/Header";
+import { useAuth } from "../../hooks/useAuth";
+import { addExternalStash, getToken, listMyWorkspaces } from "../../lib/api";
+
+import FirstShareStep from "./steps/FirstShareStep";
+import TemplatesStep from "./steps/TemplatesStep";
+import ImportsStep from "./steps/ImportsStep";
+import InviteStep from "./steps/InviteStep";
+import DoneStep from "./steps/DoneStep";
+
+// Read the token from localStorage in an SSR-safe way. useSyncExternalStore
+// gives us the right value on first client render without setState-in-effect.
+function useStashToken(): string | null {
+  return useSyncExternalStore(
+    (cb) => {
+      window.addEventListener("storage", cb);
+      return () => window.removeEventListener("storage", cb);
+    },
+    () => getToken(),
+    () => null,
+  );
+}
+
+const STEPS = ["1", "2", "3", "4", "done"] as const;
+type Step = (typeof STEPS)[number];
+
+const STEP_LABELS: Record<Step, string> = {
+  "1": "Share",
+  "2": "Templates",
+  "3": "Sources",
+  "4": "Invite",
+  done: "Done",
+};
+
+function parseStep(raw: string | null): Step {
+  return STEPS.includes(raw as Step) ? (raw as Step) : "1";
+}
+
+export default function OnboardingPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted">Loading…</div>}>
+      <OnboardingInner />
+    </Suspense>
+  );
+}
+
+function OnboardingInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user, loading, logout } = useAuth();
+  const apiKey = useStashToken();
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+
+  const step = parseStep(searchParams.get("step"));
+
+  useEffect(() => {
+    if (!loading && apiKey === null) {
+      router.replace("/login");
+    }
+  }, [loading, apiKey, router]);
+
+  useEffect(() => {
+    if (!apiKey) return;
+    listMyWorkspaces()
+      .then(({ workspaces }) => {
+        if (workspaces.length > 0) setWorkspaceId(workspaces[0].id);
+      })
+      .catch(() => {});
+  }, [apiKey]);
+
+  function gotoStep(next: Step) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("step", next);
+    router.push(`/onboarding?${params.toString()}`);
+  }
+
+  function nextStep() {
+    const i = STEPS.indexOf(step);
+    gotoStep(STEPS[Math.min(i + 1, STEPS.length - 1)]);
+  }
+
+  function skipToWorkspace() {
+    if (workspaceId) router.push(`/workspaces/${workspaceId}`);
+    else router.push("/");
+  }
+
+  if (loading || !apiKey) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-muted">
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header user={user} onLogout={logout} />
+      <main className="flex-1 px-4 py-10">
+        <div className="mx-auto w-full max-w-2xl space-y-8">
+          <ProgressBar step={step} onJump={gotoStep} />
+          <StepBody
+            step={step}
+            apiKey={apiKey}
+            workspaceId={workspaceId}
+            onContinue={nextStep}
+            onSkip={step === "done" ? skipToWorkspace : nextStep}
+            onSkipAll={skipToWorkspace}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ProgressBar({ step, onJump }: { step: Step; onJump: (s: Step) => void }) {
+  const currentIndex = STEPS.indexOf(step);
+  return (
+    <div className="flex items-center gap-2">
+      {STEPS.map((s, i) => {
+        const reached = i <= currentIndex;
+        const isCurrent = s === step;
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onJump(s)}
+            disabled={i > currentIndex}
+            className={`flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-[0.18em] transition-colors ${
+              isCurrent ? "text-foreground" : reached ? "text-muted hover:text-foreground" : "text-muted/50"
+            }`}
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${
+                isCurrent ? "bg-brand" : reached ? "bg-foreground/40" : "bg-border"
+              }`}
+            />
+            {STEP_LABELS[s]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StepBody({
+  step,
+  apiKey,
+  workspaceId,
+  onContinue,
+  onSkip,
+  onSkipAll,
+}: {
+  step: Step;
+  apiKey: string;
+  workspaceId: string | null;
+  onContinue: () => void;
+  onSkip: () => void;
+  onSkipAll: () => void;
+}) {
+  return (
+    <div className="space-y-8">
+      {step === "1" && <FirstShareStep apiKey={apiKey} />}
+      {step === "2" && (
+        <TemplatesStepContainer workspaceId={workspaceId} onContinue={onContinue} onSkip={onSkip} />
+      )}
+      {step === "3" && <ImportsStep workspaceId={workspaceId} />}
+      {step === "4" && <InviteStep workspaceId={workspaceId} />}
+      {step === "done" && <DoneStep workspaceId={workspaceId} />}
+
+      {step !== "2" && step !== "done" && (
+        <StepControls onContinue={onContinue} onSkip={onSkip} onSkipAll={onSkipAll} />
+      )}
+    </div>
+  );
+}
+
+function StepControls({
+  onContinue,
+  onSkip,
+  onSkipAll,
+  continuing,
+  continueLabel = "Continue",
+}: {
+  onContinue: () => void;
+  onSkip: () => void;
+  onSkipAll: () => void;
+  continuing?: boolean;
+  continueLabel?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between pt-2">
+      <button
+        type="button"
+        onClick={onSkipAll}
+        className="text-[12px] text-muted hover:text-foreground transition-colors"
+      >
+        Skip onboarding
+      </button>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-[12px] text-muted hover:text-foreground transition-colors"
+        >
+          Skip this step
+        </button>
+        <button
+          type="button"
+          onClick={onContinue}
+          disabled={continuing}
+          className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60 transition-colors"
+        >
+          {continuing ? "…" : continueLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Templates step owns its own continue handler (it has to fork selected stashes
+// before advancing), so we wrap it here with its own controls.
+function TemplatesStepContainer({
+  workspaceId,
+  onContinue,
+  onSkip,
+}: {
+  workspaceId: string | null;
+  onContinue: () => void;
+  onSkip: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function toggle(slug: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  const continueLabel = useMemo(() => {
+    if (selected.size === 0) return "Continue";
+    return `Add ${selected.size} and continue`;
+  }, [selected.size]);
+
+  async function handleContinue() {
+    if (selected.size === 0 || !workspaceId) {
+      onContinue();
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      for (const slug of selected) {
+        await addExternalStash(slug, workspaceId);
+      }
+      onContinue();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <TemplatesStep selected={selected} onToggle={toggle} busy={busy} error={error} />
+      <StepControls
+        onContinue={handleContinue}
+        onSkip={onSkip}
+        onSkipAll={onSkip}
+        continuing={busy}
+        continueLabel={continueLabel}
+      />
+    </>
+  );
+}

--- a/frontend/src/app/onboarding/prompts.ts
+++ b/frontend/src/app/onboarding/prompts.ts
@@ -1,0 +1,50 @@
+export type ShareKind = "html" | "markdown" | "session";
+
+const TOPIC_PLACEHOLDER = "<your topic — e.g. 'how our rate limiter works'>";
+
+function publishCurl(apiKey: string, apiUrl: string, contentType: "html" | "markdown") {
+  return `curl -sS -X POST ${apiUrl}/api/v1/publish \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'EOF'
+{
+  "title": "<your title>",
+  "content_type": "${contentType}",
+  "content": "<your generated ${contentType === "html" ? "HTML" : "markdown"}>",
+  "public_permission": "read"
+}
+EOF`;
+}
+
+export function buildPrompt(kind: ShareKind, apiKey: string, apiUrl: string): string {
+  if (kind === "html") {
+    return `Make an HTML page about ${TOPIC_PLACEHOLDER}. Make it information-dense, use SVG diagrams where they help, and optimize it to be read once.
+
+When you're done, publish it to Stash and print the share URL by running:
+
+${publishCurl(apiKey, apiUrl, "html")}`;
+  }
+
+  if (kind === "markdown") {
+    return `Write a markdown research note about ${TOPIC_PLACEHOLDER}. Use clear headings, fenced code blocks where it helps, and aim for the kind of doc a teammate would skim once.
+
+When you're done, publish it to Stash and print the share URL by running:
+
+${publishCurl(apiKey, apiUrl, "markdown")}`;
+  }
+
+  // Session trace: upload the agent's own .jsonl transcript. Needs the
+  // workspace id, so the prompt includes a one-line lookup.
+  return `Upload your current session transcript to Stash as a shareable trace. Find your transcript file (typically ~/.claude/projects/<dir>/<session>.jsonl, or your CLI's equivalent), then:
+
+WORKSPACE_ID=$(curl -sS ${apiUrl}/api/v1/workspaces/mine \\
+  -H "Authorization: Bearer ${apiKey}" | python3 -c 'import json,sys;print(json.load(sys.stdin)["workspaces"][0]["id"])')
+
+curl -sS -X POST ${apiUrl}/api/v1/workspaces/$WORKSPACE_ID/transcripts \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -F "file=@<path-to-your-session.jsonl>" \\
+  -F "session_id=<session-id>" \\
+  -F "agent_name=claude-code"
+
+Print the response so I can see the upload succeeded.`;
+}

--- a/frontend/src/app/onboarding/steps/DoneStep.tsx
+++ b/frontend/src/app/onboarding/steps/DoneStep.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+
+type Props = {
+  workspaceId: string | null;
+};
+
+export default function DoneStep({ workspaceId }: Props) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          You&rsquo;re set up
+        </h1>
+        <p className="text-sm text-dim max-w-md">
+          Two things you might want next.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-5 space-y-2">
+        <div className="text-[13px] font-semibold text-foreground">
+          Install the CLI for the full integration
+        </div>
+        <p className="text-[12px] text-muted leading-relaxed">
+          The CLI lets your agent push session transcripts automatically and
+          gives you{" "}
+          <code className="text-foreground">stash share</code>,{" "}
+          <code className="text-foreground">stash discover</code>, and more.
+        </p>
+        <pre className="rounded-md border border-border-subtle bg-background/40 px-3 py-2 text-[12px] font-mono text-foreground overflow-x-auto">
+          npm i -g @joinstash/cli
+        </pre>
+        <Link
+          href="/docs/cli"
+          className="inline-block text-[12px] font-medium text-brand hover:text-brand-hover"
+        >
+          CLI docs →
+        </Link>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-5 space-y-2">
+        <div className="text-[13px] font-semibold text-foreground">
+          Go to your workspace
+        </div>
+        <p className="text-[12px] text-muted leading-relaxed">
+          Open the workspace home — anything you shared, imported, or copied
+          in is already there.
+        </p>
+        {workspaceId && (
+          <Link
+            href={`/workspaces/${workspaceId}`}
+            className="inline-block rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors"
+          >
+            Open workspace
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/onboarding/steps/FirstShareStep.tsx
+++ b/frontend/src/app/onboarding/steps/FirstShareStep.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+
+import { buildPrompt, ShareKind } from "../prompts";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+
+const TABS: { kind: ShareKind; label: string; hint: string }[] = [
+  { kind: "html", label: "HTML page", hint: "Information-dense, optimized to read once." },
+  { kind: "markdown", label: "Markdown doc", hint: "Research note, spec, or writeup." },
+  { kind: "session", label: "Session trace", hint: "Share the agent's own transcript." },
+];
+
+type Props = {
+  apiKey: string;
+};
+
+export default function FirstShareStep({ apiKey }: Props) {
+  const [kind, setKind] = useState<ShareKind>("html");
+  const [copied, setCopied] = useState(false);
+  const prompt = buildPrompt(kind, apiKey, API_URL);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Make your first share
+        </h1>
+        <p className="text-sm text-dim max-w-md">
+          Paste this into Claude Code, Cursor, or Codex. Your agent will
+          generate the content and publish it — you&rsquo;ll get a share URL
+          back.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface overflow-hidden">
+        <div className="flex border-b border-border bg-background/40">
+          {TABS.map((t) => (
+            <button
+              key={t.kind}
+              type="button"
+              onClick={() => setKind(t.kind)}
+              className={`flex-1 px-3 py-2.5 text-[12px] font-medium border-b-2 transition-colors ${
+                kind === t.kind
+                  ? "border-brand text-foreground"
+                  : "border-transparent text-muted hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="px-4 pt-3 pb-2 text-[11px] text-muted">
+          {TABS.find((t) => t.kind === kind)?.hint}
+        </div>
+
+        <div className="flex items-center justify-between px-4 py-2 border-t border-border-subtle bg-background/40">
+          <div className="text-[11px] font-mono uppercase tracking-wider text-muted">
+            Prompt + curl
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="text-[11px] font-medium text-brand hover:text-brand-hover transition-colors"
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+
+        <pre className="p-4 text-[12px] leading-relaxed text-foreground font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-[420px]">
+          {prompt}
+        </pre>
+      </div>
+
+      <div className="rounded-xl border border-border-subtle bg-background/40 p-4 text-[12px] text-dim leading-relaxed">
+        <strong className="text-foreground font-medium">What happens next:</strong>{" "}
+        your agent runs the command and prints a URL like{" "}
+        <code className="text-foreground">{`${API_URL.replace(/\/$/, "")}/stashes/...`}</code>
+        . Open it — your content is live and shareable.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/onboarding/steps/ImportsStep.tsx
+++ b/frontend/src/app/onboarding/steps/ImportsStep.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import IntegrationCard from "@/components/integrations/IntegrationCard";
+import DriveImportDialog from "@/components/import/DriveImportDialog";
+import GitImportDialog from "@/components/import/GitImportDialog";
+import NotionImportDialog from "@/components/import/NotionImportDialog";
+import { IntegrationStatus, listIntegrations } from "@/lib/integrations";
+
+type Props = {
+  workspaceId: string | null;
+};
+
+type DialogKind = "github" | "google" | "notion" | null;
+
+const RETURN_TO = "/onboarding?step=3";
+
+export default function ImportsStep({ workspaceId }: Props) {
+  const [providers, setProviders] = useState<IntegrationStatus[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dialog, setDialog] = useState<DialogKind>(null);
+  const [dispatchedCount, setDispatchedCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await listIntegrations();
+      setProviders(r.providers);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Re-fetch when the user returns from the OAuth callback; strip the
+  // ?connected=… query so a manual refresh doesn't keep firing.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("connected")) {
+      void refresh();
+      const url = new URL(window.location.href);
+      url.searchParams.delete("connected");
+      window.history.replaceState({}, "", url.pathname + url.search);
+    }
+  }, [refresh]);
+
+  const byProvider = new Map(providers?.map((p) => [p.provider, p]) ?? []);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Connect a source
+        </h1>
+        <p className="text-sm text-dim max-w-md">
+          Pull existing docs from GitHub, Google Drive, or Notion into your
+          workspace. Connect now or skip and do it later from Settings.
+        </p>
+      </div>
+
+      {error && (
+        <div className="text-[12px] text-error rounded-lg border border-error/30 bg-error/10 px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      {providers === null ? (
+        <div className="text-[12px] text-muted">Loading…</div>
+      ) : (
+        <div className="space-y-3">
+          {providers.map((p) => (
+            <div key={p.provider} className="space-y-2">
+              <IntegrationCard status={p} onChanged={refresh} returnTo={RETURN_TO} />
+              {p.connected && workspaceId && (
+                <div className="pl-14">
+                  <button
+                    type="button"
+                    onClick={() => setDialog(p.provider as DialogKind)}
+                    className="text-[12px] font-medium text-brand hover:text-brand-hover"
+                  >
+                    Import from {p.display_name} →
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {dispatchedCount > 0 && (
+        <div className="text-[12px] text-muted rounded-lg border border-border-subtle bg-background/40 px-3 py-2">
+          {dispatchedCount} import{dispatchedCount === 1 ? "" : "s"} running in
+          the background. They&rsquo;ll appear in your workspace when ready.
+        </div>
+      )}
+
+      {dialog === "github" && workspaceId && (
+        <GitImportDialog
+          workspaceId={workspaceId}
+          onDispatched={(ids) => setDispatchedCount((n) => n + ids.length)}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog === "google" && workspaceId && (
+        <DriveImportDialog
+          workspaceId={workspaceId}
+          onDispatched={(ids) => setDispatchedCount((n) => n + ids.length)}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog === "notion" && workspaceId && (
+        <NotionImportDialog
+          workspaceId={workspaceId}
+          onDispatched={(ids) => setDispatchedCount((n) => n + ids.length)}
+          onClose={() => setDialog(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/onboarding/steps/InviteStep.tsx
+++ b/frontend/src/app/onboarding/steps/InviteStep.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getWorkspace } from "@/lib/api";
+
+const APP_URL =
+  typeof window !== "undefined" ? window.location.origin : "";
+
+type Props = {
+  workspaceId: string | null;
+};
+
+export default function InviteStep({ workspaceId }: Props) {
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    getWorkspace(workspaceId)
+      .then((ws) => setInviteCode(ws.invite_code))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, [workspaceId]);
+
+  const inviteUrl = inviteCode ? `${APP_URL}/join/${inviteCode}` : "";
+
+  async function handleCopy() {
+    if (!inviteUrl) return;
+    await navigator.clipboard.writeText(inviteUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Invite teammates
+        </h1>
+        <p className="text-sm text-dim max-w-md">
+          Send this link to anyone you want in your workspace. They&rsquo;ll
+          join with the same role anyone else has by default.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-4 space-y-3">
+        <div className="text-[11px] font-mono uppercase tracking-wider text-muted">
+          Invite link
+        </div>
+        {error ? (
+          <div className="text-[12px] text-error">{error}</div>
+        ) : inviteUrl ? (
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded-md border border-border-subtle bg-background/40 px-3 py-2 text-[12px] font-mono text-foreground">
+              {inviteUrl}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="rounded-md bg-brand px-3 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        ) : (
+          <div className="text-[12px] text-muted">Loading…</div>
+        )}
+        <div className="text-[11px] text-muted">
+          You can rotate this link anytime from workspace settings.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/onboarding/steps/TemplatesStep.tsx
+++ b/frontend/src/app/onboarding/steps/TemplatesStep.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+
+import { ONBOARDING_TEMPLATES } from "@/lib/onboarding/templates";
+
+type Props = {
+  selected: Set<string>;
+  onToggle: (slug: string) => void;
+  busy: boolean;
+  error: string | null;
+};
+
+export default function TemplatesStep({ selected, onToggle, busy, error }: Props) {
+  if (ONBOARDING_TEMPLATES.length === 0) {
+    return (
+      <div className="space-y-4">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Start from a template
+        </h1>
+        <p className="text-sm text-dim">
+          No templates available yet. Skip ahead — you can browse{" "}
+          <a href="/discover" className="text-brand underline">
+            Discover
+          </a>{" "}
+          for community Stashes anytime.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Start from a template
+        </h1>
+        <p className="text-sm text-dim max-w-md">
+          Pick any starter Stashes you want — we&rsquo;ll copy them into your
+          workspace so you have something to edit on day one.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {ONBOARDING_TEMPLATES.map((t) => {
+          const isSelected = selected.has(t.slug);
+          return (
+            <Card
+              key={t.slug}
+              title={t.title}
+              description={t.description}
+              selected={isSelected}
+              disabled={busy}
+              onClick={() => onToggle(t.slug)}
+            />
+          );
+        })}
+      </div>
+
+      <p className="text-[11px] text-muted">
+        Templates are copied into your workspace. Edits stay yours — there&rsquo;s
+        no sync from the original.
+      </p>
+
+      {error && (
+        <div className="text-[12px] text-error rounded-lg border border-error/30 bg-error/10 px-3 py-2">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Card({
+  title,
+  description,
+  selected,
+  disabled,
+  onClick,
+}: {
+  title: string;
+  description: string;
+  selected: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`text-left rounded-xl border p-4 transition-colors disabled:opacity-60 ${
+        selected
+          ? "border-brand bg-brand/5 ring-1 ring-brand"
+          : "border-border bg-surface hover:bg-raised"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="text-[13px] font-semibold text-foreground">{title}</div>
+        <span
+          aria-hidden
+          className={`h-4 w-4 rounded border flex items-center justify-center text-[10px] ${
+            selected ? "border-brand bg-brand text-white" : "border-border bg-background"
+          }`}
+        >
+          {selected ? "✓" : ""}
+        </span>
+      </div>
+      <div className="mt-1 text-[12px] text-muted leading-relaxed">{description}</div>
+    </button>
+  );
+}

--- a/frontend/src/components/integrations/IntegrationCard.tsx
+++ b/frontend/src/components/integrations/IntegrationCard.tsx
@@ -13,6 +13,7 @@ import { GitHubIcon, GoogleDriveIcon, NotionIcon } from "./BrandIcons";
 type Props = {
   status: IntegrationStatus;
   onChanged?: () => void;
+  returnTo?: string;
 };
 
 function ProviderIcon({ provider }: { provider: string }) {
@@ -28,13 +29,13 @@ function ProviderIcon({ provider }: { provider: string }) {
  * features (picker buttons, etc.) compose this for the auth state but
  * own their own resource UI.
  */
-export default function IntegrationCard({ status, onChanged }: Props) {
+export default function IntegrationCard({ status, onChanged, returnTo }: Props) {
   const [busy, setBusy] = useState(false);
 
   async function onConnect() {
     setBusy(true);
     try {
-      await startConnect(status.provider as IntegrationProvider);
+      await startConnect(status.provider as IntegrationProvider, returnTo);
     } catch (e) {
       setBusy(false);
       alert(e instanceof Error ? e.message : String(e));

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -38,9 +38,13 @@ export async function listIntegrations(): Promise<IntegrationsList> {
  * returns `{authorize_url}` as JSON; we fetch it (Bearer carried by
  * `apiFetch`), then navigate the top window to the provider's URL.
  */
-export async function startConnect(provider: IntegrationProvider): Promise<void> {
+export async function startConnect(
+  provider: IntegrationProvider,
+  returnTo?: string,
+): Promise<void> {
+  const query = returnTo ? `?return_to=${encodeURIComponent(returnTo)}` : "";
   const { authorize_url } = await apiFetch<{ authorize_url: string }>(
-    `/api/v1/integrations/${provider}/connect`,
+    `/api/v1/integrations/${provider}/connect${query}`,
   );
   window.location.href = authorize_url;
 }

--- a/frontend/src/lib/onboarding/templates.ts
+++ b/frontend/src/lib/onboarding/templates.ts
@@ -1,0 +1,31 @@
+// Curated public Stash slugs surfaced as starter templates during onboarding.
+//
+// These need to exist as public, discoverable Stashes in prod (and dev) for
+// Step 2 to render anything. If the slug list is empty (or the server returns
+// 404 for all of them), Step 2 renders an empty state and is skippable.
+//
+// To add a template: publish a public Stash, copy its slug, and append here.
+
+export type OnboardingTemplate = {
+  slug: string;
+  title: string;
+  description: string;
+};
+
+export const ONBOARDING_TEMPLATES: OnboardingTemplate[] = [
+  {
+    slug: "engineering-handbook-starter",
+    title: "Engineering handbook starter",
+    description: "Coding conventions, on-call playbook, and incident template.",
+  },
+  {
+    slug: "product-brief-template",
+    title: "Product brief template",
+    description: "Problem framing, success metrics, and rollout checklist.",
+  },
+  {
+    slug: "sales-discovery-playbook",
+    title: "Sales discovery playbook",
+    description: "Discovery questions, qualification rubric, and call notes.",
+  },
+];


### PR DESCRIPTION
## Summary

Replaces the single-page `/onboarding` with a 4-step wizard, keeping PR #285's "one prompt → share URL" wedge as **Step 1** and adding the three additional asks: choose **what** to share, fork **template Stashes**, connect a **real import source**, and surface a workspace **invite link**. The CLI install becomes the closing upsell, not the prerequisite.

This PR is **self-contained** and obsoletes #285 — it carries over PR285's backend changes (optional `workspace_id` on `/publish`, the primary-workspace migration, login → `/onboarding` redirect) and supersedes its single-page `/onboarding` with the wizard.

## What's in each step

**Step 1 — First share.** Tabs over the prompt+curl block:
- **HTML page** — PR285's existing pitch.
- **Markdown doc** — same shape, `content_type: "markdown"`.
- **Session trace** — uploads the agent's own `.jsonl` to `/workspaces/{id}/transcripts` (lookup line included so the user still pastes one thing).

**Step 2 — Start from templates.** Multi-select grid of curated public Stash slugs (`frontend/src/lib/onboarding/templates.ts`). `Continue` loops `POST /stashes/{slug}/add-to-workspace`, which already deep-copies pages, folders, tables, files, and sessions via the existing fork machinery in `stash_service._fork_object`. Forks are independent copies — no upstream sync. Empty-state copy if the slug list is empty.

**Step 3 — Connect a source.** Reuses `IntegrationCard` + `GitImportDialog` / `DriveImportDialog` / `NotionImportDialog` from the existing integrations work (#348). `Connect` uses `return_to=/onboarding?step=3` so OAuth lands back in the wizard. When a provider is connected, an inline "Import from X →" button opens the matching picker.

**Step 4 — Invite teammates.** Surfaces the workspace's invite link (`$APP_URL/join/{invite_code}`) with a Copy button. The system has no per-email invite API today — invites are link-based by design.

**Done.** Two cards: CLI install (`npm i -g @joinstash/cli`) + "Open workspace" CTA.

## Backend

- `POST /api/v1/publish` `workspace_id` is now optional; falls back to the user's primary workspace.
- Migration `0067` adds `workspace_members.is_primary` with a partial unique index per user; backfills earliest membership.
- `register_user` marks the auto-provisioned signup workspace primary.
- OAuth `/integrations/{provider}/connect` accepts `?return_to=`; callback honors it if it's a same-origin relative path. Defaults to `/settings` for any existing caller.

## On forking semantics (raised in the planning thread)

Today forking is **deep copy + lineage tracking, no sync** (`forked_from_stash_id` is purely attributional). This PR ships against current semantics — the step's footnote is "Templates are copied into your workspace. Edits stay yours — there's no sync from the original." Two follow-ups worth deciding outside this PR:
1. Should template updates flow into forks (curated templates only)?
2. Should the workspace Stashes list visually distinguish template forks from user forks?

## Files

- `backend/integrations/router.py` — `return_to` in OAuth state.
- `backend/migrations/versions/0067_workspace_member_is_primary.py` — new.
- `backend/routers/publish.py`, `backend/models.py`, `backend/services/workspace_service.py`, `backend/services/user_service.py` — primary-workspace fallback.
- `backend/tests/test_publish.py` — new tests.
- `frontend/src/app/onboarding/page.tsx` + `steps/*.tsx` + `prompts.ts` — wizard.
- `frontend/src/lib/onboarding/templates.ts` — curated template slug list.
- `frontend/src/lib/integrations.ts`, `frontend/src/components/integrations/IntegrationCard.tsx` — `returnTo` param plumbing.
- `frontend/src/app/login/page.tsx` — new-registration redirect to `/onboarding`.

## Verification gap

Local dev DB had pre-existing out-of-order migration state that blocked applying `0067` (the `alembic stamp` workaround was correctly denied as risky). **I have not yet run the wizard end-to-end in a browser.** Frontend `tsc --noEmit` is clean and all 21 backend tests pass (`pytest backend/tests/test_publish.py backend/tests/test_workspaces.py backend/tests/test_migrations.py`).

## Test plan

- [ ] Apply migration `0067` to a clean dev/staging DB.
- [ ] Seed 1-3 public Stashes whose slugs match `frontend/src/lib/onboarding/templates.ts` (or update that file with real slugs first).
- [ ] Fresh signup in an incognito window; confirm landing on `/onboarding?step=1` with the bearer token baked into the prompt block.
- [ ] Cycle the Step 1 content-type tabs; confirm each prompt is shape-correct (HTML/markdown → `/publish`, session trace → `/workspaces/{id}/transcripts` with the workspace lookup line).
- [ ] Paste the Step 1 HTML prompt into Claude Code; confirm a `/stashes/{slug}` URL comes back.
- [ ] Step 2: select 2 templates, `Continue`; confirm both appear in `/workspaces/{id}/stashes` as forks with `forked_from_stash_id` populated.
- [ ] Step 3: hit "Connect" on an unconnected provider; confirm OAuth lands back on `/onboarding?step=3` with `?connected=…`; open the import dialog; confirm a task dispatches.
- [ ] Step 4: confirm the invite link copies; open it in a second incognito window; confirm the join flow works.
- [ ] Done screen: confirm "Open workspace" navigates to `/workspaces/{primary_id}`.
- [ ] Run the entire flow once with `Skip this step` on every step; confirm the Done screen still reaches the workspace.

Closes #285 (this PR obsoletes that single-page approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)