### PR TITLE
[codex] Add sidebar session timestamps

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -227,6 +227,18 @@ function sidebarWithSessions(sessions: ReturnType<typeof sidebarSession>[]) {
   };
 }
 
+function expectedSidebarTimestamp(iso: string, includeDate = true): string {
+  const date = new Date(iso);
+  const hour24 = date.getHours();
+  const hour = hour24 % 12 || 12;
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const suffix = hour24 >= 12 ? "p" : "a";
+  const time = `${hour}:${minutes}${suffix}`;
+
+  if (!includeDate) return time;
+  return `${date.getMonth() + 1}/${date.getDate()} ${time}`;
+}
+
 function sidebarWithFiles({
   folderCount,
   pages = [],
@@ -432,6 +444,27 @@ describe("AppSidebar tree expansion", () => {
 
     fireEvent.click(day);
     expect(detailsFor(day.textContent ?? "")).toHaveAttribute("open");
+  });
+
+  it("shows compact timestamps on session rows", async () => {
+    const lastAt = "2026-05-20T12:59:00";
+    vi.mocked(getWorkspaceSidebar).mockResolvedValue(
+      sidebarWithSessions([
+        sidebarSession("timestamped", "Timestamped session", "Henry", lastAt),
+      ])
+    );
+
+    renderSidebar();
+
+    expect(await screen.findByText("Timestamped session")).toBeTruthy();
+    const timestamp = screen.getByText(expectedSidebarTimestamp(lastAt, false));
+    expect(timestamp.tagName).toBe("TIME");
+    expect(timestamp).toHaveAttribute("dateTime", lastAt);
+
+    fireEvent.change(screen.getByLabelText("Filter sessions"), {
+      target: { value: "timestamped" },
+    });
+    expect(screen.getByText(expectedSidebarTimestamp(lastAt))).toBeTruthy();
   });
 
   it("limits visible session periods and reveals more on demand", async () => {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -262,7 +262,7 @@ function NavRow({
     <Link
       href={href}
       className={
-        "page-row flex items-center gap-2 rounded-md px-2 py-1 text-[13px] transition-colors " +
+        "page-row group/nav flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-[13px] transition-colors " +
         (active
           ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
           : "text-dim hover:bg-raised hover:text-foreground")
@@ -271,7 +271,7 @@ function NavRow({
       onContextMenu={onContextMenu}
     >
       <span className="flex h-4 w-4 items-center justify-center text-[14px]">{icon}</span>
-      <span className="flex-1 truncate">{label}</span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
       {trailing}
     </Link>
   );
@@ -571,6 +571,71 @@ function sessionTimestamp(session: WorkspaceSidebarSession): number {
   return date ? date.getTime() : 0;
 }
 
+type SessionTimestampMode = "time" | "dateTime";
+
+function formatSessionSidebarTimestamp(
+  session: WorkspaceSidebarSession,
+  mode: SessionTimestampMode
+): string {
+  const date = sessionDate(session.last_at || session.updated_at);
+  if (!date) return "";
+
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hour24 = date.getHours();
+  const hour = hour24 % 12 || 12;
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const suffix = hour24 >= 12 ? "p" : "a";
+  const time = `${hour}:${minutes}${suffix}`;
+
+  if (mode === "time") return time;
+  return `${month}/${day} ${time}`;
+}
+
+function formatSessionSidebarTimestampTitle(session: WorkspaceSidebarSession): string {
+  const date = sessionDate(session.last_at || session.updated_at);
+  if (!date) return "";
+
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function SessionRowTimestamp({
+  session,
+  active,
+  mode = "dateTime",
+}: {
+  session: WorkspaceSidebarSession;
+  active?: boolean;
+  mode?: SessionTimestampMode;
+}) {
+  const compact = formatSessionSidebarTimestamp(session, mode);
+  if (!compact) return null;
+
+  const title = formatSessionSidebarTimestampTitle(session);
+
+  return (
+    <time
+      dateTime={session.last_at || session.updated_at}
+      title={title}
+      aria-label={title}
+      className={
+        "ml-1 shrink-0 font-mono text-[9.5px] leading-none tabular-nums " +
+        (active
+          ? "text-[var(--color-brand-700)] opacity-70"
+          : "text-muted/70 group-hover/nav:text-muted")
+      }
+    >
+      {compact}
+    </time>
+  );
+}
+
 function sortSessionsByRecency(
   sessions: WorkspaceSidebarSession[]
 ): WorkspaceSidebarSession[] {
@@ -657,6 +722,7 @@ function sessionBucketHasActiveSession(
 type SessionTreeDayGroup = {
   dateKey: string;
   label: string;
+  bucket: SessionBucket;
   total: number;
   users: Array<{ user: string; sessions: WorkspaceSidebarSession[] }>;
 };
@@ -767,6 +833,7 @@ function groupSidebarSessions(sessions: WorkspaceSidebarSession[]): SessionTreeD
       return {
         dateKey: key,
         label: formatBucketLabel(key, bucket),
+        bucket,
         total,
         users,
       };
@@ -844,20 +911,30 @@ function SessionNavRow({
   session,
   activeSession,
   onPinMenu,
+  timestampMode = "dateTime",
 }: {
   workspaceId: string;
   session: WorkspaceSidebarSession;
   activeSession: ActiveSessionRef;
   onPinMenu?: (event: MouseEvent<HTMLAnchorElement>, session: WorkspaceSidebarSession) => void;
+  timestampMode?: SessionTimestampMode;
 }) {
   const href = `/workspaces/${workspaceId}/sessions/${encodeURIComponent(session.session_id)}`;
+  const active = sessionMatchesActive(activeSession, workspaceId, session);
   return (
     <NavRow
       href={href}
       icon={<span className="text-muted"><SessionsIcon /></span>}
       label={sessionLabelForSidebar(session)}
-      active={sessionMatchesActive(activeSession, workspaceId, session)}
+      active={active}
       onContextMenu={(event) => onPinMenu?.(event, session)}
+      trailing={
+        <SessionRowTimestamp
+          session={session}
+          active={active}
+          mode={timestampMode}
+        />
+      }
     />
   );
 }
@@ -931,6 +1008,7 @@ function SessionsBlock({
       objectId: session?.id ?? null,
       label: pinnedLabels.sessions[sessionId] ?? (session ? sessionLabelForSidebar(session) : "Session"),
       href: `/workspaces/${workspace.id}/sessions/${encodeURIComponent(sessionId)}`,
+      session,
     };
   });
   const menuClamp =
@@ -1073,21 +1151,30 @@ function SessionsBlock({
                     Unpin all
                   </button>
                 </div>
-                {pinnedRows.map((session) => (
-                  <NavRow
-                    key={`pinned-session-${session.id}`}
-                    href={session.href}
-                    icon={<span className="text-muted"><SessionsIcon /></span>}
-                    label={session.label}
-                    active={sessionMatchesActive(activeSession, workspace.id, {
-                      id: session.objectId,
-                      session_id: session.id,
-                    })}
-                    onContextMenu={(event) =>
-                      showSessionPinMenu(event, session.id, session.label)
-                    }
-                  />
-                ))}
+                {pinnedRows.map((row) => {
+                  const active = sessionMatchesActive(activeSession, workspace.id, {
+                    id: row.objectId,
+                    session_id: row.id,
+                  });
+
+                  return (
+                    <NavRow
+                      key={`pinned-session-${row.id}`}
+                      href={row.href}
+                      icon={<span className="text-muted"><SessionsIcon /></span>}
+                      label={row.label}
+                      active={active}
+                      onContextMenu={(event) =>
+                        showSessionPinMenu(event, row.id, row.label)
+                      }
+                      trailing={
+                        row.session ? (
+                          <SessionRowTimestamp session={row.session} active={active} />
+                        ) : null
+                      }
+                    />
+                  );
+                })}
               </div>
             ) : null}
             {visibleGroups.map((group, index) => (
@@ -1161,6 +1248,8 @@ function SessionTreeDetails({
   const visibleUserLimit = Math.max(visibleUserCount, activeUserIndex + 1);
   const visibleUsers = group.users.slice(0, visibleUserLimit);
   const hiddenUserCount = group.users.length - visibleUsers.length;
+  const timestampMode: SessionTimestampMode =
+    group.bucket === "day" ? "time" : "dateTime";
 
   useEffect(() => {
     if (hasActiveSession) setOpen(true);
@@ -1194,6 +1283,7 @@ function SessionTreeDetails({
               bucket={bucket}
               activeSession={activeSession}
               onSessionPinMenu={onSessionPinMenu}
+              timestampMode={timestampMode}
             />
           ))
         )}
@@ -1215,11 +1305,13 @@ function SessionUserFolder({
   bucket,
   activeSession,
   onSessionPinMenu,
+  timestampMode,
 }: {
   workspaceId: string;
   bucket: { user: string; sessions: WorkspaceSidebarSession[] };
   activeSession: ActiveSessionRef;
   onSessionPinMenu?: (event: MouseEvent<HTMLAnchorElement>, session: WorkspaceSidebarSession) => void;
+  timestampMode: SessionTimestampMode;
 }) {
   const hasActiveSession = sessionBucketHasActiveSession(
     activeSession,
@@ -1267,6 +1359,7 @@ function SessionUserFolder({
             session={s}
             activeSession={activeSession}
             onPinMenu={onSessionPinMenu}
+            timestampMode={timestampMode}
           />
         ))}
         {hiddenSessionCount > 0 ? (
@@ -1290,6 +1383,7 @@ type StashTreeItem = {
   href?: string;
   label: string;
   icon: React.ReactNode;
+  session?: WorkspaceSidebarSession;
 };
 
 function resolveFolderPath(
@@ -1334,6 +1428,7 @@ function buildStashTreeItems(
           href: session ? `/workspaces/${workspaceId}/sessions/${encodeURIComponent(session.session_id)}` : undefined,
           icon: <span className="text-muted"><SessionsIcon /></span>,
           label: item.label_override ?? (session ? session.title || session.session_id : fallback),
+          session,
         };
       }
 
@@ -1504,17 +1599,22 @@ function StashTreeRow({ row }: { row: StashTreeItem }) {
     return (
       <div className="page-row flex items-center gap-2 rounded-md px-2 py-0.5 text-[12.5px] text-muted">
         <span className="flex h-4 w-4 items-center justify-center text-[14px]">{row.icon}</span>
-        <span className="flex-1 truncate">{row.label}</span>
+        <span className="min-w-0 flex-1 truncate">{row.label}</span>
+        {row.session ? <SessionRowTimestamp session={row.session} /> : null}
       </div>
     );
   }
 
+  const active = pathname === row.href;
   return (
     <NavRow
       href={row.href}
       icon={row.icon}
       label={row.label}
-      active={pathname === row.href}
+      active={active}
+      trailing={
+        row.session ? <SessionRowTimestamp session={row.session} active={active} /> : null
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add compact timestamps to session rows in the sidebar.
- Use time-only timestamps inside dated session buckets, and date-plus-time for search, pinned, and Stash session rows where the date context is missing.
- Keep timestamps muted, tabular, and non-shrinking so long session titles truncate cleanly without overlap.

## Screenshots
Desktop:
![stash-sidebar-timestamps-desktop.png](https://github.com/user-attachments/assets/c8ceb925-237f-4e3b-a6dd-5ca67505b54f)

Narrow viewport:
![stash-sidebar-timestamps-mobile.png](https://github.com/user-attachments/assets/29db1152-02f6-4705-b01d-f3e93e2da9c2)

## Validation
- `cd frontend && npm test -- AppSidebar.test.tsx`
- `cd frontend && npm run lint` (passes with 5 pre-existing warnings in unrelated files)
- `cd frontend && npm run build`
- Playwright smoke check against `http://localhost:3457/workspaces/ws-1` with mocked API data; verified day-bucket timestamps are time-only and timestamp/title bounding boxes do not overlap.