### PR TITLE
[codex] Hide HTML editor outline from public views

### DIFF
--- a/frontend/src/components/workspace/HtmlPageView.test.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import HtmlPageView, { stripHtmlPageRuntimeState } from "./HtmlPageView";
+
+afterEach(cleanup);
+
+const pollutedHtml = `<!doctype html>
+<html>
+  <head>
+    <style id="__stash_comments_css__">.old-blue-line{outline:2px dashed blue}</style>
+    <script id="__stash_resize_script__">window.oldResizeBootstrap = true;</script>
+  </head>
+  <body contenteditable="true" spellcheck="true">
+    <main>Public page content</main>
+  </body>
+</html>`;
+
+describe("stripHtmlPageRuntimeState", () => {
+  it("removes edit-only body attributes and stale bootstrap tags", () => {
+    const cleaned = stripHtmlPageRuntimeState(pollutedHtml);
+
+    expect(cleaned).toContain("<body>");
+    expect(cleaned).toContain("Public page content");
+    expect(cleaned).not.toMatch(/<body\b[^>]*\bcontenteditable/i);
+    expect(cleaned).not.toMatch(/<body\b[^>]*\bspellcheck/i);
+    expect(cleaned).not.toContain("old-blue-line");
+    expect(cleaned).not.toContain("oldResizeBootstrap");
+  });
+});
+
+describe("HtmlPageView", () => {
+  it("builds read-only iframe HTML without persisted edit mode state", () => {
+    render(<HtmlPageView html={pollutedHtml} title="Public proposal" />);
+
+    const iframe = screen.getByTitle("Public proposal");
+    const srcDoc = iframe.getAttribute("srcdoc") ?? "";
+
+    expect(srcDoc).toContain("Public page content");
+    expect(srcDoc).not.toMatch(/<body\b[^>]*\bcontenteditable/i);
+    expect(srcDoc).not.toMatch(/<body\b[^>]*\bspellcheck/i);
+    expect(srcDoc).not.toContain("old-blue-line");
+    expect(srcDoc).not.toContain("oldResizeBootstrap");
+  });
+});

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -83,7 +83,7 @@ export default function HtmlPageView({
   // first `html` we see so saves (wrap, edit, unwrap) don't reload the iframe
   // and trash the user's caret. Switching pages remounts this component, so
   // a new page picks up its own initial html cleanly.
-  const [initialHtml] = useState(html);
+  const [initialHtml] = useState(() => stripHtmlPageRuntimeState(html));
 
   // Slide-deck detection: any fixed-aspect HTML page whose body contains
   // <section class="slide"> elements gets prev/next navigation. Pages
@@ -706,6 +706,35 @@ export function extractCommentIdsFromHtml(html: string): string[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(html)) !== null) ids.push(m[1]);
   return Array.from(new Set(ids));
+}
+
+export function stripHtmlPageRuntimeState(html: string): string {
+  return stripBodyAttribute(
+    stripBodyAttribute(stripRuntimeTags(html), "contenteditable"),
+    "spellcheck",
+  );
+}
+
+function stripRuntimeTags(html: string): string {
+  return html
+    .replace(
+      /<script\b(?=[^>]*\bid=["']__stash_(?:resize|slide)_script__["'])[^>]*>[\s\S]*?<\/script>/gi,
+      "",
+    )
+    .replace(
+      /<style\b(?=[^>]*\bid=["']__stash_(?:comments|slide)_css__["'])[^>]*>[\s\S]*?<\/style>/gi,
+      "",
+    );
+}
+
+function stripBodyAttribute(html: string, attr: "contenteditable" | "spellcheck"): string {
+  const attrPattern = new RegExp(
+    `\\s${attr}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?`,
+    "gi",
+  );
+  return html.replace(/<body\b[^>]*>/gi, (bodyTag) =>
+    bodyTag.replace(attrPattern, ""),
+  );
 }
 
 // Bootstrap injected into fixed-aspect slide decks. Listens for


### PR DESCRIPTION
## Summary
- Strip saved HTML page runtime state before `HtmlPageView` pins iframe `srcDoc`.
- Remove stale Stash iframe bootstrap tags plus `body` `contenteditable` / `spellcheck` attributes from saved HTML.
- Add regression coverage for read-only iframe rendering with polluted saved HTML.

## Root Cause
WYSIWYG edit mode sets `body contenteditable` and injects CSS that draws the blue dashed edit outline. Older save round-trips could persist that runtime state into `content_html`. Public Stash views are read-only, but they still render the saved HTML, so stale `contenteditable` state could make the public iframe match the edit-mode outline selector.

## Screenshot
- Public Stash view with polluted saved HTML rendered without the blue outline: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/10f16600-0dce-4132-91eb-57aa7b9beb05

## Validation
- `npm test -- HtmlPageView.test.tsx`
- `npm run lint -- src/components/workspace/HtmlPageView.tsx src/components/workspace/HtmlPageView.test.tsx`
- `npm test`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- Playwright loaded a mocked public Stash containing stale `contenteditable` HTML, asserted the iframe `srcDoc` no longer persists edit-mode body attributes, and captured the linked screenshot.