### PR TITLE
fix: merge codex config.toml snippet sections instead of blindly appending

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -477,6 +477,63 @@ def _ask_codex_network_access() -> bool:
     return True if answer is None else bool(answer)
 
 
+def _merge_snippet_into_toml(existing: str, snippet: str) -> str:
+    """Merge snippet sections into existing TOML without creating duplicates.
+
+    If a section header like [features] already exists in the config, inject
+    the snippet's keys for that section into the existing section instead of
+    appending a duplicate header.
+    """
+    import re
+
+    section_re = re.compile(r"^\[([^\]]+)\]\s*$", re.MULTILINE)
+    existing_sections: set[str] = {m.group(1) for m in section_re.finditer(existing)}
+
+    if not existing_sections:
+        return existing, snippet
+
+    snippet_lines = snippet.split("\n")
+    merged_snippet_lines: list[str] = []
+    inject_into_existing: dict[str, list[str]] = {}
+    current_section: str | None = None
+    current_is_dupe = False
+
+    for line in snippet_lines:
+        m = section_re.match(line)
+        if m:
+            current_section = m.group(1)
+            if current_section in existing_sections:
+                current_is_dupe = True
+                inject_into_existing.setdefault(current_section, [])
+            else:
+                current_is_dupe = False
+                merged_snippet_lines.append(line)
+        elif current_is_dupe:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                inject_into_existing[current_section].append(line)
+        else:
+            merged_snippet_lines.append(line)
+
+    merged_existing = existing
+    for section, keys in inject_into_existing.items():
+        pattern = re.compile(
+            r"(\[" + re.escape(section) + r"\]\s*\n(?:[^\[]*?))",
+            re.DOTALL,
+        )
+        m = pattern.search(merged_existing)
+        if m:
+            insert_at = m.end()
+            injection = "\n".join(keys) + "\n"
+            merged_existing = (
+                merged_existing[:insert_at] + injection + merged_existing[insert_at:]
+            )
+
+    cleaned_snippet = "\n".join(merged_snippet_lines)
+    cleaned_snippet = re.sub(r"\n{3,}", "\n\n", cleaned_snippet)
+    return merged_existing, cleaned_snippet
+
+
 def _strip_top_level_sandbox(snippet: str) -> str:
     """Call this when the user opts not to grant outbound network
     request access. It removes the toml that grants codex outbound
@@ -515,6 +572,7 @@ def _install_codex(force: bool) -> tuple[str, str]:
 
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     if _CODEX_MARKER not in existing:
+        existing, snippet = _merge_snippet_into_toml(existing, snippet)
         sep = "\n" if existing and not existing.endswith("\n") else ""
         cfg_path.write_text(f"{existing}{sep}\n{_CODEX_MARKER}\n{snippet}\n")
 

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -54,3 +54,21 @@ def test_install_preserves_unrelated_user_config(monkeypatch, tmp_path: Path) ->
     assert "[profiles.stash]" in body
     with cfg.open("rb") as f:
         tomllib.load(f)
+
+
+def test_preexisting_features_section_no_duplicate(monkeypatch, tmp_path: Path) -> None:
+    """If the user already has [features], the installer must merge into it
+    rather than appending a duplicate header (which breaks TOML parsing)."""
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    cfg = codex_dir / "config.toml"
+    cfg.write_text('[features]\nsuppress_unstable_features_warning = true\n')
+
+    cfg = _run_install(monkeypatch, tmp_path)
+    body = cfg.read_text()
+
+    assert body.count("[features]") == 1
+    with cfg.open("rb") as f:
+        parsed = tomllib.load(f)
+    assert parsed["features"]["hooks"] is True
+    assert parsed["features"]["suppress_unstable_features_warning"] is True


### PR DESCRIPTION
## Summary
- `stash install codex` appends a config snippet containing `[features]` to `~/.codex/config.toml`. If the user already has a `[features]` section, TOML parsing fails on the duplicate header and codex won't start.
- Added `_merge_snippet_into_toml()` that detects pre-existing sections and injects keys into them instead of appending duplicate headers.
- Added test covering the exact failure scenario (pre-existing `[features]` with `suppress_unstable_features_warning`).

## Test plan
- [x] Existing `test_install_codex.py` tests pass
- [x] New `test_preexisting_features_section_no_duplicate` passes — verifies single `[features]` header, valid TOML parse, both old and new keys present

🤖 Generated with [Claude Code](https://claude.com/claude-code)