### PR TITLE
feat(slides/exports): 2x DPI + invisible text overlay + shared canvas dims

### DIFF
--- a/backend/exports/constants.py
+++ b/backend/exports/constants.py
@@ -1,0 +1,34 @@
+"""Canonical slide canvas dimensions, shared across all export targets.
+
+Every exporter (PDF, PPTX, Google Slides) and the renderer's iframe
+canvas-enforcing CSS derive from these. If you need to change the slide
+size, change it here.
+
+1 inch = 914_400 EMU (English Metric Units) — python-pptx natively
+expresses positions in EMUs.
+"""
+
+from __future__ import annotations
+
+from pptx.util import Emu
+
+# Pixel dimensions used as the Playwright viewport for both PPTX
+# screenshots and PDF rendering, and matched by the iframe canvas CSS
+# in the frontend renderer.
+SLIDE_WIDTH_PX = 1920
+SLIDE_HEIGHT_PX = 1080
+
+# Inches dimensions reported in the PPTX manifest. 13.333" x 7.5" is
+# the standard 16:9 widescreen size in PowerPoint / Keynote / Google
+# Slides. 1920 px / 144 dpi = 13.333" exactly.
+SLIDE_WIDTH_INCHES = 13.333
+SLIDE_HEIGHT_INCHES = 7.5
+
+# EMU equivalents (cached so callers don't recompute Emu(int) per slide).
+SLIDE_WIDTH_EMU = Emu(12192000)
+SLIDE_HEIGHT_EMU = Emu(6858000)
+
+# Device scale factor for raster export screenshots. 2x doubles the
+# PNG resolution to 3840x2160 — keeps slides crisp when zoomed in
+# PowerPoint or projected on a 4K screen, at ~4x file size.
+EXPORT_DEVICE_SCALE_FACTOR = 2

--- a/backend/exports/pdf.py
+++ b/backend/exports/pdf.py
@@ -22,6 +22,7 @@ from ..celery_app import celery
 from ..database import get_pool
 from ..services import storage_service
 from ..tasks._celery_helpers import run_async
+from .constants import SLIDE_HEIGHT_PX, SLIDE_WIDTH_PX
 
 logger = logging.getLogger(__name__)
 
@@ -34,16 +35,11 @@ def _safe_stem(name: str) -> str:
     return stem or "slides"
 
 
-# Default deck size — 16:9 at 1920x1080 logical. PDF resolution is
-# derived by Playwright at 96dpi which is fine for screen reading;
-# raise width/height for print quality.
-DEFAULT_WIDTH_PX = 1920
-DEFAULT_HEIGHT_PX = 1080
-
-
+# `@page size` accepts px; Chromium converts at 96dpi.
+# Text in the resulting PDF is vector (selectable, searchable).
 PAGED_CSS = """
   @page {{ size: {w}px {h}px; margin: 0; }}
-  html, body {{ margin: 0; padding: 0; }}
+  html, body {{ margin: 0; padding: 0; overflow: hidden; }}
   body > section.slide {{
     width: {w}px;
     height: {h}px;
@@ -57,7 +53,7 @@ PAGED_CSS = """
 
 
 def _inject_paged_css(html: str) -> str:
-    css = "<style>" + PAGED_CSS.format(w=DEFAULT_WIDTH_PX, h=DEFAULT_HEIGHT_PX) + "</style>"
+    css = "<style>" + PAGED_CSS.format(w=SLIDE_WIDTH_PX, h=SLIDE_HEIGHT_PX) + "</style>"
     if re.search(r"</head\s*>", html, flags=re.I):
         return re.sub(r"</head\s*>", css + "</head>", html, count=1, flags=re.I)
     return css + html
@@ -68,12 +64,16 @@ async def _render_pdf(html: str) -> bytes:
         browser = await p.chromium.launch()
         try:
             page = await browser.new_page(
-                viewport={"width": DEFAULT_WIDTH_PX, "height": DEFAULT_HEIGHT_PX},
+                viewport={"width": SLIDE_WIDTH_PX, "height": SLIDE_HEIGHT_PX},
             )
             await page.set_content(html, wait_until="networkidle")
