### PR TITLE
[codex] Record agent model metadata

### DIFF
--- a/plugins/codex-plugin/scripts/adapt.py
+++ b/plugins/codex-plugin/scripts/adapt.py
@@ -27,10 +27,15 @@ from stashai.plugin.event import HookEvent
 _TOOL_MAP = {
     "Bash": "bash",
 }
+_EXTRA_KEYS = ("model", "permission_mode")
 
 
 def _normalize(name: str) -> str:
     return _TOOL_MAP.get(name, name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
 
 
 def adapt_session_start(data: dict) -> HookEvent:
@@ -39,6 +44,7 @@ def adapt_session_start(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=data.get("cwd", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -48,6 +54,7 @@ def adapt_prompt(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=data.get("cwd", ""),
         prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
     )
 
 
@@ -62,6 +69,7 @@ def adapt_tool_use(data: dict) -> HookEvent:
         tool_name=_normalize(data.get("tool_name", "")),
         tool_input=tool_input,
         tool_response=data.get("tool_response"),
+        extras=_extras(data),
     )
 
 
@@ -72,4 +80,5 @@ def adapt_stop(data: dict) -> HookEvent:
         cwd=data.get("cwd", ""),
         last_assistant_message=data.get("last_assistant_message", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )

--- a/plugins/cursor-plugin/scripts/adapt.py
+++ b/plugins/cursor-plugin/scripts/adapt.py
@@ -38,12 +38,17 @@ _TOOL_MAP = {
     "Delete": "delete",
     "Task": "agent",
 }
+_EXTRA_KEYS = ("model", "cursor_version", "generation_id")
 
 
 def _normalize(name: str) -> str:
     if name.startswith("MCP:"):
         return name
     return _TOOL_MAP.get(name, name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
 
 
 def _cwd(data: dict) -> str:
@@ -61,6 +66,7 @@ def adapt_session_start(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -70,6 +76,7 @@ def adapt_prompt(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
     )
 
 
@@ -100,6 +107,7 @@ def adapt_tool_use(data: dict) -> HookEvent:
         tool_name=_normalize(data.get("tool_name", "")),
         tool_input=tool_input,
         tool_response=_parse_tool_output(data.get("tool_output")),
+        extras=_extras(data),
     )
 
 
@@ -111,6 +119,7 @@ def adapt_agent_response(data: dict) -> HookEvent:
         cwd=_cwd(data),
         last_assistant_message=data.get("text", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -120,4 +129,5 @@ def adapt_session_end(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )

--- a/plugins/tests/test_adapters.py
+++ b/plugins/tests/test_adapters.py
@@ -137,6 +137,36 @@ def test_cursor_tool_output_json_string_parses():
     assert event2.tool_response == {"raw": "not-json-text"}
 
 
+def test_model_extras_flow_from_agent_adapters():
+    codex = _load_adapt("codex")
+    for fixture_name in ("session_start", "prompt", "tool_use", "stop"):
+        event = getattr(
+            codex,
+            {
+                "session_start": "adapt_session_start",
+                "prompt": "adapt_prompt",
+                "tool_use": "adapt_tool_use",
+                "stop": "adapt_stop",
+            }[fixture_name],
+        )(_load_fixture("codex", fixture_name))
+        assert event.extras["model"] == "gpt-5-codex"
+        assert event.extras["permission_mode"] == "default"
+
+    cursor = _load_adapt("cursor")
+    cursor_cases = [
+        ("session_start", "adapt_session_start"),
+        ("prompt", "adapt_prompt"),
+        ("tool_use", "adapt_tool_use"),
+        ("agent_response", "adapt_agent_response"),
+        ("stop", "adapt_session_end"),
+    ]
+    for fixture_name, adapter_name in cursor_cases:
+        event = getattr(cursor, adapter_name)(_load_fixture("cursor", fixture_name))
+        assert event.extras["model"] == "claude-3.7-sonnet"
+        assert event.extras["cursor_version"] == "1.7.0"
+        assert event.extras["generation_id"].startswith("gen-")
+
+
 def test_push_event_stamps_client_into_metadata():
     """StashClient.push_event should merge the `client` facet into metadata."""
     from stashai.plugin.stash_client import StashClient
@@ -257,6 +287,79 @@ def test_client_facet_flows_through_stream_paths():
             assert body.get("metadata", {}).get("client") == client_name, (
                 f"{client_name}: missing client facet in {body}"
             )
+
+
+def test_model_metadata_flows_through_stream_paths():
+    from stashai.plugin.event import HookEvent
+    from stashai.plugin.hooks import (
+        _event_metadata,
+        stream_assistant_message,
+        stream_session_end,
+        stream_tool_use,
+        stream_user_message,
+    )
+    from stashai.plugin.stash_client import StashClient
+
+    calls = []
+
+    class FakeClient(StashClient):
+        def _post(self, path, **kwargs):
+            calls.append(kwargs.get("json", {}))
+            return {}
+
+    cfg = {"workspace_id": "ws1", "agent_name": "henry", "client": "codex_cli"}
+    state = {"session_id": "s1"}
+    c = FakeClient(base_url="http://x", api_key="k")
+    extras = {"model": "gpt-4o", "permission_mode": "default"}
+    cwd = str(Path.cwd())
+    assert _event_metadata(HookEvent(kind="prompt", extras=extras)) == extras
+
+    stream_user_message(
+        c,
+        cfg,
+        state,
+        "hello",
+        HookEvent(kind="prompt", prompt_text="hello", cwd=cwd, extras=extras),
+    )
+    stream_tool_use(
+        c,
+        cfg,
+        state,
+        HookEvent(
+            kind="tool_use",
+            tool_name="bash",
+            cwd=cwd,
+            tool_input={"command": "echo hi"},
+            tool_response={"stdout": "hi"},
+            extras=extras,
+        ),
+    )
+    stream_assistant_message(
+        c,
+        cfg,
+        state,
+        HookEvent(
+            kind="stop",
+            cwd=cwd,
+            last_assistant_message="done.",
+            extras=extras,
+        ),
+    )
+    stream_session_end(
+        c,
+        cfg,
+        state,
+        HookEvent(
+            kind="session_end",
+            cwd=cwd,
+            extras=extras,
+        ),
+    )
+
+    for body in calls:
+        assert body["metadata"].get("model") == "gpt-4o", body
+        assert body["metadata"]["permission_mode"] == "default"
+        assert body["metadata"]["client"] == "codex_cli"
 
 
 def test_stream_session_end_not_emitted_on_assistant_message():

--- a/stashai/plugin/assets/codex/scripts/adapt.py
+++ b/stashai/plugin/assets/codex/scripts/adapt.py
@@ -27,10 +27,15 @@ from stashai.plugin.event import HookEvent
 _TOOL_MAP = {
     "Bash": "bash",
 }
+_EXTRA_KEYS = ("model", "permission_mode")
 
 
 def _normalize(name: str) -> str:
     return _TOOL_MAP.get(name, name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
 
 
 def adapt_session_start(data: dict) -> HookEvent:
@@ -39,6 +44,7 @@ def adapt_session_start(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=data.get("cwd", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -48,6 +54,7 @@ def adapt_prompt(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=data.get("cwd", ""),
         prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
     )
 
 
@@ -62,6 +69,7 @@ def adapt_tool_use(data: dict) -> HookEvent:
         tool_name=_normalize(data.get("tool_name", "")),
         tool_input=tool_input,
         tool_response=data.get("tool_response"),
+        extras=_extras(data),
     )
 
 
@@ -72,4 +80,5 @@ def adapt_stop(data: dict) -> HookEvent:
         cwd=data.get("cwd", ""),
         last_assistant_message=data.get("last_assistant_message", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )

--- a/stashai/plugin/assets/cursor/scripts/adapt.py
+++ b/stashai/plugin/assets/cursor/scripts/adapt.py
@@ -38,12 +38,17 @@ _TOOL_MAP = {
     "Delete": "delete",
     "Task": "agent",
 }
+_EXTRA_KEYS = ("model", "cursor_version", "generation_id")
 
 
 def _normalize(name: str) -> str:
     if name.startswith("MCP:"):
         return name
     return _TOOL_MAP.get(name, name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
 
 
 def _cwd(data: dict) -> str:
@@ -61,6 +66,7 @@ def adapt_session_start(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -70,6 +76,7 @@ def adapt_prompt(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
     )
 
 
@@ -100,6 +107,7 @@ def adapt_tool_use(data: dict) -> HookEvent:
         tool_name=_normalize(data.get("tool_name", "")),
         tool_input=tool_input,
         tool_response=_parse_tool_output(data.get("tool_output")),
+        extras=_extras(data),
     )
 
 
@@ -111,6 +119,7 @@ def adapt_agent_response(data: dict) -> HookEvent:
         cwd=_cwd(data),
         last_assistant_message=data.get("text", ""),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )
 
 
@@ -120,4 +129,5 @@ def adapt_session_end(data: dict) -> HookEvent:
         session_id=data.get("session_id", ""),
         cwd=_cwd(data),
         transcript_path=data.get("transcript_path", ""),
+        extras=_extras(data),
     )

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -50,6 +50,7 @@ _UPLOADS_DISABLED_WARNING_MESSAGE = (
 _ENDED_SESSION_ID_KEY = "ended_session_id"
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
+_METADATA_EXTRA_KEYS = ("model", "permission_mode", "cursor_version", "generation_id")
 
 
 def _read_user_config() -> dict:
@@ -111,6 +112,18 @@ def _short_circuit(cfg: dict, event: HookEvent | None) -> tuple[bool, str | None
         return True, None
 
     return False, workspace_id
+
+
+def _event_metadata(event: HookEvent | None, base: dict | None = None) -> dict:
+    metadata = dict(base or {})
+    if event is None:
+        return metadata
+
+    for key in _METADATA_EXTRA_KEYS:
+        value = event.extras.get(key)
+        if isinstance(value, str) and value:
+            metadata[key] = value
+    return metadata
 
 
 def uploads_enabled(cfg: dict, event: HookEvent | None) -> bool:
@@ -294,6 +307,7 @@ def stream_user_message(
             event_type="user_message",
             content=prompt_text,
             session_id=state.get("session_id", ""),
+            metadata=_event_metadata(event),
             client=cfg.get("client") or None,
         )
     except Exception:
@@ -315,6 +329,7 @@ def stream_tool_use(
     content, metadata = summarize_tool_use(
         event.tool_name, event.tool_input, event.tool_response,
     )
+    metadata = _event_metadata(event, metadata)
     metadata["cwd"] = event.cwd
 
     if data_dir is not None:
@@ -355,6 +370,7 @@ def stream_assistant_message(
             event_type="assistant_message",
             content=event.last_assistant_message,
             session_id=state.get("session_id", ""),
+            metadata=_event_metadata(event),
             client=cfg.get("client") or None,
         )
     except Exception:
@@ -431,12 +447,15 @@ def stream_session_end(
             event_type="session_end",
             content=" ".join(parts),
             session_id=sid,
-            metadata={
-                "cwd": event.cwd,
-                "tool_count": tool_count,
-                "files_touched": files_touched,
-                "tools_used": tools_used,
-            },
+            metadata=_event_metadata(
+                event,
+                {
+                    "cwd": event.cwd,
+                    "tool_count": tool_count,
+                    "files_touched": files_touched,
+                    "tools_used": tools_used,
+                },
+            ),
             client=cfg.get("client") or None,
         )
     except Exception:


### PR DESCRIPTION
## Summary

- Preserve model metadata from Codex and Cursor hook payloads in `HookEvent.extras`.
- Copy allowlisted extras (`model`, plus client-specific non-sensitive fields) into streamed event metadata for user, tool, assistant, and session-end events.
- Keep packaged plugin asset copies in sync with source plugin adapters.

## Why

We could not answer which recorded sessions used `gpt-4o` because the adapters documented model fields but dropped them before upload. New events from Codex and Cursor will now include searchable `metadata.model`.

## Validation

- `python -m pytest --no-cov plugins/tests`
- `python -m ruff check stashai/plugin/hooks.py plugins/codex-plugin/scripts/adapt.py stashai/plugin/assets/codex/scripts/adapt.py plugins/cursor-plugin/scripts/adapt.py stashai/plugin/assets/cursor/scripts/adapt.py plugins/tests/test_adapters.py`
- `git diff --check`