### PR TITLE
[codex] Fix onboarding CLI install command

### DIFF
--- a/frontend/src/app/onboarding/paths/memory/MemoryImportStep.tsx
+++ b/frontend/src/app/onboarding/paths/memory/MemoryImportStep.tsx
@@ -64,7 +64,7 @@ export default function MemoryImportStep(ctx: StepCtx) {
           Install the CLI
         </div>
         <pre className="rounded-md border border-border-subtle bg-background/40 px-3 py-2 text-[12px] font-mono text-foreground overflow-x-auto">
-          npm i -g @joinstash/cli
+          pip install stashai
         </pre>
         <p className="text-[11.5px] text-muted leading-relaxed">
           On first run the CLI offers to <strong>backfill all your past

--- a/frontend/src/app/onboarding/paths/sharing/SharingHandoffStep.tsx
+++ b/frontend/src/app/onboarding/paths/sharing/SharingHandoffStep.tsx
@@ -20,7 +20,7 @@ export default function SharingHandoffStep() {
           automatically — no API key to copy around.
         </p>
         <pre className="rounded-md border border-border-subtle bg-background/40 px-3 py-2 text-[12px] font-mono text-foreground overflow-x-auto">
-          npm i -g @joinstash/cli
+          pip install stashai
         </pre>
         <p className="text-[11.5px] text-muted leading-relaxed">
           Need a raw API key for a different setup? Mint one anytime from{" "}

--- a/frontend/src/app/onboarding/steps/DoneStep.tsx
+++ b/frontend/src/app/onboarding/steps/DoneStep.tsx
@@ -45,10 +45,10 @@ export default function DoneStep({ workspaceId }: Props) {
           The CLI lets your agent push session transcripts automatically and
           gives you{" "}
           <code className="text-foreground">stash share</code>,{" "}
-          <code className="text-foreground">stash discover</code>, and more.
+          <code className="text-foreground">stash browse</code>, and more.
         </p>
         <pre className="rounded-md border border-border-subtle bg-background/40 px-3 py-2 text-[12px] font-mono text-foreground overflow-x-auto">
-          npm i -g @joinstash/cli
+          pip install stashai
         </pre>
         <a
           href="https://joinstash.ai/docs/cli"
@@ -80,4 +80,3 @@ export default function DoneStep({ workspaceId }: Props) {
     </div>
   );
 }
-

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -78,7 +78,7 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
           ? ` — share <a href="${escapeAttr(inviteLink)}">${escapeHtml(inviteLink)}</a>.`
           : ` from workspace settings.`
       }</li>
-      <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>npm i -g @joinstash/cli</code></li>
+      <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>pip install stashai</code></li>
     </ul>`,
   );
 


### PR DESCRIPTION
## What changed

- Replaced stale onboarding install instructions for `@joinstash/cli` with the published Python CLI package command: `pip install stashai`.
- Updated the done-step command reference from `stash discover` to the current `stash browse` command.

## Why

The self-hosted onboarding UI still showed `npm i -g @joinstash/cli`, but that npm package does not exist. New users following the flow hit a registry 404 instead of installing the CLI.

## Validation

- `cd frontend && npm run lint` passes with existing unrelated `ItemsColumns.tsx` warnings.
- `cd frontend && npm run build` passes.
- Searched `frontend/src` for `@joinstash/cli` and `npm i -g`; no stale matches remain.
- Captured the updated onboarding screen locally at `/tmp/stash-onboarding-cli-install.png`. I could not attach it through CLI because GitHub does not expose issue attachment upload via the public API and the local Stash upload config currently points at the self-host test stack with a stale key.