### PR TITLE
fix: replace stale .stash instead of dead-ending

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -3416,9 +3416,13 @@ def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
                 return
             except StashError as e:
                 if e.status_code in (403, 404):
-                    _handle_not_member(ws_id)
-                    return
-                raise
+                    console.print(
+                        f"  [yellow]Workspace {ws_id[:8]}… not found — "
+                        f"replacing stale .stash[/yellow]"
+                    )
+                    manifest_path.unlink()
+                else:
+                    raise
 
         repo_name = repo_root.name
         my_workspaces = c.list_workspaces()


### PR DESCRIPTION
## Summary
- When `.stash` points to a workspace that no longer exists (403/404), delete the stale manifest and fall through to create a new workspace
- Previously this dead-ended with "You're not a member. Ask a workspace admin for an invite link."
- This was the second commit from #437 that got dropped in the squash merge

## Test plan
- [x] Tested with stale `.stash` pointing to non-existent workspace — prints "replacing stale .stash" and creates new workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)