### PR TITLE
Stash: single-page-in-folder shortcut + unified file render path

### DIFF
--- a/frontend/src/app/(app)/stashes/[slug]/StashPageClient.tsx
+++ b/frontend/src/app/(app)/stashes/[slug]/StashPageClient.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../../../lib/api";
 import type { ActivityTimeline, EmbeddingProjection } from "../../../../lib/types";
 import AddToWorkspaceButton from "./AddToWorkspaceButton";
+import FileContentRenderer from "../../../../components/workspace/FileContentRenderer";
 import { PageBody, SessionBody } from "./StashItemBodies";
 
 type StashItemGroup = Partial<
@@ -400,34 +401,41 @@ type PrimaryItem =
   | { kind: "page"; item: PublicStashItem }
   | { kind: "session"; item: PublicStashItem };
 
-// "Single-content" stashes — one file, one page, or one session and nothing
-// else — open straight to that content's viewer instead of the bundle chrome
-// + viz section. The intuition is symmetric across kinds: a stash whose
-// whole point is one artifact should feel like that artifact.
+// "Single-content" stashes — the whole stash is really one artifact — open
+// straight to that artifact's viewer instead of the bundle chrome + viz
+// section. Three shapes count:
 //
-// The file variant also accepts file-plus-auto-folder bundles created by
-// `stash upload <single-file>` (description starts with "Uploaded from ").
-// Pages and sessions don't share that wrapper today, so we keep them strict.
+//   1. Exactly one item that is the artifact.
+//   2. One artifact + one folder, when the description starts with
+//      "Uploaded from " — this is what `stash upload <single>` and
+//      `stash publish <single>` produce; the folder is incidental
+//      packaging, not content.
+//   3. (sessions only) Always strict — a session-share is already
+//      a single item; we don't wrap it in a folder today.
 function primaryItemForStash(data: PublicStashDetail): PrimaryItem | null {
-  const fileItems = data.items.filter((item) => item.object_type === "file");
-  if (fileItems.length === 1) {
-    if (data.items.length === 1) return { kind: "file", item: fileItems[0] };
-    const onlyFileAndUploadFolder = data.items.every((item) =>
-      item.object_type === "file" || item.object_type === "folder"
-    );
-    if (
-      onlyFileAndUploadFolder &&
-      data.stash.description.includes("Uploaded from ")
-    ) {
-      return { kind: "file", item: fileItems[0] };
-    }
-  }
-  if (data.items.length === 1) {
-    const only = data.items[0];
-    if (only.object_type === "page") return { kind: "page", item: only };
-    if (only.object_type === "session") return { kind: "session", item: only };
+  const single = singleOfKindWithOptionalFolder(data, "file");
+  if (single) return { kind: "file", item: single };
+  const singlePage = singleOfKindWithOptionalFolder(data, "page");
+  if (singlePage) return { kind: "page", item: singlePage };
+  if (data.items.length === 1 && data.items[0].object_type === "session") {
+    return { kind: "session", item: data.items[0] };
   }
   return null;
+}
+
+function singleOfKindWithOptionalFolder(
+  data: PublicStashDetail,
+  kind: "file" | "page",
+): PublicStashItem | null {
+  const matches = data.items.filter((item) => item.object_type === kind);
+  if (matches.length !== 1) return null;
+  if (data.items.length === 1) return matches[0];
+  const onlyKindAndFolder = data.items.every(
+    (item) => item.object_type === kind || item.object_type === "folder",
+  );
+  if (!onlyKindAndFolder) return null;
+  if (!data.stash.description.includes("Uploaded from ")) return null;
+  return matches[0];
 }
 
 function SingleFilePreview({ item }: { item: PublicStashItem }) {
@@ -435,8 +443,6 @@ function SingleFilePreview({ item }: { item: PublicStashItem }) {
   const name = file.name || item.label || "Uploaded file";
   const contentType = file.content_type || "file";
   const size = formatFileSize(file.size_bytes ?? 0);
-  const isImage = contentType.startsWith("image/");
-  const isPdf = contentType.includes("pdf");
 
   return (
     <section className="mt-6">
@@ -461,27 +467,17 @@ function SingleFilePreview({ item }: { item: PublicStashItem }) {
         )}
       </div>
 
-      {!file.url && (
+      {!file.url ? (
         <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[13px] text-muted">
           This file is no longer available.
         </div>
-      )}
-      {file.url && isImage && (
-        <div className="overflow-auto rounded-lg border border-border bg-surface">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={file.url} alt={name} className="mx-auto h-auto max-w-full" />
-        </div>
-      )}
-      {file.url && isPdf && (
-        <iframe
-          src={file.url}
-          title={name}
-          className="h-[78vh] w-full rounded-lg border border-border bg-base"
-        />
-      )}
-      {file.url && !isImage && !isPdf && (
-        <div className="rounded-lg border border-border bg-base px-5 py-10 text-center text-[13px] text-muted">
-          No inline preview for this file type.
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-surface">
+          <FileContentRenderer
+            url={file.url}
+            name={name}
+            contentType={contentType}
+          />
         </div>
       )}
     </section>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -2,14 +2,8 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useState } from "react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
-import {
-  DocumentBodySkeleton,
-  FileViewerSkeleton,
-  SkeletonBlock,
-} from "../../../../../../components/SkeletonStates";
+import { FileViewerSkeleton } from "../../../../../../components/SkeletonStates";
 import { useAuth } from "../../../../../../hooks/useAuth";
 import {
   getFile,
@@ -21,22 +15,16 @@ import {
   type FolderBreadcrumb,
 } from "../../../../../../lib/api";
 import type { FileInfo } from "../../../../../../lib/types";
+import FileContentRenderer, {
+  isImage,
+  isMarkdown,
+  isPdf,
+  isText,
+} from "../../../../../../components/workspace/FileContentRenderer";
 import FileViewerHeader from "../../../../../../components/workspace/FileViewerHeader";
 
 function isCsv(ct: string) {
   return ct?.includes("csv") || ct === "text/csv";
-}
-function isPdf(ct: string) {
-  return ct?.includes("pdf");
-}
-function isImage(ct: string) {
-  return ct?.startsWith("image/");
-}
-function isMarkdown(ct: string, name: string) {
-  return ct?.includes("markdown") || name.toLowerCase().endsWith(".md");
-}
-function isText(ct: string) {
-  return ct?.startsWith("text/");
 }
 
 export default function FileViewerPage() {
@@ -65,7 +53,6 @@ function FileViewerPageInner() {
 
   const [file, setFile] = useState<FileInfo | null>(null);
   const [folderChain, setFolderChain] = useState<FolderBreadcrumb[]>([]);
-  const [textBody, setTextBody] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [stashTitle, setStashTitle] = useState<string | null>(null);
 
@@ -122,10 +109,6 @@ function FileViewerPageInner() {
         };
         setFile(synth);
         setFolderChain([]);
-        if (synth.url && (isText(synth.content_type) || isMarkdown(synth.content_type, synth.name))) {
-          const res = await fetch(synth.url);
-          if (res.ok) setTextBody(await res.text());
-        }
         return;
       }
 
@@ -158,10 +141,6 @@ function FileViewerPageInner() {
         return;
       }
 
-      if (f.url && (isText(f.content_type) || isMarkdown(f.content_type, f.name))) {
-        const res = await fetch(f.url);
-        if (res.ok) setTextBody(await res.text());
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load file");
     }
@@ -250,60 +229,14 @@ function FileViewerPageInner() {
       )}
 
       <div className="flex-1 overflow-auto bg-base scroll-thin">
-        {file && <FileBody file={file} text={textBody} />}
+        {file && (
+          <FileContentRenderer
+            url={file.url}
+            name={file.name}
+            contentType={file.content_type}
+          />
+        )}
       </div>
-    </div>
-  );
-}
-
-function FileBody({ file, text }: { file: FileInfo; text: string | null }) {
-  if (!file.url) return <p className="px-5 py-8 text-muted">No download URL.</p>;
-  if (isPdf(file.content_type)) {
-    return <iframe src={file.url} className="h-full w-full bg-gray-200" title={file.name} />;
-  }
-  if (isImage(file.content_type)) {
-    return (
-      <div className="flex items-center justify-center bg-gray-100 p-8">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={file.url} alt={file.name} className="max-h-full max-w-full" />
-      </div>
-    );
-  }
-  if (isMarkdown(file.content_type, file.name)) {
-    if (text === null) return <DocumentBodySkeleton className="mx-auto mt-8 max-w-[920px]" />;
-    return (
-      <article className="prose prose-sm markdown-content mx-auto max-w-[920px] px-12 py-8 text-foreground">
-        <Markdown remarkPlugins={[remarkGfm]}>{text || ""}</Markdown>
-      </article>
-    );
-  }
-  if (isText(file.content_type)) {
-    if (text === null) {
-      return (
-        <div className="space-y-2 px-5 py-4">
-          {[0, 1, 2, 3, 4, 5, 6, 7].map((row) => (
-            <SkeletonBlock key={row} className="h-4 w-full max-w-4xl" />
-          ))}
-        </div>
-      );
-    }
-    return (
-      <pre className="scroll-thin h-full overflow-auto px-5 py-4 font-mono text-[12.5px] text-foreground">
-        {text || ""}
-      </pre>
-    );
-  }
-  return (
-    <div className="mx-auto max-w-md px-8 py-12 text-center text-[13px] text-muted">
-      <p className="mb-3">No inline preview for this file type.</p>
-      <a
-        href={file.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-      >
-        Open original ↗
-      </a>
     </div>
   );
 }

--- a/frontend/src/components/workspace/FileContentRenderer.tsx
+++ b/frontend/src/components/workspace/FileContentRenderer.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { DocumentBodySkeleton, SkeletonBlock } from "../SkeletonStates";
+
+// Single source of truth for "show this file inline by content type."
+// Used from the workspace file viewer (/workspaces/{ws}/f/{fileId}) and
+// from the stash detail page's SingleFilePreview, so both surfaces render
+// PDFs, images, markdown, and plain text the same way. CSV stays out of
+// scope — the workspace viewer redirects CSVs to /tables/{id}, and the
+// stash viewer doesn't ingest.
+
+interface Props {
+  url: string;
+  name: string;
+  contentType: string;
+  /** Layout for the markdown article. The workspace viewer wraps in
+   *  a flex container with overflow-auto; the stash detail page sits
+   *  inside a fixed-width column. Both want a centered article. */
+  className?: string;
+}
+
+export function isPdf(ct: string) {
+  return ct?.includes("pdf");
+}
+export function isImage(ct: string) {
+  return ct?.startsWith("image/");
+}
+export function isMarkdown(ct: string, name: string) {
+  return ct?.includes("markdown") || name.toLowerCase().endsWith(".md");
+}
+export function isText(ct: string) {
+  return ct?.startsWith("text/");
+}
+
+export default function FileContentRenderer({ url, name, contentType, className }: Props) {
+  const wantsText = isMarkdown(contentType, name) || isText(contentType);
+  const [text, setText] = useState<string | null>(wantsText ? null : "");
+
+  useEffect(() => {
+    if (!wantsText || !url) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (cancelled) return;
+        if (res.ok) setText(await res.text());
+        else setText("");
+      } catch {
+        if (!cancelled) setText("");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url, wantsText]);
+
+  if (!url) {
+    return <p className="px-5 py-8 text-muted">No download URL.</p>;
+  }
+  if (isPdf(contentType)) {
+    return <iframe src={url} className={className ?? "h-[78vh] w-full bg-gray-200"} title={name} />;
+  }
+  if (isImage(contentType)) {
+    return (
+      <div className={className ?? "flex items-center justify-center bg-gray-100 p-8"}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={url} alt={name} className="max-h-full max-w-full" />
+      </div>
+    );
+  }
+  if (isMarkdown(contentType, name)) {
+    if (text === null) return <DocumentBodySkeleton className="mx-auto mt-8 max-w-[920px]" />;
+    return (
+      <article className="prose prose-sm markdown-content mx-auto max-w-[920px] px-6 py-6 text-foreground">
+        <Markdown remarkPlugins={[remarkGfm]}>{text || ""}</Markdown>
+      </article>
+    );
+  }
+  if (isText(contentType)) {
+    if (text === null) {
+      return (
+        <div className="space-y-2 px-5 py-4">
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((row) => (
+            <SkeletonBlock key={row} className="h-4 w-full max-w-4xl" />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <pre className="scroll-thin overflow-auto rounded-lg border border-border bg-base px-5 py-4 font-mono text-[12.5px] text-foreground">
+        {text || ""}
+      </pre>
+    );
+  }
+  return (
+    <div className="mx-auto max-w-md px-8 py-12 text-center text-[13px] text-muted">
+      <p className="mb-3">No inline preview for this file type.</p>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+      >
+        Open original ↗
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Followup from the page/file audit, addressing the two real gaps in this case study: the user's "20 Questions about Stash Specs" stash (one page wrapped in an upload folder) didn't trigger the new single-page shortcut, AND markdown files in stashes dead-ended on a "No inline preview" message even though the workspace file viewer rendered them just fine.

## What changed

1. **Single-page-in-folder shortcut.** A stash that is "one page + one upload folder + description starts with 'Uploaded from '" now opens straight to the page, parallel to the existing single-file rule. Same `stash publish notes.md` shape gets the same single-content treatment.

   `primaryItemForStash` refactored to share one `singleOfKindWithOptionalFolder` helper for files and pages, so adding the rule was a one-line addition and the symmetry is visible at a glance.

2. **Unified file render path.** Extracted `FileContentRenderer` from the workspace file viewer (`/workspaces/{ws}/f/{fileId}`) into `components/workspace/FileContentRenderer.tsx`. Handles pdf, image, markdown, text, fallback. Used now from both the workspace file viewer AND the stash detail page's `SingleFilePreview`. Markdown and text files in stashes now render the same way they do in the workspace.

CSV stays out of the renderer — CSV in the workspace triggers ingest-and-redirect-to-table, which the stash side can't do.

## Test plan

- [ ] Open a "single page wrapped in upload folder" stash → page renders, no bundle chrome.
- [ ] Open a "single page at top level" stash → still works (regression check).
- [ ] Open a "single file at top level" stash → file preview, regression check.
- [ ] Drop a `.md` file into a workspace, share via `stash files upload`, view the stash → markdown body renders inline.
- [ ] Drop a `.txt` file, view in stash → text renders inline.
- [ ] PDF / image stashes still render correctly in both surfaces.
- [ ] Workspace file viewer regression: open a markdown file from the workspace tree → content renders the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)