### PR TITLE
Route first-time Auth0 sign-ins into onboarding

### DIFF
--- a/backend/managed/auth0/router.py
+++ b/backend/managed/auth0/router.py
@@ -35,7 +35,7 @@ async def exchange(
     profile = await _fetch_userinfo(credentials.credentials)
     device = request.query_params.get("device", "").strip()[:96]
     key_name = f"CLI ({device})" if device else "Auth0 login"
-    user, api_key = await get_or_create_user_from_auth0(
+    user, api_key, created = await get_or_create_user_from_auth0(
         auth0_sub=claims["sub"],
         email=profile.get("email"),
         name=profile.get("name"),
@@ -46,4 +46,5 @@ async def exchange(
         name=user["name"],
         display_name=user["display_name"],
         api_key=api_key,
+        created=created,
     )

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -33,8 +33,11 @@ async def get_or_create_user_from_auth0(
     email: str | None,
     name: str | None,
     key_name: str = "Auth0 login",
-) -> tuple[dict, str]:
-    """Return (user_row, new_api_key). Mints a fresh key per exchange; prior keys stay valid.
+) -> tuple[dict, str, bool]:
+    """Return (user_row, new_api_key, created). Mints a fresh key per exchange; prior keys stay valid.
+
+    `created` is True only when this exchange inserted the user — the frontend
+    uses it to route first-time sign-ins into onboarding.
 
     Multi-device sign-in must keep both devices working, so we don't touch
     prior keys here. Users clean up stale sessions from the settings page,
@@ -58,7 +61,7 @@ async def get_or_create_user_from_auth0(
         else:
             await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
         api_key = await create_api_key(row["id"], name=key_name)
-        return dict(row), api_key
+        return dict(row), api_key, False
 
     base = _slugify_name((email or "").split("@")[0] or name or "user")
     username = await _unique_name(base)
@@ -91,4 +94,4 @@ async def get_or_create_user_from_auth0(
         except Exception:
             logger.exception("Failed to send welcome email to %s", email)
 
-    return user, api_key
+    return user, api_key, True

--- a/backend/models.py
+++ b/backend/models.py
@@ -19,6 +19,7 @@ class UserRegisterResponse(BaseModel):
     name: str
     display_name: str
     api_key: str
+    created: bool = False
 
 
 class UserProfile(BaseModel):

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -1,0 +1,46 @@
+"""Tests for Auth0 user provisioning.
+
+The `created` flag is the contract the frontend relies on to route first-time
+Auth0 sign-ins into onboarding (instead of dropping them on their workspace
+like a returning user). If this flag stops distinguishing new from returning
+users, new Google-OAuth users silently skip onboarding.
+"""
+
+import pytest
+
+from backend.managed.auth0.users import get_or_create_user_from_auth0
+
+from .conftest import unique_name
+
+
+@pytest.fixture(autouse=True)
+async def _managed_auth0_schema(pool):
+    """Auth0 lives in the managed migration chain (backend/managed/migrations),
+    which the test DB doesn't apply. Mirror m0001 so users.auth0_sub exists."""
+    await pool.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS auth0_sub VARCHAR(128) UNIQUE")
+
+
+@pytest.mark.asyncio
+async def test_first_exchange_reports_created(pool):
+    sub = f"google-oauth2|{unique_name()}"
+    user, api_key, created = await get_or_create_user_from_auth0(
+        auth0_sub=sub, email=None, name="New Person"
+    )
+    assert created is True
+    assert api_key.startswith("mc_")
+    # First sign-in provisions a workspace, so a workspace lookup alone can't
+    # tell new from returning — only `created` can.
+    ws_count = await pool.fetchval(
+        "SELECT count(*) FROM workspace_members WHERE user_id = $1", user["id"]
+    )
+    assert ws_count == 1
+
+
+@pytest.mark.asyncio
+async def test_repeat_exchange_reports_not_created(pool):
+    sub = f"google-oauth2|{unique_name()}"
+    await get_or_create_user_from_auth0(auth0_sub=sub, email=None, name="Returning Person")
+    user, _api_key, created = await get_or_create_user_from_auth0(
+        auth0_sub=sub, email=None, name="Returning Person"
+    )
+    assert created is False

--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -15,7 +15,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  async function exchange(): Promise<string> {
+  async function exchange(): Promise<{ apiKey: string; created: boolean }> {
     const tokenRes = await fetch("/auth/access-token");
     if (!tokenRes.ok) throw new Error("Auth0 session missing");
     const { token } = await tokenRes.json();
@@ -30,7 +30,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     }
     const data = await res.json();
     setToken(data.api_key);
-    return data.api_key;
+    return { apiKey: data.api_key, created: !!data.created };
   }
 
   // Non-CLI path: exchange silently and redirect. The user is already signed
@@ -39,16 +39,23 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     if (cliSession) return;
     let cancelled = false;
     (async () => {
+      let created = false;
       try {
-        await exchange();
+        ({ created } = await exchange());
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Sign-in failed");
         return;
       }
       if (cancelled) return;
-      // Exchange succeeded — the user is signed in. If the workspace lookup
-      // hiccups (transient backend), don't flash a "sign-in failed" error;
-      // just land on /, which can reload the list itself.
+      // First-time sign-in goes through onboarding, same as the password
+      // register flow. The exchange already created their workspace.
+      if (created) {
+        router.push("/onboarding");
+        return;
+      }
+      // Returning user. If the workspace lookup hiccups (transient backend),
+      // don't flash a "sign-in failed" error; just land on /, which can
+      // reload the list itself.
       const target = await listMyWorkspaces()
         .then(({ workspaces }) =>
           workspaces.length === 1 ? `/workspaces/${workspaces[0].id}` : "/",
@@ -66,7 +73,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
     setError("");
     setSubmitting(true);
     try {
-      const apiKey = await exchange();
+      const { apiKey } = await exchange();
       const approveRes = await fetch(
         `${API_BASE}/api/v1/users/cli-auth/sessions/${cliSession}/approve`,
         {


### PR DESCRIPTION
## Problem

New users signing up through **Auth0 Google OAuth never saw the onboarding flow**. They were dropped straight onto their workspace, just like a returning user.

Root cause — two separate sign-in paths, only one of which routed new users to onboarding:

- **Password/OSS path** (`login/page.tsx`): on `register`, sets `justRegistered` → redirects to `/onboarding`.
- **Auth0/Google path** (`ExchangeAndRedirect.tsx`): the non-CLI effect *unconditionally* exchanged the token and redirected to `/workspaces/{id}` (or `/`). No branch to `/onboarding`.

The frontend couldn't even tell new from returning: `get_or_create_user_from_auth0` created the user **and** their workspace but returned only `(user, api_key)`, and `/auth0/exchange` returned a `UserRegisterResponse` with no "is new" field. Because the workspace is provisioned on first exchange, by the time `listMyWorkspaces()` runs the new user already has exactly one workspace — so they get pushed right into it, masking the missing onboarding.

## Fix

Thread a `created` flag from `get_or_create_user_from_auth0` → `/auth0/exchange` → the exchange response, then branch new users into `/onboarding` in `ExchangeAndRedirect`, mirroring the password flow's `justRegistered` branch.

- `backend/managed/auth0/users.py` — return `created` (True only when the user row was inserted).
- `backend/managed/auth0/router.py` — pass it through.
- `backend/models.py` — add `created: bool = False` to `UserRegisterResponse` (OSS register/login leave it at the default; the OSS client uses its own `justRegistered` signal, so no behavior change there).
- `frontend/managed/auth0/ExchangeAndRedirect.tsx` — `exchange()` now returns `{ apiKey, created }`; first-time sign-in pushes `/onboarding`.

## Tests

`backend/tests/test_auth0_provision.py` — asserts first exchange reports `created=True` (with a workspace already provisioned, which is exactly why a workspace count can't substitute for the flag) and a repeat exchange reports `created=False`.

- `pytest backend/tests/test_auth0_provision.py` → 2 passed
- `pytest backend/tests/test_auth.py` → 7 passed (1 pre-existing failure on a clean tree: `test_missing_auth_rejected`, unrelated — env returns 401 vs expected 403)
- `tsc --noEmit` → clean; `ruff check` → clean; `npm run lint` → clean (3 pre-existing warnings in an unrelated file)

## Note on verification

No pixels change — this PR only changes *which existing screen* a first-time Auth0 user reaches (the existing `/onboarding` chooser). Full OAuth E2E requires a live Auth0 tenant + real Google login, which can't be driven headlessly here; the routing logic is covered by the unit tests and typecheck above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)