### PR TITLE
feat: publish Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Publish Docker images to GHCR
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: stash-backend
+            context: .
+            dockerfile: backend/Dockerfile
+          - image: stash-collab
+            context: ./collab
+            dockerfile: Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/fergana-labs/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,9 @@
 #   cp .env.example .env        # fill in required values
 #   docker compose -f docker-compose.prod.yml up -d --build
 #
+# Backend and collab use pre-built images from GHCR (fast).
+# Frontend builds locally because NEXT_PUBLIC_API_URL must match your domain.
+#
 # Required env vars in .env:
 #   POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
 #   PUBLIC_URL                  (your public frontend URL, e.g. https://app.example.com)
@@ -49,9 +52,7 @@ services:
       retries: 5
 
   backend:
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
+    image: ghcr.io/fergana-labs/stash-backend:latest
     restart: always
     expose:
       - "3456"
@@ -72,9 +73,7 @@ services:
       start_period: 30s
 
   worker:
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
+    image: ghcr.io/fergana-labs/stash-backend:latest
     restart: always
     depends_on:
       postgres:
@@ -90,9 +89,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
+    image: ghcr.io/fergana-labs/stash-backend:latest
     restart: always
     depends_on:
       redis:
@@ -123,9 +120,7 @@ services:
       NEXT_PUBLIC_COLLAB_URL: ${COLLAB_PUBLIC_URL:-}
 
   collab:
-    build:
-      context: ./collab
-      dockerfile: Dockerfile
+    image: ghcr.io/fergana-labs/stash-collab:latest
     restart: always
     expose:
       - "3458"


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/docker-publish.yml` builds and pushes `stash-backend` and `stash-collab` images to `ghcr.io/fergana-labs/` on every version tag
- `docker-compose.prod.yml` updated to pull pre-built images instead of building from source
- Frontend still builds locally (NEXT_PUBLIC_API_URL must match the deployer's domain at build time)

## How it works
- Triggers on `v*` tags (same as the PyPI publish workflow) + manual dispatch
- Tags images as `latest`, `x.y.z`, and `x.y`
- Uses GitHub Actions cache for layer caching across builds

## What this means for self-hosters
Production deploys (`docker-compose.prod.yml`) skip the slow backend build (~5 min for Python + LibreOffice + Playwright). They just pull the pre-built image. The frontend still builds locally (~2 min) since it needs domain-specific env vars.

The dev compose (`docker-compose.yml`) is unchanged — still builds everything locally.

## First publish
After merging, bump the version in `pyproject.toml` to trigger both the PyPI publish and the first GHCR image push. Or use the manual workflow_dispatch to push `latest` from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)