### PR TITLE
Nest stash sidebar items under folders

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -244,7 +244,19 @@ const sidebarWithNestedStashItems = {
         folder_id: null,
       },
     ],
-    files: [],
+    files: [
+      {
+        id: "file-table",
+        workspace_id: "ws-1",
+        folder_id: "folder-product",
+        name: "service-matrix.csv",
+        size_bytes: 12,
+        content_type: "text/csv",
+        url: null,
+        created_at: "2026-05-11T00:00:00Z",
+        linked_table_id: "table-1",
+      },
+    ],
   },
   stashes: [
     {
@@ -259,7 +271,7 @@ const sidebarWithNestedStashItems = {
       discoverable: false,
       is_external: false,
       forked_from_stash_id: null,
-      item_count: 3,
+      item_count: 5,
       items: [
         {
           object_type: "page" as const,
@@ -270,7 +282,7 @@ const sidebarWithNestedStashItems = {
         {
           object_type: "folder" as const,
           object_id: "folder-product",
-          label_override: null,
+          label_override: "Custom product folder",
           position: 1,
         },
         {
@@ -278,6 +290,18 @@ const sidebarWithNestedStashItems = {
           object_id: "page-hover",
           label_override: "Hover QA notes",
           position: 2,
+        },
+        {
+          object_type: "file" as const,
+          object_id: "file-table",
+          label_override: "CSV-backed service matrix",
+          position: 3,
+        },
+        {
+          object_type: "table" as const,
+          object_id: "table-1",
+          label_override: "Feature readiness table",
+          position: 4,
         },
       ],
       updated_at: "2026-05-11T00:00:00Z",
@@ -1071,7 +1095,17 @@ describe("AppSidebar tree expansion", () => {
       within(productDetails).getByRole("link", { name: "Sidebar polish notes" })
     ).toBeTruthy();
     expect(
+      within(productDetails).getAllByRole("link", { name: "service-matrix.csv" })
+    ).toHaveLength(1);
+    expect(within(stashes).queryByText("Custom product folder")).toBeNull();
+    expect(
       within(stashes).queryByRole("link", { name: "Product/Sidebar polish notes" })
+    ).toBeNull();
+    expect(
+      within(stashes).queryByRole("link", { name: "CSV-backed service matrix" })
+    ).toBeNull();
+    expect(
+      within(stashes).queryByRole("link", { name: "Feature readiness table" })
     ).toBeNull();
   });
 

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { MouseEvent, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppSidebar from "./AppSidebar";
@@ -209,6 +209,74 @@ const sidebarWithStashFiles = {
           object_type: "file" as const,
           object_id: "file-csv",
           label_override: "Launch table file",
+          position: 2,
+        },
+      ],
+      updated_at: "2026-05-11T00:00:00Z",
+    },
+  ],
+};
+
+const sidebarWithNestedStashItems = {
+  sessions: [],
+  files: {
+    folders: [
+      {
+        id: "folder-product",
+        name: "Product",
+        parent_folder_id: null,
+        page_count: 1,
+        file_count: 0,
+        has_skill: false,
+      },
+    ],
+    pages: [
+      {
+        id: "page-polish",
+        name: "Sidebar polish notes",
+        content_type: "markdown" as const,
+        folder_id: "folder-product",
+      },
+      {
+        id: "page-hover",
+        name: "Hover QA notes",
+        content_type: "markdown" as const,
+        folder_id: null,
+      },
+    ],
+    files: [],
+  },
+  stashes: [
+    {
+      id: "stash-1",
+      workspace_id: "ws-1",
+      slug: "sidebar-review-kit",
+      title: "Sidebar Review Kit",
+      description: "",
+      access: "workspace" as const,
+      workspace_permission: "read" as const,
+      public_permission: "none" as const,
+      discoverable: false,
+      is_external: false,
+      forked_from_stash_id: null,
+      item_count: 3,
+      items: [
+        {
+          object_type: "page" as const,
+          object_id: "page-polish",
+          label_override: "Product/Sidebar polish notes",
+          position: 0,
+        },
+        {
+          object_type: "folder" as const,
+          object_id: "folder-product",
+          label_override: null,
+          position: 1,
+        },
+        {
+          object_type: "page" as const,
+          object_id: "page-hover",
+          label_override: "Hover QA notes",
           position: 2,
         },
       ],
@@ -984,6 +1052,27 @@ describe("AppSidebar tree expansion", () => {
     renderSidebar();
     await screen.findByText("Project Alpha");
     expect(await screen.findByText("Launch session")).toBeTruthy();
+  });
+
+  it("nests stash items under included parent folders", async () => {
+    vi.mocked(getWorkspaceSidebar).mockResolvedValue(sidebarWithNestedStashItems);
+
+    renderSidebar();
+
+    await screen.findByText("Sidebar Review Kit");
+    fireEvent.click(screen.getByLabelText("Expand Sidebar Review Kit"));
+
+    const stashes = detailsFor("Stashes");
+    const productDetails = within(stashes).getByText("Product").closest("details");
+    if (!productDetails) throw new Error("Product folder did not render as a tree");
+
+    expect(productDetails).toHaveAttribute("open");
+    expect(
+      within(productDetails).getByRole("link", { name: "Sidebar polish notes" })
+    ).toBeTruthy();
+    expect(
+      within(stashes).queryByRole("link", { name: "Product/Sidebar polish notes" })
+    ).toBeNull();
   });
 
   it("keeps an expanded stash open when another stash is clicked", async () => {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1502,10 +1502,15 @@ type StashTreeItem = {
   key: string;
   href?: string;
   label: string;
+  nestedLabel?: string;
   icon: React.ReactNode;
   activeKind?: ActiveFileKind;
   activeId?: string;
   activeLinkedTableId?: string | null;
+  folderId?: string;
+  parentFolderId?: string | null;
+  containingFolderId?: string | null;
+  children?: StashTreeItem[];
   session?: WorkspaceSidebarSession;
 };
 
@@ -1529,6 +1534,78 @@ function resolveFolderPath(
   return next;
 }
 
+function nestedStashLabel(label: string): string {
+  const parts = label.split("/");
+  return parts[parts.length - 1]?.trim() || label;
+}
+
+function relativeNestedStashLabel(
+  label: string,
+  parentLabel: string,
+  fallback?: string
+): string {
+  const prefix = `${parentLabel}/`;
+  if (label.startsWith(prefix)) {
+    const relativeLabel = label.slice(prefix.length).trim();
+    if (relativeLabel) return relativeLabel;
+  }
+
+  return fallback ?? nestedStashLabel(label);
+}
+
+function explicitAncestorFolderId(
+  folderId: string | null | undefined,
+  folderRowsById: Map<string, StashTreeItem>,
+  folderById: Map<string, WorkspaceFolder>
+): string | null {
+  let currentId = folderId ?? null;
+  const seen = new Set<string>();
+
+  while (currentId && !seen.has(currentId)) {
+    if (folderRowsById.has(currentId)) return currentId;
+    seen.add(currentId);
+    currentId = folderById.get(currentId)?.parent_folder_id ?? null;
+  }
+
+  return null;
+}
+
+function nestStashTreeItems(
+  rows: StashTreeItem[],
+  folderById: Map<string, WorkspaceFolder>
+): StashTreeItem[] {
+  const treeRows = rows.map((row) => ({ ...row, children: [] }));
+  const rowByKey = new Map(treeRows.map((row) => [row.key, row]));
+  const folderRowsById = new Map<string, StashTreeItem>();
+
+  for (const row of treeRows) {
+    if (row.kind === "folder" && row.folderId) {
+      folderRowsById.set(row.folderId, row);
+    }
+  }
+
+  const nestedKeys = new Set<string>();
+
+  for (const row of rows) {
+    const parentFolderId =
+      row.kind === "folder"
+        ? explicitAncestorFolderId(row.parentFolderId, folderRowsById, folderById)
+        : explicitAncestorFolderId(row.containingFolderId, folderRowsById, folderById);
+
+    if (!parentFolderId) continue;
+
+    const parent = folderRowsById.get(parentFolderId);
+    const child = rowByKey.get(row.key);
+    if (!parent || !child || child.key === parent.key) continue;
+
+    child.label = relativeNestedStashLabel(child.label, parent.label, child.nestedLabel);
+    parent.children?.push(child);
+    nestedKeys.add(child.key);
+  }
+
+  return treeRows.filter((row) => !nestedKeys.has(row.key));
+}
+
 function buildStashTreeItems(
   workspaceId: string,
   items: StashItemSpec[],
@@ -1539,9 +1616,9 @@ function buildStashTreeItems(
   sessionBySessionId: Map<string, WorkspaceSidebarSession>
 ): StashTreeItem[] {
   const pathCache = new Map<string, string>();
-  return [...items]
+  const rows = [...items]
     .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
-    .map((item, index) => {
+    .map((item, index): StashTreeItem => {
       if (item.object_type === "session") {
         const session = sessionById.get(item.object_id) ?? sessionBySessionId.get(item.object_id);
         const fallback = `Session ${item.object_id}`;
@@ -1564,9 +1641,15 @@ function buildStashTreeItems(
           icon: <span className="text-muted"><FolderIcon /></span>,
           activeKind: "folder",
           activeId: item.object_id,
+          folderId: item.object_id,
+          parentFolderId: folder?.parent_folder_id ?? null,
           label:
             item.label_override ??
             (folder ? resolveFolderPath(folder.id, folderById, pathCache) : `Folder ${item.object_id}`),
+          nestedLabel:
+            item.label_override
+              ? nestedStashLabel(item.label_override)
+              : (folder ? folder.name : `Folder ${item.object_id}`),
         };
       }
 
@@ -1579,7 +1662,9 @@ function buildStashTreeItems(
             icon: <span className="text-muted"><PageIcon /></span>,
             activeKind: "page",
             activeId: item.object_id,
+            containingFolderId: null,
             label: item.label_override ?? `Page ${item.object_id}`,
+            nestedLabel: nestedStashLabel(item.label_override ?? `Page ${item.object_id}`),
           };
         }
 
@@ -1592,7 +1677,9 @@ function buildStashTreeItems(
           icon: <span className="text-muted"><PageIcon /></span>,
           activeKind: "page",
           activeId: page.id,
+          containingFolderId: page.folder_id,
           label: item.label_override ?? pagePath,
+          nestedLabel: nestedStashLabel(item.label_override ?? page.name),
         };
       }
 
@@ -1605,7 +1692,9 @@ function buildStashTreeItems(
             icon: <span className={fileIconClass(undefined)}><FileIcon /></span>,
             activeKind: "file",
             activeId: item.object_id,
+            containingFolderId: null,
             label: item.label_override ?? `File ${item.object_id}`,
+            nestedLabel: nestedStashLabel(item.label_override ?? `File ${item.object_id}`),
           };
         }
 
@@ -1619,7 +1708,9 @@ function buildStashTreeItems(
           activeKind: "file",
           activeId: file.id,
           activeLinkedTableId: file.linked_table_id,
+          containingFolderId: file.folder_id,
           label: item.label_override ?? filePath,
+          nestedLabel: nestedStashLabel(item.label_override ?? file.name),
         };
       }
 
@@ -1642,6 +1733,41 @@ function buildStashTreeItems(
         label: item.label_override ?? `${item.object_type} ${item.object_id}`,
       };
     });
+
+  return nestStashTreeItems(rows, folderById);
+}
+
+function stashTreeItemActive(
+  row: StashTreeItem,
+  workspaceId: string,
+  pathname: string
+): boolean {
+  if (!row.href) return false;
+
+  const activeFile = activeFileRef(pathname);
+  if (row.activeKind === "file") {
+    return workspaceFileMatchesActive(activeFile, workspaceId, {
+      id: row.activeId ?? "",
+      linked_table_id: row.activeLinkedTableId ?? null,
+    });
+  }
+
+  if (row.activeKind) {
+    return fileResourceMatchesActive(activeFile, workspaceId, row.activeKind, row.activeId);
+  }
+
+  return pathname === row.href;
+}
+
+function stashTreeItemOrChildActive(
+  row: StashTreeItem,
+  workspaceId: string,
+  pathname: string
+): boolean {
+  if (stashTreeItemActive(row, workspaceId, pathname)) return true;
+  return row.children?.some((child) =>
+    stashTreeItemOrChildActive(child, workspaceId, pathname)
+  ) ?? false;
 }
 
 function StashSidebarRow({
@@ -1741,6 +1867,22 @@ function StashTreeRow({
   row: StashTreeItem;
 }) {
   const pathname = usePathname();
+  const active = stashTreeItemActive(row, workspaceId, pathname);
+  const childActive = row.children?.some((child) =>
+    stashTreeItemOrChildActive(child, workspaceId, pathname)
+  ) ?? false;
+
+  if (row.children?.length) {
+    return (
+      <StashTreeBranch
+        workspaceId={workspaceId}
+        row={row}
+        active={active}
+        childActive={childActive}
+      />
+    );
+  }
+
   if (!row.href) {
     return (
       <div className="page-row flex items-center gap-2 rounded-md px-2 py-0.5 text-[12.5px] text-muted">
@@ -1751,16 +1893,6 @@ function StashTreeRow({
     );
   }
 
-  const activeFile = activeFileRef(pathname);
-  const active =
-    row.activeKind === "file"
-      ? workspaceFileMatchesActive(activeFile, workspaceId, {
-          id: row.activeId ?? "",
-          linked_table_id: row.activeLinkedTableId ?? null,
-        })
-      : row.activeKind
-        ? fileResourceMatchesActive(activeFile, workspaceId, row.activeKind, row.activeId)
-        : pathname === row.href;
   return (
     <NavRow
       href={row.href}
@@ -1771,6 +1903,84 @@ function StashTreeRow({
         row.session ? <SessionRowTrailing session={row.session} active={active} /> : null
       }
     />
+  );
+}
+
+function StashTreeBranch({
+  workspaceId,
+  row,
+  active,
+  childActive,
+}: {
+  workspaceId: string;
+  row: StashTreeItem;
+  active: boolean;
+  childActive: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (childActive) setOpen(true);
+  }, [childActive]);
+
+  return (
+    <details open={open} className="text-[12.5px]">
+      <summary
+        onClick={(event) => {
+          event.preventDefault();
+          setOpen(true);
+        }}
+        className={
+          "page-row flex items-center gap-1 rounded-md px-2 py-0.5 " +
+          (active
+            ? "bg-[var(--color-brand-50)] text-[var(--color-brand-800)]"
+            : "hover:bg-raised")
+        }
+      >
+        <ChevronToggle
+          open={open}
+          ariaLabel={`${open ? "Collapse" : "Expand"} ${row.label}`}
+          onToggle={() => setOpen((current) => !current)}
+        />
+        <span
+          className={
+            "flex h-4 w-4 items-center justify-center text-[14px] " +
+            (active ? "text-[var(--color-brand-700)]" : "text-muted")
+          }
+        >
+          {row.icon}
+        </span>
+        {row.href ? (
+          <Link
+            href={row.href}
+            onClick={(event) => {
+              event.stopPropagation();
+              setOpen(true);
+            }}
+            className={
+              "min-w-0 flex-1 truncate " +
+              (active
+                ? "font-medium text-[var(--color-brand-800)]"
+                : "text-foreground hover:text-[var(--color-brand-700)]")
+            }
+          >
+            {row.label}
+          </Link>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-muted">{row.label}</span>
+        )}
+        {row.session ? <SessionRowTimestamp session={row.session} /> : null}
+      </summary>
+      <div className="ml-2.5 space-y-0.5 border-l border-border pl-2">
+        {row.children?.map((child) => (
+          <StashTreeRow
+            key={child.key}
+            workspaceId={workspaceId}
+            row={child}
+          />
+        ))}
+      </div>
+    </details>
   );
 }
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1616,9 +1616,19 @@ function buildStashTreeItems(
   sessionBySessionId: Map<string, WorkspaceSidebarSession>
 ): StashTreeItem[] {
   const pathCache = new Map<string, string>();
+  const fileByLinkedTableId = new Map(
+    Array.from(fileById.values())
+      .filter((file) => file.linked_table_id)
+      .map((file) => [file.linked_table_id as string, file])
+  );
+  const fileItemIds = new Set(
+    items
+      .filter((item) => item.object_type === "file")
+      .map((item) => item.object_id)
+  );
   const rows = [...items]
     .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
-    .map((item, index): StashTreeItem => {
+    .map((item, index): StashTreeItem | null => {
       if (item.object_type === "session") {
         const session = sessionById.get(item.object_id) ?? sessionBySessionId.get(item.object_id);
         const fallback = `Session ${item.object_id}`;
@@ -1643,13 +1653,8 @@ function buildStashTreeItems(
           activeId: item.object_id,
           folderId: item.object_id,
           parentFolderId: folder?.parent_folder_id ?? null,
-          label:
-            item.label_override ??
-            (folder ? resolveFolderPath(folder.id, folderById, pathCache) : `Folder ${item.object_id}`),
-          nestedLabel:
-            item.label_override
-              ? nestedStashLabel(item.label_override)
-              : (folder ? folder.name : `Folder ${item.object_id}`),
+          label: folder ? folder.name : `Folder ${item.object_id}`,
+          nestedLabel: folder ? folder.name : `Folder ${item.object_id}`,
         };
       }
 
@@ -1663,8 +1668,8 @@ function buildStashTreeItems(
             activeKind: "page",
             activeId: item.object_id,
             containingFolderId: null,
-            label: item.label_override ?? `Page ${item.object_id}`,
-            nestedLabel: nestedStashLabel(item.label_override ?? `Page ${item.object_id}`),
+            label: `Page ${item.object_id}`,
+            nestedLabel: `Page ${item.object_id}`,
           };
         }
 
@@ -1678,8 +1683,8 @@ function buildStashTreeItems(
           activeKind: "page",
           activeId: page.id,
           containingFolderId: page.folder_id,
-          label: item.label_override ?? pagePath,
-          nestedLabel: nestedStashLabel(item.label_override ?? page.name),
+          label: pagePath,
+          nestedLabel: page.name,
         };
       }
 
@@ -1693,8 +1698,8 @@ function buildStashTreeItems(
             activeKind: "file",
             activeId: item.object_id,
             containingFolderId: null,
-            label: item.label_override ?? `File ${item.object_id}`,
-            nestedLabel: nestedStashLabel(item.label_override ?? `File ${item.object_id}`),
+            label: `File ${item.object_id}`,
+            nestedLabel: `File ${item.object_id}`,
           };
         }
 
@@ -1709,12 +1714,31 @@ function buildStashTreeItems(
           activeId: file.id,
           activeLinkedTableId: file.linked_table_id,
           containingFolderId: file.folder_id,
-          label: item.label_override ?? filePath,
-          nestedLabel: nestedStashLabel(item.label_override ?? file.name),
+          label: filePath,
+          nestedLabel: file.name,
         };
       }
 
       if (item.object_type === "table") {
+        const linkedFile = fileByLinkedTableId.get(item.object_id);
+        if (linkedFile && fileItemIds.has(linkedFile.id)) return null;
+
+        if (linkedFile) {
+          const folderPath = resolveFolderPath(linkedFile.folder_id, folderById, pathCache);
+          const filePath = folderPath ? `${folderPath}/${linkedFile.name}` : linkedFile.name;
+          return {
+            kind: "table",
+            key: `${item.object_id}:${index}`,
+            href: `/tables/${item.object_id}?workspaceId=${workspaceId}`,
+            icon: <span className={fileIconClass(linkedFile.content_type)}><TableIcon /></span>,
+            activeKind: "table",
+            activeId: item.object_id,
+            containingFolderId: linkedFile.folder_id,
+            label: filePath,
+            nestedLabel: linkedFile.name,
+          };
+        }
+
         return {
           kind: "table",
           key: `${item.object_id}:${index}`,
@@ -1722,7 +1746,7 @@ function buildStashTreeItems(
           icon: <span className="text-muted"><TableIcon /></span>,
           activeKind: "table",
           activeId: item.object_id,
-          label: item.label_override ?? `Table ${item.object_id}`,
+          label: `Table ${item.object_id}`,
         };
       }
 
@@ -1732,7 +1756,8 @@ function buildStashTreeItems(
         icon: <span className="text-muted"><FolderIcon /></span>,
         label: item.label_override ?? `${item.object_type} ${item.object_id}`,
       };
-    });
+    })
+    .filter((row): row is StashTreeItem => row !== null);
 
   return nestStashTreeItems(rows, folderById);
 }


### PR DESCRIPTION
## Summary
- Build stash sidebar items into a folder-aware tree when an included folder also contains included pages/files.
- Render nested stash folder rows recursively so `Product/Sidebar polish notes` appears as `Sidebar polish notes` under `Product` instead of as a confusing sibling.
- Use canonical Files tree names for folder/page/file rows in the stash sidebar instead of stash `label_override` values.
- Resolve linked table rows through their backing CSV file when available, and avoid duplicate table/file rows for the same linked CSV.
- Keep existing active-row behavior for stash-scoped file/page/table routes while allowing nested stash folders to stay open.

## Root cause
The stash sidebar used the file tree only to resolve labels, then rendered `stash.items` as a flat ordered list. When a stash included both a folder and a page/file from that folder, the folder and child were displayed at the same level. It also preferred stash item label overrides, so the same object could appear under different titles in Stashes versus Files.

## Screenshot
Captured from the local seeded development workspace after expanding `Files Highlight Demo`:

https://app.joinstash.ai/stashes/stash-canonical-sidebar-labels-jmlarw

## Validation
- `cd frontend && npm test`
- `cd frontend && npm test -- AppSidebar.test.tsx`
- `cd frontend && npm run lint` (passes with 5 existing warnings outside touched files)
- `cd frontend && npm run build` (passes; Next reports the existing multiple-lockfile root warning)
- Local Playwright browser check against `localhost:3457`: expanded a stash containing a folder plus folder children and verified canonical sidebar labels are shown while the old custom stash labels are absent.

Stacked on #390 (`highlight-bug`) so the diff stays limited to this sidebar nesting fix.