### PR TITLE
[codex] Automate stash release version bumps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash — stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "category": "productivity",
       "homepage": "https://joinstash.ai",
       "author": {

--- a/.github/workflows/bump-plugin-version.yml
+++ b/.github/workflows/bump-plugin-version.yml
@@ -1,12 +1,15 @@
-name: Bump Claude plugin version
+name: Bump release versions
 
 on:
   push:
     branches: [main]
     paths:
-      - 'plugins/**'
-      - 'src/stash_cli/**'
-      - 'pyproject.toml'
+      - 'cli/**'
+      - 'stashai/**'
+      - 'plugins/claude-plugin/**'
+      - 'plugins/codex-plugin/**'
+      - 'plugins/cursor-plugin/**'
+      - 'plugins/opencode-plugin/**'
 
 jobs:
   bump:
@@ -18,33 +21,68 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump patch version in plugin.json
+      - name: Check triggering commit
+        id: trigger
         run: |
-          FILE="plugins/claude-plugin/.claude-plugin/plugin.json"
-          CUR=$(python3 -c "import json; print(json.load(open('$FILE'))['version'])")
-          MAJOR=$(echo "$CUR" | cut -d. -f1)
-          MINOR=$(echo "$CUR" | cut -d. -f2)
-          PATCH=$(echo "$CUR" | cut -d. -f3)
-          NEW="$MAJOR.$MINOR.$((PATCH + 1))"
-          python3 -c "
-          import json, pathlib
-          p = pathlib.Path('$FILE')
-          d = json.loads(p.read_text())
-          d['version'] = '$NEW'
-          p.write_text(json.dumps(d, indent=2) + '\n')
-          "
-          echo "Bumped plugin version $CUR → $NEW"
+          if git log -1 --pretty=%s | grep -q "^chore: bump stash release"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump package and Claude plugin versions
+        id: bump
+        if: steps.trigger.outputs.skip != 'true'
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+
+          def bump_patch(version: str) -> str:
+              major, minor, patch = version.split(".")
+              return f"{major}.{minor}.{int(patch) + 1}"
+
+          pyproject = pathlib.Path("pyproject.toml")
+          pyproject_text = pyproject.read_text()
+          pyproject_match = re.search(r'(?m)^version = "([^"]+)"$', pyproject_text)
+          if pyproject_match is None:
+              raise SystemExit("pyproject.toml has no project version")
+          package_old = pyproject_match.group(1)
+          package_new = bump_patch(package_old)
+          pyproject.write_text(
+              pyproject_text[: pyproject_match.start(1)]
+              + package_new
+              + pyproject_text[pyproject_match.end(1) :]
+          )
+
+          plugin_path = pathlib.Path("plugins/claude-plugin/.claude-plugin/plugin.json")
+          plugin = json.loads(plugin_path.read_text())
+          plugin_old = plugin["version"]
+          plugin_new = bump_patch(plugin_old)
+          plugin["version"] = plugin_new
+          plugin_path.write_text(json.dumps(plugin, indent=2) + "\n")
+
+          marketplace_path = pathlib.Path(".claude-plugin/marketplace.json")
+          marketplace = json.loads(marketplace_path.read_text())
+          marketplace["plugins"][0]["version"] = plugin_new
+          marketplace_path.write_text(json.dumps(marketplace, indent=2) + "\n")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              print(f"package_version={package_new}", file=output)
+              print(f"plugin_version={plugin_new}", file=output)
+
+          print(f"Bumped stashai {package_old} -> {package_new}")
+          print(f"Bumped Claude plugin {plugin_old} -> {plugin_new}")
+          PY
 
       - name: Commit and push
+        if: steps.trigger.outputs.skip != 'true'
         run: |
-          # Skip if the triggering commit was already a plugin bump (avoid infinite loop)
-          if git log -1 --pretty=%s | grep -q "^chore: bump claude plugin"; then
-            echo "Last commit was a plugin bump — skipping"
-            exit 0
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add plugins/claude-plugin/.claude-plugin/plugin.json
+          git add pyproject.toml plugins/claude-plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
           git diff --cached --quiet && echo "No change" && exit 0
-          git commit -m "chore: bump claude plugin to $(python3 -c "import json; print(json.load(open('plugins/claude-plugin/.claude-plugin/plugin.json'))['version'])")"
+          git commit -m "chore: bump stash release to ${{ steps.bump.outputs.package_version }} and plugin to ${{ steps.bump.outputs.plugin_version }}"
           git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,24 @@ jobs:
       - run: ruff check backend/ cli/
       - run: black --check backend/ cli/
 
+  plugin-test:
+    name: Plugin tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install plugin test dependencies
+        run: pip install -r backend/requirements-dev.txt -e .
+
+      - name: Run plugin tests
+        run: python -m pytest plugins/tests --no-cov
+
   backend-test:
     name: Backend tests (pytest)
     runs-on: ubuntu-latest

--- a/plugins/tests/test_version_metadata.py
+++ b/plugins/tests/test_version_metadata.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_claude_marketplace_version_matches_plugin_manifest():
+    plugin_manifest = json.loads(
+        (REPO_ROOT / "plugins/claude-plugin/.claude-plugin/plugin.json").read_text()
+    )
+    marketplace = json.loads((REPO_ROOT / ".claude-plugin/marketplace.json").read_text())
+
+    assert marketplace["plugins"][0]["version"] == plugin_manifest["version"]


### PR DESCRIPTION
## Summary
- Converts the existing Claude-only bump workflow into a release bump workflow for Stash CLI/package and Claude plugin changes.
- After relevant changes land on `main`, the workflow now bumps `pyproject.toml`, `plugins/claude-plugin/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` together in one bot commit.
- Adds `plugins/tests` to CI and a metadata test that fails if the Claude marketplace version drifts from the plugin manifest.
- Syncs the current marketplace metadata to the already-bumped Claude plugin version on `main`.

## Why
#468 fixed the immediate stale VFS guidance, but the same class of issue can come back if shipped plugin assets drift or a release-affecting PR forgets to bump package/plugin versions. The asset-sync test already existed, but CI was not running `plugins/tests`; this PR makes that guard active and automates the release bump after merge.

## Validation
- `python -m pytest plugins/tests --no-cov`
- `python -m pytest plugins/tests/test_version_metadata.py plugins/tests/test_assets_in_sync.py --no-cov`
- Simulated the workflow bump script against temp copies: `stashai 0.1.19 -> 0.1.20`, Claude plugin `0.1.88 -> 0.1.89` before #468 merged; after main advanced, the rebased PR preserves current `pyproject.toml` and plugin versions and only syncs marketplace metadata.

## Notes
Full `cli/tests` is not added to CI here because it currently has unrelated `main.upload()` direct-call failures in `cli/tests/test_share_and_upload_helpers.py`. The new CI gate is scoped to the plugin/package drift tests that prevent this issue.