### PR TITLE
[codex] Remove markdown heading underline

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -325,10 +325,6 @@ details > summary::-webkit-details-marker {
   font-family: var(--font-display), sans-serif;
   letter-spacing: -0.015em;
 }
-.prose :where(h2):not(:where([class~="not-prose"] *)) {
-  padding-bottom: 0.2rem;
-  border-bottom: 1px solid var(--border-subtle-color, rgba(0, 0, 0, 0.06));
-}
 
 /* Inline code: orange chip with a thin tinted border to match the
    rest of the brand-accent treatment. */


### PR DESCRIPTION
## Summary

Removes the app-added `.prose h2` bottom border/padding override so markdown/editor headings no longer render with a thin horizontal rule underneath.

## Root Cause

The editor renders its TipTap document with the Tailwind Typography `prose` class. `frontend/src/app/globals.css` added an override for `.prose h2` that set `padding-bottom` and `border-bottom`, which made headings look underlined in the editor.

## Validation

- `cd frontend && npm run lint` passed with existing warnings in `frontend/src/components/workspace/file-browser/ItemsColumns.tsx`.
- Verified in the compiled app CSS with Playwright: injected `.prose` h1/h2/h3 sample reported `border-bottom-width: 0px` and `padding-bottom: 0px` for all three heading levels.

## Screenshot

Captured `/tmp/stash-heading-border-check.png` after the Playwright verification. I attempted to upload it via `stash files upload /tmp/stash-heading-border-check.png --json`, but Stash returned `403: Viewers can read but not modify files`, so I could not attach the screenshot from this environment.