### PR TITLE
feat(cli): auto-bump stashai on session start + add stash upgrade

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("stashai")

--- a/cli/main.py
+++ b/cli/main.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from stashai.plugin.upload_status import read_upload_status
 
-from . import telemetry
+from . import __version__, telemetry
 from .client import StashClient, StashError, stash_permissions_for_access
 from .config import (
     MANIFEST_FILE,
@@ -41,13 +41,49 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"stash {__version__}")
+        raise typer.Exit()
+
+
 @app.callback(invoke_without_command=True)
-def root(ctx: typer.Context) -> None:
+def root(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        is_eager=True,
+        callback=_version_callback,
+        help="Print the installed stash CLI version and exit.",
+    ),
+) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
     typer.echo(ctx.get_help())
     raise typer.Exit()
+
+
+@app.command()
+def upgrade() -> None:
+    """Upgrade the stash CLI to the latest version on PyPI."""
+    import shutil
+    import subprocess
+
+    if not shutil.which("uv"):
+        typer.echo(
+            "uv is not on PATH. Re-run the installer: "
+            'bash -c "$(curl -fsSL https://joinstash.ai/install)"',
+            err=True,
+        )
+        raise typer.Exit(1)
+    typer.echo(f"Upgrading stashai from {__version__}…")
+    result = subprocess.run(
+        ["uv", "tool", "install", "--force", "--reinstall", "--refresh", "stashai"]
+    )
+    raise typer.Exit(result.returncode)
 
 
 def _client() -> StashClient:

--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -17,6 +17,7 @@ TARGET="$(dirname "$0")/$SCRIPT.py"
 # plugin cache never drifts from the source repo.
 if [ "$SCRIPT" = "on_session_start" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   git -C "$CLAUDE_PLUGIN_ROOT" pull --ff-only origin main >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
 fi
 
 PY=""

--- a/plugins/codex-plugin/scripts/_run.sh
+++ b/plugins/codex-plugin/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 

--- a/plugins/cursor-plugin/scripts/_run.sh
+++ b/plugins/cursor-plugin/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Gemini SessionStart: save session_id and create the session record."""
 
+import shutil
+import subprocess
+
 from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
@@ -12,6 +15,14 @@ from stashai.plugin.hooks import (
     uploads_enabled,
 )
 from stashai.plugin.state import load_state, reset_stats, save_state
+
+if shutil.which("uv"):
+    subprocess.Popen(
+        ["uv", "tool", "upgrade", "--quiet", "stashai"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
 
 def main():

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -4,6 +4,16 @@
 import shutil
 import subprocess
 
+# Fire the background CLI upgrade before any `stashai` import so a broken /
+# missing install can still self-heal on the next session start.
+if shutil.which("uv"):
+    subprocess.Popen(
+        ["uv", "tool", "upgrade", "--quiet", "stashai"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
 from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
@@ -15,14 +25,6 @@ from stashai.plugin.hooks import (
     uploads_enabled,
 )
 from stashai.plugin.state import load_state, reset_stats, save_state
-
-if shutil.which("uv"):
-    subprocess.Popen(
-        ["uv", "tool", "upgrade", "--quiet", "stashai"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
 
 
 def main():

--- a/plugins/openclaw-plugin/scripts/_run.sh
+++ b/plugins/openclaw-plugin/scripts/_run.sh
@@ -10,6 +10,10 @@ SCRIPT="$1"
 shift
 TARGET="$(dirname "$0")/$SCRIPT.py"
 
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 PY="${STASH_PYTHON:-}"
 if [ -z "$PY" ] && command -v stash >/dev/null 2>&1; then
   STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"

--- a/plugins/opencode-plugin/scripts/_run.sh
+++ b/plugins/opencode-plugin/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 

--- a/stashai/plugin/assets/codex/scripts/_run.sh
+++ b/stashai/plugin/assets/codex/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 

--- a/stashai/plugin/assets/cursor/scripts/_run.sh
+++ b/stashai/plugin/assets/cursor/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 

--- a/stashai/plugin/assets/opencode/scripts/_run.sh
+++ b/stashai/plugin/assets/opencode/scripts/_run.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 SCRIPT="$1"
 shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="$SCRIPT_DIR/$SCRIPT.py"
 


### PR DESCRIPTION
## Why

Backend ships changes weekly. The plugin hooks call into a Pydantic-validated upload API on every session, so when stashai falls behind the server schema, uploads silently 4xx and the user has no idea their transcripts stopped flowing. Today the CLI never updates itself — users only catch up when they re-run the install script by hand.

## Two-layer fix

**Layer 1 — silent auto-bump for plugin users.**
Every coding-agent plugin's session-start path now backgrounds `uv tool upgrade --quiet stashai`:
- `plugins/claude-plugin/scripts/_run.sh` (extends existing `git pull` block)
- `plugins/{codex,cursor,opencode,openclaw}-plugin/scripts/_run.sh` and the source-of-truth assets at `stashai/plugin/assets/{codex,cursor,opencode}/scripts/_run.sh`
- `plugins/gemini-plugin/scripts/on_session_start.py` (Popen with `start_new_session=True` since Gemini has no `_run.sh`)

All guarded with `command -v uv` (shell) or `shutil.which("uv")` (python), so missing-uv is a silent no-op rather than a crash.

**Layer 2 — manual escape hatch for bare-shell users.**
- `stash --version` / `stash -v` (folded into the existing root callback as the eager option)
- `stash upgrade` runs `uv tool install --force --reinstall --refresh stashai`. Fails loud with the install-script one-liner if `uv` isn't on PATH — no pip fallback, per CLAUDE.md's "no fallbacks" rule.

Plugin-mediated users auto-update silently within a session of any release; bare-shell users stay frozen until they run `stash upgrade`.

## Verification

- `python -c "from cli import __version__; print(__version__)"` → `0.1.14`
- `bash -x plugins/claude-plugin/scripts/_run.sh on_session_start` with `CLAUDE_PLUGIN_ROOT=/tmp/fake-stash` shows `git pull` and `uv tool upgrade` backgrounded, exits clean.
- Same with `PATH=/usr/bin:/bin` — `command -v uv` returns false, the `&&` short-circuits, no error.
- Same trace for `plugins/codex-plugin/scripts/_run.sh` confirms the new branch fires before `SCRIPT_DIR` resolution.
- `cli/tests/` — 39 passed (one pre-existing collection error in `test_share_and_upload_helpers.py` from missing `fastapi`, unrelated).
- `ruff check cli/__init__.py cli/main.py` — all checks passed.
- Typer `CliRunner` shows `stash --version` exits 0 with `stash 0.1.14`; `stash upgrade --help` renders correctly.

## Test plan

- [ ] Pull this branch, `uv tool install --force --reinstall .`, run `stash --version`
- [ ] Run `stash upgrade` end-to-end and confirm it reinstalls cleanly
- [ ] Open Claude Code in a stash-plugin'd repo and confirm session start no longer drifts
- [ ] Repeat for one non-Claude plugin (codex or cursor) to spot-check the shell branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)