### PR TITLE
fix(import): correct CSV parsing, Sheets type inference, Notion truncation

### DIFF
--- a/backend/integrations/google/importers/drive_file.py
+++ b/backend/integrations/google/importers/drive_file.py
@@ -4,12 +4,9 @@ The API endpoint dispatches this task once per selected Drive file ID.
 The task itself reads the file's MIME, then routes:
 
 - application/vnd.google-apps.document     → markdown page (native MD export)
-- application/vnd.google-apps.spreadsheet  → table (not implemented yet)
+- application/vnd.google-apps.spreadsheet  → table (first sheet only)
 - application/vnd.openxmlformats-officedocument.presentationml.presentation
-                                            → fixed-aspect slide page (not implemented yet)
-
-Sheet + PPTX importers are stubbed for follow-up work — they fail loud
-with a clear message rather than silently dropping content.
+                                            → fixed-aspect slide page
 """
 
 from __future__ import annotations
@@ -27,6 +24,7 @@ import httpx
 from ....celery_app import celery
 from ....database import get_pool
 from ....services import table_service
+from ....services.csv_inference import coerce_value, infer_column_type
 from ....tasks._celery_helpers import run_async
 from ...storage import get_valid_token
 
@@ -153,9 +151,10 @@ async def _import_google_sheet(
     """First-tab-only Sheets import.
 
     Drive's CSV export already returns only the first sheet — that's
