### PR TITLE
[codex] fix self-host CLI onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,21 @@ The local UI runs at `http://localhost:3457` and the API runs at
 `http://localhost:3456`. Continue once the health check prints
 `{"status":"ok"}`.
 
-Install the CLI in the repo you want to connect. The CLI package is the same
-for managed and self-hosted Stash; `base_url` tells it to use your local API.
+Install the CLI, then run the first-run login flow from the repo you want to
+connect. The CLI package is the same for managed and self-hosted Stash;
+`base_url` tells it to use your local API.
 
 ```bash
 pip install stashai
-stash config base_url http://localhost:3456
-stash register alice --password 'choose-a-password'
 
 cd /path/to/the/repo/you/want/to/connect
-stash connect
+stash config base_url http://localhost:3456
+stash login
 ```
+
+`stash login` opens the local UI so you can register or sign in, then walks
+through agent and repo setup. If you are already logged in and only need to
+connect another repo, run `stash connect` from that repo.
 
 ### Local seed data
 


### PR DESCRIPTION
## Summary
- Restore the frontend `/connect-token` route used by the CLI browser-auth flow.
- Hand `/connect-token?session=...` off to the existing `/login?cli=...` authorization UI.
- Update the README self-host flow to use `stash login` instead of raw `stash register`.
- Clarify that `stash connect` is for connecting additional repos after login.

## Why
The released CLI opens `/connect-token?session=...` during `stash login`, but the self-host frontend only had `/login?cli=...`, so self-hosted browser auth showed a 404 before the user could authorize the CLI.

The README also pointed users at `stash register`, which creates credentials but bypasses the first-run CLI onboarding wizard. `stash login` is the implemented onboarding path for both managed and self-hosted installs.

## Validation
- `git diff --check`
- `docker compose up -d --build frontend`
- `curl -fsS http://localhost:3456/health`
- `curl -sS -o /tmp/stash-connect-token.html -w '%{http_code}\n' 'http://localhost:3457/connect-token?session=test-session&device=Henry'` returned `200`