### PR TITLE
Finish Stash→Cartridge rename (preview internals) + docs cleanup

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -29,7 +29,7 @@
 <body>
 <div class="wrap">
   <h1>Stash — Architecture</h1>
-  <div class="sub">One place your agent connects to see all your company data. Input pipes (sources) → output pipes (CLI, MCP, API, UI). This documents the information hierarchy, sharing model, database schema, and API as of the Cartridges / user-scoped redesign.</div>
+  <div class="sub">One place your agent connects to see all your company data. Input pipes (sources) → output pipes (CLI, MCP, API, UI). This documents the information hierarchy, sharing model, database schema, API, and the surfaces / client support as of the Cartridges / user-scoped redesign.</div>
 
   <h2>1. Information hierarchy</h2>
   <p>Everything is scoped to a <b>user</b> (one implicit, private <b>workspace</b> per user — hidden from the UI; it remains the internal scoping key). Within it:</p>
@@ -37,13 +37,13 @@
 └─ workspace                         (implicit; hidden; the scoping key)
    ├─ Agents                         chat over all sources; primary use is via your own agent (CLI/MCP/API)
    ├─ Sources                        what the agent can read
-   │  ├─ Files          (native)     folders + pages + uploaded files
+   │  ├─ Files          (native)     folders + pages + uploaded files (Obsidian vault drops in here)
    │  ├─ Sessions       (native)     agent transcripts, grouped into session folders
    │  ├─ GitHub         (connected)  repos exposed as a filesystem
    │  ├─ Google Drive   (connected)  index only; document data fetched lazily
    │  ├─ Notion         (connected)  index only; page/db data fetched lazily
    │  ├─ Slack          (connected)  full copy via webhook
-   │  └─ Granola        (connected)  full copy via webhook/pull
+   │  └─ Granola        (connected)  full copy via scheduled pull (API key)
    └─ Cartridges                     read-only, disposable, curl-able bundles (PLG sharing)</div>
   <p class="note">Native sources are workspace-scoped (owned by the user). Connected sources are user-scoped (only their owner sees them). The file system is "just another source."</p>
 
@@ -94,6 +94,8 @@ else                                                         → denied</pre>
 list_source(source, path?)      navigate a source like a file system
 read_source(source, ref)        read one document (lazy-fetched for Drive/Notion)
 search(query, source?)          FTS + vector across sources, owner/share scoped</pre>
+  <h3>Multi-turn chat</h3>
+  <p>The same loop drives a <b>multi-turn agent chat</b> in the Agents tabs. A chat <i>is</i> a workspace Session: each turn is persisted as a history event (<code>ask_service.stream_chat</code>), so chats are reloadable and show up in Sessions alongside CLI transcripts. The frontend holds one <code>session_id</code> per tab.</p>
 
   <h2>5. Key API calls</h2>
   <table>
@@ -108,10 +110,34 @@ search(query, source?)          FTS + vector across sources, owner/share scoped<
     <tr><td><code>POST /api/v1/workspaces/{ws}/cartridges</code> · <code>/publish</code></td><td>Create / publish a cartridge bundle.</td></tr>
     <tr><td><code>GET /stashes/{slug}.md</code> · <code>.json</code></td><td>Agent-readable cartridge (curl without the CLI).</td></tr>
     <tr><td><code>POST /api/v1/workspaces/{ws}/ask</code></td><td>SSE stream — ask the agent across sources.</td></tr>
+    <tr><td><code>POST /api/v1/workspaces/{ws}/agent-chat</code> · <code>GET .../{session_id}</code></td><td>Multi-turn agent chat (SSE); reload a chat by session id. Each turn is stored as a Session history event.</td></tr>
   </table>
 