-    the v1 limitation. Header row becomes the column names (text type
-    for every column; the user can refine column types in the UI
-    later). Empty cells stay empty; we don't try to coerce types.
+    the v1 limitation. Header row becomes the column names; column
+    types are inferred from the first 50 data rows (same logic as the
+    CSV ingest endpoint) so numeric/date/boolean columns aren't all
+    forced to text.
     """
     resp = await _drive_get(
         client,
@@ -171,9 +170,12 @@ async def _import_google_sheet(
     if not any(h.strip() for h in header):
         raise RuntimeError("sheet has no header row")
 
+    data_rows = rows[1:]
+    sample = data_rows[:50]
+
     columns = []
     seen_names: dict[str, int] = {}
-    for raw_name in header:
+    for ci, raw_name in enumerate(header):
         col_name = (raw_name or "").strip() or "column"
         # Disambiguate duplicate headers — Sheets allows them, our column
         # storage tolerates them, but the UI is friendlier when names differ.
@@ -182,11 +184,12 @@ async def _import_google_sheet(
             col_name = f"{col_name} ({seen_names[col_name]})"
         else:
             seen_names[col_name] = 1
+        samples = [(r[ci] if ci < len(r) else "") for r in sample]
         columns.append(
             {
                 "id": f"col_{secrets.token_hex(6)}",
                 "name": col_name,
-                "type": "text",
+                "type": infer_column_type(samples),
             }
         )
 
@@ -198,18 +201,18 @@ async def _import_google_sheet(
         created_by=user_id,
     )
 
-    data_rows: list[dict] = []
-    for row in rows[1:]:
+    records: list[dict] = []
+    for row in data_rows:
         record: dict = {}
         for i, col in enumerate(columns):
-            value = row[i] if i < len(row) else ""
-            record[col["id"]] = value
-        data_rows.append(record)
+            raw = row[i] if i < len(row) else ""
+            record[col["id"]] = coerce_value(raw, col["type"])
+        records.append(record)
 
-    if data_rows:
+    if records:
         await table_service.create_rows_batch(
             table_id=table["id"],
-            rows_data=data_rows,
+            rows_data=records,
             created_by=user_id,
         )
 

--- a/backend/integrations/notion/importers/database.py
+++ b/backend/integrations/notion/importers/database.py
@@ -194,6 +194,7 @@ async def import_database(
 
     rows: list[dict] = []
     cursor: str | None = None
+    truncated = False
     while True:
         body: dict[str, Any] = {"page_size": 100}
         if cursor:
@@ -205,17 +206,18 @@ async def import_database(
         resp.raise_for_status()
         payload = resp.json()
         for entry in payload.get("results", []):
+            if len(rows) >= MAX_ROWS_PER_IMPORT:
+                # Bail at the cap instead of raising — the user gets the
+                # first N rows in a usable table with a clear note in the
+                # description rather than an empty stub + a confusing error.
+                truncated = True
+                break
             entry_props = entry.get("properties", {}) or {}
             row: dict[str, Any] = {}
             for prop_name, col_id in prop_id_to_col_id.items():
                 row[col_id] = _notion_value_to_stash(entry_props.get(prop_name) or {})
             rows.append(row)
-            if len(rows) >= MAX_ROWS_PER_IMPORT:
-                raise RuntimeError(
-                    f"database exceeded {MAX_ROWS_PER_IMPORT}-row cap; "
-                    "filter the source database or import in slices"
-                )
-        if not payload.get("has_more"):
+        if truncated or not payload.get("has_more"):
             break
         cursor = payload.get("next_cursor")
 
@@ -226,10 +228,21 @@ async def import_database(
             created_by=user_id,
         )
 
+    if truncated:
+        await table_service.update_table(
+            table_id=table["id"],
+            description=(
+                f"Imported from Notion database ({database_id}) — "
+                f"truncated at {MAX_ROWS_PER_IMPORT} rows"
+            ),
+            updated_by=user_id,
+        )
+
     return {
         "kind": "table",
         "table_id": str(table["id"]),
         "name": title,
         "row_count": len(rows),
         "column_count": len(columns),
+        "truncated": truncated,
     }

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -9,7 +9,6 @@ import csv
 import io
 import logging
 import re
-from datetime import datetime
 from urllib.parse import quote
 from uuid import UUID
 
@@ -34,6 +33,7 @@ from ..services import (
     table_service,
     workspace_service,
 )
+from ..services.csv_inference import coerce_value, infer_column_type
 
 logger = logging.getLogger(__name__)
 
@@ -483,56 +483,6 @@ async def purge_ws_file(
 # ===== CSV → Table ingest =====
 
 
-_NUMERIC_RE = re.compile(r"^-?\$?[\d,]+(\.\d+)?%?$")
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:?\d{2})?)?$")
-_BOOL_VALUES = {"true", "false", "yes", "no", "y", "n", "0", "1"}
-
-
-def _infer_column_type(samples: list[str]) -> str:
-    """Pick the narrowest fit across the sampled values.
-
-    Promotes upward on any miss: bool → number → date → text. Empty strings
-    don't contribute to the decision.
-    """
-    nonempty = [s for s in samples if s != ""]
-    if not nonempty:
-        return "text"
-
-    def matches(pred) -> bool:
-        return all(pred(s) for s in nonempty)
-
-    if matches(lambda s: s.lower() in _BOOL_VALUES):
-        return "boolean"
-    if matches(lambda s: bool(_NUMERIC_RE.match(s))):
-        return "number"
-    if matches(lambda s: bool(_DATE_RE.match(s))):
-        # 'YYYY-MM-DD' or full ISO — use 'date' for the former, 'datetime' for the latter.
-        if all("T" in s for s in nonempty):
-            return "datetime"
-        return "date"
-    return "text"
-
-
-def _coerce_value(raw: str, col_type: str):
-    if raw == "":
-        return None
-    if col_type == "boolean":
-        return raw.lower() in ("true", "yes", "y", "1")
-    if col_type == "number":
-        cleaned = raw.replace("$", "").replace(",", "").replace("%", "").strip()
-        try:
-            v = float(cleaned)
-            return int(v) if v.is_integer() else v
-        except ValueError:
-            return raw
-    if col_type in ("date", "datetime"):
-        try:
-            return datetime.fromisoformat(raw.replace("Z", "+00:00")).isoformat()
-        except ValueError:
-            return raw
-    return raw
-
-
 @ws_router.post("/{file_id}/ingest-csv", response_model=TableResponse)
 async def ingest_csv_file(
     workspace_id: UUID,
@@ -580,7 +530,7 @@ async def ingest_csv_file(
     columns = []
     for ci, name in enumerate(header):
         samples = [(r[ci] if ci < len(r) else "") for r in sample]
-        col_type = _infer_column_type(samples)
+        col_type = infer_column_type(samples)
         columns.append(
             {
                 "id": _slugify(name) or f"col_{ci}",
@@ -607,7 +557,7 @@ async def ingest_csv_file(
         rec = {}
         for ci, col in enumerate(columns):
             raw = r[ci] if ci < len(r) else ""
-            rec[col["id"]] = _coerce_value(raw, col["type"])
+            rec[col["id"]] = coerce_value(raw, col["type"])
         payload.append(rec)
     if payload:
         await table_service.create_rows_batch(

--- a/backend/services/csv_inference.py
+++ b/backend/services/csv_inference.py
@@ -1,0 +1,59 @@
+"""Column-type inference and value coercion for CSV-like imports.
+
+Shared between the file `/ingest-csv` endpoint and the Google Sheets
+importer so both code paths produce identically-typed tables when
+given the same input data.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+_NUMERIC_RE = re.compile(r"^-?\$?[\d,]+(\.\d+)?%?$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:?\d{2})?)?$")
+_BOOL_VALUES = {"true", "false", "yes", "no", "y", "n", "0", "1"}
+
+
+def infer_column_type(samples: list[str]) -> str:
+    """Pick the narrowest fit across the sampled values.
+
+    Promotes upward on any miss: bool → number → date → text. Empty strings
+    don't contribute to the decision.
+    """
+    nonempty = [s for s in samples if s != ""]
+    if not nonempty:
+        return "text"
+
+    def matches(pred) -> bool:
+        return all(pred(s) for s in nonempty)
+
+    if matches(lambda s: s.lower() in _BOOL_VALUES):
+        return "boolean"
+    if matches(lambda s: bool(_NUMERIC_RE.match(s))):
+        return "number"
+    if matches(lambda s: bool(_DATE_RE.match(s))):
+        if all("T" in s for s in nonempty):
+            return "datetime"
+        return "date"
+    return "text"
+
+
+def coerce_value(raw: str, col_type: str):
+    if raw == "":
+        return None
+    if col_type == "boolean":
+        return raw.lower() in ("true", "yes", "y", "1")
+    if col_type == "number":
+        cleaned = raw.replace("$", "").replace(",", "").replace("%", "").strip()
+        try:
+            v = float(cleaned)
+            return int(v) if v.is_integer() else v
+        except ValueError:
+            return raw
+    if col_type in ("date", "datetime"):
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).isoformat()
+        except ValueError:
+            return raw
+    return raw

