### PR TITLE
Fix plugin session event streaming route

### DIFF
--- a/plugins/openclaw-plugin/index.ts
+++ b/plugins/openclaw-plugin/index.ts
@@ -72,9 +72,10 @@ function findManifest(): StashManifest | null {
 }
 
 function eventsPath(workspaceId: string): string {
-  return workspaceId
-    ? `/api/v1/workspaces/${workspaceId}/memory/events`
-    : `/api/v1/memory/events`;
+  if (!workspaceId) {
+    throw new Error("workspaceId is required for session events");
+  }
+  return `/api/v1/workspaces/${workspaceId}/sessions/events`;
 }
 
 function extractText(content: unknown): string {

--- a/plugins/tests/test_adapters.py
+++ b/plugins/tests/test_adapters.py
@@ -154,6 +154,7 @@ def test_push_event_stamps_client_into_metadata():
         workspace_id="ws1", agent_name="henry", event_type="tool_use",
         content="...", tool_name="edit", metadata={"cwd": "/tmp"}, client="cursor",
     )
+    assert calls[-1][0] == "/api/v1/workspaces/ws1/sessions/events"
     body = calls[-1][1]["json"]
     assert body["metadata"] == {"cwd": "/tmp", "client": "cursor"}
 
@@ -169,6 +170,19 @@ def test_push_event_stamps_client_into_metadata():
     )
     body = calls[-1][1]["json"]
     assert "metadata" not in body
+
+
+def test_push_event_requires_workspace_id():
+    from stashai.plugin.stash_client import StashClient
+
+    client = StashClient(base_url="http://x", api_key="k")
+    with pytest.raises(ValueError):
+        client.push_event(
+            workspace_id=None,
+            agent_name="henry",
+            event_type="user_message",
+            content="hi",
+        )
 
 
 def test_tool_name_normalization():

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -57,6 +57,7 @@ def test_failed_push_enqueues(tmp_path):
         )
     queued = _queue_lines(tmp_path)
     assert len(queued) == 1
+    assert queued[0]["path"] == "/api/v1/workspaces/ws-1/sessions/events"
     assert queued[0]["body"]["event_type"] == "tool_use"
     assert queued[0]["body"]["content"] == "x"
 

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -94,14 +94,11 @@ class StashClient:
         return self._list(path, "workspaces")
 
     # --- Events ---
-    #
-    # workspace_id=None targets the personal store (/api/v1/memory/events).
-    # A non-empty workspace_id scopes to that workspace.
 
     def _events_path(self, workspace_id: str | None) -> str:
-        if workspace_id:
-            return f"/api/v1/workspaces/{workspace_id}/memory/events"
-        return "/api/v1/memory/events"
+        if not workspace_id:
+            raise ValueError("workspace_id is required for session events")
+        return f"/api/v1/workspaces/{workspace_id}/sessions/events"
 
     def push_event(
         self, workspace_id: str | None,


### PR DESCRIPTION
## Summary

Fixes agent plugin event streaming to use the live workspace session-events API instead of the removed memory-events route.

## Root Cause

Codex and other shared Python-hook plugins were posting to `/api/v1/workspaces/{workspace_id}/memory/events`, which production now returns as `404 Not Found`. Hook exceptions are swallowed by design, so events accumulated locally in `~/.stash/plugins/codex/event_queue.jsonl` instead of appearing in Stash.

## Changes

- Update the shared plugin `StashClient` to post/query workspace events through `/api/v1/workspaces/{workspace_id}/sessions/events`.
- Make missing `workspace_id` fail fast for session event pushes.
- Update the Openclaw plugin's direct event path to match.
- Add regression coverage for the session-events route and required workspace id.

## Validation

- `PYTHONPATH=$PWD pytest --no-cov plugins/tests/test_adapters.py plugins/tests/test_event_queue.py`
- `node --experimental-strip-types --check plugins/openclaw-plugin/index.ts`
- `PYTHONPATH=$PWD ruff check stashai/plugin/stash_client.py plugins/tests/test_adapters.py plugins/tests/test_event_queue.py`
- `git diff --check origin/main...HEAD`