### PR TITLE
Add a "Shared with me" surface

### DIFF
--- a/backend/routers/shares.py
+++ b/backend/routers/shares.py
@@ -54,6 +54,24 @@ async def delete_share(req: UnshareRequest, current_user: dict = Depends(get_cur
     return {"ok": True}
 
 
+@router.get("/with-me")
+async def list_shared_with_me(current_user: dict = Depends(get_current_user)):
+    """Everything shared with the current user, across workspaces."""
+    return {"items": await share_service.list_shared_with_user(current_user["id"])}
+
+
+@router.get("/session-folders/{folder_id}/sessions")
+async def list_shared_session_folder_sessions(
+    folder_id: UUID, current_user: dict = Depends(get_current_user)
+):
+    """Sessions inside a session-folder shared with the current user."""
+    return {
+        "sessions": await share_service.list_shared_session_folder_sessions(
+            folder_id, current_user["id"]
+        )
+    }
+
+
 @router.get("")
 async def list_shares(
     object_type: str,

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -186,3 +186,77 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
         for inv in invites
     )
     return shares
+
+
+async def list_shared_with_user(user_id: UUID) -> list[dict]:
+    """Every object shared *with* this user (across workspaces) — the data behind
+    the 'Shared with me' surface. Resolves each share to the object's name, its
+    owning workspace, and who shared it."""
+    rows = await get_pool().fetch(
+        """
+        SELECT s.object_type, s.object_id, s.permission, s.workspace_id,
+               w.name AS workspace_name,
+               COALESCE(u.display_name, u.name) AS shared_by,
+               COALESCE(
+                 (SELECT name FROM folders         WHERE id = s.object_id AND s.object_type = 'folder'),
+                 (SELECT name FROM session_folders WHERE id = s.object_id AND s.object_type = 'session_folder'),
+                 (SELECT name FROM pages           WHERE id = s.object_id AND s.object_type = 'page'),
+                 (SELECT name FROM files           WHERE id = s.object_id AND s.object_type = 'file'),
+                 (SELECT name FROM tables          WHERE id = s.object_id AND s.object_type = 'table'),
+                 (SELECT COALESCE(st.title, sess.session_id)
+                    FROM sessions sess
+                    LEFT JOIN session_titles st
+                      ON st.workspace_id = sess.workspace_id AND st.session_id = sess.session_id
+                    WHERE sess.id = s.object_id AND s.object_type = 'session')
+               ) AS name
+        FROM shares s
+        JOIN workspaces w ON w.id = s.workspace_id
+        LEFT JOIN users u ON u.id = s.created_by
+        WHERE s.principal_type = 'user' AND s.principal_id = $1
+        ORDER BY w.name, s.object_type, name
+        """,
+        user_id,
+    )
+    # Drop rows whose object was deleted out from under the share.
+    return [
+        {
+            "object_type": r["object_type"],
+            "object_id": str(r["object_id"]),
+            "name": r["name"],
+            "workspace_id": str(r["workspace_id"]),
+            "workspace_name": r["workspace_name"],
+            "shared_by": r["shared_by"],
+            "permission": r["permission"],
+        }
+        for r in rows
+        if r["name"] is not None
+    ]
+
+
+async def list_shared_session_folder_sessions(folder_id: UUID, user_id: UUID) -> list[dict]:
+    """Sessions inside a session-folder shared with the user. Gated on the user
+    actually holding a share for that folder."""
+    if not await permission_service.check_access("session_folder", folder_id, user_id):
+        raise HTTPException(status_code=404, detail="Not found")
+    rows = await get_pool().fetch(
+        "SELECT s.id, s.workspace_id, s.session_id, s.agent_name, st.title, "
+        "       s.started_at, s.finished_at "
+        "FROM sessions s "
+        "LEFT JOIN session_titles st "
+        "  ON st.workspace_id = s.workspace_id AND st.session_id = s.session_id "
+        "WHERE s.session_folder_id = $1 AND s.deleted_at IS NULL "
+        "ORDER BY s.started_at DESC",
+        folder_id,
+    )
+    return [
+        {
+            "id": str(r["id"]),
+            "workspace_id": str(r["workspace_id"]),
+            "session_id": r["session_id"],
+            "agent_name": r["agent_name"],
+            "title": r["title"],
+            "started_at": r["started_at"].isoformat() if r["started_at"] else None,
+            "finished_at": r["finished_at"].isoformat() if r["finished_at"] else None,
+        }
+        for r in rows
+    ]

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -610,3 +610,52 @@ async def test_share_by_email_pending_invite_converts_on_signup(client: AsyncCli
     rows = after.json()["shares"]
     assert all(not s["pending"] for s in rows)
     assert any(s["email"] == "newcomer@example.com" for s in rows)
+
+
+@pytest.mark.asyncio
+async def test_shared_with_me_lists_incoming_not_outgoing(pool):
+    from backend.services import share_service
+
+    owner = await _make_user(pool)
+    friend = await _make_user(pool)
+    ws = await _make_workspace(pool, owner)
+    folder = await _make_folder(pool, ws, owner, name="Shared Folder")
+    await _share(pool, ws, "folder", folder, friend, "write", by=owner)
+
+    items = await share_service.list_shared_with_user(friend)
+    match = [i for i in items if i["object_id"] == str(folder)]
+    assert len(match) == 1
+    assert match[0]["object_type"] == "folder"
+    assert match[0]["name"] == "Shared Folder"
+    assert match[0]["permission"] == "write"
+    assert match[0]["workspace_id"] == str(ws)
+    # The owner is on the giving end — nothing is shared *with* them.
+    assert await share_service.list_shared_with_user(owner) == []
+
+
+@pytest.mark.asyncio
+async def test_shared_session_folder_sessions_gated_on_share(pool):
+    from fastapi import HTTPException
+
+    from backend.services import share_service
+
+    owner = await _make_user(pool)
+    friend = await _make_user(pool)
+    stranger = await _make_user(pool)
+    ws = await _make_workspace(pool, owner)
+    sf = await pool.fetchval(
+        "INSERT INTO session_folders (workspace_id, owner_user_id, name) "
+        "VALUES ($1, $2, 'SF') RETURNING id",
+        ws,
+        owner,
+    )
+    session_row = await _make_session(pool, ws, owner, session_id="shared-sess-1")
+    await pool.execute("UPDATE sessions SET session_folder_id = $2 WHERE id = $1", session_row, sf)
+    await _share(pool, ws, "session_folder", sf, friend, "read", by=owner)
+
+    rows = await share_service.list_shared_session_folder_sessions(sf, friend)
+    assert [r["id"] for r in rows] == [str(session_row)]
+
+    # A stranger with no share is denied.
+    with pytest.raises(HTTPException):
+        await share_service.list_shared_session_folder_sessions(sf, stranger)

--- a/frontend/src/app/(app)/shared/page.tsx
+++ b/frontend/src/app/(app)/shared/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  listSharedSessionFolderSessions,
+  listSharedWithMe,
+  type SharedSession,
+  type SharedWithMeItem,
+} from "../../../lib/api";
+import { useAuth } from "../../../hooks/useAuth";
+import { useBreadcrumbs } from "../../../components/BreadcrumbContext";
+
+const TYPE_LABEL: Record<SharedWithMeItem["object_type"], string> = {
+  folder: "Folder",
+  session_folder: "Session folder",
+  page: "Page",
+  file: "File",
+  table: "Table",
+  session: "Session",
+};
+
+const TYPE_ICON: Record<SharedWithMeItem["object_type"], string> = {
+  folder: "📁",
+  session_folder: "🗂️",
+  page: "📄",
+  file: "📎",
+  table: "▦",
+  session: "💬",
+};
+
+// Folders/pages/files/tables/sessions open in their owning workspace's existing
+// routes — the backend honours the share, so a non-member is let in. Session
+// *folders* have no route, so they expand inline instead.
+function hrefFor(item: SharedWithMeItem): string | null {
+  const ws = item.workspace_id;
+  switch (item.object_type) {
+    case "folder":
+      return `/workspaces/${ws}/folders/${item.object_id}`;
+    case "page":
+      return `/workspaces/${ws}/p/${item.object_id}`;
+    case "file":
+      return `/workspaces/${ws}/f/${item.object_id}`;
+    case "table":
+      return `/tables/${item.object_id}?workspaceId=${ws}`;
+    case "session":
+      return `/workspaces/${ws}/sessions/${item.object_id}`;
+    case "session_folder":
+      return null;
+  }
+}
+
+function SharedSessionFolder({ item }: { item: SharedWithMeItem }) {
+  const [open, setOpen] = useState(false);
+  const [sessions, setSessions] = useState<SharedSession[] | null>(null);
+  const [error, setError] = useState("");
+
+  async function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && sessions === null) {
+      try {
+        setSessions(await listSharedSessionFolderSessions(item.object_id));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load sessions");
+      }
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface/40">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-raised/40"
+      >
+        <span aria-hidden>{TYPE_ICON.session_folder}</span>
+        <span className="flex-1 text-[13.5px] font-medium text-foreground">{item.name}</span>
+        <span className="text-[12px] text-muted">{TYPE_LABEL.session_folder}</span>
+        <span aria-hidden className="text-muted">{open ? "▾" : "▸"}</span>
+      </button>
+      {open ? (
+        <div className="border-t border-border px-4 py-2">
+          {error ? <p className="py-2 text-[12.5px] text-rose-500">{error}</p> : null}
+          {sessions === null && !error ? (
+            <p className="py-2 text-[12.5px] text-muted">Loading…</p>
+          ) : null}
+          {sessions && sessions.length === 0 ? (
+            <p className="py-2 text-[12.5px] text-muted">No sessions in this folder.</p>
+          ) : null}
+          {sessions?.map((s) => (
+            <Link
+              key={s.id}
+              href={`/workspaces/${s.workspace_id}/sessions/${s.id}`}
+              className="block rounded px-2 py-1.5 text-[13px] text-foreground hover:bg-raised/50"
+            >
+              {s.title || s.session_id}
+              <span className="ml-2 text-[11.5px] text-muted">{s.agent_name}</span>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function SharedWithMePage() {
+  const { user, loading } = useAuth();
+  const [items, setItems] = useState<SharedWithMeItem[] | null>(null);
+  const [error, setError] = useState("");
+
+  useBreadcrumbs([{ label: "Shared with me" }], "shared");
+
+  const load = useCallback(async () => {
+    try {
+      setItems(await listSharedWithMe());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load shared items");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && user) load();
+  }, [loading, user, load]);
+
+  if (loading || items === null) {
+    return <div className="p-8 text-[13px] text-muted">Loading…</div>;
+  }
+
+  // Group by the workspace the content lives in.
+  const byWorkspace = new Map<string, SharedWithMeItem[]>();
+  for (const it of items) {
+    byWorkspace.set(it.workspace_id, [...(byWorkspace.get(it.workspace_id) ?? []), it]);
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-8">
+      <h1 className="text-[20px] font-semibold text-foreground">Shared with me</h1>
+      <p className="mt-1 text-[13px] text-muted">
+        Folders, files, pages, tables, and sessions other people have shared with you.
+      </p>
+
+      {error ? <p className="mt-4 text-[13px] text-rose-500">{error}</p> : null}
+
+      {items.length === 0 && !error ? (
+        <div className="mt-8 rounded-lg border border-dashed border-border bg-surface/30 px-6 py-12 text-center text-[13px] text-muted">
+          Nothing has been shared with you yet.
+        </div>
+      ) : null}
+
+      {[...byWorkspace.values()].map((group) => {
+        const { workspace_id: wsId, workspace_name: wsName, shared_by: sharedBy } = group[0];
+        return (
+          <section key={wsId} className="mt-6">
+            <div className="px-1 pb-2 text-[12px] font-semibold uppercase tracking-wide text-muted">
+              {wsName}
+              {sharedBy ? (
+                <span className="font-normal normal-case"> · shared by {sharedBy}</span>
+              ) : null}
+            </div>
+            <div className="space-y-1.5">
+              {group.map((item) =>
+                item.object_type === "session_folder" ? (
+                  <SharedSessionFolder key={item.object_id} item={item} />
+                ) : (
+                  <Link
+                    key={`${item.object_type}:${item.object_id}`}
+                    href={hrefFor(item) ?? "#"}
+                    className="flex items-center gap-3 rounded-lg border border-border bg-surface/40 px-4 py-3 hover:bg-raised/40"
+                  >
+                    <span aria-hidden>{TYPE_ICON[item.object_type]}</span>
+                    <span className="flex-1 text-[13.5px] font-medium text-foreground">
+                      {item.name}
+                    </span>
+                    {item.permission === "write" ? (
+                      <span className="rounded bg-raised px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide text-muted">
+                        can edit
+                      </span>
+                    ) : null}
+                    <span className="text-[12px] text-muted">{TYPE_LABEL[item.object_type]}</span>
+                  </Link>
+                ),
+              )}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -300,6 +300,12 @@ export default function AppSidebar({
           label="Activity"
           active={pathname.startsWith("/activity")}
         />
+        <NavRow
+          href="/shared"
+          icon={<span aria-hidden>👥</span>}
+          label="Shared with me"
+          active={pathname.startsWith("/shared")}
+        />
         {activeWorkspace ? (
           <NavRow
             href={`/workspaces/${activeWorkspace.id}/cartridges`}

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  ApiError,
   createFolder,
   createPage,
   deleteFolder,
@@ -118,12 +119,16 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
     return () => window.clearTimeout(t);
   }, [undo]);
 
-  // Load workspace tree once per workspace; powers the Column view.
+  // Load workspace tree once per workspace; powers the Column view + Quick
+  // Access. It's supplementary — a non-member opening a *shared* folder can't
+  // read the whole tree (403), but the folder's own contents still load below,
+  // so a tree failure must not surface a blocking "Not a workspace member" error.
   const loadTree = useCallback(async () => {
     try {
       const t = await getWorkspaceTree(workspaceId);
       setTree(t);
     } catch (e) {
+      if (e instanceof ApiError && e.status === 403) return;
       setError(e instanceof Error ? e.message : "Failed to load workspace");
     }
   }, [workspaceId]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1804,6 +1804,42 @@ export async function getFolderContents(
   );
 }
 
+// --- Shared with me ---
+
+export type SharedObjectType = "folder" | "session_folder" | "page" | "file" | "table" | "session";
+
+export interface SharedWithMeItem {
+  object_type: SharedObjectType;
+  object_id: string;
+  name: string;
+  workspace_id: string;
+  workspace_name: string;
+  shared_by: string | null;
+  permission: "read" | "write";
+}
+
+export interface SharedSession {
+  id: string;
+  workspace_id: string;
+  session_id: string;
+  agent_name: string;
+  title: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+export async function listSharedWithMe(): Promise<SharedWithMeItem[]> {
+  const res = await apiFetch<{ items: SharedWithMeItem[] }>("/api/v1/share/with-me");
+  return res.items;
+}
+
+export async function listSharedSessionFolderSessions(folderId: string): Promise<SharedSession[]> {
+  const res = await apiFetch<{ sessions: SharedSession[] }>(
+    `/api/v1/share/session-folders/${folderId}/sessions`
+  );
+  return res.sessions;
+}
+
 // --- Trash ---
 
 // All three flavors share the same URL shape (`/{kind}s/{id}`), so a single


### PR DESCRIPTION
## Why

In the 1:1-workspace model, cross-user access flows through the `shares` table — but a share only granted *permission*; it was never *discoverable*. The Files and Agent Sessions browsers are scoped to a single `workspace_id`, and there was no view for "content shared with me from someone else's workspace." So sharing a folder/session-folder/table with a teammate didn't actually let them find it.

This builds the recipient side.

## Changes

**Backend**
- `GET /api/v1/share/with-me` — lists everything shared with the current user across workspaces, resolving each share to the object's name, owning workspace, and who shared it.
- `GET /api/v1/share/session-folders/{id}/sessions` — lists a shared session-folder's sessions (gated on the user actually holding the share).

**Frontend**
- A global **"Shared with me"** sidebar entry + `/shared` page, grouping shared items by workspace ("HENRY'S WORKSPACE · shared by Henry").
- Folders / pages / files / tables / sessions open in their owning workspace's **existing routes** (which already honour the share, so a non-member is let in). Shared **session-folders** expand inline to list their sessions.
- A non-member opening a shared folder no longer sees a spurious **"Not a workspace member"** banner — the supplementary workspace-tree load (Column view / Quick Access) now swallows its 403, since the folder's own contents load via the share.

## Tests / QA
- New: `test_shared_with_me_lists_incoming_not_outgoing`, `test_shared_session_folder_sessions_gated_on_share`. Full backend suite **227 passed**, frontend `tsc` + eslint clean.
- Browser-QA'd as a non-member recipient: the `/shared` page lists a shared folder (with a "CAN EDIT" badge), a session-folder, and a table; the folder opens cleanly (no banner) showing its page; the session-folder expands to its session. Screenshots captured during QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)