### PR TITLE
[codex] fix self-host compose and onboarding docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # Shared environment block — backend + worker + beat all need the same
 # secrets / API keys because tasks may run on the worker. Each service
 # overrides DATABASE_URL/REDIS_URL/CORS/PUBLIC_URL inline as needed.
@@ -48,8 +46,6 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_USER: stash
       POSTGRES_PASSWORD: stash
@@ -65,8 +61,6 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data:/data
     command: ["redis-server", "--appendonly", "yes"]


### PR DESCRIPTION
## Summary
- Stop publishing Compose Postgres on host port 5432.
- Stop publishing Compose Redis on host port 6379.
- Remove the obsolete top-level Compose `version` key.
- Update the README self-host flow to use `stash login` instead of raw `stash register`, so first-run CLI onboarding runs for self-hosted users too.

## Why
The self-hosted stack failed on machines that already had local Redis or Postgres containers because Compose tried to bind those host ports. The Stash app containers use Docker service names for these dependencies, so the host bindings are not needed for the local self-hosted path.

The README also pointed users at `stash register`, which only creates credentials and bypasses the first-run CLI onboarding wizard. `stash login` is the implemented onboarding path for both managed and self-hosted installs.

## Validation
- `git diff --check`
- `docker compose config -q`
- `docker compose up -d`
- `curl -fsS http://localhost:3456/health`
- CLI smoke test with an isolated temp home: `stash config base_url http://localhost:3456` and `stash register <test-user> --password ...`