### PR TITLE
[codex] Polish sidebar session rows and filters

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1243,21 +1243,21 @@ function SessionUserFolder({
   }, [hasActiveSession]);
 
   return (
-    <details open={open} className="text-[12px]">
+    <details open={open} className="text-[12.5px]">
       <summary
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
           setOpen(true);
         }}
-        className="page-row flex items-center gap-1 rounded-md px-2 py-0.5 hover:bg-raised"
+        className="page-row flex items-center gap-1 rounded-md px-2 py-1 hover:bg-raised"
       >
         <ChevronToggle open={open} onToggle={() => setOpen((current) => !current)} />
-        <span className="flex h-4 w-4 items-center justify-center text-[13px] text-muted">
+        <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
           <PersonIcon />
         </span>
         <span className="flex-1 truncate text-muted">{bucket.user}</span>
-        <span className="text-[10px] text-muted">{bucket.sessions.length}</span>
+        <span className="text-[10.5px] text-muted">{bucket.sessions.length}</span>
       </summary>
       <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
         {visibleSessions.map((s) => (


### PR DESCRIPTION
## Summary
- Align the session user folder row sizing with the month bucket row in the sidebar.
- Rename the Sessions and Files sidebar inputs from “Search …” to “Filter …” to match their filter-only behavior.
- Update sidebar tests to use the new accessible filter labels.

## Root Cause
The month bucket summary used larger vertical padding and type/icon sizing than the user summary, making the user/name row visibly shorter. The sidebar inputs were also labeled as search even though they perform local substring filtering rather than BM25 or backend search.

## Validation
- `npm test -- AppSidebar.test.tsx` (28 passed)
- `npm run lint` (0 errors; 5 existing warnings in unrelated files)
- Playwright browser check against the Next app with mocked API data:
  - `May 2026` row height `26.75px`, `Henry` row height `26.75px`
  - Sidebar input placeholders: `Filter sessions`, `Filter files`

Screenshots added in the PR thread.