### PR TITLE
[codex] Hide sidebar session timestamps until hover

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -472,7 +472,7 @@ describe("AppSidebar tree expansion", () => {
     expect(detailsFor(day.textContent ?? "")).toHaveAttribute("open");
   });
 
-  it("shows compact timestamps on session rows", async () => {
+  it("reveals compact timestamps from session rows on hover", async () => {
     const lastAt = "2026-05-20T12:59:00";
     vi.mocked(getWorkspaceSidebar).mockResolvedValue(
       sidebarWithSessions([
@@ -486,6 +486,9 @@ describe("AppSidebar tree expansion", () => {
     const timestamp = screen.getByText(expectedSidebarTimestamp(lastAt, false));
     expect(timestamp.tagName).toBe("TIME");
     expect(timestamp).toHaveAttribute("dateTime", lastAt);
+    expect(timestamp).toHaveClass("opacity-0");
+    expect(timestamp).toHaveClass("group-hover/nav:opacity-100");
+    expect(timestamp).toHaveClass("group-focus-within/nav:opacity-100");
 
     fireEvent.change(screen.getByLabelText("Filter sessions"), {
       target: { value: "timestamped" },

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -651,9 +651,9 @@ function SessionRowTimestamp({
       title={title}
       aria-label={title}
       className={
-        "shrink-0 font-mono text-[9.5px] leading-none tabular-nums " +
+        "shrink-0 font-mono text-[9.5px] leading-none opacity-0 transition-opacity tabular-nums group-hover/nav:opacity-100 group-focus-within/nav:opacity-100 " +
         (active
-          ? "text-[var(--color-brand-700)] opacity-70"
+          ? "text-[var(--color-brand-700)]"
           : "text-muted/70 group-hover/nav:text-muted")
       }
     >
@@ -1645,10 +1645,10 @@ function StashTreeRow({ row }: { row: StashTreeItem }) {
   const pathname = usePathname();
   if (!row.href) {
     return (
-      <div className="page-row flex items-center gap-2 rounded-md px-2 py-0.5 text-[12.5px] text-muted">
+      <div className="page-row group/nav flex items-center gap-2 rounded-md px-2 py-0.5 text-[12.5px] text-muted">
         <span className="flex h-4 w-4 items-center justify-center text-[14px]">{row.icon}</span>
         <span className="min-w-0 flex-1 truncate">{row.label}</span>
-        {row.session ? <SessionRowTimestamp session={row.session} /> : null}
+        {row.session ? <SessionRowTrailing session={row.session} /> : null}
       </div>
     );
   }


### PR DESCRIPTION
## What changed

- Hide sidebar session timestamps by default and reveal them on row hover/focus.
- Keep the new Linear ticket trailing UI from `main` and apply the same hover/focus behavior to static Stash session rows.
- Update the sidebar test to assert the timestamp reveal classes.

## Why

The always-visible day/time text made the sidebar feel noisier than necessary. The timestamp is still available when the user interacts with a row, while preserving the existing `time` element metadata.

## Screenshots

- Before hover: https://app.joinstash.ai/stashes/stash-sidebar-timestamp-before-hover-current-rfuktw
- On hover: https://app.joinstash.ai/stashes/stash-sidebar-timestamp-hover-current-y0jlcq

## Validation

- `npm test -- AppSidebar.test.tsx`
- `npm run lint -- src/components/AppSidebar.tsx src/components/AppSidebar.test.tsx`
- Playwright mocked workspace check: timestamp opacity changed from `0` before hover to `1` on hover.
