### PR TITLE
feat(tables): B1 import polish — TSV paste, drag-drop CSV, XLSX, column-type change

### DIFF
--- a/backend/integrations/google/importers/drive_file.py
+++ b/backend/integrations/google/importers/drive_file.py
@@ -4,18 +4,17 @@ The API endpoint dispatches this task once per selected Drive file ID.
 The task itself reads the file's MIME, then routes:
 
 - application/vnd.google-apps.document     → markdown page (native MD export)
-- application/vnd.google-apps.spreadsheet  → table (first sheet only)
+- application/vnd.google-apps.spreadsheet  → one table per visible tab
+                                              (via Drive's XLSX export +
+                                              the shared xlsx_ingest service)
 - application/vnd.openxmlformats-officedocument.presentationml.presentation
                                             → fixed-aspect slide page
 """
 
 from __future__ import annotations
 
-import csv
-import io
 import logging
 import re
-import secrets
 from uuid import UUID
 
 import asyncpg
@@ -23,8 +22,7 @@ import httpx
 
 from ....celery_app import celery
 from ....database import get_pool
-from ....services import table_service
-from ....services.csv_inference import coerce_value, infer_column_type
+from ....services.xlsx_ingest import ingest_xlsx_bytes
 from ....tasks._celery_helpers import run_async
 from ...storage import get_valid_token
 
@@ -140,88 +138,47 @@ async def _import(
         raise RuntimeError(f"Unsupported Drive MIME type: {mime}")
 
 
+_XLSX_EXPORT_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
 async def _import_google_sheet(
     client: httpx.AsyncClient,
     workspace_id: UUID,
-    folder_id: UUID | None,
+    folder_id: UUID | None,  # noqa: ARG001 — kept for signature parity with other importers
     user_id: UUID,
     file_id: str,
     name: str,
 ) -> dict:
-    """First-tab-only Sheets import.
+    """Multi-tab Sheets import via Drive's XLSX export.
 
-    Drive's CSV export already returns only the first sheet — that's
-    the v1 limitation. Header row becomes the column names; column
-    types are inferred from the first 50 data rows (same logic as the
-    CSV ingest endpoint) so numeric/date/boolean columns aren't all
-    forced to text.
+    Drive can export a Google Sheet as a real .xlsx workbook on a single
+    HTTP call, so we don't need the Sheets API (or its extra OAuth
+    scope) just to enumerate tabs. We hand the bytes to the same
+    `ingest_xlsx_bytes` service the upload endpoint uses — one Stash
+    table per visible sheet, types inferred per sheet.
     """
     resp = await _drive_get(
         client,
-        DRIVE_EXPORT_URL.format(file_id=file_id) + "?mimeType=text/csv",
+        DRIVE_EXPORT_URL.format(file_id=file_id) + f"?mimeType={_XLSX_EXPORT_MIME}",
     )
