### PR TITLE
[codex] Hide empty sessions and dedupe session end

### DIFF
--- a/backend/routers/workspace_knowledge.py
+++ b/backend/routers/workspace_knowledge.py
@@ -425,8 +425,15 @@ async def _sidebar_etag(workspace_id: UUID, user_id: UUID) -> str:
           (SELECT MAX(created_at) FROM files
             WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS f,
           (SELECT MAX(updated_at) FROM folders WHERE workspace_id = $1)          AS d,
-          (SELECT MAX(GREATEST(COALESCE(finished_at, started_at), started_at)) FROM sessions
-            WHERE workspace_id = $1 AND deleted_at IS NULL)                       AS s,
+          (SELECT MAX(GREATEST(COALESCE(finished_at, started_at), started_at))
+           FROM sessions sidebar_session
+           WHERE sidebar_session.workspace_id = $1
+             AND sidebar_session.deleted_at IS NULL
+             AND EXISTS (
+               SELECT 1 FROM history_events sidebar_event
+               WHERE sidebar_event.workspace_id = sidebar_session.workspace_id
+                 AND sidebar_event.session_id = sidebar_session.session_id
+             ))                                                                   AS s,
           (SELECT MAX(he.created_at) FROM history_events he
             WHERE he.workspace_id = $1 AND he.session_id IS NOT NULL
             AND {memory_service.readable_session_event_condition('he', 2)})        AS he,

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -118,6 +118,43 @@ async def test_reupload_is_noop_when_events_exist(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_empty_session_shell_is_hidden_from_default_views(client: AsyncClient):
+    key = await _register(client)
+    ws = await _workspace(client, key)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    created = await client.post(
+        f"/api/v1/workspaces/{ws}/sessions",
+        json={"session_id": "empty-shell", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert created.status_code == 201
+
+    overview = await client.get(f"/api/v1/workspaces/{ws}/overview", headers=headers)
+    assert overview.status_code == 200
+    assert overview.json()["sessions"] == []
+
+    sidebar = await client.get(f"/api/v1/workspaces/{ws}/sidebar", headers=headers)
+    assert sidebar.status_code == 200
+    assert sidebar.json()["sessions"] == []
+
+    my_sessions = await client.get(
+        "/api/v1/me/sessions",
+        params={"workspace_id": ws},
+        headers=headers,
+    )
+    assert my_sessions.status_code == 200
+    assert my_sessions.json()["sessions"] == []
+
+    detail = await client.get(
+        f"/api/v1/workspaces/{ws}/sessions/empty-shell",
+        headers=headers,
+    )
+    assert detail.status_code == 200
+    assert detail.json()["session_id"] == "empty-shell"
+
+
+@pytest.mark.asyncio
 async def test_replace_reimports_existing_session(client: AsyncClient):
     key = await _register(client)
     ws = await _workspace(client, key)

--- a/plugins/tests/test_stats_counter.py
+++ b/plugins/tests/test_stats_counter.py
@@ -91,6 +91,17 @@ def test_stream_session_end_reads_counter(tmp_path):
     assert "stats_truncated" not in body["metadata"]
 
 
+def test_stream_session_end_is_idempotent_for_same_session(tmp_path):
+    cfg = {"workspace_id": "ws", "agent_name": "h", "client": "claude_code"}
+    state = {"session_id": "s1"}
+    c = _FakeClient()
+
+    stream_session_end(c, cfg, state, HookEvent(kind="session_end", session_id="s1"))
+    stream_session_end(c, cfg, state, HookEvent(kind="session_end", session_id="s1"))
+
+    assert [body["event_type"] for body in c.calls] == ["session_end"]
+
+
 def test_stream_session_end_with_no_prior_tool_use(tmp_path):
     cfg = {"workspace_id": "ws", "agent_name": "h", "client": "claude_code"}
     state = {"session_id": "s1"}

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -47,6 +47,7 @@ _UPLOADS_DISABLED_WARNING_MESSAGE = (
     "Stash is connected to this repo, but uploads aren't set up on this machine. "
     "Run `stash connect` to finish setup."
 )
+_ENDED_SESSION_ID_KEY = "ended_session_id"
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
 
@@ -154,6 +155,7 @@ _SESSION_STATE_KEYS = (
     "uploaded_workspace_id",
     "transcript_path",
     "cwd",
+    _ENDED_SESSION_ID_KEY,
 )
 
 
@@ -405,6 +407,12 @@ def stream_session_end(
     if skip:
         return None
 
+    sid = event.session_id or state.get("session_id", "")
+    if not sid.strip():
+        return None
+    if state.get(_ENDED_SESSION_ID_KEY) == sid:
+        return None
+
     stats = read_stats(state)
     tool_count = stats["tool_count"]
     files_touched = stats["files_touched"]
@@ -422,7 +430,7 @@ def stream_session_end(
             agent_name=cfg["agent_name"],
             event_type="session_end",
             content=" ".join(parts),
-            session_id=state.get("session_id", ""),
+            session_id=sid,
             metadata={
                 "cwd": event.cwd,
                 "tool_count": tool_count,
@@ -433,10 +441,11 @@ def stream_session_end(
         )
     except Exception:
         pass
+    else:
+        state[_ENDED_SESSION_ID_KEY] = sid
 
     tp = getattr(event, "transcript_path", "") or ""
-    sid = state.get("session_id", "") or ""
-    if not tp or not sid.strip():
+    if not tp:
         return None
     path = Path(tp)
     if not path.is_file():


### PR DESCRIPTION
## Summary
- Make plugin `session_end` emission idempotent per session so repeated lifecycle hooks do not write duplicate end markers.
- Keep completely empty session rows out of default UI/list surfaces while preserving direct session lookup by ID.
- Keep empty session rows out of sidebar ETag invalidation and add regressions for hidden empty shells.

## Root Cause
Hosted data showed repeated `session_end` rows from `client: claude_code`. The shared plugin helper had no guard against a session-end hook firing more than once for the same session. Empty shell rows came from session records created without subsequent content events.

## Validation
- `pytest --no-cov backend/tests/test_transcripts.py plugins/tests/test_stats_counter.py`
- `ruff check stashai/plugin/hooks.py backend/services/memory_service.py backend/routers/workspace_knowledge.py plugins/tests/test_stats_counter.py backend/tests/test_transcripts.py`