### PR TITLE
Editable markdown uploads + floating description toolbar

### DIFF
--- a/frontend/src/components/workspace/EditorToolbar.tsx
+++ b/frontend/src/components/workspace/EditorToolbar.tsx
@@ -128,15 +128,10 @@ export default function EditorToolbar({
     editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
   }
 
-  const inline = visibility === "when-focused";
   const toolbar = (
     <div
-      className={
-        inline
-          ? "inline-flex items-center gap-0.5 rounded-full border border-border bg-white px-2 py-1.5 shadow-[0_14px_36px_-8px_rgba(0,0,0,0.25),0_4px_12px_-4px_rgba(0,0,0,0.10)] ring-1 ring-black/[0.04]"
-          : "fixed left-1/2 z-40 inline-flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-border bg-white px-2 py-1.5 shadow-[0_14px_36px_-8px_rgba(0,0,0,0.25),0_4px_12px_-4px_rgba(0,0,0,0.10)] ring-1 ring-black/[0.04]"
-      }
-      style={inline ? undefined : { bottom: 40 }}
+      className="fixed left-1/2 z-40 inline-flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-border bg-white px-2 py-1.5 shadow-[0_14px_36px_-8px_rgba(0,0,0,0.25),0_4px_12px_-4px_rgba(0,0,0,0.10)] ring-1 ring-black/[0.04]"
+      style={{ bottom: 40 }}
       onMouseDown={(e) => e.preventDefault()}
     >
       <Btn
@@ -317,11 +312,11 @@ export default function EditorToolbar({
     </div>
   );
 
-  if (inline) {
-    // Render in the document flow under the editor so descriptions don't
-    // anchor their toolbar to the viewport bottom.
-    return <div className="mt-3 flex justify-start">{toolbar}</div>;
-  }
+  // Always float at the viewport bottom. For description editors
+  // (visibility="when-focused") this means the toolbar follows the user
+  // as they edit long content instead of stranding at the bottom of the
+  // editor's column. The focus gate above keeps multiple editors on the
+  // same page from stacking toolbars.
   return createPortal(toolbar, document.body);
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -743,6 +743,14 @@ function isHtmlUpload(file: File): boolean {
   return /\.html?$/i.test(file.name);
 }
 
+// Markdown gets the same page-create treatment as HTML — it's content,
+// not a blob. Without this routing, .md uploads land as Files and the
+// user can't edit them.
+function isMarkdownUpload(file: File): boolean {
+  if (file.type === "text/markdown") return true;
+  return /\.(md|markdown|mdx)$/i.test(file.name);
+}
+
 export async function uploadFileOrPage(
   workspaceId: string,
   file: File,
@@ -754,6 +762,15 @@ export async function uploadFileOrPage(
     const page = await createPage(workspaceId, name, folderId ?? null, "", {
       content_type: "html",
       content_html: text,
+    });
+    return { kind: "page", page };
+  }
+  if (isMarkdownUpload(file)) {
+    const text = await file.text();
+    const name =
+      file.name.replace(/\.(md|markdown|mdx)$/i, "") || file.name || "Untitled";
+    const page = await createPage(workspaceId, name, folderId ?? null, text, {
+      content_type: "markdown",
     });
     return { kind: "page", page };
   }


### PR DESCRIPTION
## Summary

Two unrelated small fixes you reported back-to-back.

### 1. Markdown uploads land as Pages, not Files

`uploadFileOrPage` only routed HTML through the page-create path; markdown ended up as a Files blob with no editor. That meant drag-drop / quick-add of a `.md` file produced something the user couldn't edit.

Add an `isMarkdownUpload` helper (matches `.md` / `.markdown` / `.mdx` extensions, plus the `text/markdown` MIME type) and route the same way HTML does — `createPage` with `content_type: \"markdown\"` and the file body as content. Markdown uploads now get the editable + commentable + collaborative surface.

### 2. Description-editor toolbar floats to the viewport bottom

The inline variant (`visibility=\"when-focused\"`, used on workspace home + stash home descriptions) rendered in document flow under the editor. For long descriptions that meant scrolling all the way down to format anything.

Collapse the two render paths so the toolbar always portals to `document.body` with `position: fixed` at the bottom of the viewport. The focus gate already prevents multiple toolbars from stacking when more than one description editor exists on a page.

## Test plan

- [ ] Drag a `.md` file onto the workspace home quick-add (or the sharing path drop zone). Confirm it becomes an editable page in the file tree, not a Files blob.
- [ ] Same for `.markdown` and `.mdx`.
- [ ] Open a workspace with a long About description. Click into the editor, scroll mid-document — the toolbar pill is anchored to the viewport bottom, always visible.
- [ ] With multiple description editors on a single page, only the focused one shows the toolbar (no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)