### PR TITLE
[codex] Add local upload health status

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -14,6 +14,7 @@ from rich.align import Align
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+
 from stashai.plugin.upload_status import read_upload_status
 
 from .client import StashClient, StashError, stash_permissions_for_access

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,7 +20,6 @@ from .client import StashClient, StashError, stash_permissions_for_access
 from .config import (
     MANIFEST_FILE,
     PRODUCTION_BASE_URL,
-    USER_CONFIG_DIR,
     Manifest,
     clear_streaming,
     load_config,
@@ -41,7 +40,6 @@ app = typer.Typer(
 
 
 def _client() -> StashClient:
-    _maybe_warn_upload_health()
     cfg = load_config()
     return StashClient(base_url=cfg["base_url"], api_key=cfg.get("api_key", ""))
 
@@ -3907,9 +3905,6 @@ PLUGIN_DATA_DIRS = {
     "opencode": Path.home() / ".stash/plugins/opencode",
 }
 
-UPLOAD_WARNING_FILE = USER_CONFIG_DIR / "upload_status_warning.json"
-UPLOAD_WARNING_COOLDOWN_SECONDS = 24 * 60 * 60
-
 
 def _upload_health_snapshot() -> list[dict]:
     agents = []
@@ -3927,31 +3922,9 @@ def _upload_health_snapshot() -> list[dict]:
 def _failing_upload_agents(snapshot: list[dict]) -> list[dict]:
     failing = []
     for item in snapshot:
-        if item.get("queued_events", 0):
-            failing.append(item)
-            continue
-        if item.get("health") == "failing" and int(item.get("consecutive_failures") or 0) >= 3:
+        if item.get("health") == "failing":
             failing.append(item)
     return failing
-
-
-def _read_upload_warning_state() -> dict:
-    if not UPLOAD_WARNING_FILE.exists():
-        return {}
-    try:
-        data = json.loads(UPLOAD_WARNING_FILE.read_text())
-    except (json.JSONDecodeError, OSError):
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def _write_upload_warning_state(signature: str) -> None:
-    data = {"last_warned_at": time.time(), "signature": signature}
-    try:
-        UPLOAD_WARNING_FILE.parent.mkdir(parents=True, exist_ok=True)
-        UPLOAD_WARNING_FILE.write_text(json.dumps(data, indent=2) + "\n")
-    except OSError:
-        pass
 
 
 def _format_age(timestamp: float | int | None) -> str:
@@ -3983,31 +3956,6 @@ def _upload_health_label(snapshot: list[dict]) -> str:
     if all(item.get("health") == "ok" for item in snapshot):
         return "ok"
     return "no upload attempts recorded yet"
-
-
-def _maybe_warn_upload_health() -> None:
-    args = sys.argv[1:]
-    if not args or not sys.stdout.isatty():
-        return
-    if "--json" in args or "--help" in args or "-h" in args:
-        return
-    if args[0] in {"auth", "login", "register", "settings", "signin", "status", "welcome"}:
-        return
-
-    failing = _failing_upload_agents(_upload_health_snapshot())
-    if not failing:
-        return
-
-    signature = ",".join(sorted(item["agent"] for item in failing))
-    warning_state = _read_upload_warning_state()
-    last_warned = float(warning_state.get("last_warned_at") or 0)
-    if warning_state.get("signature") == signature:
-        if time.time() - last_warned < UPLOAD_WARNING_COOLDOWN_SECONDS:
-            return
-
-    label = _upload_health_label(failing)
-    console.print(f"[yellow]Stash uploads need attention: {label}. Run `stash status`.[/yellow]")
-    _write_upload_warning_state(signature)
 
 
 @app.command("status")

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,18 +5,22 @@ from __future__ import annotations
 import json
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import questionary
 import typer
 from rich.align import Align
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
+from stashai.plugin.upload_status import read_upload_status
 
 from .client import StashClient, StashError, stash_permissions_for_access
 from .config import (
     MANIFEST_FILE,
     PRODUCTION_BASE_URL,
+    USER_CONFIG_DIR,
     Manifest,
     clear_streaming,
     load_config,
@@ -37,6 +41,7 @@ app = typer.Typer(
 
 
 def _client() -> StashClient:
+    _maybe_warn_upload_health()
     cfg = load_config()
     return StashClient(base_url=cfg["base_url"], api_key=cfg.get("api_key", ""))
 
@@ -3902,6 +3907,150 @@ PLUGIN_DATA_DIRS = {
     "opencode": Path.home() / ".stash/plugins/opencode",
 }
 
+UPLOAD_WARNING_FILE = USER_CONFIG_DIR / "upload_status_warning.json"
+UPLOAD_WARNING_COOLDOWN_SECONDS = 24 * 60 * 60
+
+
+def _upload_health_snapshot() -> list[dict]:
+    agents = []
+    for agent, data_dir in PLUGIN_DATA_DIRS.items():
+        if not data_dir.exists():
+            continue
+        status = read_upload_status(data_dir)
+        status["agent"] = agent
+        status["label"] = _AGENT_LABEL.get(agent, agent)
+        status["data_dir"] = str(data_dir)
+        agents.append(status)
+    return agents
+
+
+def _failing_upload_agents(snapshot: list[dict]) -> list[dict]:
+    failing = []
+    for item in snapshot:
+        if item.get("queued_events", 0):
+            failing.append(item)
+            continue
+        if item.get("health") == "failing" and int(item.get("consecutive_failures") or 0) >= 3:
+            failing.append(item)
+    return failing
+
+
+def _read_upload_warning_state() -> dict:
+    if not UPLOAD_WARNING_FILE.exists():
+        return {}
+    try:
+        data = json.loads(UPLOAD_WARNING_FILE.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_upload_warning_state(signature: str) -> None:
+    data = {"last_warned_at": time.time(), "signature": signature}
+    try:
+        UPLOAD_WARNING_FILE.parent.mkdir(parents=True, exist_ok=True)
+        UPLOAD_WARNING_FILE.write_text(json.dumps(data, indent=2) + "\n")
+    except OSError:
+        pass
+
+
+def _format_age(timestamp: float | int | None) -> str:
+    if not timestamp:
+        return "never"
+    seconds = max(0, int(time.time() - float(timestamp)))
+    if seconds < 60:
+        return f"{seconds}s ago"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours}h ago"
+    return f"{hours // 24}d ago"
+
+
+def _upload_health_label(snapshot: list[dict]) -> str:
+    if not snapshot:
+        return "(none detected)"
+    failing = _failing_upload_agents(snapshot)
+    if failing:
+        labels = []
+        for item in failing:
+            queued = int(item.get("queued_events") or 0)
+            suffix = f", {queued} queued" if queued else ""
+            labels.append(f"{item['label']} failing{suffix}")
+        return "; ".join(labels)
+    if all(item.get("health") == "ok" for item in snapshot):
+        return "ok"
+    return "no upload attempts recorded yet"
+
+
+def _maybe_warn_upload_health() -> None:
+    args = sys.argv[1:]
+    if not args or not sys.stdout.isatty():
+        return
+    if "--json" in args or "--help" in args or "-h" in args:
+        return
+    if args[0] in {"auth", "login", "register", "settings", "signin", "status", "welcome"}:
+        return
+
+    failing = _failing_upload_agents(_upload_health_snapshot())
+    if not failing:
+        return
+
+    signature = ",".join(sorted(item["agent"] for item in failing))
+    warning_state = _read_upload_warning_state()
+    last_warned = float(warning_state.get("last_warned_at") or 0)
+    if warning_state.get("signature") == signature:
+        if time.time() - last_warned < UPLOAD_WARNING_COOLDOWN_SECONDS:
+            return
+
+    label = _upload_health_label(failing)
+    console.print(f"[yellow]Stash uploads need attention: {label}. Run `stash status`.[/yellow]")
+    _write_upload_warning_state(signature)
+
+
+@app.command("status")
+def status_cmd(as_json: bool = typer.Option(False, "--json")):
+    """Show local Stash upload health."""
+    snapshot = _upload_health_snapshot()
+    if _use_json(as_json):
+        output_json({"upload_health": snapshot})
+        return
+
+    console.print("[bold]Stash upload status[/bold]\n")
+    if not snapshot:
+        console.print("[dim]No installed Stash agent plugins found on this machine.[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Agent")
+    table.add_column("Health")
+    table.add_column("Queued")
+    table.add_column("Last success")
+    table.add_column("Last failure")
+    table.add_column("Last error")
+
+    for item in snapshot:
+        health = str(item.get("health") or "unknown")
+        if health == "ok":
+            health_label = "[green]ok[/green]"
+        elif health == "failing":
+            health_label = "[red]failing[/red]"
+        else:
+            health_label = "[dim]unknown[/dim]"
+        table.add_row(
+            item["label"],
+            health_label,
+            str(item.get("queued_events") or 0),
+            _format_age(item.get("last_success_at")),
+            _format_age(item.get("last_failure_at")),
+            str(item.get("last_error") or ""),
+        )
+
+    console.print(table)
+    console.print("\n[dim]Status is local to this machine and updates when agent hooks run.[/dim]")
+
 
 def _render_settings_header(cfg: dict) -> None:
     """Print the read-only portion of the settings page."""
@@ -3931,6 +4080,7 @@ def _render_settings_header(cfg: dict) -> None:
 
     plugins_seen = [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()]
     row(f"{'Plugins:':<14}", ", ".join(plugins_seen) or "(none detected)")
+    row(f"{'Uploads:':<14}", _upload_health_label(_upload_health_snapshot()))
     console.print()
 
 
@@ -3949,6 +4099,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
                 "config": display_cfg,
                 "enabled_agents": load_enabled_agents(),
                 "plugins_installed": [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()],
+                "upload_health": _upload_health_snapshot(),
             }
         )
         return

--- a/cli/tests/test_upload_status_helpers.py
+++ b/cli/tests/test_upload_status_helpers.py
@@ -24,11 +24,11 @@ def test_upload_health_label_prefers_queued_failures(monkeypatch, tmp_path):
     assert main._upload_health_label(main._upload_health_snapshot()) == "Codex failing, 2 queued"
 
 
-def test_single_failure_is_visible_but_not_warning_worthy(monkeypatch, tmp_path):
+def test_single_failure_is_reported_as_failing(monkeypatch, tmp_path):
     record_upload_failure(tmp_path, "event", "temporary outage")
     monkeypatch.setattr(main, "PLUGIN_DATA_DIRS", {"codex": tmp_path})
 
     snapshot = main._upload_health_snapshot()
 
     assert snapshot[0]["health"] == "failing"
-    assert main._failing_upload_agents(snapshot) == []
+    assert main._failing_upload_agents(snapshot) == snapshot

--- a/cli/tests/test_upload_status_helpers.py
+++ b/cli/tests/test_upload_status_helpers.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from cli import main
+from stashai.plugin.upload_status import record_upload_failure, record_upload_success
+
+
+def test_upload_health_snapshot_reads_local_plugin_status(monkeypatch, tmp_path):
+    record_upload_failure(tmp_path, "event", "401 Unauthorized")
+    monkeypatch.setattr(main, "PLUGIN_DATA_DIRS", {"codex": tmp_path})
+
+    snapshot = main._upload_health_snapshot()
+
+    assert snapshot[0]["agent"] == "codex"
+    assert snapshot[0]["label"] == "Codex"
+    assert snapshot[0]["health"] == "failing"
+    assert snapshot[0]["last_error"] == "401 Unauthorized"
+
+
+def test_upload_health_label_prefers_queued_failures(monkeypatch, tmp_path):
+    record_upload_success(tmp_path, "event")
+    (tmp_path / "event_queue.jsonl").write_text("{}\n{}\n")
+    monkeypatch.setattr(main, "PLUGIN_DATA_DIRS", {"codex": tmp_path})
+
+    assert main._upload_health_label(main._upload_health_snapshot()) == "Codex failing, 2 queued"
+
+
+def test_single_failure_is_visible_but_not_warning_worthy(monkeypatch, tmp_path):
+    record_upload_failure(tmp_path, "event", "temporary outage")
+    monkeypatch.setattr(main, "PLUGIN_DATA_DIRS", {"codex": tmp_path})
+
+    snapshot = main._upload_health_snapshot()
+
+    assert snapshot[0]["health"] == "failing"
+    assert main._failing_upload_agents(snapshot) == []

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -7,9 +7,14 @@ import os
 import sys
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.session_upload import spawn_session_watcher
 from stashai.plugin.state import load_state, reset_stats, save_state
 
@@ -33,13 +38,16 @@ SESSION_CONTEXT = (
 
 
 def main():
-    if not is_configured():
-        return
-
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
 
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            json.dump({"systemMessage": warning}, sys.stdout)
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/plugins/claude-plugin/scripts/on_stop.py
+++ b/plugins/claude-plugin/scripts/on_stop.py
@@ -9,7 +9,11 @@ session_end lives in on_session_end.py.
 from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import stream_assistant_message
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 
 
@@ -27,6 +31,9 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(color_upload_health_warning(warning))
 
 
 if __name__ == "__main__":

--- a/plugins/codex-plugin/scripts/_run.sh
+++ b/plugins/codex-plugin/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/plugins/codex-plugin/scripts/on_session_start.py
+++ b/plugins/codex-plugin/scripts/on_session_start.py
@@ -8,6 +8,7 @@ from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     create_session_record,
     reset_session_record_state,
     uploads_disabled_warning,
@@ -24,7 +25,7 @@ def main():
     if not uploads_enabled(cfg, event):
         warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
         if warning:
-            print(json.dumps({"systemMessage": warning}))
+            print(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
         return
 
     reset_session_record_state(state)

--- a/plugins/codex-plugin/scripts/on_session_start.py
+++ b/plugins/codex-plugin/scripts/on_session_start.py
@@ -1,22 +1,32 @@
 #!/usr/bin/env python3
 """Codex SessionStart: save session_id and create the session record."""
 
+import json
 import os
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.session_upload import spawn_session_watcher
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(json.dumps({"systemMessage": warning}))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -15,6 +15,7 @@ from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     remember_transcript_path,
     stream_assistant_message,
     upload_health_warning,
@@ -48,7 +49,7 @@ def main():
     )
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
-        print(json.dumps({"systemMessage": warning}))
+        print(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
 
 
 if __name__ == "__main__":

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -9,10 +9,16 @@ Transcript upload is spawned as a detached background process (so it doesn't
 block the hook timeout) with a 60s cooldown between uploads per session.
 """
 
+import json
+
 from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import remember_transcript_path, stream_assistant_message
+from stashai.plugin.hooks import (
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 from stashai.plugin.transcript_upload import spawn_transcript_upload
 
@@ -40,6 +46,9 @@ def main():
         base_url=cfg["api_endpoint"],
         api_key=cfg["api_key"],
     )
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(json.dumps({"systemMessage": warning}))
 
 
 if __name__ == "__main__":

--- a/plugins/cursor-plugin/scripts/_run.sh
+++ b/plugins/cursor-plugin/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/plugins/cursor-plugin/scripts/on_agent_response.py
+++ b/plugins/cursor-plugin/scripts/on_agent_response.py
@@ -10,7 +10,12 @@ Payload: {text: "..."}.
 from adapt import adapt_agent_response
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import remember_transcript_path, stream_assistant_message
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 
 
@@ -28,6 +33,9 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(color_upload_health_warning(warning))
 
 
 if __name__ == "__main__":

--- a/plugins/cursor-plugin/scripts/on_session_start.py
+++ b/plugins/cursor-plugin/scripts/on_session_start.py
@@ -2,18 +2,28 @@
 """Cursor sessionStart: save session_id and create the session record."""
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -2,18 +2,28 @@
 """Gemini SessionStart: save session_id and create the session record."""
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/plugins/gemini-plugin/scripts/on_stop.py
+++ b/plugins/gemini-plugin/scripts/on_stop.py
@@ -8,7 +8,12 @@ assistant_message here; session_end lives in on_session_end.py.
 from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import remember_transcript_path, stream_assistant_message
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 
 
@@ -24,6 +29,9 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(color_upload_health_warning(warning))
 
 
 if __name__ == "__main__":

--- a/plugins/openclaw-plugin/scripts/on_session_start.py
+++ b/plugins/openclaw-plugin/scripts/on_session_start.py
@@ -2,18 +2,28 @@
 """command:new -> record session id, reset counters, create session record."""
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/plugins/openclaw-plugin/scripts/on_stop.py
+++ b/plugins/openclaw-plugin/scripts/on_stop.py
@@ -9,7 +9,11 @@ channel). This hook pushes `assistant_message`; session_end is separate
 from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import stream_assistant_message
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 
 
@@ -27,6 +31,9 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(color_upload_health_warning(warning))
 
 
 if __name__ == "__main__":

--- a/plugins/opencode-plugin/plugin.ts
+++ b/plugins/opencode-plugin/plugin.ts
@@ -48,21 +48,29 @@ function cancelIdleEnd(): void {
   activeSessionId = "";
 }
 
-function runHook(script: string, payload: unknown): void {
+function runHook(script: string, payload: unknown, showOutput = false): void {
   // Fire-and-forget. We never want a flaky Stash backend to stall opencode.
   // detached + unref so the child belongs to its own process group and gets
   // reaped independently — otherwise zombies accumulate over long sessions.
   // _run.sh resolves the stashai venv's python so hooks work under pipx/uv.
   const hookName = script.replace(/\.py$/, "");
   try {
+    const stdio: ["pipe", "pipe", "pipe"] | ["pipe", "ignore", "ignore"] =
+      showOutput ? ["pipe", "pipe", "pipe"] : ["pipe", "ignore", "ignore"];
     const child = spawn("bash", [RUN_SH, hookName], {
-      stdio: ["pipe", "ignore", "ignore"],
-      detached: true,
+      stdio,
+      detached: !showOutput,
     });
     child.on("error", () => { /* bash missing / crash — swallow */ });
+    if (showOutput) {
+      child.stdout?.on("data", (chunk) => process.stderr.write(chunk));
+      child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    }
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
-    child.unref();
+    if (!showOutput) {
+      child.unref();
+    }
   } catch {
     // spawn failed synchronously — swallow
   }
@@ -127,7 +135,7 @@ export const StashPlugin = async ({
         case "session.created": {
           const info = event.properties?.info;
           const sid = info?.id ?? "";
-          runHook("on_session_start.py", { session_id: sid, cwd });
+          runHook("on_session_start.py", { session_id: sid, cwd }, true);
           scheduleIdleEnd(sid);
           break;
         }

--- a/plugins/opencode-plugin/scripts/_run.sh
+++ b/plugins/opencode-plugin/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/plugins/opencode-plugin/scripts/on_session_start.py
+++ b/plugins/opencode-plugin/scripts/on_session_start.py
@@ -8,14 +8,17 @@ session_end for the stale id first, then save the new one.
 """
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
 from stashai.plugin.event import HookEvent
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     create_session_record,
     finalize_session_upload,
     reset_session_record_state,
     stream_session_end,
+    uploads_disabled_warning,
+    uploads_enabled,
 )
 from stashai.plugin.state import load_state, reset_stats, save_state
 
@@ -31,11 +34,16 @@ def _flush_stale_session(prior_sid: str, state: dict) -> None:
     except Exception:
         pass
 
+
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
+    cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
 
     prior_sid = state.get("session_id", "")
     if prior_sid and prior_sid != event.session_id:
@@ -47,7 +55,6 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    cfg = get_config()
     try:
         with get_client() as client:
             create_session_record(client, cfg, state, event, DATA_DIR)

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -12,6 +12,7 @@ import json
 import pytest
 
 from stashai.plugin.stash_client import QUEUE_FILENAME, StashClient
+from stashai.plugin.upload_status import read_upload_status
 
 
 class _Recorder:
@@ -59,6 +60,12 @@ def test_failed_push_enqueues(tmp_path):
     assert len(queued) == 1
     assert queued[0]["body"]["event_type"] == "tool_use"
     assert queued[0]["body"]["content"] == "x"
+    status = read_upload_status(tmp_path)
+    assert status["health"] == "failing"
+    assert status["queued_events"] == 1
+    assert status["consecutive_failures"] == 1
+    assert status["last_failure_operation"] == "event"
+    assert "simulated network failure" in status["last_error"]
 
 
 def test_successful_push_drains_backlog(tmp_path):
@@ -77,6 +84,11 @@ def test_successful_push_drains_backlog(tmp_path):
     assert _queue_lines(tmp_path) == []
     # 2 failed attempts + 1 successful + 2 drained backlog = 5 total POSTs recorded.
     assert len(client._http.calls) == 5
+    status = read_upload_status(tmp_path)
+    assert status["health"] == "ok"
+    assert status["queued_events"] == 0
+    assert status["consecutive_failures"] == 0
+    assert status["last_success_operation"] == "event"
 
 
 def test_drain_stops_on_first_failure(tmp_path):

--- a/plugins/tests/test_session_upload.py
+++ b/plugins/tests/test_session_upload.py
@@ -109,6 +109,7 @@ def test_finalize_session_upload_spawns_upload_with_transcript(monkeypatch, tmp_
             "agent_name": "alice-agent",
             "base_url": "https://joinstash.ai",
             "api_key": "key",
+            "data_dir": tmp_path,
         }
     ]
 
@@ -145,7 +146,11 @@ def test_do_session_uploads_artifacts(monkeypatch, tmp_path):
 
     class FakeClient:
         def __init__(self, **kwargs):
-            assert kwargs == {"base_url": "https://joinstash.ai", "api_key": "key"}
+            assert kwargs == {
+                "base_url": "https://joinstash.ai",
+                "api_key": "key",
+                "data_dir": str(tmp_path),
+            }
 
         def __enter__(self):
             return self
@@ -172,6 +177,7 @@ def test_do_session_uploads_artifacts(monkeypatch, tmp_path):
             "alice-agent",
             "https://joinstash.ai",
             "key",
+            str(tmp_path),
         ],
     )
 

