### PR TITLE
Add Webflow MCP demo dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,12 +75,13 @@ BACKEND_URL=http://localhost:3456
 
 # ── Integrations (OAuth token encryption) ────
 # Fernet key used to encrypt OAuth tokens stored for GitHub/Google Drive/Notion
-# integrations. Generate once and NEVER rotate — rotating invalidates every
-# stored token and forces every user to reconnect their integrations.
+# integrations. `./start.sh` and Docker Compose generate a durable key
+# automatically when this is unset. If you manage secrets outside Compose, set
+# your own value once and NEVER rotate it — rotating invalidates every stored
+# token and forces every user to reconnect their integrations.
 #
 #   python -c "import secrets,base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"
 #
-# Leave blank to disable integrations entirely.
 # INTEGRATIONS_ENCRYPTION_KEY=
 
 # Granola connects through its MCP server over OAuth 2.0 (Dynamic Client

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ curl http://localhost:3456/health
 open http://localhost:3457/login
 ```
 
+Docker Compose generates and persists the OAuth token encryption key when
+`INTEGRATIONS_ENCRYPTION_KEY` is unset. Set it yourself only if you manage
+deployment secrets outside Compose.
+
 For a public domain with Caddy and HTTPS:
 
 ```bash

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,11 +33,16 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 RUN playwright install chromium && chown -R stash:stash /opt/playwright
 
 COPY backend/ ./backend/
+COPY backend/entrypoint.sh ./entrypoint.sh
 COPY alembic.ini ./alembic.ini
 
-RUN chown -R stash:stash /app
+RUN mkdir -p /app/.secrets && \
+    chmod 700 /app/.secrets && \
+    chmod +x /app/entrypoint.sh && \
+    chown -R stash:stash /app
 USER stash
 
 EXPOSE 3456
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "3456", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_FILE="${INTEGRATIONS_ENCRYPTION_KEY_FILE:-/app/.secrets/integrations_encryption_key}"
+
+generate_key() {
+    python - <<'PY'
+import base64
+import secrets
+
+print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())
+PY
+}
+
+if [ -z "${INTEGRATIONS_ENCRYPTION_KEY:-}" ]; then
+    mkdir -p "$(dirname "$KEY_FILE")"
+
+    if [ ! -s "$KEY_FILE" ]; then
+        umask 077
+        tmp="${KEY_FILE}.$$"
+        generate_key > "$tmp"
+        mv "$tmp" "$KEY_FILE"
+        echo "[secrets] Generated integrations encryption key at ${KEY_FILE}."
+    fi
+
+    INTEGRATIONS_ENCRYPTION_KEY="$(cat "$KEY_FILE")"
+    export INTEGRATIONS_ENCRYPTION_KEY
+fi
+
+exec "$@"

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -83,6 +83,8 @@ class ProviderListItem(BaseModel):
     display_name: str
     scopes: list[str]
     connected: bool
+    enabled: bool
+    disabled_reason: str | None = None
     # "oauth" (the default redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP
     # server, e.g. Granola).
     auth_kind: str = "oauth"
@@ -96,6 +98,59 @@ class IntegrationsListResponse(BaseModel):
     providers: list[ProviderListItem]
 
 
