### PR TITLE
[codex] Bump stashai to 0.1.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.17"
+version = "0.1.18"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What changed

- Bumped the `stashai` package version from `0.1.17` to `0.1.18`.

## Why

PR #449 landed the corrected CLI onboarding splash, but the PyPI publish workflow skipped because tag `v0.1.17` already exists. This patch version bump gives the publish workflow a new tag/version so `pip install stashai` can receive the merged CLI fix.

## Validation

- `python -m py_compile cli/main.py`
- `python -m build --sdist --wheel`
- `git diff --check`

Build completed successfully for `stashai-0.1.18` with existing setuptools license deprecation warnings only.