### PR TITLE
feat(session): let users rename a session

### DIFF
--- a/backend/migrations/versions/0078_session_titles_user_set.py
+++ b/backend/migrations/versions/0078_session_titles_user_set.py
@@ -1,0 +1,23 @@
+"""Allow user-set session titles that survive auto-regeneration.
+
+Revision ID: 0078
+Revises: 0077
+"""
+
+from alembic import op
+
+revision = "0078"
+down_revision = "0077"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE session_titles "
+        "ADD COLUMN IF NOT EXISTS user_set BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE session_titles DROP COLUMN IF EXISTS user_set")

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -222,6 +222,43 @@ async def get_workspace_session(
     return payload
 
 
+class SessionTitleRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+
+
+@router.patch("/workspaces/{workspace_id}/sessions/{session_id}/title")
+async def rename_workspace_session(
+    workspace_id: UUID,
+    session_id: str,
+    body: SessionTitleRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    if not await workspace_service.can_write(workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Viewers can read but not modify sessions")
+    if not await memory_service.can_read_session(workspace_id, session_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    session = await session_service.get_session(workspace_id, session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    can_write = await permission_service.check_access(
+        "session",
+        session["id"],
+        current_user["id"],
+        workspace_id=workspace_id,
+        require_write=True,
+    )
+    if not can_write:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    try:
+        title = await session_title_service.set_user_title(workspace_id, session_id, body.title)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return {"title": title}
+
+
 async def _check_session_write(
     workspace_id: UUID,
     session_row_id: UUID,

--- a/backend/services/session_title_service.py
+++ b/backend/services/session_title_service.py
@@ -43,7 +43,7 @@ async def titles_for_sessions(
     pool = get_pool()
     session_ids = [s["session_id"] for s in sessions]
     rows = await pool.fetch(
-        "SELECT session_id, title, source_hash FROM session_titles "
+        "SELECT session_id, title, source_hash, user_set FROM session_titles "
         "WHERE workspace_id = $1 AND session_id = ANY($2::text[])",
         workspace_id,
         session_ids,
@@ -61,6 +61,8 @@ async def titles_for_sessions(
         else:
             titles[session_id] = title_from_text(session.get("title_source"), session_id)
 
+        if title_row and title_row.get("user_set"):
+            continue
         if title_row and title_row["source_hash"] == session_source_hash:
             continue
         stale_session_ids.append(session_id)
@@ -83,6 +85,31 @@ async def title_for_events(workspace_id: UUID, session_id: str, events: list[dic
 
     _enqueue_title_generation(workspace_id, [session_id])
     return title_from_events(events, session_id)
+
+
+async def set_user_title(workspace_id: UUID, session_id: str, title: str) -> str:
+    """Persist a user-provided title. Future auto-generation skips this row.
+
+    Returns the cleaned title that was stored.
+    """
+    cleaned = _truncate(title.strip())
+    if not cleaned:
+        raise ValueError("Title cannot be empty")
+    pool = get_pool()
+    await pool.execute(
+        """
+        INSERT INTO session_titles (workspace_id, session_id, title, source_hash, user_set)
+        VALUES ($1, $2, $3, '', TRUE)
+        ON CONFLICT (workspace_id, session_id) DO UPDATE SET
+          title = EXCLUDED.title,
+          user_set = TRUE,
+          updated_at = now()
+        """,
+        workspace_id,
+        session_id,
+        cleaned,
+    )
+    return cleaned
 
 
 def _enqueue_title_generation(workspace_id: UUID, session_ids: list[str]) -> None:

--- a/backend/tasks/session_titles.py
+++ b/backend/tasks/session_titles.py
@@ -102,10 +102,13 @@ async def _generate_for_session(workspace_id: UUID, session_id: str) -> str:
     source_hash = session_title_service.source_hash(stats)
     pool = get_pool()
     cached = await pool.fetchrow(
-        "SELECT source_hash FROM session_titles WHERE workspace_id = $1 AND session_id = $2",
+        "SELECT source_hash, user_set FROM session_titles "
+        "WHERE workspace_id = $1 AND session_id = $2",
         workspace_id,
         session_id,
     )
+    if cached and cached["user_set"]:
+        return "user-set"
     if cached and cached["source_hash"] == source_hash:
         return "fresh"
 

--- a/backend/tests/test_session_rename.py
+++ b/backend/tests/test_session_rename.py
@@ -1,0 +1,168 @@
+"""Tests for the PATCH /sessions/{session_id}/title endpoint."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient, name: str | None = None) -> tuple[str, dict]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name or unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _make_workspace_with_session(client: AsyncClient, api_key: str, session_id: str):
+    workspace_resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "Rename ws"},
+        headers=_auth(api_key),
+    )
+    assert workspace_resp.status_code == 201
+    workspace = workspace_resp.json()
+
+    session_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/sessions",
+        json={"session_id": session_id, "agent_name": "claude"},
+        headers=_auth(api_key),
+    )
+    assert session_resp.status_code == 201
+    return workspace, session_resp.json()
+
+
+@pytest.mark.asyncio
+async def test_rename_session_persists_title(client: AsyncClient, pool):
+    api_key, _user = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, api_key, "sess-rename-1")
+
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-1/title",
+        json={"title": "  Investigate flaky auth test  "},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"title": "Investigate flaky auth test"}
+
+    get_resp = await client.get(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-1",
+        headers=_auth(api_key),
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["title"] == "Investigate flaky auth test"
+
+    row = await pool.fetchrow(
+        "SELECT title, user_set FROM session_titles WHERE workspace_id = $1 AND session_id = $2",
+        workspace["id"],
+        "sess-rename-1",
+    )
+    assert row["title"] == "Investigate flaky auth test"
+    assert row["user_set"] is True
+
+
+@pytest.mark.asyncio
+async def test_rename_session_truncates_overlong_title(client: AsyncClient, pool):
+    api_key, _user = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, api_key, "sess-rename-2")
+
+    long_title = "a" * 200
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-2/title",
+        json={"title": long_title},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    # MAX_TITLE_LENGTH from the service is 80
+    assert len(resp.json()["title"]) == 80
+
+
+@pytest.mark.asyncio
+async def test_rename_session_rejects_empty_title(client: AsyncClient):
+    api_key, _user = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, api_key, "sess-rename-3")
+
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-3/title",
+        json={"title": "   "},
+        headers=_auth(api_key),
+    )
+    # Pydantic accepts whitespace (it's not empty), but the service rejects it
+    # once trimmed. Both 422 (Pydantic) and 422 (HTTPException) are acceptable.
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_session_rejects_unknown_session(client: AsyncClient):
+    api_key, _user = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, api_key, "sess-rename-4")
+
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/does-not-exist/title",
+        json={"title": "noop"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rename_session_blocks_non_member(client: AsyncClient):
+    owner_key, _owner = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, owner_key, "sess-rename-5")
+
+    outsider_key, _outsider = await _register(client)
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-5/title",
+        json={"title": "should not stick"},
+        headers=_auth(outsider_key),
+    )
+    assert resp.status_code in (403, 404)
+
+
+@pytest.mark.asyncio
+async def test_user_set_title_survives_auto_regeneration(client: AsyncClient, pool):
+    """A manual rename must not be overwritten by the title-generation task."""
+    from uuid import UUID
+
+    from backend.tasks import session_titles as session_titles_task
+
+    api_key, _user = await _register(client)
+    workspace, _session = await _make_workspace_with_session(client, api_key, "sess-rename-6")
+
+    # Seed an event so the generator sees content to work with.
+    await pool.execute(
+        "INSERT INTO history_events "
+        "(workspace_id, session_id, agent_name, event_type, content, created_at) "
+        "VALUES ($1, $2, 'claude', 'user_message', 'first prompt', now())",
+        workspace["id"],
+        "sess-rename-6",
+    )
+
+    rename_resp = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/sessions/sess-rename-6/title",
+        json={"title": "User wrote this"},
+        headers=_auth(api_key),
+    )
+    assert rename_resp.status_code == 200
+
+    # Run the generator directly. Real prod path goes through Celery but the
+    # body is the same coroutine.
+    result = await session_titles_task._generate_for_session(
+        UUID(workspace["id"]),
+        "sess-rename-6",
+    )
+    assert result == "user-set"
+
+    row = await pool.fetchrow(
+        "SELECT title, user_set FROM session_titles WHERE workspace_id = $1 AND session_id = $2",
+        workspace["id"],
+        "sess-rename-6",
+    )
+    assert row["title"] == "User wrote this"
+    assert row["user_set"] is True

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -16,13 +16,16 @@ import {
   getSessionEvents,
   getWorkspaceSidebar,
   listObjectStashes,
+  renameSession,
   trashItem,
   type PublicStashItem,
   type SessionDetail,
   type SessionEvent,
   type WorkspaceStash,
 } from "../../../../../../lib/api";
+import { refreshWorkspaceSidebar } from "../../../../../../lib/stashNavigationCache";
 import { SessionBody } from "../../../../stashes/[slug]/StashItemBodies";
+import EditableTitle from "../../../../../../components/workspace/EditableTitle";
 
 interface MessageTurn {
   kind: "message";
@@ -235,7 +238,15 @@ export default function SessionViewerPage() {
                 ))}
               </div>
               <h1 className="mt-1.5 font-display text-[28px] font-bold leading-tight tracking-[-0.02em]">
-                {sessionHeading(sessionDetail, sessionId)}
+                <EditableTitle
+                  value={sessionHeading(sessionDetail, sessionId)}
+                  onSave={async (next) => {
+                    const { title } = await renameSession(workspaceId, sessionId, next);
+                    setSessionDetail((prev) => (prev ? { ...prev, title } : prev));
+                    refreshWorkspaceSidebar(workspaceId).catch(() => {});
+                    return title;
+                  }}
+                />
               </h1>
               {turns.length > 0 && (
                 <div className="mt-1.5 flex flex-wrap items-center gap-2.5 text-[12px] text-muted">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -984,6 +984,21 @@ export async function getSessionDetail(
   return apiFetch(`/api/v1/workspaces/${workspaceId}/sessions/${encodeURIComponent(sessionId)}`);
 }
 
+export async function renameSession(
+  workspaceId: string,
+  sessionId: string,
+  title: string
+): Promise<{ title: string }> {
+  return apiFetch(
+    `/api/v1/workspaces/${workspaceId}/sessions/${encodeURIComponent(sessionId)}/title`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    }
+  );
+}
+
 export async function materializeSession(
   workspaceId: string,
   sessionId: string


### PR DESCRIPTION
## Summary
- Sessions currently get their title from an LLM summarizer (`backend/tasks/session_titles.py`); there was no way for a user to override the auto-generated title. This PR adds a rename flow end to end.
- Schema: `session_titles.user_set BOOLEAN NOT NULL DEFAULT FALSE` (migration `0078`). When TRUE, the generator skips the row and `titles_for_sessions` stops enqueueing regeneration for it — user titles stick across new events.
- API: ``PATCH /api/v1/workspaces/{id}/sessions/{session_id}/title`` with `{ title }`. Trims, enforces the existing `MAX_TITLE_LENGTH` (80), upserts with `user_set = TRUE`. Permission gating matches the rest of the sessions router (`workspace_service.can_write` + per-session `permission_service.check_access`).
- UI: the session-page ``<h1>`` now uses the existing `EditableTitle` component (the same inline-edit pattern the page / file / folder headers use). On save it patches local state and calls `refreshWorkspaceSidebar` — the sidebar ETag already includes `MAX(session_titles.updated_at)`, so the cache invalidates naturally and the sidebar label updates without a reload.

## Stacked on top of FER-142
The page ``<h1>`` only started rendering the title at all in #425 (FER-142). This PR builds on that branch, so it includes that commit too. Land #425 first and this rebases clean against `main`.

## Test plan
- [x] Backend: `pytest backend/tests/test_session_rename.py backend/tests/test_session_title_service.py backend/tests/test_permissions.py` — 41/41
  - new tests cover: persistence + canonical response, length cap, empty title rejection, unknown session 404, non-member denial, and the **user-set title survives a direct call to the auto-generator** invariant.
- [x] Frontend: ``npx tsc --noEmit`` clean, ``npm test`` 93/93 pass.
- [ ] Manual: rename a session on the page header, confirm the sidebar label updates without a reload.
- [ ] Manual: rename a session, then upload a transcript that adds events for it — confirm the user-set title is not clobbered by the regen task.

> No screenshot attached for the same reason as #425 — exercising this UI path locally needs an authenticated dev session, and the local-key mint route is out of scope. Happy to add screenshots if the reviewer wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)