### PR TITLE
fix(slides): keep slide layout stable on Edit + scroll to active slide

### DIFF
--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -495,7 +495,7 @@ function injectResizeBootstrap(
     // one slide at a time. In edit mode we override that so every slide
     // becomes visible and editable; without this the user can only edit the
     // single currently-active slide.
-    var COMMENT_HIGHLIGHT_CSS = "[data-comment-id]{background:rgba(254,240,138,.45);cursor:pointer;}[data-comment-id].is-active{background:rgba(250,204,21,.7);outline:1px solid #ca8a04;}body[contenteditable=\\"true\\"]{outline:2px dashed rgba(59,130,246,.5);outline-offset:-4px;}body[contenteditable=\\"true\\"] *{cursor:text;}body[contenteditable=\\"true\\"] section.slide{display:flex !important;position:relative !important;inset:auto !important;margin-bottom:24px !important;}";
+    var COMMENT_HIGHLIGHT_CSS = "[data-comment-id]{background:rgba(254,240,138,.45);cursor:pointer;}[data-comment-id].is-active{background:rgba(250,204,21,.7);outline:1px solid #ca8a04;}body[contenteditable=\\"true\\"]{outline:2px dashed rgba(59,130,246,.5);outline-offset:-4px;}body[contenteditable=\\"true\\"] *{cursor:text;}body[contenteditable=\\"true\\"] section.slide{position:relative !important;inset:auto !important;margin-bottom:24px !important;}";
     var editable=false;
     var mutateTimer=null;
     function post(o){parent.postMessage(Object.assign({channel:c},o),"*");}
@@ -713,7 +713,13 @@ function injectSlideDeckBootstrap(html: string, channel: string): string {
     // Visual feedback for edit mode: dashed outline on the body, text caret
     // on all descendants, and let slides flow normally so the user can scroll
     // and click between them.
-    var EDIT_CSS = "body[contenteditable=\\"true\\"]{outline:2px dashed rgba(59,130,246,.5);outline-offset:-4px;}body[contenteditable=\\"true\\"] *{cursor:text;}body[contenteditable=\\"true\\"] section.slide{display:flex !important;position:relative !important;inset:auto !important;margin-bottom:24px !important;}";
+    // Edit mode just adds a dashed outline + reflows the slide stack so all
+    // slides are visible at once. Don't override the section's display
+    // property here — clobbering it to display:flex !important rearranges
+    // children that depend on the section's natural block layout (or the
+    // agent's inline flex direction). Visibility is controlled by clearing
+    // the inline style.display in applyIndex().
+    var EDIT_CSS = "body[contenteditable=\\"true\\"]{outline:2px dashed rgba(59,130,246,.5);outline-offset:-4px;}body[contenteditable=\\"true\\"] *{cursor:text;}body[contenteditable=\\"true\\"] section.slide{position:relative !important;inset:auto !important;margin-bottom:24px !important;}";
     (function injectStyle(){
       if(document.getElementById("__stash_slide_css__")) return;
       var s=document.createElement('style');
@@ -729,10 +735,18 @@ function injectSlideDeckBootstrap(html: string, channel: string): string {
       var slides=document.querySelectorAll('body > section.slide');
       if(!slides.length) return;
       currentIdx=Math.max(0, Math.min(slides.length-1, idx|0));
-      // In edit mode, show every slide so the user can edit all of them.
-      // The deck nav still tracks currentIdx for when edit mode is exited.
+      // In edit mode every slide is rendered in a vertical flow so the user
+      // can scroll between them. Clearing the inline display lets each
+      // section fall back to its natural CSS display. Then scroll the
+      // active slide into view so clicking prev/next actually moves the
+      // viewport — without this, the counter updates but nothing visible
+      // happens.
       if(editable){
         for(var k=0;k<slides.length;k++) slides[k].style.display='';
+        var target=slides[currentIdx];
+        if(target && typeof target.scrollIntoView==='function'){
+          target.scrollIntoView({block:'start',behavior:'smooth'});
+        }
         return;
       }
       for(var k=0;k<slides.length;k++){


### PR DESCRIPTION
## Summary

Two WYSIWYG bugs surfaced during prod QA after the slide-deck work landed.

**1. Pressing Edit visibly rearranged each slide's children.**
\`EDIT_CSS\` forced \`display: flex !important\` on every \`section.slide\` to ensure visibility in edit mode. The flex override clobbered the section's natural block layout (or whatever flex direction the agent had set inline), causing visible re-flow the instant the user clicks **Edit**. Visibility is already controlled by clearing \`style.display\` in \`applyIndex()\`, so the flex override is unnecessary — drop it.

**2. Clicking next/prev in edit mode didn't scroll to the slide.**
In edit mode all slides flow vertically in the iframe. \`applyIndex()\` only un-hid them; navigation just bumped the counter without moving the viewport. Added a \`scrollIntoView({block:'start',behavior:'smooth'})\` on the active slide so prev/next + arrow keys actually move the camera.

Applies the same EDIT_CSS string fix in both \`injectSlideDeckBootstrap\` (fixed-aspect decks) and \`injectResizeBootstrap\` (responsive HTML pages that happen to contain \`section.slide\`) for consistency.

## Why this surfaced now

Both bugs were latent since \`ece3836d\` (multi-slide edit-mode landing) — the layout-shift bug was hidden by simple test decks that already used \`display:flex\`, and the scroll-doesn't-follow-nav bug only matters when there's more than one slide to navigate between.

## Test plan

- [x] \`tsc --noEmit\` clean (had to dodge a backtick-in-comment template literal trap, déjà vu).
- [ ] After merge + deploy: open a multi-slide deck, click **Edit**, confirm slide 1's children haven't shifted; click ›/‹, confirm the iframe scrolls to the target slide; press arrow keys with focus inside the iframe, same result.
- [ ] Save round-trip still works (typing text → 500 ms debounce → \`stash:html-mutated\` → API patch).

## Independence

Independent of #412 (PPTX render fixes). Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)