### PR TITLE
[codex] Fix activity timeline blank days

### DIFF
--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -23,6 +23,42 @@ _DENSITY_CACHE_TTL = timedelta(hours=24)
 _DENSITY_SIGNATURE_TOLERANCE = 0.1
 
 
+def _truncate_activity_bucket(value: datetime, bucket: str) -> datetime:
+    if bucket == "hour":
+        return value.replace(minute=0, second=0, microsecond=0)
+    if bucket == "week":
+        day = value.replace(hour=0, minute=0, second=0, microsecond=0)
+        return day - timedelta(days=day.weekday())
+    return value.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _activity_bucket_dates(days: int, bucket: str, now: datetime) -> list[datetime]:
+    end = _truncate_activity_bucket(now, bucket)
+    if bucket == "hour":
+        start = end - timedelta(hours=days * 24 - 1)
+    elif bucket == "week":
+        first_day = _truncate_activity_bucket(now, "day") - timedelta(days=days - 1)
+        start = _truncate_activity_bucket(first_day, "week")
+    else:
+        start = end - timedelta(days=days - 1)
+
+    step = _activity_bucket_step(bucket)
+    dates = []
+    current = start
+    while current <= end:
+        dates.append(current)
+        current += step
+    return dates
+
+
+def _activity_bucket_step(bucket: str) -> timedelta:
+    if bucket == "hour":
+        return timedelta(hours=1)
+    if bucket == "week":
+        return timedelta(weeks=1)
+    return timedelta(days=1)
+
+
 # Shared CTE for workspace / stash access filtering on history_events.
 # Exactly one of ws_idx and stash_idx may be passed (caller responsibility):
 #   ws_idx    -> narrow to a single workspace's events (caller has already
