### PR TITLE
feat(slides): present mode, progress bar, click-to-advance

### DIFF
--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -74,7 +74,9 @@ export default function HtmlPageView({
   editable = false,
 }: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const presentWrapRef = useRef<HTMLDivElement | null>(null);
   const [height, setHeight] = useState<number | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const channel = `stash-resize-${useId()}`;
 
   // The iframe's DOM is authoritative for its lifetime. We pin srcDoc to the
@@ -208,10 +210,12 @@ export default function HtmlPageView({
     );
   }, [isDeck, activeSlide, channel]);
 
-  // Keyboard nav (←/→) when the deck is on screen. We bail when the
-  // user is typing somewhere (any input/textarea/contenteditable),
-  // otherwise arrow keys would silently steal focus from the comment
-  // composer, share modal, page-title editor, etc.
+  // Keyboard nav when the deck is on screen. We bail when the user is
+  // typing somewhere (any input/textarea/contenteditable), otherwise
+  // arrow keys would silently steal focus from the comment composer,
+  // share modal, page-title editor, etc. Fullscreen-only keys (Space,
+  // PageDown/Up, Home/End) work everywhere too so casual viewing also
+  // gets the upgrade.
   useEffect(() => {
     if (!isDeck) return;
     function isTypingTarget(node: Element | null): boolean {
@@ -225,15 +229,50 @@ export default function HtmlPageView({
     }
     function onKey(e: KeyboardEvent) {
       if (isTypingTarget(document.activeElement)) return;
-      if (e.key === "ArrowRight") {
+      if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") {
         setActiveSlide((s) => Math.min(slideCount - 1, s + 1));
-      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+      } else if (e.key === "ArrowLeft" || e.key === "PageUp") {
         setActiveSlide((s) => Math.max(0, s - 1));
+        e.preventDefault();
+      } else if (e.key === "Home") {
+        setActiveSlide(0);
+        e.preventDefault();
+      } else if (e.key === "End") {
+        setActiveSlide(slideCount - 1);
+        e.preventDefault();
+      } else if (e.key === "f" || e.key === "F") {
+        // F toggles fullscreen. Esc exits (browser default).
+        const el = presentWrapRef.current;
+        if (!el) return;
+        if (document.fullscreenElement === el) {
+          document.exitFullscreen?.();
+        } else {
+          el.requestFullscreen?.();
+        }
+        e.preventDefault();
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [isDeck, slideCount]);
+
+  // Track fullscreen state so we can letterbox the iframe and toggle the
+  // click-to-advance overlay.
+  useEffect(() => {
+    function onChange() {
+      setIsFullscreen(document.fullscreenElement === presentWrapRef.current);
+    }
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const enterPresent = () => {
+    presentWrapRef.current?.requestFullscreen?.();
+  };
+  const advanceInPresent = () => {
+    setActiveSlide((s) => Math.min(slideCount - 1, s + 1));
+  };
 
   function onIframeLoad() {
     iframeRef.current?.contentWindow?.postMessage(
@@ -245,14 +284,60 @@ export default function HtmlPageView({
   if (layout === "fixed-aspect") {
     return (
       <div style={{ position: "relative", width: "100%" }}>
-        <iframe
-          ref={iframeRef}
-          srcDoc={srcDoc}
-          sandbox="allow-scripts"
-          title={title}
-          onLoad={onIframeLoad}
-          style={{ width: "100%", aspectRatio: "16 / 9", border: 0, display: "block" }}
-        />
+        <div
+          ref={presentWrapRef}
+          data-fullscreen={isFullscreen ? "true" : "false"}
+          style={{
+            position: "relative",
+            width: "100%",
+            // Letterbox in fullscreen: black backdrop, 16:9 iframe centered.
+            background: isFullscreen ? "#000" : "transparent",
+            display: isFullscreen ? "flex" : "block",
+            alignItems: "center",
+            justifyContent: "center",
+            height: isFullscreen ? "100vh" : undefined,
+          }}
+        >
+          <iframe
+            ref={iframeRef}
+            srcDoc={srcDoc}
+            sandbox="allow-scripts"
+            title={title}
+            onLoad={onIframeLoad}
+            style={
+              isFullscreen
+                ? {
+                    width: "min(100vw, calc(100vh * 16 / 9))",
+                    aspectRatio: "16 / 9",
+                    border: 0,
+                    display: "block",
+                  }
+                : { width: "100%", aspectRatio: "16 / 9", border: 0, display: "block" }
+            }
+          />
+          {isDeck && isFullscreen && (
+            // Click-to-advance overlay sits on top of the iframe during
+            // present mode. The iframe captures its own clicks, so without
+            // this overlay the only way to advance is the keyboard.
+            <button
+              type="button"
+              aria-label="Next slide"
+              onClick={advanceInPresent}
+              style={{
+                position: "absolute",
+                inset: 0,
+                background: "transparent",
+                border: 0,
+                cursor: "pointer",
+                padding: 0,
+                margin: 0,
+                color: "transparent",
+              }}
+            >
+              Next
+            </button>
+          )}
+        </div>
         {isDeck && (
           <div
             style={{
@@ -306,6 +391,63 @@ export default function HtmlPageView({
             >
               ›
             </button>
+            <button
+              type="button"
+              onClick={enterPresent}
+              aria-label="Present (F)"
+              title="Present (F)"
+              style={{
+                padding: "4px 10px",
+                borderRadius: 6,
+                border: "1px solid var(--border, #ddd)",
+                background: "var(--surface, #fff)",
+                cursor: "pointer",
+                marginLeft: 8,
+                fontSize: 13,
+              }}
+            >
+              Present
+            </button>
+          </div>
+        )}
+        {isDeck && slideCount > 1 && (
+          // Progress bar: one clickable segment per slide. Filled segments
+          // are slides we've reached or passed; the active segment is
+          // accented. Doubles as a jump-to.
+          <div
+            style={{
+              display: "flex",
+              gap: 2,
+              padding: "0 0 12px",
+              userSelect: "none",
+            }}
+            aria-label="Slide progress"
+          >
+            {Array.from({ length: slideCount }, (_, i) => {
+              const isActive = i === activeSlide;
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setActiveSlide(i)}
+                  aria-label={`Jump to slide ${i + 1}`}
+                  title={`Slide ${i + 1} of ${slideCount}`}
+                  style={{
+                    flex: 1,
+                    height: 4,
+                    border: 0,
+                    padding: 0,
+                    cursor: "pointer",
+                    background: isActive
+                      ? "var(--accent, #1a73e8)"
+                      : i < activeSlide
+                        ? "var(--accent-muted, rgba(26,115,232,.35))"
+                        : "var(--border, #ddd)",
+                    borderRadius: 2,
+                  }}
+                />
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

PR 2 of 3 from the slides-improvements plan. Adds present-mode affordances on top of today's prev/next slide nav in `HtmlPageView.tsx`:

- **Present button** next to the existing nav. Calls `requestFullscreen` on a wrapper around the iframe.
- **Progress bar** below the toolbar with one clickable segment per slide. Active segment is accented; passed slides are muted; upcoming are border-gray. Doubles as a slide-jump.
- **Click-to-advance overlay** that activates only in fullscreen — invisible button on top of the iframe so any click advances. (Iframes capture their own clicks, so without the overlay the only way to advance is the keyboard.)

Keyboard shortcuts expand:
- <kbd>F</kbd> — toggle fullscreen
- <kbd>Esc</kbd> — exit (browser default)
- <kbd>Space</kbd> / <kbd>→</kbd> / <kbd>PageDown</kbd> — next slide
- <kbd>←</kbd> / <kbd>PageUp</kbd> — previous slide
- <kbd>Home</kbd> / <kbd>End</kbd> — jump to first / last

Existing typing-target guard still bails when focus is in an input / textarea / contenteditable so the keys don't steal focus from the comment composer, page title editor, etc.

## Why now

Today the only way to actually present a deck is to manually fullscreen the browser tab and hit arrow keys. There's no entry point in the UI, no visual progress, and clicking the canvas does nothing.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Local demo (`/tmp/slides-pr1-demo/present-mode.html`) — toolbar and progress bar render correctly; active / passed / upcoming segment styling matches design intent.
- [ ] Manual in app: open a 5+ slide deck, click Present, walk through with <kbd>Space</kbd>, click on canvas, jump via progress bar, press <kbd>Esc</kbd>.
- [ ] Verify the existing edit-mode UX is unaffected (Edit / Done button toggles still work; arrow keys still bail when focused inside the iframe's contenteditable body).
- [ ] Cross-browser smoke: Chromium, Safari, Firefox — Fullscreen API and `requestFullscreen` behavior.

## Screenshot

Non-fullscreen state showing the new controls (toolbar with Present button + 7-segment progress bar with slide 3 active):

(Local screenshot at \`/tmp/slides-pr1-demo/present-mode-controls.png\` — needs uploading via the web UI; \`gh\` doesn't support image upload.)

## Depends on

Independent of PR #404 (canvas CSS + slides skill). Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)