### PR TITLE
Resume in-app chats from Agent Sessions

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
 
 import ChatPanel from "../../../../../components/agents/ChatPanel";
 
@@ -17,32 +17,62 @@ function tabsKey(workspaceId: string): string {
 }
 
 export default function AgentsPage() {
+  return (
+    <Suspense fallback={null}>
+      <AgentsPageInner />
+    </Suspense>
+  );
+}
+
+function AgentsPageInner() {
   const params = useParams();
   const workspaceId = params.workspaceId as string;
 
+  const searchParams = useSearchParams();
   const [chats, setChats] = useState<ChatTab[]>([]);
   const [nextId, setNextId] = useState(1);
   const [active, setActive] = useState<"connect" | number>("connect");
   const restored = useRef(false);
+  // Resume a specific chat from a `?resume=<sessionId>` link (e.g. from the
+  // Agent Sessions list).
 
-  // Restore open tabs (+ their session ids) for this workspace.
+  // Restore open tabs (+ their session ids) for this workspace, then apply any
+  // `?resume=<sessionId>` in one pass so a resume can't race the restore into a
+  // duplicate tab.
   useEffect(() => {
     if (restored.current) return;
     restored.current = true;
+    let chats: ChatTab[] = [];
+    let next = 1;
+    let active: "connect" | number = "connect";
     try {
       const raw = window.localStorage.getItem(tabsKey(workspaceId));
       if (raw) {
         const p = JSON.parse(raw) as PersistedTabs;
         if (Array.isArray(p.chats)) {
-          setChats(p.chats);
-          setNextId(p.nextId ?? p.chats.length + 1);
-          setActive(p.active ?? "connect");
+          chats = p.chats;
+          next = p.nextId ?? p.chats.length + 1;
+          active = p.active ?? "connect";
         }
       }
     } catch {
       /* ignore malformed cache */
     }
-  }, [workspaceId]);
+    const resume = searchParams.get("resume");
+    if (resume) {
+      const existing = chats.find((t) => t.sessionId === resume);
+      if (existing) {
+        active = existing.id;
+      } else {
+        chats = [...chats, { id: next, sessionId: resume, title: "Chat" }];
+        active = next;
+        next += 1;
+      }
+    }
+    setChats(chats);
+    setNextId(next);
+    setActive(active);
+  }, [workspaceId, searchParams]);
 
   // Persist whenever tabs change (after the initial restore).
   useEffect(() => {

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/[sessionId]/SessionClient.tsx
@@ -259,6 +259,16 @@ export default function SessionViewerPage() {
               )}
             </div>
             <div className="flex flex-shrink-0 items-center gap-1.5">
+              {sessionId.startsWith("agent-") && (
+                // Web chats (started in the Agents tab) can be resumed and
+                // continued server-side from where they left off.
+                <Link
+                  href={`/workspaces/${workspaceId}/agents?resume=${encodeURIComponent(sessionId)}`}
+                  className="inline-flex items-center gap-1 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+                >
+                  Resume in chat →
+                </Link>
+              )}
               <DownloadMenu
                 options={[
                   {


### PR DESCRIPTION
Debrief items 7–8 (resume design: "continue the in-app chat server-side").

## Background
In-app chats already persist: `stream_chat` writes each turn via `push_event`, which `upsert_session`s a real `sessions` row + `history_events`. So chats already (a) show up in **Agent Sessions** and (b) reopen with full history when a tab is restored — continuing server-side.

## What this adds
The missing **entry point to resume from Agent Sessions**:
- A **"Resume in chat →"** button on web-chat session pages (`session_id` starts with `agent-`).
- The Agents page now honours `?resume=<sessionId>`: it opens (or focuses) a chat tab for that session, folded into the restore pass so it can't race into a duplicate tab.

Clicking Resume → `/agents?resume=<id>` → the chat tab loads history via the existing `getAgentChat` and you keep talking to the same server-side agent.

## QA
- Verified end-to-end on a seeded chat: the history endpoint returns the prior turns; the session page shows "Resume in chat"; clicking it opens a single Chat tab with the conversation loaded.
- tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)