### PR TITLE
[codex] Clarify CLI splash without connected repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- CLI onboarding now says to run `stash connect` when setup finishes
+  without connecting a repo, instead of telling users to commit a
+  `.stash` file that was never created.
 - Self-hosting now uses a prebuilt `ghcr.io/fergana-labs/stash-frontend`
   image alongside the backend and collab images, so
   `docker-compose.prod.yml` no longer builds application containers on the

--- a/cli/main.py
+++ b/cli/main.py
@@ -4035,6 +4035,47 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
         console.print(f"  [yellow]{errors} failed — {last_error}[/yellow]")
 
 
+def _setup_complete_intro(ws_url: str) -> str:
+    workspace_link_section = (
+        "[bold]See your workspace[/bold]   [dim](transcripts and team activity)[/dim]\n"
+        f"  [link={ws_url}][bold #1e3a8a]{ws_url}[/bold #1e3a8a][/link]\n"
+        "\n"
+        if ws_url
+        else ""
+    )
+    memory_section = (
+        "It can read the transcripts your teammates' coding agents push to this\n"
+        "workspace — so it knows what the rest of your team is working on.\n"
+        "\n"
+        if ws_url
+        else "No repo is connected yet. Run [cyan]stash connect[/cyan] from a git repo when\n"
+        "you're ready to upload transcripts to a workspace.\n"
+        "\n"
+    )
+    team_section = (
+        "[bold]Share with your team[/bold]\n"
+        "Commit the [cyan].stash[/cyan] file and push. Teammates who clone the repo\n"
+        "will see a prompt to run [cyan]stash start[/cyan]."
+        if ws_url
+        else "[bold]Connect a repo when ready[/bold]\n"
+        "Run [cyan]stash connect[/cyan] from the repo you want Stash to remember."
+    )
+    return (
+        "[bold]What just happened[/bold]\n"
+        "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
+        f"{memory_section}"
+        f"{workspace_link_section}"
+        "[bold]Commands your agent can now use[/bold]\n"
+        '  [#1e3a8a]stash vfs "find /workspaces -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
+        '  [#1e3a8a]stash sessions search "<query>"[/#1e3a8a]   full-text search across transcripts\n'
+        "  [#1e3a8a]stash sessions query --agent <name>[/#1e3a8a]   pull a specific agent's events\n"
+        "\n"
+        "Run [bold]stash --help[/bold] to see everything.\n"
+        "\n"
+        f"{team_section}"
+    )
+
+
 def _show_setup_complete_splash() -> None:
     """Show a clean success splash after first-run login."""
     console.clear()
@@ -4046,36 +4087,11 @@ def _show_setup_complete_splash() -> None:
     console.print("  [bold green]You're all set up.[/bold green]\n")
 
     ws_url = _current_workspace_url()
-    workspace_link_section = (
-        "[bold]See your workspace[/bold]   [dim](transcripts and team activity)[/dim]\n"
-        f"  [link={ws_url}][bold #1e3a8a]{ws_url}[/bold #1e3a8a][/link]\n"
-        "\n"
-        if ws_url
-        else ""
-    )
-    intro = (
-        "[bold]What just happened[/bold]\n"
-        "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
-        "It can read the transcripts your teammates' coding agents push to this\n"
-        "workspace — so it knows what the rest of your team is working on.\n"
-        "\n"
-        f"{workspace_link_section}"
-        "[bold]Commands your agent can now use[/bold]\n"
-        '  [#1e3a8a]stash vfs "find /workspaces -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
-        '  [#1e3a8a]stash sessions search "<query>"[/#1e3a8a]   full-text search across transcripts\n'
-        "  [#1e3a8a]stash sessions query --agent <name>[/#1e3a8a]   pull a specific agent's events\n"
-        "\n"
-        "Run [bold]stash --help[/bold] to see everything.\n"
-        "\n"
-        "[bold]Share with your team[/bold]\n"
-        "Commit the [cyan].stash[/cyan] file and push. Teammates who clone the repo\n"
-        "will see a prompt to run [cyan]stash start[/cyan]."
-    )
-
+    title = "Your team's shared agent memory" if ws_url else "Stash CLI ready"
     console.print(
         Panel(
-            Text.from_markup(intro),
-            title="[bold #1e3a8a]Your team's shared agent memory[/bold #1e3a8a]",
+            Text.from_markup(_setup_complete_intro(ws_url)),
+            title=f"[bold #1e3a8a]{title}[/bold #1e3a8a]",
             border_style="#1e3a8a",
             padding=(1, 2),
         )

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -1,0 +1,19 @@
+from cli import main
+
+
+def test_setup_complete_intro_prompts_connect_when_no_workspace() -> None:
+    intro = main._setup_complete_intro("")
+
+    assert "No repo is connected yet" in intro
+    assert "stash connect" in intro
+    assert "Commit the [cyan].stash[/cyan]" not in intro
+    assert "See your workspace" not in intro
+
+
+def test_setup_complete_intro_includes_workspace_link_when_connected() -> None:
+    intro = main._setup_complete_intro("http://localhost:3457/workspaces/workspace-1")
+
+    assert "See your workspace" in intro
+    assert "http://localhost:3457/workspaces/workspace-1" in intro
+    assert "Commit the [cyan].stash[/cyan]" in intro
+    assert "No repo is connected yet" not in intro


### PR DESCRIPTION
## What changed

- Split the CLI setup-complete splash into connected and unconnected repo states.
- When there is no `.stash` workspace manifest, the splash now says no repo is connected and points users at `stash connect`.
- When a workspace is connected, the splash still shows the workspace link and the `.stash` commit instructions.
- Added focused tests for both splash variants and a changelog note.

## Why

During self-hosted onboarding, choosing `Done` at the repo prompt skips repo connection. The old final splash still told users to commit `.stash`, even though no `.stash` file or workspace link existed.

## Validation

- `pytest --no-cov cli/tests/test_setup_complete_splash.py`
- `ruff check cli/main.py cli/tests/test_setup_complete_splash.py`
- `black --check cli/main.py cli/tests/test_setup_complete_splash.py`
- `python -m py_compile cli/main.py`
- `git diff --check origin/main...HEAD`

Note: running the targeted pytest without `--no-cov` passes the tests but exits nonzero because repo-level pytest config enforces backend coverage for all pytest invocations.