### PR TITLE
[codex] Fix comment composer text selection

### DIFF
--- a/frontend/src/components/workspace/CommentComposerPopover.test.tsx
+++ b/frontend/src/components/workspace/CommentComposerPopover.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CommentComposerPopover from "./CommentComposerPopover";
+
+function renderComposer() {
+  return render(
+    <CommentComposerPopover
+      top={10}
+      left={20}
+      onCancel={vi.fn()}
+      onSubmit={vi.fn()}
+    />
+  );
+}
+
+describe("CommentComposerPopover", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("allows native text selection inside the comment textarea", () => {
+    renderComposer();
+
+    const textarea = screen.getByPlaceholderText(/Add a comment/i);
+
+    expect(fireEvent.mouseDown(textarea)).toBe(true);
+  });
+
+  it("keeps anchor selection alive when pressing the popover chrome", () => {
+    renderComposer();
+
+    const textarea = screen.getByPlaceholderText(/Add a comment/i);
+    const popover = textarea.parentElement;
+
+    expect(popover).not.toBeNull();
+    expect(fireEvent.mouseDown(popover as HTMLElement)).toBe(false);
+  });
+});

--- a/frontend/src/components/workspace/CommentComposerPopover.tsx
+++ b/frontend/src/components/workspace/CommentComposerPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { type MouseEvent, useEffect, useRef, useState } from "react";
 
 interface Props {
   top: number;
@@ -37,9 +37,14 @@ export default function CommentComposerPopover({
     }
   }
 
+  function keepAnchorSelectionAlive(e: MouseEvent<HTMLDivElement>) {
+    if (isTextControl(e.target)) return;
+    e.preventDefault();
+  }
+
   return (
     <div
-      onMouseDown={(e) => e.preventDefault()}
+      onMouseDown={keepAnchorSelectionAlive}
       className="absolute z-30 w-[260px] rounded-md border border-border-subtle bg-raised p-2 shadow-md"
       style={{ top, left }}
     >
@@ -82,4 +87,8 @@ export default function CommentComposerPopover({
       </div>
     </div>
   );
+}
+
+function isTextControl(target: EventTarget | null) {
+  return target instanceof HTMLElement && !!target.closest("textarea, input");
 }


### PR DESCRIPTION
## What changed

- Let native mouse behavior run inside the comment composer textarea/input fields so users can drag-select text while writing a comment.
- Kept the existing default-prevention on the popover chrome so the underlying document/comment anchor selection stays alive.
- Added a focused regression test for both behaviors.

## Root cause

The comment composer popover prevented the default action for every `mousedown` inside the popover. That preserved the page selection for anchoring comments, but it also blocked normal textarea drag-selection.

## Validation

- `npm test -- CommentComposerPopover.test.tsx`
- `npm test`
- `npm run lint -- src/components/workspace/CommentComposerPopover.tsx src/components/workspace/CommentComposerPopover.test.tsx`

## Product screenshot

- [Comment textarea with selected words](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/d857aeaa-532f-400c-9287-f8b8131e8e71)
