### PR TITLE
[codex] Detect Codex history without CLI binary

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -321,6 +321,8 @@ def _agent_present(agent: str) -> bool:
 
     if shutil.which(_AGENT_BINARY[agent]):
         return True
+    if agent == "codex":
+        return (Path.home() / ".codex" / "sessions").is_dir()
     if agent == "cursor":
         return (Path.home() / ".cursor").is_dir()
     return False

--- a/cli/tests/test_agent_detection.py
+++ b/cli/tests/test_agent_detection.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from cli.main import _agent_present
+
+
+def test_codex_detects_existing_session_history_without_binary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    (tmp_path / ".codex" / "sessions").mkdir(parents=True)
+
+    assert _agent_present("codex")


### PR DESCRIPTION
## Summary
- Treat existing `~/.codex/sessions` history as enough to detect Codex during onboarding.
- Add a focused CLI regression test for Desktop/history-only installs with no `codex` executable on PATH.

## Root Cause
Onboarding calls `_onboarding_import_history(detected)`, and `detected` came from `_agent_present()`. Codex was only considered present when `shutil.which("codex")` succeeded, so a Codex Desktop-only machine with existing `.codex/sessions` history was never scanned even though the history importer can parse those rollouts.

## Validation
- `pytest cli/tests/test_agent_detection.py -q --no-cov`
- `pytest cli/tests/test_install_codex.py -q --no-cov`
- `pytest cli/tests/test_agent_detection.py cli/tests/test_install_codex.py -q --no-cov`
- `ruff check cli/main.py cli/tests/test_agent_detection.py cli/tests/test_install_codex.py`