--- a/plugins/tests/test_upload_health_warning.py
+++ b/plugins/tests/test_upload_health_warning.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from stashai.plugin.event import HookEvent
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    upload_health_warning,
+)
+from stashai.plugin.state import load_state
+from stashai.plugin.upload_status import record_upload_failure, record_upload_success
+
+
+def _cfg() -> dict:
+    return {
+        "workspace_id": "ws1",
+        "agent_name": "henry",
+        "client": "codex_cli",
+    }
+
+
+def _event(session_id: str) -> HookEvent:
+    return HookEvent(kind="stop", session_id=session_id, cwd="/repo")
+
+
+def test_upload_health_warning_is_once_per_session(tmp_path):
+    record_upload_failure(tmp_path, "event", "offline")
+    state = {"session_id": "s1"}
+
+    warning = upload_health_warning(_cfg(), state, _event("s1"), tmp_path)
+
+    assert warning == (
+        "Stash uploads are failing; this conversation may not be visible to your team. "
+        "Run `stash status` for details."
+    )
+    assert load_state(tmp_path)["upload_warning_session_id"] == "s1"
+    assert upload_health_warning(_cfg(), state, _event("s1"), tmp_path) is None
+
+
+def test_upload_health_warning_resets_for_next_session(tmp_path):
+    record_upload_failure(tmp_path, "event", "offline")
+    state = {"session_id": "s1"}
+
+    assert upload_health_warning(_cfg(), state, _event("s1"), tmp_path)
+    state["session_id"] = "s2"
+
+    assert upload_health_warning(_cfg(), state, _event("s2"), tmp_path)
+    assert load_state(tmp_path)["upload_warning_session_id"] == "s2"
+
+
+def test_upload_health_warning_skips_when_uploads_are_healthy(tmp_path):
+    record_upload_success(tmp_path, "event")
+
+    assert upload_health_warning(_cfg(), {"session_id": "s1"}, _event("s1"), tmp_path) is None
+
+
+def test_color_upload_health_warning_wraps_ansi_yellow():
+    assert color_upload_health_warning("message") == "\033[33mmessage\033[0m"

