### PR TITLE
[codex] Align comments with anchors

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
 import { PageBody } from "../../../../stashes/[slug]/StashItemBodies";
 import {
@@ -62,6 +62,31 @@ function escapeHtml(s: string): string {
   );
 }
 
+function readCommentAnchorTops(
+  container: HTMLElement,
+  relativeTo: HTMLElement,
+): Record<string, number> {
+  const rootRect = relativeTo.getBoundingClientRect();
+  const next: Record<string, number> = {};
+  const anchors = container.querySelectorAll<HTMLElement>("[data-comment-id]");
+  anchors.forEach((anchor) => {
+    const id = anchor.getAttribute("data-comment-id");
+    if (!id) return;
+    const rects = anchor.getClientRects();
+    const rect = rects[0] ?? anchor.getBoundingClientRect();
+    const top = Math.max(0, Math.round(rect.top - rootRect.top));
+    if (next[id] === undefined || top < next[id]) next[id] = top;
+  });
+  return next;
+}
+
+function sameAnchorTops(a: Record<string, number>, b: Record<string, number>): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
+}
+
 export default function StashPageView() {
   const params = useParams();
   const router = useRouter();
@@ -86,6 +111,9 @@ export default function StashPageView() {
   // slow save is still in flight. Treat the most-recently-issued seq as
   // the source of truth so older responses can't roll back the page.
   const saveSeq = useRef(0);
+  const pageLayoutRef = useRef<HTMLDivElement | null>(null);
+  const articleRef = useRef<HTMLElement | null>(null);
+  const [commentAnchorTops, setCommentAnchorTops] = useState<Record<string, number>>({});
 
   const [threads, setThreads] = useState<CommentThread[]>([]);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -110,6 +138,10 @@ export default function StashPageView() {
   useEffect(() => {
     htmlSelectionRef.current = htmlSelection;
   }, [htmlSelection]);
+
+  useEffect(() => {
+    setCommentAnchorTops({});
+  }, [workspaceId, pageId]);
 
   useBreadcrumbs(
     [
@@ -342,6 +374,53 @@ export default function StashPageView() {
     if (!loading && !user && !stashSlug) router.push("/login");
   }, [user, loading, router, stashSlug]);
 
+  const handleHtmlAnchorTops = useCallback((iframeAnchorTops: Record<string, number>) => {
+    const layout = pageLayoutRef.current;
+    const iframeBox = iframeBoxRef.current;
+    if (!layout || !iframeBox) return;
+    const offset = iframeBox.getBoundingClientRect().top - layout.getBoundingClientRect().top;
+    const next: Record<string, number> = {};
+    for (const [id, top] of Object.entries(iframeAnchorTops)) {
+      next[id] = Math.max(0, Math.round(offset + top));
+    }
+    setCommentAnchorTops((current) => (sameAnchorTops(current, next) ? current : next));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!page || page.content_type === "html") return;
+    const article = articleRef.current;
+    const layout = pageLayoutRef.current;
+    if (!article || !layout) return;
+
+    const update = () => {
+      const next = readCommentAnchorTops(article, layout);
+      setCommentAnchorTops((current) => (sameAnchorTops(current, next) ? current : next));
+    };
+
+    update();
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+    resizeObserver?.observe(article);
+
+    const mutationObserver =
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver(update);
+    mutationObserver?.observe(article, {
+      attributes: true,
+      attributeFilter: ["data-comment-id"],
+      childList: true,
+      subtree: true,
+    });
+
+    window.addEventListener("resize", update);
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [page]);
+
   if (loading) return <DocumentPageSkeleton />;
   if (stashFallback) {
     return (
@@ -483,7 +562,10 @@ export default function StashPageView() {
             : undefined
         }
       />
-      <div className="mx-auto mt-6 grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]">
+      <div
+        ref={pageLayoutRef}
+        className="mx-auto mt-6 grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]"
+      >
         <main className="min-w-0">
           {error && (
             <div className="mb-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
@@ -491,7 +573,7 @@ export default function StashPageView() {
             </div>
           )}
 
-          <article className="text-[15px] leading-relaxed text-foreground">
+          <article ref={articleRef} className="text-[15px] leading-relaxed text-foreground">
             {page ? (
               isHtml ? (
                 <div ref={iframeBoxRef} className="relative">
@@ -502,6 +584,7 @@ export default function StashPageView() {
                     layout={page.html_layout}
                     onSelection={setHtmlSelection}
                     onActivateThread={setActiveThreadId}
+                    onAnchorTops={handleHtmlAnchorTops}
                     activeThreadId={activeThreadId}
                     pendingWrapId={pendingWrapId}
                     onWrapComplete={() => setPendingWrapId(null)}
@@ -563,18 +646,21 @@ export default function StashPageView() {
           </article>
         </main>
 
-        <div className="mt-20 hidden flex-col gap-4 lg:flex">
-          <StashAside stashes={containingStashes} />
+        <div className="hidden lg:block">
           <CommentsSidebar
             threads={threads}
             activeThreadId={activeThreadId}
             currentUserId={user.id}
+            anchorTops={commentAnchorTops}
             onActivate={setActiveThreadId}
             onReply={handleReply}
             onSetResolved={handleSetResolved}
             onDeleteThread={handleDeleteThread}
             onDeleteMessage={handleDeleteMessage}
           />
+          <div className={threads.length > 0 ? "mt-6" : "mt-20"}>
+            <StashAside stashes={containingStashes} />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/workspace/CommentsSidebar.tsx
+++ b/frontend/src/components/workspace/CommentsSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { CommentThread } from "../../lib/types";
 
@@ -8,6 +8,7 @@ interface CommentsSidebarProps {
   threads: CommentThread[];
   activeThreadId: string | null;
   currentUserId: string;
+  anchorTops?: Record<string, number>;
   onActivate: (threadId: string) => void;
   onReply: (threadId: string, body: string) => Promise<void>;
   onSetResolved: (threadId: string, resolved: boolean) => Promise<void>;
@@ -15,10 +16,14 @@ interface CommentsSidebarProps {
   onDeleteMessage: (threadId: string, messageId: string) => Promise<void>;
 }
 
+const CARD_GAP = 8;
+const ESTIMATED_CARD_HEIGHT = 124;
+
 export default function CommentsSidebar({
   threads,
   activeThreadId,
   currentUserId,
+  anchorTops = {},
   onActivate,
   onReply,
   onSetResolved,
@@ -30,6 +35,24 @@ export default function CommentsSidebar({
   const resolved = threads.filter((t) => t.resolved_at);
 
   if (threads.length === 0) return null;
+
+  if (open.some((thread) => hasAnchorTop(anchorTops, thread.id))) {
+    return (
+      <AlignedComments
+        open={open}
+        orphaned={orphaned}
+        resolved={resolved}
+        activeThreadId={activeThreadId}
+        currentUserId={currentUserId}
+        anchorTops={anchorTops}
+        onActivate={onActivate}
+        onReply={onReply}
+        onSetResolved={onSetResolved}
+        onDeleteThread={onDeleteThread}
+        onDeleteMessage={onDeleteMessage}
+      />
+    );
+  }
 
   return (
     <aside>
@@ -81,6 +104,160 @@ export default function CommentsSidebar({
       </div>
     </aside>
   );
+}
+
+function AlignedComments({
+  open,
+  orphaned,
+  resolved,
+  activeThreadId,
+  currentUserId,
+  anchorTops,
+  onActivate,
+  onReply,
+  onSetResolved,
+  onDeleteThread,
+  onDeleteMessage,
+}: {
+  open: CommentThread[];
+  orphaned: CommentThread[];
+  resolved: CommentThread[];
+  activeThreadId: string | null;
+  currentUserId: string;
+  anchorTops: Record<string, number>;
+  onActivate: (threadId: string) => void;
+  onReply: (threadId: string, body: string) => Promise<void>;
+  onSetResolved: (threadId: string, resolved: boolean) => Promise<void>;
+  onDeleteThread: (threadId: string) => Promise<void>;
+  onDeleteMessage: (threadId: string, messageId: string) => Promise<void>;
+}) {
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [cardHeights, setCardHeights] = useState<Record<string, number>>({});
+  const sortedOpen = useMemo(
+    () => sortThreadsByAnchorTop(open, anchorTops),
+    [open, anchorTops],
+  );
+  const layout = useMemo(
+    () => buildThreadLayout(sortedOpen, anchorTops, cardHeights),
+    [sortedOpen, anchorTops, cardHeights],
+  );
+
+  useLayoutEffect(() => {
+    const next: Record<string, number> = {};
+    for (const thread of sortedOpen) {
+      const node = cardRefs.current[thread.id];
+      if (node) next[thread.id] = Math.ceil(node.getBoundingClientRect().height);
+    }
+    setCardHeights((current) => (sameNumberMap(current, next) ? current : next));
+  }, [sortedOpen]);
+
+  return (
+    <aside className="relative">
+      <div className="relative" style={{ minHeight: layout.height }}>
+        {layout.items.map(({ thread, top }) => (
+          <div
+            key={thread.id}
+            ref={(node) => {
+              cardRefs.current[thread.id] = node;
+            }}
+            className="absolute left-0 right-0"
+            style={{ top }}
+          >
+            <ThreadCard
+              thread={thread}
+              active={thread.id === activeThreadId}
+              currentUserId={currentUserId}
+              onActivate={onActivate}
+              onReply={onReply}
+              onSetResolved={onSetResolved}
+              onDeleteThread={onDeleteThread}
+              onDeleteMessage={onDeleteMessage}
+            />
+          </div>
+        ))}
+      </div>
+
+      {(orphaned.length > 0 || resolved.length > 0) && (
+        <div className="card-soft mt-4 p-3.5">
+          <div className="sys-label">Comments</div>
+          <div className="mt-3 flex flex-col gap-4">
+            {orphaned.length > 0 && (
+              <Group
+                label="Orphaned"
+                threads={orphaned}
+                activeThreadId={activeThreadId}
+                currentUserId={currentUserId}
+                onActivate={onActivate}
+                onReply={onReply}
+                onSetResolved={onSetResolved}
+                onDeleteThread={onDeleteThread}
+                onDeleteMessage={onDeleteMessage}
+                hint="The anchored text was deleted from the page. Resolve to clear."
+              />
+            )}
+            {resolved.length > 0 && (
+              <Group
+                label="Resolved"
+                threads={resolved}
+                activeThreadId={activeThreadId}
+                currentUserId={currentUserId}
+                onActivate={onActivate}
+                onReply={onReply}
+                onSetResolved={onSetResolved}
+                onDeleteThread={onDeleteThread}
+                onDeleteMessage={onDeleteMessage}
+                collapsedByDefault
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function sortThreadsByAnchorTop(
+  threads: CommentThread[],
+  anchorTops: Record<string, number>,
+): CommentThread[] {
+  return [...threads].sort((a, b) => {
+    const aTop = anchorTops[a.id];
+    const bTop = anchorTops[b.id];
+    const aHasTop = typeof aTop === "number";
+    const bHasTop = typeof bTop === "number";
+    if (aHasTop && bHasTop) return aTop - bTop;
+    if (aHasTop) return -1;
+    if (bHasTop) return 1;
+    return 0;
+  });
+}
+
+function buildThreadLayout(
+  threads: CommentThread[],
+  anchorTops: Record<string, number>,
+  cardHeights: Record<string, number>,
+): { items: { thread: CommentThread; top: number }[]; height: number } {
+  let nextTop = 0;
+  const items = threads.map((thread) => {
+    const anchorTop = anchorTops[thread.id];
+    const desiredTop = typeof anchorTop === "number" ? Math.max(0, anchorTop) : nextTop;
+    const top = Math.max(desiredTop, nextTop);
+    const height = cardHeights[thread.id] ?? ESTIMATED_CARD_HEIGHT;
+    nextTop = top + height + CARD_GAP;
+    return { thread, top };
+  });
+  return { items, height: Math.max(0, nextTop - CARD_GAP) };
+}
+
+function hasAnchorTop(anchorTops: Record<string, number>, threadId: string): boolean {
+  return typeof anchorTops[threadId] === "number";
+}
+
+function sameNumberMap(a: Record<string, number>, b: Record<string, number>): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
 }
 
 function Group({
@@ -189,6 +366,7 @@ function ThreadCard({
 
   return (
     <div
+      data-comment-thread-id={thread.id}
       onClick={() => onActivate(thread.id)}
       className={`rounded-md border px-2.5 py-2 text-[12.5px] ${
         active

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -25,6 +25,7 @@ type Props = {
   /** Click on a `[data-comment-id]` span inside the iframe asks the
    *  parent to surface the matching thread. */
   onActivateThread?: (threadId: string) => void;
+  onAnchorTops?: (anchorTops: Record<string, number>) => void;
   /** Wraps the most recently reported selection with a
    *  `<span data-comment-id>` and posts the resulting full HTML back
    *  via `onHtmlMutated`. Called by the parent after the thread is
@@ -65,6 +66,7 @@ export default function HtmlPageView({
   layout = "responsive",
   onSelection,
   onActivateThread,
+  onAnchorTops,
   pendingWrapId,
   onWrapComplete,
   onHtmlMutated,
@@ -136,6 +138,14 @@ export default function HtmlPageView({
         onActivateThread?.(data.id);
         return;
       }
+      if (data.type === "stash:anchor-tops" && data.anchorTops) {
+        const anchorTops: Record<string, number> = {};
+        for (const [id, top] of Object.entries(data.anchorTops)) {
+          if (typeof top === "number") anchorTops[id] = top;
+        }
+        onAnchorTops?.(anchorTops);
+        return;
+      }
       if (data.type === "stash:html-mutated" && typeof data.html === "string") {
         onHtmlMutated?.(data.html);
         onWrapComplete?.();
@@ -157,6 +167,7 @@ export default function HtmlPageView({
     channel,
     onSelection,
     onActivateThread,
+    onAnchorTops,
     onHtmlMutated,
     onWrapComplete,
     onNavigateLink,
@@ -511,6 +522,21 @@ function injectResizeBootstrap(
         document.body ? document.body.scrollHeight : 0
       );
       post({type:"stash:resize",height:h});
+      reportAnchorTops();
+    }
+    function reportAnchorTops(){
+      var anchorTops={};
+      var nodes=document.querySelectorAll("[data-comment-id]");
+      for(var i=0;i<nodes.length;i++){
+        var el=nodes[i];
+        var id=el.getAttribute("data-comment-id");
+        if(!id) continue;
+        var rects=el.getClientRects();
+        var rect=rects[0]||el.getBoundingClientRect();
+        var top=Math.max(0,Math.round(rect.top));
+        if(anchorTops[id]===undefined || top<anchorTops[id]) anchorTops[id]=top;
+      }
+      post({type:"stash:anchor-tops",anchorTops:anchorTops});
     }
     function injectStyle(){
       if(document.getElementById("__stash_comments_css__")) return;
@@ -592,6 +618,7 @@ function injectResizeBootstrap(
         range.insertNode(span);
       }
       sel.removeAllRanges();
+      reportAnchorTops();
       post({type:"stash:html-mutated",html:serializeClean()});
     }
     function unwrap(id){
@@ -604,6 +631,7 @@ function injectResizeBootstrap(
         while(el.firstChild) parent.insertBefore(el.firstChild,el);
         parent.removeChild(el);
       }
+      reportAnchorTops();
       post({type:"stash:html-mutated",html:serializeClean()});
     }
     function applyActive(id){


### PR DESCRIPTION
## What changed

- Measures comment anchor positions in the page layout and passes those offsets into the comments sidebar.
- Renders open comment cards in a right-side aligned lane so each card starts at the same vertical position as its highlighted text.
- Adds iframe-to-parent anchor position reporting for HTML pages, matching the existing selection/comment bridge.
- Keeps orphaned and resolved threads in the existing grouped sidebar treatment below the aligned open comments.

## Why

Open comments were rendered as a normal stacked sidebar list, so their vertical position was unrelated to the text they referenced. This makes comments much harder to scan on long pages.

## Screenshot

QA screenshot: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/26a272fe-981d-4d68-a6a4-b3232acfa160

## Validation

- `npm run lint` passes; existing warnings remain in `frontend/src/components/workspace/file-browser/ItemsColumns.tsx`.
- `npm test` passes: 18 files, 92 tests.
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build` passes.
- Playwright browser QA against a disposable HTML page measured both comment cards at `0px` vertical delta from their highlighted text.
