### PR TITLE
[codex] Import Codex worktree conversations by repo

### DIFF
--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 import json
 import platform
 import sqlite3
+import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 CURSOR_PROJECTS_DIR = Path.home() / ".cursor" / "projects"
@@ -406,6 +407,7 @@ def _parse_codex_meta(path: Path) -> ConversationInfo | None:
     session_id = ""
     cwd = ""
     timestamp = None
+    repository_url = ""
 
     with open(path) as f:
         raw = f.readline()
@@ -419,6 +421,8 @@ def _parse_codex_meta(path: Path) -> ConversationInfo | None:
             payload = line.get("payload", {})
             session_id = payload.get("id", "")
             cwd = payload.get("cwd", "")
+            git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+            repository_url = git.get("repository_url", "")
             ts_str = payload.get("timestamp") or line.get("timestamp")
             if ts_str:
                 timestamp = _parse_iso(ts_str)
@@ -436,6 +440,7 @@ def _parse_codex_meta(path: Path) -> ConversationInfo | None:
         cwd=cwd,
         timestamp=timestamp,
         size_bytes=size,
+        extras={"repository_url": repository_url} if repository_url else {},
     )
 
 
@@ -462,6 +467,70 @@ def _cwd_matches(cwd: str, prefix: str, cursor_prefix: str) -> bool:
     return cwd.startswith(cursor_prefix)
 
 
+def _normalize_git_url(url: str) -> str:
+    url = url.strip().rstrip("/")
+    if not url:
+        return ""
+
+    if "://" in url:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        path = parsed.path.strip("/")
+        normalized = f"{host}/{path}"
+    elif "@" in url and ":" in url:
+        user_host, path = url.split(":", 1)
+        normalized = f"{user_host.split('@', 1)[1]}/{path.strip('/')}"
+    else:
+        normalized = url
+
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    return normalized.lower()
+
+
+def _repo_git_urls(repo_dir: Path) -> set[str]:
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get-regexp", r"^remote\..*\.url$"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return set()
+
+    if result.returncode != 0:
+        return set()
+
+    urls = set()
+    for line in result.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        normalized = _normalize_git_url(parts[1])
+        if normalized:
+            urls.add(normalized)
+    return urls
+
+
+def _conversation_matches_repo(
+    conversation: ConversationInfo,
+    prefix: str,
+    cursor_prefix: str,
+    repo_git_urls: set[str],
+) -> bool:
+    if _cwd_matches(conversation.cwd, prefix, cursor_prefix):
+        return True
+
+    if conversation.agent != "codex":
+        return False
+
+    repository_url = conversation.extras.get("repository_url", "")
+    if not repository_url:
+        return False
+    return _normalize_git_url(repository_url) in repo_git_urls
+
+
 def discover_conversations(
     agents: list[str] | None = None,
     repo_dir: str | Path | None = None,
@@ -478,7 +547,10 @@ def discover_conversations(
         resolved = Path(repo_dir).resolve()
         prefix = str(resolved)
         cursor_prefix = _encode_cursor_dir(prefix)
-        results = [c for c in results if _cwd_matches(c.cwd, prefix, cursor_prefix)]
+        repo_git_urls = _repo_git_urls(resolved)
+        results = [
+            c for c in results if _conversation_matches_repo(c, prefix, cursor_prefix, repo_git_urls)
+        ]
 
         if "cursor" in targets:
             sqlite_ids = {c.session_id for c in results if c.agent == "cursor"}

--- a/cli/tests/test_import_history.py
+++ b/cli/tests/test_import_history.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cli import import_history
+
+
+def _write_codex_session(
+    sessions_dir: Path,
+    *,
+    session_id: str,
+    cwd: Path,
+    repository_url: str,
+) -> None:
+    path = sessions_dir / "2026" / "05" / "28" / f"{session_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "cwd": str(cwd),
+                    "timestamp": "2026-05-28T12:00:00Z",
+                    "git": {
+                        "repository_url": repository_url,
+                        "branch": "feature",
+                        "commit_hash": "abc123",
+                    },
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+def test_discovers_codex_sessions_from_other_worktrees_of_same_repo(monkeypatch, tmp_path):
+    repo = tmp_path / "stash"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Fergana-Labs/stash.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    sessions_dir = tmp_path / ".codex" / "sessions"
+    worktree = tmp_path / "worktrees" / "feature"
+    other_repo = tmp_path / "unrelated-worktree"
+    _write_codex_session(
+        sessions_dir,
+        session_id="same-repo",
+        cwd=worktree,
+        repository_url="https://github.com/Fergana-Labs/stash.git",
+    )
+    _write_codex_session(
+        sessions_dir,
+        session_id="other-repo",
+        cwd=other_repo,
+        repository_url="https://github.com/Fergana-Labs/other.git",
+    )
+    monkeypatch.setattr(import_history, "CODEX_SESSIONS_DIR", sessions_dir)
+
+    conversations = import_history.discover_conversations(["codex"], repo_dir=repo)
+
+    assert [conversation.session_id for conversation in conversations] == ["same-repo"]
+    assert conversations[0].cwd == str(worktree)
+    assert conversations[0].timestamp == datetime(2026, 5, 28, 12, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- Preserve Codex transcript `git.repository_url` metadata during history discovery.
- When `stash history import` is scoped to a repo, include Codex sessions from other worktrees when their normalized repository URL matches the current repo remote.
- Add a regression that covers SSH-vs-HTTPS repo URL matching and excludes unrelated Codex transcripts.

## Root Cause
Scoped history import only checked whether each transcript `cwd` started with the current repo path. Codex Desktop / Codex sessions from linked worktrees can have a different `cwd`, so same-repo conversations were filtered out even though the transcript metadata identifies the repository.

## Validation
- `pytest cli/tests/test_import_history.py plugins/tests/test_scope.py plugins/tests/test_session_upload.py -q --no-cov`
- `ruff check cli/import_history.py cli/tests/test_import_history.py`
- Confirmed local scoped Codex discovery now includes same-repo worktree sessions.

No product screenshots: CLI/importer behavior only.