-    text = resp.text
-    reader = csv.reader(io.StringIO(text))
-    rows = list(reader)
-    if not rows:
-        raise RuntimeError("sheet is empty")
-
-    header = rows[0]
-    if not any(h.strip() for h in header):
-        raise RuntimeError("sheet has no header row")
-
-    data_rows = rows[1:]
-    sample = data_rows[:50]
-
-    columns = []
-    seen_names: dict[str, int] = {}
-    for ci, raw_name in enumerate(header):
-        col_name = (raw_name or "").strip() or "column"
-        # Disambiguate duplicate headers — Sheets allows them, our column
-        # storage tolerates them, but the UI is friendlier when names differ.
-        if col_name in seen_names:
-            seen_names[col_name] += 1
-            col_name = f"{col_name} ({seen_names[col_name]})"
-        else:
-            seen_names[col_name] = 1
-        samples = [(r[ci] if ci < len(r) else "") for r in sample]
-        columns.append(
-            {
-                "id": f"col_{secrets.token_hex(6)}",
-                "name": col_name,
-                "type": infer_column_type(samples),
-            }
-        )
-
-    table = await table_service.create_table(
+    created = await ingest_xlsx_bytes(
         workspace_id=workspace_id,
-        name=name,
-        description=f"Imported from Google Sheets ({file_id})",
-        columns=columns,
-        created_by=user_id,
+        user_id=user_id,
+        content=resp.content,
+        base_name=name,
+        description_template=(f"Imported from Google Sheets ({file_id}) — sheet: {{sheet}}"),
     )
+    if not created:
+        raise RuntimeError("sheet had no visible tabs with data")
 
-    records: list[dict] = []
-    for row in data_rows:
-        record: dict = {}
-        for i, col in enumerate(columns):
-            raw = row[i] if i < len(row) else ""
-            record[col["id"]] = coerce_value(raw, col["type"])
-        records.append(record)
-
-    if records:
-        await table_service.create_rows_batch(
-            table_id=table["id"],
-            rows_data=records,
-            created_by=user_id,
-        )
-
+    first = created[0]
     return {
         "kind": "table",
-        "table_id": str(table["id"]),
-        "name": name,
-        "row_count": len(data_rows),
-        "column_count": len(columns),
+        "table_id": str(first["id"]),
+        "name": first["name"],
+        "row_count": first.get("row_count"),
+        "column_count": len(first.get("columns") or []),
+        "sheet_count": len(created),
     }
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ google-auth>=2.30
 google-auth-oauthlib>=1.2
 google-api-python-client>=2.140
 python-pptx>=1.0
+openpyxl>=3.1
 playwright>=1.49
 Pillow>=10.0
 pillow-heif>=0.19

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -22,6 +22,7 @@ from ..models import (
     FileListResponse,
     FileResponse,
     FileUpdateRequest,
+    TableListResponse,
     TableResponse,
     UploadResponse,
 )
@@ -34,6 +35,7 @@ from ..services import (
     workspace_service,
 )
 from ..services.csv_inference import coerce_value, infer_column_type
+from ..services.xlsx_ingest import ingest_xlsx_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -568,6 +570,77 @@ async def ingest_csv_file(
 
     refreshed = await table_service.get_table(table["id"])
     return TableResponse(**(refreshed or table))
+
+
+_XLSX_CONTENT_TYPES = {
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+}
+
+
+@ws_router.post("/{file_id}/ingest-xlsx", response_model=TableListResponse)
+async def ingest_xlsx_file(
+    workspace_id: UUID,
+    file_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Parse an .xlsx file into one table per sheet.
+
+    Idempotent on the file's `linked_table_id` field, which points at the
+    first sheet's table — re-running won't create duplicates, but it also
+    won't re-discover sheets added to the workbook after the first
+    ingest. (Re-import as a new file if the source workbook changes
+    sheets.)
+    """
+    await _check_write(workspace_id, current_user["id"])
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, name, content_type, storage_key, linked_table_id "
+        "FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+        file_id,
+        workspace_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="File not found")
+    if not await _can_access_file(file_id, workspace_id, current_user["id"], require_write=True):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    ct = (row["content_type"] or "").lower()
+    if not (ct in _XLSX_CONTENT_TYPES or row["name"].lower().endswith((".xlsx", ".xls"))):
+        raise HTTPException(status_code=400, detail="File is not an Excel workbook")
+
+    if row["linked_table_id"]:
+        existing = await table_service.get_table(row["linked_table_id"])
+        if existing:
+            return TableListResponse(tables=[TableResponse(**existing)])
+
+    try:
+        content = await storage_service.download_file(row["storage_key"])
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"S3 download failed: {e}")
+
+    base_name = row["name"].rsplit(".", 1)[0] or row["name"]
+    try:
+        created = await ingest_xlsx_bytes(
+            workspace_id=workspace_id,
+            user_id=current_user["id"],
+            content=content,
+            base_name=base_name,
+            description_template=(f"Imported from {row['name']} (sheet: {{sheet}})"),
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Could not read workbook: {e}")
+
+    if not created:
+        raise HTTPException(status_code=400, detail="Workbook had no visible sheets with data")
+
+    await pool.execute(
+        "UPDATE files SET linked_table_id = $1 WHERE id = $2",
+        created[0]["id"],
+        file_id,
+    )
+
+    return TableListResponse(tables=[TableResponse(**t) for t in created])
 
 
 def _slugify(s: str) -> str:

--- a/backend/services/xlsx_ingest.py
+++ b/backend/services/xlsx_ingest.py
@@ -1,0 +1,128 @@
+"""Parse an XLSX workbook (bytes) into one Stash table per visible sheet.
+
+Shared between the `/files/{id}/ingest-xlsx` endpoint (local file
+uploads) and the Google Drive Sheets importer (Drive export → XLSX
+bytes). Reuses the CSV inference + coercion so column types end up
+identical whether the data came from a CSV, a Sheet, or a workbook.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from uuid import UUID
+
+from . import table_service
+from .csv_inference import coerce_value, infer_column_type
+
+
+def _cell_to_str(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _slugify(s: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9_]+", "_", (s or "").strip().lower())
+    return re.sub(r"_+", "_", s).strip("_")
+
+
+async def ingest_xlsx_bytes(
+    *,
+    workspace_id: UUID,
+    user_id: UUID,
+    content: bytes,
+    base_name: str,
+    description_template: str,
+) -> list[dict]:
+    """Create one Stash table per visible sheet with data. Returns the
+    list of created table rows (in workbook order).
+
+    `description_template` is `str.format`-ed with `sheet=<title>` per
+    sheet so the caller controls the per-table provenance string.
+    """
+    from openpyxl import load_workbook
+
+    wb = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+    created: list[dict] = []
+    # Only count visible sheets when deciding whether to disambiguate
+    # table names — a single visible sheet next to a hidden one shouldn't
+    # get a " — sheet" suffix it doesn't need.
+    visible_count = sum(1 for s in wb.worksheets if s.sheet_state == "visible")
+    multi_sheet = visible_count > 1
+    try:
+        for sheet in wb.worksheets:
+            if sheet.sheet_state != "visible":
+                continue
+            rows = [[_cell_to_str(c) for c in r] for r in sheet.iter_rows(values_only=True)]
+            while rows and all(c == "" for c in rows[-1]):
+                rows.pop()
+            if not rows:
+                continue
+            header = rows[0]
+            if not any(h.strip() for h in header):
+                continue
+            data_rows = rows[1:]
+            sample = data_rows[:50]
+
+            columns = []
+            seen_ids: set[str] = set()
+            for ci, name in enumerate(header):
+                samples = [(r[ci] if ci < len(r) else "") for r in sample]
+                col_id = _slugify(name) or f"col_{ci}"
+                base_id = col_id
+                n = 2
+                while col_id in seen_ids:
+                    col_id = f"{base_id}_{n}"
+                    n += 1
+                seen_ids.add(col_id)
+                columns.append(
+                    {
+                        "id": col_id,
+                        "name": (name or f"col_{ci}").strip() or f"col_{ci}",
+                        "type": infer_column_type(samples),
+                        "order": ci,
+                        "required": False,
+                        "default": None,
+                        "options": None,
+                    }
+                )
+
+            table_name = f"{base_name} — {sheet.title}" if multi_sheet else base_name
+            # Notion DB import uses random col ids (no _slugify); Sheets/CSV
+            # use slugified ones. Mix is fine — id collisions within a single
+            # table are what matters, and we de-dupe above.
+            table = await table_service.create_table(
+                workspace_id=workspace_id,
+                name=table_name,
+                description=description_template.format(sheet=sheet.title),
+                columns=columns,
+                created_by=user_id,
+            )
+
+            payload = []
+            for r in data_rows:
+                rec = {}
+                for ci, col in enumerate(columns):
+                    raw = r[ci] if ci < len(r) else ""
+                    rec[col["id"]] = coerce_value(raw, col["type"])
+                payload.append(rec)
+            if payload:
+                await table_service.create_rows_batch(
+                    table_id=table["id"], rows_data=payload, created_by=user_id
+                )
+
+            refreshed = await table_service.get_table(table["id"])
+            created.append(refreshed or table)
+    finally:
+        wb.close()
+
+    return created

--- a/backend/tests/test_xlsx_cell_to_str.py
+++ b/backend/tests/test_xlsx_cell_to_str.py
@@ -1,0 +1,51 @@
+"""Lock in the cell-to-string conversion for XLSX ingest.
+
+The XLSX importer leans on `_cell_to_str` to feed openpyxl values into
+the same `infer_column_type` / `coerce_value` pipeline as CSV cells.
+The mapping needs to be exact — integer-valued floats must lose their
+`.0` (so they infer as `number`, not `text`), and datetimes must emit
+ISO format (so the date regex matches).
+"""
+
+from datetime import date, datetime
+
+from backend.services.csv_inference import infer_column_type
+from backend.services.xlsx_ingest import _cell_to_str
+
+
+def test_none_becomes_empty_string():
+    assert _cell_to_str(None) == ""
+
+
+def test_bool_is_lowercased():
+    assert _cell_to_str(True) == "true"
+    assert _cell_to_str(False) == "false"
+
+
+def test_integer_valued_float_drops_trailing_zero():
+    # Excel stores plain numbers as floats; without the strip, "42.0"
+    # would infer as text since the numeric regex tolerates it but the
+    # row coercion would force float typing forever.
+    assert _cell_to_str(42.0) == "42"
+    assert _cell_to_str(0.0) == "0"
+
+
+def test_real_float_keeps_decimal():
+    assert _cell_to_str(2.5) == "2.5"
+
+
+def test_integer_stays_integer():
+    assert _cell_to_str(42) == "42"
+
+
+def test_datetime_emits_iso():
+    s = _cell_to_str(datetime(2026, 5, 21, 10, 0, 0))
+    assert s == "2026-05-21T10:00:00"
+    # Must round-trip through inference as datetime.
+    assert infer_column_type([s]) == "datetime"
+
+
+def test_date_emits_iso():
+    s = _cell_to_str(date(2026, 5, 21))
+    assert s == "2026-05-21"
+    assert infer_column_type([s]) == "date"

--- a/backend/tests/test_xlsx_ingest.py
+++ b/backend/tests/test_xlsx_ingest.py
@@ -1,0 +1,209 @@
+"""Verify the XLSX ingest service end-to-end against a real openpyxl
+workbook — multi-sheet, type inference, and empty-sheet handling.
+
+We mock `table_service.create_table` / `create_rows_batch` / `get_table`
+so this exercises the openpyxl walk + the per-sheet shape without
+touching the DB.
+"""
+
+import io
+from datetime import date, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from openpyxl import Workbook
+
+from backend.services.xlsx_ingest import ingest_xlsx_bytes
+
+
+def _bytes_from(wb: Workbook) -> bytes:
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def mocked_table_service():
+    """Capture create_table/create_rows_batch calls so each test can
+    inspect what would land in the DB without standing up the DB."""
+    created_tables: list[dict] = []
+    inserted_rows: dict[str, list[dict]] = {}
+
+    async def fake_create_table(**kwargs):
+        tid = uuid4()
+        rec = {
+            "id": tid,
+            "name": kwargs["name"],
+            "description": kwargs["description"],
+            "columns": kwargs["columns"],
+            "workspace_id": kwargs["workspace_id"],
+            "created_by": kwargs["created_by"],
+        }
+        created_tables.append(rec)
+        return rec
+
+    async def fake_create_rows_batch(*, table_id, rows_data, created_by):
+        inserted_rows.setdefault(str(table_id), []).extend(rows_data)
+        return rows_data
+
+    async def fake_get_table(table_id):
+        for t in created_tables:
+            if t["id"] == table_id:
+                return t
+        return None
+
+    with (
+        patch(
+            "backend.services.xlsx_ingest.table_service.create_table",
+            AsyncMock(side_effect=fake_create_table),
+        ),
+        patch(
+            "backend.services.xlsx_ingest.table_service.create_rows_batch",
+            AsyncMock(side_effect=fake_create_rows_batch),
+        ),
+        patch(
+            "backend.services.xlsx_ingest.table_service.get_table",
+            AsyncMock(side_effect=fake_get_table),
+        ),
+    ):
+        yield created_tables, inserted_rows
+
+
+async def test_single_sheet_named_after_base(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Only"
+    ws.append(["name", "score"])
+    ws.append(["alice", 91])
+    ws.append(["bob", 88])
+
+    tables = await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="report",
+        description_template="src=test sheet={sheet}",
+    )
+    assert len(tables) == 1
+    # Single-sheet workbooks keep the bare base name (no " — sheet" suffix).
+    assert created_tables[0]["name"] == "report"
+    # Numeric column inferred correctly despite openpyxl returning floats.
+    types = {c["name"]: c["type"] for c in created_tables[0]["columns"]}
+    assert types == {"name": "text", "score": "number"}
+
+
+async def test_multi_sheet_creates_one_table_per_tab(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws1 = wb.active
+    ws1.title = "Sales"
+    ws1.append(["region", "amount"])
+    ws1.append(["US", 1000])
+    ws2 = wb.create_sheet("Costs")
+    ws2.append(["category", "spend"])
+    ws2.append(["cloud", 250])
+
+    tables = await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="Q4",
+        description_template="src=test sheet={sheet}",
+    )
+    assert len(tables) == 2
+    names = [t["name"] for t in created_tables]
+    assert names == ["Q4 — Sales", "Q4 — Costs"]
+    # Description is templated per-sheet.
+    assert created_tables[0]["description"] == "src=test sheet=Sales"
+    assert created_tables[1]["description"] == "src=test sheet=Costs"
+
+
+async def test_hidden_sheets_are_skipped(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws1 = wb.active
+    ws1.title = "Visible"
+    ws1.append(["k", "v"])
+    ws1.append(["a", "b"])
+    hidden = wb.create_sheet("Hidden")
+    hidden.sheet_state = "hidden"
+    hidden.append(["should", "not appear"])
+
+    tables = await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="book",
+        description_template="{sheet}",
+    )
+    assert len(tables) == 1
+    assert created_tables[0]["name"] == "book"
+
+
+async def test_empty_sheet_is_skipped_silently(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws1 = wb.active
+    ws1.title = "Empty"
+    # No rows at all
+    ws2 = wb.create_sheet("Real")
+    ws2.append(["x", "y"])
+    ws2.append([1, 2])
+
+    tables = await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="wb",
+        description_template="{sheet}",
+    )
+    # Only the non-empty sheet should produce a table.
+    assert len(tables) == 1
+    assert created_tables[0]["name"] == "wb — Real"
+
+
+async def test_dates_and_booleans_round_trip(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Mixed"
+    ws.append(["when", "done"])
+    ws.append([date(2026, 5, 21), True])
+    ws.append([datetime(2026, 5, 22, 10, 30), False])
+
+    await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="dates",
+        description_template="{sheet}",
+    )
+    cols = {c["name"]: c["type"] for c in created_tables[0]["columns"]}
+    # `when` mixes a date (no T) and a datetime (with T) — promoted to datetime.
+    assert cols["when"] == "datetime"
+    assert cols["done"] == "boolean"
+
+
+async def test_id_collision_disambiguates(mocked_table_service):
+    created_tables, _ = mocked_table_service
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Dups"
+    # Two header cells that slugify to the same id ("name", "Name!").
+    ws.append(["name", "Name!"])
+    ws.append(["a", "b"])
+
+    await ingest_xlsx_bytes(
+        workspace_id=uuid4(),
+        user_id=uuid4(),
+        content=_bytes_from(wb),
+        base_name="dup",
+        description_template="{sheet}",
+    )
+    ids = [c["id"] for c in created_tables[0]["columns"]]
+    # Second column must get a suffixed id so JSONB writes don't clobber.
+    assert ids[0] != ids[1]
+    assert ids[0] == "name"
+    assert ids[1].startswith("name")

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -11,6 +11,7 @@ import {
   getFolderContents,
   getPublicStash,
   ingestCsvFile,
+  ingestXlsxFile,
   trashItem,
   updateFile,
   type FolderBreadcrumb,
@@ -26,6 +27,15 @@ import FileViewerHeader from "../../../../../../components/workspace/FileViewerH
 
 function isCsv(ct: string) {
   return ct?.includes("csv") || ct === "text/csv";
+}
+
+const XLSX_CONTENT_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+]);
+
+function isXlsx(ct: string, name: string) {
+  return XLSX_CONTENT_TYPES.has(ct) || /\.xlsx?$/i.test(name);
 }
 
 export default function FileViewerPage() {
@@ -146,6 +156,25 @@ function FileViewerPageInner() {
             router.replace(`/tables/${table.id}?workspaceId=${workspaceId}`);
           } catch (e) {
             setError(e instanceof Error ? e.message : "CSV ingest failed");
+          }
+        }
+        return;
+      }
+      // XLSX: same shape, but one table per sheet. Redirect to the first
+      // sheet's table; the others appear in the workspace sidebar.
+      if (isXlsx(f.content_type, f.name)) {
+        if (f.linked_table_id) {
+          router.replace(`/tables/${f.linked_table_id}?workspaceId=${workspaceId}`);
+        } else {
+          try {
+            const { tables } = await ingestXlsxFile(workspaceId, fileId);
+            if (tables.length === 0) {
+              setError("Workbook had no readable sheets");
+            } else {
+              router.replace(`/tables/${tables[0].id}?workspaceId=${workspaceId}`);
+            }
+          } catch (e) {
+            setError(e instanceof Error ? e.message : "XLSX ingest failed");
           }
         }
         return;

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../../lib/api";
 import type { Table, TableColumn, TableRow, TableView } from "../../../lib/types";
 import FileViewerHeader from "../../../components/workspace/FileViewerHeader";
-import { parseCsv, inferColumnType } from "../../../lib/csv";
+import { parseCsv, inferColumnType, detectDelimiter } from "../../../lib/csv";
 
 const TYPE_ICONS: Record<string, string> = {
   text: "Aa", number: "#", boolean: "\u2713", date: "\uD83D\uDCC5", datetime: "\uD83D\uDD53",
@@ -96,6 +96,7 @@ function TableEditorPageInner() {
 
   // Column menu, drag, visibility
   const [colMenu, setColMenu] = useState<{ colId: string; x: number; y: number } | null>(null);
+  const [colMenuTypeOpen, setColMenuTypeOpen] = useState(false);
   const [dragCol, setDragCol] = useState<string | null>(null);
   const [hiddenCols, setHiddenCols] = useState<Set<string>>(new Set());
   const [showColVisibility, setShowColVisibility] = useState(false);
@@ -125,6 +126,7 @@ function TableEditorPageInner() {
 
   // CSV import
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dropping, setDropping] = useState(false);
 
   const wsId = resolvedWorkspaceId;
   const sortedColumns = table?.columns ? [...table.columns].sort((a, b) => a.order - b.order) : [];
@@ -134,6 +136,7 @@ function TableEditorPageInner() {
   const shareModal = useShareModal();
 
   useEscapeKey(!!colMenu, () => setColMenu(null));
+  useEffect(() => { if (!colMenu) setColMenuTypeOpen(false); }, [colMenu]);
   useEscapeKey(showColVisibility, () => setShowColVisibility(false));
   useEscapeKey(showEmbeddings, () => setShowEmbeddings(false));
   useEscapeKey(showAddCol, () => setShowAddCol(false));
@@ -336,6 +339,13 @@ function TableEditorPageInner() {
     if (!name || name === col.name) return;
     try { setTable(await updateTableColumn(wsId, tableId, colId, { name })); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
+  const handleChangeColumnType = async (colId: string, type: string) => {
+    // Existing cell values stay in JSONB as-is; the new type only governs
+    // future writes (which the server validator coerces / rejects). The
+    // grid renderer treats unparseable values as plain strings, so a bad
+    // pick won't break the table — it'll just stop accepting new values.
+    try { setTable(await updateTableColumn(wsId, tableId, colId, { type })); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
+  };
   const handleColumnDrop = async (targetColId: string) => {
     if (!dragCol || dragCol === targetColId) { setDragCol(null); return; }
     const ids = sortedColumns.map((c) => c.id);
@@ -427,52 +437,104 @@ function TableEditorPageInner() {
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
 
-  // --- CSV ---
+  // --- CSV / TSV import ---
+  // Shared by the file picker, drag-drop, and clipboard paste. Auto-creates
+  // missing columns with inferred types; existing columns are matched by name.
+  const importTabular = async (text: string, delimiter: string) => {
+    const rows = parseCsv(text, delimiter);
+    if (rows.length < 2) { setError("Need a header row plus at least one data row"); return; }
+    const headers = rows[0];
+    const dataRows = rows.slice(1);
+
+    const existingNames = new Set(sortedColumns.map((c) => c.name));
+    let currentTable = table!;
+    for (let ci = 0; ci < headers.length; ci++) {
+      const name = headers[ci];
+      if (!name || existingNames.has(name)) continue;
+      const samples = dataRows.slice(0, 50).map((r) => r[ci] ?? "");
+      const colType = inferColumnType(samples);
+      currentTable = await addTableColumn(wsId, tableId, { name, type: colType });
+      existingNames.add(name);
+    }
+    setTable(currentTable);
+
+    const colIdByHeader: Record<string, string> = {};
+    for (const col of currentTable.columns) colIdByHeader[col.name] = col.id;
+
+    const payload: Record<string, unknown>[] = [];
+    for (const r of dataRows) {
+      const data: Record<string, unknown> = {};
+      headers.forEach((h, idx) => {
+        const colId = colIdByHeader[h];
+        if (!colId) return;
+        const raw = r[idx] ?? "";
+        // Server coerces raw strings per column type; empty cells become NULL.
+        data[colId] = raw === "" ? null : raw;
+      });
+      payload.push(data);
+    }
+
+    for (let i = 0; i < payload.length; i += 5000) {
+      await createTableRowsBatch(
+        wsId,
+        tableId,
+        payload.slice(i, i + 5000).map((d) => ({ data: d })),
+      );
+    }
+    await loadRows(); await loadTable();
+  };
+
   const handleCsvImport = async (file: File) => {
     try {
       const text = await file.text();
-      const rows = parseCsv(text);
-      if (rows.length < 2) { setError("CSV needs header + data"); return; }
-      const headers = rows[0];
-      const dataRows = rows.slice(1);
-
-      const existingNames = new Set(sortedColumns.map((c) => c.name));
-      let currentTable = table!;
-      for (let ci = 0; ci < headers.length; ci++) {
-        const name = headers[ci];
-        if (!name || existingNames.has(name)) continue;
-        const samples = dataRows.slice(0, 50).map((r) => r[ci] ?? "");
-        const colType = inferColumnType(samples);
-        currentTable = await addTableColumn(wsId, tableId, { name, type: colType });
-        existingNames.add(name);
-      }
-      setTable(currentTable);
-
-      const colIdByHeader: Record<string, string> = {};
-      for (const col of currentTable.columns) colIdByHeader[col.name] = col.id;
-
-      const payload: Record<string, unknown>[] = [];
-      for (const r of dataRows) {
-        const data: Record<string, unknown> = {};
-        headers.forEach((h, idx) => {
-          const colId = colIdByHeader[h];
-          if (!colId) return;
-          const raw = r[idx] ?? "";
-          // Server coerces raw strings per column type; empty cells become NULL.
-          data[colId] = raw === "" ? null : raw;
-        });
-        payload.push(data);
-      }
-
-      for (let i = 0; i < payload.length; i += 5000) {
-        await createTableRowsBatch(
-          wsId,
-          tableId,
-          payload.slice(i, i + 5000).map((d) => ({ data: d })),
-        );
-      }
-      await loadRows(); await loadTable();
+      await importTabular(text, detectDelimiter(text));
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to import"); }
+  };
+
+  const isFileDrag = (e: React.DragEvent) =>
+    Array.from(e.dataTransfer.types || []).includes("Files");
+
+  const handleFileDragOver = (e: React.DragEvent) => {
+    if (readOnly || !table || !isFileDrag(e)) return;
+    e.preventDefault();
+    if (!dropping) setDropping(true);
+  };
+
+  const handleFileDragLeave = (e: React.DragEvent) => {
+    // Only clear when the drag leaves the container, not when crossing
+    // child elements (relatedTarget within the container still counts).
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setDropping(false);
+  };
+
+  const handleFileDrop = async (e: React.DragEvent) => {
+    if (readOnly || !table || !isFileDrag(e)) return;
+    e.preventDefault();
+    setDropping(false);
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+    if (!/\.csv$/i.test(file.name) && !file.type.includes("csv")) {
+      setError("Drop a .csv file to append rows");
+      return;
+    }
+    await handleCsvImport(file);
+  };
+
+  const handlePasteTabular = async (e: React.ClipboardEvent) => {
+    if (readOnly || !table || editingCell) return;
+    // Ignore pastes inside inputs/textareas/contentEditable (cell editors,
+    // search, filter inputs). Only intercept the bare grid container.
+    const target = e.target as HTMLElement | null;
+    if (target) {
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
+    }
+    const text = e.clipboardData.getData("text/plain");
+    if (!text || !text.includes("\n")) return;
+    e.preventDefault();
+    try {
+      await importTabular(text, detectDelimiter(text));
+    } catch (err) { setError(err instanceof Error ? err.message : "Failed to paste"); }
   };
   const handleCsvExport = async () => {
     if (!table || !wsId) return;
@@ -602,7 +664,20 @@ function TableEditorPageInner() {
     : null;
 
   const tableContent = (
-      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      <div
+        className="relative flex-1 flex flex-col min-h-0 overflow-hidden"
+        onPaste={handlePasteTabular}
+        onDragOver={handleFileDragOver}
+        onDragLeave={handleFileDragLeave}
+        onDrop={handleFileDrop}
+      >
+        {dropping && (
+          <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-brand/10 border-2 border-dashed border-brand">
+            <div className="rounded-lg bg-surface/95 px-6 py-3 text-sm font-medium text-brand shadow-lg">
+              Drop a CSV to append rows
+            </div>
+          </div>
+        )}
         <FileViewerHeader
           icon={<TableGlyph />}
           iconColor="#059669"
@@ -893,11 +968,37 @@ function TableEditorPageInner() {
 
         {/* Column context menu */}
         {colMenu && (
-          <div className="fixed z-50 bg-surface border border-border rounded-lg shadow-lg py-1 min-w-[160px]" style={{ left: colMenu.x, top: colMenu.y }} onClick={(e) => e.stopPropagation()}>
-            <button onClick={() => { handleSort(colMenu.colId); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Sort {sortBy === colMenu.colId && sortOrder === "asc" ? "descending" : "ascending"}</button>
-            <button onClick={() => handleRenameColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Rename</button>
-            <button onClick={() => { setHiddenCols((prev) => new Set([...prev, colMenu.colId])); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Hide column</button>
-            <button onClick={() => handleDeleteColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-raised">Delete column</button>
+          <div className="fixed z-50 bg-surface border border-border rounded-lg shadow-lg py-1 min-w-[180px]" style={{ left: colMenu.x, top: colMenu.y }} onClick={(e) => e.stopPropagation()}>
+            {!colMenuTypeOpen ? (
+              <>
+                <button onClick={() => { handleSort(colMenu.colId); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Sort {sortBy === colMenu.colId && sortOrder === "asc" ? "descending" : "ascending"}</button>
+                <button onClick={() => handleRenameColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Rename</button>
+                <button onClick={() => setColMenuTypeOpen(true)} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised flex items-center justify-between">
+                  <span>Change type</span>
+                  <span className="text-[10px] text-muted font-mono">{sortedColumns.find((c) => c.id === colMenu.colId)?.type ?? ""} ›</span>
+                </button>
+                <button onClick={() => { setHiddenCols((prev) => new Set([...prev, colMenu.colId])); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Hide column</button>
+                <button onClick={() => handleDeleteColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-raised">Delete column</button>
+              </>
+            ) : (
+              <>
+                <button onClick={() => setColMenuTypeOpen(false)} className="w-full text-left px-3 py-1.5 text-xs text-muted hover:text-foreground hover:bg-raised">‹ Back</button>
+                {COLUMN_TYPES.map((t) => {
+                  const current = sortedColumns.find((c) => c.id === colMenu.colId)?.type;
+                  return (
+                    <button
+                      key={t}
+                      onClick={() => { void handleChangeColumnType(colMenu.colId, t); setColMenuTypeOpen(false); }}
+                      className={`w-full text-left px-3 py-1.5 text-sm hover:bg-raised flex items-center gap-2 ${current === t ? "text-brand" : "text-foreground"}`}
+                    >
+                      <span className="text-[10px] text-muted font-mono w-4 text-center">{TYPE_ICONS[t] ?? "?"}</span>
+                      <span>{t}</span>
+                      {current === t && <span className="ml-auto text-brand">✓</span>}
+                    </button>
+                  );
+                })}
+              </>
+            )}
           </div>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -896,6 +896,15 @@ export async function ingestCsvFile(workspaceId: string, fileId: string): Promis
   });
 }
 
+export async function ingestXlsxFile(
+  workspaceId: string,
+  fileId: string,
+): Promise<{ tables: Table[] }> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/files/${fileId}/ingest-xlsx`, {
+    method: "POST",
+  });
+}
+
 export async function updateFile(
   workspaceId: string,
   fileId: string,

--- a/frontend/src/lib/csv.test.ts
+++ b/frontend/src/lib/csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCsv, inferColumnType } from "./csv";
+import { parseCsv, inferColumnType, detectDelimiter } from "./csv";
 
 describe("parseCsv", () => {
   it("handles empty cells without column shift", () => {
@@ -53,6 +53,37 @@ describe("parseCsv", () => {
       ["a", "b"],
       ["", ""],
     ]);
+  });
+});
+
+describe("parseCsv with delimiter", () => {
+  it("parses TSV when given a tab delimiter", () => {
+    expect(parseCsv("a\tb\tc\n1\t2\t3", "\t")).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
+  it("preserves commas in TSV values", () => {
+    expect(parseCsv("name\tquote\nAlice\tHello, world", "\t")).toEqual([
+      ["name", "quote"],
+      ["Alice", "Hello, world"],
+    ]);
+  });
+});
+
+describe("detectDelimiter", () => {
+  it("picks tab when the first line has more tabs than commas", () => {
+    expect(detectDelimiter("a\tb\tc\n1\t2\t3")).toBe("\t");
+  });
+
+  it("picks comma by default (including ties)", () => {
+    expect(detectDelimiter("a,b,c\n1,2,3")).toBe(",");
+    expect(detectDelimiter("a\tb,c")).toBe(",");
+  });
+
+  it("handles single-column pastes", () => {
+    expect(detectDelimiter("hello\nworld")).toBe(",");
   });
 });
 

--- a/frontend/src/lib/csv.ts
+++ b/frontend/src/lib/csv.ts
@@ -15,7 +15,7 @@ export type InferredType =
   | "datetime"
   | "text";
 
-export function parseCsv(text: string): string[][] {
+export function parseCsv(text: string, delimiter: string = ","): string[][] {
   if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
 
   const rows: string[][] = [];
@@ -45,7 +45,7 @@ export function parseCsv(text: string): string[][] {
       i++;
       continue;
     }
-    if (ch === ",") {
+    if (ch === delimiter) {
       row.push(field);
       field = "";
       i++;
@@ -98,6 +98,19 @@ const BOOL_VALUES = new Set([
   "0",
   "1",
 ]);
+
+/**
+ * Pick the delimiter for a pasted blob. Anything copied out of a
+ * spreadsheet uses tabs; anything saved as a .csv uses commas. Decide
+ * based on whichever character is more common in the first line, with
+ * a tie going to comma (the more conservative default).
+ */
+export function detectDelimiter(text: string): "," | "\t" {
+  const firstLine = text.split(/\r?\n/, 1)[0] ?? "";
+  const tabs = (firstLine.match(/\t/g) || []).length;
+  const commas = (firstLine.match(/,/g) || []).length;
+  return tabs > commas ? "\t" : ",";
+}
 
 export function inferColumnType(samples: string[]): InferredType {
   const nonempty = samples.filter((s) => s !== "");


### PR DESCRIPTION
## Summary

Five small wins that unblock the obvious \"this should just work\" cases for table imports, plus an in-place column-type fix-up affordance for when inference guesses wrong. Implements **Batch 1** from `plans/tables-roadmap.md`.

### TSV paste on the grid

Paste from Excel / Sheets / Notion outside a cell editor → rows append. Delimiter auto-detected (tab vs comma based on the first line). Uses the same RFC-4180 state machine as CSV.

### Drag-and-drop CSV onto the table

Drop a `.csv` on the grid → same path as the Import button. Visual drop-zone overlay during drag. Column-reorder drag still works because we check `dataTransfer.types` includes `\"Files\"` before intercepting.

### Column-type change

Right-click a column → \"Change type ›\" sub-menu. Calls the existing PATCH endpoint. Existing JSONB values stay as-is (the new type only governs future writes — documented in code).

### XLSX import (multi-sheet)

- New `backend/services/xlsx_ingest.py`: openpyxl → one Stash table per visible sheet, with the existing CSV inference + coercion applied per-sheet. Hidden sheets and empty sheets are skipped silently; column-id collisions get disambiguated.
- New `POST /files/{id}/ingest-xlsx` endpoint, idempotent on `linked_table_id`.
- Frontend file-route auto-detects `.xlsx` MIME or extension and posts to it; redirects to the first sheet (others appear in the workspace sidebar).
- Adds `openpyxl>=3.1` to backend deps.

### Multi-tab Google Sheets

Switched the Sheets importer from Drive's CSV export (first tab only) to Drive's XLSX export (full workbook) and routed it through the same `ingest_xlsx_bytes` service. **No new OAuth scope needed** — the existing `drive.file` scope covers the export.

## Tests

- `backend/tests/test_xlsx_ingest.py` (6 cases) — single-sheet naming, multi-sheet naming, hidden-sheet skipping, empty-sheet skipping, date/boolean inference, column-id collision disambiguation.
- `backend/tests/test_xlsx_cell_to_str.py` (7 cases) — locks in the openpyxl cell-to-string contract.
- `frontend/src/lib/csv.test.ts` (+5 cases) — TSV parser + `detectDelimiter`.

All 28 backend + 21 frontend tests green locally. Black + ruff clean on changed files. `tsc --noEmit` clean.

## Test plan

- [x] `backend/.venv/bin/python -m pytest backend/tests/test_xlsx_ingest.py backend/tests/test_xlsx_cell_to_str.py backend/tests/test_csv_inference.py` passes
- [x] `cd frontend && npx vitest run src/lib/csv.test.ts` passes
- [x] `cd frontend && npx tsc --noEmit` clean
- [x] `black --check` + `ruff check` clean on changed backend files
- [ ] Manual: paste a TSV block from Google Sheets into a table grid → rows append with inferred types
- [ ] Manual: drag a `.csv` onto the grid → drop-zone overlay → rows append
- [ ] Manual: right-click a number column inferred as text → \"Change type → number\" → header icon updates, new writes coerced as numbers
- [ ] Manual: upload an `.xlsx` with 3 sheets → 3 tables created, first opens, others discoverable in sidebar
- [ ] Manual: import a Google Sheet with 2+ tabs → 2 tables created (instead of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)