### PR TITLE
[codex] Fix public Stash markdown image rendering

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -146,4 +146,9 @@ async def get_current_user_optional(
 ) -> dict | None:
     if credentials is None:
         return None
-    return await get_current_user(credentials)
+    try:
+        return await get_current_user(credentials)
+    except HTTPException as e:
+        if e.status_code == status.HTTP_401_UNAUTHORIZED:
+            return None
+        raise

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import Response
 
-from ..auth import get_current_user
+from ..auth import get_current_user, get_current_user_optional
 from ..config import settings
 from ..database import get_pool
 from ..models import FileListResponse, FileResponse, FileUpdateRequest, TableResponse
@@ -53,7 +53,7 @@ async def _check_write(workspace_id: UUID, user_id: UUID) -> None:
 async def _can_access_file(
     file_id: UUID,
     workspace_id: UUID,
-    user_id: UUID,
+    user_id: UUID | None,
     *,
     require_write: bool = False,
 ) -> bool:
@@ -207,10 +207,9 @@ async def get_ws_file(
 async def download_ws_file(
     workspace_id: UUID,
     file_id: UUID,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
     """Permanent workspace URL for file links embedded in wiki pages."""
-    await _check_member(workspace_id, current_user["id"])
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT name, content_type, storage_key FROM files "
@@ -220,17 +219,19 @@ async def download_ws_file(
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
-    if not await _can_access_file(file_id, workspace_id, current_user["id"]):
+    viewer_id = current_user["id"] if current_user else None
+    if not await _can_access_file(file_id, workspace_id, viewer_id):
         raise HTTPException(status_code=404, detail="File not found")
     try:
         content = await storage_service.download_file(row["storage_key"])
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"S3 download failed: {e}")
+    disposition = "inline" if (row["content_type"] or "").startswith("image/") else "attachment"
     return Response(
         content=content,
         media_type=row["content_type"] or "application/octet-stream",
         headers={
-            "Content-Disposition": f"attachment; filename*=UTF-8''{quote(row['name'])}",
+            "Content-Disposition": f"{disposition}; filename*=UTF-8''{quote(row['name'])}",
         },
     )
 

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -19,13 +19,6 @@ _HTML_BLOCK_END_RE = re.compile(
     r"</(article|body|div|footer|h[1-6]|header|li|main|p|section|td|th|tr)>",
     re.IGNORECASE,
 )
-_WORKSPACE_FILE_DOWNLOAD_RE = re.compile(
-    r"/api/v1/workspaces/"
-    r"(?P<workspace_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
-    r"/files/"
-    r"(?P<file_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
-    r"/download(?:[?#][^\s)\"']*)?"
-)
 
 
 def _slugify(title: str) -> str:
@@ -57,45 +50,6 @@ def _page_text(page: dict) -> str:
 
 def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
-
-
-async def _rewrite_workspace_file_download_urls(
-    content: str | None,
-    viewer_id: UUID | None,
-) -> str:
-    if not content or "/api/v1/workspaces/" not in content:
-        return content or ""
-
-    replacements: dict[str, str] = {}
-    pool = get_pool()
-    for match in _WORKSPACE_FILE_DOWNLOAD_RE.finditer(content):
-        original_url = match.group(0)
-        if original_url in replacements:
-            continue
-
-        workspace_id = UUID(match.group("workspace_id"))
-        file_id = UUID(match.group("file_id"))
-        if not await permission_service.check_access(
-            "file",
-            file_id,
-            viewer_id,
-            workspace_id=workspace_id,
-        ):
-            continue
-
-        row = await pool.fetchrow(
-            "SELECT storage_key FROM files "
-            "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
-            file_id,
-            workspace_id,
-        )
-        if row:
-            replacements[original_url] = await storage_service.get_file_url(row["storage_key"])
-
-    rewritten = content
-    for original_url, signed_url in replacements.items():
-        rewritten = rewritten.replace(original_url, signed_url)
-    return rewritten
 
 
 _STASH_COLS = (
@@ -1124,27 +1078,19 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                         "file", f["id"], viewer_id, workspace_id=stash["workspace_id"]
                     ):
                         visible_files.append(f)
-                page_payloads = []
-                for p in visible_pages:
-                    page_payloads.append(
+                inline = {
+                    "pages": [
                         {
                             "id": str(p["id"]),
                             "name": p["name"],
                             "content_type": p["content_type"],
-                            "content_markdown": await _rewrite_workspace_file_download_urls(
-                                p["content_markdown"],
-                                viewer_id,
-                            ),
-                            "content_html": await _rewrite_workspace_file_download_urls(
-                                p["content_html"],
-                                viewer_id,
-                            ),
+                            "content_markdown": p["content_markdown"],
+                            "content_html": p["content_html"],
                             "html_layout": p["html_layout"],
                             "updated_at": p["updated_at"].isoformat(),
                         }
-                    )
-                inline = {
-                    "pages": page_payloads,
+                        for p in visible_pages
+                    ],
                     "files": [
                         {
                             "id": str(f["id"]),
@@ -1170,14 +1116,8 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                         "id": str(p["id"]),
                         "name": p["name"],
                         "content_type": p["content_type"],
-                        "content_markdown": await _rewrite_workspace_file_download_urls(
-                            p["content_markdown"],
-                            viewer_id,
-                        ),
-                        "content_html": await _rewrite_workspace_file_download_urls(
-                            p["content_html"],
-                            viewer_id,
-                        ),
+                        "content_markdown": p["content_markdown"],
+                        "content_html": p["content_html"],
                         "html_layout": p["html_layout"],
                         "updated_at": p["updated_at"].isoformat(),
                     }

--- a/backend/services/stash_service.py
+++ b/backend/services/stash_service.py
@@ -19,6 +19,13 @@ _HTML_BLOCK_END_RE = re.compile(
     r"</(article|body|div|footer|h[1-6]|header|li|main|p|section|td|th|tr)>",
     re.IGNORECASE,
 )
+_WORKSPACE_FILE_DOWNLOAD_RE = re.compile(
+    r"/api/v1/workspaces/"
+    r"(?P<workspace_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    r"/files/"
+    r"(?P<file_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    r"/download(?:[?#][^\s)\"']*)?"
+)
 
 
 def _slugify(title: str) -> str:
@@ -50,6 +57,45 @@ def _page_text(page: dict) -> str:
 
 def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
+
+
+async def _rewrite_workspace_file_download_urls(
+    content: str | None,
+    viewer_id: UUID | None,
+) -> str:
+    if not content or "/api/v1/workspaces/" not in content:
+        return content or ""
+
+    replacements: dict[str, str] = {}
+    pool = get_pool()
+    for match in _WORKSPACE_FILE_DOWNLOAD_RE.finditer(content):
+        original_url = match.group(0)
+        if original_url in replacements:
+            continue
+
+        workspace_id = UUID(match.group("workspace_id"))
+        file_id = UUID(match.group("file_id"))
+        if not await permission_service.check_access(
+            "file",
+            file_id,
+            viewer_id,
+            workspace_id=workspace_id,
+        ):
+            continue
+
+        row = await pool.fetchrow(
+            "SELECT storage_key FROM files "
+            "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+            file_id,
+            workspace_id,
+        )
+        if row:
+            replacements[original_url] = await storage_service.get_file_url(row["storage_key"])
+
+    rewritten = content
+    for original_url, signed_url in replacements.items():
+        rewritten = rewritten.replace(original_url, signed_url)
+    return rewritten
 
 
 _STASH_COLS = (
@@ -1078,19 +1124,27 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                         "file", f["id"], viewer_id, workspace_id=stash["workspace_id"]
                     ):
                         visible_files.append(f)
-                inline = {
-                    "pages": [
+                page_payloads = []
+                for p in visible_pages:
+                    page_payloads.append(
                         {
                             "id": str(p["id"]),
                             "name": p["name"],
                             "content_type": p["content_type"],
-                            "content_markdown": p["content_markdown"],
-                            "content_html": p["content_html"],
+                            "content_markdown": await _rewrite_workspace_file_download_urls(
+                                p["content_markdown"],
+                                viewer_id,
+                            ),
+                            "content_html": await _rewrite_workspace_file_download_urls(
+                                p["content_html"],
+                                viewer_id,
+                            ),
                             "html_layout": p["html_layout"],
                             "updated_at": p["updated_at"].isoformat(),
                         }
-                        for p in visible_pages
-                    ],
+                    )
+                inline = {
+                    "pages": page_payloads,
                     "files": [
                         {
                             "id": str(f["id"]),
@@ -1116,8 +1170,14 @@ async def inline_items(stash: dict, viewer_id: UUID | None = None) -> list[dict]
                         "id": str(p["id"]),
                         "name": p["name"],
                         "content_type": p["content_type"],
-                        "content_markdown": p["content_markdown"],
-                        "content_html": p["content_html"],
+                        "content_markdown": await _rewrite_workspace_file_download_urls(
+                            p["content_markdown"],
+                            viewer_id,
+                        ),
+                        "content_html": await _rewrite_workspace_file_download_urls(
+                            p["content_html"],
+                            viewer_id,
+                        ),
                         "html_layout": p["html_layout"],
                         "updated_at": p["updated_at"].isoformat(),
                     }

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -114,14 +114,17 @@ async def _make_table(pool, workspace_id, created_by, name="table"):
     return row["id"]
 
 
-async def _make_file(pool, workspace_id, uploaded_by, folder_id=None, name="file.txt"):
+async def _make_file(
+    pool, workspace_id, uploaded_by, folder_id=None, name="file.txt", content_type="text/plain"
+):
     row = await pool.fetchrow(
         "INSERT INTO files "
         "(workspace_id, folder_id, name, content_type, size_bytes, storage_key, uploaded_by) "
-        "VALUES ($1, $2, $3, 'text/plain', 12, $4, $5) RETURNING id",
+        "VALUES ($1, $2, $3, $4, 12, $5, $6) RETURNING id",
         workspace_id,
         folder_id,
         name,
+        content_type,
         f"test/{uuid.uuid4().hex}.txt",
         uploaded_by,
     )
@@ -1079,16 +1082,27 @@ async def test_folder_stash_inlines_folder_files(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_public_folder_stash_rewrites_readable_markdown_file_urls(pool, monkeypatch):
+async def test_public_folder_stash_file_download_url_works_anonymously(client, pool, monkeypatch):
+    async def fake_download_file(storage_key):
+        return f"bytes from {storage_key}".encode()
+
     async def fake_file_url(storage_key, expires_in=3600):
         return f"https://files.test/{storage_key}?expires={expires_in}"
 
     monkeypatch.setattr(stash_service.storage_service, "get_file_url", fake_file_url)
+    monkeypatch.setattr("backend.routers.files.storage_service.download_file", fake_download_file)
 
     owner_id = await _make_user(pool)
     ws_id = await _make_workspace(pool, owner_id)
     folder_id = await _make_folder(pool, ws_id, owner_id)
-    public_file_id = await _make_file(pool, ws_id, owner_id, folder_id=folder_id, name="shot.png")
+    public_file_id = await _make_file(
+        pool,
+        ws_id,
+        owner_id,
+        folder_id=folder_id,
+        name="shot.png",
+        content_type="image/png",
+    )
     private_file_id = await _make_file(pool, ws_id, owner_id, name="private.png")
     public_url = f"/api/v1/workspaces/{ws_id}/files/{public_file_id}/download"
     private_url = f"/api/v1/workspaces/{ws_id}/files/{private_file_id}/download"
@@ -1105,9 +1119,17 @@ async def test_public_folder_stash_rewrites_readable_markdown_file_urls(pool, mo
     items = await stash_service.inline_items(stash, None)
 
     content = items[0]["inline"]["pages"][0]["content_markdown"]
-    assert public_url not in content
+    assert public_url in content
     assert private_url in content
-    assert "https://files.test/" in content
+
+    public_resp = await client.get(public_url)
+    private_resp = await client.get(private_url)
+
+    assert public_resp.status_code == 200
+    assert public_resp.content.startswith(b"bytes from test/")
+    assert public_resp.headers["content-type"] == "image/png"
+    assert public_resp.headers["content-disposition"].startswith("inline;")
+    assert private_resp.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -1122,9 +1122,14 @@ async def test_public_folder_stash_file_download_url_works_anonymously(client, p
     assert public_url in content
     assert private_url in content
 
+    stale_token_resp = await client.get(
+        f"/api/v1/stashes/{stash['slug']}",
+        headers={"Authorization": "Bearer mc_invalid"},
+    )
     public_resp = await client.get(public_url)
     private_resp = await client.get(private_url)
 
+    assert stale_token_resp.status_code == 200
     assert public_resp.status_code == 200
     assert public_resp.content.startswith(b"bytes from test/")
     assert public_resp.headers["content-type"] == "image/png"

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -78,13 +78,16 @@ async def _make_folder(pool, workspace_id, created_by, name="folder", parent_fol
     return row["id"]
 
 
-async def _make_page(pool, workspace_id, created_by, folder_id=None, name="page"):
+async def _make_page(
+    pool, workspace_id, created_by, folder_id=None, name="page", content="content"
+):
     row = await pool.fetchrow(
         "INSERT INTO pages (workspace_id, folder_id, name, content_markdown, created_by) "
-        "VALUES ($1, $2, $3, 'content', $4) RETURNING id",
+        "VALUES ($1, $2, $3, $4, $5) RETURNING id",
         workspace_id,
         folder_id,
         name,
+        content,
         created_by,
     )
     return row["id"]
@@ -1073,6 +1076,38 @@ async def test_folder_stash_inlines_folder_files(pool, monkeypatch):
     files = items[0]["inline"]["files"]
     assert [file["name"] for file in files] == ["brief.pdf"]
     assert files[0]["url"].startswith("https://files.test/")
+
+
+@pytest.mark.asyncio
+async def test_public_folder_stash_rewrites_readable_markdown_file_urls(pool, monkeypatch):
+    async def fake_file_url(storage_key, expires_in=3600):
+        return f"https://files.test/{storage_key}?expires={expires_in}"
+
+    monkeypatch.setattr(stash_service.storage_service, "get_file_url", fake_file_url)
+
+    owner_id = await _make_user(pool)
+    ws_id = await _make_workspace(pool, owner_id)
+    folder_id = await _make_folder(pool, ws_id, owner_id)
+    public_file_id = await _make_file(pool, ws_id, owner_id, folder_id=folder_id, name="shot.png")
+    private_file_id = await _make_file(pool, ws_id, owner_id, name="private.png")
+    public_url = f"/api/v1/workspaces/{ws_id}/files/{public_file_id}/download"
+    private_url = f"/api/v1/workspaces/{ws_id}/files/{private_file_id}/download"
+
+    await _make_page(
+        pool,
+        ws_id,
+        owner_id,
+        folder_id=folder_id,
+        content=f"![public]({public_url})\n![private]({private_url})",
+    )
+    stash = await _make_stash(ws_id, owner_id, "public", "folder", folder_id)
+
+    items = await stash_service.inline_items(stash, None)
+
+    content = items[0]["inline"]["pages"][0]["content_markdown"]
+    assert public_url not in content
+    assert private_url in content
+    assert "https://files.test/" in content
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/workspace/EditorToolbar.tsx
+++ b/frontend/src/components/workspace/EditorToolbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Editor } from "@tiptap/react";
-import { uploadFile } from "../../lib/api";
+import { uploadFile, workspaceFileDownloadUrl } from "../../lib/api";
 
 interface EditorToolbarProps {
   editor: Editor | null;
@@ -103,9 +103,9 @@ export default function EditorToolbar({
     setUploading(true);
     try {
       const result = await uploadFile(workspaceId, file);
-      const href = `/api/v1/workspaces/${workspaceId}/files/${result.id}/download`;
+      const href = workspaceFileDownloadUrl(workspaceId, result.id);
       if (result.content_type.startsWith("image/")) {
-        editor.chain().focus().setImage({ src: result.url, alt: result.name }).run();
+        editor.chain().focus().setImage({ src: href, alt: result.name }).run();
       } else {
         editor.chain().focus().setLink({ href }).insertContent(result.name).run();
       }

--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -22,7 +22,12 @@ import EditorToolbar from "./EditorToolbar";
 import CommentMark from "./CommentMark";
 import CommentComposerPopover from "./CommentComposerPopover";
 import { Page } from "../../lib/types";
-import { getCollabUrl, getToken, uploadFile } from "../../lib/api";
+import {
+  getCollabUrl,
+  getToken,
+  uploadFile,
+  workspaceFileDownloadUrl,
+} from "../../lib/api";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 const ANCHOR_CONTEXT_CHARS = 32;
@@ -348,13 +353,14 @@ export default function MarkdownEditor({
         // overlap with remote Yjs updates, so old transactions may no longer
         // match the document by the time the upload finishes.
         if (editor.isDestroyed) return;
+        const href = workspaceFileDownloadUrl(workspaceId, result.id);
         if (result.content_type.startsWith("image/")) {
-          editor.commands.setImage({ src: result.url, alt: result.name });
+          editor.commands.setImage({ src: href, alt: result.name });
         } else {
           editor.commands.insertContent({
             type: "text",
             text: result.name,
-            marks: [{ type: "link", attrs: { href: result.url } }],
+            marks: [{ type: "link", attrs: { href } }],
           });
         }
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -704,6 +704,10 @@ export async function deleteTableView(
 
 // --- Files ---
 
+export function workspaceFileDownloadUrl(workspaceId: string, fileId: string): string {
+  return `/api/v1/workspaces/${workspaceId}/files/${fileId}/download`;
+}
+
 export async function uploadFile(
   workspaceId: string,
   file: File,


### PR DESCRIPTION
## What changed

- Removes the public Stash markdown/HTML URL rewriting path.
- Makes `/api/v1/workspaces/{workspace}/files/{file}/download` use the existing Stash permission model with optional authentication.
  - Workspace/private files still return 404 to anonymous viewers.
  - Files readable through a public Stash can be fetched anonymously by their stable workspace download URL.
- Treats invalid credentials on optional-auth public endpoints as anonymous, so stale browser `stash_token` values do not break public Stash pages.
- Serves image downloads with `Content-Disposition: inline` so markdown `<img>` requests render instead of being treated as attachments.
- Changes markdown editor upload insertion to store stable workspace download URLs instead of temporary signed storage URLs.
- Keeps migration `0068` as a no-op because the current `stashes` table no longer has the old session-bundle `status` column.

## Root cause

Uploaded page content could embed `/api/v1/workspaces/{workspace}/files/{file}/download`. Public Stash pages render that URL as a plain image request, so the browser does not add the bearer token that `apiFetch` normally adds. The workspace download route required authenticated workspace membership before reaching the Stash permission check, so public Stash images returned 403 instead of bytes.

A second local verification issue came from stale browser API keys: public Stash fetches use optional auth, but an invalid stored token caused the optional dependency to raise `401 Invalid API key` instead of rendering anonymously.

## Validation

- `ruff check backend/routers/files.py backend/services/stash_service.py backend/tests/test_permissions.py`
- `ruff check backend/auth.py backend/tests/test_permissions.py`
- `black --check backend/routers/files.py backend/services/stash_service.py backend/tests/test_permissions.py`
- `black --check backend/auth.py backend/tests/test_permissions.py`
- `python -m py_compile backend/routers/files.py backend/services/stash_service.py backend/tests/test_permissions.py`
- `python -m py_compile backend/auth.py backend/tests/test_permissions.py`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_pr375 pytest backend/tests/test_permissions.py -k public_folder_stash_file_download_url_works_anonymously --no-cov`
- `cd frontend && npm test -- MarkdownEditor.test.ts --run`
- `cd frontend && npm run lint` (passes with existing unrelated warnings)
- `git diff --check -- backend/routers/files.py backend/services/stash_service.py backend/tests/test_permissions.py frontend/src/lib/api.ts frontend/src/components/workspace/EditorToolbar.tsx frontend/src/components/workspace/MarkdownEditor.tsx`
- Local browser smoke: public Stash page renders an uploaded PNG with `localStorage.stash_token = "mc_invalid"`; image reports `naturalWidth: 1`, `naturalHeight: 1`.

No screenshot included: this change alters file authorization and stored markdown URLs, not a visible UI layout.
