### PR TITLE
[codex] Use chat icon for session groups

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1178,7 +1178,7 @@ function SessionTreeDetails({
       >
         <ChevronToggle open={open} onToggle={() => setOpen((current) => !current)} />
         <span className="flex h-4 w-4 items-center justify-center text-[14px] text-muted">
-          <FolderIcon />
+          <SessionsIcon />
         </span>
         <span className="flex-1 truncate text-foreground">{group.label}</span>
         <span className="text-[10.5px] text-muted">{group.total}</span>


### PR DESCRIPTION
## Summary
- Replace the folder icon on session date/month group rows with the existing session chat-bubble icon.

## Why
Session buckets represent grouped sessions, not filesystem folders, so the icon should match the Sessions section and individual session rows.

## Validation
- `npm test -- AppSidebar.test.tsx` (28 passed)
- `npm run lint` (0 errors; 5 existing warnings in unrelated files)
- Playwright browser check against the Next app with mocked API data confirmed the session bucket rows render with chat-bubble icons.

Screenshot added in the PR thread.