### PR TITLE
[codex] Fix session title sidebar cache

### DIFF
--- a/backend/migrations/versions/0072_ensure_session_titles.py
+++ b/backend/migrations/versions/0072_ensure_session_titles.py
@@ -1,0 +1,37 @@
+"""Ensure AI-generated session title cache exists.
+
+Revision ID: 0072
+Revises: 0071
+"""
+
+from alembic import op
+
+revision = "0072"
+down_revision = "0071"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS session_titles (
+            workspace_id UUID NOT NULL,
+            session_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (workspace_id, session_id),
+            FOREIGN KEY (workspace_id, session_id)
+                REFERENCES sessions(workspace_id, session_id)
+                ON DELETE CASCADE
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_titles_updated "
+        "ON session_titles(updated_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS session_titles")

--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -26,7 +26,7 @@ from ..services import (
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
-SIDEBAR_ETAG_VERSION = "sidebar-generated-title-linear-ticket-v1"
+SIDEBAR_ETAG_VERSION = "sidebar-generated-title-linear-ticket-v2"
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +326,20 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
           (SELECT COUNT(*) FROM history_events he
             WHERE he.workspace_id = $1 AND he.session_id IS NOT NULL
             AND {memory_service.readable_session_event_condition('he', 2)})        AS hc,
+          (SELECT MAX(stt.updated_at) FROM session_titles stt
+           JOIN sessions stt_session
+             ON stt_session.workspace_id = stt.workspace_id
+            AND stt_session.session_id = stt.session_id
+           WHERE stt.workspace_id = $1
+             AND stt_session.deleted_at IS NULL
+             AND {memory_service.readable_session_event_condition('stt_session', 2)}) AS tt,
+          (SELECT COUNT(*) FROM session_titles stt
+           JOIN sessions stt_session
+             ON stt_session.workspace_id = stt.workspace_id
+            AND stt_session.session_id = stt.session_id
+           WHERE stt.workspace_id = $1
+             AND stt_session.deleted_at IS NULL
+             AND {memory_service.readable_session_event_condition('stt_session', 2)}) AS tc,
           (SELECT MAX(updated_at) FROM stashes WHERE workspace_id = $1)            AS st,
           (SELECT MAX(sm.created_at) FROM stash_members sm
            JOIN stashes s ON s.id = sm.stash_id
@@ -337,7 +351,7 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
     )
     raw = "|".join(
         [SIDEBAR_ETAG_VERSION]
-        + [str(row[k] or "") for k in ("p", "f", "d", "s", "he", "hc", "st", "sm", "w")]
+        + [str(row[k] or "") for k in ("p", "f", "d", "s", "he", "hc", "tt", "tc", "st", "sm", "w")]
     )
     return f'W/"{_short_hash(raw)}"'
 

--- a/backend/services/github_pr_service.py
+++ b/backend/services/github_pr_service.py
@@ -23,9 +23,7 @@ _PULL_REQUEST_URL = re.compile(
     r"pull/(?P<number>\d+)",
     re.IGNORECASE,
 )
-_SQL_PULL_REQUEST_URL = (
-    r"https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+"
-)
+_SQL_PULL_REQUEST_URL = r"https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+"
 
 
 @dataclass(frozen=True)
@@ -73,8 +71,7 @@ def labels_for_pull_request(pr: GitHubPullRequest) -> list[linear_ticket_service
         (pr.body, "github_pr_body", 0.85),
     ]
     sources.extend(
-        (message, "github_pr_commit", 0.8)
-        for message in pr.commit_messages[:MAX_COMMIT_MESSAGES]
+        (message, "github_pr_commit", 0.8) for message in pr.commit_messages[:MAX_COMMIT_MESSAGES]
     )
     return linear_ticket_service.extract_ticket_mentions(sources)
 

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -236,9 +236,7 @@ async def _upsert_sessions_for_events(
             created_by=created_by,
         )
         contents = [
-            event.get("content") or ""
-            for event in events
-            if event.get("session_id") == session_id
+            event.get("content") or "" for event in events if event.get("session_id") == session_id
         ]
         if linear_ticket_service.has_ticket_hint(contents):
             await linear_ticket_service.sync_session_labels(workspace_id, row["id"], session_id)

--- a/backend/tasks/linear_tickets.py
+++ b/backend/tasks/linear_tickets.py
@@ -33,4 +33,6 @@ def reconcile() -> int:
 
 @celery.task(name="backend.tasks.linear_tickets.reconcile_github_prs")
 def reconcile_github_prs() -> int:
-    return run_async(github_pr_service.discover_unprocessed_sessions(GITHUB_PR_RECONCILE_BATCH_SIZE))
+    return run_async(
+        github_pr_service.discover_unprocessed_sessions(GITHUB_PR_RECONCILE_BATCH_SIZE)
+    )

--- a/backend/tests/test_github_pr_service.py
+++ b/backend/tests/test_github_pr_service.py
@@ -52,8 +52,7 @@ def test_labels_for_pull_request_reads_branch_title_body_and_commits():
     )
 
     labels = {
-        label.ticket_identifier: label
-        for label in github_pr_service.labels_for_pull_request(pr)
+        label.ticket_identifier: label for label in github_pr_service.labels_for_pull_request(pr)
     }
 
     assert labels["FER-19"].source == "github_pr_title"

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -7,6 +7,7 @@ endpoint in the shape the session viewer can parse.
 
 import io
 import json
