### PR TITLE
[codex] Show single-file Stashes as previews

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1137,9 +1137,11 @@ def upload(
     with _client() as c:
         root_folder = c.create_folder(ws, root_name)
         folder_cache: dict[tuple[str, str], str] = {}
-        stash_items: list[dict] = [
-            {"object_type": "folder", "object_id": root_folder["id"], "position": 0},
-        ]
+        stash_items: list[dict] = []
+        if target.is_dir():
+            stash_items.append(
+                {"object_type": "folder", "object_id": root_folder["id"], "position": 0}
+            )
 
         for file_path in files:
             relative_path = (
@@ -1155,7 +1157,16 @@ def upload(
 
             if _is_upload_text_file(file_path):
                 content = file_path.read_text(errors="replace")
-                c.create_page(ws, file_path.name, content=content, folder_id=folder_id)
+                page = c.create_page(ws, file_path.name, content=content, folder_id=folder_id)
+                if target.is_file():
+                    stash_items.append(
+                        {
+                            "object_type": "page",
+                            "object_id": page["id"],
+                            "position": len(stash_items),
+                            "label_override": str(relative_path),
+                        }
+                    )
                 console.print(f"  [dim]Page: {relative_path}[/dim]")
                 continue
 

--- a/cli/tests/test_share_and_upload_helpers.py
+++ b/cli/tests/test_share_and_upload_helpers.py
@@ -28,3 +28,94 @@ def test_file_app_url_points_to_workspace_file_viewer(monkeypatch) -> None:
         _file_app_url({"workspace_id": workspace_id, "id": file_id})
         == f"https://app.example/workspaces/{workspace_id}/f/{file_id}"
     )
+
+
+def test_single_blob_upload_publishes_only_the_file_item(monkeypatch, tmp_path) -> None:
+    uploaded = tmp_path / "shot.png"
+    uploaded.write_bytes(b"png")
+    published_items = []
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def create_folder(self, _workspace_id, name, parent_folder_id=None):
+            assert parent_folder_id is None
+            return {"id": "folder-1", "name": name}
+
+        def upload_ws_file(self, _workspace_id, path):
+            assert path == str(uploaded)
+            return {"id": "file-1", "name": uploaded.name, "url": "https://files.test/shot.png"}
+
+        def create_page(self, *_args, **_kwargs):
+            return {"id": "page-1"}
+
+        def publish_stash(self, _workspace_id, title, description, items):
+            published_items.extend(items)
+            return {
+                "stash": {"id": "stash-1", "slug": "shot"},
+                "url": "https://app.example/stashes/shot",
+            }
+
+    monkeypatch.setattr(main, "_require_auth", lambda: None)
+    monkeypatch.setattr(main, "_resolve_workspace", lambda: "workspace-1")
+    monkeypatch.setattr(main, "_client", lambda: FakeClient())
+
+    main.upload(str(uploaded), name="", workspace_id=None, public=True, as_json=False)
+
+    assert published_items == [
+        {
+            "object_type": "file",
+            "object_id": "file-1",
+            "position": 0,
+            "label_override": "shot.png",
+        }
+    ]
+
+
+def test_single_text_upload_publishes_only_the_page_item(monkeypatch, tmp_path) -> None:
+    uploaded = tmp_path / "notes.md"
+    uploaded.write_text("# Notes")
+    published_items = []
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def create_folder(self, _workspace_id, name, parent_folder_id=None):
+            assert parent_folder_id is None
+            return {"id": "folder-1", "name": name}
+
+        def create_page(self, _workspace_id, name, content, folder_id):
+            assert name == "notes.md"
+            assert content == "# Notes"
+            assert folder_id == "folder-1"
+            return {"id": "page-1"}
+
+        def publish_stash(self, _workspace_id, title, description, items):
+            published_items.extend(items)
+            return {
+                "stash": {"id": "stash-1", "slug": "notes"},
+                "url": "https://app.example/stashes/notes",
+            }
+
+    monkeypatch.setattr(main, "_require_auth", lambda: None)
+    monkeypatch.setattr(main, "_resolve_workspace", lambda: "workspace-1")
+    monkeypatch.setattr(main, "_client", lambda: FakeClient())
+
+    main.upload(str(uploaded), name="", workspace_id=None, public=True, as_json=False)
+
+    assert published_items == [
+        {
+            "object_type": "page",
+            "object_id": "page-1",
+            "position": 0,
+            "label_override": "notes.md",
+        }
+    ]

--- a/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.test.tsx
@@ -394,4 +394,52 @@ describe("StashPageClient sharing", () => {
 
     expect(await screen.findByText("by Sam")).toBeInTheDocument();
   });
+
+  it("opens single uploaded file stashes directly on the file preview", async () => {
+    const detail = stashDetail({
+      description: "<p>Uploaded from shot.png</p>",
+    });
+    detail.items = [
+      {
+        object_type: "folder",
+        object_id: "folder-1",
+        position: 0,
+        label: "shot",
+        inline: {
+          pages: [],
+          files: [
+            {
+              id: "file-1",
+              name: "shot.png",
+              content_type: "image/png",
+              size_bytes: 1234,
+              url: "https://files.test/shot.png",
+            },
+          ],
+        },
+      },
+      {
+        object_type: "file",
+        object_id: "file-1",
+        position: 1,
+        label: "shot.png",
+        inline: {
+          name: "shot.png",
+          content_type: "image/png",
+          size_bytes: 1234,
+          url: "https://files.test/shot.png",
+        },
+      },
+    ];
+    vi.mocked(getPublicStash).mockResolvedValueOnce(detail);
+
+    render(<StashPageClient slug="shared-stash" />);
+
+    const image = await screen.findByRole("img", { name: "shot.png" });
+    expect(image).toHaveAttribute("src", "https://files.test/shot.png");
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Files" })).not.toBeInTheDocument();
+    expect(getActivityTimeline).not.toHaveBeenCalled();
+    expect(getEmbeddingProjection).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/app/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/stashes/[slug]/StashPageClient.tsx
@@ -39,6 +39,14 @@ type StashItemGroup = Partial<
   Record<PublicStashItem["object_type"], PublicStashItem[]>
 >;
 
+type InlineFile = {
+  name?: string;
+  content_type?: string;
+  size_bytes?: number;
+  url?: string;
+  created_at?: string;
+};
+
 // Signed-in viewers see the Stash inside AppShell (sidebar + top bar) so
 // navigation context is preserved. Anonymous viewers see the raw page.
 function StashChrome({
@@ -169,6 +177,8 @@ function StashPageBody({
 }) {
   const { stash, workspace_name, items, can_write } = data;
   const groups = groupStashItems(items);
+  const primaryFile = primaryFileItemForStash(data);
+  const displayedItemCount = primaryFile ? 1 : items.length;
   const [addOpen, setAddOpen] = useState(false);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(
@@ -177,6 +187,13 @@ function StashPageBody({
   const [insightsLoaded, setInsightsLoaded] = useState(false);
 
   useEffect(() => {
+    if (primaryFile) {
+      setTimeline(null);
+      setProjection(null);
+      setInsightsLoaded(true);
+      return;
+    }
+
     // Visualizations are workspace-scoped — they show the owning workspace's
     // activity so the stash detail page has the same "knowledge map" feel
     // as the workspace home.
@@ -194,7 +211,7 @@ function StashPageBody({
     return () => {
       cancelled = true;
     };
-  }, [stash.workspace_id]);
+  }, [primaryFile, stash.workspace_id]);
 
   const cover = stash.cover_image_url
     ? { backgroundImage: `url(${stash.cover_image_url})` }
@@ -240,7 +257,8 @@ function StashPageBody({
                 <span>by {author}</span>
                 <span className="text-muted/60">·</span>
                 <span>
-                  {items.length} item{items.length === 1 ? "" : "s"}
+                  {displayedItemCount} item
+                  {displayedItemCount === 1 ? "" : "s"}
                 </span>
                 {stash.updated_at && (
                   <>
@@ -297,83 +315,89 @@ function StashPageBody({
           }}
         />
 
-        {/* Compact item lists by kind. Items deep-link to the editor /
-            viewer in the owning workspace — no inline rendering. */}
-        <div className="mt-6 flex flex-col gap-6">
-          {/* Two high-level taxonomies: Files (folders + pages + files +
-              tables — anything you could drop into Drive) and Sessions
-              (agent transcripts). Tables are a structured kind of file,
-              so they live under Files rather than as a separate section. */}
-          <StashItemSection
-            title="Files"
-            items={[
-              ...(groups.folder ?? []),
-              ...(groups.page ?? []),
-              ...(groups.file ?? []),
-              ...(groups.table ?? []),
-            ]}
-            stashSlug={stash.slug}
-            workspaceId={stash.workspace_id}
-          />
-          <StashItemSection
-            title="Sessions"
-            items={groups.session ?? []}
-            stashSlug={stash.slug}
-            workspaceId={stash.workspace_id}
-          />
-          {items.length === 0 && (
-            <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[13px] text-muted">
-              No items yet.{" "}
-              {can_write && (
-                <button
-                  type="button"
-                  onClick={() => setAddOpen(true)}
-                  className="font-medium text-[var(--color-brand-700)] hover:underline"
-                >
-                  Add things →
-                </button>
+        {primaryFile ? (
+          <SingleFilePreview item={primaryFile} />
+        ) : (
+          <>
+            {/* Compact item lists by kind. Items deep-link to the editor /
+                viewer in the owning workspace — no inline rendering. */}
+            <div className="mt-6 flex flex-col gap-6">
+              {/* Two high-level taxonomies: Files (folders + pages + files +
+                  tables — anything you could drop into Drive) and Sessions
+                  (agent transcripts). Tables are a structured kind of file,
+                  so they live under Files rather than as a separate section. */}
+              <StashItemSection
+                title="Files"
+                items={[
+                  ...(groups.folder ?? []),
+                  ...(groups.page ?? []),
+                  ...(groups.file ?? []),
+                  ...(groups.table ?? []),
+                ]}
+                stashSlug={stash.slug}
+                workspaceId={stash.workspace_id}
+              />
+              <StashItemSection
+                title="Sessions"
+                items={groups.session ?? []}
+                stashSlug={stash.slug}
+                workspaceId={stash.workspace_id}
+              />
+              {items.length === 0 && (
+                <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[13px] text-muted">
+                  No items yet.{" "}
+                  {can_write && (
+                    <button
+                      type="button"
+                      onClick={() => setAddOpen(true)}
+                      className="font-medium text-[var(--color-brand-700)] hover:underline"
+                    >
+                      Add things →
+                    </button>
+                  )}
+                </div>
               )}
             </div>
-          )}
-        </div>
 
-        {/* Visualizations: human/agent session activity + 3D embedding view of the
-            owning workspace — same shape as workspace home. */}
-        <section className="mt-8">
-          <div className="sys-label mb-1.5">
-            Human / agent commits — last 30 days
-          </div>
-          <div className="card-soft overflow-x-auto p-3">
-            {!insightsLoaded ? (
-              <SkeletonBlock className="h-40 w-full" />
-            ) : timeline && timeline.contributors.length > 0 ? (
-              <ContributorActivityTimeline data={timeline} />
-            ) : (
-              <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No agent session commits yet. Add a session to this Stash or
-                push a transcript via the CLI.
+            {/* Visualizations: human/agent session activity + 3D embedding view of the
+                owning workspace — same shape as workspace home. */}
+            <section className="mt-8">
+              <div className="sys-label mb-1.5">
+                Human / agent commits — last 30 days
               </div>
-            )}
-          </div>
-        </section>
+              <div className="card-soft overflow-x-auto p-3">
+                {!insightsLoaded ? (
+                  <SkeletonBlock className="h-40 w-full" />
+                ) : timeline && timeline.contributors.length > 0 ? (
+                  <ContributorActivityTimeline data={timeline} />
+                ) : (
+                  <div className="px-2 py-6 text-center text-[12.5px] text-muted">
+                    No agent session commits yet. Add a session to this Stash or
+                    push a transcript via the CLI.
+                  </div>
+                )}
+              </div>
+            </section>
 
-        <section className="mt-6">
-          <div className="sys-label mb-1.5">
-            Embedding space — workspace knowledge map
-          </div>
-          <div className="card-soft p-3">
-            {!insightsLoaded ? (
-              <SkeletonBlock className="h-40 w-full" />
-            ) : projection && projection.points.length > 0 ? (
-              <EmbeddingSpaceExplorer data={projection} />
-            ) : (
-              <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No embeddings indexed yet. Pages, table rows, and session events
-                get embedded as they&apos;re added.
+            <section className="mt-6">
+              <div className="sys-label mb-1.5">
+                Embedding space — workspace knowledge map
               </div>
-            )}
-          </div>
-        </section>
+              <div className="card-soft p-3">
+                {!insightsLoaded ? (
+                  <SkeletonBlock className="h-40 w-full" />
+                ) : projection && projection.points.length > 0 ? (
+                  <EmbeddingSpaceExplorer data={projection} />
+                ) : (
+                  <div className="px-2 py-6 text-center text-[12.5px] text-muted">
+                    No embeddings indexed yet. Pages, table rows, and session
+                    events get embedded as they&apos;re added.
+                  </div>
+                )}
+              </div>
+            </section>
+          </>
+        )}
       </div>
 
       {can_write && (
@@ -390,6 +414,83 @@ function StashPageBody({
       )}
     </div>
   );
+}
+
+function primaryFileItemForStash(data: PublicStashDetail): PublicStashItem | null {
+  const fileItems = data.items.filter((item) => item.object_type === "file");
+  if (fileItems.length !== 1) return null;
+  if (data.items.length === 1) return fileItems[0];
+
+  const onlyFileAndUploadFolder = data.items.every((item) =>
+    item.object_type === "file" || item.object_type === "folder"
+  );
+  if (!onlyFileAndUploadFolder) return null;
+  if (!data.stash.description.includes("Uploaded from ")) return null;
+  return fileItems[0];
+}
+
+function SingleFilePreview({ item }: { item: PublicStashItem }) {
+  const file = item.inline as InlineFile;
+  const name = file.name || item.label || "Uploaded file";
+  const contentType = file.content_type || "file";
+  const size = formatFileSize(file.size_bytes ?? 0);
+  const isImage = contentType.startsWith("image/");
+  const isPdf = contentType.includes("pdf");
+
+  return (
+    <section className="mt-6">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="m-0 truncate font-display text-[16px] font-semibold text-foreground">
+            {name}
+          </h2>
+          <div className="mt-0.5 text-[12px] text-muted">
+            {contentType} · {size}
+          </div>
+        </div>
+        {file.url && (
+          <a
+            href={file.url}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
+          >
+            Download ↗
+          </a>
+        )}
+      </div>
+
+      {!file.url && (
+        <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[13px] text-muted">
+          This file is no longer available.
+        </div>
+      )}
+      {file.url && isImage && (
+        <div className="overflow-auto rounded-lg border border-border bg-surface">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={file.url} alt={name} className="mx-auto h-auto max-w-full" />
+        </div>
+      )}
+      {file.url && isPdf && (
+        <iframe
+          src={file.url}
+          title={name}
+          className="h-[78vh] w-full rounded-lg border border-border bg-base"
+        />
+      )}
+      {file.url && !isImage && !isPdf && (
+        <div className="rounded-lg border border-border bg-base px-5 py-10 text-center text-[13px] text-muted">
+          No inline preview for this file type.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 // Clickable banner. Writers see a faint "Change banner" hint on hover and


### PR DESCRIPTION
## Summary

Single-file Stash upload links now open as content-first preview pages instead of showing the generic folder/file listing.

- Detects one-file upload Stashes, including existing CLI-created Stashes that contain both the wrapper folder and the file item.
- Shows the uploaded image/PDF/file metadata as the primary content and counts it as `1 item` in the header.
- Skips workspace insight panels for that one-file payload case so the file is immediately visible.
- Changes `stash upload <single-file>` so future single-file uploads publish only the file item; single text-file uploads publish only the page item.

## Root Cause

`stash upload` always created a wrapper folder, uploaded the file inside it, and added both the folder and the file to the public Stash item list. That made a single image upload look like two things and forced the user to click deeper before seeing the payload.

## Validation

- `cd frontend && npm test -- StashPageClient.test.tsx`
- `cd frontend && npm run build`
- `cd frontend && npm run lint` (passes with 5 existing warnings outside this change)
- `python -m ruff check cli/main.py cli/tests/test_share_and_upload_helpers.py`
- `pytest --no-cov cli/tests/test_share_and_upload_helpers.py`
- Browser check with local frontend against public Stash API: `http://localhost:3467/stashes/cleanshot-2026-05-20-at-17-11-21-2x-zp9r6g`

## Product Screenshot

Captured local validation screenshot: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/7d050564-849f-4ec8-adc0-85152a4ba87b