### PR TITLE
[codex] Show CLI help when no command is passed

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -41,6 +41,15 @@ app = typer.Typer(
 )
 
 
+@app.callback(invoke_without_command=True)
+def root(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+
+    typer.echo(ctx.get_help())
+    raise typer.Exit()
+
+
 def _client() -> StashClient:
     cfg = load_config()
     return StashClient(base_url=cfg["base_url"], api_key=cfg.get("api_key", ""))

--- a/cli/tests/test_root_help.py
+++ b/cli/tests/test_root_help.py
@@ -1,0 +1,13 @@
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+def test_root_command_without_args_shows_help() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, [])
+    help_result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert result.output == help_result.output


### PR DESCRIPTION
## Summary

- Add a root CLI callback that prints the existing Typer help when `stash` is run without a command.
- Add a regression test asserting no-argument invocation exits successfully and matches `stash --help` output.

## Validation

- `pytest cli/tests --no-cov`
- `ruff check cli/main.py cli/tests/test_root_help.py`
- `python -m cli.main` output diffed against `python -m cli.main --help`