### PR TITLE
[codex] restore frontend connect-token route

### DIFF
--- a/frontend/src/app/connect-token/page.tsx
+++ b/frontend/src/app/connect-token/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function ConnectTokenPage() {
+  return (
+    <Suspense fallback={<RedirectShell />}>
+      <ConnectTokenRedirect />
+    </Suspense>
+  );
+}
+
+function ConnectTokenRedirect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const session = searchParams.get("session");
+    if (!session) {
+      router.replace("/login");
+      return;
+    }
+
+    const params = new URLSearchParams({ cli: session });
+    router.replace(`/login?${params.toString()}`);
+  }, [router, searchParams]);
+
+  return <RedirectShell />;
+}
+
+function RedirectShell() {
+  return <div className="min-h-screen bg-base" />;
+}


### PR DESCRIPTION
## Summary
- Add the frontend `/connect-token` route used by CLI browser auth.
- Redirect `?session=...` into the existing `/login?cli=...` authorization UI.

## Why
`stash login` opens `/connect-token?session=...`, but the self-host frontend did not have that route, so browser auth landed on a 404 before the user could authorize the CLI.

## Validation
- `git diff --check origin/main...HEAD`
- `docker compose up -d --build frontend`
- `curl -fsS http://localhost:3456/health`
- `curl -sS -o /tmp/stash-connect-token.html -w '%{http_code}\n' 'http://localhost:3457/connect-token?session=test-session&device=Henry'` returned `200`