--- a/backend/tests/test_csv_inference.py
+++ b/backend/tests/test_csv_inference.py
@@ -1,0 +1,81 @@
+"""Lock in the shared CSV type-inference + coercion behaviour.
+
+Both /files/{id}/ingest-csv and the Google Sheets importer depend on
+these helpers producing identical results, so changes here would break
+import parity between the two paths.
+"""
+
+import pytest
+
+from backend.services.csv_inference import coerce_value, infer_column_type
+
+
+class TestInferColumnType:
+    def test_empty_samples_default_to_text(self):
+        assert infer_column_type([]) == "text"
+        assert infer_column_type(["", "", ""]) == "text"
+
+    def test_boolean(self):
+        assert infer_column_type(["true", "false", "yes", "no"]) == "boolean"
+        assert infer_column_type(["Y", "N", "0", "1"]) == "boolean"
+
+    def test_number_with_currency_commas_percent(self):
+        assert infer_column_type(["1", "2.5", "$1,234.50", "-3", "12%"]) == "number"
+
+    def test_date_without_time(self):
+        assert infer_column_type(["2026-01-01", "2026-05-21"]) == "date"
+
+    def test_datetime_when_every_value_has_T(self):
+        assert (
+            infer_column_type(["2026-01-01T10:00:00Z", "2026-05-21T00:00:00+00:00"])
+            == "datetime"
+        )
+
+    def test_mixed_falls_back_to_text(self):
+        assert infer_column_type(["1", "hello"]) == "text"
+
+    def test_empty_strings_dont_affect_inference(self):
+        assert infer_column_type(["", "42", "", "7"]) == "number"
+
+
+class TestCoerceValue:
+    def test_empty_becomes_none(self):
+        assert coerce_value("", "text") is None
+        assert coerce_value("", "number") is None
+
+    def test_boolean(self):
+        assert coerce_value("yes", "boolean") is True
+        assert coerce_value("Y", "boolean") is True
+        assert coerce_value("1", "boolean") is True
+        assert coerce_value("no", "boolean") is False
+        assert coerce_value("0", "boolean") is False
+
+    def test_number_strips_formatting(self):
+        assert coerce_value("$1,234.50", "number") == 1234.5
+        assert coerce_value("12%", "number") == 12
+        assert coerce_value("-3", "number") == -3
+
+    def test_number_returns_int_when_integer_valued(self):
+        assert coerce_value("42", "number") == 42
+        assert isinstance(coerce_value("42", "number"), int)
+
+    def test_number_falls_through_on_unparseable(self):
+        # Garbage strings pass through rather than crashing the import.
+        assert coerce_value("not-a-number", "number") == "not-a-number"
+
+    def test_date_normalises_to_isoformat(self):
+        assert coerce_value("2026-05-21", "date") == "2026-05-21T00:00:00"
+
+    def test_datetime_with_z_suffix(self):
+        # Z gets rewritten to +00:00 so Python's fromisoformat can parse it.
+        assert (
+            coerce_value("2026-05-21T10:00:00Z", "datetime")
+            == "2026-05-21T10:00:00+00:00"
+        )
+
+    def test_text_passes_through(self):
+        assert coerce_value("hello", "text") == "hello"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_csv_inference.py
+++ b/backend/tests/test_csv_inference.py
@@ -27,8 +27,7 @@ class TestInferColumnType:
 
     def test_datetime_when_every_value_has_T(self):
         assert (
-            infer_column_type(["2026-01-01T10:00:00Z", "2026-05-21T00:00:00+00:00"])
-            == "datetime"
+            infer_column_type(["2026-01-01T10:00:00Z", "2026-05-21T00:00:00+00:00"]) == "datetime"
         )
 
     def test_mixed_falls_back_to_text(self):
