### PR TITLE
[codex] Order sidebar sessions by recency

### DIFF
--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -665,6 +665,31 @@ describe("AppSidebar tree expansion", () => {
     expect(screen.getByText("Bucket session 10")).toBeTruthy();
   });
 
+  it("orders sessions newest-first within each day and user bucket", async () => {
+    vi.mocked(getWorkspaceSidebar).mockResolvedValue(
+      sidebarWithSessions([
+        sidebarSession("older", "Older session", "Henry", "2026-05-20T09:00:00Z"),
+        sidebarSession("newest", "Newest session", "Henry", "2026-05-20T15:00:00Z"),
+        sidebarSession("middle", "Middle session", "Henry", "2026-05-20T12:00:00Z"),
+      ])
+    );
+
+    renderSidebar();
+
+    expect(await screen.findByText("Newest session")).toBeTruthy();
+
+    const rows = screen
+      .getAllByRole("link")
+      .map((link) => link.textContent ?? "")
+      .filter((text) => /session/.test(text));
+
+    expect(rows).toEqual([
+      expect.stringContaining("Newest session"),
+      expect.stringContaining("Middle session"),
+      expect.stringContaining("Older session"),
+    ]);
+  });
+
   it("renders Linear ticket pills for session rows", async () => {
     vi.mocked(getWorkspaceSidebar).mockResolvedValue(
       sidebarWithSessions([

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -934,7 +934,7 @@ function chooseSessionBucket(sessions: WorkspaceSidebarSession[]): SessionBucket
 function groupSidebarSessions(sessions: WorkspaceSidebarSession[]): SessionTreeDayGroup[] {
   const bucket = chooseSessionBucket(sessions);
   const byBucket = new Map<string, Map<string, WorkspaceSidebarSession[]>>();
-  for (const session of sessions) {
+  for (const session of sortSessionsByRecency(sessions)) {
     const date = sessionDate(session.last_at || session.updated_at);
     const key = date ? bucketKey(date, bucket) : UNKNOWN_SESSION_DATE;
     const user = displaySidebarSessionUser(session.user_name);
@@ -960,7 +960,7 @@ function groupSidebarSessions(sessions: WorkspaceSidebarSession[]): SessionTreeD
         })
         .map(([user, sessionRows]) => ({
           user,
-          sessions: sortSessionsByRecency(sessionRows),
+          sessions: sessionRows,
         }));
       const total = users.reduce((sum, b) => sum + b.sessions.length, 0);
       return {


### PR DESCRIPTION
## Summary
- Sort sidebar sessions once by recency before grouping them into period and person buckets.
- Preserve that sorted order inside each person bucket so newest sessions render first.
- Add a sidebar regression test with shuffled same-day, same-person sessions.

## Screenshot
- Sidebar session ordering screenshot: https://docs.google.com/presentation/d/1rpYZcHKmMSHEdwKUzIbFSkQpUT-oROCJ0ol8hXPGd2g

## Validation
- `cd frontend && npm test -- AppSidebar.test.tsx` (34 tests passed)
- `cd frontend && npm run lint` (exit 0; existing warnings in `ItemsColumns.tsx`)
- `cd frontend && npm run build` (exit 0; Next.js workspace-root warning only)
- Playwright screenshot check with mocked sidebar data confirmed visible order: `Newest session`, `Middle session`, `Older session`.