### PR TITLE
[codex] Add local self-host compose override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Added a committed `docker-compose.local.yml` override for laptop
+  self-hosting dry runs. It exposes backend, frontend, and collab on
+  localhost ports and disables Caddy.
 - CLI onboarding now says to run `stash connect` when setup finishes
   without connecting a repo, instead of telling users to commit a
   `.stash` file that was never created.

--- a/README.md
+++ b/README.md
@@ -134,10 +134,20 @@ See [here](https://www.joinstash.ai/docs/cli) for a CLI reference.
 
 Run Stash with prebuilt GHCR images:
 
+For a local laptop dry run:
+
 ```bash
 git clone https://github.com/Fergana-Labs/stash.git
 cd stash
 cp .env.example .env
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+curl http://localhost:3456/health
+open http://localhost:3457/login
+```
+
+For a public domain with Caddy and HTTPS:
+
+```bash
 # Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
 docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health
@@ -146,10 +156,17 @@ curl https://app.example.com/health
 Then install the CLI:
 
 ```bash
-pip install stashai / uv tool install stashai
+pip install stashai   # or: uv tool install stashai
 cd /path/to/the/repo/you/want/to/connect
-stash config base_url https://app.example.com
+stash config base_url http://localhost:3456
 stash login
+```
+
+Use your public URL instead of `http://localhost:3456` when connecting to a
+domain-backed install:
+
+```bash
+stash config base_url https://app.example.com
 ```
 
 Finally see it in action:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,24 @@
+# Local laptop override for docker-compose.prod.yml.
+#
+# Use this when testing Stash on localhost without a public domain:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+#
+# Caddy is disabled here because local dry runs do not need 80/443, HTTPS,
+# or domain routing. The app is exposed directly on the product dev ports.
+
+services:
+  backend:
+    ports:
+      - "3456:3456"
+
+  frontend:
+    ports:
+      - "3457:3457"
+
+  collab:
+    ports:
+      - "3458:3458"
+
+  caddy:
+    profiles:
+      - production-domain

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,9 @@
 #   cp .env.example .env        # fill in required values
 #   docker compose -f docker-compose.prod.yml up -d
 #
+# Local laptop dry run:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+#
 # Backend, frontend, and collab use pre-built images from GHCR.
 #
 # Required env vars in .env:

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -8,10 +8,19 @@ export default function SelfHostingPage() {
         Run Stash on your own machine with Docker Compose.
       </Subtitle>
 
-      <H3>Quick start</H3>
+      <H3>Local laptop dry run</H3>
       <CodeBlock>{`git clone https://github.com/Fergana-Labs/stash.git
 cd stash
 cp .env.example .env
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+curl http://localhost:3456/health   # wait for {"status":"ok"}`}</CodeBlock>
+      <P>
+        The local override exposes the app directly on localhost and disables
+        Caddy, so you do not need ports 80/443 or a public domain.
+      </P>
+
+      <H3>Production domain</H3>
+      <CodeBlock>{`cp .env.example .env
 # Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
 docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
@@ -20,10 +29,11 @@ curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       </P>
       <CodeBlock>{`pip install stashai   # or: uv tool install stashai
 cd /path/to/your/repo
-stash config base_url https://app.example.com
+stash config base_url http://localhost:3456
 stash login`}</CodeBlock>
       <P>
-        The UI is at your <Code>PUBLIC_URL</Code>.{" "}
+        Use your public URL instead of <Code>http://localhost:3456</Code> for a
+        Caddy-backed install.{" "}
         <Code>stash login</Code> opens it to register and authorize the CLI.
       </P>
 


### PR DESCRIPTION
## What changed

- Added `docker-compose.local.yml` for laptop self-hosting dry runs.
- The local override exposes backend `3456`, frontend `3457`, and collab `3458` directly on localhost.
- The local override puts Caddy behind an inactive profile so local runs do not bind ports `80` and `443`.
- Updated README, production compose comments, docs site self-hosting page, and changelog to separate local laptop runs from Caddy-backed domain installs.

## Why

The E2E demo flow required users to create a local override by hand. That made the first-run self-host path feel more complicated than it needs to be and caused heredoc/port-conflict issues during dry runs.

## Validation

- `docker compose --env-file .env.example -f docker-compose.prod.yml config --quiet`
- `docker compose --env-file .env.example -f docker-compose.prod.yml -f docker-compose.local.yml config --quiet`
- `docker compose --dry-run --env-file .env.example -p stash-local-config-test -f docker-compose.prod.yml -f docker-compose.local.yml up -d`
- `cd www && npm run lint` passes with existing unrelated warnings.
- `cd www && npm run build` passes.
- `git diff --check`

Screenshot note: this changes the docs page copy. I validated the rendered docs build locally, but did not attach a screenshot because the available GitHub API path here cannot upload binary PR attachments.