+            # `prefer_css_page_size=True` honours the injected @page block;
+            # this keeps slide dims locked to the shared constants instead
+            # of relying on the width/height args (which Chromium otherwise
+            # uses as a fallback).
             pdf = await page.pdf(
-                width=f"{DEFAULT_WIDTH_PX}px",
-                height=f"{DEFAULT_HEIGHT_PX}px",
+                width=f"{SLIDE_WIDTH_PX}px",
+                height=f"{SLIDE_HEIGHT_PX}px",
                 print_background=True,
                 prefer_css_page_size=True,
             )

--- a/backend/exports/pptx.py
+++ b/backend/exports/pptx.py
@@ -113,7 +113,9 @@ async def _capture_slide(page, slide_index: int, html: str) -> tuple[bytes, list
     try:
         text_blocks = await page.evaluate(_TEXT_HARVEST_JS)
     except Exception:
-        logger.warning("text harvest failed for slide %s; export will lack selectable text", slide_index)
+        logger.warning(
+            "text harvest failed for slide %s; export will lack selectable text", slide_index
+        )
         text_blocks = []
     return png, text_blocks
 

--- a/backend/exports/pptx.py
+++ b/backend/exports/pptx.py
@@ -1,9 +1,11 @@
-"""PPTX export — rasterized slides.
+"""PPTX export — rasterized slides + invisible text overlay.
 
-Uses Playwright to screenshot each `<section class="slide">` as a PNG,
-then assembles a 16:9 deck with one slide per image (full-bleed). Text
-is not editable in the resulting PPTX — this is intentional; extracting
-Tiptap structure into PPTX shapes is a rabbit hole.
+Uses Playwright to screenshot each `<section class="slide">` as a PNG
+at 2x device scale, then assembles a 16:9 deck with one image per
+slide and a transparent text layer harvested from the rendered DOM.
+The text layer makes the exported PPTX selectable, copyable, and
+searchable in PowerPoint / Keynote / Google Slides, without trying to
+reconstruct native shapes (which would be a rabbit hole).
 
 Reused by the Google Slides exporter (uploads the same PPTX to Drive
 with `convertTo=true`).
@@ -18,26 +20,32 @@ from uuid import UUID, uuid4
 
 from playwright.async_api import async_playwright
 from pptx import Presentation
-from pptx.util import Emu
+from pptx.dml.color import RGBColor
+from pptx.util import Emu, Pt
 
 from ..celery_app import celery
 from ..database import get_pool
 from ..services import storage_service
 from ..tasks._celery_helpers import run_async
+from .constants import (
+    EXPORT_DEVICE_SCALE_FACTOR,
+    SLIDE_HEIGHT_EMU,
+    SLIDE_HEIGHT_PX,
+    SLIDE_WIDTH_EMU,
+    SLIDE_WIDTH_PX,
+)
 
 logger = logging.getLogger(__name__)
-
-SLIDE_WIDTH_PX = 1920
-SLIDE_HEIGHT_PX = 1080
-# python-pptx uses EMU (English Metric Units). 1 inch = 914400 EMU.
-# 16:9 at 13.33 in x 7.5 in is the standard widescreen size.
-PPTX_SLIDE_WIDTH = Emu(12192000)  # 13.333"
-PPTX_SLIDE_HEIGHT = Emu(6858000)  # 7.5"
 
 SECTION_RE = re.compile(
     r"<section\b[^>]*\bclass\s*=\s*[\"'][^\"']*\bslide\b[^\"']*[\"'][^>]*>",
     re.IGNORECASE,
 )
+
+# Text elements we harvest into the invisible PPTX text overlay. Limited
+# to leaf-ish content elements — picking up <div> would double-count text
+# because divs commonly wrap other elements we already capture.
+TEXT_SELECTOR = "h1, h2, h3, h4, h5, h6, p, li, td, th, blockquote, figcaption"
 
 
 def _count_slides(html: str) -> int:
@@ -46,8 +54,6 @@ def _count_slides(html: str) -> int:
 
 def _build_single_slide_html(source_html: str, slide_index: int) -> str:
     """Return HTML showing only the Nth <section class="slide">."""
-    # Inject a bootstrap that hides every other section. Cheaper than
-    # splitting the source HTML server-side.
     script = (
         "<script>(function(){var s=document.querySelectorAll('body > section.slide');"
         + f"var i={slide_index};"
@@ -58,43 +64,164 @@ def _build_single_slide_html(source_html: str, slide_index: int) -> str:
     return source_html + script
 
 
-async def _screenshot_slides(html: str, count: int) -> list[bytes]:
+# JS executed inside the Playwright page to collect (text, bounds, size)
+# tuples for the active slide. Bounds are in CSS px relative to the
+# slide section so we can map them into PPTX EMUs by ratio.
+_TEXT_HARVEST_JS = """
+() => {
+  const slide = document.querySelector('body > section.slide:not([style*="display: none"])')
+            || document.querySelector('body > section.slide');
+  if (!slide) return [];
+  const slideRect = slide.getBoundingClientRect();
+  const sel = "{SEL}";
+  const out = [];
+  slide.querySelectorAll(sel).forEach(el => {
+    const text = el.innerText.trim();
+    if (!text) return;
+    const r = el.getBoundingClientRect();
+    if (r.width < 4 || r.height < 4) return;
+    const style = getComputedStyle(el);
+    out.push({
+      text,
+      x: r.left - slideRect.left,
+      y: r.top - slideRect.top,
+      w: r.width,
+      h: r.height,
+      fontSize: parseFloat(style.fontSize) || 16,
+      bold: parseInt(style.fontWeight, 10) >= 600,
+      italic: style.fontStyle === 'italic',
+    });
+  });
+  return out;
+}
+""".replace("{SEL}", TEXT_SELECTOR)
+
+
+async def _capture_slide(page, slide_index: int, html: str) -> tuple[bytes, list[dict]]:
+    """Render one slide, return (png_bytes, text_blocks).
+
+    `text_blocks` are CSS-px coordinates relative to the slide section's
+    top-left; the caller maps them to EMUs.
+    """
+    slide_html = _build_single_slide_html(html, slide_index)
+    await page.set_content(slide_html, wait_until="networkidle")
+    png = await page.screenshot(
+        type="png",
+        full_page=False,
+        clip={"x": 0, "y": 0, "width": SLIDE_WIDTH_PX, "height": SLIDE_HEIGHT_PX},
+    )
+    try:
+        text_blocks = await page.evaluate(_TEXT_HARVEST_JS)
+    except Exception:
+        logger.warning("text harvest failed for slide %s; export will lack selectable text", slide_index)
+        text_blocks = []
+    return png, text_blocks
+
+
+async def _capture_all_slides(html: str, count: int) -> list[tuple[bytes, list[dict]]]:
     async with async_playwright() as p:
         browser = await p.chromium.launch()
         try:
-            shots: list[bytes] = []
-            for i in range(count):
-                page = await browser.new_page(
-                    viewport={"width": SLIDE_WIDTH_PX, "height": SLIDE_HEIGHT_PX},
-                )
-                slide_html = _build_single_slide_html(html, i)
-                await page.set_content(slide_html, wait_until="networkidle")
-                png = await page.screenshot(
-                    type="png",
-                    full_page=False,
-                    clip={"x": 0, "y": 0, "width": SLIDE_WIDTH_PX, "height": SLIDE_HEIGHT_PX},
-                )
-                shots.append(png)
-                await page.close()
-            return shots
+            results: list[tuple[bytes, list[dict]]] = []
+            context = await browser.new_context(
+                viewport={"width": SLIDE_WIDTH_PX, "height": SLIDE_HEIGHT_PX},
+                device_scale_factor=EXPORT_DEVICE_SCALE_FACTOR,
+            )
+            try:
+                for i in range(count):
+                    page = await context.new_page()
+                    try:
+                        results.append(await _capture_slide(page, i, html))
+                    finally:
+                        await page.close()
+            finally:
+                await context.close()
+            return results
         finally:
             await browser.close()
 
 
-def _build_pptx(shots: list[bytes]) -> bytes:
+def _px_to_emu(px: float, total_px: int, total_emu: int) -> int:
+    """Convert CSS px in a `total_px`-wide canvas to EMU in a
+    `total_emu`-wide slide. Clamps to slide bounds so a stray
+    out-of-bounds element doesn't produce a negative offset."""
+    if total_px <= 0:
+        return 0
+    emu = int(px * total_emu / total_px)
+    return max(0, min(total_emu, emu))
+
+
+def _add_invisible_text(slide, text_blocks: list[dict]) -> None:
+    """Add transparent text boxes positioned over the slide image so the
+    text is selectable, copyable, and searchable in the export viewers."""
+    for block in text_blocks:
+        left = _px_to_emu(block["x"], SLIDE_WIDTH_PX, int(SLIDE_WIDTH_EMU))
+        top = _px_to_emu(block["y"], SLIDE_HEIGHT_PX, int(SLIDE_HEIGHT_EMU))
+        width = _px_to_emu(block["w"], SLIDE_WIDTH_PX, int(SLIDE_WIDTH_EMU))
+        height = _px_to_emu(block["h"], SLIDE_HEIGHT_PX, int(SLIDE_HEIGHT_EMU))
+        if width <= 0 or height <= 0:
+            continue
+        box = slide.shapes.add_textbox(Emu(left), Emu(top), Emu(width), Emu(height))
+        tf = box.text_frame
+        tf.margin_left = tf.margin_right = tf.margin_top = tf.margin_bottom = 0
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        run = p.add_run()
+        run.text = block["text"]
+        font = run.font
+        # CSS px ≈ Pt * 96/72; the rendered image already encodes the
+        # visual size, so this is purely for selection-rectangle sizing.
+        font.size = Pt(max(6, int(block.get("fontSize", 16) * 72 / 96)))
+        font.bold = bool(block.get("bold"))
+        font.italic = bool(block.get("italic"))
+        # Make the text invisible: matching white fill is fragile across
+        # themes, so we drop alpha to 0 via the underlying XML. python-pptx
+        # doesn't expose alpha directly on color, but the run's solid fill
+        # accepts an `<a:alpha>` child via XML.
+        font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
+        _set_run_alpha(run, 0)
+
+
+def _set_run_alpha(run, alpha_pct: int) -> None:
+    """Set the alpha channel of a run's font color via the OOXML
+    `<a:alpha val="..."/>` child. `alpha_pct` is in thousandths of a
+    percent: 0 = fully transparent, 100000 = opaque."""
+    from pptx.oxml.ns import qn
+
+    rPr = run._r.get_or_add_rPr()
+    solid = rPr.find(qn("a:solidFill"))
+    if solid is None:
+        # Color hasn't been written yet — touch it so python-pptx emits
+        # the <a:solidFill> element, then re-find.
+        run.font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
+        solid = rPr.find(qn("a:solidFill"))
+    srgb = solid.find(qn("a:srgbClr")) if solid is not None else None
+    if srgb is None:
+        return
+    # Drop any existing alpha child, then add a fresh one.
+    for existing in srgb.findall(qn("a:alpha")):
+        srgb.remove(existing)
+    from lxml import etree
+
+    alpha = etree.SubElement(srgb, qn("a:alpha"))
+    alpha.set("val", str(int(alpha_pct * 1000)))
+
+
+def _build_pptx(captures: list[tuple[bytes, list[dict]]]) -> bytes:
     prs = Presentation()
-    prs.slide_width = PPTX_SLIDE_WIDTH
-    prs.slide_height = PPTX_SLIDE_HEIGHT
+    prs.slide_width = SLIDE_WIDTH_EMU
+    prs.slide_height = SLIDE_HEIGHT_EMU
     blank = prs.slide_layouts[6]  # blank layout
-    for png in shots:
+    for png, text_blocks in captures:
         slide = prs.slides.add_slide(blank)
         slide.shapes.add_picture(
             io.BytesIO(png),
             left=0,
             top=0,
-            width=PPTX_SLIDE_WIDTH,
-            height=PPTX_SLIDE_HEIGHT,
+            width=SLIDE_WIDTH_EMU,
+            height=SLIDE_HEIGHT_EMU,
         )
+        _add_invisible_text(slide, text_blocks)
     buf = io.BytesIO()
     prs.save(buf)
     return buf.getvalue()
@@ -119,8 +246,8 @@ async def build_pptx_bytes_for_page(page_id: UUID) -> tuple[str, bytes]:
 
     source_html = page_row["content_html"] or ""
     count = _count_slides(source_html)
-    shots = await _screenshot_slides(source_html, count)
-    pptx_bytes = _build_pptx(shots)
+    captures = await _capture_all_slides(source_html, count)
+    pptx_bytes = _build_pptx(captures)
     return page_row["name"] or "slides", pptx_bytes
 
 

--- a/backend/tests/test_export_constants.py
+++ b/backend/tests/test_export_constants.py
@@ -1,0 +1,62 @@
+"""Lock-in tests for the slide export canvas constants.
+
+The PPTX, PDF, and Google Slides exporters all derive their dimensions
+from `backend.exports.constants`. If these values drift, exports stop
+matching the renderer's iframe (which targets the same 1920x1080 box).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.exports import constants, pptx
+
+REPO_BACKEND = Path(__file__).resolve().parents[1]
+
+
+def test_canvas_dimensions_consistent():
+    assert constants.SLIDE_WIDTH_PX == 1920
+    assert constants.SLIDE_HEIGHT_PX == 1080
+    # 16:9 aspect ratio across all units.
+    assert constants.SLIDE_WIDTH_PX / constants.SLIDE_HEIGHT_PX == pytest.approx(16 / 9)
+    assert constants.SLIDE_WIDTH_INCHES / constants.SLIDE_HEIGHT_INCHES == pytest.approx(
+        16 / 9, rel=1e-3
+    )
+    # EMU values match python-pptx's standard widescreen size.
+    assert int(constants.SLIDE_WIDTH_EMU) == 12_192_000
+    assert int(constants.SLIDE_HEIGHT_EMU) == 6_858_000
+
+
+def test_device_scale_factor_is_meaningful():
+    # 1x is the historical default; we explicitly want >=2 so exports
+    # stay crisp on 4K displays / when zoomed in PowerPoint.
+    assert constants.EXPORT_DEVICE_SCALE_FACTOR >= 2
+
+
+def test_px_to_emu_clamps_within_bounds():
+    convert = pptx._px_to_emu
+    width_emu = int(constants.SLIDE_WIDTH_EMU)
+    assert convert(0, constants.SLIDE_WIDTH_PX, width_emu) == 0
+    assert convert(constants.SLIDE_WIDTH_PX, constants.SLIDE_WIDTH_PX, width_emu) == width_emu
+    # Mid-canvas.
+    mid = convert(960, constants.SLIDE_WIDTH_PX, width_emu)
+    assert width_emu // 2 - 100 < mid < width_emu // 2 + 100
+    # Out-of-bounds high gets clamped to slide width, not extended past.
+    assert convert(9999, constants.SLIDE_WIDTH_PX, width_emu) == width_emu
+    # Out-of-bounds low (negative) gets clamped to 0.
+    assert convert(-50, constants.SLIDE_WIDTH_PX, width_emu) == 0
+
+
+def test_no_hardcoded_canvas_dims_in_exporters():
+    """Catch a future regression where someone re-introduces 1920 or
+    1080 as a literal in an exporter instead of importing the constant.
+    Guards the consistency story in the PR plan."""
+    for path in (REPO_BACKEND / "exports" / "pptx.py", REPO_BACKEND / "exports" / "pdf.py"):
+        text = path.read_text()
+        # Strip out comments so the audit doesn't flag explanatory text.
+        no_comments = re.sub(r"#.*", "", text)
+        assert "1920" not in no_comments, f"{path.name} hardcodes 1920 (use SLIDE_WIDTH_PX)"
+        assert "1080" not in no_comments, f"{path.name} hardcodes 1080 (use SLIDE_HEIGHT_PX)"


### PR DESCRIPTION
## Summary

PR 3 of 3 from the slides-improvements plan. Turns the PPTX / Google Slides exports from \"screenshots of slides\" into artifacts users can actually select, copy, and search inside.

- **`backend/exports/constants.py`** — single source of truth for the slide canvas (1920×1080 px, 13.333\"×7.5\", 16:9, 2× device scale). All three exporters (PPTX, PDF, Google Slides) now derive their dimensions from it. Magic numbers eliminated.
- **2× device scale** on PPTX screenshots — the embedded PNGs are now 3840×2160 instead of 1920×1080. Slides stay crisp when zoomed in PowerPoint / projected on a 4K screen, at ~4× file size.
- **Invisible text overlay** in PPTX — for each slide we harvest text from `<h1>…<h6>, <p>, <li>, <td>, <th>, <blockquote>, <figcaption>` with bounding boxes, and emit transparent text shapes at matching EMU coords. Text is now selectable, copyable, and searchable in PowerPoint / Keynote / Slides without reconstructing native styled shapes (which the code comment had previously called \"a rabbit hole\").
- **PDF tightening**: `html, body { overflow: hidden }` in the print CSS so a slide that overflows the 16:9 page gets clipped at the page boundary instead of leaking visual artifacts onto adjacent pages.

The Google Slides exporter (`backend/integrations/google/exporters/slides.py`) inherits the upgrade for free — it just calls `build_pptx_bytes_for_page` and uploads the result.

## Why now

Reported: \"current exports have fidelity loss across pptx, slides, pdf.\" The image-embed approach was deliberately simple but cost users the ability to do anything other than view the slides. The text-overlay trick gets the most-asked-for property (selection + search) without committing to a long native-shape conversion project.

## Test plan

- [x] `tests/test_export_constants.py` (new) — locks 1920 / 1080 / 16:9 / 2× and grep-asserts that pptx.py and pdf.py don't re-introduce hardcoded dims.
- [x] Smoke-test: `_capture_all_slides()` returns correct text blocks with bounds for a 2-slide HTML; generated PPTX contains `<a:alpha val=\"0\"/>` confirming the text overlay is invisible; `_render_pdf()` produces a valid 24 KB PDF (vector text, 16:9 page size). Screenshot of the rendered PDF page 1 attached.
- [ ] After deploy: real PPTX export from the app, open in **Keynote** and **PowerPoint** — text selectable, image crisp at 200% zoom, slide dims exactly 13.333\"×7.5\".
- [ ] Google Slides upload: convert lands cleanly, text selectable in Slides UI.
- [ ] PDF export from the app: open in Preview + Chrome — slide size 13.333\"×7.5\", no margins, text vector + selectable.

## Screenshot

PDF export rendered via `pdftoppm` (1920×1080 vector page, two-slide deck):

(Local at \`/tmp/slides-pr1-demo/pdf-page-1.png\` — \`gh\` doesn't support direct image upload; will attach via web UI.)

## Depends on

Independent of #404 and #405; merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)