### PR TITLE
[codex] Document GHCR self-hosting path

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For a local laptop dry run:
 git clone https://github.com/Fergana-Labs/stash.git
 cd stash
 cp .env.example .env
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
 docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 curl http://localhost:3456/health
 open http://localhost:3457/login
@@ -149,6 +150,7 @@ For a public domain with Caddy and HTTPS:
 
 ```bash
 # Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
+docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,9 +2,11 @@
 #
 # Usage:
 #   cp .env.example .env        # fill in required values
+#   docker compose -f docker-compose.prod.yml pull
 #   docker compose -f docker-compose.prod.yml up -d
 #
 # Local laptop dry run:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
 #   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 #
 # Backend, frontend, and collab use pre-built images from GHCR.

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -5,13 +5,19 @@ export default function SelfHostingPage() {
     <>
       <Title>Self-Hosting</Title>
       <Subtitle>
-        Run Stash on your own machine with Docker Compose.
+        Run Stash on your own machine with Docker Compose and prebuilt GHCR images.
       </Subtitle>
+      <P>
+        The production Compose file pulls Stash application images from{" "}
+        <Code>ghcr.io/fergana-labs</Code>. You do not need to build the backend,
+        frontend, or collab containers locally.
+      </P>
 
       <H3>Local laptop dry run</H3>
       <CodeBlock>{`git clone https://github.com/Fergana-Labs/stash.git
 cd stash
 cp .env.example .env
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
 docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 curl http://localhost:3456/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>
@@ -22,6 +28,7 @@ curl http://localhost:3456/health   # wait for {"status":"ok"}`}</CodeBlock>
       <H3>Production domain</H3>
       <CodeBlock>{`cp .env.example .env
 # Set PUBLIC_URL and CORS_ORIGINS in .env, then replace app.example.com in Caddyfile.
+docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>


### PR DESCRIPTION
## Summary

Make the self-hosting docs explicit that the recommended Compose path uses prebuilt GHCR images.

## Changes

- Say the production Compose file pulls images from `ghcr.io/fergana-labs`.
- Add explicit `docker compose pull` steps before `up -d` in the local laptop and production-domain docs.
- Match the README and `docker-compose.prod.yml` header comments to the same flow.

## Validation

- `npm run lint` in `www` completed with existing warnings only in unrelated files.
- `npm run build` in `www`
- `git diff --check`

No screenshot attached: docs text-only copy change.