+from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
@@ -275,6 +276,59 @@ URL: https://linear.app/ferganalabs/issue/FER-19/we-should-be-able-to-update-the
     )
     assert mine.status_code == 200
     assert mine.json()["sessions"][0]["linear_tickets"][0]["ticket_identifier"] == "FER-19"
+
+
+@pytest.mark.asyncio
+async def test_workspace_sidebar_etag_changes_after_generated_title(
+    client: AsyncClient,
+    pool,
+):
+    key = await _register(client)
+    ws = await _workspace(client, key)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    pushed = await client.post(
+        f"/api/v1/workspaces/{ws}/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "codex",
+                    "event_type": "user_message",
+                    "content": "Please make the release checklist easier to scan.",
+                    "session_id": "sess-generated-title",
+                    "created_at": "2026-05-10T20:00:00Z",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert pushed.status_code == 201
+
+    sidebar = await client.get(f"/api/v1/workspaces/{ws}/sidebar", headers=headers)
+    assert sidebar.status_code == 200
+    etag = sidebar.headers["etag"]
+    [fallback_session] = sidebar.json()["sessions"]
+    assert fallback_session["title"] == "Make the release checklist easier to scan"
+
+    await pool.execute(
+        """
+        INSERT INTO session_titles (workspace_id, session_id, title, source_hash)
+        VALUES ($1, $2, $3, $4)
+        """,
+        UUID(ws),
+        "sess-generated-title",
+        "Release Checklist Readability",
+        "test-source-hash",
+    )
+
+    refreshed = await client.get(
+        f"/api/v1/workspaces/{ws}/sidebar",
+        headers={**headers, "If-None-Match": etag},
+    )
+    assert refreshed.status_code == 200
+    assert refreshed.headers["etag"] != etag
+    [generated_session] = refreshed.json()["sessions"]
+    assert generated_session["title"] == "Release Checklist Readability"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Include `session_titles` updates in the workspace sidebar ETag, so generated titles invalidate cached sidebar payloads.
- Add a forward repair migration that ensures the `session_titles` cache table exists after the current migration chain.
- Add regression coverage for a fallback sidebar title becoming an AI-generated cached title.
- Run Black on the backend files that the current `main` merge caused CI to flag.

## Why
The sidebar could serve fallback, prompt-derived titles before background AI generation finished. After Celery wrote `session_titles`, the sidebar ETag did not change, so clients could keep getting `304 Not Modified` and continue rendering the fallback title.

I also found a database stamped at migration `0069` without the `session_titles` table. The new `0072` migration repairs that state while remaining harmless for databases where `0069_session_titles` already ran.

## Validation
- `ruff check backend/ cli/ && black --check backend/ cli/`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_session_titles pytest --no-cov backend/tests/test_transcripts.py::test_workspace_sidebar_etag_changes_after_generated_title backend/tests/test_transcripts.py::test_workspace_sidebar_sessions_include_human_author backend/tests/test_transcripts.py::test_session_linear_ticket_labels_are_extracted`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_session_titles pytest --no-cov backend/tests/test_session_title_service.py`