### PR TITLE
[codex] Fix file viewer scroll ownership

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -220,57 +220,57 @@ function FileViewerPageInner() {
 
   return (
     <div className="scroll-thin flex flex-1 min-h-0 flex-col overflow-hidden">
-      <FileViewerHeader
-        icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
-        iconColor={kindIconColor(file?.content_type ?? "")}
-        title={file?.name ?? "File"}
-        onRenameTitle={
-          file
-            ? async (next) => {
-                const updated = await updateFile(workspaceId, file.id, { name: next });
-                setFile(updated);
-                return updated.name;
-              }
-            : undefined
-        }
-        readOnly={readOnly}
-        readOnlyLabel="read-only · via Stash"
-        backLink={readOnly && stashSlug ? { label: stashTitle ?? "Stash", href: `/stashes/${stashSlug}` } : undefined}
-        tags={tags}
-        meta={meta}
-        downloadOptions={
-          file?.url
-            ? [
-                { label: "Download", onSelect: () => triggerDownload(file.url, file.name) },
-                ...(readOnly
-                  ? []
-                  : [
-                      {
-                        label: "Delete",
-                        destructive: true,
-                        onSelect: async () => {
-                          if (!window.confirm(`Move "${file.name}" to trash?`)) return;
-                          try {
-                            await trashItem(workspaceId, "file", fileId);
-                            router.push(`/workspaces/${workspaceId}`);
-                          } catch (e) {
-                            setError(e instanceof Error ? e.message : "Delete failed");
-                          }
-                        },
-                      },
-                    ]),
-              ]
-            : undefined
-        }
-      />
-
-      {error && (
-        <div className="border-b border-red-300/40 bg-red-500/10 px-5 py-2 text-[13px] text-red-500">
-          {error}
-        </div>
-      )}
-
       <div className="flex-1 overflow-auto bg-base scroll-thin">
+        <FileViewerHeader
+          icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
+          iconColor={kindIconColor(file?.content_type ?? "")}
+          title={file?.name ?? "File"}
+          onRenameTitle={
+            file
+              ? async (next) => {
+                  const updated = await updateFile(workspaceId, file.id, { name: next });
+                  setFile(updated);
+                  return updated.name;
+                }
+              : undefined
+          }
+          readOnly={readOnly}
+          readOnlyLabel="read-only · via Stash"
+          backLink={readOnly && stashSlug ? { label: stashTitle ?? "Stash", href: `/stashes/${stashSlug}` } : undefined}
+          tags={tags}
+          meta={meta}
+          downloadOptions={
+            file?.url
+              ? [
+                  { label: "Download", onSelect: () => triggerDownload(file.url, file.name) },
+                  ...(readOnly
+                    ? []
+                    : [
+                        {
+                          label: "Delete",
+                          destructive: true,
+                          onSelect: async () => {
+                            if (!window.confirm(`Move "${file.name}" to trash?`)) return;
+                            try {
+                              await trashItem(workspaceId, "file", fileId);
+                              router.push(`/workspaces/${workspaceId}`);
+                            } catch (e) {
+                              setError(e instanceof Error ? e.message : "Delete failed");
+                            }
+                          },
+                        },
+                      ]),
+                ]
+              : undefined
+          }
+        />
+
+        {error && (
+          <div className="border-b border-red-300/40 bg-red-500/10 px-5 py-2 text-[13px] text-red-500">
+            {error}
+          </div>
+        )}
+
         {file && (
           <FileContentRenderer
             url={file.url}

--- a/frontend/src/components/SkeletonStates.tsx
+++ b/frontend/src/components/SkeletonStates.tsx
@@ -476,9 +476,11 @@ export function DocumentBodySkeleton({ className }: SkeletonProps) {
 export function FileViewerSkeleton() {
   return (
     <div className="scroll-thin flex min-h-0 flex-1 flex-col overflow-hidden">
-      <ViewerHeaderSkeleton />
-      <div className="flex-1 overflow-auto bg-base p-8">
-        <SkeletonBlock className="h-full min-h-[420px] w-full rounded-lg" />
+      <div className="flex-1 overflow-auto bg-base">
+        <ViewerHeaderSkeleton />
+        <div className="p-8">
+          <SkeletonBlock className="h-full min-h-[420px] w-full rounded-lg" />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/workspace/FileContentRenderer.tsx
+++ b/frontend/src/components/workspace/FileContentRenderer.tsx
@@ -91,7 +91,7 @@ export default function FileContentRenderer({ url, name, contentType, className 
       );
     }
     return (
-      <pre className="scroll-thin overflow-auto rounded-lg border border-border bg-base px-5 py-4 font-mono text-[12.5px] text-foreground">
+      <pre className="scroll-thin overflow-x-auto rounded-lg border border-border bg-base px-5 py-4 font-mono text-[12.5px] text-foreground">
         {text || ""}
       </pre>
     );


### PR DESCRIPTION
## What changed

- Moves the workspace file viewer header, error banner, and file preview into the same vertical scroll container.
- Changes plain-text file previews to own horizontal scrolling only, leaving vertical scrolling to the file viewer.
- Updates the file viewer skeleton to match the same single-scroll layout while loading.

## Why

The file viewer had competing scroll regions: the app shell, the file viewer content pane, and, for text files, the `<pre>` itself. The header sat outside the file body scroller, so a wheel gesture over the title/header could be consumed by a non-scrolling ancestor instead of scrolling the preview. This made the first scroll feel ignored.

## Impact

Wheel/trackpad gestures over the file title/header now scroll the same container as the file content. Text previews keep horizontal scrolling for long lines without creating a second vertical scroll target.

## Screenshot

[Screenshot after wheel-over-title scroll check](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/43481f85-b061-4dfd-acdb-08697017f3f5)

## Validation

- `npm run lint` (passes with existing `ItemsColumns.tsx` warnings)
- `npm test -- src/components/AppShell.test.tsx src/components/workspace/MarkdownEditor.test.ts`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- Playwright browser check with mocked APIs: wheel over `Long transcript.txt` title moved the file viewer scroller from `0` to `700`.
