### PR TITLE
[codex] Fix frontend backend origin fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Frontend managed Auth0 deploys now fall back to `https://api.joinstash.ai`
+  when no internal backend URL is configured, so public Stash pages do not
+  crash from localhost backend fetches while generic self-hosts keep their
+  localhost fallback.
 - Added a committed `docker-compose.local.yml` override for laptop
   self-hosting dry runs. It exposes backend, frontend, and collab on
   localhost ports and disables Caddy.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,10 +3,14 @@ import type { NextConfig } from "next";
 // Rewrites are evaluated by the Next.js node server (server-side). In
 // docker / self-host setups the frontend container reaches the backend
 // via the internal docker network hostname — not the public URL the
-// browser uses.
+// browser uses. Managed Auth0 deploys fall back to the public API origin
+// if no internal hostname is configured.
 const backend =
   process.env.BACKEND_INTERNAL_URL ||
-  "http://localhost:3456";
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true"
+    ? "https://api.joinstash.ai"
+    : "http://localhost:3456");
 
 const acceptsJson = ".*application/json.*";
 const acceptsMarkdown = ".*(text/markdown|text/plain).*";

--- a/frontend/src/lib/backendOrigin.test.ts
+++ b/frontend/src/lib/backendOrigin.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBackendOrigin } from "./backendOrigin";
+
+describe("resolveBackendOrigin", () => {
+  it("prefers the internal backend URL", () => {
+    expect(
+      resolveBackendOrigin({
+        BACKEND_INTERNAL_URL: "http://backend:3456",
+        NEXT_PUBLIC_API_URL: "https://api.example.com",
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv),
+    ).toBe("http://backend:3456");
+  });
+
+  it("uses the configured public API URL when there is no internal URL", () => {
+    expect(
+      resolveBackendOrigin({
+        NEXT_PUBLIC_API_URL: "https://api.example.com",
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv),
+    ).toBe("https://api.example.com");
+  });
+
+  it("uses the managed API for Auth0 deploys when no backend URL is configured", () => {
+    expect(
+      resolveBackendOrigin({
+        NEXT_PUBLIC_AUTH0_ENABLED: "true",
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv),
+    ).toBe("https://api.joinstash.ai");
+  });
+
+  it("uses localhost for generic production self-hosts", () => {
+    expect(resolveBackendOrigin({ NODE_ENV: "production" } as NodeJS.ProcessEnv)).toBe(
+      "http://localhost:3456",
+    );
+  });
+
+  it("uses localhost for local development", () => {
+    expect(resolveBackendOrigin({ NODE_ENV: "development" } as NodeJS.ProcessEnv)).toBe(
+      "http://localhost:3456",
+    );
+  });
+});

--- a/frontend/src/lib/backendOrigin.ts
+++ b/frontend/src/lib/backendOrigin.ts
@@ -5,7 +5,16 @@
 // not via the public URL the browser uses. Set BACKEND_INTERNAL_URL in
 // the frontend container's env to point at the in-network hostname.
 //
-// Falls back to localhost:3456 for vanilla `npm run dev`.
-export const SSR_BACKEND_ORIGIN =
-  process.env.BACKEND_INTERNAL_URL ||
-  "http://localhost:3456";
+// Managed Auth0 deploys use the public API origin when no internal backend
+// hostname is configured. Generic self-hosts still fall back to localhost.
+export function resolveBackendOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.BACKEND_INTERNAL_URL ||
+    env.NEXT_PUBLIC_API_URL ||
+    (env.NEXT_PUBLIC_AUTH0_ENABLED === "true"
+      ? "https://api.joinstash.ai"
+      : "http://localhost:3456")
+  );
+}
+
+export const SSR_BACKEND_ORIGIN = resolveBackendOrigin();


### PR DESCRIPTION
## Summary

Fixes the public Stash page crash caused by managed/Auth0 frontend deploys falling back to `localhost:3456` when no backend origin is configured.

## Changes

- Resolve frontend backend origin as `BACKEND_INTERNAL_URL`, then `NEXT_PUBLIC_API_URL`, then managed API only for `NEXT_PUBLIC_AUTH0_ENABLED=true`, then local backend.
- Apply the same fallback in `next.config.ts` rewrites and SSR fetches.
- Add focused Vitest coverage for backend origin resolution, including generic production self-host fallback.
- Add an Unreleased changelog entry.

## Related issues

Observed while loading a demo Stash link: `app.joinstash.ai` returned a Next.js server-side exception while `api.joinstash.ai` returned healthy Stash data.

## Test plan

- [x] New tests added: `npm test -- backendOrigin.test.ts`
- [x] Focused lint passes: `npm run lint -- src/lib/backendOrigin.ts src/lib/backendOrigin.test.ts next.config.ts`
- [x] Frontend build passes: `npm run build`

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Documentation updated if behaviour changed
- [x] CHANGELOG.md updated (for user-facing changes)

No screenshots attached because this is a deployment/backend-origin configuration fix with no UI change.
