### PR TITLE
[codex] Fix Auth0 onboarding duplicate exchange

### DIFF
--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -11,6 +11,7 @@ from backend.services.email_service import send_welcome_email
 logger = logging.getLogger(__name__)
 
 _NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+_NEW_USER_WINDOW_SQL = "2 minutes"
 
 
 def _slugify_name(raw: str) -> str:
@@ -36,8 +37,9 @@ async def get_or_create_user_from_auth0(
 ) -> tuple[dict, str, bool]:
     """Return (user_row, new_api_key, created). Mints a fresh key per exchange; prior keys stay valid.
 
-    `created` is True only when this exchange inserted the user — the frontend
-    uses it to route first-time sign-ins into onboarding.
+    `created` is True when this exchange inserted the user, or when the user
+    was inserted moments ago and the signup callback exchanged twice. The
+    frontend uses it to route first-time sign-ins into onboarding.
 
     Multi-device sign-in must keep both devices working, so we don't touch
     prior keys here. Users clean up stale sessions from the settings page,
@@ -47,7 +49,8 @@ async def get_or_create_user_from_auth0(
     pool = get_pool()
 
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, description, created_at, last_seen "
+        "SELECT id, name, display_name, description, created_at, last_seen, "
+        f"created_at >= now() - interval '{_NEW_USER_WINDOW_SQL}' AS is_new_user "
         "FROM users WHERE auth0_sub = $1",
         auth0_sub,
     )
@@ -61,7 +64,9 @@ async def get_or_create_user_from_auth0(
         else:
             await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
         api_key = await create_api_key(row["id"], name=key_name)
-        return dict(row), api_key, False
+        user = dict(row)
+        is_new_user = bool(user.pop("is_new_user"))
+        return user, api_key, is_new_user
 
     base = _slugify_name((email or "").split("@")[0] or name or "user")
     username = await _unique_name(base)

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -39,8 +39,24 @@ async def test_first_exchange_reports_created(pool):
 @pytest.mark.asyncio
 async def test_repeat_exchange_reports_not_created(pool):
     sub = f"google-oauth2|{unique_name()}"
-    await get_or_create_user_from_auth0(auth0_sub=sub, email=None, name="Returning Person")
-    user, _api_key, created = await get_or_create_user_from_auth0(
+    first_user, _api_key, _created = await get_or_create_user_from_auth0(
+        auth0_sub=sub, email=None, name="Returning Person"
+    )
+    await pool.execute(
+        "UPDATE users SET created_at = now() - interval '1 hour' WHERE id = $1",
+        first_user["id"],
+    )
+    _user, _api_key, created = await get_or_create_user_from_auth0(
         auth0_sub=sub, email=None, name="Returning Person"
     )
     assert created is False
+
+
+@pytest.mark.asyncio
+async def test_immediate_duplicate_exchange_still_reports_created(pool):
+    sub = f"google-oauth2|{unique_name()}"
+    await get_or_create_user_from_auth0(auth0_sub=sub, email=None, name="Strict Mode Person")
+    _user, _api_key, created = await get_or_create_user_from_auth0(
+        auth0_sub=sub, email=None, name="Strict Mode Person"
+    )
+    assert created is True

--- a/frontend/src/components/share/StashShareModal.tsx
+++ b/frontend/src/components/share/StashShareModal.tsx
@@ -292,7 +292,9 @@ export default function StashShareModal() {
           label_override: sess.label,
         });
       }
-      const finalTitle = title.trim() || defaultTitle;
+      const finalTitle = hasUserEditedTitle.current
+        ? title.trim() || defaultTitle
+        : defaultTitle;
       const stash =
         publicPermission !== "none"
           ? (await publishStash(workspaceId, finalTitle, items, {


### PR DESCRIPTION
## Summary

Fixes the Auth0 signup path so a just-created user still gets routed into onboarding when the Auth0 exchange is repeated immediately. Also fixes the share modal title race that CI exposed while validating this PR.

## Root Cause

The frontend routes first-time Auth0 sign-ins to `/onboarding` based on the backend `created` flag. That flag was only true for the exact exchange request that inserted the user. If the callback/exchange ran twice, such as React Strict Mode remounting the exchange component in development or a quick duplicate callback, the second request saw an existing user, returned `created: false`, and redirected straight to the workspace.

The frontend suite also surfaced a separate race in `StashShareModal`: a resolved session label could update before the title sync effect ran, so submit could use the stale route-id title even though the selected item had the friendly title.

## Changes

- Treat Auth0 users created in the last two minutes as first-time users for the exchange response.
- Keep older repeat sign-ins returning `created: false`.
- Add a regression test for an immediate duplicate exchange.
- Use the resolved default share title on submit unless the user manually edited the title.

## Validation

- `pytest backend/tests/test_auth0_provision.py -q --no-cov`
- `pytest backend/tests/test_auth0_provision.py backend/tests/test_auth.py -q --no-cov`
- `ruff check backend/managed/auth0/users.py backend/tests/test_auth0_provision.py`
- `cd frontend && npm test -- --run src/components/share/StashShareModal.test.tsx`
- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `git diff --check`

Note: `npm run lint` exits 0 with existing warnings in `frontend/src/components/workspace/file-browser/ItemsColumns.tsx`. `ruff check .` still fails on pre-existing unrelated lint in `powerpoint-mcp/src/*`.
