### PR TITLE
[codex] Publish frontend image for self-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,8 @@ CORS_ORIGINS=http://localhost:3457,http://localhost:3456
 
 # ── Live Collaboration ───────────────────────
 # The frontend defaults to ws://localhost:3458 in local dev and /collab on
-# deployed same-origin installs. Set this when the collab service has its own
-# public host, e.g. wss://stash-collab.onrender.com.
-# COLLAB_PUBLIC_URL=ws://localhost:3458
+# deployed same-origin installs. Keep Caddy's /collab route when using the
+# prebuilt self-host frontend image.
 
 # Used by the collab sidecar to authorize users through FastAPI.
 BACKEND_URL=http://localhost:3456

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,9 +21,17 @@ jobs:
           - image: stash-backend
             context: .
             dockerfile: backend/Dockerfile
+            build_args: ""
           - image: stash-collab
             context: ./collab
             dockerfile: Dockerfile
+            build_args: ""
+          - image: stash-frontend
+            context: ./frontend
+            dockerfile: Dockerfile
+            build_args: |
+              BACKEND_INTERNAL_URL=http://backend:3456
+              NEXT_PUBLIC_AUTH0_ENABLED=false
     steps:
       - uses: actions/checkout@v4
 
@@ -54,5 +62,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Self-hosting now uses a prebuilt `ghcr.io/fergana-labs/stash-frontend`
+  image alongside the backend and collab images, so
+  `docker-compose.prod.yml` no longer builds application containers on the
+  target machine.
 - Backend now routes markdown and HTML uploads to the pages table on the
   one upload endpoint, so every surface (frontend drag-drop, CLI `stash
   files upload`, MCP `stash_upload_file`) gets the same behavior. The

