### PR TITLE
Add api_key auth path + Gong as an agent source

### DIFF
--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -17,6 +17,7 @@ for a new provider — only the explicit list of providers grows.
 from . import (
     asana,  # noqa: F401
     github,  # noqa: F401 — import for side-effect (provider self-registration)
+    gong,  # noqa: F401
     google,  # noqa: F401
     granola,  # noqa: F401
     jira,  # noqa: F401

--- a/backend/integrations/base.py
+++ b/backend/integrations/base.py
@@ -30,6 +30,16 @@ class AccountInfo:
     display_name: str | None
 
 
+@dataclass
+class CredentialField:
+    """One input in an api_key provider's connect form (see below)."""
+
+    name: str
+    label: str
+    secret: bool = False  # render as a password field + never echo back
+    placeholder: str = ""
+
+
 class Integration(Protocol):
     name: str
     """URL segment + provider key. e.g. 'google', 'github'."""
@@ -63,3 +73,23 @@ class Integration(Protocol):
     async def fetch_account(self, access_token: str) -> AccountInfo:
         """Resolve the connected account identity for display."""
         ...
+
+
+# --- api_key providers -------------------------------------------------------
+#
+# Some services (Gong, Snowflake) authenticate with pasted credentials, not an
+# OAuth redirect. Such a provider sets `auth_kind = "api_key"`, declares its
+# `credential_fields`, and implements `connect_with_credentials` instead of the
+# OAuth methods. The router renders a form from the fields and POSTs the values
+# to /credentials. The provider validates them against the upstream and returns
+# the credential bundle as the access token (JSON-encoded, with no expiry) so it
+# rides the same encrypted storage column as OAuth tokens — callers recover it
+# with `json.loads(await get_valid_token(...))`.
+#
+#   class GongIntegration:
+#       name = "gong"
+#       display_name = "Gong"
+#       auth_kind = "api_key"
+#       credential_fields = [CredentialField("access_key", "Access Key", secret=True), ...]
+#       async def connect_with_credentials(self, values: dict[str, str])
+#           -> tuple[TokenSet, AccountInfo]: ...

--- a/backend/integrations/gong/__init__.py
+++ b/backend/integrations/gong/__init__.py
@@ -1,0 +1,11 @@
+"""Gong integration: api_key provider.
+
+Connected Gong calls are indexed into gong_documents by
+backend/integrations/gong/indexer.py (dispatched from backend/tasks/sources) —
+each call's transcript becomes a searchable document.
+"""
+
+from ..registry import register_provider
+from .provider import GongIntegration
+
+register_provider(GongIntegration())

--- a/backend/integrations/gong/indexer.py
+++ b/backend/integrations/gong/indexer.py
@@ -1,0 +1,116 @@
+"""Gong → gong_documents indexer (copied content; FTS-searchable).
+
+One Gong connection = one source (external_ref "calls"). We pull calls from a
+rolling window (last LOOKBACK_DAYS) plus their transcripts in two paged passes,
+then write each call as a text document (title + date + speaker-labelled
+transcript). Idempotent re-sync via source_service; calls that age out of the
+window are soft-deleted.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+
+from ...services import source_service
+from ..storage import get_valid_token
+from .provider import API_BASE, basic_auth_header
+
+logger = logging.getLogger(__name__)
+
+LOOKBACK_DAYS = 90
+MAX_CALLS = 5000
+
+
+def _render_call(meta: dict, monologues: list[dict]) -> str:
+    title = meta.get("title") or "Untitled call"
+    started = meta.get("started") or ""
+    lines = [f"# {title}", f"Date: {started}", ""]
+    speaker_num: dict[str, int] = {}
+    for mono in monologues:
+        sid = mono.get("speakerId") or "?"
+        if sid not in speaker_num:
+            speaker_num[sid] = len(speaker_num) + 1
+        text = " ".join(s.get("text", "") for s in mono.get("sentences", []))
+        if text.strip():
+            lines.append(f"[Speaker {speaker_num[sid]}]: {text}")
+    return "\n".join(lines)
+
+
+async def _fetch_call_meta(client: httpx.AsyncClient, from_dt: str, to_dt: str) -> dict[str, dict]:
+    meta_by_id: dict[str, dict] = {}
+    cursor: str | None = None
+    while len(meta_by_id) < MAX_CALLS:
+        params = {"fromDateTime": from_dt, "toDateTime": to_dt}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await client.get(f"{API_BASE}/v2/calls", params=params)
+        if resp.status_code == 404:
+            break  # no calls in window
+        resp.raise_for_status()
+        payload = resp.json()
+        for call in payload.get("calls", []):
+            meta_by_id[call["id"]] = call
+        cursor = (payload.get("records") or {}).get("cursor")
+        if not cursor:
+            break
+    return meta_by_id
+
+
+async def _fetch_transcripts(
+    client: httpx.AsyncClient, from_dt: str, to_dt: str
+) -> dict[str, list[dict]]:
+    transcript_by_id: dict[str, list[dict]] = {}
+    cursor: str | None = None
+    while True:
+        body: dict = {"filter": {"fromDateTime": from_dt, "toDateTime": to_dt}}
+        if cursor:
+            body["cursor"] = cursor
+        resp = await client.post(f"{API_BASE}/v2/calls/transcript", json=body)
+        if resp.status_code == 404:
+            break
+        resp.raise_for_status()
+        payload = resp.json()
+        for entry in payload.get("callTranscripts", []):
+            transcript_by_id[entry["callId"]] = entry.get("transcript", [])
+        cursor = (payload.get("records") or {}).get("cursor")
+        if not cursor:
+            break
+    return transcript_by_id
+
+
+async def index_gong(source: dict) -> str | None:
+    source_id = UUID(source["id"])
+    workspace_id = UUID(source["workspace_id"])
+    owner_user_id = UUID(source["owner_user_id"])
+
+    creds = json.loads(await get_valid_token(owner_user_id, "gong"))
+    headers = {"Authorization": basic_auth_header(creds["access_key"], creds["access_key_secret"])}
+    to_dt = datetime.now(UTC).isoformat()
+    from_dt = (datetime.now(UTC) - timedelta(days=LOOKBACK_DAYS)).isoformat()
+
+    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+        meta_by_id = await _fetch_call_meta(client, from_dt, to_dt)
+        transcript_by_id = await _fetch_transcripts(client, from_dt, to_dt)
+
+    present: list[str] = []
+    for call_id, meta in meta_by_id.items():
+        await source_service.upsert_content_document(
+            table="gong_documents",
+            source_id=source_id,
+            workspace_id=workspace_id,
+            path=call_id,
+            name=meta.get("title") or call_id,
+            kind="call",
+            content=_render_call(meta, transcript_by_id.get(call_id, [])),
+            external_ref=call_id,
+        )
+        present.append(call_id)
+
+    await source_service.soft_delete_missing("gong_documents", source_id, present)
+    logger.info("gong source: indexed %d call(s)", len(present))
+    return None

--- a/backend/integrations/gong/provider.py
+++ b/backend/integrations/gong/provider.py
@@ -1,0 +1,64 @@
+"""Gong api_key provider.
+
+Gong authenticates per customer with an Access Key + Secret (HTTP Basic),
+not OAuth — Gong OAuth is gated on marketplace-partner approval. The user
+pastes both in the connect form; we validate them against /v2/workspaces and
+store the bundle as the access token (see integrations/base.py for the
+api_key contract).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+
+from ..base import AccountInfo, CredentialField, TokenSet
+
+API_BASE = "https://api.gong.io"
+
+
+def basic_auth_header(access_key: str, secret: str) -> str:
+    raw = f"{access_key}:{secret}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+class GongIntegration:
+    name = "gong"
+    display_name = "Gong"
+    scopes: list[str] = []
+    supports_refresh = False
+    auth_kind = "api_key"
+    credential_fields = [
+        CredentialField("access_key", "Access Key", secret=True, placeholder="Gong API access key"),
+        CredentialField(
+            "access_key_secret", "Access Key Secret", secret=True, placeholder="Gong API secret"
+        ),
+    ]
+
+    async def connect_with_credentials(
+        self, values: dict[str, str]
+    ) -> tuple[TokenSet, AccountInfo]:
+        access_key = (values.get("access_key") or "").strip()
+        secret = (values.get("access_key_secret") or "").strip()
+        if not access_key or not secret:
+            raise ValueError("Both Access Key and Access Key Secret are required")
+
+        headers = {"Authorization": basic_auth_header(access_key, secret)}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            resp = await client.get(f"{API_BASE}/v2/workspaces")
+        # Any non-200 means we couldn't validate the keys — a client error, so
+        # surface it as ValueError (the router maps it to 400) rather than 500.
+        if resp.status_code != 200:
+            raise ValueError(f"Gong rejected these credentials (HTTP {resp.status_code})")
+        workspaces = resp.json().get("workspaces", [])
+
+        display_name = workspaces[0]["name"] if workspaces else "Gong"
+        token = TokenSet(
+            access_token=json.dumps({"access_key": access_key, "access_key_secret": secret}),
+            refresh_token=None,
+            expires_at=None,
+            scopes=[],
+        )
+        return token, AccountInfo(email=None, display_name=display_name)

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -85,9 +85,11 @@ class ProviderListItem(BaseModel):
     connected: bool
     enabled: bool
     disabled_reason: str | None = None
-    # "oauth" (the default redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP
-    # server, e.g. Granola).
+    # "oauth" (the default redirect flow), "mcp_oauth" (DCR+PKCE via an MCP
+    # server, e.g. Granola), or "api_key" (pasted credentials, e.g. Gong).
     auth_kind: str = "oauth"
+    # For api_key providers: the form fields the frontend should render.
+    credential_fields: list[dict] | None = None
     account_email: str | None = None
     account_display_name: str | None = None
     expires_at: str | None = None
@@ -181,6 +183,11 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
                 enabled=disabled_reason is None,
                 disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
+                credential_fields=[
+                    {"name": f.name, "label": f.label, "secret": f.secret, "placeholder": f.placeholder}
+                    for f in getattr(p, "credential_fields", [])
+                ]
+                or None,
                 account_email=conn["account_email"] if conn else None,
                 account_display_name=conn["account_display_name"] if conn else None,
                 expires_at=conn["expires_at"] if conn else None,
@@ -264,6 +271,38 @@ async def integration_disconnect(
     get_provider(provider)  # 404 if unknown
     await storage.revoke_stored(current_user["id"], provider)
     return {"ok": True}
+
+
+class CredentialConnectResponse(BaseModel):
+    connected: bool
+    account_email: str | None
+    account_display_name: str | None
+
+
+@router.post("/{provider}/credentials", response_model=CredentialConnectResponse)
+async def integration_connect_with_credentials(
+    provider: str,
+    values: dict[str, str],
+    current_user: dict = Depends(get_current_user),
+):
+    """Connect an api_key provider (Gong, Snowflake) from pasted credentials.
+    The provider validates them against the upstream and returns the bundle as
+    the stored token; we never echo the secrets back."""
+    p = get_provider(provider)
+    _ensure_provider_enabled(provider)
+    if getattr(p, "auth_kind", "oauth") != "api_key":
+        raise HTTPException(status_code=400, detail=f"{provider} does not use credential auth")
+    try:
+        token, account = await p.connect_with_credentials(values)
+    except ValueError as e:
+        # Bad/rejected credentials — a client error, not a server fault.
+        raise HTTPException(status_code=400, detail=str(e))
+    await storage.store_token(current_user["id"], provider, token, account)
+    return CredentialConnectResponse(
+        connected=True,
+        account_email=account.email,
+        account_display_name=account.display_name,
+    )
 
 
 class GooglePickerTokenResponse(BaseModel):

--- a/backend/migrations/versions/0089_gong_source.py
+++ b/backend/migrations/versions/0089_gong_source.py
@@ -1,0 +1,51 @@
+"""Per-integration source table for Gong.
+
+Copied-content source (FTS + embeddings live in the table), same shape as
+github_documents (migration 0084): each Gong call's transcript becomes a
+document keyed by (source_id, path).
+
+Revision ID: 0089
+Revises: 0088
+"""
+
+from alembic import op
+
+revision = "0089"
+down_revision = "0088"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = """
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id        uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    source_id           uuid NOT NULL REFERENCES workspace_sources(id) ON DELETE CASCADE,
+    path                text NOT NULL,
+    name                text NOT NULL,
+    kind                text NOT NULL DEFAULT 'file',
+    external_ref        text,
+    external_updated_at timestamptz,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    deleted_at          timestamptz,
+    content             text,
+    content_hash        text,
+    embedding           vector(384),
+    embed_stale         boolean NOT NULL DEFAULT FALSE
+"""
+
+
+def upgrade() -> None:
+    op.execute(f"CREATE TABLE gong_documents ({_COLUMNS}, UNIQUE (source_id, path))")
+    op.execute(
+        "CREATE INDEX gong_documents_source_idx ON gong_documents (source_id, path) "
+        "WHERE deleted_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX gong_documents_fts_idx ON gong_documents "
+        "USING gin (to_tsvector('english', coalesce(content, '')))"
+    )
+    op.execute("CREATE INDEX gong_documents_embed_stale_idx ON gong_documents (id) WHERE embed_stale")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS gong_documents")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -54,6 +54,13 @@ async def _resolve_granola_source(user_id) -> tuple[str, str]:
     return "granola", "Granola"
 
 
+async def _resolve_gong_source(user_id) -> tuple[str, str]:
+    """Gong is one connection per user (all calls); external_ref is constant.
+    Confirm the credentials exist (raises 401 if not connected)."""
+    await integration_storage.get_valid_token(user_id, "gong")
+    return "calls", "Gong"
+
+
 @router.get("")
 async def list_sources(workspace_id: UUID, current_user: dict = Depends(get_current_user)):
     """Sources this user can see here: native files + sessions, plus their own
@@ -136,6 +143,9 @@ async def add_source(
         display_name = display_name or resolved_name
     elif body.source_type == "granola" and not external_ref:
         external_ref, resolved_name = await _resolve_granola_source(current_user["id"])
+        display_name = display_name or resolved_name
+    elif body.source_type == "gong_calls" and not external_ref:
+        external_ref, resolved_name = await _resolve_gong_source(current_user["id"])
         display_name = display_name or resolved_name
 
     if not external_ref:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -41,6 +41,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "granola": 21600,
     "jira_project": 1800,
     "asana_project": 1800,
+    "gong_calls": 21600,
 }
 
 # Which capability each connected source type exposes.
@@ -52,6 +53,7 @@ SOURCE_CAPABILITY = {
     "granola": "searchable",
     "jira_project": "searchable",
     "asana_project": "navigable",
+    "gong_calls": "searchable",
 }
 
 
@@ -226,6 +228,7 @@ SOURCE_TABLE = {
     "granola": "granola_notes",
     "jira_project": "jira_documents",
     "asana_project": "asana_documents",
+    "gong_calls": "gong_documents",
 }
 
 # Tables that COPY content (FTS + embeddings live in them). The rest are
@@ -236,6 +239,7 @@ CONTENT_TABLES = {
     "granola_notes",
     "jira_documents",
     "asana_documents",
+    "gong_documents",
 }
 
 

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from ..celery_app import celery
 from ..integrations.asana.indexer import index_asana
 from ..integrations.github.indexer import index_github_repo
+from ..integrations.gong.indexer import index_gong
 from ..integrations.google.indexer import index_google_drive
 from ..integrations.granola.indexer import index_granola
 from ..integrations.jira.indexer import index_jira
@@ -38,6 +39,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "granola": index_granola,
     "jira_project": index_jira,
     "asana_project": index_asana,
+    "gong_calls": index_gong,
 }
 
 

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -1,17 +1,21 @@
-"""Jira + Asana source unit tests.
+"""Jira + Asana + Gong source unit tests.
 
 Two things worth pinning that don't need a DB or live OAuth:
 
-1. The rendering helpers decide what text the agent actually reads for an issue
-   or task — so we assert the human-meaningful fields (status, assignee, body,
-   comments) survive into the document.
+1. The rendering helpers decide what text the agent actually reads for an issue,
+   task, or call — so we assert the human-meaningful fields (status, assignee,
+   body, comments, transcript) survive into the document.
 2. A connected source type is only usable if it's wired into EVERY map at once
    (capability, table, content-vs-index, indexer, sync interval). The
    consistency test fails loudly if a future integration wires only some of
    them — the exact bug that makes a source silently un-syncable.
 """
 
+import pytest
+
 from backend.integrations.asana.indexer import _render_task
+from backend.integrations.gong.indexer import _render_call
+from backend.integrations.gong.provider import GongIntegration
 from backend.integrations.jira.indexer import _adf_to_text, _render_issue
 from backend.services import source_service
 from backend.tasks import sources as source_tasks
@@ -122,3 +126,36 @@ def test_jira_and_asana_are_searchable_content_sources():
     assert "asana_documents" in source_service.CONTENT_TABLES
     assert source_service.SOURCE_CAPABILITY["jira_project"] == "searchable"
     assert source_service.SOURCE_CAPABILITY["asana_project"] == "navigable"
+
+
+def test_render_call_labels_speakers_and_keeps_transcript():
+    text = _render_call(
+        {"title": "Q3 sync", "started": "2026-06-01T10:00:00Z"},
+        [
+            {"speakerId": "a", "sentences": [{"text": "hello there"}]},
+            {"speakerId": "b", "sentences": [{"text": "hi"}, {"text": "good to meet you"}]},
+            {"speakerId": "a", "sentences": [{"text": "likewise"}]},
+        ],
+    )
+    assert "# Q3 sync" in text
+    assert "Date: 2026-06-01T10:00:00Z" in text
+    # Stable per-call speaker numbering: first speaker is 1, second is 2.
+    assert "[Speaker 1]: hello there" in text
+    assert "[Speaker 2]: hi good to meet you" in text
+    assert "[Speaker 1]: likewise" in text
+
+
+def test_gong_is_api_key_searchable_source():
+    gong = GongIntegration()
+    assert gong.auth_kind == "api_key"
+    assert [f.name for f in gong.credential_fields] == ["access_key", "access_key_secret"]
+    assert all(f.secret for f in gong.credential_fields)
+    assert source_service.SOURCE_TABLE["gong_calls"] == "gong_documents"
+    assert "gong_documents" in source_service.CONTENT_TABLES
+    assert source_service.SOURCE_CAPABILITY["gong_calls"] == "searchable"
+
+
+@pytest.mark.asyncio
+async def test_gong_rejects_missing_credentials():
+    with pytest.raises(ValueError):
+        await GongIntegration().connect_with_credentials({"access_key": "", "access_key_secret": ""})

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -83,6 +83,23 @@ export function NotionIcon({ className, size = defaultSize }: Props) {
   );
 }
 
+export function GongIcon({ className, size = defaultSize }: Props) {
+  // Gong mark — a purple ring with a centered dot.
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="9.2" stroke="#8039DF" strokeWidth="2.2" />
+      <circle cx="12" cy="12" r="3.4" fill="#8039DF" />
+    </svg>
+  );
+}
+
 export function JiraIcon({ className, size = defaultSize }: Props) {
   // Official Jira mark — interlocking chevrons in Jira blue.
   return (

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -17,7 +17,9 @@ import {
   listJiraProjects,
   listNotionPages,
   startConnect,
+  submitCredentials,
   type AsanaProjectSummary,
+  type CredentialField,
   type GitHubRepoSummary,
   type IntegrationProvider,
   type IntegrationStatus,
@@ -28,6 +30,7 @@ import {
 import {
   AsanaIcon,
   GitHubIcon,
+  GongIcon,
   GoogleDriveIcon,
   GranolaIcon,
   JiraIcon,
@@ -113,6 +116,14 @@ const CONNECTORS: Connector[] = [
     kind: "auto",
     blurb: "Meeting notes and transcripts.",
   },
+  {
+    provider: "gong",
+    label: "Gong",
+    sourceType: "gong_calls",
+    icon: <GongIcon />,
+    kind: "auto",
+    blurb: "Call transcripts, kept in sync.",
+  },
 ];
 
 export default function SourceConnectorList({
@@ -192,6 +203,22 @@ export default function SourceConnectorList({
     }
   }
 
+  async function submitCreds(connector: Connector, values: Record<string, string>) {
+    setBusy(connector.provider);
+    setError(null);
+    try {
+      await submitCredentials(connector.provider, values);
+      setExpanded(null);
+      await refresh();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not connect");
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function syncSource(source: WorkspaceSource) {
     if (!workspaceId) return;
     setBusy(`sync:${source.source}`);
@@ -256,6 +283,7 @@ export default function SourceConnectorList({
                 connector={connector}
                 connected={connected}
                 enabled={enabled}
+                authKind={status?.auth_kind ?? "oauth"}
                 disabledReason={status?.disabled_reason ?? null}
                 busy={busy === connector.provider}
                 workspaceReady={!!workspaceId}
@@ -305,6 +333,16 @@ export default function SourceConnectorList({
                 })}
               />
             )}
+            {expanded === connector.provider &&
+              !connected &&
+              status?.auth_kind === "api_key" &&
+              status.credential_fields && (
+                <CredentialForm
+                  fields={status.credential_fields}
+                  busy={busy === connector.provider}
+                  onSubmit={(values) => submitCreds(connector, values)}
+                />
+              )}
           </div>
         );
       })}
@@ -358,6 +396,7 @@ function ConnectorAction({
   connector,
   connected,
   enabled,
+  authKind,
   disabledReason,
   busy,
   workspaceReady,
@@ -369,6 +408,7 @@ function ConnectorAction({
   connector: Connector;
   connected: boolean;
   enabled: boolean;
+  authKind: IntegrationStatus["auth_kind"];
   disabledReason: string | null;
   busy: boolean;
   workspaceReady: boolean;
@@ -385,6 +425,15 @@ function ConnectorAction({
     );
   }
   if (!connected) {
+    // api_key providers (Gong) reveal an inline credential form instead of
+    // redirecting to an OAuth consent screen.
+    if (authKind === "api_key") {
+      return (
+        <button type="button" onClick={onExpand} disabled={busy} className={primaryButton()}>
+          {expanded ? "Cancel" : "Connect"}
+        </button>
+      );
+    }
     return (
       <button type="button" onClick={onConnect} disabled={busy} className={primaryButton()}>
         {busy ? "Connecting..." : "Connect"}
@@ -679,6 +728,46 @@ function AsanaProjectPicker({
   );
 }
 
+function CredentialForm({
+  fields,
+  busy,
+  onSubmit,
+}: {
+  fields: CredentialField[];
+  busy: boolean;
+  onSubmit: (values: Record<string, string>) => Promise<boolean>;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const complete = fields.every((f) => (values[f.name] ?? "").trim().length > 0);
+
+  return (
+    <form
+      className="mt-2.5 space-y-2 rounded-md border border-border bg-base p-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (complete) void onSubmit(values);
+      }}
+    >
+      {fields.map((field) => (
+        <label key={field.name} className="block">
+          <span className="mb-1 block text-[11.5px] text-muted">{field.label}</span>
+          <input
+            type={field.secret ? "password" : "text"}
+            value={values[field.name] ?? ""}
+            placeholder={field.placeholder}
+            autoComplete="off"
+            onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
+            className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+          />
+        </label>
+      ))}
+      <button type="submit" disabled={!complete || busy} className={primaryButton()}>
+        {busy ? "Connecting..." : "Connect"}
+      </button>
+    </form>
+  );
+}
+
 function PickerShell({
   error,
   loading,
@@ -758,6 +847,7 @@ function labelForSourceType(type: string): string {
   if (type === "granola") return "Granola";
   if (type === "jira_project") return "Jira";
   if (type === "asana_project") return "Asana";
+  if (type === "gong_calls") return "Gong";
   return type;
 }
 

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -15,7 +15,15 @@ export type IntegrationProvider =
   | "slack"
   | "granola"
   | "jira"
-  | "asana";
+  | "asana"
+  | "gong";
+
+export type CredentialField = {
+  name: string;
+  label: string;
+  secret: boolean;
+  placeholder: string;
+};
 
 export type IntegrationStatus = {
   provider: string;
@@ -28,8 +36,11 @@ export type IntegrationStatus = {
   account_display_name: string | null;
   expires_at: string | null;
   connected_at: string | null;
-  // "oauth" (redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP server, e.g. Granola).
-  auth_kind: "oauth" | "mcp_oauth";
+  // "oauth" (redirect flow), "mcp_oauth" (DCR+PKCE via an MCP server, e.g.
+  // Granola), or "api_key" (pasted credentials, e.g. Gong).
+  auth_kind: "oauth" | "mcp_oauth" | "api_key";
+  // Present only for api_key providers — the fields to render in the connect form.
+  credential_fields: CredentialField[] | null;
 };
 
 export type IntegrationsList = {
@@ -62,6 +73,20 @@ export async function startConnect(
 
 export async function disconnectIntegration(provider: IntegrationProvider): Promise<void> {
   await apiFetch(`/api/v1/integrations/${provider}/disconnect`, { method: "POST" });
+}
+
+/**
+ * Connect an api_key provider (e.g. Gong) by POSTing the pasted credential
+ * values. The backend validates them upstream and stores them encrypted.
+ */
+export async function submitCredentials(
+  provider: IntegrationProvider,
+  values: Record<string, string>,
+): Promise<void> {
+  await apiFetch(`/api/v1/integrations/${provider}/credentials`, {
+    method: "POST",
+    body: JSON.stringify(values),
+  });
 }
 
 export type GitHubRepoSummary = {


### PR DESCRIPTION
## What

**PR 2 of 3.** Adds a small, reusable **`api_key` auth path** for providers that authenticate with pasted credentials instead of an OAuth redirect, then adds **Gong** on top of it.

> Stacked on #505 (Jira/Asana). Base is `integrations-jira-asana`; review/merge that first. GitHub will retarget this to `main` once #505 merges.

## Why api_key

Gong OAuth requires Gong to whitelist our app as a marketplace partner (external dependency). Per-customer **Access Key + Secret** (HTTP Basic) needs no approval — but the framework was OAuth-redirect-only. This adds the missing path, reusable for Snowflake in PR 3.

## How

**Framework** (`base.py` + `router.py`):
- `CredentialField` + the api_key contract: a provider sets `auth_kind="api_key"`, declares `credential_fields`, and implements `connect_with_credentials`, which validates the creds upstream and returns them JSON-encoded as the access token (no expiry) so they ride the **same encrypted storage column** as OAuth tokens. No DB schema change, no token-storage change.
- `POST /integrations/{provider}/credentials` validates + stores; the providers list now surfaces `auth_kind` + `credential_fields` so the UI can render a form. Bad/rejected credentials surface as **400**, not 500.

**Gong**:
- Access Key + Secret validated against `/v2/workspaces`. One connection = one source (`gong_calls`). Calls + transcripts from a rolling 90-day window become **searchable** documents (title, date, speaker-labelled transcript) in `gong_documents` (migration 0089).

**Frontend**: inline credential form (password fields built from `credential_fields`) revealed when an api_key provider's Connect is clicked; Gong connector card + icon.

## Verification

- `ruff` + `pytest` (`test_integration_sources.py`: transcript render, api_key wiring, missing-credential rejection) — green. Full `test_sources.py` suite (26 tests) green.
- Frontend `tsc --noEmit` + `eslint` — green. Migration 0089 applies; `gong_documents` matches the `github_documents` shape.
- Throwaway backend confirmed: Gong lists `enabled` with `auth_kind=api_key` and two secret credential fields; `POST /gong/credentials` with bad keys returns **400** (validated against the live Gong API, which 401s); `add_source` for `gong_calls` without a connection returns 401.
- UI: the Gong connector card renders in Settings → Sources (screenshot in thread). The credential form (verified by tests/API) shows on Connect once the backend reports `auth_kind=api_key`.

Connecting for real needs a customer's Gong Access Key + Secret (with `api:calls:read:*` scopes) — entered in the form, no server-side env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)