### PR TITLE
Restore AI-generated session titles

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -25,6 +25,7 @@ celery = Celery(
     include=[
         "backend.tasks.extraction",
         "backend.tasks.embeddings",
+        "backend.tasks.session_titles",
         "backend.tasks.viz",
         "backend.integrations.github.importers.repo",
         "backend.integrations.google.importers.drive_file",
@@ -59,6 +60,10 @@ celery.conf.update(
         },
         "extraction-enqueue-pending": {
             "task": "backend.tasks.extraction.enqueue_pending",
+            "schedule": 60.0,
+        },
+        "session-title-reconcile": {
+            "task": "backend.tasks.session_titles.reconcile_missing",
             "schedule": 60.0,
         },
     },

--- a/backend/config.py
+++ b/backend/config.py
@@ -96,6 +96,7 @@ class Settings:
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+    ANTHROPIC_FAST_MODEL: str = os.getenv("ANTHROPIC_FAST_MODEL", "claude-haiku-4-5")
 
 
 settings = Settings()

--- a/backend/migrations/versions/0068_drop_summarizing_stash_status.py
+++ b/backend/migrations/versions/0068_drop_summarizing_stash_status.py
@@ -1,15 +1,11 @@
-"""Drop 'summarizing' from stashes.status CHECK constraint.
+"""Reserved cleanup revision for removed session-bundle stash status.
 
-The Celery summarize task was removed in #369, so no code path ever sets
-`stashes.status = 'summarizing'` anymore. The status column itself is
-basically vestigial — only 'live' is ever set — but we keep the column
-for now and just narrow the allowed values.
+The old session-bundle `stashes.status` column is gone from the current
+product Stash schema, so there is no status constraint left to narrow.
 
 Revision ID: 0068
 Revises: 0067
 """
-
-from alembic import op
 
 revision = "0068"
 down_revision = "0067"
@@ -18,16 +14,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE stashes DROP CONSTRAINT IF EXISTS stashes_status_check")
-    op.execute(
-        "ALTER TABLE stashes ADD CONSTRAINT stashes_status_check "
-        "CHECK (status IN ('live', 'ready', 'failed'))"
-    )
+    pass
 
 
 def downgrade() -> None:
-    op.execute("ALTER TABLE stashes DROP CONSTRAINT IF EXISTS stashes_status_check")
-    op.execute(
-        "ALTER TABLE stashes ADD CONSTRAINT stashes_status_check "
-        "CHECK (status IN ('live', 'summarizing', 'ready', 'failed'))"
-    )
+    pass

--- a/backend/migrations/versions/0069_session_titles.py
+++ b/backend/migrations/versions/0069_session_titles.py
@@ -1,0 +1,34 @@
+"""Cache AI-generated session titles.
+
+Revision ID: 0069
+Revises: 0068
+"""
+
+from alembic import op
+
+revision = "0069"
+down_revision = "0068"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE session_titles (
+            workspace_id UUID NOT NULL,
+            session_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (workspace_id, session_id),
+            FOREIGN KEY (workspace_id, session_id)
+                REFERENCES sessions(workspace_id, session_id)
+                ON DELETE CASCADE
+        )
+    """)
+    op.execute("CREATE INDEX idx_session_titles_updated ON session_titles(updated_at DESC)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE session_titles")

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..auth import get_current_user
+from ..config import settings
 from ..models import (
     HistoryEventBatchRequest,
     HistoryEventCreateRequest,
@@ -17,8 +18,11 @@ from ..models import (
     HistoryEventResponse,
 )
 from ..services import memory_service, stash_service, workspace_service
+from ..tasks.session_titles import generate_session_title
 
 ws_router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/sessions", tags=["sessions"])
+
+_TITLE_EVENT_TYPES = {"user_message", "user_prompt", "prompt", "assistant_message", "session_end"}
 
 
 # --- Shared auth helpers ---
@@ -62,6 +66,8 @@ async def push_ws_event(
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+    if settings.ANTHROPIC_API_KEY and req.session_id and req.event_type in _TITLE_EVENT_TYPES:
+        generate_session_title.delay(str(workspace_id), req.session_id)
     return HistoryEventResponse(**event)
 
 
@@ -85,6 +91,16 @@ async def push_ws_events_batch(
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+    title_session_ids = sorted(
+        {
+            event.session_id
+            for event in req.events
+            if event.session_id and event.event_type in _TITLE_EVENT_TYPES
+        }
+    )
+    if settings.ANTHROPIC_API_KEY:
+        for session_id in title_session_ids:
+            generate_session_title.delay(str(workspace_id), session_id)
     return [HistoryEventResponse(**e) for e in events]
 
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -155,10 +155,17 @@ async def list_my_sessions(
     for session in sessions:
         if not session["user_name"]:
             raise RuntimeError(f"Session {session['session_id']} has no author display_name")
-        session["title"] = session_title_service.title_from_text(
-            session.pop("title_source"),
-            session["session_id"],
+    sessions_by_workspace: dict[UUID, list[dict]] = {}
+    for session in sessions:
+        sessions_by_workspace.setdefault(session["workspace_id"], []).append(session)
+    for session_group in sessions_by_workspace.values():
+        titles = await session_title_service.titles_for_sessions(
+            session_group[0]["workspace_id"],
+            session_group,
         )
+        for session in session_group:
+            session["title"] = titles[session["session_id"]]
+            session.pop("title_source", None)
     return {"sessions": sessions}
 
 
@@ -202,7 +209,7 @@ async def get_workspace_session(
     events = await memory_service.read_session_events(workspace_id, session_id, current_user["id"])
     payload = _session_response(
         session,
-        title=session_title_service.title_from_events(events, session_id),
+        title=await session_title_service.title_for_events(workspace_id, session_id, events),
     )
     payload["artifacts"] = await _session_artifacts(session["id"])
     return payload

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -25,7 +25,7 @@ from ..services import (
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
-SIDEBAR_ETAG_VERSION = "sidebar-event-title-v1"
+SIDEBAR_ETAG_VERSION = "sidebar-generated-title-v1"
 
 
 # ---------------------------------------------------------------------------
@@ -40,11 +40,12 @@ SIDEBAR_ETAG_VERSION = "sidebar-event-title-v1"
 async def _list_sessions(workspace_id: UUID, user_id: UUID) -> list[dict]:
     """Sessions in this workspace, sourced from history_events rows."""
     sessions = await memory_service.list_workspace_sessions(workspace_id, user_id)
+    titles = await session_title_service.titles_for_sessions(workspace_id, sessions)
     return [
         {
             "id": s["id"],
             "session_id": s["session_id"],
-            "title": _auto_session_title(s),
+            "title": titles[s["session_id"]],
             "user_name": s["user_name"],
             "agent_name": s["agent_name"] or "",
             "size_bytes": int(s["size_bytes"] or 0),
@@ -53,13 +54,6 @@ async def _list_sessions(workspace_id: UUID, user_id: UUID) -> list[dict]:
         }
         for s in sessions
     ]
-
-
-def _auto_session_title(session: dict) -> str:
-    return session_title_service.title_from_text(
-        session.get("title_source"),
-        session["session_id"],
-    )
 
 
 async def _files_tree(workspace_id: UUID, user_id: UUID) -> dict:

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -42,10 +42,29 @@ def _title_from_first_matching_event(events: list[dict], event_types: tuple[str,
 
 
 def _title_from_content(content: str | None) -> str:
+    title = _title_from_structured_context(content)
+    if title:
+        return title
+
     for line in (content or "").splitlines():
         title = _title_from_line(line)
         if title:
             return title
+    return ""
+
+
+def _title_from_structured_context(content: str | None) -> str:
+    lines = (content or "").splitlines()
+    first_line = next((line.strip() for line in lines if line.strip()), "")
+    if not first_line.lower().startswith("you are working on a linear ticket"):
+        return ""
+
+    for line in lines:
+        match = re.match(r"^\s*Title:\s*(.+?)\s*$", line)
+        if not match:
+            continue
+        return _title_from_line(match.group(1))
+
     return ""
 
 

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -1,10 +1,17 @@
-"""Readable titles for sessions."""
+"""AI-generated and fallback readable titles for sessions."""
 
 from __future__ import annotations
 
+import hashlib
 import re
+from datetime import datetime
+from uuid import UUID
+
+from ..config import settings
+from ..database import get_pool
 
 MAX_TITLE_LENGTH = 80
+ENQUEUE_MISSING_LIMIT = 40
 
 _USER_EVENT_TYPES = (
     "user_message",
@@ -14,6 +21,78 @@ _USER_EVENT_TYPES = (
     "user",
 )
 _ASSISTANT_EVENT_TYPES = ("assistant_message", "assistant")
+
+
+def source_hash(session: dict) -> str:
+    last_at = session.get("last_at") or session.get("last_event_at") or session.get("updated_at")
+    if isinstance(last_at, datetime):
+        last_at = last_at.isoformat()
+    raw = f"{session['session_id']}|{session.get('event_count')}|{last_at or ''}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def titles_for_sessions(
+    workspace_id: UUID,
+    sessions: list[dict],
+    *,
+    enqueue_missing: bool = True,
+) -> dict[str, str]:
+    if not sessions:
+        return {}
+
+    pool = get_pool()
+    session_ids = [s["session_id"] for s in sessions]
+    rows = await pool.fetch(
+        "SELECT session_id, title, source_hash FROM session_titles "
+        "WHERE workspace_id = $1 AND session_id = ANY($2::text[])",
+        workspace_id,
+        session_ids,
+    )
+    cached = {r["session_id"]: dict(r) for r in rows}
+
+    titles: dict[str, str] = {}
+    stale_session_ids: list[str] = []
+    for session in sessions:
+        session_id = session["session_id"]
+        title_row = cached.get(session_id)
+        session_source_hash = source_hash(session)
+        if title_row:
+            titles[session_id] = title_row["title"]
+        else:
+            titles[session_id] = title_from_text(session.get("title_source"), session_id)
+
+        if title_row and title_row["source_hash"] == session_source_hash:
+            continue
+        stale_session_ids.append(session_id)
+
+    if enqueue_missing and stale_session_ids:
+        _enqueue_title_generation(workspace_id, stale_session_ids[:ENQUEUE_MISSING_LIMIT])
+
+    return titles
+
+
+async def title_for_events(workspace_id: UUID, session_id: str, events: list[dict]) -> str:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT title FROM session_titles WHERE workspace_id = $1 AND session_id = $2",
+        workspace_id,
+        session_id,
+    )
+    if row:
+        return row["title"]
+
+    _enqueue_title_generation(workspace_id, [session_id])
+    return title_from_events(events, session_id)
+
+
+def _enqueue_title_generation(workspace_id: UUID, session_ids: list[str]) -> None:
+    if not settings.ANTHROPIC_API_KEY:
+        return
+
+    from ..tasks.session_titles import generate_session_title
+
+    for session_id in session_ids:
+        generate_session_title.delay(str(workspace_id), session_id)
 
 
 def title_from_text(text: str | None, session_id: str) -> str:

--- a/backend/tasks/session_titles.py
+++ b/backend/tasks/session_titles.py
@@ -1,0 +1,175 @@
+"""AI session title generation tasks."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ..celery_app import celery
+from ..config import settings
+from ..database import get_pool
+from ..services import session_title_service
+from ._celery_helpers import run_async
+
+MAX_SOURCE_CHARS = 2_000
+RECONCILE_BATCH_SIZE = 25
+
+
+def _clean_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _clean_title(text: str) -> str:
+    title = _clean_text(text).strip("`\"' ")
+    if title.lower().startswith("title:"):
+        title = title[6:].strip()
+    return session_title_service._truncate(title)
+
+
+async def _session_stats(workspace_id: UUID, session_id: str) -> dict | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        SELECT
+          h.session_id,
+          COUNT(*)::INT AS event_count,
+          MAX(h.created_at) AS last_at
+        FROM history_events h
+        JOIN sessions s ON s.workspace_id = h.workspace_id AND s.session_id = h.session_id
+        WHERE h.workspace_id = $1
+          AND h.session_id = $2
+          AND NULLIF(BTRIM(h.content), '') IS NOT NULL
+          AND s.deleted_at IS NULL
+        GROUP BY h.session_id
+        """,
+        workspace_id,
+        session_id,
+    )
+    return dict(row) if row else None
+
+
+async def _session_source(workspace_id: UUID, session_id: str) -> str:
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT event_type, tool_name, content
+        FROM history_events
+        WHERE workspace_id = $1
+          AND session_id = $2
+          AND NULLIF(BTRIM(content), '') IS NOT NULL
+        ORDER BY created_at ASC, id ASC
+        LIMIT 16
+        """,
+        workspace_id,
+        session_id,
+    )
+    parts: list[str] = []
+    for row in rows:
+        label = row["event_type"] or "event"
+        if row["tool_name"]:
+            label = f"{label}:{row['tool_name']}"
+        content = _clean_text(row["content"] or "")
+        if content:
+            parts.append(f"{label}: {content[:600]}")
+    return "\n".join(parts)[:MAX_SOURCE_CHARS]
+
+
+async def _generate_title(source: str) -> str:
+    if not settings.ANTHROPIC_API_KEY:
+        return ""
+
+    from anthropic import AsyncAnthropic
+
+    client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+    response = await client.messages.create(
+        model=settings.ANTHROPIC_FAST_MODEL,
+        max_tokens=48,
+        system=(
+            "Generate a concise title for a coding-agent session. "
+            "Use 3 to 8 words. Name the specific task or outcome. "
+            "Do not include ticket IDs, agent names, session IDs, dates, or the word session. "
+            "Return only the title text."
+        ),
+        messages=[{"role": "user", "content": source}],
+    )
+    text = "\n".join(
+        block.text for block in response.content if getattr(block, "type", "") == "text"
+    )
+    return _clean_title(text)
+
+
+async def _generate_for_session(workspace_id: UUID, session_id: str) -> str:
+    stats = await _session_stats(workspace_id, session_id)
+    if not stats:
+        return "missing"
+
+    source_hash = session_title_service.source_hash(stats)
+    pool = get_pool()
+    cached = await pool.fetchrow(
+        "SELECT source_hash FROM session_titles WHERE workspace_id = $1 AND session_id = $2",
+        workspace_id,
+        session_id,
+    )
+    if cached and cached["source_hash"] == source_hash:
+        return "fresh"
+
+    source = await _session_source(workspace_id, session_id)
+    if not source:
+        return "empty"
+
+    title = await _generate_title(source)
+    if not title:
+        return "unconfigured"
+
+    await pool.execute(
+        """
+        INSERT INTO session_titles (workspace_id, session_id, title, source_hash)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (workspace_id, session_id) DO UPDATE SET
+          title = EXCLUDED.title,
+          source_hash = EXCLUDED.source_hash,
+          updated_at = now()
+        """,
+        workspace_id,
+        session_id,
+        title,
+        source_hash,
+    )
+    return "generated"
+
+
+@celery.task(name="backend.tasks.session_titles.generate_session_title")
+def generate_session_title(workspace_id: str, session_id: str) -> str:
+    return run_async(_generate_for_session(UUID(workspace_id), session_id))
+
+
+async def _reconcile_missing() -> int:
+    if not settings.ANTHROPIC_API_KEY:
+        return 0
+
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT h.workspace_id, h.session_id
+        FROM history_events h
+        JOIN sessions s ON s.workspace_id = h.workspace_id AND s.session_id = h.session_id
+        LEFT JOIN session_titles st
+          ON st.workspace_id = h.workspace_id AND st.session_id = h.session_id
+        WHERE h.workspace_id IS NOT NULL
+          AND h.session_id IS NOT NULL
+          AND st.session_id IS NULL
+          AND s.deleted_at IS NULL
+          AND NULLIF(BTRIM(h.content), '') IS NOT NULL
+        GROUP BY h.workspace_id, h.session_id
+        ORDER BY MAX(h.created_at) DESC
+        LIMIT $1
+        """,
+        RECONCILE_BATCH_SIZE,
+    )
+    for row in rows:
+        generate_session_title.delay(str(row["workspace_id"]), row["session_id"])
+    return len(rows)
+
+
+@celery.task(name="backend.tasks.session_titles.reconcile_missing")
+def reconcile_missing() -> int:
+    return run_async(_reconcile_missing())

--- a/backend/tests/test_session_title_service.py
+++ b/backend/tests/test_session_title_service.py
@@ -1,3 +1,8 @@
+from uuid import UUID
+
+import pytest
+
+from backend.services import session_title_service
 from backend.services.session_title_service import title_from_events, title_from_text
 
 
@@ -60,3 +65,57 @@ def test_title_from_text_uses_linear_issue_title():
 
 def test_title_from_text_falls_back_to_session_id_for_empty_text():
     assert title_from_text("", "session-1") == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_titles_for_sessions_prefers_generated_cache(monkeypatch):
+    class Pool:
+        async def fetch(self, *args):
+            return [
+                {
+                    "session_id": "s1",
+                    "title": "Fix Authentication Flow",
+                    "source_hash": "stale",
+                }
+            ]
+
+    monkeypatch.setattr(session_title_service, "get_pool", lambda: Pool())
+
+    titles = await session_title_service.titles_for_sessions(
+        UUID("00000000-0000-0000-0000-000000000001"),
+        [
+            {
+                "session_id": "s1",
+                "title_source": "can you fix auth?",
+                "event_count": 2,
+                "last_at": "2026-05-20T00:00:00Z",
+            }
+        ],
+        enqueue_missing=False,
+    )
+
+    assert titles == {"s1": "Fix Authentication Flow"}
+
+
+@pytest.mark.asyncio
+async def test_titles_for_sessions_falls_back_while_title_is_missing(monkeypatch):
+    class Pool:
+        async def fetch(self, *args):
+            return []
+
+    monkeypatch.setattr(session_title_service, "get_pool", lambda: Pool())
+
+    titles = await session_title_service.titles_for_sessions(
+        UUID("00000000-0000-0000-0000-000000000001"),
+        [
+            {
+                "session_id": "s1",
+                "title_source": "can you fix auth?",
+                "event_count": 2,
+                "last_at": "2026-05-20T00:00:00Z",
+            }
+        ],
+        enqueue_missing=False,
+    )
+
+    assert titles == {"s1": "Fix auth"}

--- a/backend/tests/test_session_title_service.py
+++ b/backend/tests/test_session_title_service.py
@@ -42,5 +42,21 @@ def test_title_from_events_falls_back_to_assistant_message():
     assert title == "Implemented auth checks"
 
 
+def test_title_from_text_uses_linear_issue_title():
+    title = title_from_text(
+        """
+        You are working on a Linear ticket `FER-19`
+
+        Issue context:
+        Identifier: FER-19
+        Title: Update the Stash homepage background
+        Current status: In Progress
+        """,
+        "session-1",
+    )
+
+    assert title == "Update the Stash homepage background"
+
+
 def test_title_from_text_falls_back_to_session_id_for_empty_text():
     assert title_from_text("", "session-1") == "session-1"


### PR DESCRIPTION
## Summary
- Restore AI-generated session titles as the primary title path.
- Add a `session_titles` cache table and Celery title-generation task.
- Enqueue title generation when session user/assistant/end events arrive, and add a Beat reconciliation task to backfill recent sessions missing titles.
- Have sidebar, session list, and session detail endpoints prefer cached generated titles, with deterministic transcript parsing only as a temporary fallback while generation is pending.
- Keep the `0068` migration fix CI exposed: current product `stashes` no longer has the old session-bundle `status` column, so that cleanup revision is now reserved/no-op.

## Root Cause
The merged title PRs drifted away from the desired end state. #361 removed generated session summaries and also removed the last generation-backed title path. The current sidebar/list APIs were deriving labels from the first useful transcript line, which is why unattended Linear sessions showed generic wrappers like `You are working on a Linear ticket ...`.

The desired behavior is AI-generated session titles, not a better first-line parser. This PR restores generated titles without bringing back full handoff summaries.

## Validation
- `.venv/bin/pytest --no-cov --noconftest backend/tests/test_session_title_service.py`
- `.venv/bin/ruff check backend/services/session_title_service.py backend/tasks/session_titles.py backend/routers/memory.py backend/routers/sessions.py backend/routers/workspace_knowledge.py backend/celery_app.py backend/config.py backend/tests/test_session_title_service.py backend/migrations/versions/0069_session_titles.py backend/migrations/versions/0068_drop_summarizing_stash_status.py`
- `.venv/bin/black --check backend/services/session_title_service.py backend/tasks/session_titles.py backend/routers/memory.py backend/routers/sessions.py backend/routers/workspace_knowledge.py backend/celery_app.py backend/config.py backend/tests/test_session_title_service.py backend/migrations/versions/0069_session_titles.py backend/migrations/versions/0068_drop_summarizing_stash_status.py`
- `.venv/bin/alembic heads`
- `.venv/bin/python -m py_compile backend/tasks/session_titles.py backend/services/session_title_service.py backend/routers/memory.py backend/routers/sessions.py backend/routers/workspace_knowledge.py`
- `git diff --check`

## Runtime Notes
- Standard local backend pytest is blocked because Docker/Postgres is not running on `localhost:5432`; the pure helper tests were run with `--noconftest` to avoid the repo-wide database fixture.
- No product screenshot attached: this is backend title-generation/cache behavior with no layout or styling change.