### PR TITLE
CLI: add --layout flag to add-page / edit-page

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -302,6 +302,7 @@ class StashClient:
         folder_id: str | None = None,
         content_type: str = "markdown",
         content_html: str = "",
+        html_layout: str | None = None,
     ) -> dict:
         body: dict = {
             "name": name,
@@ -311,6 +312,8 @@ class StashClient:
         }
         if folder_id:
             body["folder_id"] = folder_id
+        if html_layout:
+            body["html_layout"] = html_layout
         return self._post(f"/api/v1/workspaces/{workspace_id}/pages/new", json=body)
 
     def list_pages(self, workspace_id: str) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1787,6 +1787,12 @@ def files_add_page(
     html_file: str = typer.Option(
         None, "--html-file", help="Local HTML file to load as content for an html page."
     ),
+    layout: str = typer.Option(
+        None,
+        "--layout",
+        help="HTML layout: 'responsive' (default) or 'fixed-aspect' for 16:9 slide decks.",
+        case_sensitive=False,
+    ),
     attach: list[str] = typer.Option(
         None, "--attach", help="Local file path to upload and embed (repeatable)."
     ),
@@ -1797,6 +1803,16 @@ def files_add_page(
     if page_type not in ("markdown", "html"):
         console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
         raise typer.Exit(1)
+    if layout is not None:
+        layout = layout.lower()
+        if layout not in ("responsive", "fixed-aspect"):
+            console.print(
+                f"[red]--layout must be 'responsive' or 'fixed-aspect', got: {layout}[/red]"
+            )
+            raise typer.Exit(1)
+        if page_type != "html":
+            console.print("[yellow]--layout only applies to html pages; ignoring[/yellow]")
+            layout = None
     if page_type == "html" and html_file:
         if not Path(html_file).is_file():
             console.print(f"[red]Not a file: {html_file}[/red]")
@@ -1828,6 +1844,7 @@ def files_add_page(
                 folder_id=folder,
                 content_type=page_type,
                 content_html=html_body,
+                html_layout=layout,
             )
         except StashError as e:
             _err(e)
@@ -1875,6 +1892,12 @@ def files_edit_page(
     html_file: str = typer.Option(
         None, "--html-file", help="Local HTML file to load as content_html."
     ),
+    layout: str = typer.Option(
+        None,
+        "--layout",
+        help="Switch HTML layout: 'responsive' or 'fixed-aspect' (16:9 slide decks).",
+        case_sensitive=False,
+    ),
     attach: list[str] = typer.Option(
         None, "--attach", help="Local file path to upload and prepend (repeatable)."
     ),
@@ -1893,6 +1916,13 @@ def files_edit_page(
         page_type = page_type.lower()
         if page_type not in ("markdown", "html"):
             console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
+            raise typer.Exit(1)
+    if layout is not None:
+        layout = layout.lower()
+        if layout not in ("responsive", "fixed-aspect"):
+            console.print(
+                f"[red]--layout must be 'responsive' or 'fixed-aspect', got: {layout}[/red]"
+            )
             raise typer.Exit(1)
     if html_body is not None and page_type is None:
         page_type = "html"
@@ -1925,6 +1955,8 @@ def files_edit_page(
                 kwargs["content_type"] = page_type
             if html_body is not None:
                 kwargs["content_html"] = html_body
+            if layout is not None:
+                kwargs["html_layout"] = layout
             data = c.update_page(ws, page_id, **kwargs)
         except StashError as e:
             _err(e)


### PR DESCRIPTION
## Summary

Exposes the existing `html_layout` field on `PageCreateRequest` /
`PageUpdateRequest` through the CLI so HTML pages can be created or
flipped between **responsive** and **fixed-aspect** (16:9 slide deck)
without dropping to direct API calls.

## Usage

```bash
# Create a slide deck from an HTML file
stash files add-page "Q2 Roadmap" --type html --layout fixed-aspect --html-file deck.html

# Flip an existing page to slide-deck mode
stash files edit-page <page-id> --layout fixed-aspect
```

Validates `--layout` against `{responsive, fixed-aspect}`. Passing
`--layout` on a non-html page logs a yellow warning and ignores the
flag — preserves existing `add-page name` (markdown default) behavior.

## Why now

Caught while flipping the production "Product Deck" page from
responsive to fixed-aspect. The CLI's `edit-page` had `--type`,
`--html-file`, `--name`, but no `--layout` — so the only path was a
manual `curl PATCH …/html_layout=fixed-aspect`. This closes that gap.

## Test plan

- [ ] `stash files add-page "Test" --type html --layout fixed-aspect --html-file /tmp/deck.html`
- [ ] `stash files edit-page <id> --layout responsive`
- [ ] `--layout bogus` → exits 1 with clear error
- [ ] `--layout fixed-aspect` without `--type html` on add-page → yellow warning + ignored