### PR TITLE
[codex] Fix markdown page top click target on canonical route

### DIFF
--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -660,7 +660,10 @@ export default function SkillPageView() {
       />
       <div
         ref={pageLayoutRef}
-        className="mx-auto mt-6 grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]"
+        className={
+          "mx-auto grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]" +
+          (isHtml ? " mt-6" : "")
+        }
       >
         <main className="min-w-0">
           {externalEdit && (

--- a/frontend/src/components/workspace/MarkdownEditor.dom.test.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.dom.test.tsx
@@ -41,4 +41,19 @@ describe("MarkdownEditor DOM", () => {
       );
     });
   });
+
+  it("keeps top document whitespace on the editable surface", async () => {
+    render(
+      <MarkdownEditor
+        workspaceId={null}
+        file={page}
+        onSave={vi.fn()}
+        collaborationUser={{ id: "user-1", name: "Test User" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".ProseMirror")).toHaveClass("pt-16");
+    });
+  });
 });

--- a/frontend/src/components/workspace/MarkdownEditor.tsx
+++ b/frontend/src/components/workspace/MarkdownEditor.tsx
@@ -249,7 +249,7 @@ export default function MarkdownEditor({
     editorProps: {
       attributes: {
         class:
-          "prose prose-sm max-w-none min-h-full px-12 pt-10 pb-24 focus:outline-none file-page-body" +
+          "prose prose-sm max-w-none min-h-full px-12 pt-16 pb-24 focus:outline-none file-page-body" +
           (canEdit ? " cursor-text" : ""),
         spellcheck: "false",
       },


### PR DESCRIPTION
## Summary
- Rebase the original markdown top-click fix onto the current canonical `/p/[pageId]` page route.
- Remove the page body's external top margin for markdown pages so the blank header-to-document gap is no longer dead space.
- Move that preserved spacing into the editable ProseMirror surface with `pt-16`, while HTML pages keep the external `mt-6` used by iframe edit mode.
- Add focused DOM regression coverage for the editable top whitespace.

## Context
PR #567 moved page detail clients from `/workspaces/[workspaceId]/p/[pageId]` to `/p/[pageId]`, which made the old branch stale. This PR now applies the same fix to `frontend/src/app/(app)/p/[pageId]/PageClient.tsx`.

## Root Cause
PR #484 moved editor padding onto `.ProseMirror`, but the page layout still had `mt-6` outside the markdown editor. Clicks in that visual band landed on the page wrapper instead of the contenteditable ProseMirror node, so the editor did not receive focus.

## Fix
Markdown pages now start their page layout immediately below the header. The visual top spacing lives inside `.ProseMirror`, so clicking the blank area above the first block focuses the editor and places the selection inside it. HTML pages keep the external margin because they render through a separate iframe edit mode.

## Screenshot
- Browser QA screenshot: https://app.joinstash.ai/f/083047ad-b99c-4ce1-b280-a7cf6212ab89

## Verification
- `git diff --check origin/main...HEAD`
- `npm run lint -- src/components/workspace/MarkdownEditor.tsx src/components/workspace/MarkdownEditor.dom.test.tsx 'src/app/(app)/p/[pageId]/PageClient.tsx'`
- `npm test -- MarkdownEditor.dom`
- Playwright browser check against local Next dev with API stubs: clicked the top `.ProseMirror` padding; `elementFromPoint` was the editor, `document.activeElement` became the editor, and the selection was inside the editor. The only console error was the expected missing local collaboration websocket in the stubbed run.
