### PR TITLE
[codex] Rename sidebar search inputs to filters

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -507,7 +507,7 @@ describe("AppSidebar tree expansion", () => {
     expect(screen.getByText("Bucket session 10")).toBeTruthy();
   });
 
-  it("searches hidden sidebar sessions", async () => {
+  it("filters hidden sidebar sessions", async () => {
     vi.mocked(getWorkspaceSidebar).mockResolvedValue(
       sidebarWithSessions(
         Array.from({ length: 11 }, (_, index) =>
@@ -526,7 +526,7 @@ describe("AppSidebar tree expansion", () => {
     await screen.findByText("Search session 0");
     expect(screen.queryByText("Unique hidden decision")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Search sessions"), {
+    fireEvent.change(screen.getByLabelText("Filter sessions"), {
       target: { value: "unique hidden" },
     });
 
@@ -607,7 +607,7 @@ describe("AppSidebar tree expansion", () => {
     expect(await screen.findByText("Roadmap")).toBeTruthy();
   });
 
-  it("searches hidden sidebar files", async () => {
+  it("filters hidden sidebar files", async () => {
     vi.mocked(getWorkspaceSidebar).mockResolvedValue({
       sessions: [],
       files: {
@@ -658,7 +658,7 @@ describe("AppSidebar tree expansion", () => {
     await screen.findByText("00 Huge Folder");
     expect(screen.queryByText("00 Huge Folder/Deep Search File.md")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Search files"), {
+    fireEvent.change(screen.getByLabelText("Filter files"), {
       target: { value: "deep search" },
     });
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1017,10 +1017,10 @@ function SessionsBlock({
       <div className="ml-3 space-y-0.5 border-l border-border pl-2">
         {sessionsDrop?.message ? <DropMessage state={sessionsDrop} /> : null}
         <SidebarSearchField
-          label="Search sessions"
+          label="Filter sessions"
           value={query}
           onChange={setQuery}
-          placeholder="Search sessions"
+          placeholder="Filter sessions"
           onClear={() => setQuery("")}
         />
         {queryActive ? (
@@ -2092,10 +2092,10 @@ function FilesBlock({
       <div className="ml-3 space-y-0.5 border-l border-border pl-2">
         {filesDrop?.message ? <DropMessage state={filesDrop} /> : null}
         <SidebarSearchField
-          label="Search files"
+          label="Filter files"
           value={query}
           onChange={setQuery}
-          placeholder="Search files"
+          placeholder="Filter files"
           onClear={() => setQuery("")}
         />
         {queryActive ? (


### PR DESCRIPTION
## Summary
- Rename the Sessions sidebar input placeholder and accessible label from `Search sessions` to `Filter sessions`.
- Rename the Files sidebar input placeholder and accessible label from `Search files` to `Filter files`.
- Update sidebar tests to use the new filter labels.

## Why
These inputs perform local substring filtering, not BM25 or backend search, so the UI should describe them as filters.

## Validation
- `npm test -- AppSidebar.test.tsx` (28 passed)
- `npm run lint` (0 errors; 5 existing warnings in unrelated files)
- Playwright browser check against the Next app with mocked API data confirmed placeholders: `Filter sessions`, `Filter files`

Screenshot added in the PR thread.