### PR TITLE
[codex] Fix cmd-click file navigation

### DIFF
--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -28,6 +28,7 @@ import {
   uploadFile,
   workspaceFileDownloadUrl,
 } from "../../lib/api";
+import { openInNewTab, shouldOpenInNewTab } from "../../lib/linkNavigation";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 const ANCHOR_CONTEXT_CHARS = 32;
@@ -292,13 +293,17 @@ export default function MarkdownEditor({
 
           if (isStashAbsolute || isRouteRelative) {
             event.preventDefault();
-            onNavigateInternal?.(href);
+            if (shouldOpenInNewTab(event)) {
+              openInNewTab(href);
+            } else {
+              onNavigateInternal?.(href);
+            }
             return true;
           }
 
           if (hasScheme) {
             event.preventDefault();
-            window.open(href, "_blank", "noopener,noreferrer");
+            openInNewTab(href);
             return true;
           }
 

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type DragEvent } from "react";
+import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
 import { type FBDragPayload } from "./WorkspaceFileBrowser";
 import { SelectBox, handleFolderDrop, isFbDrag, startItemDrag } from "./ItemsList";
@@ -23,8 +24,8 @@ export interface GridItem {
 interface Props {
   items: GridItem[];
   selectedId: string | null;
-  onSelect: (item: GridItem) => void;
-  onNavigate: (item: GridItem) => void;
+  onSelect: (item: GridItem, options?: NavigateOptions) => void;
+  onNavigate: (item: GridItem, options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
@@ -64,8 +65,8 @@ export default function FolderItemGrid({
             item={item}
             selected={item.id === selectedId}
             multiSelected={!!selectedIds?.has(item.id)}
-            onSelect={() => onSelect(item)}
-            onNavigate={() => onNavigate(item)}
+            onSelect={(options) => onSelect(item, options)}
+            onNavigate={(options) => onNavigate(item, options)}
             onReparent={onReparent}
             onReparentMany={onReparentMany}
             onDelete={onDelete}
@@ -93,8 +94,8 @@ function Tile({
   item: GridItem;
   selected: boolean;
   multiSelected: boolean;
-  onSelect: () => void;
-  onNavigate: () => void;
+  onSelect: (options?: NavigateOptions) => void;
+  onNavigate: (options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
@@ -106,8 +107,11 @@ function Tile({
 
   return (
     <div
-      onClick={onSelect}
-      onDoubleClick={onNavigate}
+      onClick={(e) => onSelect({ newTab: shouldOpenInNewTab(e) })}
+      onAuxClick={(e) => {
+        if (shouldOpenInNewTab(e)) onSelect({ newTab: true });
+      }}
+      onDoubleClick={() => onNavigate()}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { getFolderContents, type FolderContents } from "../../../lib/api";
-import type { FolderTreeNode, WorkspaceTree } from "../../../lib/types";
+import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
 import type { GridItem, ItemKind } from "./FolderItemGrid";
 import { FB_DRAG_MIME, type FBDragPayload } from "./WorkspaceFileBrowser";
 
 interface Props {
   workspaceId: string;
-  tree: WorkspaceTree | null;
   rootItems: GridItem[];
-  onNavigate: (item: GridItem) => void;
+  onNavigate: (item: GridItem, options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
 }
@@ -23,7 +22,6 @@ interface Props {
 // a non-folder selects it for the preview.
 export default function ItemsColumns({
   workspaceId,
-  tree,
   rootItems,
   onNavigate,
   onReparent,
@@ -85,9 +83,9 @@ export default function ItemsColumns({
     setSelected({ columnIdx, item });
   }
 
-  function handleOpen(item: GridItem) {
-    if (item.kind === "folder") return; // drilling handled above
-    onNavigate(item);
+  function handleOpen(item: GridItem, options?: NavigateOptions) {
+    if (item.kind === "folder" && !options?.newTab) return; // drilling handled above
+    onNavigate(item, options);
   }
 
   // Build column data: root + one per element of path.
@@ -132,7 +130,6 @@ export default function ItemsColumns({
       </div>
       <PreviewPanel
         selected={selected?.item ?? null}
-        tree={tree}
         onOpen={() => selected && handleOpen(selected.item)}
         onDelete={onDelete ? () => selected && onDelete(selected.item) : undefined}
       />
@@ -153,7 +150,7 @@ function Column({
   items: GridItem[];
   activeId: string | null;
   onPick: (item: GridItem) => void;
-  onOpen: (item: GridItem) => void;
+  onOpen: (item: GridItem, options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
   folderIdForDrop: string | null;
@@ -202,7 +199,7 @@ function Column({
           item={item}
           active={item.id === activeId}
           onPick={() => onPick(item)}
-          onOpen={() => onOpen(item)}
+          onOpen={(options) => onOpen(item, options)}
           onReparent={onReparent}
           onDelete={onDelete}
         />
@@ -222,7 +219,7 @@ function ColumnRow({
   item: GridItem;
   active: boolean;
   onPick: () => void;
-  onOpen: () => void;
+  onOpen: (options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onDelete?: (item: GridItem) => Promise<void>;
 }) {
@@ -230,8 +227,17 @@ function ColumnRow({
   const isFolder = item.kind === "folder";
   return (
     <div
-      onClick={onPick}
-      onDoubleClick={onOpen}
+      onClick={(e) => {
+        if (shouldOpenInNewTab(e)) {
+          onOpen({ newTab: true });
+          return;
+        }
+        onPick();
+      }}
+      onAuxClick={(e) => {
+        if (shouldOpenInNewTab(e)) onOpen({ newTab: true });
+      }}
+      onDoubleClick={() => onOpen()}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
@@ -306,12 +312,10 @@ function ColumnRow({
 
 function PreviewPanel({
   selected,
-  tree: _tree,
   onOpen,
   onDelete,
 }: {
   selected: GridItem | null;
-  tree: WorkspaceTree | null;
   onOpen: () => void;
   onDelete?: () => void;
 }) {

--- a/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ItemsList from "./ItemsList";
+import type { GridItem } from "./FolderItemGrid";
+
+const item: GridItem = {
+  kind: "html",
+  id: "page-1",
+  name: "Stash Product Memo 6.1.25",
+  subtitle: "html page",
+  updatedAt: "2026-06-02T21:35:23Z",
+};
+
+function renderList(onNavigate = vi.fn()) {
+  render(
+    <ItemsList
+      items={[item]}
+      onNavigate={onNavigate}
+      onReparent={vi.fn()}
+      onReparentMany={vi.fn()}
+      onDelete={vi.fn()}
+      isPinned={() => false}
+      onTogglePin={vi.fn()}
+      selectedIds={new Set()}
+      onToggleSelect={vi.fn()}
+      selectedDragPayloads={[]}
+    />
+  );
+  return onNavigate;
+}
+
+function rowFor(name: string): HTMLElement {
+  const row = screen.getByText(name).closest('[role="button"]');
+  if (!row) throw new Error(`No row for ${name}`);
+  return row as HTMLElement;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ItemsList navigation", () => {
+  it("opens list rows in a new tab on command-click", () => {
+    const onNavigate = renderList();
+
+    fireEvent.click(rowFor(item.name), { metaKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith(item, { newTab: true });
+  });
+
+  it("keeps normal list row clicks in the current tab", () => {
+    const onNavigate = renderList();
+
+    fireEvent.click(rowFor(item.name));
+
+    expect(onNavigate).toHaveBeenCalledWith(item, { newTab: false });
+  });
+});

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -6,6 +6,7 @@ import {
   FB_DRAG_MULTI_MIME,
   type FBDragPayload,
 } from "./WorkspaceFileBrowser";
+import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { FileIcon, FolderIcon, PageIcon, PinIcon, TableIcon } from "../../StashIcons";
 import type { GridItem, ItemKind } from "./FolderItemGrid";
 
@@ -70,7 +71,7 @@ const LIST_GRID_COLS = "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) 64px";
 
 interface Props {
   items: GridItem[];
-  onNavigate: (item: GridItem) => void;
+  onNavigate: (item: GridItem, options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
   onDelete: (item: GridItem) => Promise<void>;
@@ -231,7 +232,7 @@ function Row({
   selectedDragPayloads,
 }: {
   item: GridItem;
-  onNavigate: (item: GridItem) => void;
+  onNavigate: (item: GridItem, options?: NavigateOptions) => void;
   onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
   onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
   onDelete: (item: GridItem) => Promise<void>;
@@ -246,7 +247,10 @@ function Row({
 
   return (
     <div
-      onClick={() => onNavigate(item)}
+      onClick={(e) => onNavigate(item, { newTab: shouldOpenInNewTab(e) })}
+      onAuxClick={(e) => {
+        if (shouldOpenInNewTab(e)) onNavigate(item, { newTab: true });
+      }}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {

--- a/frontend/src/components/workspace/file-browser/QuickAccess.tsx
+++ b/frontend/src/components/workspace/file-browser/QuickAccess.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { PinIcon } from "../../StashIcons";
 import type { GridItem } from "./FolderItemGrid";
 import { KindIcon, tintFor, typeFor } from "./ItemsList";
@@ -7,7 +8,7 @@ import { KindIcon, tintFor, typeFor } from "./ItemsList";
 interface Props {
   pinned: GridItem[];
   recent: GridItem[];
-  onOpen: (item: GridItem) => void;
+  onOpen: (item: GridItem, options?: NavigateOptions) => void;
   isPinned: (item: GridItem) => boolean;
   onTogglePin: (item: GridItem) => void;
 }
@@ -74,14 +75,17 @@ function Card({
 }: {
   item: GridItem;
   pinned: boolean;
-  onOpen: (item: GridItem) => void;
+  onOpen: (item: GridItem, options?: NavigateOptions) => void;
   onTogglePin: (item: GridItem) => void;
 }) {
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={() => onOpen(item)}
+      onClick={(e) => onOpen(item, { newTab: shouldOpenInNewTab(e) })}
+      onAuxClick={(e) => {
+        if (shouldOpenInNewTab(e)) onOpen(item, { newTab: true });
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") onOpen(item);
       }}

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -24,6 +24,7 @@ import type {
 } from "../../../lib/types";
 import { refreshWorkspaceSidebar } from "../../../lib/stashNavigationCache";
 import { useFilePins } from "../../../lib/filePins";
+import { openInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { useWorkspaceRecents } from "../../../lib/pins";
 import { FileBrowserSkeleton } from "../../SkeletonStates";
 import EditableTitle from "../EditableTitle";
@@ -329,16 +330,26 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     }
   }
 
-  function navigateTo(item: GridItem) {
+  function hrefForItem(item: GridItem): string {
     if (item.kind === "folder") {
-      router.push(`/workspaces/${workspaceId}/folders/${item.id}`);
-    } else if (item.kind === "page" || item.kind === "html") {
-      router.push(`/workspaces/${workspaceId}/p/${item.id}`);
-    } else if (item.kind === "table" && item.linkedTableId) {
-      router.push(`/tables/${item.linkedTableId}?workspaceId=${workspaceId}`);
-    } else {
-      router.push(`/workspaces/${workspaceId}/f/${item.id}`);
+      return `/workspaces/${workspaceId}/folders/${item.id}`;
     }
+    if (item.kind === "page" || item.kind === "html") {
+      return `/workspaces/${workspaceId}/p/${item.id}`;
+    }
+    if (item.kind === "table" && item.linkedTableId) {
+      return `/tables/${item.linkedTableId}?workspaceId=${workspaceId}`;
+    }
+    return `/workspaces/${workspaceId}/f/${item.id}`;
+  }
+
+  function navigateTo(item: GridItem, options?: NavigateOptions) {
+    const href = hrefForItem(item);
+    if (options?.newTab) {
+      openInNewTab(href);
+      return;
+    }
+    router.push(href);
   }
 
   async function handleUploadFile() {
@@ -573,7 +584,6 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           {view === "column" && (
             <ItemsColumns
               workspaceId={workspaceId}
-              tree={tree}
               rootItems={rootItems}
               onNavigate={navigateTo}
               onReparent={reparent}

--- a/frontend/src/lib/linkNavigation.test.ts
+++ b/frontend/src/lib/linkNavigation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { shouldOpenInNewTab } from "./linkNavigation";
+
+describe("shouldOpenInNewTab", () => {
+  it("opens command/control clicks in a new tab", () => {
+    expect(shouldOpenInNewTab({ metaKey: true, ctrlKey: false, button: 0 })).toBe(true);
+    expect(shouldOpenInNewTab({ metaKey: false, ctrlKey: true, button: 0 })).toBe(true);
+  });
+
+  it("opens middle clicks in a new tab", () => {
+    expect(shouldOpenInNewTab({ metaKey: false, ctrlKey: false, button: 1 })).toBe(true);
+  });
+
+  it("keeps normal primary clicks in the current tab", () => {
+    expect(shouldOpenInNewTab({ metaKey: false, ctrlKey: false, button: 0 })).toBe(false);
+  });
+});

--- a/frontend/src/lib/linkNavigation.ts
+++ b/frontend/src/lib/linkNavigation.ts
@@ -1,0 +1,17 @@
+export type NavigateOptions = {
+  newTab?: boolean;
+};
+
+type LinkClickEvent = {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  button: number;
+};
+
+export function shouldOpenInNewTab(event: LinkClickEvent): boolean {
+  return event.metaKey || event.ctrlKey || event.button === 1;
+}
+
+export function openInNewTab(href: string): void {
+  window.open(href, "_blank", "noopener,noreferrer");
+}


### PR DESCRIPTION
## What changed
- Added a shared `shouldOpenInNewTab` navigation helper for Cmd/Ctrl-click and middle-click handling.
- Updated markdown editor link routing so modified internal-link clicks open a new tab instead of forcing `router.push` in the current tab.
- Updated the Files browser list/grid/column/quick-access navigation path so modified clicks open the target in a new tab.
- Added a focused regression test for the exact file-list row behavior from the reported screenshot.

## Why
The file browser rendered navigable rows as custom click targets and always routed through client-side navigation. That meant the browser never got native link semantics, so Cmd-click on a row like `Stash Product Memo 6.1.25` stayed in the current tab.

## Screenshot
Captured from a local render of the Files list component:
https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/09e2dd40-27bc-492b-8106-b81605bd6bad

## Validation
- `cd frontend && npm test -- ItemsList.test.tsx linkNavigation.test.ts MarkdownEditor.test.ts`
- `cd frontend && npm run lint`
- `cd frontend && npm test`
- `cd frontend && BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
