### PR TITLE
[codex] Gate disabled upload warnings to connected repos

### DIFF
--- a/plugins/tests/test_upload_health_warning.py
+++ b/plugins/tests/test_upload_health_warning.py
@@ -81,14 +81,44 @@ def test_uploads_disabled_warning_is_once_per_session(monkeypatch, tmp_path):
     warning = uploads_disabled_warning(cfg, state, _event("s1"), tmp_path)
 
     assert warning == (
-        "Hey btw, Stash uploads aren't enabled. Run `stash connect` or `stash start` "
-        "to enable them."
+        "Stash is connected to this repo, but uploads aren't set up on this machine. "
+        "Run `stash connect` to finish setup."
     )
     assert load_state(tmp_path)["uploads_disabled_warning_session_id"] == "s1"
     assert uploads_disabled_warning(cfg, state, _event("s1"), tmp_path) is None
 
     assert uploads_disabled_warning(cfg, state, _event("s2"), tmp_path)
     assert load_state(tmp_path)["uploads_disabled_warning_session_id"] == "s2"
+
+
+def test_uploads_disabled_warning_skips_unconnected_repo(monkeypatch, tmp_path):
+    monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
+    monkeypatch.setattr(hooks, "find_manifest", lambda cwd: None)
+
+    cfg = {**_cfg(), "workspace_id": "", "api_key": ""}
+
+    warning = uploads_disabled_warning(cfg, {}, _event("s1"), tmp_path)
+
+    assert warning is None
+
+
+def test_uploads_disabled_warning_skips_disabled_agent(monkeypatch, tmp_path):
+    monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {"enabled_agents": ["claude"]})
+
+    warning = uploads_disabled_warning(_cfg(), {}, _event("s1"), tmp_path)
+
+    assert warning is None
+
+
+def test_uploads_disabled_warning_skips_stopped_workspace(monkeypatch, tmp_path):
+    monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
+    monkeypatch.setattr(hooks, "_read_user_config", lambda: {"stopped_streaming": ["ws1"]})
+
+    warning = uploads_disabled_warning(_cfg(), {}, _event("s1"), tmp_path)
+
+    assert warning is None
 
 
 def test_uploads_disabled_warning_requires_stash_cli(monkeypatch, tmp_path):

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -44,8 +44,8 @@ _UPLOAD_WARNING_MESSAGE = (
 )
 _UPLOADS_DISABLED_WARNING_SESSION_KEY = "uploads_disabled_warning_session_id"
 _UPLOADS_DISABLED_WARNING_MESSAGE = (
-    "Hey btw, Stash uploads aren't enabled. Run `stash connect` or `stash start` "
-    "to enable them."
+    "Stash is connected to this repo, but uploads aren't set up on this machine. "
+    "Run `stash connect` to finish setup."
 )
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
@@ -125,7 +125,7 @@ def uploads_disabled_warning(
     event: HookEvent | None,
     data_dir: Path,
 ) -> str | None:
-    """Return the once-per-session warning when Stash is installed but idle."""
+    """Return the once-per-session warning for a connected repo missing setup."""
     if uploads_enabled(cfg, event):
         return None
     session_id = getattr(event, "session_id", "") if event is not None else ""
@@ -134,6 +134,10 @@ def uploads_disabled_warning(
     if state.get(_UPLOADS_DISABLED_WARNING_SESSION_KEY) == session_id:
         return None
     if shutil.which("stash") is None:
+        return None
+    if not _resolve_workspace(cfg, event):
+        return None
+    if cfg.get("api_key") and cfg.get("agent_name"):
         return None
 
     state[_UPLOADS_DISABLED_WARNING_SESSION_KEY] = session_id


### PR DESCRIPTION
## Summary
- Gate the SessionStart disabled-upload warning to connected repos only.
- Keep the warning silent when the current repo has no Stash manifest, the current agent is disabled, or the workspace was explicitly stopped.
- Reword the remaining setup warning so it points at local setup instead of implying hooks are missing.

## Root Cause
The warning treated every non-uploading state as actionable, so globally installed hooks warned in repos where Stash was never connected and in cases where the user had intentionally disabled streaming.

## Validation
- `PYTHONPATH=$PWD pytest --no-cov plugins/tests/test_upload_health_warning.py`
- `PYTHONPATH=$PWD pytest --no-cov plugins/tests/test_session_upload.py plugins/tests/test_scope.py`
- `ruff check stashai/plugin/hooks.py plugins/tests/test_upload_health_warning.py`