### PR TITLE
[codex] Disable file editor spellcheck

### DIFF
--- a/frontend/src/components/workspace/MarkdownEditor.dom.test.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.dom.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Page } from "../../lib/types";
+import MarkdownEditor from "./MarkdownEditor";
+
+afterEach(() => {
+  cleanup();
+});
+
+const page: Page = {
+  id: "page-1",
+  workspace_id: "workspace-1",
+  folder_id: null,
+  name: "Stash ICP - Rachel",
+  content_type: "markdown",
+  content_markdown: "Rachel Wolan uses Stash at Webflow and biglabs.",
+  content_html: "",
+  html_layout: "responsive",
+  created_by: "user-1",
+  updated_by: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+};
+
+describe("MarkdownEditor DOM", () => {
+  it("disables browser spellcheck on the editable surface", async () => {
+    render(
+      <MarkdownEditor
+        workspaceId={null}
+        file={page}
+        onSave={vi.fn()}
+        collaborationUser={{ id: "user-1", name: "Test User" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".ProseMirror")).toHaveAttribute(
+        "spellcheck",
+        "false",
+      );
+    });
+  });
+});

--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -249,6 +249,7 @@ export default function MarkdownEditor({
       attributes: {
         class:
           "prose prose-sm max-w-none min-h-[200px] focus:outline-none file-page-body",
+        spellcheck: "false",
       },
       handleDOMEvents: {
         paste: (_view, event) => {


### PR DESCRIPTION
## Summary
- Disable native browser spellcheck on the Tiptap/ProseMirror file editor surface.
- Add a render test that asserts the editor DOM sets `spellcheck="false"`.

## Why
The red wavy underlines in the file editor are browser spellcheck decorations on the contenteditable node. Turning spellcheck off at the ProseMirror boundary removes those marks without changing document content or save behavior.

## Validation
- `cd frontend && npm run lint`
- `cd frontend && npm test -- MarkdownEditor`
- Playwright local browser check confirmed `.ProseMirror` renders with `spellcheck="false"`.

## Screenshot
- Editor after change: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/cd18b305-2d35-42d4-ae51-28a3f0aa29df

Note: the screenshot was captured against the local dev frontend with a prebuilt local collab container that showed an unrelated live-editing warning; the inspected editor DOM still rendered with `spellcheck="false"`.