-  <h2>6. Status</h2>
-  <p><span class="ok">Shipped:</span> Cartridge rename; user-scoped UI (no workspace switcher/Members); the <code>shares</code> permission model + per-object/folder sharing, share-by-email with pending invites that convert on signup; session folders with a "By folder" view on the Sessions page; Agents view with the CLI/MCP/API install tab; per-integration source storage (copied content for GitHub/Slack/Granola, index-only + lazy read for Drive/Notion); cartridge snapshot-on-add for source content; cleanup of the legacy import UI.</p>
+  <h2>6. Surfaces &amp; client support</h2>
+  <p>Five ways data flows in and out. The product is deliberately client-agnostic: the same MCP tools + AGENTS.md context work in any agent, and <code>stash install</code> wires them up per client.</p>
+  <h3>The five surfaces</h3>
+  <table>
+    <tr><th>Surface</th><th>What it is</th><th>Auth</th><th>Primary user</th></tr>
+    <tr><td><b>MCP</b></td><td>70+ <code>stash_*</code> tools served by the CLI's MCP server (<code>cli/mcp_server.py</code>): <code>list_sources</code>, <code>browse_source</code>, <code>add_source</code>, <code>list_skills</code>, <code>read_skill</code>, pages, tables, cartridges…</td><td>CLI signin</td><td>agents, in any MCP client</td></tr>
+    <tr><td><b>CLI</b></td><td><code>stash</code> binary: <code>signin</code>, <code>install</code>, <code>hist import</code>, source/files/sessions/cartridges/tables verbs, hidden FUSE <code>mount</code> of the source VFS</td><td>device consent</td><td>setup, scripting, history import</td></tr>
+    <tr><td><b>REST API</b></td><td><code>/api/v1/…</code> — the same endpoints the UI uses</td><td>personal API key</td><td>direct programmatic access</td></tr>
+    <tr><td><b>UI</b></td><td>browser: Agents chat tabs, Files, Sessions, Cartridges</td><td>session login</td><td>humans</td></tr>
+    <tr><td><b>Plugins</b></td><td>per-client packages that wire MCP + AGENTS.md + hooks in one <code>stash install</code></td><td>inherits CLI signin</td><td>one-command setup inside a specific agent</td></tr>
+  </table>
+  <h3>Per-client integration</h3>
+  <p><code>stash install</code> autodetects which agents are present (<code>_SUPPORTED_AGENTS = claude, cursor, codex, opencode</code>) and writes a marker-fenced, idempotent block into each. Every client reaches the same MCP tools; they differ in how the plugin is wired and whether we can import their past transcripts as Sessions.</p>
+  <table>
+    <tr><th>Client</th><th>How the plugin installs</th><th>MCP</th><th>Context file</th><th>Hooks</th><th>Session import</th></tr>
+    <tr><td><b>Claude Code</b></td><td><code>claude plugin install stash@stash-plugins</code> (marketplace <code>Fergana-Labs/stash</code>)</td><td class="ok">yes</td><td><code>CLAUDE.md</code> block</td><td class="ok">yes</td><td class="ok">yes — <code>~/.claude/*.jsonl</code></td></tr>
+    <tr><td><b>Codex</b></td><td><code>~/.codex/config.toml</code> + <code>hooks.json</code> (prompts to allow bash network access)</td><td class="ok">yes</td><td><code>~/.codex/AGENTS.md</code></td><td class="ok">yes</td><td class="ok">yes — <code>~/.codex/sessions</code></td></tr>
+    <tr><td><b>Cursor</b></td><td><code>~/.cursor/hooks.json</code></td><td class="ok">yes</td><td>— (hooks only)</td><td class="ok">yes</td><td class="ok">yes — <code>cursorDiskKV</code> sqlite</td></tr>
+    <tr><td><b>OpenCode</b></td><td><code>~/.config/opencode/opencode.json</code> + <code>plugin.ts</code></td><td class="ok">yes</td><td>AGENTS.md</td><td>via <code>plugin.ts</code></td><td class="todo">not yet</td></tr>
+    <tr><td>Any other MCP client</td><td>manual MCP config</td><td class="ok">yes</td><td>—</td><td>—</td><td>—</td></tr>
+  </table>
+  <p class="note">Skills are themselves a portable plugin format: a Files folder whose immediate child is a <code>SKILL.md</code> (the same convention Claude Code uses) is exposed over MCP (<code>stash_list_skills</code>/<code>stash_read_skill</code>) and drops straight into any agent's <code>~/.claude/skills/</code>. AGENTS.md is the cross-tool context file — Codex, OpenCode, and Cursor read it the way Claude Code reads CLAUDE.md.</p>
+
+  <h2>7. Status</h2>
+  <p><span class="ok">Shipped:</span> Cartridge rename; user-scoped UI (no workspace switcher/Members); the <code>shares</code> permission model + per-object/folder sharing, share-by-email with pending invites that convert on signup; session folders with a "By folder" view on the Sessions page; Agents view with the CLI/MCP/API install tab; per-integration source storage (copied content for GitHub/Slack/Granola — Granola on its real key-based API, index-only + lazy read for Drive/Notion); cartridge snapshot-on-add for source content; Obsidian vault upload (lands in native Files); multi-turn agent chat stored as Sessions; the add-source modal + flat Sources sidebar; cleanup of the legacy import UI.</p>
 </div>
 </body>
 </html>

--- a/frontend/src/app/(app)/cartridges/[slug]/page.tsx
+++ b/frontend/src/app/(app)/cartridges/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { metadataForPublicStash } from "@/lib/stashMetadata";
+import { metadataForPublicCartridge } from "@/lib/cartridgeMetadata";
 
 import CartridgePageClient from "./CartridgePageClient";
 
@@ -10,7 +10,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const metadata = await metadataForPublicStash({
+  const metadata = await metadataForPublicCartridge({
     slug,
     path: `/cartridges/${slug}`,
   });

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/f/[fileId]/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 
 import {
   firstSearchParam,
-  metadataForPublicStashItem,
-} from "../../../../../../lib/stashMetadata";
+  metadataForPublicCartridgeItem,
+} from "../../../../../../lib/cartridgeMetadata";
 import FileClient from "./FileClient";
 
 type PageProps = {
@@ -19,7 +19,7 @@ export async function generateMetadata({
   const slug = firstSearchParam(query.stash);
   if (!slug) return { title: "File - Stash" };
 
-  return metadataForPublicStashItem({
+  return metadataForPublicCartridgeItem({
     slug,
     itemType: "file",
     itemId: fileId,

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/folders/[folderId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/folders/[folderId]/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import { FileBrowserSkeleton } from "../../../../../../components/SkeletonStates";
 import {
   firstSearchParam,
-  metadataForPublicStashItem,
-} from "../../../../../../lib/stashMetadata";
+  metadataForPublicCartridgeItem,
+} from "../../../../../../lib/cartridgeMetadata";
 import FolderClient from "./FolderClient";
 
 type PageProps = {
@@ -21,7 +21,7 @@ export async function generateMetadata({
   const slug = firstSearchParam(query.stash);
   if (!slug) return { title: "Folder - Stash" };
 
-  return metadataForPublicStashItem({
+  return metadataForPublicCartridgeItem({
     slug,
     itemType: "folder",
     itemId: folderId,

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import { DocumentPageSkeleton } from "../../../../../../components/SkeletonStates";
 import {
   firstSearchParam,
-  metadataForPublicStashItem,
-} from "../../../../../../lib/stashMetadata";
+  metadataForPublicCartridgeItem,
+} from "../../../../../../lib/cartridgeMetadata";
 import PageClient from "./PageClient";
 
 type PageProps = {
@@ -21,7 +21,7 @@ export async function generateMetadata({
   const slug = firstSearchParam(query.stash);
   if (!slug) return { title: "Page - Stash" };
 
-  return metadataForPublicStashItem({
+  return metadataForPublicCartridgeItem({
     slug,
     itemType: "page",
     itemId: pageId,

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import { SessionDetailSkeleton } from "../../../../../../components/SkeletonStates";
 import {
   firstSearchParam,
-  metadataForPublicStashItem,
-} from "../../../../../../lib/stashMetadata";
+  metadataForPublicCartridgeItem,
+} from "../../../../../../lib/cartridgeMetadata";
 import SessionClient from "./SessionClient";
 
 type PageProps = {
@@ -25,7 +25,7 @@ export async function generateMetadata({
   if (!slug) return { title: "Session - Stash" };
 
   const sessionId = decodeURIComponent(encodedSessionId);
-  return metadataForPublicStashItem({
+  return metadataForPublicCartridgeItem({
     slug,
     itemType: "session",
     itemId: sessionId,

--- a/frontend/src/app/api/og/cartridge/route.tsx
+++ b/frontend/src/app/api/og/cartridge/route.tsx
@@ -1,14 +1,14 @@
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 
-import { loadPublicStashPreview } from "@/lib/stashPreviewFetch";
+import { loadPublicCartridgePreview } from "@/lib/cartridgePreviewFetch";
 import {
   buildItemPreviewCard,
-  buildStashPreviewCard,
-  findStashItem,
-  isStashItemType,
+  buildCartridgePreviewCard,
+  findCartridgeItem,
+  isCartridgeItemType,
   type PreviewCard,
-} from "@/lib/stashPreview";
+} from "@/lib/cartridgePreview";
 
 export const dynamic = "force-dynamic";
 
@@ -16,14 +16,14 @@ export async function GET(request: NextRequest) {
   const slug = request.nextUrl.searchParams.get("slug") ?? "";
   if (!slug) return new Response("Missing slug", { status: 400 });
 
-  const data = await loadPublicStashPreview(slug);
+  const data = await loadPublicCartridgePreview(slug);
   if (!data) return new Response("Stash not found", { status: 404 });
 
   const itemType = request.nextUrl.searchParams.get("type");
   const itemId = request.nextUrl.searchParams.get("id");
   const item =
-    isStashItemType(itemType) && itemId ? findStashItem(data.items, itemType, itemId) : null;
-  const card = item ? buildItemPreviewCard(data, item) : buildStashPreviewCard(data);
+    isCartridgeItemType(itemType) && itemId ? findCartridgeItem(data.items, itemType, itemId) : null;
+  const card = item ? buildItemPreviewCard(data, item) : buildCartridgePreviewCard(data);
 
   return new ImageResponse(<PreviewImage card={card} />, {
     width: 1200,

--- a/frontend/src/app/tables/[tableId]/page.tsx
+++ b/frontend/src/app/tables/[tableId]/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 
 import {
   firstSearchParam,
-  metadataForPublicStashItem,
-} from "../../../lib/stashMetadata";
+  metadataForPublicCartridgeItem,
+} from "../../../lib/cartridgeMetadata";
 import TableClient from "./TableClient";
 
 type PageProps = {
@@ -24,7 +24,7 @@ export async function generateMetadata({
 
   const workspaceId = firstSearchParam(query.workspaceId);
   const workspacePart = workspaceId ? `&workspaceId=${encodeURIComponent(workspaceId)}` : "";
-  return metadataForPublicStashItem({
+  return metadataForPublicCartridgeItem({
     slug,
     itemType: "table",
     itemId: tableId,

--- a/frontend/src/lib/cartridgeMetadata.ts
+++ b/frontend/src/lib/cartridgeMetadata.ts
@@ -1,17 +1,17 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 
-import { loadPublicStashPreview } from "./stashPreviewFetch";
+import { loadPublicCartridgePreview } from "./cartridgePreviewFetch";
 import {
-  findStashItem,
-  isStashItemType,
+  findCartridgeItem,
+  isCartridgeItemType,
   itemMetadataDescription,
   itemMetadataTitle,
-  stashMetadataDescription,
-  stashMetadataTitle,
-  stashOgImagePath,
-  type StashItemType,
-} from "./stashPreview";
+  cartridgeMetadataDescription,
+  cartridgeMetadataTitle,
+  cartridgeOgImagePath,
+  type CartridgeItemType,
+} from "./cartridgePreview";
 
 type MetadataInput = {
   slug: string;
@@ -19,38 +19,38 @@ type MetadataInput = {
 };
 
 type ItemMetadataInput = MetadataInput & {
-  itemType: StashItemType;
+  itemType: CartridgeItemType;
   itemId: string;
 };
 
-export async function metadataForPublicStash({
+export async function metadataForPublicCartridge({
   slug,
   path,
 }: MetadataInput): Promise<Metadata> {
-  const data = await loadPublicStashPreview(slug);
+  const data = await loadPublicCartridgePreview(slug);
   if (!data) return { title: "Stash - Stash" };
 
-  const title = stashMetadataTitle(data);
-  const description = stashMetadataDescription(data);
+  const title = cartridgeMetadataTitle(data);
+  const description = cartridgeMetadataDescription(data);
   return metadataForPreview({
     title,
     description,
     path,
-    imagePath: stashOgImagePath(slug),
+    imagePath: cartridgeOgImagePath(slug),
   });
 }
 
-export async function metadataForPublicStashItem({
+export async function metadataForPublicCartridgeItem({
   slug,
   itemType,
   itemId,
   path,
 }: ItemMetadataInput): Promise<Metadata> {
-  const data = await loadPublicStashPreview(slug);
+  const data = await loadPublicCartridgePreview(slug);
   if (!data) return { title: "Stash - Stash" };
 
-  const item = findStashItem(data.items, itemType, itemId);
-  if (!item) return metadataForPublicStash({ slug, path: `/cartridges/${slug}` });
+  const item = findCartridgeItem(data.items, itemType, itemId);
+  if (!item) return metadataForPublicCartridge({ slug, path: `/cartridges/${slug}` });
 
   const title = itemMetadataTitle(data, item);
   const description = itemMetadataDescription(data, item);
@@ -58,7 +58,7 @@ export async function metadataForPublicStashItem({
     title,
     description,
     path,
-    imagePath: stashOgImagePath(slug, itemType, itemId),
+    imagePath: cartridgeOgImagePath(slug, itemType, itemId),
   });
 }
 
@@ -67,9 +67,9 @@ export function firstSearchParam(value: string | string[] | undefined): string {
   return value ?? "";
 }
 
-export function typedSearchParam(value: string | string[] | undefined): StashItemType | null {
+export function typedSearchParam(value: string | string[] | undefined): CartridgeItemType | null {
   const first = firstSearchParam(value);
-  return isStashItemType(first) ? first : null;
+  return isCartridgeItemType(first) ? first : null;
 }
 
 async function metadataForPreview({

--- a/frontend/src/lib/cartridgePreview.test.ts
+++ b/frontend/src/lib/cartridgePreview.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   buildItemPreviewCard,
-  buildStashPreviewCard,
-  findStashItem,
+  buildCartridgePreviewCard,
+  findCartridgeItem,
   itemMetadataDescription,
   itemMetadataTitle,
-  stashMetadataDescription,
-  stashMetadataTitle,
-  type StashPreviewData,
-} from "./stashPreview";
+  cartridgeMetadataDescription,
+  cartridgeMetadataTitle,
+  type CartridgePreviewData,
+} from "./cartridgePreview";
 
-function detail(): StashPreviewData {
+function detail(): CartridgePreviewData {
   return {
     cartridge: {
       id: "stash-1",
@@ -75,8 +75,8 @@ describe("stash preview metadata", () => {
   it("builds stash-level titles and descriptions from item counts", () => {
     const data = detail();
 
-    expect(stashMetadataTitle(data)).toBe("Launch Plan - Stash");
-    expect(stashMetadataDescription(data)).toBe(
+    expect(cartridgeMetadataTitle(data)).toBe("Launch Plan - Stash");
+    expect(cartridgeMetadataDescription(data)).toBe(
       "A Stash with 3 items: 1 page, 1 file, 1 session from Product.",
     );
   });
@@ -96,14 +96,14 @@ describe("stash preview metadata", () => {
   it("matches session routes by session_id", () => {
     const data = detail();
 
-    expect(findStashItem(data.items, "session", "agent-session-1")?.label).toBe(
+    expect(findCartridgeItem(data.items, "session", "agent-session-1")?.label).toBe(
       "Launch research",
     );
   });
 
   it("builds preview cards with content lines", () => {
     const data = detail();
-    const stashCard = buildStashPreviewCard(data);
+    const stashCard = buildCartridgePreviewCard(data);
     const itemCard = buildItemPreviewCard(data, data.items[0]);
 
     expect(stashCard.lines.map((line) => line.label)).toContain("Announcement Draft");

--- a/frontend/src/lib/cartridgePreview.ts
+++ b/frontend/src/lib/cartridgePreview.ts
@@ -1,14 +1,14 @@
-export type StashItemType = "folder" | "page" | "table" | "file" | "session";
+export type CartridgeItemType = "folder" | "page" | "table" | "file" | "session";
 
-export type StashPreviewItem = {
-  object_type: StashItemType;
+export type CartridgePreviewItem = {
+  object_type: CartridgeItemType;
   object_id: string;
   position: number;
   label: string;
   inline: Record<string, unknown>;
 };
 
-export type StashPreviewData = {
+export type CartridgePreviewData = {
   cartridge: {
     id: string;
     workspace_id: string;
@@ -21,7 +21,7 @@ export type StashPreviewData = {
     icon_url?: string | null;
   };
   workspace_name: string;
-  items: StashPreviewItem[];
+  items: CartridgePreviewItem[];
   can_write?: boolean;
 };
 
@@ -54,15 +54,15 @@ const ACCENTS = [
   { primary: "#0F766E", secondary: "#E11D48", wash: "#CCFBF1" },
 ];
 
-export function isStashItemType(value: string | null): value is StashItemType {
+export function isCartridgeItemType(value: string | null): value is CartridgeItemType {
   return !!value && ITEM_TYPES.has(value);
 }
 
-export function findStashItem(
-  items: StashPreviewItem[],
-  objectType: StashItemType,
+export function findCartridgeItem(
+  items: CartridgePreviewItem[],
+  objectType: CartridgeItemType,
   objectId: string,
-): StashPreviewItem | null {
+): CartridgePreviewItem | null {
   return (
     items.find((item) => {
       if (item.object_type !== objectType) return false;
@@ -74,11 +74,11 @@ export function findStashItem(
   );
 }
 
-export function stashMetadataTitle(data: StashPreviewData): string {
+export function cartridgeMetadataTitle(data: CartridgePreviewData): string {
   return `${data.cartridge.title} - Stash`;
 }
 
-export function stashMetadataDescription(data: StashPreviewData): string {
+export function cartridgeMetadataDescription(data: CartridgePreviewData): string {
   const description = cleanText(data.cartridge.description);
   if (description) return truncateText(description, 220);
 
@@ -90,25 +90,25 @@ export function stashMetadataDescription(data: StashPreviewData): string {
 }
 
 export function itemMetadataTitle(
-  data: StashPreviewData,
-  item: StashPreviewItem,
+  data: CartridgePreviewData,
+  item: CartridgePreviewItem,
 ): string {
   const label = item.label || formatItemType(item.object_type);
   return `${label} - ${data.cartridge.title} - Stash`;
 }
 
 export function itemMetadataDescription(
-  data: StashPreviewData,
-  item: StashPreviewItem,
+  data: CartridgePreviewData,
+  item: CartridgePreviewItem,
 ): string {
   const summary = itemSummary(item);
   const prefix = `${formatItemType(item.object_type)} in ${data.cartridge.title}`;
   return truncateText(summary ? `${prefix}: ${summary}` : prefix, 220);
 }
 
-export function stashOgImagePath(
+export function cartridgeOgImagePath(
   slug: string,
-  itemType?: StashItemType,
+  itemType?: CartridgeItemType,
   itemId?: string,
 ): string {
   const params = new URLSearchParams({ slug });
@@ -116,11 +116,11 @@ export function stashOgImagePath(
     params.set("type", itemType);
     params.set("id", itemId);
   }
-  return `/api/og/stash?${params.toString()}`;
+  return `/api/og/cartridge?${params.toString()}`;
 }
 
-export function buildStashPreviewCard(data: StashPreviewData): PreviewCard {
-  const description = stashMetadataDescription(data);
+export function buildCartridgePreviewCard(data: CartridgePreviewData): PreviewCard {
+  const description = cartridgeMetadataDescription(data);
   const stats = [
     data.workspace_name,
     ...itemTypeCounts(data.items).slice(0, 3),
@@ -137,8 +137,8 @@ export function buildStashPreviewCard(data: StashPreviewData): PreviewCard {
 }
 
 export function buildItemPreviewCard(
-  data: StashPreviewData,
-  item: StashPreviewItem,
+  data: CartridgePreviewData,
+  item: CartridgePreviewItem,
 ): PreviewCard {
   const label = item.label || formatItemType(item.object_type);
   return {
@@ -151,12 +151,12 @@ export function buildItemPreviewCard(
   };
 }
 
-export function formatItemType(type: StashItemType): string {
+export function formatItemType(type: CartridgeItemType): string {
   if (type === "session") return "Session";
   return type[0].toUpperCase() + type.slice(1);
 }
 
-export function itemPreviewLine(item: StashPreviewItem): PreviewLine {
+export function itemPreviewLine(item: CartridgePreviewItem): PreviewLine {
   return {
     label: item.label || formatItemType(item.object_type),
     meta: itemMeta(item),
@@ -164,7 +164,7 @@ export function itemPreviewLine(item: StashPreviewItem): PreviewLine {
   };
 }
 
-export function itemSummary(item: StashPreviewItem): string {
+export function itemSummary(item: CartridgePreviewItem): string {
   const inline = item.inline ?? {};
 
   if (item.object_type === "folder") {
@@ -214,7 +214,7 @@ export function itemSummary(item: StashPreviewItem): string {
   return item.label;
 }
 
-function itemPreviewLines(item: StashPreviewItem): PreviewLine[] {
+function itemPreviewLines(item: CartridgePreviewItem): PreviewLine[] {
   const inline = item.inline ?? {};
 
   if (item.object_type === "folder") {
@@ -293,7 +293,7 @@ function itemPreviewLines(item: StashPreviewItem): PreviewLine[] {
   return [itemPreviewLine(item)];
 }
 
-function itemMeta(item: StashPreviewItem): string {
+function itemMeta(item: CartridgePreviewItem): string {
   const inline = item.inline ?? {};
   if (item.object_type === "folder") {
     const pages = arrayValue(inline.pages).length;
@@ -354,8 +354,8 @@ function pageText(page: Record<string, unknown>): string {
   return stripHtml(stringValue(page.content_html));
 }
 
-function itemTypeCounts(items: StashPreviewItem[]): string[] {
-  const counts = new Map<StashItemType, number>();
+function itemTypeCounts(items: CartridgePreviewItem[]): string[] {
+  const counts = new Map<CartridgeItemType, number>();
   for (const item of items) {
     counts.set(item.object_type, (counts.get(item.object_type) ?? 0) + 1);
   }

--- a/frontend/src/lib/cartridgePreviewFetch.ts
+++ b/frontend/src/lib/cartridgePreviewFetch.ts
@@ -1,9 +1,9 @@
 import { SSR_BACKEND_ORIGIN as BACKEND_ORIGIN } from "@/lib/backendOrigin";
-import type { StashPreviewData } from "./stashPreview";
+import type { CartridgePreviewData } from "./cartridgePreview";
 
-export async function loadPublicStashPreview(
+export async function loadPublicCartridgePreview(
   slug: string,
-): Promise<StashPreviewData | null> {
+): Promise<CartridgePreviewData | null> {
   const res = await fetch(`${BACKEND_ORIGIN}/api/v1/cartridges/${encodeURIComponent(slug)}`, {
     cache: "no-store",
   });


### PR DESCRIPTION
Follow-up to #473. Two things:

**1. Full naming consistency.** The Slack-preview helpers that came from main's #481 kept the old "Stash" bundle naming after the reshape. Renames the bundle-concept identifiers to Cartridge so the codebase is internally consistent. The **brand** "Stash" stays (page title suffixes, `siteName`).
- `lib/stashMetadata.ts` → `cartridgeMetadata.ts` (`metadataForPublicStash[Item]` → `metadataForPublicCartridge[Item]`)
- `lib/stashPreview.ts` → `cartridgePreview.ts` (`StashPreviewData/Item`, `StashItemType`, `findStashItem`, `stashOgImagePath` → Cartridge*)
- `lib/stashPreviewFetch.ts` → `cartridgePreviewFetch.ts`
- `app/api/og/stash` → `app/api/og/cartridge`

Pure identifier/file rename — no behavior change.

**2. Docs.** Remove `docs/before-after.html`; keep + update `docs/architecture.html`.

## Verification
- `tsc --noEmit`: 0 errors
- ESLint: clean
- Vitest: 107/107
- No references to the old route/symbols anywhere outside the renamed files (checked backend, www, e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)