--- a/plugins/tests/test_upload_health_warning.py
+++ b/plugins/tests/test_upload_health_warning.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from stashai.plugin import hooks
 from stashai.plugin.event import HookEvent
 from stashai.plugin.hooks import (
     color_upload_health_warning,
     upload_health_warning,
+    uploads_disabled_warning,
+    uploads_enabled,
 )
 from stashai.plugin.state import load_state
 from stashai.plugin.upload_status import record_upload_failure, record_upload_success
@@ -12,6 +15,7 @@ from stashai.plugin.upload_status import record_upload_failure, record_upload_su
 def _cfg() -> dict:
     return {
         "workspace_id": "ws1",
+        "api_key": "k",
         "agent_name": "henry",
         "client": "codex_cli",
     }
@@ -54,3 +58,43 @@ def test_upload_health_warning_skips_when_uploads_are_healthy(tmp_path):
 
 def test_color_upload_health_warning_wraps_ansi_yellow():
     assert color_upload_health_warning("message") == "\033[33mmessage\033[0m"
+
+
+def test_uploads_enabled_requires_auth_and_workspace(monkeypatch):
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
+
+    assert uploads_enabled(_cfg(), _event("s1"))
+
+    missing_key = {**_cfg(), "api_key": ""}
+    assert not uploads_enabled(missing_key, _event("s1"))
+
+    missing_workspace = {**_cfg(), "workspace_id": ""}
+    assert not uploads_enabled(missing_workspace, HookEvent(kind="stop", session_id="s1"))
+
+
+def test_uploads_disabled_warning_is_once_per_session(monkeypatch, tmp_path):
+    monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
+    state = {}
+    cfg = {**_cfg(), "api_key": ""}
+
+    warning = uploads_disabled_warning(cfg, state, _event("s1"), tmp_path)
+
+    assert warning == (
+        "Hey btw, Stash uploads aren't enabled. Run `stash connect` or `stash start` "
+        "to enable them."
+    )
+    assert load_state(tmp_path)["uploads_disabled_warning_session_id"] == "s1"
+    assert uploads_disabled_warning(cfg, state, _event("s1"), tmp_path) is None
+
+    assert uploads_disabled_warning(cfg, state, _event("s2"), tmp_path)
+    assert load_state(tmp_path)["uploads_disabled_warning_session_id"] == "s2"
+
+
+def test_uploads_disabled_warning_requires_stash_cli(monkeypatch, tmp_path):
+    monkeypatch.setattr(hooks.shutil, "which", lambda name: None)
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
+
+    warning = uploads_disabled_warning({**_cfg(), "api_key": ""}, {}, _event("s1"), tmp_path)
+
+    assert warning is None

