### PR TITLE
[codex] Fix sidebar session title display

### DIFF
--- a/backend/migrations/versions/0073_clean_session_title_markdown.py
+++ b/backend/migrations/versions/0073_clean_session_title_markdown.py
@@ -1,0 +1,32 @@
+"""Clean markdown prefixes from generated session titles.
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+
+revision = "0073"
+down_revision = "0072"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE session_titles
+        SET title = BTRIM(
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(title, '^[[:space:]]*title:[[:space:]]*', '', 'i'),
+                '^[[:space:]]{0,3}#{1,6}[[:space:]]*',
+                ''
+            )
+        ),
+        updated_at = now()
+        WHERE title ~* '^[[:space:]]*(title:[[:space:]]*)?[[:space:]]*#{1,6}[[:space:]]*'
+        """)
+
+
+def downgrade() -> None:
+    pass

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -110,6 +110,15 @@ def title_from_events(events: list[dict], session_id: str) -> str:
     return session_id
 
 
+def clean_generated_title(text: str) -> str:
+    title = re.sub(r"\s+", " ", text).strip("`\"' ")
+    title = re.sub(r"^\s*title:\s*", "", title, flags=re.IGNORECASE)
+    title = _strip_markdown(title)
+    if not title:
+        return ""
+    return _truncate(_first_clause(title))
+
+
 def _title_from_first_matching_event(events: list[dict], event_types: tuple[str, ...]) -> str:
     for event in events:
         if event.get("event_type") not in event_types:

--- a/backend/tasks/session_titles.py
+++ b/backend/tasks/session_titles.py
@@ -19,10 +19,7 @@ def _clean_text(text: str) -> str:
 
 
 def _clean_title(text: str) -> str:
-    title = _clean_text(text).strip("`\"' ")
-    if title.lower().startswith("title:"):
-        title = title[6:].strip()
-    return session_title_service._truncate(title)
+    return session_title_service.clean_generated_title(text)
 
 
 async def _session_stats(workspace_id: UUID, session_id: str) -> dict | None:

--- a/backend/tests/test_session_title_service.py
+++ b/backend/tests/test_session_title_service.py
@@ -3,7 +3,11 @@ from uuid import UUID
 import pytest
 
 from backend.services import session_title_service
-from backend.services.session_title_service import title_from_events, title_from_text
+from backend.services.session_title_service import (
+    clean_generated_title,
+    title_from_events,
+    title_from_text,
+)
 
 
 def test_title_from_text_uses_first_non_empty_line():
@@ -65,6 +69,15 @@ def test_title_from_text_uses_linear_issue_title():
 
 def test_title_from_text_falls_back_to_session_id_for_empty_text():
     assert title_from_text("", "session-1") == "session-1"
