### PR TITLE
[codex] Handle unconfigured integrations

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -83,6 +83,8 @@ class ProviderListItem(BaseModel):
     display_name: str
     scopes: list[str]
     connected: bool
+    enabled: bool
+    disabled_reason: str | None = None
     # "oauth" (the default redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP
     # server, e.g. Granola).
     auth_kind: str = "oauth"
@@ -96,6 +98,59 @@ class IntegrationsListResponse(BaseModel):
     providers: list[ProviderListItem]
 
 
+def _provider_disabled_reason(provider: str) -> str | None:
+    if not settings.INTEGRATIONS_ENCRYPTION_KEY:
+        return (
+            "OAuth integrations are not configured for this server. "
+            "Set INTEGRATIONS_ENCRYPTION_KEY to enable them."
+        )
+    try:
+        Fernet(settings.INTEGRATIONS_ENCRYPTION_KEY.encode())
+    except ValueError:
+        return "INTEGRATIONS_ENCRYPTION_KEY must be a valid Fernet key."
+
+    required: dict[str, list[str]] = {
+        "github": [
+            "GITHUB_OAUTH_CLIENT_ID",
+            "GITHUB_OAUTH_CLIENT_SECRET",
+            "GITHUB_OAUTH_REDIRECT_URI",
+        ],
+        "google": [
+            "GOOGLE_OAUTH_CLIENT_ID",
+            "GOOGLE_OAUTH_CLIENT_SECRET",
+            "GOOGLE_OAUTH_REDIRECT_URI",
+        ],
+        "notion": [
+            "NOTION_OAUTH_CLIENT_ID",
+            "NOTION_OAUTH_CLIENT_SECRET",
+            "NOTION_OAUTH_REDIRECT_URI",
+        ],
+        "slack": [
+            "SLACK_OAUTH_CLIENT_ID",
+            "SLACK_OAUTH_CLIENT_SECRET",
+            "SLACK_OAUTH_REDIRECT_URI",
+        ],
+        "granola": ["GRANOLA_OAUTH_REDIRECT_URI"],
+    }
+    missing = [name for name in required.get(provider, []) if not getattr(settings, name)]
+    if missing:
+        display_names = {
+            "github": "GitHub",
+            "google": "Google",
+            "notion": "Notion",
+            "slack": "Slack",
+            "granola": "Granola",
+        }
+        return f"{display_names.get(provider, provider)} OAuth is not configured for this server."
+    return None
+
+
+def _ensure_provider_enabled(provider: str) -> None:
+    disabled_reason = _provider_disabled_reason(provider)
+    if disabled_reason:
+        raise HTTPException(status_code=503, detail=disabled_reason)
+
+
 @router.get("", response_model=IntegrationsListResponse)
 async def list_integrations(current_user: dict = Depends(get_current_user)):
     user_connections = {
@@ -104,12 +159,15 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
     items = []
     for p in list_providers():
         conn = user_connections.get(p.name)
+        disabled_reason = _provider_disabled_reason(p.name)
         items.append(
             ProviderListItem(
                 provider=p.name,
                 display_name=p.display_name,
                 scopes=p.scopes,
                 connected=conn is not None,
+                enabled=disabled_reason is None,
+                disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
                 account_email=conn["account_email"] if conn else None,
                 account_display_name=conn["account_display_name"] if conn else None,
@@ -151,6 +209,7 @@ async def integration_connect(
     started (e.g. /onboarding) instead of /settings.
     """
     p = get_provider(provider)
+    _ensure_provider_enabled(provider)
     # MCP OAuth providers (Granola) register a client + carry PKCE through their
     # own state, so they own the connect step end-to-end.
     if getattr(p, "auth_kind", "oauth") == "mcp_oauth":

--- a/backend/tests/test_granola.py
+++ b/backend/tests/test_granola.py
@@ -102,6 +102,39 @@ async def test_callback_exchanges_and_marks_connected(client: AsyncClient, monke
     assert granola["account_email"] == "sam@example.com"
 
 
+@pytest.mark.asyncio
+async def test_integrations_are_unavailable_without_encryption_key(client: AsyncClient, monkeypatch):
+    api_key, _ = await _register(client)
+    monkeypatch.setattr(oauth.settings, "INTEGRATIONS_ENCRYPTION_KEY", None)
+
+    auth = {"Authorization": f"Bearer {api_key}"}
+    response = await client.get("/api/v1/integrations", headers=auth)
+    assert response.status_code == 200
+    github = next(p for p in response.json()["providers"] if p["provider"] == "github")
+    assert github["enabled"] is False
+    assert github["connected"] is False
+    assert "INTEGRATIONS_ENCRYPTION_KEY" in github["disabled_reason"]
+
+    connect = await client.get("/api/v1/integrations/github/connect", headers=auth)
+    assert connect.status_code == 503
+    assert "INTEGRATIONS_ENCRYPTION_KEY" in connect.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_integrations_are_unavailable_with_invalid_encryption_key(
+    client: AsyncClient, monkeypatch
+):
+    api_key, _ = await _register(client)
+    monkeypatch.setattr(oauth.settings, "INTEGRATIONS_ENCRYPTION_KEY", "not-a-fernet-key")
+
+    auth = {"Authorization": f"Bearer {api_key}"}
+    response = await client.get("/api/v1/integrations", headers=auth)
+    assert response.status_code == 200
+    github = next(p for p in response.json()["providers"] if p["provider"] == "github")
+    assert github["enabled"] is False
+    assert github["disabled_reason"] == "INTEGRATIONS_ENCRYPTION_KEY must be a valid Fernet key."
+
+
 def _fake_session(tool_routes: dict):
     @asynccontextmanager
     async def _factory(access_token):

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -132,6 +132,13 @@ export default function SourceConnectorList({
     onSourceCountChange?.(sources.length);
   }, [onSourceCountChange, sources.length]);
 
+  const disabledReasons = useMemo(() => {
+    const reasons = Object.values(statuses)
+      .map((status) => status.disabled_reason)
+      .filter((reason): reason is string => Boolean(reason));
+    return Array.from(new Set(reasons));
+  }, [statuses]);
+
   async function addSource(connector: Connector, body?: { external_ref?: string; display_name?: string }) {
     if (!workspaceId) return false;
     setBusy(connector.provider);
@@ -148,6 +155,17 @@ export default function SourceConnectorList({
       setError(e instanceof Error ? e.message : "Could not add source");
       return false;
     } finally {
+      setBusy(null);
+    }
+  }
+
+  async function connect(connector: Connector) {
+    setBusy(connector.provider);
+    setError(null);
+    try {
+      await startConnect(connector.provider, returnTo);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not start connection");
       setBusy(null);
     }
   }
@@ -182,9 +200,18 @@ export default function SourceConnectorList({
 
   return (
     <div className="space-y-2">
+      {disabledReasons.length > 0 && (
+        <div className="rounded-md border border-border bg-base px-3 py-2 text-[12px] text-muted">
+          {disabledReasons.length === 1
+            ? disabledReasons[0]
+            : "Some integrations need server configuration before they can be connected."}
+        </div>
+      )}
+
       {CONNECTORS.map((connector) => {
         const status = statuses[connector.provider];
         const connected = !!status?.connected;
+        const enabled = status?.enabled ?? true;
         const count = sources.filter((source) => source.type === connector.sourceType).length;
         return (
           <div key={connector.provider} className="rounded-lg border border-border bg-surface px-3 py-2.5">
@@ -206,10 +233,12 @@ export default function SourceConnectorList({
               <ConnectorAction
                 connector={connector}
                 connected={connected}
+                enabled={enabled}
+                disabledReason={status?.disabled_reason ?? null}
                 busy={busy === connector.provider}
                 workspaceReady={!!workspaceId}
                 expanded={expanded === connector.provider}
-                onConnect={() => void startConnect(connector.provider, returnTo)}
+                onConnect={() => void connect(connector)}
                 onExpand={() => setExpanded((value) => value === connector.provider ? null : connector.provider)}
                 onAdd={() => void addSource(connector, connector.kind === "drive" ? {
                   external_ref: "root",
@@ -288,6 +317,8 @@ export default function SourceConnectorList({
 function ConnectorAction({
   connector,
   connected,
+  enabled,
+  disabledReason,
   busy,
   workspaceReady,
   expanded,
@@ -297,6 +328,8 @@ function ConnectorAction({
 }: {
   connector: Connector;
   connected: boolean;
+  enabled: boolean;
+  disabledReason: string | null;
   busy: boolean;
   workspaceReady: boolean;
   expanded: boolean;
@@ -304,10 +337,17 @@ function ConnectorAction({
   onExpand: () => void;
   onAdd: () => void;
 }) {
+  if (!enabled) {
+    return (
+      <button type="button" disabled title={disabledReason ?? undefined} className={secondaryButton()}>
+        Unavailable
+      </button>
+    );
+  }
   if (!connected) {
     return (
-      <button type="button" onClick={onConnect} className={primaryButton()}>
-        Connect
+      <button type="button" onClick={onConnect} disabled={busy} className={primaryButton()}>
+        {busy ? "Connecting..." : "Connect"}
       </button>
     );
   }
@@ -547,7 +587,7 @@ function labelForSourceType(type: string): string {
 }
 
 function primaryButton(): string {
-  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover";
+  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
 }
 
 function secondaryButton(): string {

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -20,6 +20,8 @@ export type IntegrationStatus = {
   display_name: string;
   scopes: string[];
   connected: boolean;
+  enabled: boolean;
+  disabled_reason: string | null;
   account_email: string | null;
   account_display_name: string | null;
   expires_at: string | null;


### PR DESCRIPTION
## Summary

- Generates a durable integrations encryption key automatically for `./start.sh` by writing `INTEGRATIONS_ENCRYPTION_KEY` into the repo `.env` only when it is absent.
- Generates and persists the same key automatically for Docker/self-hosting through a backend secret volume mounted into backend, worker, and beat.
- Keeps manual `INTEGRATIONS_ENCRYPTION_KEY` values as the override for operators who manage secrets outside Compose.
- Keeps the UI/backend fallback from the first commit: unavailable integrations return non-500 responses and render disabled actions instead of a Next.js runtime overlay.

## Screenshot

- Fallback disabled integrations state: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/c02c56da-945c-407d-9397-1f9bfb13cf38

## Validation

- `bash -n start.sh backend/entrypoint.sh`
- `docker compose -f docker-compose.yml config`
- `POSTGRES_USER=stash POSTGRES_PASSWORD=stash POSTGRES_DB=stash PUBLIC_URL=http://localhost:3457 CORS_ORIGINS=http://localhost:3457,http://localhost:3456 docker compose -f docker-compose.prod.yml -f docker-compose.local.yml config`
- temporary entrypoint run generated a 44-character Fernet key into a temp key file and exported it to the child process
- `PYTEST_ADDOPTS=--no-cov python -m pytest backend/tests/test_granola.py::test_integrations_are_unavailable_without_encryption_key backend/tests/test_granola.py::test_integrations_are_unavailable_with_invalid_encryption_key -q`
- `ruff check backend/integrations/router.py backend/tests/test_granola.py`
- `cd frontend && npm run lint`
- `cd frontend && npm test`
- Manual Playwright check against the fallback UI: `/settings/integrations` showed disabled OAuth providers, the inline configuration notice, and no runtime overlay.