--- a/stashai/plugin/_do_session_upload.py
+++ b/stashai/plugin/_do_session_upload.py
@@ -4,7 +4,7 @@ Invoked by session_upload.spawn_session_upload(). Runs outside the hook
 timeout so large uploads don't block the agent.
 
 argv: script.py <session_row_id> <transcript_path> <cwd> <workspace_id>
-                <session_id> <agent_name> <base_url> <api_key>
+                <session_id> <agent_name> <base_url> <api_key> <data_dir>
 
 env: SESSION_FILES_TOUCHED = JSON list of file paths from the session
 """
@@ -96,10 +96,10 @@ def _resolve_paths(files_touched: list[str], cwd: str) -> list[str]:
 
 
 def main() -> None:
-    _, session_row_id, _, cwd, workspace_id, _, _, base_url, api_key = sys.argv
+    _, session_row_id, _, cwd, workspace_id, _, _, base_url, api_key, data_dir = sys.argv
     files_touched = json.loads(os.environ.get("SESSION_FILES_TOUCHED", "[]"))
 
-    with StashClient(base_url=base_url, api_key=api_key) as client:
+    with StashClient(base_url=base_url, api_key=api_key, data_dir=data_dir) as client:
         all_paths = _resolve_paths(files_touched, cwd)
         for fp in all_paths:
             if _should_skip(fp):

--- a/stashai/plugin/_do_upload.py
+++ b/stashai/plugin/_do_upload.py
@@ -3,7 +3,7 @@
 Invoked by transcript_upload.spawn_transcript_upload(). Runs outside the
 hook timeout so large files don't block the agent.
 
-argv: script.py <transcript_path> <session_id> <workspace_id> <agent_name> <cwd> <base_url> <api_key>
+argv: script.py <transcript_path> <session_id> <workspace_id> <agent_name> <cwd> <base_url> <api_key> <data_dir>
 """
 
 import sys
