### PR TITLE
[codex] Rename local hosting docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ See [here](https://www.joinstash.ai/docs/cli) for a CLI reference.
 
 Run Stash with prebuilt GHCR images:
 
-For a local laptop dry run:
+To host locally:
 
 ```bash
 git clone https://github.com/Fergana-Labs/stash.git

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,9 +1,9 @@
-# Local laptop override for docker-compose.prod.yml.
+# Local hosting override for docker-compose.prod.yml.
 #
-# Use this when testing Stash on localhost without a public domain:
+# Use this when hosting Stash on localhost without a public domain:
 #   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 #
-# Caddy is disabled here because local dry runs do not need 80/443, HTTPS,
+# Caddy is disabled here because local hosting does not need 80/443, HTTPS,
 # or domain routing. The app is exposed directly on the product dev ports.
 
 services:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@
 #   docker compose -f docker-compose.prod.yml pull
 #   docker compose -f docker-compose.prod.yml up -d
 #
-# Local laptop dry run:
+# Host locally:
 #   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
 #   docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 #

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -13,7 +13,7 @@ export default function SelfHostingPage() {
         frontend, or collab containers locally.
       </P>
 
-      <H3>Local laptop dry run</H3>
+      <H3>Host locally</H3>
       <CodeBlock>{`git clone https://github.com/Fergana-Labs/stash.git
 cd stash
 cp .env.example .env
@@ -21,7 +21,7 @@ docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
 docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 curl http://localhost:3456/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>
-        The local override exposes the app directly on localhost and disables
+        This local setup exposes the app directly on localhost and disables
         Caddy, so you do not need ports 80/443 or a public domain.
       </P>
 


### PR DESCRIPTION
## Summary

Rename the self-hosting local path from “local laptop dry run” to “Host locally”.

## Changes

- Rename the docs heading to `Host locally`.
- Reword the localhost paragraph so it treats local hosting as a real supported option.
- Align README and Compose file comments with the same wording.

## Validation

- `npm run lint` in `www` completed with existing unrelated warnings only.
- `npm run build` in `www`
- `git diff --check`
- Captured local screenshot of `/docs/self-hosting` at `/tmp/stash-self-hosting-docs-ghcr.png`; not committed.

Screenshot note: GitHub CLI cannot upload binary image attachments directly, so the local screenshot was used for verification only.