--- a/README.md
+++ b/README.md
@@ -132,13 +132,15 @@ See [here](https://www.joinstash.ai/docs/cli) for a CLI reference.
 
 ## Self-Hosted
 
-Run Stash locally with Docker Compose:
+Run Stash with prebuilt GHCR images:
 
 ```bash
 git clone https://github.com/Fergana-Labs/stash.git
 cd stash
-docker compose up -d --build
-curl http://localhost:3456/health
+cp .env.example .env
+# Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
+docker compose -f docker-compose.prod.yml up -d
+curl https://app.example.com/health
 ```
 
 Then install the CLI:
@@ -146,7 +148,7 @@ Then install the CLI:
 ```bash
 pip install stashai / uv tool install stashai
 cd /path/to/the/repo/you/want/to/connect
-stash config base_url http://localhost:3456
+stash config base_url https://app.example.com
 stash login
 ```
 

--- a/backend/exports/native/aspose_builder.py
+++ b/backend/exports/native/aspose_builder.py
@@ -54,7 +54,9 @@ async def build_pptx_via_aspose(
 
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     client = http_client or httpx.AsyncClient(
-        base_url=base_url, timeout=_DEFAULT_TIMEOUT_S, headers=headers,
+        base_url=base_url,
+        timeout=_DEFAULT_TIMEOUT_S,
+        headers=headers,
     )
     owns_client = http_client is None
 
@@ -62,7 +64,10 @@ async def build_pptx_via_aspose(
     try:
         resp = await client.post(
             "/sessions",
-            json={"slide_width_px": float(SLIDE_WIDTH_PX), "slide_height_px": float(SLIDE_HEIGHT_PX)},
+            json={
+                "slide_width_px": float(SLIDE_WIDTH_PX),
+                "slide_height_px": float(SLIDE_HEIGHT_PX),
+            },
         )
         resp.raise_for_status()
         session_id = resp.json()["session_id"]
@@ -104,7 +109,9 @@ async def _post_slide(
         png = rasters.get((spec.index, spec.bg_raster_selector))
         if png:
             await _post_raster(
-                client, session_id, slide_index,
+                client,
+                session_id,
+                slide_index,
                 bbox=BBox(x=0, y=0, w=SLIDE_WIDTH_PX, h=SLIDE_HEIGHT_PX),
                 png=png,
             )
@@ -151,7 +158,10 @@ async def _post_shape(
 
 
 async def _post_svg(
-    client: httpx.AsyncClient, session_id: str, slide_index: int, sh: ShapeSpec,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    sh: ShapeSpec,
 ) -> None:
     resp = await client.post(
         f"/sessions/{session_id}/slides/{slide_index}/svg",
@@ -161,7 +171,10 @@ async def _post_svg(
 
 
 async def _post_chart(
-    client: httpx.AsyncClient, session_id: str, slide_index: int, sh: ShapeSpec,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    sh: ShapeSpec,
 ) -> None:
     chart = sh.chart
     if chart is None:
@@ -181,7 +194,10 @@ async def _post_chart(
 
 
 async def _post_text(
-    client: httpx.AsyncClient, session_id: str, slide_index: int, sh: ShapeSpec,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    sh: ShapeSpec,
 ) -> None:
     resp = await client.post(
         f"/sessions/{session_id}/slides/{slide_index}/text",
@@ -196,8 +212,12 @@ async def _post_text(
 
 
 async def _post_raster(
-    client: httpx.AsyncClient, session_id: str, slide_index: int,
-    *, bbox: BBox, png: bytes,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    *,
+    bbox: BBox,
+    png: bytes,
 ) -> None:
     resp = await client.post(
         f"/sessions/{session_id}/slides/{slide_index}/raster",
@@ -210,8 +230,12 @@ async def _post_raster(
 
 
 async def _post_image(
-    client: httpx.AsyncClient, session_id: str, slide_index: int,
-    *, bbox: BBox, data: bytes,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    *,
+    bbox: BBox,
+    data: bytes,
 ) -> None:
     resp = await client.post(
         f"/sessions/{session_id}/slides/{slide_index}/image",
@@ -224,18 +248,25 @@ async def _post_image(
 
 
 async def _post_table(
-    client: httpx.AsyncClient, session_id: str, slide_index: int, sh: ShapeSpec,
+    client: httpx.AsyncClient,
+    session_id: str,
+    slide_index: int,
+    sh: ShapeSpec,
 ) -> None:
     cells_payload: list[list[dict]] = []
     for row in sh.cells:
         row_payload: list[dict] = []
         for cell in row:
             first = cell.paragraphs[0] if cell.paragraphs else None
-            paragraph = asdict(first) if first else {"runs": [], "align": "left", "line_height": 1.2}
-            row_payload.append({
-                "paragraph": paragraph,
-                "bg_color": cell.bg_color,
-            })
+            paragraph = (
+                asdict(first) if first else {"runs": [], "align": "left", "line_height": 1.2}
+            )
+            row_payload.append(
+                {
+                    "paragraph": paragraph,
+                    "bg_color": cell.bg_color,
+                }
+            )
         cells_payload.append(row_payload)
 
     resp = await client.post(

--- a/backend/exports/native/cli.py
+++ b/backend/exports/native/cli.py
@@ -82,7 +82,10 @@ async def main_async(args: argparse.Namespace) -> None:
                 raise SystemExit("ASPOSE_PPTX_URL must be set when --builder=aspose")
             token = os.environ.get("ASPOSE_PPTX_TOKEN")
             pptx_bytes = await build_pptx_via_aspose(
-                specs, html, base_url=base_url, token=token,
+                specs,
+                html,
+                base_url=base_url,
+                token=token,
             )
             suffix = "aspose"
         else:
@@ -90,8 +93,7 @@ async def main_async(args: argparse.Namespace) -> None:
             suffix = "native"
 
         out_path = (
-            Path(args.out) if args.out
-            else Path(f"/tmp/{name.replace(' ', '_')}-{suffix}.pptx")
+            Path(args.out) if args.out else Path(f"/tmp/{name.replace(' ', '_')}-{suffix}.pptx")
         )
         out_path.write_bytes(pptx_bytes)
         log.info("wrote %s (%d bytes)", out_path, len(pptx_bytes))
@@ -104,7 +106,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     parser = argparse.ArgumentParser(description="Native-shape PPTX export sandbox driver.")
     parser.add_argument(
-        "page_id", nargs="?",
+        "page_id",
+        nargs="?",
         help="UUID of a fixed-aspect HTML slide page (omit if using --html-file)",
     )
     parser.add_argument(
@@ -120,7 +123,7 @@ def main() -> None:
         choices=["python-pptx", "aspose"],
         default="python-pptx",
         help="which builder to use; aspose hits the remote REST service "
-             "and requires ASPOSE_PPTX_URL (+ optional ASPOSE_PPTX_TOKEN)",
+        "and requires ASPOSE_PPTX_URL (+ optional ASPOSE_PPTX_TOKEN)",
     )
     args = parser.parse_args()
     asyncio.run(main_async(args))

--- a/backend/exports/native/diff.py
+++ b/backend/exports/native/diff.py
@@ -17,6 +17,7 @@ Usage:
 
 from __future__ import annotations
 
+# ruff: noqa: E402
 import argparse
 import asyncio
 import base64
@@ -37,16 +38,20 @@ load_dotenv(REPO_ROOT / "backend" / ".env")
 
 sys.path.insert(0, str(REPO_ROOT))
 
-from backend import database  # noqa: E402
-from backend.exports.constants import SLIDE_HEIGHT_PX, SLIDE_WIDTH_PX  # noqa: E402
-from backend.exports.native.aspose_builder import build_pptx_via_aspose  # noqa: E402
-from backend.exports.native.layout_probe import probe  # noqa: E402
-from backend.exports.native.pptx_builder import build_pptx  # noqa: E402
-from backend.exports.html_canvas import (  # noqa: E402
+from backend import database
+from backend.exports.constants import SLIDE_HEIGHT_PX, SLIDE_WIDTH_PX
+from backend.exports.html_canvas import (
     build_single_slide_html as _build_single_slide_html,
+)
+from backend.exports.html_canvas import (
     count_slides as _count_slides,
+)
+from backend.exports.html_canvas import (
     strip_body_state as _strip_body_state,
 )
+from backend.exports.native.aspose_builder import build_pptx_via_aspose
+from backend.exports.native.layout_probe import probe
+from backend.exports.native.pptx_builder import build_pptx
 
 log = logging.getLogger("native-diff")
 
@@ -176,7 +181,10 @@ async def main_async(args: argparse.Namespace) -> None:
             token = os.environ.get("ASPOSE_PPTX_TOKEN")
             log.info("running aspose builder against %s…", base_url)
             aspose_pptx = await build_pptx_via_aspose(
-                specs, html, base_url=base_url, token=token,
+                specs,
+                html,
+                base_url=base_url,
+                token=token,
             )
             log.info("rasterising aspose pptx via libreoffice…")
             aspose_pngs = _pptx_to_pngs(aspose_pptx)
@@ -257,7 +265,8 @@ def main() -> None:
         description="Diff: HTML render vs screenshot export vs native export."
     )
     parser.add_argument(
-        "page_id", nargs="?",
+        "page_id",
+        nargs="?",
         help="UUID of a fixed-aspect HTML slide page (omit if using --html-file)",
     )
     parser.add_argument(
@@ -268,7 +277,7 @@ def main() -> None:
         "--aspose",
         action="store_true",
         help="also build via the remote aspose-pptx service "
-             "(requires ASPOSE_PPTX_URL + optional ASPOSE_PPTX_TOKEN)",
+        "(requires ASPOSE_PPTX_URL + optional ASPOSE_PPTX_TOKEN)",
     )
     args = parser.parse_args()
     asyncio.run(main_async(args))

--- a/backend/exports/native/layout_probe.py
+++ b/backend/exports/native/layout_probe.py
@@ -687,13 +687,19 @@ def _chart_from_raw(raw: dict | None) -> ChartSpec | None:
                 label=str(d.get("label") or ""),
                 data=[float(v) for v in (d.get("data") or [])],
                 color=d.get("color"),
-                line_width_px=(float(d["line_width_px"]) if d.get("line_width_px") is not None else None),
-                point_radius_px=(float(d["point_radius_px"]) if d.get("point_radius_px") is not None else None),
+                line_width_px=(
+                    float(d["line_width_px"]) if d.get("line_width_px") is not None else None
+                ),
+                point_radius_px=(
+                    float(d["point_radius_px"]) if d.get("point_radius_px") is not None else None
+                ),
             )
             for d in (raw.get("datasets") or [])
         ],
         title=str(raw.get("title") or ""),
-        axis_font_size_px=(float(raw["axis_font_size_px"]) if raw.get("axis_font_size_px") is not None else None),
+        axis_font_size_px=(
+            float(raw["axis_font_size_px"]) if raw.get("axis_font_size_px") is not None else None
+        ),
     )
 
 

--- a/backend/exports/native/tests/test_aspose_builder.py
+++ b/backend/exports/native/tests/test_aspose_builder.py
@@ -51,16 +51,18 @@ class _Recorder:
 
         if request.method == "POST" and request.url.path == "/sessions":
             return httpx.Response(200, json={"session_id": self.session_id})
-        if request.method == "POST" and request.url.path.endswith("/slides") \
-                and not request.url.path.endswith("/slides/0/text"):
+        if (
+            request.method == "POST"
+            and request.url.path.endswith("/slides")
+            and not request.url.path.endswith("/slides/0/text")
+        ):
             # /sessions/{sid}/slides — add a blank slide
             if request.url.path == f"/sessions/{self.session_id}/slides":
                 idx = self.next_slide_index
                 self.next_slide_index += 1
                 return httpx.Response(200, json={"slide_index": idx})
         if request.method == "POST" and any(
-            request.url.path.endswith(suffix)
-            for suffix in ("/text", "/image", "/raster", "/table")
+            request.url.path.endswith(suffix) for suffix in ("/text", "/image", "/raster", "/table")
         ):
             idx = self.next_shape_index
             self.next_shape_index += 1
@@ -69,7 +71,9 @@ class _Recorder:
             return httpx.Response(
                 200,
                 content=b"PK\x03\x04stub-pptx-bytes",
-                headers={"content-type": "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+                headers={
+                    "content-type": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                },
             )
         if request.method == "DELETE" and request.url.path.startswith("/sessions/"):
             return httpx.Response(200, json={"ok": True})
@@ -93,7 +97,9 @@ def _build(specs: list[SlideSpec]) -> tuple[bytes, _Recorder]:
 
     async def _run() -> bytes:
         async with httpx.AsyncClient(
-            base_url="http://aspose.test", transport=transport, timeout=5.0,
+            base_url="http://aspose.test",
+            transport=transport,
+            timeout=5.0,
         ) as client:
             return await build_pptx_via_aspose(
                 specs,
@@ -198,10 +204,18 @@ def test_shapes_posted_in_z_order_low_to_high():
     spec = SlideSpec(
         index=0,
         shapes=[
-            ShapeSpec(kind="text", bbox=BBox(0, 0, 10, 10), z=5,
-                      paragraphs=[Paragraph(runs=[TextRun(text="top")])]),
-            ShapeSpec(kind="text", bbox=BBox(0, 0, 10, 10), z=1,
-                      paragraphs=[Paragraph(runs=[TextRun(text="bottom")])]),
+            ShapeSpec(
+                kind="text",
+                bbox=BBox(0, 0, 10, 10),
+                z=5,
+                paragraphs=[Paragraph(runs=[TextRun(text="top")])],
+            ),
+            ShapeSpec(
+                kind="text",
+                bbox=BBox(0, 0, 10, 10),
+                z=1,
+                paragraphs=[Paragraph(runs=[TextRun(text="bottom")])],
+            ),
         ],
     )
     _, recorder = _build([spec])
@@ -244,12 +258,17 @@ def test_teardown_runs_even_when_pptx_fetch_fails():
 
     async def _run():
         async with httpx.AsyncClient(
-            base_url="http://aspose.test", transport=transport, timeout=5.0,
+            base_url="http://aspose.test",
+            transport=transport,
+            timeout=5.0,
         ) as client:
             try:
                 await build_pptx_via_aspose(
-                    [spec], html="", base_url="http://aspose.test",
-                    image_fetcher=_StubFetcher(), http_client=client,
+                    [spec],
+                    html="",
+                    base_url="http://aspose.test",
+                    image_fetcher=_StubFetcher(),
+                    http_client=client,
                 )
             except httpx.HTTPStatusError:
                 pass

--- a/backend/exports/pptx.py
+++ b/backend/exports/pptx.py
@@ -65,7 +65,10 @@ async def build_pptx_bytes_for_page(page_id: UUID) -> tuple[str, bytes]:
     logger.info("probed %d slide(s) for page %s", len(specs), page_id)
 
     pptx_bytes = await build_pptx_via_aspose(
-        specs, source_html, base_url=base_url, token=token,
+        specs,
+        source_html,
+        base_url=base_url,
+        token=token,
     )
     return page_row["name"] or "slides", pptx_bytes
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -3403,7 +3403,11 @@ def _self_host_walkthrough(cfg: dict) -> str:
         "  [dim]1.[/dim] [cyan]git clone https://github.com/Fergana-Labs/stash.git[/cyan]"
     )
     console.print("  [dim]2.[/dim] [cyan]cd stash[/cyan]")
-    console.print("  [dim]3.[/dim] [cyan]docker compose up -d[/cyan]")
+    console.print("  [dim]3.[/dim] [cyan]cp .env.example .env[/cyan]")
+    console.print(
+        "  [dim]4.[/dim] edit [cyan].env[/cyan] and [cyan]Caddyfile[/cyan] for your domain"
+    )
+    console.print("  [dim]5.[/dim] [cyan]docker compose -f docker-compose.prod.yml up -d[/cyan]")
     console.print("\n  [dim]Already running? Skip to the URL prompt below.[/dim]\n")
 
     _reserve_bottom_padding(6)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,10 +2,9 @@
 #
 # Usage:
 #   cp .env.example .env        # fill in required values
-#   docker compose -f docker-compose.prod.yml up -d --build
+#   docker compose -f docker-compose.prod.yml up -d
 #
-# Backend and collab use pre-built images from GHCR (fast).
-# Frontend builds locally because NEXT_PUBLIC_API_URL must match your domain.
+# Backend, frontend, and collab use pre-built images from GHCR.
 #
 # Required env vars in .env:
 #   POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
@@ -17,7 +16,6 @@
 #   OPENAI_API_KEY or HF_TOKEN  (use hosted embedding provider instead of local)
 #   S3_ENDPOINT / S3_BUCKET / …  (enable file uploads)
 #   INTEGRATIONS_ENCRYPTION_KEY (Fernet key — encrypt OAuth tokens at rest)
-#   COLLAB_PUBLIC_URL           (WebSocket URL if collab is not routed under /collab)
 
 services:
   postgres:
@@ -103,21 +101,14 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-      args:
-        BACKEND_INTERNAL_URL: http://backend:3456
-        NEXT_PUBLIC_API_URL: ${PUBLIC_URL:-http://localhost:3456}
+    image: ghcr.io/fergana-labs/stash-frontend:latest
     restart: always
     expose:
       - "3457"
     depends_on:
       - backend
     environment:
-      NEXT_PUBLIC_API_URL: ${PUBLIC_URL:-http://localhost:3456}
       BACKEND_INTERNAL_URL: http://backend:3456
-      NEXT_PUBLIC_COLLAB_URL: ${COLLAB_PUBLIC_URL:-}
 
   collab:
     image: ghcr.io/fergana-labs/stash-collab:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,13 +139,10 @@ services:
         # Next.js rewrites() is evaluated at build time, so the internal
         # URL must be present then — not only at runtime.
         BACKEND_INTERNAL_URL: http://backend:3456
-        NEXT_PUBLIC_API_URL: http://localhost:3456
     restart: unless-stopped
     ports:
       - "3457:3457"
     environment:
-      # Browser-side: what the user types into their browser.
-      NEXT_PUBLIC_API_URL: http://localhost:3456
       # Server-side (SSR): in-network hostname the frontend container
       # uses to reach the backend — localhost is the frontend itself
       # inside the container.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,10 +19,6 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# NEXT_PUBLIC_* vars must be present at build time so Next.js inlines them
-# into the client bundle. Render passes service env vars as --build-arg.
-ARG NEXT_PUBLIC_API_URL
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_COLLAB_URL
 ENV NEXT_PUBLIC_COLLAB_URL=$NEXT_PUBLIC_COLLAB_URL
 ARG NEXT_PUBLIC_AUTH0_ENABLED

--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -3,9 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { listMyWorkspaces, setToken } from "@/lib/api";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+import { API_BASE, listMyWorkspaces, setToken } from "@/lib/api";
 
 type Props = {
   cliSession?: string | null;
@@ -22,7 +20,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     if (!tokenRes.ok) throw new Error("Auth0 session missing");
     const { token } = await tokenRes.json();
 
-    const res = await fetch(`${API_URL}/api/v1/auth0/exchange`, {
+    const res = await fetch(`${API_BASE}/api/v1/auth0/exchange`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -70,7 +68,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     try {
       const apiKey = await exchange();
       const approveRes = await fetch(
-        `${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
+        `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
         {
           method: "POST",
           headers: { Authorization: `Bearer ${apiKey}` },

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,7 +6,6 @@ import type { NextConfig } from "next";
 // browser uses.
 const backend =
   process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:3456";
 
 const acceptsJson = ".*application/json.*";

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -8,10 +8,7 @@ import { BasicPageSkeleton, CardGridSkeleton } from "../../components/SkeletonSt
 import ForkStashCardButton from "../../components/stash/ForkStashCardButton";
 import StashCard from "../../components/stash/StashCard";
 import { useAuth } from "../../hooks/useAuth";
-import type { PublicStashCard } from "../../lib/api";
-
-const BACKEND_ORIGIN =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
+import { API_BASE, type PublicStashCard } from "../../lib/api";
 
 const SORTS = ["trending", "newest", "popular"] as const;
 type Sort = (typeof SORTS)[number];
@@ -27,7 +24,7 @@ async function fetchPublicStashes(params: {
     if (value) qs.set(key, value);
   }
   const res = await fetch(
-    `${BACKEND_ORIGIN}/api/v1/discover/stashes${qs.size ? `?${qs}` : ""}`,
+    `${API_BASE}/api/v1/discover/stashes${qs.size ? `?${qs}` : ""}`,
   );
   if (!res.ok) return [];
   const data = await res.json();

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,9 +6,8 @@ import Header from "../../components/Header";
 import { AuthPageSkeleton, SkeletonBlock } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
-import { getToken, setToken, listMyWorkspaces } from "../../lib/api";
+import { API_BASE, getToken, setToken, listMyWorkspaces } from "../../lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
 // FastAPI returns `detail` as either a string or an array of validation errors
@@ -105,7 +104,7 @@ function LoginPageInner() {
       const body = mode === "login"
         ? { name, password }
         : { name, display_name: name, description: "", password };
-      const res = await fetch(`${API_URL}/api/v1/users/${endpoint}`, {
+      const res = await fetch(`${API_BASE}/api/v1/users/${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -127,7 +126,7 @@ function LoginPageInner() {
 
       if (cliSession) {
         const approveRes = await fetch(
-          `${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
+          `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
           {
             method: "POST",
             headers: { Authorization: `Bearer ${data.api_key}` },
@@ -255,7 +254,7 @@ function AuthorizeCliPanel({
       const token = getToken();
       if (!token) throw new Error("Not signed in");
       const res = await fetch(
-        `${API_URL}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
+        `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
         {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/app/onboarding/paths/memory/MemoryAskStep.tsx
+++ b/frontend/src/app/onboarding/paths/memory/MemoryAskStep.tsx
@@ -3,10 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { track } from "@/lib/analytics";
-import { apiFetch, getToken } from "@/lib/api";
+import { API_BASE, apiFetch, getToken } from "@/lib/api";
 import type { StepCtx } from "@/lib/onboarding/paths";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
 type Overview = {
   sessions: { session_id?: string; name?: string }[];
@@ -92,7 +90,7 @@ export default function MemoryAskStep({ workspaceId }: StepCtx) {
 
       try {
         const res = await fetch(
-          `${API_URL}/api/v1/workspaces/${workspaceId}/ask`,
+          `${API_BASE}/api/v1/workspaces/${workspaceId}/ask`,
           {
             method: "POST",
             headers: {

--- a/frontend/src/app/onboarding/paths/sharing/SharingDropStep.tsx
+++ b/frontend/src/app/onboarding/paths/sharing/SharingDropStep.tsx
@@ -5,12 +5,11 @@ import { type DragEvent, type ReactNode, useRef, useState } from "react";
 import { createPage, uploadFileOrPage, uploadTranscript } from "@/lib/api";
 import type { StepCtx } from "@/lib/onboarding/paths";
 import { buildPrompt, type ShareKind } from "@/app/onboarding/prompts";
+import { usePublicApiBase } from "@/hooks/usePublicApiBase";
 
 function Ext({ children }: { children: string }) {
   return <code className="text-foreground">{children}</code>;
 }
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
 type OptionId = "drop" | "html" | "markdown" | "session";
 
@@ -293,9 +292,11 @@ function matchesAllowed(name: string): boolean {
 
 function PromptPanel({ kind, apiKey }: { kind: ShareKind; apiKey: string }) {
   const [copied, setCopied] = useState(false);
-  const prompt = buildPrompt(kind, apiKey, API_URL);
+  const apiUrl = usePublicApiBase();
+  const prompt = apiUrl ? buildPrompt(kind, apiKey, apiUrl) : "Preparing Stash URL...";
 
   async function handleCopy() {
+    if (!apiUrl) return;
     await navigator.clipboard.writeText(prompt);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -310,6 +311,7 @@ function PromptPanel({ kind, apiKey }: { kind: ShareKind; apiKey: string }) {
         <button
           type="button"
           onClick={handleCopy}
+          disabled={!apiUrl}
           className="text-[11px] font-medium text-brand hover:text-brand-hover transition-colors"
         >
           {copied ? "Copied" : "Copy"}

--- a/frontend/src/app/onboarding/steps/FirstShareStep.tsx
+++ b/frontend/src/app/onboarding/steps/FirstShareStep.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 
+import { usePublicApiBase } from "@/hooks/usePublicApiBase";
 import { buildPrompt, ShareKind } from "../prompts";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3456";
 
 const TABS: { kind: ShareKind; label: string; hint: string }[] = [
   { kind: "html", label: "HTML page", hint: "Information-dense, optimized to read once." },
@@ -19,9 +18,11 @@ type Props = {
 export default function FirstShareStep({ apiKey }: Props) {
   const [kind, setKind] = useState<ShareKind>("html");
   const [copied, setCopied] = useState(false);
-  const prompt = buildPrompt(kind, apiKey, API_URL);
+  const apiUrl = usePublicApiBase();
+  const prompt = apiUrl ? buildPrompt(kind, apiKey, apiUrl) : "Preparing Stash URL...";
 
   async function handleCopy() {
+    if (!apiUrl) return;
     await navigator.clipboard.writeText(prompt);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -69,6 +70,7 @@ export default function FirstShareStep({ apiKey }: Props) {
           <button
             type="button"
             onClick={handleCopy}
+            disabled={!apiUrl}
             className="text-[11px] font-medium text-brand hover:text-brand-hover transition-colors"
           >
             {copied ? "Copied" : "Copy"}
@@ -83,7 +85,7 @@ export default function FirstShareStep({ apiKey }: Props) {
       <div className="rounded-xl border border-border-subtle bg-background/40 p-4 text-[12px] text-dim leading-relaxed">
         <strong className="text-foreground font-medium">What happens next:</strong>{" "}
         your agent runs the command and prints a URL like{" "}
-        <code className="text-foreground">{`${API_URL.replace(/\/$/, "")}/stashes/...`}</code>
+        <code className="text-foreground">{`${apiUrl || "https://your-stash-host"}/stashes/...`}</code>
         . Open it — your content is live and shareable.
       </div>
     </div>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { ApiError, clearToken, getMe, getToken } from "../lib/api";
+import { API_BASE, ApiError, clearToken, getMe, getToken } from "../lib/api";
 import { User } from "../lib/types";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 /**
  * Auth hook. Reads the API key from localStorage and loads /users/me.
@@ -62,7 +61,7 @@ export function useAuth() {
     clearToken();
     setUser(null);
     if (token) {
-      fetch(`${API_URL}/api/v1/users/logout`, {
+      fetch(`${API_BASE}/api/v1/users/logout`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         keepalive: true,

--- a/frontend/src/hooks/usePublicApiBase.ts
+++ b/frontend/src/hooks/usePublicApiBase.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+function configuredPublicApiBase(): string {
+  return (process.env.NEXT_PUBLIC_API_URL || "").trim().replace(/\/$/, "");
+}
+
+export function usePublicApiBase(): string {
+  const [apiBase, setApiBase] = useState(configuredPublicApiBase);
+
+  useEffect(() => {
+    if (apiBase) return;
+    setApiBase(window.location.origin);
+  }, [apiBase]);
+
+  return apiBase;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,7 +20,7 @@ import {
 } from "./types";
 
 const TOKEN_KEY = "stash_token";
-const API_BASE = "";
+export const API_BASE = "";
 
 // Local trampoline so api.ts can fire analytics without importing analytics.ts
 // (which would create a cycle — analytics.ts reads the auth token).

--- a/frontend/src/lib/backendOrigin.ts
+++ b/frontend/src/lib/backendOrigin.ts
@@ -5,9 +5,7 @@
 // not via the public URL the browser uses. Set BACKEND_INTERNAL_URL in
 // the frontend container's env to point at the in-network hostname.
 //
-// Falls back to NEXT_PUBLIC_API_URL (the public URL) for non-docker
-// dev, and finally to localhost:3456 for vanilla `npm run dev`.
+// Falls back to localhost:3456 for vanilla `npm run dev`.
 export const SSR_BACKEND_ORIGIN =
   process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:3456";

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -11,23 +11,26 @@ export default function SelfHostingPage() {
       <H3>Quick start</H3>
       <CodeBlock>{`git clone https://github.com/Fergana-Labs/stash.git
 cd stash
-docker compose up -d --build
-curl http://localhost:3456/health   # wait for {"status":"ok"}`}</CodeBlock>
+cp .env.example .env
+# Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
+docker compose -f docker-compose.prod.yml up -d
+curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>
         Then install the CLI and connect a repo:
       </P>
       <CodeBlock>{`pip install stashai   # or: uv tool install stashai
 cd /path/to/your/repo
-stash config base_url http://localhost:3456
+stash config base_url https://app.example.com
 stash login`}</CodeBlock>
       <P>
-        The UI is at <Code>http://localhost:3457</Code>.{" "}
+        The UI is at your <Code>PUBLIC_URL</Code>.{" "}
         <Code>stash login</Code> opens it to register and authorize the CLI.
       </P>
 
       <H3>Upgrading</H3>
       <CodeBlock>{`git pull
-docker compose up -d --build`}</CodeBlock>
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d`}</CodeBlock>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- publish `ghcr.io/fergana-labs/stash-frontend` from the Docker workflow
- make browser API calls same-origin so the frontend image is safe to reuse across self-host domains
- switch `docker-compose.prod.yml` and self-host docs to the pull-only GHCR path
- format the newly merged native export Python files so the PR merge ref passes backend lint

## Validation
- `docker compose --env-file .env.example -f docker-compose.prod.yml config --quiet`
- `docker compose config --quiet`
- `cd frontend && npm run lint` (passes with existing warnings in `ItemsColumns.tsx`)
- `cd frontend && npm run build`
- `docker build -t stash-frontend:ghcr-test -f frontend/Dockerfile --build-arg BACKEND_INTERNAL_URL=http://backend:3456 --build-arg NEXT_PUBLIC_AUTH0_ENABLED=false frontend`
- `ruff check backend/ cli/`
- `black --check backend/ cli/`
- `python -m py_compile cli/main.py`
- `git diff --check`