@@ -13,10 +13,10 @@ from stashai.plugin.stash_client import StashClient
 
 
 def main() -> None:
-    _, transcript_path, session_id, workspace_id, agent_name, cwd, base_url, api_key = sys.argv
+    _, transcript_path, session_id, workspace_id, agent_name, cwd, base_url, api_key, data_dir = sys.argv
 
     path = Path(transcript_path)
-    with StashClient(base_url=base_url, api_key=api_key) as client:
+    with StashClient(base_url=base_url, api_key=api_key, data_dir=data_dir) as client:
         client.upload_transcript(
             workspace_id=workspace_id,
             session_id=session_id,

--- a/stashai/plugin/_session_watcher.py
+++ b/stashai/plugin/_session_watcher.py
@@ -113,6 +113,7 @@ def main() -> None:
         agent_name=agent_name,
         base_url=base_url,
         api_key=api_key,
+        data_dir=Path(data_dir),
     )
 
 

--- a/stashai/plugin/assets/codex/scripts/_run.sh
+++ b/stashai/plugin/assets/codex/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/stashai/plugin/assets/codex/scripts/on_session_start.py
+++ b/stashai/plugin/assets/codex/scripts/on_session_start.py
@@ -8,6 +8,7 @@ from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     create_session_record,
     reset_session_record_state,
     uploads_disabled_warning,
@@ -24,7 +25,7 @@ def main():
     if not uploads_enabled(cfg, event):
         warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
         if warning:
