### PR TITLE
[codex] Require explicit frontend backend origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
-- Frontend managed Auth0 deploys now fall back to `https://api.joinstash.ai`
-  when no internal backend URL is configured, so public Stash pages do not
-  crash from localhost backend fetches while generic self-hosts keep their
-  localhost fallback.
+- Frontend server-side backend requests now require `BACKEND_INTERNAL_URL`
+  or `NEXT_PUBLIC_API_URL` instead of guessing an environment, so missing
+  managed deploy config fails during build rather than crashing public
+  Stash pages at runtime.
 - Added a committed `docker-compose.local.yml` override for laptop
   self-hosting dry runs. It exposes backend, frontend, and collab on
   localhost ports and disables Caddy.

--- a/docs/managed-overlay.md
+++ b/docs/managed-overlay.md
@@ -33,6 +33,7 @@ AUTH0_CLIENT_SECRET=<from Auth0 dashboard>
 APP_BASE_URL=https://www.joinstash.ai
 
 NEXT_PUBLIC_AUTH0_ENABLED=true
+NEXT_PUBLIC_API_URL=https://api.joinstash.ai
 ```
 
 `start.sh` runs the managed alembic chain (`backend/managed/alembic.ini`) automatically when `AUTH0_ENABLED=true`.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,16 +1,15 @@
 import type { NextConfig } from "next";
 
-// Rewrites are evaluated by the Next.js node server (server-side). In
-// docker / self-host setups the frontend container reaches the backend
-// via the internal docker network hostname — not the public URL the
-// browser uses. Managed Auth0 deploys fall back to the public API origin
-// if no internal hostname is configured.
-const backend =
-  process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true"
-    ? "https://api.joinstash.ai"
-    : "http://localhost:3456");
+// Rewrites are evaluated by the Next.js node server (server-side). Set
+// BACKEND_INTERNAL_URL for same-network backends (Docker/self-host) or
+// NEXT_PUBLIC_API_URL for managed deployments with a separate API host.
+const backend = process.env.BACKEND_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL;
+
+if (!backend) {
+  throw new Error(
+    "Set BACKEND_INTERNAL_URL or NEXT_PUBLIC_API_URL for frontend backend rewrites.",
+  );
+}
 
 const acceptsJson = ".*application/json.*";
 const acceptsMarkdown = ".*(text/markdown|text/plain).*";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "BACKEND_INTERNAL_URL=http://localhost:3456 next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/frontend/src/lib/backendOrigin.test.ts
+++ b/frontend/src/lib/backendOrigin.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { resolveBackendOrigin } from "./backendOrigin";
+let resolveBackendOrigin: typeof import("./backendOrigin").resolveBackendOrigin;
+const originalBackendInternalUrl = process.env.BACKEND_INTERNAL_URL;
+
+beforeAll(async () => {
+  process.env.BACKEND_INTERNAL_URL = "http://localhost:3456";
+  ({ resolveBackendOrigin } = await import("./backendOrigin"));
+});
+
+afterAll(() => {
+  if (originalBackendInternalUrl === undefined) {
+    delete process.env.BACKEND_INTERNAL_URL;
+  } else {
+    process.env.BACKEND_INTERNAL_URL = originalBackendInternalUrl;
+  }
+});
 
 describe("resolveBackendOrigin", () => {
   it("prefers the internal backend URL", () => {
@@ -22,24 +36,9 @@ describe("resolveBackendOrigin", () => {
     ).toBe("https://api.example.com");
   });
 
-  it("uses the managed API for Auth0 deploys when no backend URL is configured", () => {
-    expect(
-      resolveBackendOrigin({
-        NEXT_PUBLIC_AUTH0_ENABLED: "true",
-        NODE_ENV: "production",
-      } as NodeJS.ProcessEnv),
-    ).toBe("https://api.joinstash.ai");
-  });
-
-  it("uses localhost for generic production self-hosts", () => {
-    expect(resolveBackendOrigin({ NODE_ENV: "production" } as NodeJS.ProcessEnv)).toBe(
-      "http://localhost:3456",
-    );
-  });
-
-  it("uses localhost for local development", () => {
-    expect(resolveBackendOrigin({ NODE_ENV: "development" } as NodeJS.ProcessEnv)).toBe(
-      "http://localhost:3456",
+  it("fails loud when no backend URL is configured", () => {
+    expect(() => resolveBackendOrigin({} as NodeJS.ProcessEnv)).toThrow(
+      "Set BACKEND_INTERNAL_URL or NEXT_PUBLIC_API_URL",
     );
   });
 });

--- a/frontend/src/lib/backendOrigin.ts
+++ b/frontend/src/lib/backendOrigin.ts
@@ -1,20 +1,10 @@
-// Backend origin for SSR fetches.
-//
-// In docker/self-host setups, the frontend container needs to reach the
-// backend over the internal docker network (e.g. http://backend:3456),
-// not via the public URL the browser uses. Set BACKEND_INTERNAL_URL in
-// the frontend container's env to point at the in-network hostname.
-//
-// Managed Auth0 deploys use the public API origin when no internal backend
-// hostname is configured. Generic self-hosts still fall back to localhost.
+const BACKEND_ORIGIN_ERROR =
+  "Set BACKEND_INTERNAL_URL or NEXT_PUBLIC_API_URL for frontend server-side backend requests.";
+
 export function resolveBackendOrigin(env: NodeJS.ProcessEnv = process.env): string {
-  return (
-    env.BACKEND_INTERNAL_URL ||
-    env.NEXT_PUBLIC_API_URL ||
-    (env.NEXT_PUBLIC_AUTH0_ENABLED === "true"
-      ? "https://api.joinstash.ai"
-      : "http://localhost:3456")
-  );
+  const origin = env.BACKEND_INTERNAL_URL || env.NEXT_PUBLIC_API_URL;
+  if (!origin) throw new Error(BACKEND_ORIGIN_ERROR);
+  return origin;
 }
 
 export const SSR_BACKEND_ORIGIN = resolveBackendOrigin();


### PR DESCRIPTION
## Summary

Removes the managed/self-host backend-origin fallback added in #461. The frontend now requires an explicit backend origin for server-side fetches and rewrites, so missing deployment config fails loudly instead of silently routing to the wrong environment.

## Changes

- Require `BACKEND_INTERNAL_URL` or `NEXT_PUBLIC_API_URL` in `frontend/src/lib/backendOrigin.ts`.
- Require the same explicit origin in `frontend/next.config.ts` rewrites.
- Set local `npm run dev` to pass `BACKEND_INTERNAL_URL=http://localhost:3456` explicitly.
- Document `NEXT_PUBLIC_API_URL=https://api.joinstash.ai` for managed/Auth0 deploys.
- Update tests and changelog for the fail-loud behavior.

## Related issues

Follow-up to #461. The root issue is missing managed deployment config; the app should not fallback between managed and self-hosted environments.

## Test plan

- [x] `npm test -- backendOrigin.test.ts`
- [x] `npm run lint -- src/lib/backendOrigin.ts src/lib/backendOrigin.test.ts next.config.ts`
- [x] `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- [x] `env -u BACKEND_INTERNAL_URL -u NEXT_PUBLIC_API_URL npm run build` fails during config load with the expected explicit-config error

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Documentation updated if behaviour changed
- [x] CHANGELOG.md updated (for user-facing changes)

No screenshots attached because this is a deployment/configuration contract fix with no UI change.