+def _provider_disabled_reason(provider: str) -> str | None:
+    if not settings.INTEGRATIONS_ENCRYPTION_KEY:
+        return (
+            "OAuth integrations are not configured for this server. "
+            "Set INTEGRATIONS_ENCRYPTION_KEY to enable them."
+        )
+    try:
+        Fernet(settings.INTEGRATIONS_ENCRYPTION_KEY.encode())
+    except ValueError:
+        return "INTEGRATIONS_ENCRYPTION_KEY must be a valid Fernet key."
+
+    required: dict[str, list[str]] = {
+        "github": [
+            "GITHUB_OAUTH_CLIENT_ID",
+            "GITHUB_OAUTH_CLIENT_SECRET",
+            "GITHUB_OAUTH_REDIRECT_URI",
+        ],
+        "google": [
+            "GOOGLE_OAUTH_CLIENT_ID",
+            "GOOGLE_OAUTH_CLIENT_SECRET",
+            "GOOGLE_OAUTH_REDIRECT_URI",
+        ],
+        "notion": [
+            "NOTION_OAUTH_CLIENT_ID",
+            "NOTION_OAUTH_CLIENT_SECRET",
+            "NOTION_OAUTH_REDIRECT_URI",
+        ],
+        "slack": [
+            "SLACK_OAUTH_CLIENT_ID",
+            "SLACK_OAUTH_CLIENT_SECRET",
+            "SLACK_OAUTH_REDIRECT_URI",
+        ],
+        "granola": ["GRANOLA_OAUTH_REDIRECT_URI"],
+    }
+    missing = [name for name in required.get(provider, []) if not getattr(settings, name)]
+    if missing:
+        display_names = {
+            "github": "GitHub",
+            "google": "Google",
+            "notion": "Notion",
+            "slack": "Slack",
+            "granola": "Granola",
+        }
+        return f"{display_names.get(provider, provider)} OAuth is not configured for this server."
+    return None
+
+
+def _ensure_provider_enabled(provider: str) -> None:
+    disabled_reason = _provider_disabled_reason(provider)
+    if disabled_reason:
+        raise HTTPException(status_code=503, detail=disabled_reason)
+
+
 @router.get("", response_model=IntegrationsListResponse)
 async def list_integrations(current_user: dict = Depends(get_current_user)):
     user_connections = {
@@ -104,12 +159,15 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
     items = []
     for p in list_providers():
         conn = user_connections.get(p.name)
+        disabled_reason = _provider_disabled_reason(p.name)
         items.append(
             ProviderListItem(
                 provider=p.name,
                 display_name=p.display_name,
                 scopes=p.scopes,
                 connected=conn is not None,
+                enabled=disabled_reason is None,
+                disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
                 account_email=conn["account_email"] if conn else None,
                 account_display_name=conn["account_display_name"] if conn else None,
@@ -151,6 +209,7 @@ async def integration_connect(
     started (e.g. /onboarding) instead of /settings.
     """
     p = get_provider(provider)
+    _ensure_provider_enabled(provider)
     # MCP OAuth providers (Granola) register a client + carry PKCE through their
     # own state, so they own the connect step end-to-end.
     if getattr(p, "auth_kind", "oauth") == "mcp_oauth":

--- a/backend/tests/test_granola.py
+++ b/backend/tests/test_granola.py
@@ -102,6 +102,39 @@ async def test_callback_exchanges_and_marks_connected(client: AsyncClient, monke
     assert granola["account_email"] == "sam@example.com"
 
 
+@pytest.mark.asyncio
+async def test_integrations_are_unavailable_without_encryption_key(client: AsyncClient, monkeypatch):
+    api_key, _ = await _register(client)
+    monkeypatch.setattr(oauth.settings, "INTEGRATIONS_ENCRYPTION_KEY", None)
+
+    auth = {"Authorization": f"Bearer {api_key}"}
+    response = await client.get("/api/v1/integrations", headers=auth)
+    assert response.status_code == 200
+    github = next(p for p in response.json()["providers"] if p["provider"] == "github")
+    assert github["enabled"] is False
+    assert github["connected"] is False
+    assert "INTEGRATIONS_ENCRYPTION_KEY" in github["disabled_reason"]
+
+    connect = await client.get("/api/v1/integrations/github/connect", headers=auth)
+    assert connect.status_code == 503
+    assert "INTEGRATIONS_ENCRYPTION_KEY" in connect.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_integrations_are_unavailable_with_invalid_encryption_key(
+    client: AsyncClient, monkeypatch
+):
+    api_key, _ = await _register(client)
+    monkeypatch.setattr(oauth.settings, "INTEGRATIONS_ENCRYPTION_KEY", "not-a-fernet-key")
+
+    auth = {"Authorization": f"Bearer {api_key}"}
+    response = await client.get("/api/v1/integrations", headers=auth)
+    assert response.status_code == 200
+    github = next(p for p in response.json()["providers"] if p["provider"] == "github")
+    assert github["enabled"] is False
+    assert github["disabled_reason"] == "INTEGRATIONS_ENCRYPTION_KEY must be a valid Fernet key."
+
+
 def _fake_session(tool_routes: dict):
     @asynccontextmanager
     async def _factory(access_token):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@
 #   ANTHROPIC_API_KEY           (enables ask-the-workspace + session summarization)
 #   OPENAI_API_KEY or HF_TOKEN  (use hosted embedding provider instead of local)
 #   S3_ENDPOINT / S3_BUCKET / …  (enable file uploads)
-#   INTEGRATIONS_ENCRYPTION_KEY (Fernet key — encrypt OAuth tokens at rest)
+#   INTEGRATIONS_ENCRYPTION_KEY (optional override; generated durably when unset)
 
 services:
   postgres:
@@ -68,6 +68,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 30s
@@ -89,6 +91,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
@@ -103,6 +107,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
@@ -148,5 +154,6 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  backend_secrets:
   caddy_data:
   caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
       REDIS_URL: redis://redis:6379/0
       PUBLIC_URL: http://localhost:3457
       CORS_ORIGINS: "http://localhost:3457,http://localhost:3456"
+    volumes:
+      - backend_secrets:/app/.secrets
     # /health returns 200 only after Alembic finishes inside the
     # lifespan, so worker + beat can wait on this before starting.
     healthcheck:
@@ -113,6 +115,8 @@ services:
       <<: *stash-env
       DATABASE_URL: postgresql://stash:stash@postgres:5432/stash
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
@@ -129,6 +133,8 @@ services:
       <<: *stash-env
       DATABASE_URL: postgresql://stash:stash@postgres:5432/stash
       REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
@@ -169,3 +175,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  backend_secrets:

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/dashboard/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/dashboard/page.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
+import { WorkspaceHomeSkeleton } from "../../../../../components/SkeletonStates";
+import { useAuth } from "../../../../../hooks/useAuth";
+import { listMySessions, type SessionSummary } from "../../../../../lib/api";
+
+type Health = "On track" | "Watch" | "Blocked";
+type EvidenceType = "Session" | "Slack" | "Gong";
+
+interface Workstream {
+  name: string;
+  owner: string;
+  status: Health;
+  progress: number;
+  focus: string;
+  next: string;
+}
+
+interface Evidence {
+  type: EvidenceType;
+  title: string;
+  source: string;
+  time: string;
+  owner: string;
+  quote: string;
+  sessionId?: string;
+}
+
+const SEEDED_SESSION_PREFIX = "webflow-mcp-";
+
+const WORKSTREAMS: Workstream[] = [
+  {
+    name: "OAuth + workspace auth",
+    owner: "Nadia",
+    status: "On track",
+    progress: 86,
+    focus: "Finish scoped token exchange for Webflow sites and collections.",
+    next: "Pair review on consent screen copy",
+  },
+  {
+    name: "Designer context tools",
+    owner: "Eli",
+    status: "Watch",
+    progress: 61,
+    focus: "Expose selected element, style panel state, and page tree to MCP clients.",
+    next: "Resolve iframe message contract",
+  },
+  {
+    name: "CMS schema + publish actions",
+    owner: "Maya",
+    status: "On track",
+    progress: 74,
+    focus: "Add safe read/write tools for collections, fields, drafts, and publish jobs.",
+    next: "Close validation cases for reference fields",
+  },
+  {
+    name: "Sales engineering pilot",
+    owner: "Sam",
+    status: "Blocked",
+    progress: 38,
+    focus: "Validate agency workflows using fake customer calls and Slack asks.",
+    next: "Get Webflow sandbox credentials",
+  },
+];
+
+const RISKS = [
+  {
+    label: "Sandbox credentials",
+    owner: "Sam",
+    impact: "Pilot team cannot reproduce enterprise site permissions.",
+  },
+  {
+    label: "Designer state drift",
+    owner: "Eli",
+    impact: "Agent reads can mismatch what the human is editing.",
+  },
+  {
+    label: "Collection writes",
+    owner: "Maya",
+    impact: "Need stricter shape checks before write tools leave staging.",
+  },
+];
+
+const SIGNALS = [
+  { label: "Engineer sessions", value: "12", tone: "border-sky-200 bg-sky-50 text-sky-900" },
+  { label: "Slack messages", value: "184", tone: "border-emerald-200 bg-emerald-50 text-emerald-900" },
+  { label: "Gong calls", value: "8", tone: "border-amber-200 bg-amber-50 text-amber-900" },
+  { label: "Open launch risks", value: "3", tone: "border-rose-200 bg-rose-50 text-rose-900" },
+];
+
+const EVIDENCE: Evidence[] = [
+  {
+    type: "Session",
+    title: "OAuth handshake and site picker",
+    source: "Codex transcript",
+    time: "Jun 4, 9:20 AM",
+    owner: "Nadia",
+    quote: "Token exchange works locally; the remaining decision is where to persist per-site scopes.",
+    sessionId: "webflow-mcp-auth-handshake",
+  },
+  {
+    type: "Slack",
+    title: "#webflow-mcp launch-room",
+    source: "Slack",
+    time: "Jun 4, 10:05 AM",
+    owner: "Maya",
+    quote: "If collection writes stay behind a dry-run preview, agencies will try this in production sooner.",
+  },
+  {
+    type: "Gong",
+    title: "Acme Sites agency pilot",
+    source: "Gong sales call",
+    time: "Jun 3, 2:30 PM",
+    owner: "Sam",
+    quote: "The buyer wants an agent that can audit CMS fields before a migration, not just generate pages.",
+  },
+  {
+    type: "Session",
+    title: "Designer iframe context bridge",
+    source: "Claude transcript",
+    time: "Jun 3, 4:15 PM",
+    owner: "Eli",
+    quote: "The bridge can emit selection changes; the unresolved part is debouncing page tree updates.",
+    sessionId: "webflow-mcp-designer-context",
+  },
+  {
+    type: "Gong",
+    title: "Northstar Commerce discovery",
+    source: "Gong sales call",
+    time: "Jun 2, 11:00 AM",
+    owner: "Aria",
+    quote: "Their must-have is checking publish readiness across locales before Friday launches.",
+  },
+  {
+    type: "Slack",
+    title: "#solutions-eng triage",
+    source: "Slack",
+    time: "Jun 2, 4:45 PM",
+    owner: "Nadia",
+    quote: "Sales engineers need a one-screen explanation of what the MCP can read versus mutate.",
+  },
+];
+
+const MILESTONES = [
+  { date: "Jun 5", label: "Auth and site picker review", done: true },
+  { date: "Jun 7", label: "Read-only tools dogfood", done: true },
+  { date: "Jun 11", label: "CMS dry-run writes", done: false },
+  { date: "Jun 14", label: "Agency pilot walkthrough", done: false },
+];
+
+function statusClass(status: Health): string {
+  if (status === "On track") return "tag tag-success";
+  if (status === "Watch") return "tag tag-warning";
+  return "tag bg-rose-100 text-rose-700";
+}
+
+function evidenceClass(type: EvidenceType): string {
+  if (type === "Session") return "tag tag-agent";
+  if (type === "Slack") return "tag tag-human";
+  return "tag border border-amber-200 bg-amber-50 text-amber-800";
+}
+
+function totalProgress(workstreams: Workstream[]): number {
+  const total = workstreams.reduce((sum, item) => sum + item.progress, 0);
+  return Math.round(total / workstreams.length);
+}
+
+function sessionTitle(session: SessionSummary): string {
+  return session.title?.trim() || session.session_id;
+}
+
+export default function WebflowMcpDashboardPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+  const { user, loading } = useAuth();
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+
+  useBreadcrumbs([{ label: "Dashboard" }], `${workspaceId}/dashboard`);
+
+  const load = useCallback(async () => {
+    const list = await listMySessions(workspaceId, 200);
+    setSessions(list.filter((session) => session.session_id.startsWith(SEEDED_SESSION_PREFIX)));
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (!user) return;
+    load().catch(() => setSessions([]));
+  }, [user, load]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  const sessionIds = useMemo(
+    () => new Set(sessions.map((session) => session.session_id)),
+    [sessions],
+  );
+  const progress = totalProgress(WORKSTREAMS);
+  const visibleSignals = SIGNALS.map((signal) => {
+    if (signal.label !== "Engineer sessions") return signal;
+    return { ...signal, value: String(Math.max(sessions.length, Number(signal.value))) };
+  });
+
+  if (loading) return <WorkspaceHomeSkeleton />;
+  if (!user) return null;
+
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto bg-base">
+      <div className="mx-auto max-w-[1180px] px-8 py-7 lg:px-12">
+        <header className="border-b border-border pb-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="sys-label">Project dashboard</div>
+              <h1 className="mt-1 font-display text-[30px] font-bold leading-tight text-foreground">
+                Webflow MCP Rollout
+              </h1>
+              <p className="mt-2 max-w-3xl text-[14px] leading-6 text-dim">
+                Demo view for tracking engineering transcripts, Slack launch-room signals,
+                and Gong sales-call evidence around adding MCP tools to Webflow.
+              </p>
+            </div>
+            <div className="min-w-[190px] rounded-lg border border-border bg-surface px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <span className="sys-label">Readiness</span>
+                <span className="font-display text-[24px] font-bold text-foreground">{progress}%</span>
+              </div>
+              <div className="mt-3 h-2 rounded-full bg-raised">
+                <div
+                  className="h-2 rounded-full bg-emerald-500"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {visibleSignals.map((signal) => (
+            <div key={signal.label} className={`rounded-lg border px-4 py-3 ${signal.tone}`}>
+              <div className="font-display text-[24px] font-bold leading-none">{signal.value}</div>
+              <div className="mt-1 text-[12px] font-medium">{signal.label}</div>
+            </div>
+          ))}
+        </section>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(280px,0.9fr)]">
+          <section className="min-w-0">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h2 className="font-display text-[18px] font-semibold text-foreground">Workstreams</h2>
+              <span className="sys-label">4 owners</span>
+            </div>
+            <div className="overflow-hidden rounded-lg border border-border bg-base">
+              {WORKSTREAMS.map((item) => (
+                <div key={item.name} className="border-b border-border-subtle px-4 py-3 last:border-b-0">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-[14px] font-semibold text-foreground">{item.name}</h3>
+                        <span className={statusClass(item.status)}>{item.status}</span>
+                      </div>
+                      <p className="mt-1 text-[13px] leading-5 text-dim">{item.focus}</p>
+                    </div>
+                    <div className="text-right text-[12px] text-muted">{item.owner}</div>
+                  </div>
+                  <div className="mt-3 flex items-center gap-3">
+                    <div className="h-1.5 flex-1 rounded-full bg-raised">
+                      <div
+                        className="h-1.5 rounded-full bg-[var(--color-brand-500)]"
+                        style={{ width: `${item.progress}%` }}
+                      />
+                    </div>
+                    <span className="w-9 text-right text-[12px] font-medium text-dim">
+                      {item.progress}%
+                    </span>
+                  </div>
+                  <div className="mt-2 text-[12px] text-muted">Next: {item.next}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <aside className="min-w-0">
+            <h2 className="mb-2 font-display text-[18px] font-semibold text-foreground">Milestones</h2>
+            <div className="rounded-lg border border-border bg-surface px-4 py-3">
+              {MILESTONES.map((item) => (
+                <div key={item.label} className="flex gap-3 border-b border-border-subtle py-2 last:border-b-0">
+                  <div
+                    className={
+                      "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[11px] " +
+                      (item.done
+                        ? "border-emerald-500 bg-emerald-500 text-white"
+                        : "border-border bg-base text-muted")
+                    }
+                  >
+                    {item.done ? <span className="h-1.5 w-1.5 rounded-full bg-white" /> : null}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-[12px] font-medium text-muted">{item.date}</div>
+                    <div className="text-[13px] leading-5 text-foreground">{item.label}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <h2 className="mb-2 mt-5 font-display text-[18px] font-semibold text-foreground">Risks</h2>
+            <div className="space-y-2">
+              {RISKS.map((risk) => (
+                <div key={risk.label} className="rounded-lg border border-border bg-base px-3 py-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-[13px] font-semibold text-foreground">{risk.label}</div>
+                    <span className="sys-label">{risk.owner}</span>
+                  </div>
+                  <p className="mt-1 text-[12px] leading-5 text-dim">{risk.impact}</p>
+                </div>
+              ))}
+            </div>
+          </aside>
+        </div>
+
+        <section className="mt-7">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="font-display text-[18px] font-semibold text-foreground">Evidence Feed</h2>
+            <span className="sys-label">Sessions / Slack / Gong</span>
+          </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            {EVIDENCE.map((item) => {
+              const href =
+                item.sessionId && sessionIds.has(item.sessionId)
+                  ? `/workspaces/${workspaceId}/sessions/${item.sessionId}`
+                  : null;
+              return (
+                <article key={`${item.type}-${item.title}`} className="rounded-lg border border-border bg-base p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={evidenceClass(item.type)}>{item.type}</span>
+                    <span className="text-[12px] text-muted">{item.source}</span>
+                    <span className="text-[12px] text-muted">-</span>
+                    <span className="text-[12px] text-muted">{item.time}</span>
+                  </div>
+                  <h3 className="mt-2 text-[14px] font-semibold text-foreground">
+                    {href ? (
+                      <Link href={href} className="hover:text-[var(--color-brand-700)] hover:underline">
+                        {item.title}
+                      </Link>
+                    ) : (
+                      item.title
+                    )}
+                  </h3>
+                  <p className="mt-1 text-[13px] leading-5 text-dim">{item.quote}</p>
+                  <div className="mt-3 sys-label">{item.owner}</div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        {sessions.length > 0 && (
+          <section className="mt-7">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h2 className="font-display text-[18px] font-semibold text-foreground">Seeded Transcripts</h2>
+              <span className="sys-label">{sessions.length} live</span>
+            </div>
+            <div className="rounded-lg border border-border bg-surface">
+              {sessions.slice(0, 8).map((session) => (
+                <Link
+                  key={session.session_id}
+                  href={`/workspaces/${workspaceId}/sessions/${session.session_id}`}
+                  className="flex items-center justify-between gap-3 border-b border-border-subtle px-4 py-2.5 text-[13px] last:border-b-0 hover:bg-raised"
+                >
+                  <span className="min-w-0 truncate text-foreground">{sessionTitle(session)}</span>
+                  <span className="shrink-0 text-muted">
+                    {session.event_count} events
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -25,6 +25,7 @@ import type { User, Workspace } from "../lib/types";
 import AddSourceModal from "./integrations/AddSourceModal";
 import {
   ActivityIcon,
+  DashboardIcon,
   FileIcon,
   HelpIcon,
   SessionsIcon,
@@ -279,6 +280,14 @@ export default function AppSidebar({
               : pathname === "/"
           }
         />
+        {activeWorkspace ? (
+          <NavRow
+            href={`/workspaces/${activeWorkspace.id}/dashboard`}
+            icon={<DashboardIcon />}
+            label="Dashboard"
+            active={pathname === `/workspaces/${activeWorkspace.id}/dashboard`}
+          />
+        ) : null}
         {activeWorkspace ? (
           <NavRow
             href={`/workspaces/${activeWorkspace.id}/agents`}

--- a/frontend/src/components/StashIcons.tsx
+++ b/frontend/src/components/StashIcons.tsx
@@ -8,6 +8,7 @@ import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutl
 import NotificationsNoneOutlinedIcon from "@mui/icons-material/NotificationsNoneOutlined";
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 import CloseOutlinedIcon from "@mui/icons-material/CloseOutlined";
+import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
 import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
@@ -97,6 +98,10 @@ export function TableIcon(props: IconProps) {
 
 export function ActivityIcon(props: IconProps) {
   return <MaterialIcon icon={ScheduleOutlinedIcon} {...props} />;
+}
+
+export function DashboardIcon(props: IconProps) {
+  return <MaterialIcon icon={DashboardOutlinedIcon} {...props} />;
 }
 
 export function DiscoverIcon(props: IconProps) {

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -132,6 +132,13 @@ export default function SourceConnectorList({
     onSourceCountChange?.(sources.length);
   }, [onSourceCountChange, sources.length]);
 
+  const disabledReasons = useMemo(() => {
+    const reasons = Object.values(statuses)
+      .map((status) => status.disabled_reason)
+      .filter((reason): reason is string => Boolean(reason));
+    return Array.from(new Set(reasons));
+  }, [statuses]);
+
   async function addSource(connector: Connector, body?: { external_ref?: string; display_name?: string }) {
     if (!workspaceId) return false;
     setBusy(connector.provider);
@@ -148,6 +155,17 @@ export default function SourceConnectorList({
       setError(e instanceof Error ? e.message : "Could not add source");
       return false;
     } finally {
+      setBusy(null);
+    }
+  }
+
+  async function connect(connector: Connector) {
+    setBusy(connector.provider);
+    setError(null);
+    try {
+      await startConnect(connector.provider, returnTo);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not start connection");
       setBusy(null);
     }
   }
@@ -182,9 +200,18 @@ export default function SourceConnectorList({
 
   return (
     <div className="space-y-2">
+      {disabledReasons.length > 0 && (
+        <div className="rounded-md border border-border bg-base px-3 py-2 text-[12px] text-muted">
+          {disabledReasons.length === 1
+            ? disabledReasons[0]
+            : "Some integrations need server configuration before they can be connected."}
+        </div>
+      )}
+
       {CONNECTORS.map((connector) => {
         const status = statuses[connector.provider];
         const connected = !!status?.connected;
+        const enabled = status?.enabled ?? true;
         const count = sources.filter((source) => source.type === connector.sourceType).length;
         return (
           <div key={connector.provider} className="rounded-lg border border-border bg-surface px-3 py-2.5">
@@ -206,10 +233,12 @@ export default function SourceConnectorList({
               <ConnectorAction
                 connector={connector}
                 connected={connected}
+                enabled={enabled}
+                disabledReason={status?.disabled_reason ?? null}
                 busy={busy === connector.provider}
                 workspaceReady={!!workspaceId}
                 expanded={expanded === connector.provider}
-                onConnect={() => void startConnect(connector.provider, returnTo)}
+                onConnect={() => void connect(connector)}
                 onExpand={() => setExpanded((value) => value === connector.provider ? null : connector.provider)}
                 onAdd={() => void addSource(connector, connector.kind === "drive" ? {
                   external_ref: "root",
@@ -288,6 +317,8 @@ export default function SourceConnectorList({
 function ConnectorAction({
   connector,
   connected,
+  enabled,
+  disabledReason,
   busy,
   workspaceReady,
   expanded,
@@ -297,6 +328,8 @@ function ConnectorAction({
 }: {
   connector: Connector;
   connected: boolean;
+  enabled: boolean;
+  disabledReason: string | null;
   busy: boolean;
   workspaceReady: boolean;
   expanded: boolean;
@@ -304,10 +337,17 @@ function ConnectorAction({
   onExpand: () => void;
   onAdd: () => void;
 }) {
+  if (!enabled) {
+    return (
+      <button type="button" disabled title={disabledReason ?? undefined} className={secondaryButton()}>
+        Unavailable
+      </button>
+    );
+  }
   if (!connected) {
     return (
-      <button type="button" onClick={onConnect} className={primaryButton()}>
-        Connect
+      <button type="button" onClick={onConnect} disabled={busy} className={primaryButton()}>
+        {busy ? "Connecting..." : "Connect"}
       </button>
     );
   }
@@ -547,7 +587,7 @@ function labelForSourceType(type: string): string {
 }
 
 function primaryButton(): string {
-  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover";
+  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
 }
 
 function secondaryButton(): string {

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -20,6 +20,8 @@ export type IntegrationStatus = {
   display_name: string;
   scopes: string[];
   connected: boolean;
+  enabled: boolean;
+  disabled_reason: string | null;
   account_email: string | null;
   account_display_name: string | null;
   expires_at: string | null;

--- a/scripts/seed_dev_data.py
+++ b/scripts/seed_dev_data.py
@@ -26,11 +26,13 @@ load_dotenv(REPO_ROOT / "backend" / ".env")
 sys.path.insert(0, str(REPO_ROOT))
 
 from backend import database  # noqa: E402
+from backend.auth import hash_password  # noqa: E402
+from backend.services import cartridge_service as stash_service  # noqa: E402
 from backend.services import (  # noqa: E402
     files_tree_service,
     memory_service,
     session_service,
-    stash_service,
+    source_service,
     storage_service,
     table_service,
     user_service,
@@ -394,6 +396,342 @@ SAMPLE_FILES = [
     },
 ]
 
+WEBFLOW_WORKSPACE_NAME = "Webflow MCP Launch Room"
+WEBFLOW_WORKSPACE_DESCRIPTION = (
+    "Demo project dataset for tracking Webflow MCP engineering work, Slack "
+    "launch-room messages, and Gong sales-call evidence."
+)
+
+WEBFLOW_USERS = [
+    {
+        "name": "demo_nadia",
+        "display_name": "Nadia Brooks",
+        "description": "Platform engineer leading Webflow MCP auth.",
+        "password": "demo",
+    },
+    {
+        "name": "demo_eli",
+        "display_name": "Eli Foster",
+        "description": "Frontend engineer building Designer context tools.",
+        "password": "demo",
+    },
+    {
+        "name": "demo_sam",
+        "display_name": "Sam Rivera",
+        "description": "Solutions engineer collecting customer evidence.",
+        "password": "demo",
+    },
+    {
+        "name": "demo_zoe",
+        "display_name": "Zoe Kim",
+        "description": "Product lead for the Webflow MCP rollout.",
+        "password": "demo",
+    },
+]
+
+WEBFLOW_FOLDERS = [
+    ("Project", None),
+    ("Engineering Sessions", None),
+    ("Customer Signals", None),
+    ("Slack", "Customer Signals"),
+    ("Gong Calls", "Customer Signals"),
+    ("Specs", None),
+]
+
+WEBFLOW_PAGES = [
+    {
+        "name": "Webflow MCP Project Brief",
+        "folder": "Project",
+        "content": (
+            "# Webflow MCP Project Brief\n\n"
+            "Goal: add MCP tools that let trusted agents inspect Webflow sites, "
+            "CMS collections, Designer context, and publish readiness.\n\n"
+            "Demo scope is local-only and uses fake customer evidence."
+        ),
+    },
+    {
+        "name": "Slack Launch Room Digest",
+        "folder": "Customer Signals / Slack",
+        "content": (
+            "# Slack Launch Room Digest\n\n"
+            "- Agencies want dry-run collection writes before production access.\n"
+            "- Sales engineers need clear read versus mutate positioning.\n"
+            "- Designer context must stay current while a human edits the canvas."
+        ),
+    },
+    {
+        "name": "Gong Call - Acme Sites",
+        "folder": "Customer Signals / Gong Calls",
+        "content": (
+            "# Gong Call - Acme Sites\n\n"
+            "Buyer asked for CMS migration audits, locale readiness checks, and "
+            "plain-language explanations of which Webflow objects an agent can read."
+        ),
+    },
+    {
+        "name": "Gong Call - Northstar Commerce",
+        "folder": "Customer Signals / Gong Calls",
+        "content": (
+            "# Gong Call - Northstar Commerce\n\n"
+            "The team launches every Friday and wants an agent to inspect publish "
+            "blockers across locales before a launch manager presses publish."
+        ),
+    },
+    {
+        "name": "MCP Tool Contract",
+        "folder": "Specs",
+        "content": (
+            "# MCP Tool Contract\n\n"
+            "Tools are grouped into auth, site inventory, Designer context, CMS "
+            "schema, draft writes, and publish readiness."
+        ),
+    },
+]
+
+WEBFLOW_TABLES = [
+    {
+        "name": "Webflow MCP Workstreams",
+        "description": "Demo readiness tracker for the Webflow MCP rollout.",
+        "columns": [
+            {"name": "Workstream", "type": "text", "required": True},
+            {"name": "Owner", "type": "text", "required": True},
+            {"name": "Status", "type": "text", "required": True},
+            {"name": "Progress", "type": "number", "required": True},
+            {"name": "Next", "type": "text", "required": False},
+        ],
+        "rows": [
+            {
+                "Workstream": "OAuth and site picker",
+                "Owner": "Nadia",
+                "Status": "On track",
+                "Progress": 86,
+                "Next": "Consent copy review",
+            },
+            {
+                "Workstream": "Designer context tools",
+                "Owner": "Eli",
+                "Status": "Watch",
+                "Progress": 61,
+                "Next": "Iframe message contract",
+            },
+            {
+                "Workstream": "CMS schema and publish readiness",
+                "Owner": "Maya",
+                "Status": "On track",
+                "Progress": 74,
+                "Next": "Reference field validation",
+            },
+            {
+                "Workstream": "Sales engineering pilot",
+                "Owner": "Sam",
+                "Status": "Blocked",
+                "Progress": 38,
+                "Next": "Sandbox credentials",
+            },
+        ],
+    },
+    {
+        "name": "Webflow MCP Customer Signals",
+        "description": "Fake Slack and Gong evidence for the demo dashboard.",
+        "columns": [
+            {"name": "Source", "type": "text", "required": True},
+            {"name": "Account", "type": "text", "required": True},
+            {"name": "Signal", "type": "text", "required": True},
+            {"name": "Priority", "type": "number", "required": True},
+            {"name": "Owner", "type": "text", "required": True},
+        ],
+        "rows": [
+            {
+                "Source": "Slack",
+                "Account": "Internal launch room",
+                "Signal": "Dry-run collection writes are required before pilot access.",
+                "Priority": 1,
+                "Owner": "Maya",
+            },
+            {
+                "Source": "Gong",
+                "Account": "Acme Sites",
+                "Signal": "CMS migration audit is the strongest agency use case.",
+                "Priority": 1,
+                "Owner": "Sam",
+            },
+            {
+                "Source": "Gong",
+                "Account": "Northstar Commerce",
+                "Signal": "Publish readiness across locales matters more than page generation.",
+                "Priority": 2,
+                "Owner": "Zoe",
+            },
+            {
+                "Source": "Slack",
+                "Account": "Solutions engineering",
+                "Signal": "Need a one-screen read-versus-mutate explanation.",
+                "Priority": 2,
+                "Owner": "Nadia",
+            },
+        ],
+    },
+]
+
+WEBFLOW_SESSIONS = [
+    {
+        "session_id": "webflow-mcp-auth-handshake",
+        "agent_name": "codex",
+        "cwd": "/workspace/webflow-mcp",
+        "created_by": "demo_nadia",
+        "files_touched": ["backend/integrations/webflow/oauth.py", "cli/mcp_server.py"],
+        "events": [
+            ("prompt", "Trace the Webflow OAuth handshake and site picker for the MCP demo."),
+            ("assistant", "I mapped the token exchange and found the per-site scope boundary."),
+            ("tool_call", "rg", "rg -n \"webflow|oauth|site\" backend cli"),
+            ("assistant", "The local flow can store workspace and site ids; consent copy still needs review."),
+        ],
+    },
+    {
+        "session_id": "webflow-mcp-designer-context",
+        "agent_name": "claude",
+        "cwd": "/workspace/frontend",
+        "created_by": "demo_eli",
+        "files_touched": ["frontend/src/designer/bridge.ts", "frontend/src/mcp/context.ts"],
+        "events": [
+            ("prompt", "Prototype Designer context reads for selected element and page tree."),
+            ("assistant", "I added a message contract for selected element, active page, and style panel state."),
+            ("tool_call", "npm test", "npm test -- designer bridge"),
+            ("assistant", "Selection changes work; page tree updates need debouncing before dogfood."),
+        ],
+    },
+    {
+        "session_id": "webflow-mcp-cms-schema",
+        "agent_name": "assistant",
+        "cwd": "/workspace/backend",
+        "created_by": "demo_nadia",
+        "files_touched": ["backend/services/webflow_cms.py", "backend/tests/test_webflow_cms.py"],
+        "events": [
+            ("prompt", "Add fake CMS schema introspection for Webflow collections."),
+            ("assistant", "I modeled collection fields, references, option fields, and draft-only writes."),
+            ("assistant", "The schema parser now fails loudly on unknown field types."),
+        ],
+    },
+    {
+        "session_id": "webflow-mcp-publish-readiness",
+        "agent_name": "codex",
+        "cwd": "/workspace/webflow-mcp",
+        "created_by": "demo_zoe",
+        "files_touched": ["product/readiness.md", "backend/services/webflow_publish.py"],
+        "events": [
+            ("prompt", "Use customer evidence to define publish readiness checks."),
+            ("assistant", "I grouped checks around locales, draft status, missing fields, and queued publish jobs."),
+            ("assistant", "Gong calls suggest readiness checks are stronger than generic page generation."),
+        ],
+    },
+    {
+        "session_id": "webflow-mcp-sales-pilot",
+        "agent_name": "claude",
+        "cwd": "/workspace/solutions",
+        "created_by": "demo_sam",
+        "files_touched": ["solutions/pilot-script.md", "docs/webflow-demo.md"],
+        "events": [
+            ("prompt", "Prepare the sales engineering pilot script from Slack and Gong notes."),
+            ("assistant", "I drafted a pilot script that starts with CMS audit and ends with read-only Designer context."),
+            ("assistant", "The blocker is still sandbox credentials for enterprise site permissions."),
+        ],
+    },
+    {
+        "session_id": "webflow-mcp-dry-run-writes",
+        "agent_name": "assistant",
+        "cwd": "/workspace/backend",
+        "created_by": "demo_nadia",
+        "files_touched": ["backend/services/webflow_actions.py", "backend/tests/test_webflow_actions.py"],
+        "events": [
+            ("prompt", "Define dry-run writes for CMS items before enabling mutations."),
+            ("assistant", "I added a dry-run response shape that lists field changes and validation errors."),
+            ("tool_call", "pytest", "pytest backend/tests/test_webflow_actions.py"),
+            ("assistant", "Dry-run responses now show exactly what would change without writing to Webflow."),
+        ],
+    },
+]
+
+WEBFLOW_SLACK_MESSAGES = [
+    {
+        "channel_id": "CWEBFLOW",
+        "channel_name": "webflow-mcp",
+        "ts": "1790851200.000100",
+        "name": "Dry-run writes before pilot",
+        "content": (
+            "Maya: If collection writes stay behind a dry-run preview, agencies will "
+            "try this in production sooner.\n"
+            "Nadia: Agreed. The MCP should return the exact fields it would mutate."
+        ),
+    },
+    {
+        "channel_id": "CWEBFLOW",
+        "channel_name": "webflow-mcp",
+        "ts": "1790854800.000200",
+        "name": "Designer context drift",
+        "content": (
+            "Eli: Designer context is useful only if selected element and page tree "
+            "stay current while the human edits.\n"
+            "Zoe: Call this out as a launch risk until the bridge settles."
+        ),
+    },
+    {
+        "channel_id": "CSE",
+        "channel_name": "solutions-eng",
+        "ts": "1790937600.000300",
+        "name": "Read versus mutate positioning",
+        "content": (
+            "Sam: Sales engineers need a one-screen explanation of what the MCP can "
+            "read versus mutate.\n"
+            "Nadia: I can seed examples for site inventory, CMS schema, and dry-run writes."
+        ),
+    },
+    {
+        "channel_id": "CWEBFLOW",
+        "channel_name": "webflow-mcp",
+        "ts": "1791020400.000400",
+        "name": "Agency migration workflow",
+        "content": (
+            "Zoe: The strongest demo is auditing CMS fields before migration, then "
+            "showing publish readiness across locales."
+        ),
+    },
+]
+
+WEBFLOW_GONG_CALLS = [
+    {
+        "path": "gong/acme-sites-agency-pilot.md",
+        "name": "Gong - Acme Sites agency pilot",
+        "content": (
+            "# Acme Sites agency pilot\n\n"
+            "Summary: buyer wants an agent that audits CMS fields before migration.\n\n"
+            "**Buyer:** We do not need another page generator. We need to know which "
+            "fields block migration and what will break on publish.\n\n"
+            "**Sam:** The Webflow MCP pilot can start read-only, then add dry-run "
+            "collection writes."
+        ),
+    },
+    {
+        "path": "gong/northstar-commerce-discovery.md",
+        "name": "Gong - Northstar Commerce discovery",
+        "content": (
+            "# Northstar Commerce discovery\n\n"
+            "Summary: Friday launches need publish readiness checks across locales.\n\n"
+            "**Buyer:** If the agent can tell us what is missing before launch day, "
+            "that is worth testing immediately."
+        ),
+    },
+    {
+        "path": "gong/brightlane-webflow-admin.md",
+        "name": "Gong - Brightlane Webflow admin",
+        "content": (
+            "# Brightlane Webflow admin\n\n"
+            "Summary: admin team wants transparent permissions and audit logs.\n\n"
+            "**Buyer:** We need to see which workspace, site, and collection the "
+            "agent touched before we approve writes."
+        ),
+    },
+]
+
 
 def _folder_path(parts: str) -> tuple[str, ...]:
     return tuple(part.strip() for part in parts.split("/") if part.strip())
@@ -421,16 +759,70 @@ def _item(
     return SimpleNamespace(object_type=object_type, object_id=object_id, position=position, label_override=label_override)
 
 
+def _permission_pair(access: str) -> tuple[str, str]:
+    if access == "private":
+        return "none", "none"
+    if access == "workspace":
+        return "read", "none"
+    if access == "public":
+        return "read", "read"
+    raise ValueError(f"Unsupported cartridge access: {access}")
+
+
+async def _create_seed_cartridge(
+    *,
+    workspace_id: UUID,
+    owner_id: UUID,
+    title: str,
+    description: str,
+    access: str,
+    discoverable: bool,
+    cover_image_url: str | None,
+    items: list[SimpleNamespace],
+) -> dict:
+    workspace_permission, public_permission = _permission_pair(access)
+    return await stash_service.create_cartridge(
+        workspace_id=workspace_id,
+        owner_id=owner_id,
+        title=title,
+        description=description,
+        workspace_permission=workspace_permission,
+        public_permission=public_permission,
+        discoverable=discoverable,
+        cover_image_url=cover_image_url,
+        items=items,
+    )
+
+
+async def _update_seed_cartridge(
+    *,
+    cartridge_id: UUID,
+    user_id: UUID,
+    items: list[SimpleNamespace],
+) -> dict | None:
+    return await stash_service.update_cartridge(
+        cartridge_id=cartridge_id,
+        user_id=user_id,
+        updates={"items": items},
+    )
+
+
 async def _ensure_user(pool, user: dict) -> tuple[dict, str | None, bool]:
     row = await pool.fetchrow("SELECT id, name, display_name FROM users WHERE name = $1", user["name"])
     if row:
+        if user.get("password"):
+            await pool.execute(
+                "UPDATE users SET password_hash = COALESCE(password_hash, $1) WHERE id = $2",
+                hash_password(user["password"]),
+                row["id"],
+            )
         return dict(row), None, False
 
     new_user, api_key = await user_service.register_user(
         name=user["name"],
         display_name=user["display_name"],
         description=user["description"],
-        password=None,
+        password=user.get("password"),
     )
     return new_user, api_key, True
 
@@ -483,10 +875,14 @@ async def _get_folder(
     )
 
 
-async def _ensure_folders(workspace_id: UUID, creator_id: UUID) -> dict[str, dict]:
+async def _ensure_folders(
+    workspace_id: UUID,
+    creator_id: UUID,
+    folder_specs: list[tuple[str, str | None]] | None = None,
+) -> dict[str, dict]:
     created: dict[str, dict] = {}
     folders_by_name: dict[str, UUID | None] = {}
-    for item in SAMPLE_FOLDERS:
+    for item in folder_specs or SAMPLE_FOLDERS:
         name, parent_name = item
         if parent_name is None:
             parent_id = None
@@ -509,9 +905,14 @@ async def _ensure_folders(workspace_id: UUID, creator_id: UUID) -> dict[str, dic
     return created
 
 
-async def _ensure_pages(workspace_id: UUID, creator_id: UUID, folders: dict[str, dict]) -> dict[str, dict]:
+async def _ensure_pages(
+    workspace_id: UUID,
+    creator_id: UUID,
+    folders: dict[str, dict],
+    page_specs: list[dict[str, Any]] | None = None,
+) -> dict[str, dict]:
     out: dict[str, dict] = {}
-    for spec in SAMPLE_PAGES:
+    for spec in page_specs or SAMPLE_PAGES:
         folder_key = spec["folder"]
         parent_parts = _folder_path(folder_key)
         if len(parent_parts) == 1:
@@ -554,9 +955,13 @@ async def _ensure_pages(workspace_id: UUID, creator_id: UUID, folders: dict[str,
     return out
 
 
-async def _ensure_tables(workspace_id: UUID, creator_id: UUID) -> dict[str, dict]:
+async def _ensure_tables(
+    workspace_id: UUID,
+    creator_id: UUID,
+    table_specs: list[dict[str, Any]] | None = None,
+) -> dict[str, dict]:
     out: dict[str, dict] = {}
-    for spec in SAMPLE_TABLES:
+    for spec in table_specs or SAMPLE_TABLES:
         table = await database.get_pool().fetchrow(
             "SELECT t.id, t.workspace_id, t.name, t.description, t.columns, t.created_by, "
             "t.updated_by, t.created_at, t.updated_at, "
@@ -603,9 +1008,14 @@ async def _session_time_offset(index: int, event_offset: int) -> datetime:
     return base
 
 
-async def _ensure_sessions(workspace_id: UUID, users: dict[str, dict], folders: dict[str, dict]) -> dict[str, dict]:
+async def _ensure_sessions(
+    workspace_id: UUID,
+    users: dict[str, dict],
+    folders: dict[str, dict],
+    session_specs: list[dict[str, Any]] | None = None,
+) -> dict[str, dict]:
     created: dict[str, dict] = {}
-    for i, spec in enumerate(SAMPLE_SESSIONS):
+    for i, spec in enumerate(session_specs or SAMPLE_SESSIONS):
         existing = await session_service.get_session(workspace_id, spec["session_id"])
         if existing:
             created[spec["session_id"]] = existing
@@ -651,6 +1061,7 @@ async def _ensure_files(
     creator_id: UUID,
     folders: dict[str, dict],
     tables: dict[str, dict],
+    file_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict]:
     if not storage_service.is_configured():
         log.warning(
@@ -659,7 +1070,7 @@ async def _ensure_files(
         return {}
 
     out: dict[str, dict] = {}
-    for spec in SAMPLE_FILES:
+    for spec in file_specs or SAMPLE_FILES:
         parent_id = folders.get(spec["folder"], {}).get("id")
         storage_key = await storage_service.upload_file(
             str(workspace_id),
@@ -751,24 +1162,24 @@ async def _ensure_stashes(workspace_id: UUID, user: dict, folders: dict[str, dic
 
     for spec in stash_defs:
         exists = await database.get_pool().fetchrow(
-            "SELECT id FROM stashes WHERE workspace_id = $1 AND title = $2",
+            "SELECT id FROM cartridges WHERE workspace_id = $1 AND title = $2",
             workspace_id,
             spec["title"],
         )
         if exists:
             item_count = await database.get_pool().fetchval(
-                "SELECT COUNT(*) FROM stash_items WHERE stash_id = $1",
+                "SELECT COUNT(*) FROM cartridge_items WHERE cartridge_id = $1",
                 exists["id"],
             )
             if item_count:
                 continue
-            await stash_service.update_stash(
-                stash_id=exists["id"],
+            await _update_seed_cartridge(
+                cartridge_id=exists["id"],
                 user_id=user["id"],
                 items=spec["items"],
             )
             continue
-        await stash_service.create_stash(
+        await _create_seed_cartridge(
             workspace_id=workspace_id,
             owner_id=user["id"],
             title=spec["title"],
@@ -811,6 +1222,149 @@ async def _seed_workspace_bundle(
     }
 
 
+async def _ensure_webflow_connected_sources(workspace_id: UUID, owner_id: UUID) -> int:
+    pool = database.get_pool()
+    slack_source = await source_service.create_source(
+        workspace_id=workspace_id,
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_WEBFLOW_DEMO",
+        display_name="Webflow MCP Slack",
+    )
+    gong_source = await source_service.create_source(
+        workspace_id=workspace_id,
+        owner_user_id=owner_id,
+        source_type="granola",
+        external_ref="gong-webflow-demo",
+        display_name="Gong Sales Calls",
+    )
+
+    await pool.execute(
+        "UPDATE workspace_sources SET sync_enabled = false, sync_status = 'idle', "
+        "last_synced_at = now(), updated_at = now() WHERE id = ANY($1::uuid[])",
+        [UUID(slack_source["id"]), UUID(gong_source["id"])],
+    )
+
+    docs = 0
+    for message in WEBFLOW_SLACK_MESSAGES:
+        await source_service.upsert_content_document(
+            table="slack_messages",
+            source_id=UUID(slack_source["id"]),
+            workspace_id=workspace_id,
+            path=f"#{message['channel_name']}/{message['ts']}.md",
+            name=message["name"],
+            kind="message",
+            content=message["content"],
+            external_ref=message["ts"],
+            extra={
+                "channel_id": message["channel_id"],
+                "channel_name": message["channel_name"],
+                "ts": message["ts"],
+            },
+        )
+        docs += 1
+
+    for call in WEBFLOW_GONG_CALLS:
+        await source_service.upsert_content_document(
+            table="granola_notes",
+            source_id=UUID(gong_source["id"]),
+            workspace_id=workspace_id,
+            path=call["path"],
+            name=call["name"],
+            kind="meeting",
+            content=call["content"],
+            external_ref=call["path"],
+        )
+        docs += 1
+
+    return docs
+
+
+async def _ensure_webflow_stashes(
+    workspace_id: UUID,
+    owner_id: UUID,
+    pages: dict[str, dict],
+    tables: dict[str, dict],
+    sessions: dict[str, dict],
+) -> None:
+    session_items = [
+        _item("session", sessions[session_key]["id"], position)
+        for position, session_key in enumerate(
+            [
+                "webflow-mcp-auth-handshake",
+                "webflow-mcp-designer-context",
+                "webflow-mcp-cms-schema",
+                "webflow-mcp-publish-readiness",
+                "webflow-mcp-sales-pilot",
+            ]
+        )
+        if session_key in sessions
+    ]
+    items = [
+        _item("page", pages["Webflow MCP Project Brief"]["id"], 0),
+        _item("table", tables["Webflow MCP Workstreams"]["id"], 1),
+        _item("table", tables["Webflow MCP Customer Signals"]["id"], 2),
+        _item("page", pages["Slack Launch Room Digest"]["id"], 3),
+        _item("page", pages["Gong Call - Acme Sites"]["id"], 4),
+    ] + [
+        _item(item.object_type, item.object_id, index + 5, item.label_override)
+        for index, item in enumerate(session_items)
+    ]
+
+    title = "Webflow MCP Demo Evidence"
+    existing = await database.get_pool().fetchrow(
+        "SELECT id FROM cartridges WHERE workspace_id = $1 AND title = $2",
+        workspace_id,
+        title,
+    )
+    if existing:
+        item_count = await database.get_pool().fetchval(
+            "SELECT COUNT(*) FROM cartridge_items WHERE cartridge_id = $1",
+            existing["id"],
+        )
+        if item_count:
+            return
+        await _update_seed_cartridge(
+            cartridge_id=existing["id"],
+            user_id=owner_id,
+            items=items,
+        )
+        return
+
+    await _create_seed_cartridge(
+        workspace_id=workspace_id,
+        owner_id=owner_id,
+        title=title,
+        description="Fake project evidence for the Webflow MCP dashboard demo.",
+        access="workspace",
+        discoverable=False,
+        cover_image_url=None,
+        items=items,
+    )
+
+
+async def _seed_webflow_workspace_bundle(
+    workspace_id: UUID,
+    workspace_owner_id: UUID,
+    created_users: dict[str, dict],
+) -> dict[str, int]:
+    folders = await _ensure_folders(workspace_id, workspace_owner_id, WEBFLOW_FOLDERS)
+    pages = await _ensure_pages(workspace_id, workspace_owner_id, folders, WEBFLOW_PAGES)
+    tables = await _ensure_tables(workspace_id, workspace_owner_id, WEBFLOW_TABLES)
+    sessions = await _ensure_sessions(workspace_id, created_users, folders, WEBFLOW_SESSIONS)
+    source_docs = await _ensure_webflow_connected_sources(workspace_id, workspace_owner_id)
+    await _ensure_webflow_stashes(workspace_id, workspace_owner_id, pages, tables, sessions)
+
+    return {
+        "folders": len(folders),
+        "pages": len(pages),
+        "tables": len(tables),
+        "files": 0,
+        "sessions": len(sessions),
+        "source_docs": source_docs,
+    }
+
+
 async def _ensure_external_stash_sample(
     workspace_id: UUID,
     workspace_owner: dict,
@@ -849,24 +1403,24 @@ async def _ensure_external_stash_sample(
 
     external_stash_title = "Partner Briefs"
     existing_external = await database.get_pool().fetchrow(
-        "SELECT id, slug FROM stashes WHERE workspace_id = $1 AND title = $2",
+        "SELECT id, slug FROM cartridges WHERE workspace_id = $1 AND title = $2",
         external_workspace_id,
         external_stash_title,
     )
     if existing_external:
         external_slug = existing_external["slug"]
         item_count = await database.get_pool().fetchval(
-            "SELECT COUNT(*) FROM stash_items WHERE stash_id = $1",
+            "SELECT COUNT(*) FROM cartridge_items WHERE cartridge_id = $1",
             existing_external["id"],
         )
         if not item_count:
-            await stash_service.update_stash(
-                stash_id=existing_external["id"],
+            await _update_seed_cartridge(
+                cartridge_id=existing_external["id"],
                 user_id=external_owner["id"],
                 items=[_item("page", page["id"], 0)],
             )
     else:
-        created_external = await stash_service.create_stash(
+        created_external = await _create_seed_cartridge(
             workspace_id=external_workspace_id,
             owner_id=external_owner["id"],
             title=external_stash_title,
@@ -878,7 +1432,7 @@ async def _ensure_external_stash_sample(
         )
         external_slug = created_external["slug"]
 
-    attached = await stash_service.add_external_stash(
+    attached = await stash_service.add_external_cartridge(
         workspace_id,
         external_slug,
         workspace_owner["id"],
@@ -913,7 +1467,7 @@ async def main() -> int:
         created_users: dict[str, dict] = {}
         created_api_keys: dict[str, str] = {}
 
-        for user in SAMPLE_USERS:
+        for user in [*SAMPLE_USERS, *WEBFLOW_USERS]:
             row, api_key, created = await _ensure_user(pool, user)
             created_users[row["name"]] = row
             if api_key:
@@ -924,6 +1478,7 @@ async def main() -> int:
         seeded_workspace_count = 0
         seeded_session_total = 0
         seeded_file_total = 0
+        seeded_source_doc_total = 0
 
         if args.workspace_id:
             target_workspace = await database.get_pool().fetchrow(
@@ -953,7 +1508,8 @@ async def main() -> int:
             )
             workspace_name = workspace["name"]
             workspace_id = workspace["id"]
-            await _ensure_membership(workspace_id, list(created_users.values()), workspace_owner)
+            sample_members = [created_users[user["name"]] for user in SAMPLE_USERS]
+            await _ensure_membership(workspace_id, sample_members, workspace_owner)
 
             if created:
                 log.info("Created workspace: %s", workspace_name)
@@ -966,12 +1522,38 @@ async def main() -> int:
             seeded_session_total += metrics["sessions"]
             seeded_file_total += metrics["files"]
 
+            webflow_owner = created_users[WEBFLOW_USERS[0]["name"]]
+            webflow_workspace, webflow_created = await _ensure_workspace(
+                pool,
+                webflow_owner,
+                workspace_name=WEBFLOW_WORKSPACE_NAME,
+                workspace_description=WEBFLOW_WORKSPACE_DESCRIPTION,
+            )
+            webflow_workspace_id = webflow_workspace["id"]
+            webflow_members = [created_users[user["name"]] for user in WEBFLOW_USERS]
+            await _ensure_membership(webflow_workspace_id, webflow_members, webflow_owner)
+
+            if webflow_created:
+                log.info("Created Webflow MCP demo workspace: %s", webflow_workspace["name"])
+            else:
+                log.info("Reusing Webflow MCP demo workspace: %s", webflow_workspace["name"])
+
+            webflow_metrics = await _seed_webflow_workspace_bundle(
+                webflow_workspace_id,
+                webflow_owner["id"],
+                created_users,
+            )
+            seeded_workspace_count += 1
+            seeded_session_total += webflow_metrics["sessions"]
+            seeded_file_total += webflow_metrics["files"]
+            seeded_source_doc_total += webflow_metrics["source_docs"]
+
             if args.seed_empty_workspaces:
                 empty_workspaces = await pool.fetch(
                     """
                     SELECT w.id, w.name, w.creator_id
                     FROM workspaces w
-                    LEFT JOIN stashes s ON s.workspace_id = w.id
+                    LEFT JOIN cartridges s ON s.workspace_id = w.id
                     WHERE s.id IS NULL
                     ORDER BY w.created_at
                     """
@@ -998,7 +1580,7 @@ async def main() -> int:
                 log.info("  %s: %s", username, key)
 
         stash_count = await database.get_pool().fetchval(
-            "SELECT count(*) FROM stashes WHERE workspace_id = $1",
+            "SELECT count(*) FROM cartridges WHERE workspace_id = $1",
             workspace_id,
         )
         print(
@@ -1006,6 +1588,7 @@ async def main() -> int:
             f"users={len(created_users)} "
             f"sessions={seeded_session_total} "
             f"files={seeded_file_total} "
+            f"source_docs={seeded_source_doc_total} "
             f"stashes={stash_count}"
         )
     finally:

--- a/start.sh
+++ b/start.sh
@@ -51,6 +51,55 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
     echo "Loaded environment from .env"
 fi
 
+generate_integrations_encryption_key() {
+    python - <<'PY'
+import base64
+import secrets
+
+print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())
+PY
+}
+
+ensure_integrations_encryption_key() {
+    if [ -n "${INTEGRATIONS_ENCRYPTION_KEY:-}" ]; then
+        return
+    fi
+
+    local env_file="$PROJECT_ROOT/.env"
+    local generated_key
+    local tmp_file
+
+    generated_key="$(generate_integrations_encryption_key)"
+
+    if [ -f "$env_file" ]; then
+        tmp_file="$(mktemp)"
+        awk -v key="$generated_key" '
+            BEGIN { written = 0 }
+            /^INTEGRATIONS_ENCRYPTION_KEY=/ {
+                if (!written) {
+                    print "INTEGRATIONS_ENCRYPTION_KEY=" key
+                    written = 1
+                }
+                next
+            }
+            { print }
+            END {
+                if (!written) {
+                    print "INTEGRATIONS_ENCRYPTION_KEY=" key
+                }
+            }
+        ' "$env_file" > "$tmp_file"
+        mv "$tmp_file" "$env_file"
+    else
+        printf 'INTEGRATIONS_ENCRYPTION_KEY=%s\n' "$generated_key" > "$env_file"
+    fi
+
+    export INTEGRATIONS_ENCRYPTION_KEY="$generated_key"
+    echo "[secrets] Generated INTEGRATIONS_ENCRYPTION_KEY in .env."
+}
+
+ensure_integrations_encryption_key
+
 export DATABASE_URL="${DATABASE_URL:-$LOCAL_DATABASE_URL}"
 BACKEND_PORT="${BACKEND_PORT:-$DEFAULT_BACKEND_PORT}"
 FRONTEND_PORT="${FRONTEND_PORT:-$DEFAULT_FRONTEND_PORT}"


### PR DESCRIPTION
Summary
- Add a workspace Dashboard route for the Webflow MCP rollout demo.
- Add sidebar navigation and a dashboard icon.
- Seed a Webflow MCP demo workspace with fake engineer sessions, Slack messages, Gong-style sales call notes, readiness tables, pages, connected source rows, and an evidence cartridge.

Verification
- python -m py_compile scripts/seed_dev_data.py
- ruff check scripts/seed_dev_data.py
- cd frontend && npm run lint
- cd frontend && BACKEND_INTERNAL_URL=http://localhost:3456 npm run build
- python scripts/seed_dev_data.py
- Playwright smoke check against local backend/frontend; screenshot attached in PR thread.