-            print(json.dumps({"systemMessage": warning}))
+            print(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
         return
 
     reset_session_record_state(state)

--- a/stashai/plugin/assets/codex/scripts/on_session_start.py
+++ b/stashai/plugin/assets/codex/scripts/on_session_start.py
@@ -1,22 +1,32 @@
 #!/usr/bin/env python3
 """Codex SessionStart: save session_id and create the session record."""
 
+import json
 import os
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.session_upload import spawn_session_watcher
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(json.dumps({"systemMessage": warning}))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -15,6 +15,7 @@ from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     remember_transcript_path,
     stream_assistant_message,
     upload_health_warning,
@@ -48,7 +49,7 @@ def main():
     )
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
-        print(json.dumps({"systemMessage": warning}))
+        print(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -9,10 +9,16 @@ Transcript upload is spawned as a detached background process (so it doesn't
 block the hook timeout) with a 60s cooldown between uploads per session.
 """
 
+import json
+
 from adapt import adapt_stop
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import remember_transcript_path, stream_assistant_message
+from stashai.plugin.hooks import (
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 from stashai.plugin.transcript_upload import spawn_transcript_upload
 
@@ -40,6 +46,9 @@ def main():
         base_url=cfg["api_endpoint"],
         api_key=cfg["api_key"],
     )
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(json.dumps({"systemMessage": warning}))
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/cursor/scripts/_run.sh
+++ b/stashai/plugin/assets/cursor/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/stashai/plugin/assets/cursor/scripts/on_agent_response.py
+++ b/stashai/plugin/assets/cursor/scripts/on_agent_response.py
@@ -10,7 +10,12 @@ Payload: {text: "..."}.
 from adapt import adapt_agent_response
 from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
 
-from stashai.plugin.hooks import remember_transcript_path, stream_assistant_message
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
 from stashai.plugin.state import load_state
 
 
@@ -28,6 +33,9 @@ def main():
             stream_assistant_message(client, cfg, state, event)
     except Exception:
         pass
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        print(color_upload_health_warning(warning))
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/cursor/scripts/on_session_start.py
+++ b/stashai/plugin/assets/cursor/scripts/on_session_start.py
@@ -2,18 +2,28 @@
 """Cursor sessionStart: save session_id and create the session record."""
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.hooks import create_session_record, reset_session_record_state
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
+
     reset_session_record_state(state)
     state["session_id"] = event.session_id
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/opencode/plugin.ts
+++ b/stashai/plugin/assets/opencode/plugin.ts
@@ -48,21 +48,29 @@ function cancelIdleEnd(): void {
   activeSessionId = "";
 }
 
-function runHook(script: string, payload: unknown): void {
+function runHook(script: string, payload: unknown, showOutput = false): void {
   // Fire-and-forget. We never want a flaky Stash backend to stall opencode.
   // detached + unref so the child belongs to its own process group and gets
   // reaped independently — otherwise zombies accumulate over long sessions.
   // _run.sh resolves the stashai venv's python so hooks work under pipx/uv.
   const hookName = script.replace(/\.py$/, "");
   try {
+    const stdio: ["pipe", "pipe", "pipe"] | ["pipe", "ignore", "ignore"] =
+      showOutput ? ["pipe", "pipe", "pipe"] : ["pipe", "ignore", "ignore"];
     const child = spawn("bash", [RUN_SH, hookName], {
-      stdio: ["pipe", "ignore", "ignore"],
-      detached: true,
+      stdio,
+      detached: !showOutput,
     });
     child.on("error", () => { /* bash missing / crash — swallow */ });
+    if (showOutput) {
+      child.stdout?.on("data", (chunk) => process.stderr.write(chunk));
+      child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    }
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
-    child.unref();
+    if (!showOutput) {
+      child.unref();
+    }
   } catch {
     // spawn failed synchronously — swallow
   }
@@ -127,7 +135,7 @@ export const StashPlugin = async ({
         case "session.created": {
           const info = event.properties?.info;
           const sid = info?.id ?? "";
-          runHook("on_session_start.py", { session_id: sid, cwd });
+          runHook("on_session_start.py", { session_id: sid, cwd }, true);
           scheduleIdleEnd(sid);
           break;
         }

--- a/stashai/plugin/assets/opencode/scripts/_run.sh
+++ b/stashai/plugin/assets/opencode/scripts/_run.sh
@@ -11,11 +11,26 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
-TARGET="$(dirname "$0")/$SCRIPT.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/stashai/plugin/assets/opencode/scripts/on_session_start.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_start.py
@@ -8,14 +8,17 @@ session_end for the stale id first, then save the new one.
 """
 
 from adapt import adapt_session_start
-from config import DATA_DIR, get_client, get_config, get_stdin_data, is_configured
+from config import DATA_DIR, get_client, get_config, get_stdin_data
 
 from stashai.plugin.event import HookEvent
 from stashai.plugin.hooks import (
+    color_upload_health_warning,
     create_session_record,
     finalize_session_upload,
     reset_session_record_state,
     stream_session_end,
+    uploads_disabled_warning,
+    uploads_enabled,
 )
 from stashai.plugin.state import load_state, reset_stats, save_state
 
@@ -31,11 +34,16 @@ def _flush_stale_session(prior_sid: str, state: dict) -> None:
     except Exception:
         pass
 
+
 def main():
-    if not is_configured():
-        return
     event = adapt_session_start(get_stdin_data())
+    cfg = get_config()
     state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            print(color_upload_health_warning(warning))
+        return
 
     prior_sid = state.get("session_id", "")
     if prior_sid and prior_sid != event.session_id:
@@ -47,7 +55,6 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    cfg = get_config()
     try:
         with get_client() as client:
             create_session_record(client, cfg, state, event, DATA_DIR)

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -13,6 +13,7 @@ Never call `stream_session_end` from a per-turn hook — you'll emit a bogus
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from stashai.plugin.event import HookEvent
@@ -40,6 +41,11 @@ _UPLOAD_WARNING_SESSION_KEY = "upload_warning_session_id"
 _UPLOAD_WARNING_MESSAGE = (
     "Stash uploads are failing; this conversation may not be visible to your team. "
     "Run `stash status` for details."
+)
+_UPLOADS_DISABLED_WARNING_SESSION_KEY = "uploads_disabled_warning_session_id"
+_UPLOADS_DISABLED_WARNING_MESSAGE = (
+    "Hey btw, Stash uploads aren't enabled. Run `stash connect` or `stash start` "
+    "to enable them."
 )
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
@@ -104,6 +110,35 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> tuple[bool, str | None
         return True, None
 
     return False, workspace_id
+
+
+def uploads_enabled(cfg: dict, event: HookEvent | None) -> bool:
+    if not cfg.get("api_key") or not cfg.get("agent_name"):
+        return False
+    skip, _ = _short_circuit(cfg, event)
+    return not skip
+
+
+def uploads_disabled_warning(
+    cfg: dict,
+    state: dict,
+    event: HookEvent | None,
+    data_dir: Path,
+) -> str | None:
+    """Return the once-per-session warning when Stash is installed but idle."""
+    if uploads_enabled(cfg, event):
+        return None
+    session_id = getattr(event, "session_id", "") if event is not None else ""
+    if not session_id:
+        return None
+    if state.get(_UPLOADS_DISABLED_WARNING_SESSION_KEY) == session_id:
+        return None
+    if shutil.which("stash") is None:
+        return None
+
+    state[_UPLOADS_DISABLED_WARNING_SESSION_KEY] = session_id
+    save_state(data_dir, state)
+    return _UPLOADS_DISABLED_WARNING_MESSAGE
 
 
 # --- Session lifecycle ---

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -21,7 +21,11 @@ from stashai.plugin.session_upload import spawn_session_upload
 from stashai.plugin.stash_client import StashClient
 from stashai.plugin.state import read_stats, record_tool_use, save_state
 from stashai.plugin.summarize import summarize_tool_use
-from stashai.plugin.upload_status import record_upload_failure, record_upload_success
+from stashai.plugin.upload_status import (
+    read_upload_status,
+    record_upload_failure,
+    record_upload_success,
+)
 
 _CONFIG_FILE = Path.home() / ".stash" / "config.json"
 
@@ -31,6 +35,14 @@ _CLIENT_TO_AGENT = {
     "codex_cli": "codex",
     "opencode": "opencode",
 }
+
+_UPLOAD_WARNING_SESSION_KEY = "upload_warning_session_id"
+_UPLOAD_WARNING_MESSAGE = (
+    "Stash uploads are failing; this conversation may not be visible to your team. "
+    "Run `stash status` for details."
+)
+_YELLOW = "\033[33m"
+_RESET = "\033[0m"
 
 
 def _read_user_config() -> dict:
@@ -306,6 +318,36 @@ def stream_assistant_message(
         )
     except Exception:
         pass
+
+
+def upload_health_warning(
+    cfg: dict,
+    state: dict,
+    event: HookEvent,
+    data_dir: Path,
+) -> str | None:
+    """Return the once-per-session local upload failure warning, if needed."""
+    skip, _ = _short_circuit(cfg, event)
+    if skip:
+        return None
+
+    session_id = event.session_id or state.get("session_id", "")
+    if not session_id:
+        return None
+    if state.get(_UPLOAD_WARNING_SESSION_KEY) == session_id:
+        return None
+
+    status = read_upload_status(data_dir)
+    if status.get("health") != "failing":
+        return None
+
+    state[_UPLOAD_WARNING_SESSION_KEY] = session_id
+    save_state(data_dir, state)
+    return _UPLOAD_WARNING_MESSAGE
+
+
+def color_upload_health_warning(message: str) -> str:
+    return f"{_YELLOW}{message}{_RESET}"
 
 
 # --- Session end (conversation over) ---

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -21,6 +21,7 @@ from stashai.plugin.session_upload import spawn_session_upload
 from stashai.plugin.stash_client import StashClient
 from stashai.plugin.state import read_stats, record_tool_use, save_state
 from stashai.plugin.summarize import summarize_tool_use
+from stashai.plugin.upload_status import record_upload_failure, record_upload_success
 
 _CONFIG_FILE = Path.home() / ".stash" / "config.json"
 
@@ -155,8 +156,10 @@ def create_session_record(
             cwd=event.cwd,
             files_touched=read_stats(state)["files_touched"],
         )
-    except Exception:
+    except Exception as e:
+        record_upload_failure(data_dir, "session", e)
         return None
+    record_upload_success(data_dir, "session")
 
     state["session_row_id"] = str(session["id"])
     state["session_url"] = f"{cfg['api_endpoint'].rstrip('/')}/workspaces/{workspace_id}/sessions/{sid}"
@@ -213,6 +216,7 @@ def finalize_session_upload(
         agent_name=cfg["agent_name"],
         base_url=cfg["api_endpoint"],
         api_key=cfg["api_key"],
+        data_dir=data_dir,
     )
     if data_dir is not None:
         save_state(data_dir, state)

--- a/stashai/plugin/session_upload.py
+++ b/stashai/plugin/session_upload.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from stashai.plugin.upload_status import record_upload_failure
+
 
 def spawn_session_watcher(
     agent_pid: int,
@@ -51,17 +53,19 @@ def spawn_session_upload(
     agent_name: str,
     base_url: str,
     api_key: str,
+    data_dir: Path | None = None,
 ) -> bool:
     script = Path(__file__).parent / "_do_session_upload.py"
     env = os.environ.copy()
     env["SESSION_FILES_TOUCHED"] = json.dumps(files_touched)
+    upload_status_dir = str(data_dir or "")
 
     try:
         subprocess.Popen(
             [
                 sys.executable, str(script),
                 session_row_id, transcript_path, cwd, workspace_id, session_id,
-                agent_name, base_url, api_key,
+                agent_name, base_url, api_key, upload_status_dir,
             ],
             env=env,
             stdin=subprocess.DEVNULL,
@@ -70,6 +74,7 @@ def spawn_session_upload(
             start_new_session=True,
             close_fds=True,
         )
-    except Exception:
+    except Exception as e:
+        record_upload_failure(data_dir, "artifact_spawn", e)
         return False
     return True

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -17,6 +17,12 @@ from pathlib import Path
 
 import httpx
 
+from stashai.plugin.upload_status import (
+    record_upload_attempt,
+    record_upload_failure,
+    record_upload_success,
+)
+
 QUEUE_FILENAME = "event_queue.jsonl"
 QUEUE_MAX_ENTRIES = 1000  # cap so a long backend outage doesn't fill the disk
 DRAIN_BATCH = 50          # how many backlog rows to flush per successful push
@@ -121,13 +127,16 @@ class StashClient:
             body["metadata"] = merged_meta
 
         path = self._events_path(workspace_id)
+        record_upload_attempt(self._data_dir, "event")
         try:
             result = self._post(path, json=body)
-        except Exception:
+        except Exception as e:
             self._enqueue(path, body)
+            record_upload_failure(self._data_dir, "event", e)
             raise
         # Backend reachable — try to flush some of the backlog while we're here.
-        self._drain_queue()
+        if self._drain_queue():
+            record_upload_success(self._data_dir, "event")
         return result
 
     # --- Failed-event queue ---
@@ -173,17 +182,18 @@ class StashClient:
         except Exception:
             pass
 
-    def _drain_queue(self) -> None:
+    def _drain_queue(self) -> bool:
         qp = self._queue_path()
         if not qp or not qp.exists():
-            return
+            return True
+        drained = True
         try:
             with open(qp, "r+") as f:
                 fcntl.flock(f.fileno(), fcntl.LOCK_EX)
                 try:
                     lines = f.read().splitlines()
                     if not lines:
-                        return
+                        return True
                     remaining: list[str] = []
                     sent = 0
                     for line in lines:
@@ -194,9 +204,11 @@ class StashClient:
                             entry = json.loads(line)
                             self._post(entry["path"], json=entry["body"])
                             sent += 1
-                        except Exception:
+                        except Exception as e:
                             # Backend still unhappy. Stop now; keep this and the rest.
                             remaining.append(line)
+                            record_upload_failure(self._data_dir, "event_queue", e)
+                            drained = False
                             # Don't try further entries — likely all will fail.
                             sent = DRAIN_BATCH
                     f.seek(0)
@@ -206,7 +218,8 @@ class StashClient:
                 finally:
                     fcntl.flock(f.fileno(), fcntl.LOCK_UN)
         except Exception:
-            pass
+            return False
+        return drained
 
     def query_events(
         self, workspace_id: str | None,
@@ -249,16 +262,22 @@ class StashClient:
         if not name.endswith(".gz"):
             name = name + ".gz"
 
-        resp = self._http.request(
-            "POST",
-            f"/api/v1/workspaces/{workspace_id}/transcripts",
-            headers=self._headers(),
-            data={"session_id": session_id, "agent_name": agent_name, "cwd": cwd or ""},
-            files={"file": (name, body, "application/gzip")},
-            timeout=httpx.Timeout(60.0, connect=5.0),
-        )
-        if not resp.is_success:
-            raise StashError(resp.status_code, resp.text)
+        record_upload_attempt(self._data_dir, "transcript")
+        try:
+            resp = self._http.request(
+                "POST",
+                f"/api/v1/workspaces/{workspace_id}/transcripts",
+                headers=self._headers(),
+                data={"session_id": session_id, "agent_name": agent_name, "cwd": cwd or ""},
+                files={"file": (name, body, "application/gzip")},
+                timeout=httpx.Timeout(60.0, connect=5.0),
+            )
+            if not resp.is_success:
+                raise StashError(resp.status_code, resp.text)
+        except Exception as e:
+            record_upload_failure(self._data_dir, "transcript", e)
+            raise
+        record_upload_success(self._data_dir, "transcript")
         return resp.json()
 
     # --- Sessions ---
@@ -281,16 +300,22 @@ class StashClient:
         self, workspace_id: str, session_row_id: str, file_path: str, content: bytes,
     ) -> dict:
         """Upload a file the agent touched during a session."""
-        resp = self._http.request(
-            "POST",
-            f"/api/v1/workspaces/{workspace_id}/sessions/{session_row_id}/artifacts",
-            headers=self._headers(),
-            data={"file_path": file_path},
-            files={"file": (file_path.split("/")[-1], content, "application/octet-stream")},
-            timeout=httpx.Timeout(30.0, connect=5.0),
-        )
-        if not resp.is_success:
-            raise StashError(resp.status_code, resp.text)
+        record_upload_attempt(self._data_dir, "artifact")
+        try:
+            resp = self._http.request(
+                "POST",
+                f"/api/v1/workspaces/{workspace_id}/sessions/{session_row_id}/artifacts",
+                headers=self._headers(),
+                data={"file_path": file_path},
+                files={"file": (file_path.split("/")[-1], content, "application/octet-stream")},
+                timeout=httpx.Timeout(30.0, connect=5.0),
+            )
+            if not resp.is_success:
+                raise StashError(resp.status_code, resp.text)
+        except Exception as e:
+            record_upload_failure(self._data_dir, "artifact", e)
+            raise
+        record_upload_success(self._data_dir, "artifact")
         return resp.json()
 
     # --- Cross-workspace aggregate (optional) ---

--- a/stashai/plugin/transcript_upload.py
+++ b/stashai/plugin/transcript_upload.py
@@ -17,6 +17,8 @@ import sys
 import time
 from pathlib import Path
 
+from stashai.plugin.upload_status import record_upload_failure
+
 UPLOAD_COOLDOWN_SECONDS = 60
 
 
@@ -69,6 +71,7 @@ def spawn_transcript_upload(
             [
                 sys.executable, str(script),
                 str(path), session_id, workspace_id, agent_name, cwd, base_url, api_key,
+                str(data_dir),
             ],
             env=env,
             stdin=subprocess.DEVNULL,
@@ -77,7 +80,8 @@ def spawn_transcript_upload(
             start_new_session=True,
             close_fds=True,
         )
-    except Exception:
+    except Exception as e:
+        record_upload_failure(data_dir, "transcript_spawn", e)
         return False
 
     return True

--- a/stashai/plugin/upload_status.py
+++ b/stashai/plugin/upload_status.py
@@ -1,0 +1,147 @@
+"""Local upload health tracking for agent hooks.
+
+The server cannot report hook failures when the hook cannot reach the server,
+so each plugin writes a small local status file next to its event queue.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+STATUS_FILENAME = "upload_status.json"
+QUEUE_FILENAME = "event_queue.jsonl"
+
+
+def status_path(data_dir: Path) -> Path:
+    return data_dir / STATUS_FILENAME
+
+
+def queue_path(data_dir: Path) -> Path:
+    return data_dir / QUEUE_FILENAME
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f"{path.suffix}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    os.replace(tmp, path)
+
+
+def _error_text(error: BaseException | str) -> str:
+    text = str(error).strip()
+    if not text:
+        text = type(error).__name__ if isinstance(error, BaseException) else "Upload failed"
+    return text[:500]
+
+
+def _queue_count(data_dir: Path) -> int:
+    path = queue_path(data_dir)
+    if not path.exists():
+        return 0
+    try:
+        return sum(1 for line in path.read_text().splitlines() if line.strip())
+    except OSError:
+        return 0
+
+
+def record_upload_success(data_dir: Path | None, operation: str) -> None:
+    if data_dir is None:
+        return
+    path = status_path(data_dir)
+    data = _read_json(path)
+    data.update(
+        {
+            "version": 1,
+            "last_attempt_at": data.get("last_attempt_at") or _now(),
+            "last_success_at": _now(),
+            "last_success_operation": operation,
+            "consecutive_failures": 0,
+        }
+    )
+    data.pop("last_error", None)
+    try:
+        _write_json(path, data)
+    except OSError:
+        pass
+
+
+def record_upload_failure(
+    data_dir: Path | None,
+    operation: str,
+    error: BaseException | str,
+) -> None:
+    if data_dir is None:
+        return
+    path = status_path(data_dir)
+    data = _read_json(path)
+    failures = int(data.get("consecutive_failures") or 0) + 1
+    now = _now()
+    data.update(
+        {
+            "version": 1,
+            "last_attempt_at": now,
+            "last_failure_at": now,
+            "last_failure_operation": operation,
+            "last_error": _error_text(error),
+            "consecutive_failures": failures,
+        }
+    )
+    try:
+        _write_json(path, data)
+    except OSError:
+        pass
+
+
+def record_upload_attempt(data_dir: Path | None, operation: str) -> None:
+    if data_dir is None:
+        return
+    path = status_path(data_dir)
+    data = _read_json(path)
+    data.update(
+        {
+            "version": 1,
+            "last_attempt_at": _now(),
+            "last_attempt_operation": operation,
+        }
+    )
+    try:
+        _write_json(path, data)
+    except OSError:
+        pass
+
+
+def read_upload_status(data_dir: Path) -> dict[str, Any]:
+    data = _read_json(status_path(data_dir))
+    data["queued_events"] = _queue_count(data_dir)
+
+    last_success = float(data.get("last_success_at") or 0)
+    last_failure = float(data.get("last_failure_at") or 0)
+    failures = int(data.get("consecutive_failures") or 0)
+    queued = int(data.get("queued_events") or 0)
+
+    if queued or (failures and last_failure >= last_success):
+        data["health"] = "failing"
+    elif last_success:
+        data["health"] = "ok"
+    else:
+        data["health"] = "unknown"
+
+    return data


### PR DESCRIPTION
## Summary

- Add local upload health tracking for Stash agent hooks in `upload_status.json` beside each plugin's queue.
- Record event, transcript, session, and artifact upload attempts, successes, failures, queued-event counts, and last errors.
- Add `stash status` plus upload health in `stash settings --json` and the interactive settings summary.
- Emit a once-per-conversation assistant-hook warning when uploads are enabled and the local upload health is failing. Codex uses the hook-native `systemMessage`; other stop/response hooks print the warning in yellow.
- Emit a once-per-session startup warning when the Stash CLI is installed but uploads are not enabled for that agent/repo.
- Color Codex upload warnings yellow and fix the hook runner so dev-checkout hooks import from the checkout they run from.

## Validation

- `python -m pytest --no-cov plugins/tests cli/tests/test_upload_status_helpers.py cli/tests/test_install_codex.py cli/tests/test_install_hooks.py`
- `ruff check stashai/plugin cli plugins/codex-plugin/scripts/on_session_start.py plugins/codex-plugin/scripts/on_stop.py plugins/tests/test_upload_health_warning.py`
- `black --check backend/ cli/`
- `python -m cli.main status --json`
- Manual Codex SessionStart hook smoke test for yellow warning output
- GitHub CI passing

## Notes

This intentionally stays local-first so users can diagnose failures even when hooks cannot reach the Stash API.