### PR TITLE
Page/file parity: file embeddings + page download + files metadata

### DIFF
--- a/backend/migrations/versions/0076_files_embedding_and_metadata.py
+++ b/backend/migrations/versions/0076_files_embedding_and_metadata.py
@@ -1,0 +1,50 @@
+"""Page/file parity: files get embedding, embed_stale, metadata.
+
+Pages already carry an `embedding vector(384)` + `embed_stale boolean` so
+they show up in the embedding map and feed semantic search. Files
+already carry `extracted_text`, but no embedding — they're invisible to
+the same surfaces. This migration closes that gap: a follow-up worker
+batch consumes `extracted_text` and writes the embedding.
+
+`metadata jsonb` mirrors `pages.metadata` so files can carry the same
+kind of side-band state (e.g. `shared_in_stash_id`) when we need it.
+
+Revision ID: 0076
+Revises: 0075
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+
+revision = "0076"
+down_revision = "0075"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE files "
+        "ADD COLUMN IF NOT EXISTS embedding vector(384), "
+        "ADD COLUMN IF NOT EXISTS embed_stale boolean NOT NULL DEFAULT FALSE, "
+        "ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb"
+    )
+    # Mark every file that already has extracted text so the embedding
+    # reconciler picks it up on its next pass.
+    op.execute(
+        "UPDATE files SET embed_stale = TRUE "
+        "WHERE extracted_text IS NOT NULL AND extracted_text <> '' "
+        "AND deleted_at IS NULL"
+    )
+    # Partial index matches the reconciler's hot path.
+    op.execute("CREATE INDEX IF NOT EXISTS idx_files_embed_stale " "ON files(id) WHERE embed_stale")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_files_embed_stale")
+    op.execute(
+        "ALTER TABLE files "
+        "DROP COLUMN IF EXISTS embedding, "
+        "DROP COLUMN IF EXISTS embed_stale, "
+        "DROP COLUMN IF EXISTS metadata"
+    )

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -1,8 +1,9 @@
 """Files router: workspace-scoped folders (nested) and pages."""
 
+from urllib.parse import quote
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from ..auth import get_current_user
 from ..database import get_pool
@@ -433,6 +434,38 @@ async def get_page(
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
     return PageResponse(**page)
+
+
+@router.get("/pages/{page_id}/download")
+async def download_page(
+    workspace_id: UUID,
+    page_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Raw page body, parallel to /files/{file_id}/download.
+
+    Returns the page's markdown source (or HTML, for html-typed pages) so
+    callers can export, diff, or feed it to other tools the same way they
+    would a binary file. Permission is the existing page-read check —
+    members of the workspace plus anyone the page is shared with.
+    """
+    await _check_ws_access(workspace_id, current_user["id"])
+    page = await files_tree_service.get_page(page_id, workspace_id, current_user["id"])
+    if not page:
+        raise HTTPException(status_code=404, detail="Page not found")
+    is_html = (page.get("content_type") or "").lower() == "html"
+    body = (page.get("content_html") if is_html else page.get("content_markdown")) or ""
+    suffix = ".html" if is_html else ".md"
+    media = "text/html; charset=utf-8" if is_html else "text/markdown; charset=utf-8"
+    name = page.get("name") or "page"
+    filename = name if name.lower().endswith(suffix) else f"{name}{suffix}"
+    return Response(
+        content=body,
+        media_type=media,
+        headers={
+            "Content-Disposition": f"inline; filename*=UTF-8''{quote(filename)}",
+        },
+    )
 
 
 @router.patch("/pages/{page_id}", response_model=PageResponse)

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -172,6 +172,63 @@ def _accessible_tables_cte(
     """
 
 
+def _accessible_files_cte(
+    ws_idx: int | None = None,
+    user_idx: int = 1,
+    stash_idx: int | None = None,
+) -> str:
+    readable_files = permission_service.readable_content_condition("file", "f", user_idx)
+    if stash_idx is not None:
+        # Same folder-expansion pattern as pages: a stash can list files
+        # directly, or wrap them in a folder, so walk descendant folders.
+        return f"""
+        WITH RECURSIVE stash_folder_descendants AS (
+            SELECT object_id::uuid AS folder_id
+            FROM stash_items
+            WHERE stash_id = ${stash_idx}
+              AND object_type = 'folder'
+            UNION
+            SELECT fld.id
+            FROM folders fld
+            JOIN stash_folder_descendants d
+              ON fld.parent_folder_id = d.folder_id
+        ),
+        accessible_files AS (
+            SELECT f.id AS file_id
+            FROM files f
+            WHERE f.deleted_at IS NULL
+              AND {readable_files}
+              AND (
+                f.id IN (
+                    SELECT object_id::uuid FROM stash_items
+                    WHERE stash_id = ${stash_idx}
+                      AND object_type = 'file'
+                )
+                OR f.folder_id IN (SELECT folder_id FROM stash_folder_descendants)
+              )
+        )
+        """
+    if ws_idx is not None:
+        return f"""
+        WITH accessible_files AS (
+            SELECT f.id AS file_id
+            FROM files f
+            WHERE f.workspace_id = ${ws_idx}
+              AND f.deleted_at IS NULL
+              AND {readable_files}
+        )
+        """
+    return f"""
+    WITH accessible_files AS (
+        SELECT f.id AS file_id
+        FROM files f
+        WHERE f.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
+          AND f.deleted_at IS NULL
+          AND {readable_files}
+    )
+    """
+
+
 async def get_activity_timeline(
     user_id: UUID,
     days: int = 30,
@@ -780,6 +837,18 @@ async def get_embedding_projection(
         )
         total_count += row or 0
 
+    if source is None or source == "files":
+        row = await pool.fetchval(
+            _accessible_files_cte(ws_idx=content_count_ws_idx, stash_idx=content_count_stash_idx)
+            + """
+            SELECT COUNT(*) FROM files f
+            WHERE f.id IN (SELECT file_id FROM accessible_files)
+              AND f.embedding IS NOT NULL
+            """,
+            *content_count_args,
+        )
+        total_count += row or 0
+
     # Check if cache is still valid
     one_hour_ago = datetime.now(UTC) - timedelta(hours=1)
     if cache and cache["computed_at"] > one_hour_ago:
@@ -794,9 +863,10 @@ async def get_embedding_projection(
     if total_count == 0:
         return {"points": [], "stats": {"total_embeddings": 0, "projected": 0}, "cached": False}
 
-    # Fetch embeddings from each source
+    # Fetch embeddings from each source. Divide by the number of sources
+    # so the union doesn't exceed max_points by much.
     all_items: list[dict] = []
-    per_source_limit = max_points if source else max_points // 3
+    per_source_limit = max_points if source else max(max_points // 4, 1)
     content_fetch_args = [user_id, per_source_limit]
     content_fetch_ws_idx = None
     content_fetch_stash_idx = None
@@ -883,6 +953,30 @@ async def get_embedding_projection(
                     "id": str(r["id"]),
                     "label": f"{r['agent_name'] or 'agent'}: {r['event_type'] or 'event'}",
                     "source": "history_events",
+                    "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                    "embedding": np.array(r["embedding"]),
+                }
+            )
+
+    if source is None or source == "files":
+        rows = await pool.fetch(
+            _accessible_files_cte(ws_idx=content_fetch_ws_idx, stash_idx=content_fetch_stash_idx)
+            + """
+            SELECT f.id, f.name AS label, f.embedding, f.created_at
+            FROM files f
+            WHERE f.id IN (SELECT file_id FROM accessible_files)
+              AND f.embedding IS NOT NULL
+            ORDER BY f.created_at DESC
+            LIMIT $2
+            """,
+            *content_fetch_args,
+        )
+        for r in rows:
+            all_items.append(
+                {
+                    "id": str(r["id"]),
+                    "label": r["label"],
+                    "source": "files",
                     "created_at": r["created_at"].isoformat() if r["created_at"] else None,
                     "embedding": np.array(r["embedding"]),
                 }

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -100,11 +100,43 @@ async def _reconcile_history_events() -> int:
     return len(ids)
 
 
+async def _reconcile_files() -> int:
+    # Files only get embeddings once `extract_one` lands the extracted text.
+    # The worker flips embed_stale to TRUE; this reconciler turns it back
+    # off after embedding the text.
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, extracted_text FROM files "
+        "WHERE embed_stale AND deleted_at IS NULL "
+        "AND extraction_status = 'done' "
+        "AND extracted_text IS NOT NULL AND extracted_text <> '' "
+        "LIMIT $1",
+        BATCH_SIZE,
+    )
+    if not rows:
+        return 0
+    ids = [r["id"] for r in rows]
+    texts = [r["extracted_text"] for r in rows]
+    vecs = await embedding_service.embed_batch(texts)
+    if not vecs:
+        return 0
+    await pool.executemany(
+        "UPDATE files SET embedding = $1, embed_stale = FALSE WHERE id = $2",
+        list(zip(vecs, ids)),
+    )
+    return len(ids)
+
+
 async def _reconcile() -> int:
     if not embedding_service.is_configured():
         return 0
     done = 0
-    for fn in (_reconcile_pages, _reconcile_table_rows, _reconcile_history_events):
+    for fn in (
+        _reconcile_pages,
+        _reconcile_table_rows,
+        _reconcile_history_events,
+        _reconcile_files,
+    ):
         done += await fn()
     if done:
         logger.info("embedding reconciler: refreshed %d row(s)", done)

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -75,12 +75,15 @@ async def _run(file_id: UUID) -> int:
         if text and len(text) > MAX_EXTRACTED_TEXT:
             text = text[:MAX_EXTRACTED_TEXT] + "\n\n[truncated]"
 
+        # embed_stale flips on if there's text to embed. The reconciler
+        # in backend/tasks/embeddings.py picks files up from there.
         await conn.execute(
             "UPDATE files SET "
             "extracted_text = $2, "
             "extraction_status = 'done', "
             "extraction_error = NULL, "
-            "locked_at = NULL "
+            "locked_at = NULL, "
+            "embed_stale = CASE WHEN $2 IS NOT NULL AND $2 <> '' THEN TRUE ELSE embed_stale END "
             "WHERE id = $1",
             file_id,
             text,


### PR DESCRIPTION
## Summary

Closes the three accidental gaps the page/file audit surfaced. A page is a file with a special editor; the schema and surfaces should reflect that.

1. **Files get embeddings** (audit item #1).
   - Migration 0076 adds `files.embedding vector(384)`, `files.embed_stale boolean`, and `files.metadata jsonb` (mirrors pages).
   - Upgrade marks existing files with `extracted_text` as stale.
   - `backend/workers/extract_one` flips `embed_stale = TRUE` after writing extracted text.
   - `backend/tasks/embeddings._reconcile_files` consumes the queue using the existing Beat loop.
   - `backend/services/analytics_service` gains `_accessible_files_cte` and a `files` source in `get_embedding_projection`. The workspace and stash embedding maps now include files alongside pages, tables, and sessions.

2. **Page download endpoint** (audit item #3).
   - `GET /api/v1/workspaces/{ws}/pages/{page_id}/download` returns raw markdown (or HTML for html-typed pages) with `Content-Type: text/markdown` / `text/html` and `Content-Disposition: inline; filename=<name>.{md,html}`.
   - Parallel to `files/{file_id}/download`. Permission gate: existing page-read check.

3. **`files.metadata` column** (audit item #5).
   - Adds the `jsonb` column. No consumer yet — same role `pages.metadata` plays for `shared_in_stash_id`. Lays groundwork for future side-band state on files.

Audit item #4 (route prefix normalization) was a no-op — files are already at `/api/v1/workspaces/{ws}/files/...`. The audit was wrong about that. No comments on files because comments are part of the page-specialized editor.

## Test plan

- [ ] `alembic upgrade head` adds three columns + the partial index. Existing files with extracted_text flip `embed_stale = TRUE`.
- [ ] Drop a PDF into a workspace, wait for extraction, then poll `embedding_projection` — the file appears.
- [ ] `GET /api/v1/workspaces/{ws}/pages/{id}/download` returns markdown for a markdown page, html for an HTML page, correct Content-Disposition. 403 for non-members. 404 for missing.
- [ ] Stash that contains a folder with files in it → embedding map shows file points (folder expansion works for files, mirroring the pages fix from PR #403).
- [ ] Workspace homepage embedding map still renders pages + tables + sessions (regression check).
- [ ] `?stash_id=X` + `?workspace_id=Y` still returns 400 (mutual exclusion regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)