### PR TITLE
[codex] Add table results to search

### DIFF
--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -12,6 +12,7 @@ import {
   getWorkspaceSidebar,
   getPublicCartridge,
   getSessionEvents,
+  listAllTables,
   listStashes,
   listMyWorkspaces,
   searchWorkspaceEvents,
@@ -23,9 +24,9 @@ import {
   type WorkspaceCartridge,
   type WorkspaceFolder,
 } from "../../lib/api";
-import type { Page, Workspace } from "../../lib/types";
+import type { Page, TableWithWorkspace, Workspace } from "../../lib/types";
 
-type ContentScope = "all" | "sessions" | "pages" | "cartridges";
+type ContentScope = "all" | "sessions" | "pages" | "tables" | "cartridges";
 
 // Coarse buckets for analytics — actual counts have high cardinality
 // and add no signal beyond "no results / few / many."
@@ -39,7 +40,7 @@ function bucketCount(n: number): string {
 
 interface SearchResult {
   id: string;
-  kind: "Session" | "Page" | "Stash";
+  kind: "Session" | "Page" | "Table" | "Stash";
   title: string;
   href: string;
   sourceName: string;
@@ -57,11 +58,14 @@ const CONTENT_SCOPES: { id: ContentScope; label: string }[] = [
   { id: "sessions", label: "Sessions" },
   { id: "pages", label: "Pages" },
   { id: "cartridges", label: "Cartridges" },
+  { id: "tables", label: "Tables" },
 ];
 
 function initialContentScope(value: string | null, sessionId: string): ContentScope {
   if (sessionId) return "sessions";
-  if (value === "sessions" || value === "pages" || value === "cartridges") return value;
+  if (value === "sessions" || value === "pages" || value === "tables" || value === "cartridges") {
+    return value;
+  }
   return "all";
 }
 
@@ -212,6 +216,7 @@ function SearchPageInner() {
       const nextResults: SearchResult[] = [];
       const includeSessions = contentScope === "all" || contentScope === "sessions";
       const includePages = contentScope === "all" || contentScope === "pages";
+      const includeTables = contentScope === "all" || contentScope === "tables";
       const includeStashes = contentScope === "all" || contentScope === "cartridges";
       const workspace =
         workspaces.find((item) => item.id === selectedWorkspaceId) ??
@@ -239,6 +244,7 @@ function SearchPageInner() {
           ...searchPublicCartridgeItems(detail, q, {
             includePages,
             includeSessions,
+            includeTables,
           })
         );
         setResults(sortResults(nextResults));
@@ -289,6 +295,20 @@ function SearchPageInner() {
         if (pageGroups.length < searchedWorkspaces.length) {
           setError("Page search is unavailable for one or more workspaces.");
         }
+      }
+
+      if (includeTables && !selectedFolderId && !selectedPageId) {
+        const workspaceIds = new Set(searchedWorkspaces.map((item) => item.id));
+        const { tables } = await listAllTables();
+        nextResults.push(
+          ...searchTables(
+            tables.filter((table) => {
+              if (!table.workspace_id) return !selectedWorkspaceId;
+              return workspaceIds.has(table.workspace_id);
+            }),
+            q
+          )
+        );
       }
 
       setResults(sortResults(nextResults));
@@ -344,12 +364,12 @@ function SearchPageInner() {
             Search
           </p>
           <h1 className="mt-3 font-display text-[34px] font-bold tracking-tight text-foreground">
-            Search pages, sessions, and Cartridges.
+            Search pages, sessions, tables, and Cartridges.
           </h1>
           <p className="mt-2 max-w-[700px] text-[14.5px] leading-relaxed text-muted">
             Search one workspace, one Stash, a folder inside a workspace, or
             internal knowledge only. Stash results are published bundles created from
-            workspace pages and sessions.
+            workspace pages, tables, and sessions.
           </p>
         </header>
 
@@ -508,7 +528,7 @@ function SearchPageInner() {
             >
               <input
                 type="text"
-                placeholder="Search for a decision, transcript, Stash, or page..."
+                placeholder="Search for a decision, transcript, table, Stash, or page..."
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 className="min-w-0 flex-1 bg-transparent text-[15px] text-foreground placeholder:text-muted focus:outline-none"
@@ -745,6 +765,44 @@ function searchPages(
   );
 }
 
+function searchTables(tables: TableWithWorkspace[], query: string): SearchResult[] {
+  return tables
+    .map((table) => {
+      const relevance = scoreValues(query, [
+        { value: table.name, weight: 8 },
+        { value: table.description, weight: 3 },
+        { value: table.columns.map((column) => column.name).join(" "), weight: 2 },
+        { value: table.workspace_name ?? undefined, weight: 1 },
+      ]);
+      return { table, relevance };
+    })
+    .filter(({ relevance }) => relevance > 0)
+    .map(({ table, relevance }) => ({
+      id: table.id,
+      kind: "Table" as const,
+      title: table.name,
+      href: tableSearchHref(table),
+      sourceName: table.workspace_name ?? "Personal",
+      detail: tableSearchDetail(table),
+      updatedAt: table.updated_at,
+      relevance,
+    }));
+}
+
+function tableSearchHref(table: TableWithWorkspace): string {
+  if (!table.workspace_id) return `/tables/${table.id}`;
+  return `/tables/${table.id}?workspaceId=${table.workspace_id}`;
+}
+
+function tableSearchDetail(table: TableWithWorkspace): string {
+  if (table.description.trim()) return table.description;
+  const parts = [`${table.columns.length} column${table.columns.length === 1 ? "" : "s"}`];
+  if (typeof table.row_count === "number") {
+    parts.push(`${table.row_count} row${table.row_count === 1 ? "" : "s"}`);
+  }
+  return parts.join(" / ");
+}
+
 function descendantFolderIds(
   folders: WorkspaceFolder[],
   selectedFolderId: string
@@ -774,7 +832,7 @@ function descendantFolderIds(
 function searchPublicCartridgeItems(
   detail: PublicCartridgeDetail,
   query: string,
-  scope: { includePages: boolean; includeSessions: boolean }
+  scope: { includePages: boolean; includeSessions: boolean; includeTables: boolean }
 ): SearchResult[] {
   return detail.items.flatMap((item, index) => {
     if (item.object_type === "folder" && scope.includePages) {
@@ -785,6 +843,9 @@ function searchPublicCartridgeItems(
     }
     if (item.object_type === "session" && scope.includeSessions) {
       return searchPublicSession(detail, item, index, query);
+    }
+    if (item.object_type === "table" && scope.includeTables) {
+      return searchPublicTable(detail, item, index, query);
     }
     return [];
   });
@@ -911,6 +972,80 @@ function searchPublicSession(
       ]),
     },
   ];
+}
+
+type PublicTableColumn = { name?: string | null };
+type PublicTableRow = { data?: Record<string, unknown> | null };
+
+function searchPublicTable(
+  detail: PublicCartridgeDetail,
+  item: PublicCartridgeDetail["items"][number],
+  index: number,
+  query: string
+): SearchResult[] {
+  const inline = item.inline as {
+    description?: string | null;
+    columns?: PublicTableColumn[];
+    rows?: PublicTableRow[];
+  };
+  const columns = inline.columns ?? [];
+  const rows = inline.rows ?? [];
+  const columnText = columns.map((column) => column.name ?? "").join(" ");
+  const rowsText = rows.map(tableRowText).join(" ");
+  if (!textIncludes(query, item.label, inline.description, columnText, rowsText)) return [];
+
+  return [
+    {
+      id: item.object_id,
+      kind: "Table" as const,
+      title: item.label,
+      href: `/cartridges/${detail.cartridge.slug}#item-${index}`,
+      sourceName: detail.cartridge.title,
+      detail: publicTableSnippet(inline.description, columns, rows, query),
+      updatedAt: detail.cartridge.updated_at,
+      relevance: scoreValues(query, [
+        { value: item.label, weight: 8 },
+        { value: inline.description, weight: 3 },
+        { value: columnText, weight: 2 },
+        { value: rowsText, weight: 1 },
+        { value: detail.cartridge.title, weight: 1 },
+      ]),
+    },
+  ];
+}
+
+function publicTableSnippet(
+  description: string | null | undefined,
+  columns: PublicTableColumn[],
+  rows: PublicTableRow[],
+  query: string
+): string {
+  if (description?.trim()) return description.slice(0, 220);
+
+  const matchingRow = rows.find((row) => textIncludes(query, tableRowText(row)));
+  if (matchingRow) return tableRowText(matchingRow).slice(0, 220);
+
+  return `${columns.length} column${columns.length === 1 ? "" : "s"}, ${rows.length} row${
+    rows.length === 1 ? "" : "s"
+  }`;
+}
+
+function tableRowText(row: PublicTableRow): string {
+  return Object.values(row.data ?? {}).map(searchValueText).filter(Boolean).join(" ");
+}
+
+function searchValueText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return value.map(searchValueText).filter(Boolean).join(" ");
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>)
+      .map(searchValueText)
+      .filter(Boolean)
+      .join(" ");
+  }
+  return "";
 }
 
 function textIncludes(query: string, ...values: (string | null | undefined)[]): boolean {

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -6,9 +6,9 @@ import {
   getCachedWorkspaceSidebar,
   readCachedWorkspaceSidebar,
 } from "../lib/stashNavigationCache";
-import { semanticSearchPages } from "../lib/api";
+import { listAllTables, semanticSearchPages } from "../lib/api";
 
-const searchPlaceholder = "Search Stash or jump to a page, session, or file...";
+const searchPlaceholder = "Search Stash or jump to a page, session, file, or table...";
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),
@@ -48,6 +48,7 @@ vi.mock("../lib/stashNavigationCache", () => ({
 }));
 
 vi.mock("../lib/api", () => ({
+  listAllTables: vi.fn(),
   semanticSearchPages: vi.fn(),
 }));
 
@@ -91,6 +92,7 @@ describe("CommandPalette search", () => {
     vi.clearAllMocks();
     vi.mocked(readCachedWorkspaceSidebar).mockReturnValue(sidebar);
     vi.mocked(getCachedWorkspaceSidebar).mockResolvedValue(sidebar);
+    vi.mocked(listAllTables).mockResolvedValue({ tables: [] });
     vi.mocked(semanticSearchPages).mockResolvedValue([]);
   });
 
@@ -119,5 +121,38 @@ describe("CommandPalette search", () => {
     fireEvent.keyDown(window, { key: "Enter" });
 
     expect(router.push).toHaveBeenCalledWith("/workspaces/ws-1/p/page-1");
+  });
+
+  it("finds matching tables in the active workspace", async () => {
+    vi.mocked(listAllTables).mockResolvedValue({
+      tables: [
+        {
+          id: "table-1",
+          workspace_id: "ws-1",
+          workspace_name: "Demo Workspace",
+          name: "Hiring Outreach CRM",
+          description: "",
+          columns: [],
+          views: [],
+          created_by: "user-1",
+          updated_by: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+          row_count: 177,
+        },
+      ],
+    });
+    renderPalette();
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "hiring outreach" },
+    });
+
+    expect(await screen.findByText("Hiring Outreach CRM")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(router.push).toHaveBeenCalledWith("/tables/table-1?workspaceId=ws-1");
   });
 });

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { semanticSearchPages, type WorkspaceSidebar } from "../lib/api";
+import { listAllTables, semanticSearchPages, type WorkspaceSidebar } from "../lib/api";
 import {
   getCachedWorkspaceSidebar,
   readCachedWorkspaceSidebar,
 } from "../lib/stashNavigationCache";
