### PR TITLE
ci: build Docker images on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Publish Docker images to GHCR
 on:
   push:
     tags: ["v*"]
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Missed in the squash merge of #434.