### PR TITLE
[codex] Detect Codex desktop installs

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -314,6 +314,51 @@ _AGENT_BINARY = {
     "opencode": "opencode",
 }
 
+_CODEX_HOME_MARKERS = (
+    "sessions",
+    "config.toml",
+    "auth.json",
+    ".codex-global-state.json",
+    "state_5.sqlite",
+)
+
+_CODEX_MACOS_DESKTOP_MARKERS = (
+    "Library/Application Support/Codex",
+    "Library/Caches/com.openai.codex",
+    "Library/Logs/com.openai.codex",
+    "Library/Preferences/com.openai.codex.plist",
+)
+
+_CODEX_LINUX_DESKTOP_MARKERS = (
+    ".config/Codex",
+    ".cache/com.openai.codex",
+)
+
+_CODEX_WINDOWS_DESKTOP_MARKERS = (
+    "AppData/Roaming/Codex",
+    "AppData/Local/Codex",
+    "AppData/Local/com.openai.codex",
+)
+
+
+def _codex_present() -> bool:
+    home = Path.home()
+    codex_home = home / ".codex"
+    if any((codex_home / marker).exists() for marker in _CODEX_HOME_MARKERS):
+        return True
+
+    if sys.platform == "darwin":
+        return any((home / marker).exists() for marker in _CODEX_MACOS_DESKTOP_MARKERS)
+    if sys.platform.startswith("linux"):
+        return any((home / marker).exists() for marker in _CODEX_LINUX_DESKTOP_MARKERS)
+    if sys.platform.startswith("win"):
+        if any((home / marker).exists() for marker in _CODEX_WINDOWS_DESKTOP_MARKERS):
+            return True
+        packages = home / "AppData" / "Local" / "Packages"
+        return packages.is_dir() and any(packages.glob("OpenAI.Codex_*"))
+
+    return False
+
 
 def _agent_present(agent: str) -> bool:
     """True if the agent is usable on this machine (binary on PATH or config dir exists)."""
@@ -322,7 +367,7 @@ def _agent_present(agent: str) -> bool:
     if shutil.which(_AGENT_BINARY[agent]):
         return True
     if agent == "codex":
-        return (Path.home() / ".codex" / "sessions").is_dir()
+        return _codex_present()
     if agent == "cursor":
         return (Path.home() / ".cursor").is_dir()
     return False

--- a/cli/tests/test_agent_detection.py
+++ b/cli/tests/test_agent_detection.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from cli import main
 from cli.main import _agent_present
 
 
@@ -8,5 +9,29 @@ def test_codex_detects_existing_session_history_without_binary(monkeypatch, tmp_
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
 
     (tmp_path / ".codex" / "sessions").mkdir(parents=True)
+
+    assert _agent_present("codex")
+
+
+def test_codex_detects_existing_config_without_binary_or_session_history(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("[features]\n")
+
+    assert _agent_present("codex")
+
+
+def test_codex_detects_macos_desktop_app_without_binary_or_session_history(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(main.sys, "platform", "darwin")
+
+    (tmp_path / "Library" / "Application Support" / "Codex").mkdir(parents=True)
 
     assert _agent_present("codex")


### PR DESCRIPTION
## What changed

- Expand Codex agent detection beyond the `codex` binary and `~/.codex/sessions`.
- Treat existing Codex home state such as `~/.codex/config.toml`, `auth.json`, `.codex-global-state.json`, or `state_5.sqlite` as Codex presence.
- Detect Codex desktop app footprints on macOS, Linux, and Windows without matching generic OpenAI/ChatGPT app state.
- Add focused tests for Codex config-only and macOS desktop-only installs.

## Why

`stash login` only offers hook installation for agents returned by `_detected_agents()`. Codex users who only use the desktop app can have no `codex` binary on `PATH` and no `~/.codex/sessions` directory yet, so Stash skipped Codex even though Codex was installed and in use.

## Validation

- `ruff check cli/main.py cli/tests/test_agent_detection.py`
- `pytest --no-cov cli/tests/test_agent_detection.py`
- `pytest --no-cov cli/tests/test_install_codex.py cli/tests/test_install_hooks.py`

Broader sweep: `pytest --no-cov cli/tests` ran 50 passing tests and failed 2 existing upload helper tests in `cli/tests/test_share_and_upload_helpers.py` because direct calls to `main.upload(...)` omit the `stash` parameter, leaving Typer's `OptionInfo` default in place.