### PR TITLE
fix(plugin): use uv tool install @latest for auto-update + bump to 0.1.17

### DIFF
--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -17,7 +17,7 @@ TARGET="$(dirname "$0")/$SCRIPT.py"
 # plugin cache never drifts from the source repo.
 if [ "$SCRIPT" = "on_session_start" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   git -C "$CLAUDE_PLUGIN_ROOT" pull --ff-only origin main >/dev/null 2>&1 &
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 PY=""

--- a/plugins/codex-plugin/scripts/_run.sh
+++ b/plugins/codex-plugin/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/plugins/cursor-plugin/scripts/_run.sh
+++ b/plugins/cursor-plugin/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -8,7 +8,7 @@ import subprocess
 # missing install can still self-heal on the next session start.
 if shutil.which("uv"):
     subprocess.Popen(
-        ["uv", "tool", "upgrade", "--quiet", "stashai"],
+        ["uv", "tool", "install", "--quiet", "stashai@latest"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,

--- a/plugins/openclaw-plugin/scripts/_run.sh
+++ b/plugins/openclaw-plugin/scripts/_run.sh
@@ -11,7 +11,7 @@ shift
 TARGET="$(dirname "$0")/$SCRIPT.py"
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 PY="${STASH_PYTHON:-}"

--- a/plugins/opencode-plugin/scripts/_run.sh
+++ b/plugins/opencode-plugin/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.16"
+version = "0.1.17"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/stashai/plugin/assets/codex/scripts/_run.sh
+++ b/stashai/plugin/assets/codex/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/stashai/plugin/assets/cursor/scripts/_run.sh
+++ b/stashai/plugin/assets/cursor/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/stashai/plugin/assets/opencode/scripts/_run.sh
+++ b/stashai/plugin/assets/opencode/scripts/_run.sh
@@ -13,7 +13,7 @@ SCRIPT="$1"
 shift
 
 if [ "$SCRIPT" = "on_session_start" ]; then
-  command -v uv >/dev/null 2>&1 && uv tool upgrade --quiet stashai >/dev/null 2>&1 &
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
- Fix a real correctness gap discovered during QA of PR #402: `uv tool upgrade --quiet stashai` silently no-ops on installs pinned to a specific version (anyone who ever ran `uv tool install stashai==X.Y.Z` or `@X.Y.Z`). Replaces with `uv tool install --quiet stashai@latest` — works on both pinned and unpinned installs, and is what `uv tool upgrade` itself recommends in its hint output.
- Bumps to 0.1.17 to publish the fix and verify the end-to-end auto-update loop (an unpinned 0.1.16 install should pick up 0.1.17 on the next session-start hook fire).

## How the bug surfaced
During end-to-end QA: ran `uv tool install --quiet stashai@0.1.15` to set up a downgrade scenario, then fired the hook. `uv tool upgrade --quiet stashai` reported success but didn't bump the version. Removing `--quiet` revealed the hint: `stashai is pinned to 0.1.15 (installed with an exact version pin); reinstall with uv tool install stashai@latest`.

Install.sh users (`uv tool install --force --reinstall --refresh stashai`, no version → unpinned) were never affected, but anyone with a manual pin would have been silently stuck forever.

## Test plan
- [x] All 9 sites patched (8 `_run.sh` files + gemini `on_session_start.py`)
- [x] `grep -r 'uv tool upgrade' plugins/ stashai/plugin/assets/` returns nothing
- [ ] CI green
- [ ] After merge: my unpinned 0.1.16 install picks up 0.1.17 via session-start hook fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)