### PR TITLE
Stash: single-page and single-session shortcuts (parity with single-file)

### DIFF
--- a/frontend/src/app/(app)/stashes/[slug]/StashItemBodies.tsx
+++ b/frontend/src/app/(app)/stashes/[slug]/StashItemBodies.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import HtmlPageView from "../../../../components/workspace/HtmlPageView";
+import type { PublicStashItem } from "../../../../lib/api";
+
+// Inline body renderers shared between two surfaces:
+//   1. The /stashes/[slug]/items/[type]/[id] viewer (one item, full page).
+//   2. The /stashes/[slug] detail page when the stash contains a single
+//      page or single session — we render the content inline instead of
+//      making the user click through.
+// Files are not here yet because the existing SingleFilePreview lives in
+// StashPageClient and renders a viewer (image/PDF) rather than markdown.
+
+interface InlineSessionEvent {
+  agent_name?: string;
+  event_type?: string;
+  tool_name?: string | null;
+  content?: string;
+  created_at?: string;
+}
+
+export function PageBody({ item }: { item: PublicStashItem }) {
+  const p = (item.inline as {
+    page?: {
+      content_type?: string;
+      content_markdown?: string;
+      content_html?: string;
+      html_layout?: "responsive" | "fixed-aspect";
+      name?: string;
+    };
+  }).page;
+  if (!p) return null;
+  if (p.content_type === "html") {
+    return (
+      <HtmlPageView
+        html={p.content_html || ""}
+        title={p.name || item.label}
+        layout={p.html_layout}
+      />
+    );
+  }
+  return (
+    <div className="markdown-content">
+      <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>
+    </div>
+  );
+}
+
+export function SessionBody({ item }: { item: PublicStashItem }) {
+  const s = (item.inline as {
+    session?: {
+      agent_name?: string;
+      started_at?: string | null;
+      finished_at?: string | null;
+      events?: InlineSessionEvent[];
+    };
+  }).session;
+  if (!s) return null;
+  const events = s.events ?? [];
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-base px-4 py-3 text-[13px] text-foreground">
+        <div className="flex flex-wrap items-center gap-3 text-[11.5px] uppercase tracking-wide text-muted">
+          {s.agent_name && <span>agent · {s.agent_name}</span>}
+          {s.started_at && <span>started · {new Date(s.started_at).toLocaleString()}</span>}
+          {s.finished_at && <span>ended · {new Date(s.finished_at).toLocaleString()}</span>}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {events.map((event, i) => (
+          <div
+            key={`${event.created_at ?? "evt"}-${i}`}
+            className="rounded-md border border-border-subtle bg-base/40 px-3 py-2 text-[12.5px]"
+          >
+            <div className="flex items-center gap-2 text-[10.5px] uppercase tracking-wide text-muted">
+              <span>{event.event_type || "event"}</span>
+              {event.tool_name && <span>· {event.tool_name}</span>}
+              {event.created_at && (
+                <span>· {new Date(event.created_at).toLocaleTimeString()}</span>
+              )}
+            </div>
+            <pre className="mt-1.5 m-0 whitespace-pre-wrap font-sans text-[12.5px] leading-relaxed text-foreground">
+              {event.content || ""}
+            </pre>
+          </div>
+        ))}
+        {events.length === 0 && (
+          <p className="text-[12.5px] text-muted">No events recorded.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/(app)/stashes/[slug]/StashPageClient.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../../../lib/api";
 import type { ActivityTimeline, EmbeddingProjection } from "../../../../lib/types";
 import AddToWorkspaceButton from "./AddToWorkspaceButton";
+import { PageBody, SessionBody } from "./StashItemBodies";
 
 type StashItemGroup = Partial<
   Record<PublicStashItem["object_type"], PublicStashItem[]>
@@ -146,8 +147,8 @@ function StashPageBody({
 }) {
   const { stash, workspace_name, items, can_write } = data;
   const groups = groupStashItems(items);
-  const primaryFile = primaryFileItemForStash(data);
-  const displayedItemCount = primaryFile ? 1 : items.length;
+  const primary = primaryItemForStash(data);
+  const displayedItemCount = primary ? 1 : items.length;
   const [addOpen, setAddOpen] = useState(false);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(
@@ -156,7 +157,7 @@ function StashPageBody({
   const [insightsLoaded, setInsightsLoaded] = useState(false);
 
   useEffect(() => {
-    if (primaryFile) {
+    if (primary) {
       setTimeline(null);
       setProjection(null);
       setInsightsLoaded(true);
@@ -179,7 +180,7 @@ function StashPageBody({
     return () => {
       cancelled = true;
     };
-  }, [primaryFile, stash.id]);
+  }, [primary, stash.id]);
 
   const cover = stash.cover_image_url
     ? { backgroundImage: `url(${stash.cover_image_url})` }
@@ -283,8 +284,18 @@ function StashPageBody({
           }}
         />
 
-        {primaryFile ? (
-          <SingleFilePreview item={primaryFile} />
+        {primary ? (
+          primary.kind === "file" ? (
+            <SingleFilePreview item={primary.item} />
+          ) : primary.kind === "page" ? (
+            <section className="mt-6">
+              <PageBody item={primary.item} />
+            </section>
+          ) : (
+            <section className="mt-6">
+              <SessionBody item={primary.item} />
+            </section>
+          )
         ) : (
           <>
             {/* Compact item lists by kind. Items deep-link to the editor /
@@ -384,17 +395,39 @@ function StashPageBody({
   );
 }
 
-function primaryFileItemForStash(data: PublicStashDetail): PublicStashItem | null {
-  const fileItems = data.items.filter((item) => item.object_type === "file");
-  if (fileItems.length !== 1) return null;
-  if (data.items.length === 1) return fileItems[0];
+type PrimaryItem =
+  | { kind: "file"; item: PublicStashItem }
+  | { kind: "page"; item: PublicStashItem }
+  | { kind: "session"; item: PublicStashItem };
 
-  const onlyFileAndUploadFolder = data.items.every((item) =>
-    item.object_type === "file" || item.object_type === "folder"
-  );
-  if (!onlyFileAndUploadFolder) return null;
-  if (!data.stash.description.includes("Uploaded from ")) return null;
-  return fileItems[0];
+// "Single-content" stashes — one file, one page, or one session and nothing
+// else — open straight to that content's viewer instead of the bundle chrome
+// + viz section. The intuition is symmetric across kinds: a stash whose
+// whole point is one artifact should feel like that artifact.
+//
+// The file variant also accepts file-plus-auto-folder bundles created by
+// `stash upload <single-file>` (description starts with "Uploaded from ").
+// Pages and sessions don't share that wrapper today, so we keep them strict.
+function primaryItemForStash(data: PublicStashDetail): PrimaryItem | null {
+  const fileItems = data.items.filter((item) => item.object_type === "file");
+  if (fileItems.length === 1) {
+    if (data.items.length === 1) return { kind: "file", item: fileItems[0] };
+    const onlyFileAndUploadFolder = data.items.every((item) =>
+      item.object_type === "file" || item.object_type === "folder"
+    );
+    if (
+      onlyFileAndUploadFolder &&
+      data.stash.description.includes("Uploaded from ")
+    ) {
+      return { kind: "file", item: fileItems[0] };
+    }
+  }
+  if (data.items.length === 1) {
+    const only = data.items[0];
+    if (only.object_type === "page") return { kind: "page", item: only };
+    if (only.object_type === "session") return { kind: "session", item: only };
+  }
+  return null;
 }
 
 function SingleFilePreview({ item }: { item: PublicStashItem }) {

--- a/frontend/src/app/(app)/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
+++ b/frontend/src/app/(app)/stashes/[slug]/items/[type]/[id]/StashItemClient.tsx
@@ -15,6 +15,7 @@ import {
   type PublicStashDetail,
   type PublicStashItem,
 } from "../../../../../../../lib/api";
+import { PageBody, SessionBody } from "../../../StashItemBodies";
 
 // Stash-scoped item viewer.
 //
@@ -172,33 +173,6 @@ function ItemBody({ item }: { item: PublicStashItem }) {
   if (item.object_type === "folder") return <FolderBody item={item} />;
   if (item.object_type === "session") return <SessionBody item={item} />;
   return null;
-}
-
-function PageBody({ item }: { item: PublicStashItem }) {
-  const p = (item.inline as {
-    page?: {
-      content_type?: string;
-      content_markdown?: string;
-      content_html?: string;
-      html_layout?: "responsive" | "fixed-aspect";
-      name?: string;
-    };
-  }).page;
-  if (!p) return null;
-  if (p.content_type === "html") {
-    return (
-      <HtmlPageView
-        html={p.content_html || ""}
-        title={p.name || item.label}
-        layout={p.html_layout}
-      />
-    );
-  }
-  return (
-    <div className="markdown-content">
-      <Markdown remarkPlugins={[remarkGfm]}>{p.content_markdown || ""}</Markdown>
-    </div>
-  );
 }
 
 interface InlineTableColumn {
@@ -383,60 +357,6 @@ function FolderBody({ item }: { item: PublicStashItem }) {
           </div>
         </section>
       )}
-    </div>
-  );
-}
-
-interface InlineSessionEvent {
-  agent_name?: string;
-  event_type?: string;
-  tool_name?: string | null;
-  content?: string;
-  created_at?: string;
-}
-
-function SessionBody({ item }: { item: PublicStashItem }) {
-  const s = (item.inline as {
-    session?: {
-      agent_name?: string;
-      started_at?: string | null;
-      finished_at?: string | null;
-      events?: InlineSessionEvent[];
-    };
-  }).session;
-  if (!s) return null;
-  const events = s.events ?? [];
-  return (
-    <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-base px-4 py-3 text-[13px] text-foreground">
-        <div className="flex flex-wrap items-center gap-3 text-[11.5px] uppercase tracking-wide text-muted">
-          {s.agent_name && <span>agent · {s.agent_name}</span>}
-          {s.started_at && <span>started · {new Date(s.started_at).toLocaleString()}</span>}
-          {s.finished_at && <span>ended · {new Date(s.finished_at).toLocaleString()}</span>}
-        </div>
-      </div>
-      <div className="space-y-2">
-        {events.map((event, i) => (
-          <div
-            key={`${event.created_at ?? "evt"}-${i}`}
-            className="rounded-md border border-border-subtle bg-base/40 px-3 py-2 text-[12.5px]"
-          >
-            <div className="flex items-center gap-2 text-[10.5px] uppercase tracking-wide text-muted">
-              <span>{event.event_type || "event"}</span>
-              {event.tool_name && <span>· {event.tool_name}</span>}
-              {event.created_at && (
-                <span>· {new Date(event.created_at).toLocaleTimeString()}</span>
-              )}
-            </div>
-            <pre className="mt-1.5 m-0 whitespace-pre-wrap font-sans text-[12.5px] leading-relaxed text-foreground">
-              {event.content || ""}
-            </pre>
-          </div>
-        ))}
-        {events.length === 0 && (
-          <p className="text-[12.5px] text-muted">No events recorded.</p>
-        )}
-      </div>
     </div>
   );
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.16"
+version = "0.1.15"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.15"
+version = "0.1.16"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

A stash whose entire purpose is one artifact should open straight to that artifact. The single-file-upload case already does this (file preview, no bundle chrome, no empty viz section). This PR extends the same shortcut to one-page stashes (`stash publish notes.md`) and one-session stashes (`stash share <session>` when nothing else is attached).

## What changed

- `primaryFileItemForStash` → `primaryItemForStash`, returning a discriminated union `{ kind: "file" | "page" | "session", item }`. File rules unchanged. Page and session require the stash to contain exactly that one item.
- `StashPageClient` dispatches to `<SingleFilePreview>`, `<PageBody>`, or `<SessionBody>`.
- `PageBody` and `SessionBody` extracted from `StashItemClient.tsx` into a shared `StashItemBodies.tsx` so the new inline preview and the existing `/stashes/[slug]/items/[type]/[id]` viewer render content identically.

## Test plan

- [ ] Open a one-page stash (`stash publish notes.md` flow) → page renders inline, no bundle chrome, no viz section.
- [ ] Open a one-session stash (`stash share <session>` when only the session was attached) → session transcript renders inline.
- [ ] Open a multi-item stash → bundle chrome + viz section as before (regression check).
- [ ] Open a single-file stash → file preview as before (regression check).
- [ ] `/stashes/[slug]/items/page/<id>` viewer still renders the page (shared `PageBody`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)