### PR TITLE
UI debrief: terminology, chrome cleanup, wider chat (batch 1)

### DIFF
--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -87,10 +87,9 @@ async def get_or_create_user_from_auth0(
     user = dict(row)
     api_key = await create_api_key(user["id"], name=key_name)
 
-    suffix = "'s Workspace"
-    ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"
+    # Named "Stash" — we don't surface "workspace" terminology in the product.
     await workspace_service.create_workspace(
-        name=ws_name,
+        name="Stash",
         description="",
         creator_id=user["id"],
     )

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -34,14 +34,12 @@ async def register_user(
     user = dict(row)
     api_key = await create_api_key(user["id"], name="password register")
 
-    # Auto-provision a default workspace for new users.
-    # workspaces.name is VARCHAR(128); trim the display so the suffix always fits.
+    # Auto-provision a default space for new users. Named "Stash" — we don't
+    # surface "workspace" terminology in the product anymore.
     from . import workspace_service
 
-    suffix = "'s Workspace"
-    ws_name = f"{user['display_name'][: 128 - len(suffix)]}{suffix}"
     await workspace_service.create_workspace(
-        name=ws_name,
+        name="Stash",
         description="",
         creator_id=user["id"],
         is_primary=True,

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -76,7 +76,7 @@ async def test_registration_auto_provisions_default_workspace(client: AsyncClien
     assert resp.status_code == 200
     workspaces = resp.json()["workspaces"]
     assert len(workspaces) == 1
-    assert workspaces[0]["name"] == f"{body['display_name']}'s Workspace"
+    assert workspaces[0]["name"] == "Stash"
     assert workspaces[0]["member_count"] == 1
 
 

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -167,8 +167,29 @@ function Code({ children }: { children: string }) {
 function ConnectGuide() {
   return (
     <div className="rounded-xl border border-border bg-base p-5">
+      <div className="mb-5 rounded-lg border border-border bg-surface/60 p-4 text-[13px] text-dim">
+        <div className="text-[13.5px] font-semibold text-foreground">What this sets up</div>
+        <p className="mt-1.5">
+          Installing the CLI adds a small <strong>plugin with hooks</strong> to your coding agent
+          (Claude Code, Codex, and friends). It works in two directions:
+        </p>
+        <ul className="mt-2 list-disc space-y-1.5 pl-5">
+          <li>
+            <strong>Push (hooks)</strong> — as your agent runs, the hooks automatically stream each
+            session&rsquo;s transcript, the files it touches, and the artifacts it produces into your
+            Stash. Nothing to remember to save; your history lands in{" "}
+            <strong>Agent Sessions</strong> on its own.
+          </li>
+          <li>
+            <strong>Pull (search &amp; query)</strong> — everything in your Stash (sessions, files,
+            pages, tables, connected sources) is indexed, so your agent can search it and answer
+            questions grounded on your own work.
+          </li>
+        </ul>
+      </div>
       <Step n={1} title="Install the Stash CLI">
-        The CLI is the preferred way for your agent to reach Stash.
+        The CLI is the preferred way for your agent to reach Stash — it installs the plugin and hooks
+        above.
         <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
       </Step>
       <Step n={2} title="Sign in">

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -75,7 +75,13 @@ export default function AgentsPage() {
 
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
-      <div className="mx-auto w-full max-w-3xl px-8 py-8">
+      <div
+        className={
+          // Chats want room to breathe (ChatGPT-style); the Connect guide reads
+          // better narrow.
+          "mx-auto w-full px-8 py-8 " + (active === "connect" ? "max-w-3xl" : "max-w-5xl")
+        }
+      >
         <div className="flex items-center gap-1 border-b border-border">
           <button
             type="button"

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -76,12 +76,7 @@ export default function AgentsPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-8 py-8">
-        <h1 className="font-display text-[26px] font-bold tracking-tight text-foreground">Agents</h1>
-        <p className="mt-1 text-[13px] text-muted">
-          Use Stash through your own agent. Connect once, then ask it anything about your company data.
-        </p>
-
-        <div className="mt-5 flex items-center gap-1 border-b border-border">
+        <div className="flex items-center gap-1 border-b border-border">
           <button
             type="button"
             onClick={() => setActive("connect")}

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
@@ -163,9 +163,8 @@ export default function WorkspaceStashesPage() {
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-[1120px] px-12 pb-20 pt-8">
         <div className="flex items-center justify-between gap-4">
-          <h1 className="m-0 font-display text-[34px] font-bold tracking-[-0.02em]">
-            Cartridges
-          </h1>
+          {/* Breadcrumb + sidebar already say "Cartridges"; no redundant title. */}
+          <div />
           <button
             type="button"
             onClick={() => shareModal.open({ workspaceId })}

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
@@ -128,7 +128,6 @@ export default function CartridgeSessionsPage() {
   if (!user) return null;
   if (sorted === null) return <SessionsListSkeleton />;
 
-  const total = sessions?.length ?? 0;
   const pinnedSessions = (sorted ?? []).filter((s) =>
     pins.pinnedSet.has(s.session_id),
   );
@@ -197,15 +196,6 @@ export default function CartridgeSessionsPage() {
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-12 py-8">
-        <div className="flex items-baseline justify-between gap-4">
-          <h1 className="font-display text-[28px] font-bold tracking-tight text-foreground">
-            Sessions
-          </h1>
-          <span className="sys-label" style={{ fontSize: 10.5 }}>
-            {total} total
-          </span>
-        </div>
-
         {error && (
           <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
             {error}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -47,7 +47,7 @@ export default function SettingsPage() {
           <div>
             <h1 className="text-2xl font-semibold text-foreground">Settings</h1>
             <p className="text-sm text-muted mt-1">
-              Your profile and workspace, connected sources, sessions, and password.
+              Your profile, branding, connected sources, sessions, and password.
             </p>
           </div>
           <Profile user={user} onUpdated={refresh} />

--- a/frontend/src/components/settings/WorkspaceSection.tsx
+++ b/frontend/src/components/settings/WorkspaceSection.tsx
@@ -70,14 +70,14 @@ export default function WorkspaceSection() {
     <>
       <section className="rounded-2xl border border-border bg-surface p-6 space-y-4">
         <div>
-          <h2 className="text-base font-semibold text-foreground">Workspace</h2>
+          <h2 className="text-base font-semibold text-foreground">General</h2>
           <p className="text-xs text-muted mt-0.5">
             Branding for <span className="font-medium text-foreground">{workspace.name}</span>.
           </p>
         </div>
         <ImageField
           label="Banner"
-          sub="Wide image rendered above the workspace header."
+          sub="Wide image rendered above the header."
           url={workspace.cover_image_url ?? null}
           onUpload={(f) => uploadAndSet(f, "cover_image_url")}
           onClear={() => clearField("cover_image_url")}
@@ -85,7 +85,7 @@ export default function WorkspaceSection() {
         />
         <ImageField
           label="Icon"
-          sub="Square logo for the workspace hero."
+          sub="Square logo for the hero."
           url={workspace.icon_url ?? null}
           onUpload={(f) => uploadAndSet(f, "icon_url")}
           onClear={() => clearField("icon_url")}
@@ -125,7 +125,7 @@ export default function WorkspaceSection() {
         <div>
           <h2 className="text-base font-semibold text-foreground">Danger zone</h2>
           <p className="text-xs text-muted mt-0.5">
-            Deleting a workspace removes its pages, sessions, tables, and files. This cannot be
+            Deleting this removes its pages, sessions, tables, and files. This cannot be
             undone.
           </p>
         </div>

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -556,9 +556,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
               />
             </h1>
           ) : (
-            <h1 className="m-0 font-display text-[28px] font-bold tracking-tight text-foreground">
-              Files
-            </h1>
+            // Root: the breadcrumb + sidebar already say "Files"; no redundant title.
+            <div />
           )}
           <div className="flex flex-wrap items-center gap-2">
             <ViewToggle view={view} onChange={setViewPersisted} />

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -20,7 +20,7 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
   const parts: string[] = [];
 
   parts.push(
-    `<h1>Welcome to your workspace, ${escapeHtml(displayName)}</h1>`,
+    `<h1>Welcome to Stash, ${escapeHtml(displayName)}</h1>`,
   );
   parts.push(
     `<p><em>This is your About page. It&rsquo;s editable like any other doc — keep what&rsquo;s useful, delete the rest.</em></p>`,
@@ -40,11 +40,11 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
   parts.push(
     `<ul>
       <li><strong><a href="/settings/integrations">Connect a data source</a></strong> — GitHub, Google Drive, Notion, Slack, Granola. Your agent reads across everything you connect.</li>
-      <li><strong><a href="/discover">Discover &amp; install Cartridges</a></strong> — browse skills and knowledge others have published; copy into this workspace.</li>
-      <li><strong>Invite a teammate to this workspace</strong>${
+      <li><strong><a href="/discover">Discover &amp; install Cartridges</a></strong> — browse skills and knowledge others have published; add them to your Stash.</li>
+      <li><strong>Invite a teammate</strong>${
         inviteLink
           ? ` — share <a href="${escapeAttr(inviteLink)}">${escapeHtml(inviteLink)}</a>.`
-          : ` from workspace settings.`
+          : ` from settings.`
       }</li>
       <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>pip install stashai</code></li>
     </ul>`,

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -52,11 +52,16 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
 
   parts.push(`<h2>How Stash works</h2>`);
   parts.push(
-    `<p>Everything is organized within a <strong>Workspace</strong>. This is a shared hopper for everything agents produce or consume: session transcripts, HTML pages, markdown docs, images, tables, raw files. Structured or not. Within it, there are three main structures:</p>
+    `<p>Stash is built around <strong>sources</strong> your agents read and write, <strong>cartridges</strong> you share on top of them, and the <strong>agents</strong> you talk to over all of it.</p>
     <ul>
-      <li><strong>Cartridges</strong> — virtual sub-workspaces. Bundle any subset of workspace data into a Cartridge; share to the public or make it private to everyone else in the workspace. This becomes the go-to point for teams, workstreams, or projects (e.g. LinkedIn marketing, Backend infra team, Kernel optimization reading group).</li>
-      <li><strong>Files</strong> — a file system for documents (e.g. markdown, HTML, images, PDF, CSV). Built so agents can natively use it.</li>
-      <li><strong>Sessions</strong> — history of conversations between users and agents. Automatically pushed from your agent of choice (e.g. Claude Code, Codex, Openclaw).</li>
+      <li><strong>Sources</strong> — everything your agents produce or consume, all searchable:
+        <ul>
+          <li><strong>Agent Sessions</strong> — the history of your agent conversations, automatically pushed in from Claude Code, Codex, and friends.</li>
+          <li><strong>Files</strong> — a file system for documents (markdown, HTML, images, PDF, CSV, tables), plus connected sources like Notion, Google Drive, Slack, and GitHub. Built so agents can use it natively.</li>
+        </ul>
+      </li>
+      <li><strong>Cartridges</strong> — curated bundles you share on top of your sources: pick any subset and publish it, or share it with specific people. The go-to surface for a team, workstream, or project.</li>
+      <li><strong>Agents</strong> — talk to an agent grounded on everything above: search it, ask about it, and let your coding agents work against it.</li>
     </ul>`,
   );
 


### PR DESCRIPTION
First batch from the "Refactor stash app UI" debrief. Each item is its own commit.

## Done in this PR
- **Onboarding copy** — "Welcome to Stash" (not "…your workspace"); dropped "workspace" wording.
- **How Stash works** — reframed the intro around **Sources** (Agent Sessions + Files) / **Cartridges** / **Agents**.
- **Default space name** — new users get a space named **"Stash"**, not "X's Workspace" (both signup paths).
- **Settings** — removed user-facing "workspace" terminology.
- **Agents page** — dropped the "Agents" header + "use Stash through your own agent" subtitle; leads with the tabs.
- **Removed redundant page titles** on Sessions / Files / Cartridges (breadcrumb + sidebar already name them).
- **Wider chat** — the Agents chat session is now ChatGPT-width; the Connect guide stays narrow.

tsc + eslint + ruff clean.

## Already in place (verified, not changed here)
- **Shared folders visible to Sam** — shipped in #494/#495 and live; Files has a "Shared with me" section and Agent Sessions shows shared session-folder vaults.
- **Open chat tabs persist** — the Agents page already persists tabs to localStorage and treats each chat as a stored Session.

## Still outstanding (bigger, separate PRs)
- **Agents page detail** — explain the plugin/hooks: what data is pushed, that it's queryable/searchable, the auto-push hooks.
- **Glyph/icon inconsistency** when clicking Sessions/Pages/Cartridges — needs a repro + fix.
- **Activity redesign** + move the git-commit-graph & embedding-space **visualizations into Activity**.
- **Combine Discover + Cartridges** into one sharing/discovery surface (IA change).
- **Chat → Agent Sessions auto-push + resume** for web/local agents (backend + frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)