### PR TITLE
[codex] fix stash upload publish permissions

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -16,6 +16,16 @@ class StashError(Exception):
         super().__init__(f"[{status_code}] {detail}")
 
 
+def stash_permissions_for_access(access: str) -> dict[str, str]:
+    if access == "public":
+        return {"workspace_permission": "read", "public_permission": "read"}
+    if access == "workspace":
+        return {"workspace_permission": "read", "public_permission": "none"}
+    if access == "private":
+        return {"workspace_permission": "none", "public_permission": "none"}
+    raise ValueError("access must be public, workspace, or private")
+
+
 class StashClient:
     def __init__(self, base_url: str, api_key: str = ""):
         self._base_url = base_url.rstrip("/")
@@ -149,7 +159,8 @@ class StashClient:
         workspace_id: str,
         title: str,
         description: str = "",
-        access: str = "workspace",
+        workspace_permission: str = "read",
+        public_permission: str = "none",
         discoverable: bool = False,
         items: list | None = None,
     ) -> dict:
@@ -158,7 +169,8 @@ class StashClient:
             json={
                 "title": title,
                 "description": description,
-                "access": access,
+                "workspace_permission": workspace_permission,
+                "public_permission": public_permission,
                 "discoverable": discoverable,
                 "items": items or [],
             },
@@ -178,7 +190,8 @@ class StashClient:
             json={
                 "title": title,
                 "description": description,
-                "access": "public",
+                "workspace_permission": "read",
+                "public_permission": "read",
                 "discoverable": discoverable,
                 "items": items or [],
             },

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,7 +13,7 @@ from rich.align import Align
 from rich.panel import Panel
 from rich.text import Text
 
-from .client import StashClient, StashError
+from .client import StashClient, StashError, stash_permissions_for_access
 from .config import (
     MANIFEST_FILE,
     PRODUCTION_BASE_URL,
@@ -1186,7 +1186,6 @@ def upload(
                 ws,
                 title=root_name,
                 description=f"Uploaded from {target.name}",
-                access="workspace",
                 items=stash_items,
             )
             stash_url = _stash_url(stash)
@@ -1290,7 +1289,6 @@ def stashes_create(
                     ws_id,
                     title=title,
                     description=description,
-                    access="workspace",
                     discoverable=False,
                     items=items,
                 )
@@ -1326,7 +1324,7 @@ def stashes_publish(
         try:
             stash = c.update_stash(
                 stash_id,
-                access=access,
+                **stash_permissions_for_access(access),
                 discoverable=False if access != "public" else discover,
             )
         except StashError as e:
@@ -1373,7 +1371,7 @@ def stashes_update(
         if access not in {"workspace", "private", "public"}:
             console.print("[red]--access must be workspace, private, or public.[/red]")
             raise typer.Exit(1)
-        fields["access"] = access
+        fields.update(stash_permissions_for_access(access))
     if discover is not None:
         fields["discoverable"] = discover
     if items_json is not None:

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -4,7 +4,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 
-from cli.client import StashClient
+from cli.client import StashClient, stash_permissions_for_access
 from cli.config import load_config, load_manifest
 
 mcp = FastMCP("stash", instructions="Stash — shared memory for AI coding agents")
@@ -479,7 +479,7 @@ def stash_create_stash(
             ws,
             title,
             description=description,
-            access=access,
+            **stash_permissions_for_access(access),
             discoverable=discoverable,
             items=item_list,
         )
@@ -503,7 +503,7 @@ def stash_update_stash(
     if description:
         fields["description"] = description
     if access:
-        fields["access"] = access
+        fields.update(stash_permissions_for_access(access))
     if discoverable:
         fields["discoverable"] = discoverable.lower() in {"1", "true", "yes", "on"}
     if items:

--- a/cli/tests/test_stash_client_permissions.py
+++ b/cli/tests/test_stash_client_permissions.py
@@ -1,0 +1,68 @@
+from cli.client import StashClient, stash_permissions_for_access
+
+
+def _post_stub_client():
+    client = StashClient.__new__(StashClient)
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, json=None) -> dict:
+        calls.append((path, json))
+        return {"ok": True}
+
+    client._post = fake_post  # type: ignore[method-assign]
+    return client, calls
+
+
+def test_stash_permissions_for_access() -> None:
+    assert stash_permissions_for_access("public") == {
+        "workspace_permission": "read",
+        "public_permission": "read",
+    }
+    assert stash_permissions_for_access("workspace") == {
+        "workspace_permission": "read",
+        "public_permission": "none",
+    }
+    assert stash_permissions_for_access("private") == {
+        "workspace_permission": "none",
+        "public_permission": "none",
+    }
+
+
+def test_create_stash_uses_permission_fields() -> None:
+    client, calls = _post_stub_client()
+
+    client.create_stash("WS", "Launch notes", items=[{"object_type": "folder", "object_id": "F1"}])
+
+    assert calls == [
+        (
+            "/api/v1/workspaces/WS/stashes",
+            {
+                "title": "Launch notes",
+                "description": "",
+                "workspace_permission": "read",
+                "public_permission": "none",
+                "discoverable": False,
+                "items": [{"object_type": "folder", "object_id": "F1"}],
+            },
+        )
+    ]
+
+
+def test_publish_stash_uses_public_permission_fields() -> None:
+    client, calls = _post_stub_client()
+
+    client.publish_stash("WS", "Launch notes", items=[{"object_type": "folder", "object_id": "F1"}])
+
+    assert calls == [
+        (
+            "/api/v1/workspaces/WS/stashes/publish",
+            {
+                "title": "Launch notes",
+                "description": "",
+                "workspace_permission": "read",
+                "public_permission": "read",
+                "discoverable": False,
+                "items": [{"object_type": "folder", "object_id": "F1"}],
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary
- send `workspace_permission`/`public_permission` from the CLI client instead of the stale `access` request field
- update CLI and MCP Stash create/update paths to use the current backend permission shape
- add focused client tests for create/publish payloads

## Root Cause
`stash upload` calls `/api/v1/workspaces/{workspace_id}/stashes/publish` after uploading files. The CLI was still posting `access: "public"`, but the backend now validates `public_permission`; because the field was missing, it defaulted to `none` and returned `400 Published Stashes must be public`.

## Validation
- `pytest cli/tests --no-cov`
- `ruff check cli/client.py cli/main.py cli/mcp_server.py cli/tests/test_stash_client_permissions.py cli/tests/test_share_and_upload_helpers.py`
- production smoke test: `python -m cli.main upload /Users/henrydowling/Desktop/IMG_0370.HEIC --name "IMG_0370 publish fix verification" --json` returned `https://app.joinstash.ai/stashes/img-0370-publish-fix-verification-9-ipka`