### PR TITLE
Fix Vercel www build + CI black lint

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -525,9 +525,7 @@ def _merge_snippet_into_toml(existing: str, snippet: str) -> str:
         if m:
             insert_at = m.end()
             injection = "\n".join(keys) + "\n"
-            merged_existing = (
-                merged_existing[:insert_at] + injection + merged_existing[insert_at:]
-            )
+            merged_existing = merged_existing[:insert_at] + injection + merged_existing[insert_at:]
 
     cleaned_snippet = "\n".join(merged_snippet_lines)
     cleaned_snippet = re.sub(r"\n{3,}", "\n\n", cleaned_snippet)

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -62,7 +62,7 @@ def test_preexisting_features_section_no_duplicate(monkeypatch, tmp_path: Path) 
     codex_dir = tmp_path / ".codex"
     codex_dir.mkdir()
     cfg = codex_dir / "config.toml"
-    cfg.write_text('[features]\nsuppress_unstable_features_warning = true\n')
+    cfg.write_text("[features]\nsuppress_unstable_features_warning = true\n")
 
     cfg = _run_install(monkeypatch, tmp_path)
     body = cfg.read_text()

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -1,4 +1,4 @@
-import { Code, CodeBlock, H3, Title, Subtitle } from "../components";
+import { Code, CodeBlock, H3, P, Title, Subtitle } from "../components";
 
 export default function SelfHostingPage() {
   return (


### PR DESCRIPTION
## Summary
- **Vercel www build:** `app/docs/self-hosting/page.tsx` used `<P>` but the import line only pulled in `Code, CodeBlock, H3, Title, Subtitle`. Production build failed with `Type error: Cannot find name 'P'` after compile, blocking every preview + production deploy of the landing site. Added `P` to the import.
- **Backend CI lint:** `cli/main.py` and `cli/tests/test_install_codex.py` were not formatted with black 26.x (string-quote nit + a single-line wrap), causing the `Backend lint (ruff + black)` job on main to fail. Ran `black` on the two offenders; `black --check backend/ cli/` is now clean.

Both issues landed on main via separate merges (landing-page-edits and the tables B1 import polish respectively); this PR clears the red on main.

## Test plan
- [x] `black --check backend/ cli/` → All 242 files clean
- [x] `npx tsc --noEmit` in `www/` → no errors
- [ ] Vercel preview for this PR deploys successfully
- [ ] CI on this PR passes all jobs