### PR TITLE
[codex] Generate integration encryption key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,12 +75,13 @@ BACKEND_URL=http://localhost:3456
 
 # ── Integrations (OAuth token encryption) ────
 # Fernet key used to encrypt OAuth tokens stored for GitHub/Google Drive/Notion
-# integrations. Generate once and NEVER rotate — rotating invalidates every
-# stored token and forces every user to reconnect their integrations.
+# integrations. `./start.sh` and Docker Compose generate a durable key
+# automatically when this is unset. If you manage secrets outside Compose, set
+# your own value once and NEVER rotate it — rotating invalidates every stored
+# token and forces every user to reconnect their integrations.
 #
 #   python -c "import secrets,base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"
 #
-# Leave blank to disable integrations entirely.
 # INTEGRATIONS_ENCRYPTION_KEY=
 
 # Granola connects through its MCP server over OAuth 2.0 (Dynamic Client

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ curl http://localhost:3456/health
 open http://localhost:3457/login
 ```
 
+Docker Compose generates and persists the OAuth token encryption key when
+`INTEGRATIONS_ENCRYPTION_KEY` is unset. Set it yourself only if you manage
+deployment secrets outside Compose.
+
 For a public domain with Caddy and HTTPS:
 
 ```bash

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,11 +33,16 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 RUN playwright install chromium && chown -R stash:stash /opt/playwright
 
 COPY backend/ ./backend/
+COPY backend/entrypoint.sh ./entrypoint.sh
 COPY alembic.ini ./alembic.ini
 
-RUN chown -R stash:stash /app
+RUN mkdir -p /app/.secrets && \
+    chmod 700 /app/.secrets && \
+    chmod +x /app/entrypoint.sh && \
+    chown -R stash:stash /app
 USER stash
 
 EXPOSE 3456
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "3456", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_FILE="${INTEGRATIONS_ENCRYPTION_KEY_FILE:-/app/.secrets/integrations_encryption_key}"
+
+generate_key() {
+    python - <<'PY'
+import base64
+import secrets
+
+print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())
+PY
+}
+
+if [ -z "${INTEGRATIONS_ENCRYPTION_KEY:-}" ]; then
+    mkdir -p "$(dirname "$KEY_FILE")"
+
+    if [ ! -s "$KEY_FILE" ]; then
+        umask 077
+        tmp="${KEY_FILE}.$$"
+        generate_key > "$tmp"
+        mv "$tmp" "$KEY_FILE"
+        echo "[secrets] Generated integrations encryption key at ${KEY_FILE}."
+    fi
+
+    INTEGRATIONS_ENCRYPTION_KEY="$(cat "$KEY_FILE")"
+    export INTEGRATIONS_ENCRYPTION_KEY
+fi
+
+exec "$@"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@
 #   ANTHROPIC_API_KEY           (enables ask-the-workspace + session summarization)
 #   OPENAI_API_KEY or HF_TOKEN  (use hosted embedding provider instead of local)
 #   S3_ENDPOINT / S3_BUCKET / …  (enable file uploads)
-#   INTEGRATIONS_ENCRYPTION_KEY (Fernet key — encrypt OAuth tokens at rest)
+#   INTEGRATIONS_ENCRYPTION_KEY (optional override; generated durably when unset)
 
 services:
   postgres:
@@ -68,6 +68,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 30s
@@ -89,6 +91,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
@@ -103,6 +107,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
@@ -148,5 +154,6 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  backend_secrets:
   caddy_data:
   caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
       REDIS_URL: redis://redis:6379/0
       PUBLIC_URL: http://localhost:3457
       CORS_ORIGINS: "http://localhost:3457,http://localhost:3456"
+    volumes:
+      - backend_secrets:/app/.secrets
     # /health returns 200 only after Alembic finishes inside the
     # lifespan, so worker + beat can wait on this before starting.
     healthcheck:
@@ -113,6 +115,8 @@ services:
       <<: *stash-env
       DATABASE_URL: postgresql://stash:stash@postgres:5432/stash
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
@@ -129,6 +133,8 @@ services:
       <<: *stash-env
       DATABASE_URL: postgresql://stash:stash@postgres:5432/stash
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
@@ -169,3 +175,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  backend_secrets:

--- a/start.sh
+++ b/start.sh
@@ -51,6 +51,55 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
     echo "Loaded environment from .env"
 fi
 
+generate_integrations_encryption_key() {
+    python - <<'PY'
+import base64
+import secrets
+
+print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())
+PY
+}
+
+ensure_integrations_encryption_key() {
+    if [ -n "${INTEGRATIONS_ENCRYPTION_KEY:-}" ]; then
+        return
+    fi
+
+    local env_file="$PROJECT_ROOT/.env"
+    local generated_key
+    local tmp_file
+
+    generated_key="$(generate_integrations_encryption_key)"
+
+    if [ -f "$env_file" ]; then
+        tmp_file="$(mktemp)"
+        awk -v key="$generated_key" '
+            BEGIN { written = 0 }
+            /^INTEGRATIONS_ENCRYPTION_KEY=/ {
+                if (!written) {
+                    print "INTEGRATIONS_ENCRYPTION_KEY=" key
+                    written = 1
+                }
+                next
+            }
+            { print }
+            END {
+                if (!written) {
+                    print "INTEGRATIONS_ENCRYPTION_KEY=" key
+                }
+            }
+        ' "$env_file" > "$tmp_file"
+        mv "$tmp_file" "$env_file"
+    else
+        printf 'INTEGRATIONS_ENCRYPTION_KEY=%s\n' "$generated_key" > "$env_file"
+    fi
+
+    export INTEGRATIONS_ENCRYPTION_KEY="$generated_key"
+    echo "[secrets] Generated INTEGRATIONS_ENCRYPTION_KEY in .env."
+}
+
+ensure_integrations_encryption_key
+
 export DATABASE_URL="${DATABASE_URL:-$LOCAL_DATABASE_URL}"
 BACKEND_PORT="${BACKEND_PORT:-$DEFAULT_BACKEND_PORT}"
 FRONTEND_PORT="${FRONTEND_PORT:-$DEFAULT_FRONTEND_PORT}"


### PR DESCRIPTION
## Summary

- Generates a durable `INTEGRATIONS_ENCRYPTION_KEY` automatically for `./start.sh` by writing it into the repo `.env` only when absent.
- Generates and persists a durable key for Docker/self-hosting through a shared backend secret volume mounted into backend, worker, and beat.
- Keeps manually supplied `INTEGRATIONS_ENCRYPTION_KEY` values as the override for operators using external secret management.
- Updates docs to make the key automatic for supported startup paths.

## Validation

- `bash -n start.sh backend/entrypoint.sh`
- temporary entrypoint run generated a 44-character Fernet key into a temp key file and exported it to the child process
- `docker compose -f docker-compose.yml config`
- `cp .env.example .env && POSTGRES_USER=stash POSTGRES_PASSWORD=stash POSTGRES_DB=stash PUBLIC_URL=http://localhost:3457 CORS_ORIGINS=http://localhost:3457,http://localhost:3456 docker compose -f docker-compose.prod.yml -f docker-compose.local.yml config`
- `git diff --check HEAD`
