### PR TITLE
[codex] Publish multi-arch GHCR images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,12 +42,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What changed

- Publish GHCR images for both `linux/amd64` and `linux/arm64`.
- Add QEMU setup before Buildx so the GitHub-hosted runner can build the ARM image variants.

## Why

The GHCR packages are now public, which fixes the anonymous `unauthorized` pull failure. The next self-hosting blocker on Apple Silicon was that `latest` only had an `amd64` manifest, so Docker could not pull the backend/worker/beat image on `linux/arm64/v8`.

## Validation

- Confirmed `stash-backend` and `stash-collab` package visibility is `public` via GitHub API.
- Confirmed anonymous Docker manifest reads now pass for both packages.
- Re-ran `docker compose -f docker-compose.prod.yml up -d` from a clean temp clone; it now pulls anonymously and fails only because the current published manifest is still amd64-only until this workflow rebuilds images.
- Ran `git diff --check -- .github/workflows/docker-publish.yml`.
- `actionlint` is not installed locally.
