### PR TITLE
[codex] Format activity timeline agent labels

### DIFF
--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -124,7 +124,7 @@ async def get_activity_timeline(
                 me.agent_name,
                 me.created_by,
                 CASE NULLIF(me.metadata->>'client', '')
-                    WHEN 'claude_code' THEN 'claude'
+                    WHEN 'claude_code' THEN 'claude code'
                     WHEN 'codex_cli' THEN 'codex'
                     WHEN 'gemini_cli' THEN 'gemini'
                     ELSE NULLIF(me.metadata->>'client', '')
@@ -163,7 +163,8 @@ async def get_activity_timeline(
             COALESCE(
                 sc.client_name,
                 CASE
-                    WHEN sc.agent_name = 'claude-subagent' THEN 'claude'
+                    WHEN sc.agent_name IN ('claude', 'claude-subagent') THEN 'claude code'
+                    WHEN sc.agent_name LIKE '%claude-code%' THEN 'claude code'
                     ELSE NULLIF(sc.agent_name, '')
                 END,
                 'unknown agent'
@@ -182,7 +183,7 @@ async def get_activity_timeline(
 
     for row in rows:
         date_str = row["bucket_date"].isoformat()
-        contributor = f"{row['human_name']} / {row['agent_name']}"
+        contributor = f"{row['human_name']} ({row['agent_name']})"
         cnt = row["cnt"]
 
         contributors_set.add(contributor)

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -90,7 +90,7 @@ async def test_activity_timeline_pivots_on_human_and_agent_sessions(client: Asyn
     assert resp.status_code == 200
 
     timeline = resp.json()
-    assert timeline["contributors"] == ["Timeline Human / codex"]
+    assert timeline["contributors"] == ["Timeline Human (codex)"]
     assert "Pages" not in timeline["contributors"]
 
     totals = [
@@ -128,6 +128,19 @@ async def test_activity_timeline_uses_client_name_for_agent_label(client: AsyncC
     )
     assert event_resp.status_code == 201
 
+    claude_event_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/events",
+        json={
+            "agent_name": "user",
+            "event_type": "assistant_message",
+            "content": "done",
+            "session_id": "claude-client-label-session",
+            "metadata": {"client": "claude_code"},
+        },
+        headers=_auth(api_key),
+    )
+    assert claude_event_resp.status_code == 201
+
     resp = await client.get(
         "/api/v1/me/activity-timeline",
         params={"days": 365, "workspace_id": workspace["id"]},
@@ -136,11 +149,14 @@ async def test_activity_timeline_uses_client_name_for_agent_label(client: AsyncC
     assert resp.status_code == 200
 
     timeline = resp.json()
-    assert timeline["contributors"] == ["Client Human / codex"]
+    assert timeline["contributors"] == [
+        "Client Human (claude code)",
+        "Client Human (codex)",
+    ]
 
 
 @pytest.mark.asyncio
-async def test_activity_timeline_counts_claude_subagents_as_claude(client: AsyncClient):
+async def test_activity_timeline_normalizes_claude_code_agent_names(client: AsyncClient):
     register_resp = await client.post(
         "/api/v1/users/register",
         json={
@@ -155,6 +171,7 @@ async def test_activity_timeline_counts_claude_subagents_as_claude(client: Async
 
     await _event(client, api_key, workspace["id"], "claude-parent", "claude")
     await _event(client, api_key, workspace["id"], "claude-child", "claude-subagent")
+    await _event(client, api_key, workspace["id"], "claude-prefixed", "sam-claude-code")
 
     resp = await client.get(
         "/api/v1/me/activity-timeline",
@@ -164,14 +181,14 @@ async def test_activity_timeline_counts_claude_subagents_as_claude(client: Async
     assert resp.status_code == 200
 
     timeline = resp.json()
-    assert timeline["contributors"] == ["Claude Human / claude"]
+    assert timeline["contributors"] == ["Claude Human (claude code)"]
 
     totals = [
         contributor["total"]
         for bucket in timeline["buckets"]
         for contributor in bucket["contributors"].values()
     ]
-    assert totals == [2]
+    assert totals == [3]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Format activity timeline contributors as `Human (agent)` instead of `Human / agent`.
- Normalize Claude Code sources to `claude code`, including `metadata.client = claude_code`, `claude`, `claude-subagent`, and prefixed `*-claude-code` agent names.
- Update activity timeline API tests around contributor labels and aggregation.

## Screenshot
- Workspace timeline after the change: https://app.joinstash.ai/stashes/stash-activity-labels-lwhxoa

## Validation
- `pytest --no-cov backend/tests/test_activity.py`
- `ruff check backend/services/analytics_service.py backend/tests/test_activity.py`
- `pytest backend/tests/test_activity.py` passed all selected tests, then failed the repo coverage gate because a narrow file run reports 26.27% total coverage against the 30% threshold.
