### PR TITLE
Fix spurious 'Not a workspace member' banner on shared pages

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -590,7 +590,6 @@ async def list_comment_threads(
     page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     threads = await comment_service.list_threads(page_id)
@@ -609,7 +608,6 @@ async def create_comment_thread(
     current_user: dict = Depends(get_current_user),
 ):
     # Comments are read-level permission — any workspace member can comment.
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     thread = await comment_service.create_thread(
@@ -635,7 +633,6 @@ async def reply_to_thread(
     req: CommentReplyRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     thread = await comment_service.add_reply(thread_id, body=req.body, author_id=current_user["id"])
@@ -655,7 +652,6 @@ async def update_thread_resolved(
     req: CommentResolveRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     thread = await comment_service.set_resolved(
@@ -677,7 +673,6 @@ async def delete_comment_thread(
     current_user: dict = Depends(get_current_user),
 ):
     """Delete an entire thread. Only the thread creator is allowed."""
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     result = await comment_service.delete_thread(thread_id, user_id=current_user["id"])
@@ -701,7 +696,6 @@ async def delete_comment_message(
     response body's `thread` field is null — the frontend should then
     strip the inline anchor from the page content.
     """
-    await _check_ws_access(workspace_id, current_user["id"])
     await _check_content_access("page", page_id, workspace_id, current_user["id"])
     await _check_page_in_workspace(workspace_id, page_id)
     status, thread = await comment_service.delete_message(message_id, user_id=current_user["id"])

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
@@ -184,18 +184,9 @@ export default function StashPageView() {
   }, [stashSlug, pageId]);
 
   const load = useCallback(async () => {
+    let p;
     try {
-      const p = await getPage(workspaceId, pageId);
-      setPage(p);
-      setStashFallback(null);
-      setContainingStashes(await listObjectStashes(workspaceId, "page", pageId));
-      if (p.folder_id) {
-        const contents = await getFolderContents(workspaceId, p.folder_id);
-        setFolderChain(contents.breadcrumbs);
-      } else {
-        setFolderChain([]);
-      }
-      await refreshThreads();
+      p = await getPage(workspaceId, pageId);
     } catch (e) {
       // Non-members of the workspace fall back to the stash payload when
       // a ?stash=<slug> hint is present. The stash's readability check is
@@ -208,7 +199,26 @@ export default function StashPageView() {
         if (await loadStashFallback()) return;
       }
       setError(e instanceof Error ? e.message : "Failed to load page");
+      return;
     }
+    // getPage is the authorization gate (member OR share OR cartridge). The
+    // rest is enrichment — a shared viewer may not have access to every related
+    // resource (folder, containing cartridges), and that must never blank the
+    // page they were legitimately shared.
+    setPage(p);
+    setStashFallback(null);
+    setError("");
+    listObjectStashes(workspaceId, "page", pageId)
+      .then(setContainingStashes)
+      .catch(() => {});
+    if (p.folder_id) {
+      getFolderContents(workspaceId, p.folder_id)
+        .then((contents) => setFolderChain(contents.breadcrumbs))
+        .catch(() => setFolderChain([]));
+    } else {
+      setFolderChain([]);
+    }
+    refreshThreads().catch(() => {});
   }, [workspaceId, pageId, refreshThreads, stashSlug, loadStashFallback]);
 
   const reconcileAfterSave = useCallback(


### PR DESCRIPTION
## Bug
Opening a page you were **shared** (with edit) showed a red **"Not a workspace member"** banner — even though, in the new model, there's no workspace concept for users and the share grants access. (Screenshot: a shared HTML page rendering its content *and* the banner.)

## Cause
The page **comment-thread endpoints** double-gated: `_check_ws_access` (workspace membership) *before* the share-aware `_check_content_access`. The page viewer fetches comment threads on load (`refreshThreads`), so a share-only viewer got a 403 → the page's catch set the "Not a workspace member" error.

## Fix
- **Backend**: drop the redundant `_check_ws_access` from all 6 page comment endpoints (list / create / reply / resolve / delete-thread / delete-message). `_check_content_access("page", …)` is the correct gate — it already allows member **or** share **or** cartridge access.
- **Frontend (`PageClient`)**: `getPage` is the single auth gate; the follow-up enrichment (containing cartridges, folder breadcrumb, comment threads) is now best-effort, so a 403 on any *related* resource can't blank a page the user was legitimately shared. (Mirrors the earlier folder-view fix.)

## QA
- The comment-threads endpoint now returns **200** (was 403) for a share-only user.
- Browser-verified: a non-member opening a folder-shared page sees the content + **Edit**, with **no** banner. Backend comments + permissions tests pass (24).

Note: the file viewer already guarded its folder enrichment, so it wasn't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)