@@ -68,10 +67,7 @@ class TestCoerceValue:
 
     def test_datetime_with_z_suffix(self):
         # Z gets rewritten to +00:00 so Python's fromisoformat can parse it.
-        assert (
-            coerce_value("2026-05-21T10:00:00Z", "datetime")
-            == "2026-05-21T10:00:00+00:00"
-        )
+        assert coerce_value("2026-05-21T10:00:00Z", "datetime") == "2026-05-21T10:00:00+00:00"
 
     def test_text_passes_through(self):
         assert coerce_value("hello", "text") == "hello"

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../../lib/api";
 import type { Table, TableColumn, TableRow, TableView } from "../../../lib/types";
 import FileViewerHeader from "../../../components/workspace/FileViewerHeader";
+import { parseCsv, inferColumnType } from "../../../lib/csv";
 
 const TYPE_ICONS: Record<string, string> = {
   text: "Aa", number: "#", boolean: "\u2713", date: "\uD83D\uDCC5", datetime: "\uD83D\uDD53",
@@ -430,22 +431,46 @@ function TableEditorPageInner() {
   const handleCsvImport = async (file: File) => {
     try {
       const text = await file.text();
-      const lines = text.split("\n").filter((l) => l.trim());
-      if (lines.length < 2) { setError("CSV needs header + data"); return; }
-      const headers = lines[0].split(",").map((h) => h.trim().replace(/^"|"$/g, ""));
+      const rows = parseCsv(text);
+      if (rows.length < 2) { setError("CSV needs header + data"); return; }
+      const headers = rows[0];
+      const dataRows = rows.slice(1);
+
       const existingNames = new Set(sortedColumns.map((c) => c.name));
       let currentTable = table!;
-      for (const h of headers) { if (!existingNames.has(h)) currentTable = await addTableColumn(wsId, tableId, { name: h, type: "text" }); }
-      setTable(currentTable);
-      const colMap: Record<string, string> = {}; for (const col of currentTable.columns) colMap[col.name] = col.id;
-      const rowsData: Record<string, unknown>[] = [];
-      for (let i = 1; i < lines.length; i++) {
-        const values = lines[i].match(/(".*?"|[^,]+)/g)?.map((v) => v.trim().replace(/^"|"$/g, "")) || [];
-        const data: Record<string, unknown> = {};
-        headers.forEach((h, idx) => { if (colMap[h] && idx < values.length) data[colMap[h]] = values[idx]; });
-        rowsData.push(data);
+      for (let ci = 0; ci < headers.length; ci++) {
+        const name = headers[ci];
+        if (!name || existingNames.has(name)) continue;
+        const samples = dataRows.slice(0, 50).map((r) => r[ci] ?? "");
+        const colType = inferColumnType(samples);
+        currentTable = await addTableColumn(wsId, tableId, { name, type: colType });
+        existingNames.add(name);
       }
-      for (let i = 0; i < rowsData.length; i += 5000) { await createTableRowsBatch(wsId, tableId, rowsData.slice(i, i + 5000).map((d) => ({ data: d }))); }
+      setTable(currentTable);
+
+      const colIdByHeader: Record<string, string> = {};
+      for (const col of currentTable.columns) colIdByHeader[col.name] = col.id;
+
+      const payload: Record<string, unknown>[] = [];
+      for (const r of dataRows) {
+        const data: Record<string, unknown> = {};
+        headers.forEach((h, idx) => {
+          const colId = colIdByHeader[h];
+          if (!colId) return;
+          const raw = r[idx] ?? "";
+          // Server coerces raw strings per column type; empty cells become NULL.
+          data[colId] = raw === "" ? null : raw;
+        });
+        payload.push(data);
+      }
+
+      for (let i = 0; i < payload.length; i += 5000) {
+        await createTableRowsBatch(
+          wsId,
+          tableId,
+          payload.slice(i, i + 5000).map((d) => ({ data: d })),
+        );
+      }
       await loadRows(); await loadTable();
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to import"); }
   };

--- a/frontend/src/lib/csv.test.ts
+++ b/frontend/src/lib/csv.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { parseCsv, inferColumnType } from "./csv";
+
+describe("parseCsv", () => {
+  it("handles empty cells without column shift", () => {
+    expect(parseCsv("a,,b\n1,,3")).toEqual([
+      ["a", "", "b"],
+      ["1", "", "3"],
+    ]);
+  });
+
+  it("preserves commas inside quoted fields", () => {
+    expect(parseCsv('a,"b,c",d')).toEqual([["a", "b,c", "d"]]);
+  });
+
+  it("handles escaped quotes (RFC double-quote)", () => {
+    expect(parseCsv('"hello ""world"""')).toEqual([['hello "world"']]);
+  });
+
+  it("handles embedded newlines inside quoted fields", () => {
+    expect(parseCsv('a,"line1\nline2",c')).toEqual([
+      ["a", "line1\nline2", "c"],
+    ]);
+  });
+
+  it("handles CRLF line endings without trailing carriage returns", () => {
+    expect(parseCsv("a,b\r\n1,2\r\n")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("strips UTF-8 BOM", () => {
+    expect(parseCsv("﻿a,b\n1,2")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("does not trim whitespace inside fields", () => {
+    expect(parseCsv("  spaced  ,trim me  ")).toEqual([["  spaced  ", "trim me  "]]);
+  });
+
+  it("drops a trailing empty row from a final newline", () => {
+    expect(parseCsv("a,b\n1,2\n")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("keeps genuinely-empty quoted rows", () => {
+    expect(parseCsv('a,b\n"",""')).toEqual([
+      ["a", "b"],
+      ["", ""],
+    ]);
+  });
+});
+
+describe("inferColumnType", () => {
+  it("detects boolean from yes/no/true/false", () => {
+    expect(inferColumnType(["true", "false", "yes", "no"])).toBe("boolean");
+  });
+
+  it("detects number with currency, commas, percent", () => {
+    expect(inferColumnType(["1", "2.5", "$1,234.50", "-3", "12%"])).toBe(
+      "number",
+    );
+  });
+
+  it("detects date (no time component)", () => {
+    expect(inferColumnType(["2026-01-01", "2026-05-21"])).toBe("date");
+  });
+
+  it("detects datetime when every value has T", () => {
+    expect(inferColumnType(["2026-01-01T10:00:00Z", "2026-05-21T00:00:00+00:00"])).toBe(
+      "datetime",
+    );
+  });
+
+  it("falls back to text on mixed", () => {
+    expect(inferColumnType(["1", "hello"])).toBe("text");
+  });
+
+  it("ignores empty samples for inference", () => {
+    expect(inferColumnType(["", "42", "", "7"])).toBe("number");
+  });
+
+  it("returns text when all samples are empty", () => {
+    expect(inferColumnType(["", "", ""])).toBe("text");
+  });
+});

--- a/frontend/src/lib/csv.ts
+++ b/frontend/src/lib/csv.ts
@@ -1,0 +1,111 @@
+/**
+ * RFC-4180 CSV parser + column-type inference.
+ *
+ * Mirrors the server-side type detection in `backend/routers/files.py`
+ * (`_infer_column_type`) so a CSV imported into an existing table from the
+ * table page lands with the same column types as one imported into a brand-new
+ * table via /files/{id}/ingest-csv. Values themselves are coerced server-side
+ * by `row_validation.py`, so we ship raw strings (or `null` for empties).
+ */
+
+export type InferredType =
+  | "boolean"
+  | "number"
+  | "date"
+  | "datetime"
+  | "text";
+
+export function parseCsv(text: string): string[][] {
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(field);
+      field = "";
+      i++;
+      continue;
+    }
+    if (ch === "\r") {
+      row.push(field);
+      field = "";
+      rows.push(row);
+      row = [];
+      if (text[i + 1] === "\n") i += 2;
+      else i++;
+      continue;
+    }
+    if (ch === "\n") {
+      row.push(field);
+      field = "";
+      rows.push(row);
+      row = [];
+      i++;
+      continue;
+    }
+    field += ch;
+    i++;
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  while (
+    rows.length > 0 &&
+    rows[rows.length - 1].length === 1 &&
+    rows[rows.length - 1][0] === ""
+  ) {
+    rows.pop();
+  }
+  return rows;
+}
+
+const NUMERIC_RE = /^-?\$?[\d,]+(\.\d+)?%?$/;
+const DATE_RE =
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:?\d{2})?)?$/;
+const BOOL_VALUES = new Set([
+  "true",
+  "false",
+  "yes",
+  "no",
+  "y",
+  "n",
+  "0",
+  "1",
+]);
+
+export function inferColumnType(samples: string[]): InferredType {
+  const nonempty = samples.filter((s) => s !== "");
+  if (nonempty.length === 0) return "text";
+  if (nonempty.every((s) => BOOL_VALUES.has(s.toLowerCase()))) return "boolean";
+  if (nonempty.every((s) => NUMERIC_RE.test(s))) return "number";
+  if (nonempty.every((s) => DATE_RE.test(s))) {
+    return nonempty.every((s) => s.includes("T")) ? "datetime" : "date";
+  }
+  return "text";
+}

--- a/plans/tables-roadmap.md
+++ b/plans/tables-roadmap.md
@@ -1,0 +1,175 @@
+# Tables roadmap: closing the Notion / AFFiNE gap
+
+Where Stash tables stand today vs. Notion databases and AFFiNE's data-view,
+and the work we'd need to close the gap. Companion to the bug-fix PR that
+landed the CSV parser fix, Sheets type inference, and Notion partial-import
+handling — those were _correctness_ fixes; this is the _feature_ plan.
+
+## Today
+
+- Storage: `tables` + `table_rows` (JSONB) in Postgres. 10 column types:
+  text, number, boolean, date, datetime, url, email, select, multiselect,
+  json. Validation in `backend/services/row_validation.py`.
+- Views: single grid (`frontend/src/app/tables/[tableId]/page.tsx`).
+  Saved-layout persists hidden cols + sort + filters.
+- Filtering/sort/group: 9 ops, single-column sort, in-memory group-by
+  (text/select only; not persisted in saved layouts).
+- Imports: CSV (server `ingest-csv` + in-place table-page import), Google
+  Docs → markdown, Google Sheets → table (first tab), Notion DB → table,
+  Notion pages → pages, PPTX → slides, GitHub repo → folder.
+- Exports: CSV only.
+
+## What's missing — ranked by leverage
+
+### Tier 1 — high-leverage, low-cost
+
+1. **TSV paste from Excel / Sheets / Notion** into the grid. ~30 LOC. The
+   single biggest UX gap relative to Notion ("copy a block of cells and
+   paste"). Reuses `parseCsv` (swap `,` delimiter for `\t`) + the existing
+   batch-row endpoint. Land before any new view.
+
+2. **Drag-and-drop CSV onto the table grid.** Same handler; replaces the
+   `Import` button as the primary affordance.
+
+3. **Column-type change post-import.** UI already exists to set type at
+   create-time (`COLUMN_TYPES` dropdown) but there's no "change type" path
+   on an existing column. Backend `update_column` already supports it —
+   wire it through the column header menu. Closes the loop on bad type
+   inference from CSV/Sheets.
+
+4. **XLSX → table.** UI already advertises `.xlsx` in
+   `EditorToolbar.tsx:307`. Add `openpyxl` server-side and a
+   `/files/{id}/ingest-xlsx` endpoint mirroring `ingest-csv`. Each sheet
+   → one table (named `<filename> — <sheet>`). Probably the most-asked
+   import format we don't support.
+
+5. **Multi-tab Sheets import.** Today only the first tab imports;
+   silently. Hit `spreadsheets.get` (Sheets API) to enumerate sheets,
+   then one table per tab. Same shape as XLSX above — the importer task
+   loop just iterates tabs instead of files.
+
+### Tier 2 — alternate views
+
+Stash has one view (grid). Notion has six; AFFiNE ships three
+(table/kanban/calendar). Grouping logic already exists; views mostly
+re-render the same `groupedRows`/`filteredRows` source-of-truth.
+
+6. **Kanban view.** Re-render `groupedRows` as columns of cards instead of
+   collapsed table sections. Drag-card-to-column = `updateRow` with new
+   group-by value. Only meaningful on `select` columns. ~1–2 days.
+
+7. **Calendar view.** Render rows on a month grid keyed by a `date` or
+   `datetime` column. Drag-card-to-day = `updateRow`. Month-only for v1
+   (no week/agenda). ~3 days.
+
+8. **Gallery view.** Card-per-row with a cover image. Requires a new
+   `image` column type (see Tier 3), so dependent.
+
+Views need a `kind` discriminator on the saved view payload
+(`backend/services/table_service.py:save_view`). Currently views only
+encode filter/sort/hidden state — adding `view_kind: "grid" | "kanban" |
+"calendar"` is a forward-compatible JSON field.
+
+### Tier 3 — new column types
+
+Notion has ~25 property types; we have 10. The high-leverage ones we
+don't:
+
+9. **Image / file attachment column.** Storage already exists via
+   `files_service`; new column type stores a list of file_ids. Render as
+   thumbnails in cells, full preview in row-detail. Prereq for gallery
+   view.
+
+10. **Person column.** Workspace already has users + permissions; column
+    stores `user_id`. Renders as avatar + name. Mostly UI; the hard part
+    is membership autocomplete.
+
+11. **Relation column.** Foreign key to another table's row. Storage:
+    `list[uuid]` of `table_rows.id`. Validation needs a join check.
+    Renders as pill links. The Notion killer feature we don't have.
+
+12. **Rollup column.** Aggregate over a `relation`. Computed at read
+    time. Specs: `relation_col_id`, `target_col_id`, `agg` (count/sum/
+    avg/min/max/concat). Cheap to implement once `relation` exists.
+
+13. **Formula column.** Computed via a small expression DSL. Significant
+    scope — spec, parser, evaluator, dependency graph for cache
+    invalidation. Park until Tier 1–2 ship.
+
+### Tier 4 — Notion-equivalent affordances
+
+14. **Row-as-page.** Each row opens to a full editable doc body, same
+    editor as `pages`. Storage: a `page_id` per row, lazily-created on
+    first open; rendered in the detail panel. The single highest-impact
+    feature we don't have — it's how Notion blurs the line between docs
+    and DBs.
+
+15. **Linked / synced views of a table** inside a page. Tiptap node
+    that embeds a table by id; renders the standard grid in read-only
+    mode by default, opens to the full table page on click.
+
+16. **Re-sync from source** (Notion / Sheets / CSV-file). Store
+    `source_kind` + `source_id` on the table; "Refresh from source"
+    action re-runs the importer with merge semantics (match-by-primary-
+    key; new rows append, missing rows soft-delete). One-shot imports
+    today turn the table into a fork at import time.
+
+17. **Realtime collab on tables.** `collab/` is wired for docs (yjs +
+    hocuspocus). Tables aren't. Cell-level CRDT or row-level OT — pick
+    one. Comments at row level depend on this.
+
+18. **Notion HTML / ZIP import (no OAuth).** AFFiNE ships this in their
+    `notion-html` block adapter. Users with a Notion export ZIP could
+    import without setting up an integration. Strict subset of what the
+    API path does, but unblocks the "I just want to try it" flow.
+
+## Suggested sequencing
+
+```
+PR1 (this branch): correctness fixes — CSV parser, Sheets inference,
+                   Notion truncation.
+
+Phase A (≈1 week):  TSV paste, drag-drop CSV, column-type change post-
+                    import, XLSX importer, multi-tab Sheets.
+                    [Tier 1: items 1-5]
+
+Phase B (≈2 weeks): kanban view + calendar view + view_kind on saved
+                    views + image column + gallery view.
+                    [Tier 2 + image dep from Tier 3]
+
+Phase C (≈3 weeks): person + relation + rollup columns.
+                    [Tier 3 minus formula]
+
+Phase D (open):     row-as-page (highest UX leverage but largest scope),
+                    re-sync, linked views, formula columns, realtime
+                    collab, Notion HTML import.
+                    [Tier 4]
+```
+
+## Non-goals (for now)
+
+- Pivot tables / cross-tab aggregations beyond the existing summary row.
+- Gantt / timeline view.
+- Sub-items / hierarchical rows.
+- Button / automation columns.
+- AI autofill of empty cells (we have ask-the-stash; "autofill column X
+  from rows" is a follow-on, not in scope here).
+- Conditional formatting beyond the existing hard-coded quartile
+  coloring.
+
+## Schema notes
+
+The current `table.columns` field is a JSONB list of column descriptors;
+adding new types (image, person, relation, rollup) doesn't require a
+migration — just new `type` values plus matching branches in
+`row_validation._coerce` and the frontend renderer. Same for views:
+`table.views` is already JSONB.
+
+Two cases _do_ need migrations:
+
+- **Row-as-page**: new `table_row_pages` table mapping `row_id → page_id`,
+  or a `page_id` column on `table_rows`. Column variant is simpler.
+- **Source provenance for re-sync**: add `source_kind text`, `source_id
+  text`, `source_synced_at timestamptz` to `tables`. ~1 migration.
+
+Everything else fits inside existing JSONB.


### PR DESCRIPTION
## Summary

QA of the data-import paths (CSV / XLSX / Google Drive Sheets / Notion DBs) surfaced three real bugs. This PR fixes them and adds a companion roadmap doc covering the feature gaps to Notion/AFFiNE that aren't bugs.

### Bugs fixed

1. **Frontend CSV parser corrupted data.** `frontend/src/app/tables/[tableId]/page.tsx`'s in-place \"Import CSV\" button used `lines[i].match(/(\".*?\"|[^,]+)/g)`. Failure modes:
   - **Empty cells dropped**: `a,,b` → `[\"a\",\"b\"]` → column shift on every subsequent row.
   - **Escaped quotes broken**: `\"hello \"\"world\"\"\"` → matched only the first `\"hello \"`.
   - **CRLF leakage**: `split(\"\\n\")` left trailing `\\r` on every value.
   - **No type inference**: all columns forced to `text`, diverging from the server `/ingest-csv` path which infers bool/number/date/datetime.

   Replaced with a small RFC-4180 state-machine parser (`frontend/src/lib/csv.ts`) + shared type inference. Server already coerces values per column type via `row_validation.py`, so the client just ships raw strings.

2. **Google Sheets importer dropped all type info.** Docstring claimed Sheets was \"not implemented\" but the code path is live — it just imported every column as `text`. Extracted `infer_column_type` + `coerce_value` from `backend/routers/files.py` into `backend/services/csv_inference.py` and wired both ingest paths through it. Same CSV/Sheet now produces the same column types regardless of entry point.

3. **Notion DB importer left empty stubs on row-cap overflow.** `database.py` raised `RuntimeError` mid-loop when a source database exceeded 5k rows. The table had already been created but no rows were inserted, so users saw an empty broken table + a generic Celery error. Now imports the first N rows cleanly and appends `\"— truncated at 5000 rows\"` to the description so the user can re-import in slices.

### Tests

- `backend/tests/test_csv_inference.py` — 15 cases locking in inference + coercion (currency, percent, date vs datetime promotion, empty-sample handling, fallthrough on garbage). Pass on `backend/.venv/bin/python -m pytest`.
- `frontend/src/lib/csv.test.ts` — 16 cases for the parser (empty cells, escaped quotes, CRLF, BOM, embedded newlines, quoted blanks) + inference. Pass under vitest.
- TypeScript + ESLint clean on the changed frontend files.

### Roadmap doc

`plans/tables-roadmap.md` covers the feature-level gaps that came out of the same audit but aren't bugs — alternate views (kanban/calendar/gallery), new column types (relation, rollup, formula, person, image), row-as-page, multi-tab XLSX, TSV paste, source re-sync. Sequenced into 4 phases.

## Test plan

- [x] Backend pytest scope passes (`backend/.venv/bin/python -m pytest backend/tests/test_csv_inference.py -v`)
- [x] Frontend vitest scope passes (`cd frontend && npx vitest run src/lib/csv.test.ts`)
- [x] `tsc --noEmit` clean (project errors only from generated `.next/dev/types/`, pre-existing)
- [x] `eslint` clean on changed files
- [ ] Manual: import a CSV with `a,,b` rows into an existing table — confirm no column shift
- [ ] Manual: re-import the same CSV into a brand-new table via Files → \"Open as table\" — confirm same column types as in-place import
- [ ] Manual: import a Google Sheet with numeric/date columns — confirm columns aren't all `text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)