### PR TITLE
[codex] Replace table link prompt with inline editor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,9 @@ POSTGRES_USER=stash
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=stash
 
-# Full connection string used by the backend directly.
-DATABASE_URL=postgresql://stash:changeme@postgres:5432/stash
+# Full connection string used by direct backend runs (`./start.sh`).
+# Docker Compose sets its own in-network DATABASE_URL for containers.
+DATABASE_URL=postgresql://stash:stash@localhost:5432/stash
 
 # Connection pool sizing. Increase DB_POOL_MAX for high-traffic deployments.
 DB_POOL_MIN=2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "BACKEND_INTERNAL_URL=http://localhost:3456 next dev",
+    "dev": "BACKEND_INTERNAL_URL=${BACKEND_INTERNAL_URL:-http://localhost:3456} next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -8,8 +8,10 @@ import {
   useRef,
   useState,
   type AnchorHTMLAttributes,
+  type FormEvent,
   type HTMLAttributes,
   type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
 } from "react";
 import Markdown from "react-markdown";
 import AppShell from "../../../components/AppShell";
@@ -66,6 +68,16 @@ type SummaryData = { total_rows: number; columns: Record<string, { name: string;
 type TableUndoAction =
   | { kind: "row-create"; row: TableRow }
   | { kind: "row-update"; row: TableRow };
+type CellLinkEditorState = {
+  value: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  top: number;
+  left: number;
+};
+
+const LINK_EDITOR_DEFAULT_HREF = "https://";
+const LINK_EDITOR_WIDTH = 320;
 
 const isDraftRowId = (rowId: string) => rowId.startsWith(DRAFT_ROW_PREFIX);
 const cloneTableRow = (row: TableRow): TableRow => ({ ...row, data: { ...row.data } });
@@ -109,6 +121,80 @@ function linkMarkdownSelection(
   return `${value.slice(0, start)}[${markdownLinkText(label)}](${markdownLinkHref(
     href,
   )})${value.slice(end)}`;
+}
+
+function linkEditorPositionFor(input: HTMLInputElement) {
+  const rect = input.getBoundingClientRect();
+  const viewportPadding = 12;
+  const maxLeft = Math.max(viewportPadding, window.innerWidth - LINK_EDITOR_WIDTH - viewportPadding);
+  const left = Math.min(Math.max(viewportPadding, rect.left), maxLeft);
+  return {
+    top: rect.bottom + 6,
+    left,
+  };
+}
+
+interface CellLinkEditorPopoverProps {
+  href: string;
+  inputRef: RefObject<HTMLInputElement | null>;
+  popoverRef: RefObject<HTMLFormElement | null>;
+  top: number;
+  left: number;
+  onCancel: () => void;
+  onHrefChange: (href: string) => void;
+  onSubmit: () => void;
+}
+
+function CellLinkEditorPopover({
+  href,
+  inputRef,
+  popoverRef,
+  top,
+  left,
+  onCancel,
+  onHrefChange,
+  onSubmit,
+}: CellLinkEditorPopoverProps) {
+  function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    onSubmit();
+  }
+
+  return (
+    <form
+      ref={popoverRef}
+      role="dialog"
+      aria-label="Edit link"
+      onSubmit={submit}
+      className="fixed z-50 w-[320px] rounded-lg border border-border bg-base p-2 shadow-[0_12px_32px_-10px_rgba(0,0,0,0.35),0_4px_12px_-6px_rgba(0,0,0,0.18)]"
+      style={{ top, left }}
+    >
+      <div className="flex items-center gap-1.5">
+        <input
+          ref={inputRef}
+          aria-label="Link URL"
+          value={href}
+          onChange={(e) => onHrefChange(e.target.value)}
+          placeholder="Paste link or URL"
+          className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2 py-1.5 text-[13px] text-foreground outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+        />
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-2 py-1.5 text-[12.5px] font-medium text-muted hover:bg-raised hover:text-foreground"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!href.trim()}
+          className="rounded-md bg-brand px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+        >
+          Save
+        </button>
+      </div>
+    </form>
+  );
 }
 
 function TableCellText({ value }: { value: string }) {
@@ -175,6 +261,10 @@ function TableEditorPageInner() {
   const [editingCell, setEditingCell] = useState<{ rowId: string; colId: string } | null>(null);
   const [cellValue, setCellValue] = useState("");
   const cellInputRef = useRef<HTMLInputElement>(null);
+  const linkHrefInputRef = useRef<HTMLInputElement>(null);
+  const linkEditorRef = useRef<HTMLFormElement>(null);
+  const [linkEditor, setLinkEditor] = useState<CellLinkEditorState | null>(null);
+  const [linkHref, setLinkHref] = useState(LINK_EDITOR_DEFAULT_HREF);
   const undoStackRef = useRef<TableUndoAction[]>([]);
   const undoInFlightRef = useRef(false);
 
@@ -541,12 +631,14 @@ function TableEditorPageInner() {
 
   const startEditing = (rowId: string, colId: string, currentValue: unknown) => {
     if (readOnly) return;
+    setLinkEditor(null);
     setEditingCell({ rowId, colId }); setCellValue(currentValue != null ? String(currentValue) : "");
   };
-  const commitEdit = async (nextValue = cellValue) => {
+  const commitEdit = useCallback(async (nextValue = cellValue) => {
     if (!editingCell) return;
+    setLinkEditor(null);
     const { rowId, colId } = editingCell;
-    const col = sortedColumns.find((c) => c.id === colId);
+    const col = table?.columns.find((c) => c.id === colId);
     if (isDraftRowId(rowId) && nextValue === "") {
       setEditingCell(null);
       return;
@@ -574,23 +666,70 @@ function TableEditorPageInner() {
     }
     catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
     setEditingCell(null);
+  }, [cellValue, editingCell, rememberUndo, rows, table, tableId, wsId]);
+  const cancelEdit = () => {
+    setLinkEditor(null);
+    setEditingCell(null);
   };
-  const cancelEdit = () => setEditingCell(null);
-  const applyCellLink = async (input: HTMLInputElement, col: TableColumn) => {
-    if (!canLinkCellText(col)) return;
-    const href = window.prompt("Link URL", "https://");
-    if (href == null) return;
-    const trimmedHref = href.trim();
+  const openCellLinkEditor = (input: HTMLInputElement, col: TableColumn) => {
+    if (!canLinkCellText(col) || !editingCell) return;
+    const position = linkEditorPositionFor(input);
+    setLinkHref(LINK_EDITOR_DEFAULT_HREF);
+    setLinkEditor({
+      value: cellValue,
+      selectionStart: input.selectionStart,
+      selectionEnd: input.selectionEnd,
+      top: position.top,
+      left: position.left,
+    });
+  };
+  const cancelCellLink = () => {
+    const selectionStart = linkEditor?.selectionStart;
+    const selectionEnd = linkEditor?.selectionEnd;
+    setLinkEditor(null);
+    window.requestAnimationFrame(() => {
+      cellInputRef.current?.focus();
+      if (selectionStart != null && selectionEnd != null) {
+        cellInputRef.current?.setSelectionRange(selectionStart, selectionEnd);
+      }
+    });
+  };
+  const submitCellLink = async () => {
+    if (!linkEditor) return;
+    const trimmedHref = linkHref.trim();
     if (!trimmedHref) return;
     const nextValue = linkMarkdownSelection(
-      cellValue,
-      input.selectionStart,
-      input.selectionEnd,
+      linkEditor.value,
+      linkEditor.selectionStart,
+      linkEditor.selectionEnd,
       trimmedHref,
     );
     setCellValue(nextValue);
     await commitEdit(nextValue);
   };
+
+  useEffect(() => {
+    if (!linkEditor) return;
+    linkHrefInputRef.current?.focus();
+    linkHrefInputRef.current?.select();
+  }, [linkEditor]);
+
+  useEffect(() => {
+    if (!linkEditor) return;
+    const handler = (e: MouseEvent) => {
+      if (linkEditorRef.current?.contains(e.target as Node)) return;
+      if (isTableCellEditorTarget(e.target)) {
+        setLinkEditor(null);
+        return;
+      }
+      void commitEdit();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [linkEditor, commitEdit]);
+
+  useEscapeKey(!!linkEditor, cancelCellLink);
+
   const handleCellInputKeyDown = (
     e: ReactKeyboardEvent<HTMLInputElement>,
     col: TableColumn,
@@ -603,7 +742,7 @@ function TableEditorPageInner() {
       e.key.toLowerCase() === "k"
     ) {
       e.preventDefault();
-      void applyCellLink(e.currentTarget, col);
+      openCellLinkEditor(e.currentTarget, col);
       return;
     }
 
@@ -862,7 +1001,7 @@ function TableEditorPageInner() {
                 type={cellInputType(col)}
                 value={cellValue}
                 onChange={(e) => setCellValue(e.target.value)}
-                onBlur={() => void commitEdit()}
+                onBlur={() => { if (!linkEditor) void commitEdit(); }}
                 onKeyDown={(e) => handleCellInputKeyDown(e, col)}
                 className="w-full h-8 px-2 text-sm bg-transparent outline-none ring-1 ring-brand rounded font-mono text-foreground"
               />
@@ -1236,6 +1375,19 @@ function TableEditorPageInner() {
               </div>
             )}
           </div>
+        )}
+
+        {linkEditor && (
+          <CellLinkEditorPopover
+            href={linkHref}
+            inputRef={linkHrefInputRef}
+            popoverRef={linkEditorRef}
+            top={linkEditor.top}
+            left={linkEditor.left}
+            onCancel={cancelCellLink}
+            onHrefChange={setLinkHref}
+            onSubmit={() => void submitCellLink()}
+          />
         )}
 
         {/* Column context menu */}

--- a/frontend/src/app/tables/[tableId]/page.test.tsx
+++ b/frontend/src/app/tables/[tableId]/page.test.tsx
@@ -257,7 +257,8 @@ describe("TableEditorPage row creation", () => {
       data: { name: linkedValue },
     };
     api.updateTableRow.mockResolvedValue(linkedRow);
-    vi.stubGlobal("prompt", vi.fn(() => "https://example.com"));
+    const prompt = vi.fn();
+    vi.stubGlobal("prompt", prompt);
 
     render(<TableEditorPage />);
 
@@ -269,12 +270,17 @@ describe("TableEditorPage row creation", () => {
       fireEvent.keyDown(input, { key: "k", metaKey: true });
       await Promise.resolve();
     });
+    const linkInput = await screen.findByLabelText("Link URL");
+    expect(linkInput).toHaveValue("https://");
+    fireEvent.change(linkInput, { target: { value: "https://example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
       expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-1", {
         name: linkedValue,
       }),
     );
+    expect(prompt).not.toHaveBeenCalled();
   });
 
   it("renders markdown links in text cells", async () => {

--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # -------------------------------------------------------
 # start.sh — Start all Stash services locally
-# Assumes: PostgreSQL is already running and npm
-#          dependencies are installed.
+# Starts a local pgvector database when DATABASE_URL points
+# at localhost:5432 and no database is reachable yet.
 # -------------------------------------------------------
 
 PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
@@ -12,6 +12,15 @@ PIDS=()
 # Keep local dev ports aligned with backend defaults and docker compose.
 BACKEND_PORT=3456
 FRONTEND_PORT=3457
+LOCAL_DATABASE_URL="postgresql://stash:stash@localhost:5432/stash"
+DEV_DB_CONTAINER="stash-dev-postgres"
+DEV_DB_IMAGE="pgvector/pgvector:pg16"
+DEV_DB_VOLUME="stash_dev_postgres_data"
+DEV_DB_USER="stash"
+DEV_DB_PASSWORD="stash"
+DEV_DB_NAME="stash"
+DEV_DB_PORT="5432"
+STARTED_DEV_DB=false
 
 cleanup() {
     echo ""
@@ -20,6 +29,10 @@ cleanup() {
         kill "$pid" 2>/dev/null || true
     done
     wait 2>/dev/null
+    if [ "$STARTED_DEV_DB" = "true" ]; then
+        echo "[db]      Stopping dev database container..."
+        docker stop "$DEV_DB_CONTAINER" >/dev/null 2>&1 || true
+    fi
     echo "All services stopped."
     exit 0
 }
@@ -35,8 +48,109 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
     echo "Loaded environment from .env"
 fi
 
+export DATABASE_URL="${DATABASE_URL:-$LOCAL_DATABASE_URL}"
+
+database_is_ready() {
+    python - <<'PY' >/dev/null 2>&1
+import asyncio
+import os
+
+import asyncpg
+
+
+async def main():
+    conn = await asyncpg.connect(os.environ["DATABASE_URL"], timeout=2)
+    await conn.close()
+
+
+asyncio.run(main())
+PY
+}
+
+uses_local_dev_database() {
+    case "$DATABASE_URL" in
+        postgresql://*@localhost:5432/*|postgresql://*@127.0.0.1:5432/*|postgres://*@localhost:5432/*|postgres://*@127.0.0.1:5432/*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+container_exists() {
+    docker container inspect "$DEV_DB_CONTAINER" >/dev/null 2>&1
+}
+
+container_is_running() {
+    [ "$(docker inspect -f '{{.State.Running}}' "$DEV_DB_CONTAINER" 2>/dev/null)" = "true" ]
+}
+
+ensure_local_database() {
+    if database_is_ready; then
+        echo "[db]      PostgreSQL is reachable."
+        return
+    fi
+
+    if ! uses_local_dev_database; then
+        echo "[db]      DATABASE_URL is not reachable."
+        echo "[db]      Start the configured database, then rerun ./start.sh."
+        exit 1
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "[db]      Docker is required to start the local dev database."
+        exit 1
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        echo "[db]      Docker is installed, but the daemon is not running."
+        exit 1
+    fi
+
+    if container_exists; then
+        if container_is_running; then
+            echo "[db]      Dev database container is already running."
+        else
+            echo "[db]      Starting existing dev database container..."
+            docker start "$DEV_DB_CONTAINER" >/dev/null
+            STARTED_DEV_DB=true
+        fi
+    else
+        echo "[db]      Creating dev database container..."
+        if ! docker run -d \
+            --name "$DEV_DB_CONTAINER" \
+            -e POSTGRES_USER="$DEV_DB_USER" \
+            -e POSTGRES_PASSWORD="$DEV_DB_PASSWORD" \
+            -e POSTGRES_DB="$DEV_DB_NAME" \
+            -p "$DEV_DB_PORT:5432" \
+            -v "$DEV_DB_VOLUME:/var/lib/postgresql/data" \
+            "$DEV_DB_IMAGE" >/dev/null; then
+            echo "[db]      Failed to start the dev database container."
+            echo "[db]      Check whether port ${DEV_DB_PORT} is already in use."
+            exit 1
+        fi
+        STARTED_DEV_DB=true
+    fi
+
+    echo "[db]      Waiting for PostgreSQL..."
+    for _ in {1..60}; do
+        if database_is_ready; then
+            echo "[db]      PostgreSQL is ready."
+            return
+        fi
+        sleep 1
+    done
+
+    echo "[db]      Dev database did not become ready in time."
+    exit 1
+}
+
 echo "Starting Stash services..."
 echo "================================"
+
+# --- Database ---
+ensure_local_database
 
 # --- Migrations ---
 cd "$PROJECT_ROOT"

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,8 @@ DEV_DB_PORT="5432"
 STARTED_DEV_DB=false
 
 cleanup() {
+    local exit_code="${1:-0}"
+
     echo ""
     echo "Shutting down all services..."
     for pid in "${PIDS[@]}"; do
@@ -34,10 +36,10 @@ cleanup() {
         docker stop "$DEV_DB_CONTAINER" >/dev/null 2>&1 || true
     fi
     echo "All services stopped."
-    exit 0
+    exit "$exit_code"
 }
 
-trap cleanup SIGINT SIGTERM
+trap 'cleanup 0' SIGINT SIGTERM
 
 # Load .env if present
 if [ -f "$PROJECT_ROOT/.env" ]; then
@@ -206,6 +208,30 @@ choose_dev_ports() {
     fi
 }
 
+wait_for_services() {
+    local pid
+    local status
+
+    while true; do
+        for pid in "${PIDS[@]}"; do
+            if jobs -pr | grep -qx "$pid"; then
+                continue
+            fi
+
+            if wait "$pid"; then
+                status=0
+            else
+                status=$?
+            fi
+
+            echo "[start]  Process ${pid} exited with status ${status}."
+            cleanup "$status"
+        done
+
+        sleep 1
+    done
+}
+
 echo "Starting Stash services..."
 echo "================================"
 
@@ -245,5 +271,5 @@ echo "  Backend  -> http://localhost:${BACKEND_PORT}"
 echo "  Frontend -> http://localhost:${FRONTEND_PORT}"
 echo "================================"
 
-# Wait for all background processes
-wait
+# Wait for both app processes; if either exits, stop the other one too.
+wait_for_services

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,7 @@ PIDS=()
 # Keep local dev ports aligned with backend defaults and docker compose when free.
 DEFAULT_BACKEND_PORT=3456
 DEFAULT_FRONTEND_PORT=3457
+DEFAULT_COLLAB_PORT=3458
 LOCAL_DATABASE_URL="postgresql://stash:stash@localhost:5432/stash"
 DEV_DB_CONTAINER="stash-dev-postgres"
 DEV_DB_IMAGE="pgvector/pgvector:pg16"
@@ -53,6 +54,7 @@ fi
 export DATABASE_URL="${DATABASE_URL:-$LOCAL_DATABASE_URL}"
 BACKEND_PORT="${BACKEND_PORT:-$DEFAULT_BACKEND_PORT}"
 FRONTEND_PORT="${FRONTEND_PORT:-$DEFAULT_FRONTEND_PORT}"
+COLLAB_PORT="${COLLAB_PORT:-$DEFAULT_COLLAB_PORT}"
 
 database_is_ready() {
     python - <<'PY' >/dev/null 2>&1
@@ -185,7 +187,7 @@ find_free_port() {
     local candidate="$1"
     local avoid="${2:-}"
 
-    while [ "$candidate" = "$avoid" ] || ! port_is_free "$candidate"; do
+    while [[ ",${avoid}," == *",${candidate},"* ]] || ! port_is_free "$candidate"; do
         candidate=$((candidate + 1))
     done
 
@@ -195,9 +197,11 @@ find_free_port() {
 choose_dev_ports() {
     local requested_backend_port="$BACKEND_PORT"
     local requested_frontend_port="$FRONTEND_PORT"
+    local requested_collab_port="$COLLAB_PORT"
 
     BACKEND_PORT="$(find_free_port "$requested_backend_port")"
     FRONTEND_PORT="$(find_free_port "$requested_frontend_port" "$BACKEND_PORT")"
+    COLLAB_PORT="$(find_free_port "$requested_collab_port" "${BACKEND_PORT},${FRONTEND_PORT}")"
 
     if [ "$BACKEND_PORT" != "$requested_backend_port" ]; then
         echo "[ports]   Backend port ${requested_backend_port} is busy; using ${BACKEND_PORT}."
@@ -205,6 +209,10 @@ choose_dev_ports() {
 
     if [ "$FRONTEND_PORT" != "$requested_frontend_port" ]; then
         echo "[ports]   Frontend port ${requested_frontend_port} is busy; using ${FRONTEND_PORT}."
+    fi
+
+    if [ "$COLLAB_PORT" != "$requested_collab_port" ]; then
+        echo "[ports]   Collab port ${requested_collab_port} is busy; using ${COLLAB_PORT}."
     fi
 }
 
@@ -259,15 +267,28 @@ uvicorn backend.main:app --host 0.0.0.0 --port "$BACKEND_PORT" \
     --proxy-headers --forwarded-allow-ips '*' &
 PIDS+=($!)
 
+# --- Collab (Hocuspocus) ---
+echo "[collab]   Starting on port ${COLLAB_PORT}..."
+cd "$PROJECT_ROOT/collab"
+PORT="$COLLAB_PORT" \
+BACKEND_URL="http://localhost:${BACKEND_PORT}" \
+DATABASE_URL="$DATABASE_URL" \
+npm run dev &
+PIDS+=($!)
+
 # --- Frontend (Next.js) ---
 echo "[frontend] Starting on port ${FRONTEND_PORT}..."
 cd "$PROJECT_ROOT/frontend"
-BACKEND_INTERNAL_URL="http://localhost:${BACKEND_PORT}" PORT="$FRONTEND_PORT" npm run dev &
+BACKEND_INTERNAL_URL="http://localhost:${BACKEND_PORT}" \
+NEXT_PUBLIC_COLLAB_URL="ws://localhost:${COLLAB_PORT}" \
+PORT="$FRONTEND_PORT" \
+npm run dev &
 PIDS+=($!)
 
 echo "================================"
 echo "All services started. Press Ctrl+C to stop."
 echo "  Backend  -> http://localhost:${BACKEND_PORT}"
+echo "  Collab   -> ws://localhost:${COLLAB_PORT}"
 echo "  Frontend -> http://localhost:${FRONTEND_PORT}"
 echo "================================"
 

--- a/start.sh
+++ b/start.sh
@@ -9,9 +9,9 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
 PIDS=()
-# Keep local dev ports aligned with backend defaults and docker compose.
-BACKEND_PORT=3456
-FRONTEND_PORT=3457
+# Keep local dev ports aligned with backend defaults and docker compose when free.
+DEFAULT_BACKEND_PORT=3456
+DEFAULT_FRONTEND_PORT=3457
 LOCAL_DATABASE_URL="postgresql://stash:stash@localhost:5432/stash"
 DEV_DB_CONTAINER="stash-dev-postgres"
 DEV_DB_IMAGE="pgvector/pgvector:pg16"
@@ -49,6 +49,8 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
 fi
 
 export DATABASE_URL="${DATABASE_URL:-$LOCAL_DATABASE_URL}"
+BACKEND_PORT="${BACKEND_PORT:-$DEFAULT_BACKEND_PORT}"
+FRONTEND_PORT="${FRONTEND_PORT:-$DEFAULT_FRONTEND_PORT}"
 
 database_is_ready() {
     python - <<'PY' >/dev/null 2>&1
@@ -146,11 +148,72 @@ ensure_local_database() {
     exit 1
 }
 
+port_is_free() {
+    python - "$1" <<'PY' >/dev/null 2>&1
+import errno
+import socket
+import sys
+
+port = int(sys.argv[1])
+
+for family, host in ((socket.AF_INET6, "::"), (socket.AF_INET, "0.0.0.0")):
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if family == socket.AF_INET6:
+            try:
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            except OSError:
+                pass
+        sock.bind((host, port))
+    except OSError as exc:
+        if family == socket.AF_INET6 and exc.errno in {
+            errno.EAFNOSUPPORT,
+            errno.EADDRNOTAVAIL,
+            errno.EPROTONOSUPPORT,
+        }:
+            continue
+        raise
+    finally:
+        sock.close()
+PY
+}
+
+find_free_port() {
+    local candidate="$1"
+    local avoid="${2:-}"
+
+    while [ "$candidate" = "$avoid" ] || ! port_is_free "$candidate"; do
+        candidate=$((candidate + 1))
+    done
+
+    echo "$candidate"
+}
+
+choose_dev_ports() {
+    local requested_backend_port="$BACKEND_PORT"
+    local requested_frontend_port="$FRONTEND_PORT"
+
+    BACKEND_PORT="$(find_free_port "$requested_backend_port")"
+    FRONTEND_PORT="$(find_free_port "$requested_frontend_port" "$BACKEND_PORT")"
+
+    if [ "$BACKEND_PORT" != "$requested_backend_port" ]; then
+        echo "[ports]   Backend port ${requested_backend_port} is busy; using ${BACKEND_PORT}."
+    fi
+
+    if [ "$FRONTEND_PORT" != "$requested_frontend_port" ]; then
+        echo "[ports]   Frontend port ${requested_frontend_port} is busy; using ${FRONTEND_PORT}."
+    fi
+}
+
 echo "Starting Stash services..."
 echo "================================"
 
 # --- Database ---
 ensure_local_database
+
+# --- Ports ---
+choose_dev_ports
 
 # --- Migrations ---
 cd "$PROJECT_ROOT"
@@ -164,6 +227,8 @@ fi
 
 # --- Backend (FastAPI) ---
 echo "[backend]  Starting on port ${BACKEND_PORT}..."
+PUBLIC_URL="http://localhost:${FRONTEND_PORT}" \
+CORS_ORIGINS="http://localhost:${FRONTEND_PORT},http://localhost:${BACKEND_PORT},http://localhost:3000" \
 uvicorn backend.main:app --host 0.0.0.0 --port "$BACKEND_PORT" \
     --proxy-headers --forwarded-allow-ips '*' &
 PIDS+=($!)
@@ -171,7 +236,7 @@ PIDS+=($!)
 # --- Frontend (Next.js) ---
 echo "[frontend] Starting on port ${FRONTEND_PORT}..."
 cd "$PROJECT_ROOT/frontend"
-PORT="$FRONTEND_PORT" npm run dev &
+BACKEND_INTERNAL_URL="http://localhost:${BACKEND_PORT}" PORT="$FRONTEND_PORT" npm run dev &
 PIDS+=($!)
 
 echo "================================"


### PR DESCRIPTION
## What changed
- Replaced the table cell Command-K browser prompt with an anchored in-app link editor.
- Preserved selected text while the URL field is focused and committed the markdown link only on Save.
- Updated the table test to drive the native UI and assert `window.prompt` is not called.
- Made `./start.sh` bootstrap a local `pgvector/pgvector:pg16` dev database when `DATABASE_URL` points at `localhost:5432` and no DB is reachable.
- Made `./start.sh` auto-select free backend/frontend/collab ports when the defaults are occupied, and print the actual URLs.
- Made `./start.sh` start the collab Hocuspocus service and pass its selected WebSocket URL to the frontend.
- Made `./start.sh` stop sibling services when any backend/frontend/collab process exits.
- Updated the frontend dev script so `start.sh` can pass the selected backend URL into Next.
- Updated `.env.example` so direct local backend runs point at `localhost:5432`; Docker Compose still supplies its own in-network database URL.

## Validation
- `npm test -- src/app/tables/[tableId]/page.test.tsx`
- `npm run lint`
- `npm test`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- `cd collab && npm run build`
- `bash -n start.sh`
- `BACKEND_INTERNAL_URL=http://localhost:9999 npm run dev -- --help`
- helper test: a short-lived child caused `start.sh` cleanup and propagated exit status 7.
- `./start.sh` with 3456/3457/3458 occupied selected 3461/3462/3463, started backend and collab, passed the selected collab URL to frontend, then cleaned up when the duplicate Next dev lock stopped frontend.

## Notes
The page editor warning “Live editing connection closed” happened because `start.sh` was not starting the collab WebSocket service; the frontend defaulted to `ws://localhost:3458` and nothing from this dev stack was listening there.