+
+
+def test_clean_generated_title_strips_markdown_heading_prefixes():
+    assert clean_generated_title("# Update CLI API Shape for Stash Publishing") == (
+        "Update CLI API Shape for Stash Publishing"
+    )
+    assert clean_generated_title("Title: **Review Stash PRD for Contradictions**") == (
+        "Review Stash PRD for Contradictions"
+    )
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -453,7 +453,7 @@ export default function AppShell({
         style={{
           gridTemplateColumns: sidebarCollapsed
             ? "minmax(0, 1fr)"
-            : "260px minmax(0, 1fr)",
+            : "300px minmax(0, 1fr)",
         }}
       >
         {!sidebarCollapsed && (

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -493,6 +493,25 @@ describe("AppSidebar tree expansion", () => {
     expect(screen.getByText(expectedSidebarTimestamp(lastAt))).toBeTruthy();
   });
 
+  it("keeps full cleaned session titles in the sidebar row", async () => {
+    vi.mocked(getWorkspaceSidebar).mockResolvedValue(
+      sidebarWithSessions([
+        sidebarSession(
+          "generated-title",
+          "# Integrate Stash VFS with Agent Environments",
+          "Henry",
+          "2026-05-20T12:00:00Z"
+        ),
+      ])
+    );
+
+    renderSidebar();
+
+    const title = await screen.findByText("Integrate Stash VFS with Agent Environments");
+    expect(title).toHaveAttribute("title", "Integrate Stash VFS with Agent Environments");
+    expect(screen.queryByText("# Integrate Stash VFS with")).toBeNull();
+  });
+
   it("limits visible session periods and reveals more on demand", async () => {
     vi.mocked(getWorkspaceSidebar).mockResolvedValue(
       sidebarWithSessions(

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -262,7 +262,7 @@ function NavRow({
     <Link
       href={href}
       className={
-        "page-row group/nav flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-[13px] transition-colors " +
+        "page-row group/nav flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-[13px] transition-colors " +
         (active
           ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
           : "text-dim hover:bg-raised hover:text-foreground")
@@ -270,8 +270,8 @@ function NavRow({
       onClick={onClick}
       onContextMenu={onContextMenu}
     >
-      <span className="flex h-4 w-4 items-center justify-center text-[14px]">{icon}</span>
-      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center text-[14px]">{icon}</span>
+      <span className="min-w-0 flex-1 truncate" title={label}>{label}</span>
       {trailing}
     </Link>
   );
@@ -559,7 +559,17 @@ function fileIconClass(contentType: string | undefined): string {
 
 function sessionLabelForSidebar(session: WorkspaceSidebarSession): string {
   const raw = (session.title || session.session_id).trim();
-  return raw.length > 26 ? `${raw.slice(0, 26)}…` : raw;
+  return cleanSessionTitle(raw) || session.session_id;
+}
+
+function cleanSessionTitle(title: string): string {
+  return title
+    .replace(/^\s*title:\s*/i, "")
+    .replace(/^\s{0,3}#{1,6}\s*/, "")
+    .replace(/\*\*/g, "")
+    .replace(/__/g, "")
+    .replace(/`/g, "")
+    .trim();
 }
 
 function primarySessionTicket(session: WorkspaceSidebarSession) {
@@ -597,7 +607,7 @@ function sessionTimestamp(session: WorkspaceSidebarSession): number {
   return date ? date.getTime() : 0;
 }
 
-type SessionTimestampMode = "time" | "dateTime";
+type SessionTimestampMode = "time" | "date" | "dateTime";
 
 function formatSessionSidebarTimestamp(
   session: WorkspaceSidebarSession,
@@ -615,6 +625,7 @@ function formatSessionSidebarTimestamp(
   const time = `${hour}:${minutes}${suffix}`;
 
   if (mode === "time") return time;
+  if (mode === "date") return `${month}/${day}`;
   return `${month}/${day} ${time}`;
 }
 
@@ -672,7 +683,7 @@ function SessionRowTrailing({
   timestampMode?: SessionTimestampMode;
 }) {
   return (
-    <span className="ml-1 flex shrink-0 items-center gap-1">
+    <span className="ml-0.5 flex shrink-0 items-center gap-1">
       <SessionTicketPill ticket={primarySessionTicket(session)} />
       <SessionRowTimestamp session={session} active={active} mode={timestampMode} />
     </span>
@@ -1297,7 +1308,7 @@ function SessionTreeDetails({
   const visibleUsers = group.users.slice(0, visibleUserLimit);
   const hiddenUserCount = group.users.length - visibleUsers.length;
   const timestampMode: SessionTimestampMode =
-    group.bucket === "day" ? "time" : "dateTime";
+    group.bucket === "day" ? "time" : "date";
 
   useEffect(() => {
     if (hasActiveSession) setOpen(true);

--- a/frontend/src/components/SkeletonStates.tsx
+++ b/frontend/src/components/SkeletonStates.tsx
@@ -83,7 +83,7 @@ export function AppShellSkeleton({
       <HeaderSkeleton />
       <div
         className="grid min-h-0 flex-1 overflow-hidden"
-        style={{ gridTemplateColumns: sidebar ? "260px minmax(0, 1fr)" : "minmax(0, 1fr)" }}
+        style={{ gridTemplateColumns: sidebar ? "300px minmax(0, 1fr)" : "minmax(0, 1fr)" }}
       >
         {sidebar && <SidebarSkeleton />}
         <main className="min-w-0 overflow-y-auto bg-base">


### PR DESCRIPTION
## Summary

Fixes the sidebar session-title display regression visible in prod:

- keep the full cleaned session title in sidebar rows instead of pre-truncating to 26 characters
- strip markdown/title prefixes like `#` and `Title:` from generated session titles
- shorten rolled-up session timestamps from `M/D h:mm` to `M/D` to give titles more room
- widen the app sidebar from 260px to 300px and keep skeleton layout in sync
- add a migration to clean existing cached `session_titles` rows with markdown heading prefixes

## Root Cause

The previous backend cache fix made generated titles available to the sidebar, but the UI still made them look broken. The row label helper truncated every session title before layout, then the nested sidebar/timestamp layout clipped that already-short string again. Separately, AI-generated titles could be stored with markdown heading prefixes, so rows displayed as `# ...` even when they were generated summaries.

## Screenshot

Browser-verified against prod API with this branch: https://app.joinstash.ai/stashes/stash-sidebar-session-rows-title-display-ymhwew

## Validation

- `pytest --no-cov backend/tests/test_session_title_service.py`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_session_titles pytest --no-cov backend/tests/test_transcripts.py::test_workspace_sidebar_etag_changes_after_generated_title`
- `black --check backend/ cli/ && ruff check backend/ cli/`
- `cd frontend && npm test -- AppSidebar.test.tsx --run`
- `cd frontend && npm run lint` (passes with existing warnings only)
- `cd frontend && npm run build`
- `alembic upgrade head`
