### PR TITLE
fix: auto-join workspaces on self-hosted instances

### DIFF
--- a/backend/routers/workspaces.py
+++ b/backend/routers/workspaces.py
@@ -18,6 +18,7 @@ from ..models import (
     WorkspaceResponse,
     WorkspaceUpdateRequest,
 )
+from ..config import settings
 from ..services import invite_token_service, workspace_service
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
@@ -28,7 +29,11 @@ async def _serialize_workspace_for_viewer(
 ) -> WorkspaceResponse:
     is_member = bool(viewer_id and await workspace_service.is_member(workspace["id"], viewer_id))
     if not is_member:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+        # Self-hosted (password auth): auto-join authenticated users to any workspace.
+        if viewer_id and not settings.AUTH0_ENABLED:
+            await workspace_service.join_workspace(workspace["id"], viewer_id)
+        else:
+            raise HTTPException(status_code=404, detail="Workspace not found")
 
     data = dict(workspace)
     return WorkspaceResponse(**data)


### PR DESCRIPTION
## Summary
- On self-hosted instances (AUTH0_ENABLED=false), authenticated users are now automatically added as editors when they access a workspace they're not a member of
- This removes the "You're not a member. Ask a workspace admin for an invite link." dead end that blocks self-hosters when a repo's `.stash` manifest points to another user's workspace
- Managed instances (AUTH0_ENABLED=true) are unaffected — strict access control is preserved

## Context
When self-hosting, if user A connects a repo (writes `.stash`), and user B registers on the same instance and runs `stash connect` in that repo, user B hits a 404 with no way to proceed. On a self-hosted instance everyone is on the same team, so the workspace boundary shouldn't be a wall.

## Test plan
- [x] Registered a new user on self-hosted instance, accessed another user's workspace via API — auto-joined as editor
- [x] Verified the user appears in `workspace_members` with role `editor`
- [ ] Verify managed instances still reject non-members (behind `AUTH0_ENABLED` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)