### PR TITLE
[codex] Make agents screen chat-first

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -5,15 +5,23 @@ import { Suspense, useEffect, useRef, useState } from "react";
 
 import ChatPanel from "../../../../../components/agents/ChatPanel";
 
-// Agents: the primary way to use Stash is through your own agent. The first tab
-// (unclosable) explains how to connect the CLI / MCP / API; extra tabs are
-// multi-turn chats over your sources. Each chat is a stored Session, so its
-// session_id + the open tabs persist across reloads.
+// Agents is a chat surface. Each tab is a stored Session, so its session_id and
+// the open tabs persist across reloads.
 type ChatTab = { id: number; sessionId: string | null; title: string };
-type PersistedTabs = { chats: ChatTab[]; nextId: number; active: "connect" | number };
+type PersistedTabs = { chats: ChatTab[]; nextId: number; active: number };
+
+const firstChatId = 1;
 
 function tabsKey(workspaceId: string): string {
-  return `stash_agent_tabs:${workspaceId}`;
+  return `stash_agent_chat_tabs:${workspaceId}`;
+}
+
+function defaultTabs(): PersistedTabs {
+  return {
+    chats: [{ id: firstChatId, sessionId: null, title: "Chat" }],
+    nextId: firstChatId + 1,
+    active: firstChatId,
+  };
 }
 
 export default function AgentsPage() {
@@ -29,9 +37,10 @@ function AgentsPageInner() {
   const workspaceId = params.workspaceId as string;
 
   const searchParams = useSearchParams();
-  const [chats, setChats] = useState<ChatTab[]>([]);
-  const [nextId, setNextId] = useState(1);
-  const [active, setActive] = useState<"connect" | number>("connect");
+  const initialTabs = defaultTabs();
+  const [chats, setChats] = useState<ChatTab[]>(initialTabs.chats);
+  const [nextId, setNextId] = useState(initialTabs.nextId);
+  const [active, setActive] = useState(initialTabs.active);
   const restored = useRef(false);
   // Resume a specific chat from a `?resume=<sessionId>` link (e.g. from the
   // Agent Sessions list).
@@ -42,17 +51,18 @@ function AgentsPageInner() {
   useEffect(() => {
     if (restored.current) return;
     restored.current = true;
-    let chats: ChatTab[] = [];
-    let next = 1;
-    let active: "connect" | number = "connect";
+    let state = defaultTabs();
     try {
       const raw = window.localStorage.getItem(tabsKey(workspaceId));
       if (raw) {
         const p = JSON.parse(raw) as PersistedTabs;
-        if (Array.isArray(p.chats)) {
-          chats = p.chats;
-          next = p.nextId ?? p.chats.length + 1;
-          active = p.active ?? "connect";
+        if (Array.isArray(p.chats) && p.chats.length > 0 && typeof p.active === "number") {
+          const activeExists = p.chats.some((t) => t.id === p.active);
+          state = {
+            chats: p.chats,
+            nextId: p.nextId ?? Math.max(...p.chats.map((t) => t.id)) + 1,
+            active: activeExists ? p.active : p.chats[0].id,
+          };
         }
       }
     } catch {
@@ -60,18 +70,20 @@ function AgentsPageInner() {
     }
     const resume = searchParams.get("resume");
     if (resume) {
-      const existing = chats.find((t) => t.sessionId === resume);
+      const existing = state.chats.find((t) => t.sessionId === resume);
       if (existing) {
-        active = existing.id;
+        state = { ...state, active: existing.id };
       } else {
-        chats = [...chats, { id: next, sessionId: resume, title: "Chat" }];
-        active = next;
-        next += 1;
+        state = {
+          chats: [...state.chats, { id: state.nextId, sessionId: resume, title: "Chat" }],
+          active: state.nextId,
+          nextId: state.nextId + 1,
+        };
       }
     }
-    setChats(chats);
-    setNextId(next);
-    setActive(active);
+    setChats(state.chats);
+    setNextId(state.nextId);
+    setActive(state.active);
   }, [workspaceId, searchParams]);
 
   // Persist whenever tabs change (after the initial restore).
@@ -95,8 +107,10 @@ function AgentsPageInner() {
   }
 
   function closeChat(id: number) {
-    setChats((c) => c.filter((t) => t.id !== id));
-    setActive((a) => (a === id ? "connect" : a));
+    if (chats.length === 1) return;
+    const remaining = chats.filter((t) => t.id !== id);
+    setChats(remaining);
+    if (active === id) setActive(remaining[remaining.length - 1].id);
   }
 
   function setChatSession(id: number, sessionId: string) {
@@ -104,35 +118,47 @@ function AgentsPageInner() {
   }
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto">
-      <div
-        className={
-          // Chats want room to breathe (ChatGPT-style); the Connect guide reads
-          // better narrow.
-          "mx-auto w-full px-8 py-8 " + (active === "connect" ? "max-w-3xl" : "max-w-5xl")
-        }
-      >
-        <div className="flex items-center gap-1 border-b border-border">
-          <button
-            type="button"
-            onClick={() => setActive("connect")}
-            className={tabClass(active === "connect")}
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+        <div className="mb-4 flex min-w-0 items-end justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="truncate text-[20px] font-semibold text-foreground">
+              Chat with your agent
+            </h1>
+            <p className="mt-1 text-[13px] text-muted">
+              Ask across this workspace from one place.
+            </p>
+          </div>
+          <a
+            className="shrink-0 rounded-md border border-border px-3 py-1.5 text-[12.5px] font-medium text-dim hover:border-[var(--color-brand-300)] hover:bg-surface hover:text-foreground"
+            href="https://joinstash.ai/docs/mcp"
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            Connect your agent
-          </button>
+            Setup docs
+          </a>
+        </div>
+
+        <div className="flex min-w-0 items-center gap-1 border-b border-border">
           {chats.map((t) => (
             <span key={t.id} className={tabClass(active === t.id)}>
-              <button type="button" onClick={() => setActive(t.id)} className="outline-none">
-                {t.title}
-              </button>
               <button
                 type="button"
-                aria-label="Close chat"
-                onClick={() => closeChat(t.id)}
-                className="ml-1 text-muted hover:text-error"
+                onClick={() => setActive(t.id)}
+                className="min-w-0 truncate outline-none"
               >
-                ×
+                {t.title}
               </button>
+              {chats.length > 1 && (
+                <button
+                  type="button"
+                  aria-label="Close chat"
+                  onClick={() => closeChat(t.id)}
+                  className="ml-1 text-muted hover:text-error"
+                >
+                  ×
+                </button>
+              )}
             </span>
           ))}
           <button
@@ -145,14 +171,11 @@ function AgentsPageInner() {
           </button>
         </div>
 
-        <div className="pt-5">
+        <div className="min-h-0 flex-1 pt-4">
           {/* All panels stay mounted (toggled with `hidden`) so a chat keeps
               its transcript, scroll, and in-flight stream when you switch tabs. */}
-          <div className={active === "connect" ? "" : "hidden"}>
-            <ConnectGuide />
-          </div>
           {chats.map((t) => (
-            <div key={t.id} className={active === t.id ? "" : "hidden"}>
+            <div key={t.id} className={active === t.id ? "h-full" : "hidden"}>
               <ChatPanel
                 workspaceId={workspaceId}
                 sessionId={t.sessionId}
@@ -168,86 +191,9 @@ function AgentsPageInner() {
 
 function tabClass(activeTab: boolean): string {
   return (
-    "flex items-center gap-0.5 rounded-t-md border border-b-0 px-3 py-2 text-[12.5px] -mb-px " +
+    "flex min-w-0 max-w-[180px] items-center gap-0.5 rounded-t-md border border-b-0 px-3 py-2 text-[12.5px] -mb-px " +
     (activeTab
       ? "border-border bg-base font-semibold text-foreground"
       : "border-transparent bg-surface text-dim hover:text-foreground")
-  );
-}
-
-function Step({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
-  return (
-    <div className="mb-5">
-      <div className="text-[13.5px] font-semibold text-foreground">
-        {n}. {title}
-      </div>
-      <div className="mt-2 text-[13px] text-dim">{children}</div>
-    </div>
-  );
-}
-
-function Code({ children }: { children: string }) {
-  return (
-    <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-surface px-3 py-2 font-mono text-[12px] text-foreground">
-      {children}
-    </pre>
-  );
-}
-
-function ConnectGuide() {
-  return (
-    <div className="rounded-xl border border-border bg-base p-5">
-      <div className="mb-5 rounded-lg border border-border bg-surface/60 p-4 text-[13px] text-dim">
-        <div className="text-[13.5px] font-semibold text-foreground">What this sets up</div>
-        <p className="mt-1.5">
-          Installing the CLI adds a small <strong>plugin with hooks</strong> to your coding agent
-          (Claude Code, Codex, and friends). It works in two directions:
-        </p>
-        <ul className="mt-2 list-disc space-y-1.5 pl-5">
-          <li>
-            <strong>Push (hooks)</strong> — as your agent runs, the hooks automatically stream each
-            session&rsquo;s transcript, the files it touches, and the artifacts it produces into your
-            Stash. Nothing to remember to save; your history lands in{" "}
-            <strong>Agent Sessions</strong> on its own.
-          </li>
-          <li>
-            <strong>Pull (search &amp; query)</strong> — everything in your Stash (sessions, files,
-            pages, tables, connected sources) is indexed, so your agent can search it and answer
-            questions grounded on your own work.
-          </li>
-        </ul>
-      </div>
-      <Step n={1} title="Install the Stash CLI">
-        The CLI is the preferred way for your agent to reach Stash — it installs the plugin and hooks
-        above.
-        <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
-      </Step>
-      <Step n={2} title="Sign in">
-        Authorize the CLI for this account — it prints a consent URL.
-        <Code>stash signin</Code>
-      </Step>
-      <Step n={3} title="Point your agent at it (MCP)">
-        Add Stash as an MCP server so your agent can navigate and search every source.
-        See the{" "}
-        <a className="text-[var(--color-brand-700)] underline" href="https://joinstash.ai/docs/mcp" target="_blank" rel="noopener noreferrer">
-          MCP setup docs
-        </a>
-        .
-      </Step>
-      <Step n={4} title="Or call the API directly">
-        Create a personal API key in{" "}
-        <a className="text-[var(--color-brand-700)] underline" href="/settings">
-          Settings
-        </a>{" "}
-        and read the{" "}
-        <a className="text-[var(--color-brand-700)] underline" href="https://joinstash.ai/docs/api" target="_blank" rel="noopener noreferrer">
-          API docs
-        </a>
-        .
-      </Step>
-      <div className="mt-4 rounded-md bg-surface px-3 py-2 text-[12.5px] text-muted">
-        Prefer the browser? Open a chat tab above and ask across your sources right here.
-      </div>
-    </div>
   );
 }

--- a/frontend/src/components/agents/ChatPanel.test.tsx
+++ b/frontend/src/components/agents/ChatPanel.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ChatPanel from "./ChatPanel";
+import { getAgentChat, streamAgentChat } from "@/lib/agentChat";
+
+vi.mock("@/lib/agentChat", () => ({
+  getAgentChat: vi.fn(),
+  streamAgentChat: vi.fn(),
+}));
+
+describe("ChatPanel", () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = vi.fn();
+    vi.mocked(getAgentChat).mockResolvedValue([]);
+    vi.mocked(streamAgentChat).mockImplementation(async (opts) => {
+      opts.onSession?.("agent-session-1");
+      opts.onText?.("Here is what I found.");
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows setup guidance inside the empty chat state", () => {
+    render(<ChatPanel workspaceId="ws-1" sessionId={null} onSessionId={vi.fn()} />);
+
+    expect(screen.getByText("Chat with your agent")).toBeInTheDocument();
+    expect(screen.getByText("Connect your local agent")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Ask your agent anything...")).toBeInTheDocument();
+  });
+
+  it("hides setup guidance after the first message starts a chat", async () => {
+    const onSessionId = vi.fn();
+    render(<ChatPanel workspaceId="ws-1" sessionId={null} onSessionId={onSessionId} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Ask your agent anything..."), {
+      target: { value: "What changed recently?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(streamAgentChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "What changed recently?",
+          workspaceId: "ws-1",
+        }),
+      );
+    });
+    expect(await screen.findByText("Here is what I found.")).toBeInTheDocument();
+    expect(screen.queryByText("Connect your local agent")).not.toBeInTheDocument();
+    expect(onSessionId).toHaveBeenCalledWith("agent-session-1");
+  });
+});

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -114,13 +114,10 @@ export default function ChatPanel({
   );
 
   return (
-    <div className="flex h-[60vh] flex-col rounded-xl border border-border bg-base">
+    <div className="flex h-full min-h-[520px] flex-col rounded-xl border border-border bg-base">
       <div ref={scrollRef} className="scroll-thin flex-1 space-y-4 overflow-y-auto p-4">
         {messages.length === 0 && !streaming ? (
-          <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-muted">
-            Ask your agent anything about your sources — files, sessions, GitHub,
-            Drive, Notion, Slack, Granola. It searches across everything.
-          </div>
+          <EmptyChatState onPrompt={(prompt) => void send(prompt)} />
         ) : (
           messages.map((m, i) => <MessageBubble key={i} message={m} />)
         )}
@@ -138,6 +135,111 @@ export default function ChatPanel({
         disabled={streaming}
       />
     </div>
+  );
+}
+
+const suggestedPrompts = [
+  "Catch me up on this workspace",
+  "What changed recently?",
+  "Find the planning docs",
+];
+
+function EmptyChatState({ onPrompt }: { onPrompt: (prompt: string) => void }) {
+  return (
+    <div className="flex min-h-full items-center justify-center px-2 py-8">
+      <div className="w-full max-w-3xl">
+        <div className="text-center">
+          <div className="text-[20px] font-semibold text-foreground">
+            Chat with your agent
+          </div>
+          <p className="mx-auto mt-2 max-w-xl text-[13px] leading-5 text-dim">
+            Ask about files, sessions, pages, tables, and connected sources in this workspace.
+          </p>
+        </div>
+
+        <div className="mt-5 grid gap-2 sm:grid-cols-3">
+          {suggestedPrompts.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => onPrompt(prompt)}
+              className="min-h-12 rounded-md border border-border bg-surface px-3 py-2 text-left text-[12.5px] leading-4 text-foreground hover:border-[var(--color-brand-300)] hover:bg-raised"
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-7 border-t border-border pt-5 text-left">
+          <div className="text-[13.5px] font-semibold text-foreground">
+            Connect your local agent
+          </div>
+          <p className="mt-1.5 text-[13px] leading-5 text-dim">
+            Install the CLI when you want Codex, Claude Code, or another coding agent to push
+            sessions into Stash and search this workspace directly.
+          </p>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <SetupStep n={1} title="Install the Stash CLI">
+              <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
+            </SetupStep>
+            <SetupStep n={2} title="Sign in">
+              <Code>stash signin</Code>
+            </SetupStep>
+            <SetupStep n={3} title="Point your agent at Stash">
+              <a
+                className="text-[var(--color-brand-700)] underline"
+                href="https://joinstash.ai/docs/mcp"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                MCP setup docs
+              </a>
+            </SetupStep>
+            <SetupStep n={4} title="Use the API directly">
+              <a className="text-[var(--color-brand-700)] underline" href="/settings">
+                Settings
+              </a>
+              <span className="text-dim"> and </span>
+              <a
+                className="text-[var(--color-brand-700)] underline"
+                href="https://joinstash.ai/docs/api"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                API docs
+              </a>
+            </SetupStep>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SetupStep({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-[12.5px] font-semibold text-foreground">
+        {n}. {title}
+      </div>
+      <div className="mt-1.5 text-[12.5px] text-dim">{children}</div>
+    </div>
+  );
+}
+
+function Code({ children }: { children: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
+      {children}
+    </pre>
   );
 }
 
@@ -197,7 +299,7 @@ function Composer({
             }
           }}
           rows={2}
-          placeholder="Message your agent…  (Enter to send, Shift+Enter for newline)"
+          placeholder="Ask your agent anything..."
           className="flex-1 resize-none rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
         />
         <button


### PR DESCRIPTION
## Summary
- Make the workspace Agents route open directly into a chat-first interface.
- Move agent setup instructions into the empty chat transcript state, where they disappear after the first message.
- Keep multi-chat tabs, resume links, and persisted chat sessions, with a fresh chat created by default.
- Add regression coverage for the empty-state setup guidance and the first-message transition.

## Screenshots
- Empty chat onboarding: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/9f6c621c-e546-4276-baaa-31dbaf6e54b4
- After first message: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/edce0043-f121-4227-b868-32f76382a2d5

## Validation
- `npm run lint`
- `npm test -- ChatPanel.test.tsx`
- `npm test`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- Playwright desktop smoke test with mocked auth/API responses for the empty state and after-message state.
