### PR TITLE
Refresh sidebar after creating a Stash from the share modal

### DIFF
--- a/frontend/src/components/share/StashShareModal.tsx
+++ b/frontend/src/components/share/StashShareModal.tsx
@@ -9,6 +9,7 @@ import {
   type WorkspaceSidebar,
   type StashItemSpec,
 } from "../../lib/api";
+import { refreshWorkspaceSidebar } from "../../lib/stashNavigationCache";
 import { useShareModal } from "../../lib/shareModalContext";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import CustomSelect from "../CustomSelect";
@@ -276,6 +277,10 @@ export default function StashShareModal() {
       setSelected(EMPTY_SELECTED);
       setTitle("");
       setShareToDiscover(false);
+      // Re-fetch the workspace sidebar so the new Stash shows up without
+      // requiring a page reload. refreshWorkspaceSidebar hits the API,
+      // updates the cache, and notifies AppSidebar's subscriber.
+      refreshWorkspaceSidebar(workspaceId).catch(() => {});
       bumpVersion();
       close();
     } catch (e) {


### PR DESCRIPTION
## Summary

Creating a Stash via the share modal didn't update the sidebar — users had to reload the page to see the new Stash appear in the tree.

**Root cause:** `StashShareModal.onSubmit` called `bumpVersion()` (the share modal context's version counter) but no sidebar consumer subscribes to that. `AppSidebar` caches a `spine` per workspace and only fetches one if there isn't a cached value (`AppSidebar.tsx` ~line 3010: `.filter((workspaceId) => !spines[workspaceId])`). The bump was effectively a no-op for sidebar visibility.

**Fix:** Call `refreshWorkspaceSidebar(workspaceId)` from `stashNavigationCache` after the Stash is created. That helper hits `/api/v1/workspaces/{id}/sidebar`, updates the in-memory cache, and fires the subscriber that `AppSidebar` already listens to via `subscribeToSidebarRefresh`. New Stashes appear the moment the modal closes.

`bumpVersion()` stays — it's still consumed by surfaces that read `version` as a dep.

## Test plan

- [ ] Open a workspace. Open the share modal from any page/file/etc. Pick at least one item. Create Stash.
- [ ] Confirm the new Stash shows up in the sidebar's Stashes section without reloading.
- [ ] Same flow for `publishStash` (public access selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)