+import type { TableWithWorkspace } from "../lib/types";
 import type { SearchScope } from "./AppShell";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 
@@ -20,7 +21,7 @@ interface CommandPaletteProps {
 }
 
 interface Result {
-  kind: "search" | "page" | "session" | "folder" | "file";
+  kind: "search" | "page" | "session" | "folder" | "file" | "table";
   label: string;
   href: string;
   detail?: string;
@@ -38,6 +39,7 @@ export default function CommandPalette({
   const [spine, setSpine] = useState<WorkspaceSidebar | null>(() =>
     workspaceId ? readCachedWorkspaceSidebar(workspaceId) : null
   );
+  const [tables, setTables] = useState<TableWithWorkspace[]>([]);
   const [results, setResults] = useState<Result[]>([]);
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -46,21 +48,35 @@ export default function CommandPalette({
 
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setQuery("");
     setResults([]);
     setSelected(0);
+    setTables([]);
     inputRef.current?.focus();
     const cached = workspaceId ? readCachedWorkspaceSidebar(workspaceId) : null;
     if (cached) {
       setSpine(cached);
-      return;
+    } else {
+      setSpine(null);
     }
-    setSpine(null);
-    if (workspaceId) {
+    if (workspaceId && !cached) {
       getCachedWorkspaceSidebar(workspaceId)
-        .then(setSpine)
+        .then((nextSpine) => {
+          if (!cancelled) setSpine(nextSpine);
+        })
         .catch(() => {});
     }
+    listAllTables()
+      .then((data) => {
+        if (!cancelled) setTables(data.tables);
+      })
+      .catch(() => {
+        if (!cancelled) setTables([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open, workspaceId]);
 
   useEffect(() => {
@@ -120,6 +136,16 @@ export default function CommandPalette({
           });
       });
     }
+    tables.forEach((table) => {
+      if (workspaceId && table.workspace_id !== workspaceId) return;
+      if (!tableMatchesQuery(table, q)) return;
+      local.push({
+        kind: "table",
+        label: table.name,
+        href: tableHref(table),
+        detail: tableDetail(table),
+      });
+    });
     setResults(local.slice(0, 12));
     setSelected(0);
 
@@ -143,7 +169,7 @@ export default function CommandPalette({
       }
     }, 250);
     return () => clearTimeout(timer);
-  }, [query, open, spine, workspaceId, workspaceName, searchScope]);
+  }, [query, open, spine, tables, workspaceId, workspaceName, searchScope]);
 
   useEffect(() => {
     if (!open) return;
@@ -171,6 +197,7 @@ export default function CommandPalette({
     session: "#",
     skill: "⚙︎",
     file: "📁",
+    table: "T",
   };
 
   return (
@@ -190,7 +217,7 @@ export default function CommandPalette({
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search Stash or jump to a page, session, or file..."
+            placeholder="Search Stash or jump to a page, session, file, or table..."
             className="min-w-0 flex-1 bg-transparent text-[14px] text-foreground placeholder:text-muted focus:outline-none"
             autoFocus
           />
@@ -267,4 +294,25 @@ function fullPageSearchResult(
     href: hrefParams ? `/search?${hrefParams}` : "/search",
     detail: scope?.detail ?? (workspaceId ? "Search this workspace" : "Search all workspaces"),
   };
+}
+
+function tableMatchesQuery(table: TableWithWorkspace, query: string): boolean {
+  const columns = table.columns.map((column) => column.name).join(" ");
+  return [table.name, table.description, columns].some((value) =>
+    value.toLowerCase().includes(query)
+  );
+}
+
+function tableHref(table: TableWithWorkspace): string {
+  if (!table.workspace_id) return `/tables/${table.id}`;
+  return `/tables/${table.id}?workspaceId=${table.workspace_id}`;
+}
+
+function tableDetail(table: TableWithWorkspace): string {
+  const parts = ["Table"];
+  if (typeof table.row_count === "number") {
+    parts.push(`${table.row_count} row${table.row_count === 1 ? "" : "s"}`);
+  }
+  if (table.workspace_name) parts.push(table.workspace_name);
+  return parts.join(" · ");
 }


### PR DESCRIPTION
## What changed
- Adds table results to the command palette so table names, descriptions, and columns can be matched and opened directly.
- Adds Tables as a full search content scope and returns table metadata matches on `/search`.
- Includes table items in Stash-scoped search when inline table content is available.

## Why
The search surfaces only aggregated pages, sessions, files/folders, and Stashes. Standalone tables such as “Hiring Outreach CRM” were not included in the searchable result set, so users could be sitting on a table page and still fail to find it from search.

## Screenshots
- Command palette table result: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/c3a3aabc-c3a2-4e7b-b07c-22b5c8b3facf
- Full search table result: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/f5e41acc-5290-4496-a2f2-0d6534fb46c3

## Validation
- `cd frontend && npm test -- --run src/components/CommandPalette.test.tsx`
- `cd frontend && npm run lint -- src/components/CommandPalette.tsx src/components/CommandPalette.test.tsx src/app/search/page.tsx`
- `cd frontend && BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- Manual screenshot pass against a temporary local DB on `localhost:3459`
