### PR TITLE
[codex] Fix Codex history imports

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -53,10 +53,14 @@ async def upload_transcript(
     agent_name: str = Form(...),
     cwd: str | None = Form(None),
     default_stash_id: UUID | None = Form(None),
+    replace: bool = Form(False),
     current_user: dict = Depends(get_current_user),
 ):
-    """Parse the uploaded JSONL into history_events rows. No-op if the
-    session already has events."""
+    """Parse the uploaded JSONL into history_events rows.
+
+    Existing sessions are left alone unless the caller explicitly asks to
+    replace them.
+    """
     await _check_member(workspace_id, current_user["id"])
     if not _is_jsonl(file.filename):
         raise HTTPException(status_code=400, detail="Session uploads must be .JSONL files")
@@ -76,6 +80,38 @@ async def upload_transcript(
     if existing:
         if not await memory_service.can_read_session(workspace_id, session_id, current_user["id"]):
             raise HTTPException(status_code=404, detail="Transcript not found")
+        if replace:
+            await pool.execute(
+                "DELETE FROM history_events WHERE workspace_id = $1 AND session_id = $2",
+                workspace_id,
+                session_id,
+            )
+        else:
+            await session_service.upsert_session(
+                workspace_id,
+                session_id,
+                agent_name=agent_name,
+                cwd=cwd,
+                created_by=current_user["id"],
+            )
+            if default_stash_id:
+                try:
+                    await stash_service.add_sessions_to_stash(
+                        stash_id=default_stash_id,
+                        workspace_id=workspace_id,
+                        user_id=current_user["id"],
+                        session_ids=[session_id],
+                    )
+                except ValueError as e:
+                    raise HTTPException(status_code=400, detail=str(e))
+            return {
+                "session_id": session_id,
+                "imported": 0,
+                "skipped": True,
+                "reason": "session already has events",
+            }
+
+    if not existing or replace:
         await session_service.upsert_session(
             workspace_id,
             session_id,
@@ -83,22 +119,6 @@ async def upload_transcript(
             cwd=cwd,
             created_by=current_user["id"],
         )
-        if default_stash_id:
-            try:
-                await stash_service.add_sessions_to_stash(
-                    stash_id=default_stash_id,
-                    workspace_id=workspace_id,
-                    user_id=current_user["id"],
-                    session_ids=[session_id],
-                )
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=str(e))
-        return {
-            "session_id": session_id,
-            "imported": 0,
-            "skipped": True,
-            "reason": "session already has events",
-        }
 
     events = transcript_import.parse_jsonl_to_events(
         body, session_id=session_id, agent_name=agent_name

--- a/backend/services/transcript_import.py
+++ b/backend/services/transcript_import.py
@@ -59,17 +59,81 @@ def _text_from_content(content: Any) -> str:
     for block in content:
         if not isinstance(block, dict):
             continue
-        if block.get("type") == "text":
+        if block.get("type") in ("text", "input_text", "output_text"):
             txt = block.get("text", "")
             if isinstance(txt, str) and txt.strip():
                 parts.append(txt)
     return "\n\n".join(parts)
 
 
+def _content_repr(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def _tool_blocks(content: Any) -> list[dict]:
     if not isinstance(content, list):
         return []
     return [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+
+def _parse_codex_response_item(obj: dict, *, session_id: str, agent_name: str) -> list[dict]:
+    payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else {}
+    payload_type = payload.get("type")
+    created_at = _parse_ts(obj.get("timestamp")) or _parse_ts(payload.get("timestamp"))
+
+    if payload_type == "message":
+        role = payload.get("role")
+        if role not in ("user", "assistant"):
+            return []
+        text_content = _text_from_content(payload.get("content", ""))
+        if not text_content.strip():
+            return []
+        return [
+            {
+                "agent_name": agent_name,
+                "event_type": "user_message" if role == "user" else "assistant_message",
+                "content": text_content,
+                "session_id": session_id,
+                "tool_name": None,
+                "metadata": {"source": "transcript_import"},
+                "created_at": created_at,
+            }
+        ]
+
+    if payload_type == "function_call":
+        return [
+            {
+                "agent_name": agent_name,
+                "event_type": "tool_use",
+                "content": _content_repr(payload.get("arguments")),
+                "session_id": session_id,
+                "tool_name": payload.get("name") or None,
+                "metadata": {"source": "transcript_import"},
+                "created_at": created_at,
+            }
+        ]
+
+    if payload_type == "function_call_output":
+        return [
+            {
+                "agent_name": agent_name,
+                "event_type": "tool_result",
+                "content": _content_repr(payload.get("output")),
+                "session_id": session_id,
+                "tool_name": None,
+                "metadata": {"source": "transcript_import"},
+                "created_at": created_at,
+            }
+        ]
+
+    return []
 
 
 def parse_jsonl_to_events(
@@ -99,6 +163,12 @@ def parse_jsonl_to_events(
             continue
 
         entry_type = obj.get("type")
+        if entry_type == "response_item":
+            events.extend(
+                _parse_codex_response_item(obj, session_id=session_id, agent_name=agent_name)
+            )
+            continue
+
         if entry_type not in ("user", "assistant"):
             continue
 
@@ -126,17 +196,11 @@ def parse_jsonl_to_events(
         for tu in _tool_blocks(content_raw):
             tool_name = tu.get("name") or ""
             tool_input = tu.get("input")
-            try:
-                content_repr = (
-                    json.dumps(tool_input, ensure_ascii=False) if tool_input is not None else ""
-                )
-            except (TypeError, ValueError):
-                content_repr = str(tool_input)
             events.append(
                 {
                     "agent_name": agent_name,
                     "event_type": "tool_use",
-                    "content": content_repr,
+                    "content": _content_repr(tool_input),
                     "session_id": session_id,
                     "tool_name": tool_name or None,
                     "metadata": {"source": "transcript_import"},

--- a/backend/tests/test_transcript_import.py
+++ b/backend/tests/test_transcript_import.py
@@ -63,6 +63,68 @@ def test_surfaces_tool_use_blocks_as_events():
     assert "x.py" in events[1]["content"]
 
 
+def test_parses_codex_response_items():
+    body = (
+        "\n".join(
+            [
+                _line(type="session_meta", payload={"id": "codex-1"}),
+                _line(
+                    type="response_item",
+                    payload={
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": "rules"}],
+                    },
+                ),
+                _line(
+                    type="response_item",
+                    payload={
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "fix the build"}],
+                    },
+                    timestamp="2026-05-10T00:00:00Z",
+                ),
+                _line(
+                    type="response_item",
+                    payload={
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "running tests"}],
+                    },
+                    timestamp="2026-05-10T00:00:01Z",
+                ),
+                _line(
+                    type="response_item",
+                    payload={
+                        "type": "function_call",
+                        "name": "exec_command",
+                        "arguments": {"cmd": "pytest"},
+                    },
+                ),
+                _line(
+                    type="response_item",
+                    payload={"type": "function_call_output", "output": "passed"},
+                ),
+            ]
+        )
+        + "\n"
+    ).encode()
+
+    events = parse_jsonl_to_events(body, session_id="codex-1", agent_name="codex")
+
+    assert [event["event_type"] for event in events] == [
+        "user_message",
+        "assistant_message",
+        "tool_use",
+        "tool_result",
+    ]
+    assert [event["content"] for event in events[:2]] == ["fix the build", "running tests"]
+    assert events[2]["tool_name"] == "exec_command"
+    assert events[2]["content"] == '{"cmd": "pytest"}'
+    assert events[3]["content"] == "passed"
+
+
 def test_skips_unknown_types_and_invalid_json():
     body = (
         _line(type="system", message={"content": "ignored"})

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -118,6 +118,50 @@ async def test_reupload_is_noop_when_events_exist(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_replace_reimports_existing_session(client: AsyncClient):
+    key = await _register(client)
+    ws = await _workspace(client, key)
+    headers = {"Authorization": f"Bearer {key}"}
+    replacement = (
+        json.dumps(
+            {
+                "type": "user",
+                "message": {"content": "updated"},
+                "timestamp": "2026-05-10T20:00:02Z",
+            }
+        )
+        + "\n"
+    ).encode()
+
+    first = await client.post(
+        f"/api/v1/workspaces/{ws}/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
+        data={"session_id": "sess-replace", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert first.status_code == 201
+    assert first.json()["imported"] == 2
+
+    second = await client.post(
+        f"/api/v1/workspaces/{ws}/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(replacement), "application/jsonl")},
+        data={"session_id": "sess-replace", "agent_name": "claude", "replace": "true"},
+        headers=headers,
+    )
+    assert second.status_code == 201, second.text
+    assert second.json()["skipped"] is False
+    assert second.json()["imported"] == 1
+
+    events_resp = await client.get(
+        f"/api/v1/workspaces/{ws}/transcripts/sess-replace/events",
+        headers=headers,
+    )
+    assert events_resp.status_code == 200
+    events = events_resp.json()["events"]
+    assert [event["content"] for event in events] == ["updated"]
+
+
+@pytest.mark.asyncio
 async def test_upload_adds_session_to_default_stash(client: AsyncClient):
     key = await _register(client)
     ws = await _workspace(client, key)

--- a/cli/client.py
+++ b/cli/client.py
@@ -463,6 +463,7 @@ class StashClient:
         agent_name: str,
         cwd: str = "",
         default_stash_id: str | None = None,
+        replace: bool = False,
     ) -> dict:
         import gzip as _gzip
 
@@ -479,6 +480,7 @@ class StashClient:
                 "session_id": session_id,
                 "agent_name": agent_name,
                 "cwd": cwd,
+                "replace": str(replace).lower(),
                 **({"default_stash_id": default_stash_id} if default_stash_id else {}),
             },
             files={"file": (name, body, "application/gzip")},

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -506,6 +506,7 @@ def upload_conversation(
     workspace_id: str,
     conv: ConversationInfo,
     default_stash_id: str = "",
+    replace: bool = False,
 ) -> dict:
     """Upload a single conversation transcript + push a summary event."""
     import os
@@ -525,6 +526,7 @@ def upload_conversation(
             agent_name=conv.agent,
             cwd=conv.cwd,
             default_stash_id=default_stash_id,
+            replace=replace,
         )
     finally:
         if materialized:

--- a/cli/main.py
+++ b/cli/main.py
@@ -2501,6 +2501,7 @@ def hist_import(
     workspace_id: str = typer.Option(None, "--ws"),
     agent_name: str = typer.Option(None, "--agent", help="Only import from this agent."),
     limit: int = typer.Option(0, "-n", "--limit", help="Max conversations to import (0 = all)."),
+    replace: bool = typer.Option(False, "--replace", help="Replace sessions that already exist."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     as_json: bool = typer.Option(False, "--json"),
 ):
@@ -2554,7 +2555,13 @@ def hist_import(
         task = progress.add_task("Importing…", total=len(conversations))
         for conv in conversations:
             try:
-                upload_conversation(c, ws, conv, default_stash_id=_default_stash_id())
+                upload_conversation(
+                    c,
+                    ws,
+                    conv,
+                    default_stash_id=_default_stash_id(),
+                    replace=replace,
+                )
                 imported += 1
             except StashError:
                 errors += 1

--- a/sdk/src/stash_sdk/client.py
+++ b/sdk/src/stash_sdk/client.py
@@ -492,6 +492,7 @@ class Stash:
         cwd: str = "",
         workspace: str | None = None,
         default_stash_id: str | None = None,
+        replace: bool = False,
     ) -> dict:
         import gzip as _gzip
 
@@ -508,6 +509,7 @@ class Stash:
                 "session_id": session_id,
                 "agent_name": agent_name,
                 "cwd": cwd,
+                "replace": str(replace).lower(),
                 **({"default_stash_id": default_stash_id} if default_stash_id else {}),
             },
             files={"file": (name, body, "application/gzip")},


### PR DESCRIPTION
## Summary

Fixes Codex history imports that uploaded successfully but produced empty session contents.

Root cause: the transcript parser only understood Claude-style JSONL entries (`type=user|assistant` with `message.content`). Current Codex session files use `type=response_item` with message/function payloads, so historical Codex uploads parsed zero chat turns.

## Changes

- Parse Codex `response_item` messages with `input_text` and `output_text` content blocks.
- Import Codex function calls and outputs as tool events.
- Add `replace=true` support to transcript uploads and expose it through `stash sessions import --replace` so bad prior imports can be overwritten.
- Cover Codex parsing and replacement re-import behavior with tests.

## Validation

- `ruff check backend/services/transcript_import.py backend/routers/transcripts.py cli/import_history.py cli/main.py cli/client.py sdk/src/stash_sdk/client.py backend/tests/test_transcript_import.py backend/tests/test_transcripts.py`
- `pytest --no-cov backend/tests/test_transcript_import.py`
- `pytest --no-cov backend/tests/test_transcripts.py::test_reupload_is_noop_when_events_exist backend/tests/test_transcripts.py::test_replace_reimports_existing_session`
- Local Codex session parse check: latest session now parses into 110 events instead of zero.