@@ -246,17 +282,19 @@ async def get_activity_timeline(
     if bucket not in ("hour", "day", "week"):
         bucket = "day"
 
-    cutoff = datetime.now(UTC) - timedelta(days=days)
+    bucket_dates = _activity_bucket_dates(days, bucket, datetime.now(UTC))
+    cutoff = bucket_dates[0]
+    end_exclusive = bucket_dates[-1] + _activity_bucket_step(bucket)
 
-    args: list = [user_id, bucket, cutoff]
+    args: list = [user_id, bucket, cutoff, end_exclusive]
     ws_idx = None
     stash_idx = None
     if stash_id is not None:
         args.append(stash_id)
-        stash_idx = 4
+        stash_idx = 5
     elif workspace_id is not None:
         args.append(workspace_id)
-        ws_idx = 4
+        ws_idx = 5
 
     rows = await pool.fetch(
         _accessible_events_cte(ws_idx=ws_idx, stash_idx=stash_idx) + """
@@ -276,6 +314,7 @@ async def get_activity_timeline(
             FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
             WHERE me.created_at >= $3
+              AND me.created_at < $4
               AND me.session_id IS NOT NULL
         )
         , session_commits AS (
@@ -323,7 +362,9 @@ async def get_activity_timeline(
     )
 
     contributors_set: set[str] = set()
-    buckets_map: dict[str, dict] = {}
+    buckets_map: dict[str, dict] = {
+        date.isoformat(): {"date": date.isoformat(), "contributors": {}} for date in bucket_dates
+    }
 
     for row in rows:
         date_str = row["bucket_date"].isoformat()
@@ -331,9 +372,6 @@ async def get_activity_timeline(
         cnt = row["cnt"]
 
         contributors_set.add(contributor)
-
-        if date_str not in buckets_map:
-            buckets_map[date_str] = {"date": date_str, "contributors": {}}
 
         b = buckets_map[date_str]
         if contributor not in b["contributors"]:

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, time, timedelta
+
 import pytest
 from httpx import AsyncClient
 
@@ -33,6 +35,7 @@ async def _event(
     workspace_id: str,
     session_id: str,
     agent_name: str = "tester",
+    created_at: str = "2026-01-02T00:00:00Z",
 ) -> None:
     resp = await client.post(
         f"/api/v1/workspaces/{workspace_id}/sessions/events",
@@ -41,7 +44,7 @@ async def _event(
             "event_type": "assistant_message",
             "content": session_id,
             "session_id": session_id,
-            "created_at": "2026-01-02T00:00:00Z",
+            "created_at": created_at,
         },
         headers=_auth(api_key),
     )
@@ -99,6 +102,111 @@ async def test_activity_timeline_pivots_on_human_and_agent_sessions(client: Asyn
         for contributor in bucket["contributors"].values()
     ]
     assert totals == [1]
+
+
+@pytest.mark.asyncio
+async def test_activity_timeline_includes_blank_day_buckets(client: AsyncClient):
+    api_key = await _register(client, "activity_blank_days")
+    workspace = await _workspace(client, api_key, "Blank Day Activity")
+    event_day = datetime.now(UTC).date() - timedelta(days=1)
+    event_at = datetime.combine(event_day, time(hour=12), tzinfo=UTC)
+
+    await _event(
+        client,
+        api_key,
+        workspace["id"],
+        "middle-day-session",
+        created_at=event_at.isoformat(),
+    )
+
+    resp = await client.get(
+        "/api/v1/me/activity-timeline",
+        params={"days": 3, "bucket": "day", "workspace_id": workspace["id"]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    buckets = resp.json()["buckets"]
+    assert len(buckets) == 3
+
+    active_buckets = [bucket for bucket in buckets if bucket["contributors"]]
+    assert len(active_buckets) == 1
+    assert datetime.fromisoformat(active_buckets[0]["date"]).date() == event_day
+
+    blank_buckets = [bucket for bucket in buckets if not bucket["contributors"]]
+    assert len(blank_buckets) == 2
+
+
+@pytest.mark.asyncio
+async def test_activity_timeline_can_scope_blank_day_buckets_to_stash(client: AsyncClient):
+    api_key = await _register(client, "activity_stash_blank_days")
+    workspace = await _workspace(client, api_key, "Stash Blank Day Activity")
+    event_day = datetime.now(UTC).date() - timedelta(days=1)
+    event_at = datetime.combine(event_day, time(hour=12), tzinfo=UTC).isoformat()
+
+    included_session_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/sessions",
+        json={"session_id": "included-session", "agent_name": "tester"},
+        headers=_auth(api_key),
+    )
+    assert included_session_resp.status_code == 201
+
+    hidden_session_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/sessions",
+        json={"session_id": "hidden-session", "agent_name": "tester"},
+        headers=_auth(api_key),
+    )
+    assert hidden_session_resp.status_code == 201
+
+    await _event(
+        client,
+        api_key,
+        workspace["id"],
+        "included-session",
+        created_at=event_at,
+    )
+    await _event(
+        client,
+        api_key,
+        workspace["id"],
+        "hidden-session",
+        created_at=event_at,
+    )
+
+    stash_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/stashes",
+        json={
+            "title": "Timeline Stash",
+            "items": [
+                {
+                    "object_type": "session",
+                    "object_id": included_session_resp.json()["id"],
+                }
+            ],
+        },
+        headers=_auth(api_key),
+    )
+    assert stash_resp.status_code == 201
+
+    resp = await client.get(
+        "/api/v1/me/activity-timeline",
+        params={"days": 3, "bucket": "day", "stash_id": stash_resp.json()["id"]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    buckets = resp.json()["buckets"]
+    assert len(buckets) == 3
+
+    totals = [
+        contributor["total"]
+        for bucket in buckets
+        for contributor in bucket["contributors"].values()
+    ]
+    assert totals == [1]
+
+    blank_buckets = [bucket for bucket in buckets if not bucket["contributors"]]
+    assert len(blank_buckets) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Generate the full requested activity bucket range before merging session commit rows.
- Add an upper time bound to the activity timeline query so buckets stay inside the requested range.
- Preserve current `main` stash-scoped timeline filtering while resolving conflicts.
- Cover blank-day behavior for workspace and stash-scoped timelines.

## Root Cause
The timeline API only returned buckets that had session commits, so the frontend canvas only drew active dates and skipped blank days entirely.

## Validation
- `pytest backend/tests/test_activity.py backend/tests/test_permissions.py::test_private_stash_hides_session_surfaces_until_user_is_added --no-cov`
- `ruff check backend/services/analytics_service.py backend/tests/test_activity.py`
- `black --check backend/services/analytics_service.py backend/tests/test_activity.py`

Fixes FER-117.