### PR TITLE
Return durable Stash upload links

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -670,6 +670,7 @@ class FileResponse(BaseModel):
     content_type: str
     size_bytes: int
     url: str
+    app_url: str
     uploaded_by: UUID
     created_at: datetime
     linked_table_id: UUID | None = None

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import Response
 
 from ..auth import get_current_user
+from ..config import settings
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, FileUpdateRequest, TableResponse
 from ..services import (
@@ -67,6 +68,10 @@ async def _can_access_file(
     return False
 
 
+def _file_app_url(row: dict) -> str:
+    return f"{settings.PUBLIC_URL.rstrip('/')}/workspaces/{row['workspace_id']}/f/{row['id']}"
+
+
 async def _file_to_response(row: dict) -> FileResponse:
     url = await storage_service.get_file_url(row["storage_key"])
     return FileResponse(
@@ -77,6 +82,7 @@ async def _file_to_response(row: dict) -> FileResponse:
         content_type=row["content_type"],
         size_bytes=row["size_bytes"],
         url=url,
+        app_url=_file_app_url(row),
         uploaded_by=row["uploaded_by"],
         created_at=row["created_at"],
         linked_table_id=row.get("linked_table_id"),

--- a/cli/main.py
+++ b/cli/main.py
@@ -664,6 +664,10 @@ def _web_app_url() -> str:
     return api
 
 
+def _stash_url(stash: dict) -> str:
+    return f"{_web_app_url()}/stashes/{stash['slug']}"
+
+
 @app.command("browse")
 def browse(
     query: str = typer.Argument("", help="Optional search query."),
@@ -1176,6 +1180,7 @@ def upload(
                 items=stash_items,
             )
             stash = bundle["stash"]
+            stash_url = bundle["url"]
         else:
             stash = c.create_stash(
                 ws,
@@ -1184,17 +1189,15 @@ def upload(
                 access="workspace",
                 items=stash_items,
             )
+            stash_url = _stash_url(stash)
 
-    result = {"folder": root_folder, "stash": stash}
+    result = {"folder": root_folder, "stash": stash, "url": stash_url}
     if _use_json(as_json):
         output_json(result)
         return
-    if public:
-        public_url = f"{_web_app_url()}/stashes/{stash['slug']}"
-        console.print(f"\n[green bold]Uploaded![/green bold]  {public_url}")
-        return
     console.print(
-        f"\n[green bold]Uploaded![/green bold]  Folder: {root_folder['id']}  Stash: {stash['id']}"
+        f"\n[green bold]Uploaded![/green bold]  {result['url']}\n"
+        f"[dim]Folder: {root_folder['id']}  Stash: {stash['id']}[/dim]"
     )
 
 
@@ -3019,7 +3022,7 @@ def files_upload(
         output_json(data)
     else:
         console.print(f"[green]Uploaded[/green] {data['name']}  [dim]{data['id']}[/dim]")
-        console.print(data["url"])
+        console.print(data["app_url"])
 
 
 @files_app.command("list")

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -403,7 +403,7 @@ def stash_file_text(file_id: str, workspace_id: str = "") -> str:
 
 @mcp.tool()
 def stash_upload_file(file_path: str, workspace_id: str = "") -> str:
-    """Upload a local file to the workspace."""
+    """Upload a local file to the workspace. Returns a stable app_url for the user."""
     client, default_ws = _client()
     ws = _require_ws(workspace_id or default_ws)
     return _json(client.upload_ws_file(ws, file_path))

--- a/cli/tests/test_share_and_upload_helpers.py
+++ b/cli/tests/test_share_and_upload_helpers.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+from uuid import uuid4
 
+from backend.config import settings
+from backend.routers.files import _file_app_url
+from cli import main
 from cli.main import _is_upload_text_file
 
 
@@ -7,3 +11,20 @@ def test_upload_text_file_detection() -> None:
     assert _is_upload_text_file(Path("notes.md"))
     assert _is_upload_text_file(Path("script.py"))
     assert not _is_upload_text_file(Path("diagram.png"))
+
+
+def test_stash_url_uses_web_app_url(monkeypatch) -> None:
+    monkeypatch.setattr(main, "_web_app_url", lambda: "https://app.example")
+
+    assert main._stash_url({"slug": "demo-stash"}) == "https://app.example/stashes/demo-stash"
+
+
+def test_file_app_url_points_to_workspace_file_viewer(monkeypatch) -> None:
+    workspace_id = uuid4()
+    file_id = uuid4()
+    monkeypatch.setattr(settings, "PUBLIC_URL", "https://app.example/")
+
+    assert (
+        _file_app_url({"workspace_id": workspace_id, "id": file_id})
+        == f"https://app.example/workspaces/{workspace_id}/f/{file_id}"
+    )

--- a/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -116,6 +116,7 @@ function FileViewerPageInner() {
           content_type: inline.content_type ?? "",
           size_bytes: inline.size_bytes ?? 0,
           url: inline.url ?? "",
+          app_url: `/workspaces/${stash.stash.workspace_id}/f/${fileId}?stash=${stashSlug}`,
           uploaded_by: "",
           created_at: inline.created_at ?? "",
         };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1399,6 +1399,7 @@ export interface WorkspaceFile {
   size_bytes: number;
   content_type: string;
   url: string | null;
+  app_url?: string;
   created_at: string;
   linked_table_id?: string | null;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -162,6 +162,7 @@ export interface FileInfo {
   content_type: string;
   size_bytes: number;
   url: string;
+  app_url: string;
   uploaded_by: string;
   created_at: string;
   linked_table_id?: string | null;

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -6,6 +6,8 @@ IMPORTANT: You have the `stash` CLI on your PATH. When the user mentions "Stash"
 
 Most things are plain `stash` CLI subcommands. Always use `--json` for machine-readable output when parsing results.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 ### Virtual filesystem
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 ```bash

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -10,6 +10,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -15,6 +15,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/plugins/gemini-plugin/GEMINI.md
+++ b/plugins/gemini-plugin/GEMINI.md
@@ -4,6 +4,8 @@ You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use i
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -89,3 +89,7 @@ stash history search "<query>" --ws <id> --json
 stash whoami --json
 stash workspaces list --json
 ```
+
+For user-requested uploads, run `stash upload <path> --json` and return the
+response `url`. If you use `stash files upload <path> --json` for a raw file,
+return the response `app_url`.

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -10,6 +10,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -10,6 +10,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -15,6 +15,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -10,6 +10,8 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+
 Common reads (all support `--json`):
 - `stash history search "<query>"` — full-text search across transcripts
 - `stash history query --limit 20` — recent events


### PR DESCRIPTION
## Summary
- add a durable app_url to workspace file upload responses
- include the generated Stash url in stash upload JSON and CLI output
- update agent prompt snippets so agents return upload links to users

## Tests
- pytest cli/tests/test_share_and_upload_helpers.py plugins/tests/test_assets_in_sync.py --no-cov
- ruff check backend/routers/files.py backend/models.py cli/main.py cli/mcp_server.py cli/tests/test_share_and_upload_helpers.py
- npm run lint (passes with existing warnings)
- npm run build