### PR TITLE
Add Snowflake as a read-only SQL query source

### DIFF
--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -23,4 +23,5 @@ from . import (
     jira,  # noqa: F401
     notion,  # noqa: F401
     slack,  # noqa: F401
+    snowflake,  # noqa: F401
 )

--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -17,6 +17,7 @@ for a new provider — only the explicit list of providers grows.
 from . import (
     asana,  # noqa: F401
     github,  # noqa: F401 — import for side-effect (provider self-registration)
+    gong,  # noqa: F401
     google,  # noqa: F401
     granola,  # noqa: F401
     jira,  # noqa: F401

--- a/backend/integrations/base.py
+++ b/backend/integrations/base.py
@@ -30,6 +30,16 @@ class AccountInfo:
     display_name: str | None
 
 
+@dataclass
+class CredentialField:
+    """One input in an api_key provider's connect form (see below)."""
+
+    name: str
+    label: str
+    secret: bool = False  # render as a password field + never echo back
+    placeholder: str = ""
+
+
 class Integration(Protocol):
     name: str
     """URL segment + provider key. e.g. 'google', 'github'."""
@@ -63,3 +73,23 @@ class Integration(Protocol):
     async def fetch_account(self, access_token: str) -> AccountInfo:
         """Resolve the connected account identity for display."""
         ...
+
+
+# --- api_key providers -------------------------------------------------------
+#
+# Some services (Gong, Snowflake) authenticate with pasted credentials, not an
+# OAuth redirect. Such a provider sets `auth_kind = "api_key"`, declares its
+# `credential_fields`, and implements `connect_with_credentials` instead of the
+# OAuth methods. The router renders a form from the fields and POSTs the values
+# to /credentials. The provider validates them against the upstream and returns
+# the credential bundle as the access token (JSON-encoded, with no expiry) so it
+# rides the same encrypted storage column as OAuth tokens — callers recover it
+# with `json.loads(await get_valid_token(...))`.
+#
+#   class GongIntegration:
+#       name = "gong"
+#       display_name = "Gong"
+#       auth_kind = "api_key"
+#       credential_fields = [CredentialField("access_key", "Access Key", secret=True), ...]
+#       async def connect_with_credentials(self, values: dict[str, str])
+#           -> tuple[TokenSet, AccountInfo]: ...

--- a/backend/integrations/gong/__init__.py
+++ b/backend/integrations/gong/__init__.py
@@ -1,0 +1,11 @@
+"""Gong integration: api_key provider.
+
+Connected Gong calls are indexed into gong_documents by
+backend/integrations/gong/indexer.py (dispatched from backend/tasks/sources) —
+each call's transcript becomes a searchable document.
+"""
+
+from ..registry import register_provider
+from .provider import GongIntegration
+
+register_provider(GongIntegration())

--- a/backend/integrations/gong/indexer.py
+++ b/backend/integrations/gong/indexer.py
@@ -1,0 +1,116 @@
+"""Gong → gong_documents indexer (copied content; FTS-searchable).
+
+One Gong connection = one source (external_ref "calls"). We pull calls from a
+rolling window (last LOOKBACK_DAYS) plus their transcripts in two paged passes,
+then write each call as a text document (title + date + speaker-labelled
+transcript). Idempotent re-sync via source_service; calls that age out of the
+window are soft-deleted.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+
+from ...services import source_service
+from ..storage import get_valid_token
+from .provider import API_BASE, basic_auth_header
+
+logger = logging.getLogger(__name__)
+
+LOOKBACK_DAYS = 90
+MAX_CALLS = 5000
+
+
+def _render_call(meta: dict, monologues: list[dict]) -> str:
+    title = meta.get("title") or "Untitled call"
+    started = meta.get("started") or ""
+    lines = [f"# {title}", f"Date: {started}", ""]
+    speaker_num: dict[str, int] = {}
+    for mono in monologues:
+        sid = mono.get("speakerId") or "?"
+        if sid not in speaker_num:
+            speaker_num[sid] = len(speaker_num) + 1
+        text = " ".join(s.get("text", "") for s in mono.get("sentences", []))
+        if text.strip():
+            lines.append(f"[Speaker {speaker_num[sid]}]: {text}")
+    return "\n".join(lines)
+
+
+async def _fetch_call_meta(client: httpx.AsyncClient, from_dt: str, to_dt: str) -> dict[str, dict]:
+    meta_by_id: dict[str, dict] = {}
+    cursor: str | None = None
+    while len(meta_by_id) < MAX_CALLS:
+        params = {"fromDateTime": from_dt, "toDateTime": to_dt}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await client.get(f"{API_BASE}/v2/calls", params=params)
+        if resp.status_code == 404:
+            break  # no calls in window
+        resp.raise_for_status()
+        payload = resp.json()
+        for call in payload.get("calls", []):
+            meta_by_id[call["id"]] = call
+        cursor = (payload.get("records") or {}).get("cursor")
+        if not cursor:
+            break
+    return meta_by_id
+
+
+async def _fetch_transcripts(
+    client: httpx.AsyncClient, from_dt: str, to_dt: str
+) -> dict[str, list[dict]]:
+    transcript_by_id: dict[str, list[dict]] = {}
+    cursor: str | None = None
+    while True:
+        body: dict = {"filter": {"fromDateTime": from_dt, "toDateTime": to_dt}}
+        if cursor:
+            body["cursor"] = cursor
+        resp = await client.post(f"{API_BASE}/v2/calls/transcript", json=body)
+        if resp.status_code == 404:
+            break
+        resp.raise_for_status()
+        payload = resp.json()
+        for entry in payload.get("callTranscripts", []):
+            transcript_by_id[entry["callId"]] = entry.get("transcript", [])
+        cursor = (payload.get("records") or {}).get("cursor")
+        if not cursor:
+            break
+    return transcript_by_id
+
+
+async def index_gong(source: dict) -> str | None:
+    source_id = UUID(source["id"])
+    workspace_id = UUID(source["workspace_id"])
+    owner_user_id = UUID(source["owner_user_id"])
+
+    creds = json.loads(await get_valid_token(owner_user_id, "gong"))
+    headers = {"Authorization": basic_auth_header(creds["access_key"], creds["access_key_secret"])}
+    to_dt = datetime.now(UTC).isoformat()
+    from_dt = (datetime.now(UTC) - timedelta(days=LOOKBACK_DAYS)).isoformat()
+
+    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+        meta_by_id = await _fetch_call_meta(client, from_dt, to_dt)
+        transcript_by_id = await _fetch_transcripts(client, from_dt, to_dt)
+
+    present: list[str] = []
+    for call_id, meta in meta_by_id.items():
+        await source_service.upsert_content_document(
+            table="gong_documents",
+            source_id=source_id,
+            workspace_id=workspace_id,
+            path=call_id,
+            name=meta.get("title") or call_id,
+            kind="call",
+            content=_render_call(meta, transcript_by_id.get(call_id, [])),
+            external_ref=call_id,
+        )
+        present.append(call_id)
+
+    await source_service.soft_delete_missing("gong_documents", source_id, present)
+    logger.info("gong source: indexed %d call(s)", len(present))
+    return None

--- a/backend/integrations/gong/provider.py
+++ b/backend/integrations/gong/provider.py
@@ -1,0 +1,64 @@
+"""Gong api_key provider.
+
+Gong authenticates per customer with an Access Key + Secret (HTTP Basic),
+not OAuth — Gong OAuth is gated on marketplace-partner approval. The user
+pastes both in the connect form; we validate them against /v2/workspaces and
+store the bundle as the access token (see integrations/base.py for the
+api_key contract).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+
+from ..base import AccountInfo, CredentialField, TokenSet
+
+API_BASE = "https://api.gong.io"
+
+
+def basic_auth_header(access_key: str, secret: str) -> str:
+    raw = f"{access_key}:{secret}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+class GongIntegration:
+    name = "gong"
+    display_name = "Gong"
+    scopes: list[str] = []
+    supports_refresh = False
+    auth_kind = "api_key"
+    credential_fields = [
+        CredentialField("access_key", "Access Key", secret=True, placeholder="Gong API access key"),
+        CredentialField(
+            "access_key_secret", "Access Key Secret", secret=True, placeholder="Gong API secret"
+        ),
+    ]
+
+    async def connect_with_credentials(
+        self, values: dict[str, str]
+    ) -> tuple[TokenSet, AccountInfo]:
+        access_key = (values.get("access_key") or "").strip()
+        secret = (values.get("access_key_secret") or "").strip()
+        if not access_key or not secret:
+            raise ValueError("Both Access Key and Access Key Secret are required")
+
+        headers = {"Authorization": basic_auth_header(access_key, secret)}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            resp = await client.get(f"{API_BASE}/v2/workspaces")
+        # Any non-200 means we couldn't validate the keys — a client error, so
+        # surface it as ValueError (the router maps it to 400) rather than 500.
+        if resp.status_code != 200:
+            raise ValueError(f"Gong rejected these credentials (HTTP {resp.status_code})")
+        workspaces = resp.json().get("workspaces", [])
+
+        display_name = workspaces[0]["name"] if workspaces else "Gong"
+        token = TokenSet(
+            access_token=json.dumps({"access_key": access_key, "access_key_secret": secret}),
+            refresh_token=None,
+            expires_at=None,
+            scopes=[],
+        )
+        return token, AccountInfo(email=None, display_name=display_name)

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -85,9 +85,11 @@ class ProviderListItem(BaseModel):
     connected: bool
     enabled: bool
     disabled_reason: str | None = None
-    # "oauth" (the default redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP
-    # server, e.g. Granola).
+    # "oauth" (the default redirect flow), "mcp_oauth" (DCR+PKCE via an MCP
+    # server, e.g. Granola), or "api_key" (pasted credentials, e.g. Gong).
     auth_kind: str = "oauth"
+    # For api_key providers: the form fields the frontend should render.
+    credential_fields: list[dict] | None = None
     account_email: str | None = None
     account_display_name: str | None = None
     expires_at: str | None = None
@@ -181,6 +183,11 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
                 enabled=disabled_reason is None,
                 disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
+                credential_fields=[
+                    {"name": f.name, "label": f.label, "secret": f.secret, "placeholder": f.placeholder}
+                    for f in getattr(p, "credential_fields", [])
+                ]
+                or None,
                 account_email=conn["account_email"] if conn else None,
                 account_display_name=conn["account_display_name"] if conn else None,
                 expires_at=conn["expires_at"] if conn else None,
@@ -264,6 +271,38 @@ async def integration_disconnect(
     get_provider(provider)  # 404 if unknown
     await storage.revoke_stored(current_user["id"], provider)
     return {"ok": True}
+
+
+class CredentialConnectResponse(BaseModel):
+    connected: bool
+    account_email: str | None
+    account_display_name: str | None
+
+
+@router.post("/{provider}/credentials", response_model=CredentialConnectResponse)
+async def integration_connect_with_credentials(
+    provider: str,
+    values: dict[str, str],
+    current_user: dict = Depends(get_current_user),
+):
+    """Connect an api_key provider (Gong, Snowflake) from pasted credentials.
+    The provider validates them against the upstream and returns the bundle as
+    the stored token; we never echo the secrets back."""
+    p = get_provider(provider)
+    _ensure_provider_enabled(provider)
+    if getattr(p, "auth_kind", "oauth") != "api_key":
+        raise HTTPException(status_code=400, detail=f"{provider} does not use credential auth")
+    try:
+        token, account = await p.connect_with_credentials(values)
+    except ValueError as e:
+        # Bad/rejected credentials — a client error, not a server fault.
+        raise HTTPException(status_code=400, detail=str(e))
+    await storage.store_token(current_user["id"], provider, token, account)
+    return CredentialConnectResponse(
+        connected=True,
+        account_email=account.email,
+        account_display_name=account.display_name,
+    )
 
 
 class GooglePickerTokenResponse(BaseModel):

--- a/backend/integrations/snowflake/__init__.py
+++ b/backend/integrations/snowflake/__init__.py
@@ -1,0 +1,11 @@
+"""Snowflake integration: api_key provider.
+
+Snowflake is a *queryable* source — the agent runs read-only SQL against it via
+the source tools (see backend/integrations/snowflake/client.py). There is no
+indexer or document table; queries run live.
+"""
+
+from ..registry import register_provider
+from .provider import SnowflakeIntegration
+
+register_provider(SnowflakeIntegration())

--- a/backend/integrations/snowflake/client.py
+++ b/backend/integrations/snowflake/client.py
@@ -1,0 +1,161 @@
+"""Snowflake read-only query client.
+
+Snowflake is a *queryable* source, not a document store: the agent runs SELECTs
+against it live instead of crawling it into FTS. Everything here is read-only —
+we allowlist the leading statement keyword, reject multiple statements, and cap
+returned rows. The driver is blocking, so every call runs in a thread.
+
+`snowflake.connector` is imported lazily inside `_connect` so the integration
+registers (and the rest of the app imports) even where the driver isn't
+installed; only an actual connection needs it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from uuid import UUID
+
+from ..storage import get_valid_token
+
+# Statements we allow. Everything else (INSERT/UPDATE/DELETE/MERGE/CREATE/DROP/
+# ALTER/GRANT/CALL/…) is rejected before it reaches Snowflake.
+READ_ONLY_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN")
+ROW_CAP = 200
+# A qualified table identifier: db.schema.table, optionally double-quoted parts.
+_IDENTIFIER_RE = re.compile(r'^[A-Za-z0-9_$."]+$')
+
+
+def _assert_read_only(sql: str) -> str:
+    """Return a single read-only statement or raise ValueError."""
+    stmt = sql.strip().rstrip(";").strip()
+    if not stmt:
+        raise ValueError("empty query")
+    if ";" in stmt:
+        raise ValueError("only a single statement is allowed")
+    keyword = stmt.split(None, 1)[0].upper()
+    if keyword not in READ_ONLY_PREFIXES:
+        raise ValueError(
+            f"only read-only statements are allowed (SELECT/WITH/SHOW/DESCRIBE/EXPLAIN); got {keyword}"
+        )
+    return stmt
+
+
+def _validate_identifier(ref: str) -> str:
+    if not ref or not _IDENTIFIER_RE.match(ref):
+        raise ValueError(f"invalid table identifier: {ref!r}")
+    return ref
+
+
+def _cell(value):
+    """Coerce a Snowflake cell to something JSON-serializable (Decimal, datetime,
+    bytes, etc. become strings)."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _connect(creds: dict):
+    import snowflake.connector  # lazy: only needed for a live connection
+
+    kwargs: dict = {"account": creds["account"], "user": creds["user"]}
+    for key in ("role", "warehouse", "database", "schema"):
+        if creds.get(key):
+            kwargs[key] = creds[key]
+
+    private_key = creds.get("private_key")
+    if private_key:
+        from cryptography.hazmat.primitives import serialization
+
+        passphrase = creds.get("private_key_passphrase") or None
+        key = serialization.load_pem_private_key(
+            private_key.encode(),
+            password=passphrase.encode() if passphrase else None,
+        )
+        kwargs["private_key"] = key.private_bytes(
+            serialization.Encoding.DER,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    elif creds.get("password"):
+        kwargs["password"] = creds["password"]
+    else:
+        raise ValueError("Snowflake credentials need a private key or password")
+
+    return snowflake.connector.connect(**kwargs)
+
+
+def _run_sync(creds: dict, sql: str, limit: int) -> dict:
+    conn = _connect(creds)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        columns = [c[0] for c in cur.description] if cur.description else []
+        rows = cur.fetchmany(limit)
+        return {
+            "columns": columns,
+            "rows": [[_cell(v) for v in row] for row in rows],
+            "row_count": len(rows),
+            "truncated": len(rows) >= limit,
+        }
+    finally:
+        conn.close()
+
+
+async def _creds(owner_user_id: UUID) -> dict:
+    return json.loads(await get_valid_token(owner_user_id, "snowflake"))
+
+
+async def test_connection(creds: dict) -> str:
+    """Validate credentials and return 'user @ account' for the integration card."""
+    result = await asyncio.to_thread(
+        _run_sync, creds, "SELECT CURRENT_USER(), CURRENT_ACCOUNT()", 1
+    )
+    if result["rows"]:
+        user, account = result["rows"][0]
+        return f"{user} @ {account}"
+    return creds.get("user", "Snowflake")
+
+
+async def run_query(source: dict, sql: str, limit: int = ROW_CAP) -> dict:
+    """Run one read-only statement on behalf of the source's owner."""
+    stmt = _assert_read_only(sql)
+    creds = await _creds(UUID(source["owner_user_id"]))
+    return await asyncio.to_thread(_run_sync, creds, stmt, min(limit, ROW_CAP))
+
+
+async def list_tables(source: dict) -> list[dict]:
+    """List tables as navigation entries: path = fully-qualified name."""
+    creds = await _creds(UUID(source["owner_user_id"]))
+    result = await asyncio.to_thread(
+        _run_sync, creds, "SHOW TERSE TABLES IN ACCOUNT", 500
+    )
+    name_i = result["columns"].index("name") if "name" in result["columns"] else 1
+    db_i = result["columns"].index("database_name") if "database_name" in result["columns"] else None
+    schema_i = (
+        result["columns"].index("schema_name") if "schema_name" in result["columns"] else None
+    )
+    entries = []
+    for row in result["rows"]:
+        name = row[name_i]
+        parts = [row[db_i] if db_i is not None else None, row[schema_i] if schema_i is not None else None, name]
+        full = ".".join(str(p) for p in parts if p)
+        entries.append({"path": full, "name": name, "kind": "table"})
+    return entries
+
+
+async def describe_table(source: dict, ref: str) -> dict:
+    """Return a table's columns (name + type) so the agent can write a query."""
+    table = _validate_identifier(ref)
+    creds = await _creds(UUID(source["owner_user_id"]))
+    result = await asyncio.to_thread(_run_sync, creds, f"DESCRIBE TABLE {table}", ROW_CAP)
+    name_i = result["columns"].index("name") if "name" in result["columns"] else 0
+    type_i = result["columns"].index("type") if "type" in result["columns"] else 1
+    cols = [f"{row[name_i]} {row[type_i]}" for row in result["rows"]]
+    return {
+        "path": ref,
+        "name": ref,
+        "kind": "table",
+        "content": f"Table {ref}\nColumns:\n" + "\n".join(cols),
+    }

--- a/backend/integrations/snowflake/provider.py
+++ b/backend/integrations/snowflake/provider.py
@@ -1,0 +1,57 @@
+"""Snowflake api_key provider.
+
+Snowflake is a SQL warehouse, exposed to the agent as a read-only *query*
+source rather than a crawled document source. Credentials are pasted (key-pair
+auth recommended — Snowflake is phasing out single-factor passwords for service
+accounts; a password field is accepted as an alternative). See client.py for
+the read-only query path and integrations/base.py for the api_key contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ..base import AccountInfo, CredentialField, TokenSet
+from .client import test_connection
+
+
+class SnowflakeIntegration:
+    name = "snowflake"
+    display_name = "Snowflake"
+    scopes: list[str] = []
+    supports_refresh = False
+    auth_kind = "api_key"
+    credential_fields = [
+        CredentialField("account", "Account", placeholder="orgname-account_name"),
+        CredentialField("user", "User", placeholder="SVC_AGENT"),
+        CredentialField("private_key", "Private Key (PEM)", secret=True, placeholder="-----BEGIN PRIVATE KEY-----"),
+        CredentialField("private_key_passphrase", "Private Key Passphrase", secret=True),
+        CredentialField("warehouse", "Warehouse", placeholder="COMPUTE_WH"),
+        CredentialField("role", "Role", placeholder="READ_ONLY"),
+        CredentialField("database", "Database", placeholder="(optional default)"),
+    ]
+
+    async def connect_with_credentials(
+        self, values: dict[str, str]
+    ) -> tuple[TokenSet, AccountInfo]:
+        creds = {k: v.strip() for k, v in values.items() if v and v.strip()}
+        if not creds.get("account") or not creds.get("user"):
+            raise ValueError("Account and User are required")
+        if not creds.get("private_key") and not creds.get("password"):
+            raise ValueError("A private key (or password) is required")
+
+        try:
+            display_name = await test_connection(creds)
+        except ValueError:
+            raise
+        except Exception as e:
+            # Connection / auth failure → a client error, surfaced as 400.
+            raise ValueError(f"Could not connect to Snowflake: {e}")
+
+        token = TokenSet(
+            access_token=json.dumps(creds),
+            refresh_token=None,
+            expires_at=None,
+            scopes=[],
+        )
+        return token, AccountInfo(email=None, display_name=display_name)

--- a/backend/migrations/versions/0089_gong_source.py
+++ b/backend/migrations/versions/0089_gong_source.py
@@ -1,0 +1,51 @@
+"""Per-integration source table for Gong.
+
+Copied-content source (FTS + embeddings live in the table), same shape as
+github_documents (migration 0084): each Gong call's transcript becomes a
+document keyed by (source_id, path).
+
+Revision ID: 0089
+Revises: 0088
+"""
+
+from alembic import op
+
+revision = "0089"
+down_revision = "0088"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = """
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id        uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    source_id           uuid NOT NULL REFERENCES workspace_sources(id) ON DELETE CASCADE,
+    path                text NOT NULL,
+    name                text NOT NULL,
+    kind                text NOT NULL DEFAULT 'file',
+    external_ref        text,
+    external_updated_at timestamptz,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    deleted_at          timestamptz,
+    content             text,
+    content_hash        text,
+    embedding           vector(384),
+    embed_stale         boolean NOT NULL DEFAULT FALSE
+"""
+
+
+def upgrade() -> None:
+    op.execute(f"CREATE TABLE gong_documents ({_COLUMNS}, UNIQUE (source_id, path))")
+    op.execute(
+        "CREATE INDEX gong_documents_source_idx ON gong_documents (source_id, path) "
+        "WHERE deleted_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX gong_documents_fts_idx ON gong_documents "
+        "USING gin (to_tsvector('english', coalesce(content, '')))"
+    )
+    op.execute("CREATE INDEX gong_documents_embed_stale_idx ON gong_documents (id) WHERE embed_stale")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS gong_documents")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,4 @@ openpyxl>=3.1
 playwright>=1.49
 Pillow>=10.0
 pillow-heif>=0.19
+snowflake-connector-python>=3.12

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -54,6 +54,13 @@ async def _resolve_granola_source(user_id) -> tuple[str, str]:
     return "granola", "Granola"
 
 
+async def _resolve_gong_source(user_id) -> tuple[str, str]:
+    """Gong is one connection per user (all calls); external_ref is constant.
+    Confirm the credentials exist (raises 401 if not connected)."""
+    await integration_storage.get_valid_token(user_id, "gong")
+    return "calls", "Gong"
+
+
 @router.get("")
 async def list_sources(workspace_id: UUID, current_user: dict = Depends(get_current_user)):
     """Sources this user can see here: native files + sessions, plus their own
@@ -136,6 +143,9 @@ async def add_source(
         display_name = display_name or resolved_name
     elif body.source_type == "granola" and not external_ref:
         external_ref, resolved_name = await _resolve_granola_source(current_user["id"])
+        display_name = display_name or resolved_name
+    elif body.source_type == "gong_calls" and not external_ref:
+        external_ref, resolved_name = await _resolve_gong_source(current_user["id"])
         display_name = display_name or resolved_name
 
     if not external_ref:

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -61,6 +61,16 @@ async def _resolve_gong_source(user_id) -> tuple[str, str]:
     return "calls", "Gong"
 
 
+async def _resolve_snowflake_source(user_id) -> tuple[str, str]:
+    """Snowflake is one connection per user; external_ref is the account.
+    Confirm the credentials exist (raises 401 if not connected)."""
+    import json
+
+    creds = json.loads(await integration_storage.get_valid_token(user_id, "snowflake"))
+    account = creds.get("account", "snowflake")
+    return account, f"Snowflake ({account})"
+
+
 @router.get("")
 async def list_sources(workspace_id: UUID, current_user: dict = Depends(get_current_user)):
     """Sources this user can see here: native files + sessions, plus their own
@@ -126,6 +136,28 @@ async def read_source_doc(
     return doc
 
 
+class QuerySourceRequest(BaseModel):
+    sql: str
+    limit: int = 200
+
+
+@router.post("/{source}/query")
+async def query_source(
+    workspace_id: UUID,
+    source: str,
+    body: QuerySourceRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Run a read-only SQL query against a queryable source (Snowflake)."""
+    await _require_member(workspace_id, current_user["id"])
+    result = await source_service.query_source(
+        workspace_id, current_user["id"], source, body.sql, limit=body.limit
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return result
+
+
 @router.post("")
 async def add_source(
     workspace_id: UUID,
@@ -146,6 +178,9 @@ async def add_source(
         display_name = display_name or resolved_name
     elif body.source_type == "gong_calls" and not external_ref:
         external_ref, resolved_name = await _resolve_gong_source(current_user["id"])
+        display_name = display_name or resolved_name
+    elif body.source_type == "snowflake" and not external_ref:
+        external_ref, resolved_name = await _resolve_snowflake_source(current_user["id"])
         display_name = display_name or resolved_name
 
     if not external_ref:

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -515,8 +515,10 @@ async def _delete_cartridge(args: dict) -> dict:
 @tool(
     "list_sources",
     "List every source this user can read: native 'files' and 'sessions', plus "
-    "their connected sources (GitHub, Drive, Notion, Slack, Granola). Use the "
-    "returned `source` handle with list_source / read_source / search.",
+    "their connected sources (GitHub, Drive, Notion, Slack, Granola, Jira, Asana, "
+    "Gong, Snowflake). Each has a `capability`: 'navigable'/'searchable' sources "
+    "use list_source / read_source / search; a 'queryable' source (Snowflake) uses "
+    "query_source. Use the returned `source` handle with those tools.",
     {"type": "object", "properties": {}},
 )
 async def _list_sources(args: dict) -> dict:
@@ -599,6 +601,35 @@ async def _search(args: dict) -> dict:
     return _text_result(json.dumps(results))
 
 
+@tool(
+    "query_source",
+    "Run a read-only SQL query against a queryable source (e.g. Snowflake). "
+    "`source` is the handle from list_sources; use list_source to see its tables "
+    "and read_source on a table to see its columns first. Only SELECT/WITH/SHOW/"
+    "DESCRIBE/EXPLAIN are allowed and rows are capped.",
+    {
+        "type": "object",
+        "properties": {
+            "source": {"type": "string"},
+            "sql": {"type": "string"},
+            "limit": {"type": "integer", "default": 200},
+        },
+        "required": ["source", "sql"],
+    },
+)
+async def _query_source(args: dict) -> dict:
+    result = await source_service.query_source(
+        _current_workspace(),
+        _current_user(),
+        args.get("source", ""),
+        args.get("sql", ""),
+        limit=int(args.get("limit", 200)),
+    )
+    if result is None:
+        return _text_result(json.dumps({"error": "source not found"}))
+    return _text_result(json.dumps(result))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
@@ -616,6 +647,7 @@ _TOOLS_BY_NAME = {
     "list_source": _list_source,
     "read_source": _read_source,
     "search": _search,
+    "query_source": _query_source,
 }
 
 

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -55,6 +55,7 @@ STASH_TOOL_SET = (
     "list_source",
     "read_source",
     "search",
+    "query_source",
 )
 
 # Read-only subset for ask-the-workspace and other Q&A surfaces. Drops
@@ -75,4 +76,5 @@ ASK_TOOL_SET = (
     "list_source",
     "read_source",
     "search",
+    "query_source",
 )

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -41,6 +41,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "granola": 21600,
     "jira_project": 1800,
     "asana_project": 1800,
+    "gong_calls": 21600,
 }
 
 # Which capability each connected source type exposes.
@@ -52,6 +53,7 @@ SOURCE_CAPABILITY = {
     "granola": "searchable",
     "jira_project": "searchable",
     "asana_project": "navigable",
+    "gong_calls": "searchable",
 }
 
 
@@ -226,6 +228,7 @@ SOURCE_TABLE = {
     "granola": "granola_notes",
     "jira_project": "jira_documents",
     "asana_project": "asana_documents",
+    "gong_calls": "gong_documents",
 }
 
 # Tables that COPY content (FTS + embeddings live in them). The rest are
@@ -236,6 +239,7 @@ CONTENT_TABLES = {
     "granola_notes",
     "jira_documents",
     "asana_documents",
+    "gong_documents",
 }
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -54,6 +54,9 @@ SOURCE_CAPABILITY = {
     "jira_project": "searchable",
     "asana_project": "navigable",
     "gong_calls": "searchable",
+    # Queryable sources run live read-only SQL; they have no document table or
+    # indexer (see source_entries / query_source).
+    "snowflake": "queryable",
 }
 
 
@@ -565,6 +568,11 @@ async def source_entries(
     connected = await _resolve_connected(source, user_id)
     if connected is None:
         return None
+    if connected["capability"] == "queryable":
+        # A queryable source (Snowflake) has no document table — list its tables.
+        from ..integrations.snowflake.client import list_tables
+
+        return await list_tables(connected)
     return await list_documents(connected, prefix=prefix)
 
 
@@ -599,7 +607,31 @@ async def source_document(
     connected = await _resolve_connected(source, user_id)
     if connected is None:
         return False, None
+    if connected["capability"] == "queryable":
+        # Reading a "document" from a queryable source means describing a table.
+        from ..integrations.snowflake.client import describe_table
+
+        return True, await describe_table(connected, ref)
     return True, await read_document(connected, ref)
+
+
+async def query_source(
+    workspace_id: UUID, user_id: UUID, source: str, sql: str, limit: int = 200
+) -> dict | None:
+    """Run a read-only SQL query against a queryable source (Snowflake). Returns
+    None when the handle is unknown / not owned, or an error dict when the source
+    isn't queryable or the SQL is rejected."""
+    connected = await _resolve_connected(source, user_id)
+    if connected is None:
+        return None
+    if connected["capability"] != "queryable":
+        return {"error": "source is not queryable"}
+    from ..integrations.snowflake.client import run_query
+
+    try:
+        return await run_query(connected, sql, limit)
+    except ValueError as e:
+        return {"error": str(e)}
 
 
 async def search_all(

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from ..celery_app import celery
 from ..integrations.asana.indexer import index_asana
 from ..integrations.github.indexer import index_github_repo
+from ..integrations.gong.indexer import index_gong
 from ..integrations.google.indexer import index_google_drive
 from ..integrations.granola.indexer import index_granola
 from ..integrations.jira.indexer import index_jira
@@ -38,6 +39,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "granola": index_granola,
     "jira_project": index_jira,
     "asana_project": index_asana,
+    "gong_calls": index_gong,
 }
 
 

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -17,7 +17,9 @@ from backend.integrations.asana.indexer import _render_task
 from backend.integrations.gong.indexer import _render_call
 from backend.integrations.gong.provider import GongIntegration
 from backend.integrations.jira.indexer import _adf_to_text, _render_issue
-from backend.services import source_service
+from backend.integrations.snowflake.client import _assert_read_only, _validate_identifier
+from backend.integrations.snowflake.provider import SnowflakeIntegration
+from backend.services import agent_runtime, prompts, source_service
 from backend.tasks import sources as source_tasks
 
 
@@ -100,18 +102,21 @@ def test_render_task_completed_and_unassigned():
 
 
 def test_connected_source_types_are_fully_wired():
-    """Every connected (non-native) source type must appear in all of the maps
-    that make it usable, and its document table must be classified as either
-    copied-content or index-only — never neither."""
-    capability_types = set(source_service.SOURCE_CAPABILITY)
-    for source_type in capability_types:
-        assert source_type in source_service.DEFAULT_SYNC_INTERVAL_S, source_type
+    """Document sources must appear in every map that makes them syncable +
+    readable. Queryable sources (Snowflake) are the exception: they run live SQL
+    and deliberately have no document table or indexer."""
+    for source_type, capability in source_service.SOURCE_CAPABILITY.items():
+        if capability == "queryable":
+            # No table / indexer; reached via query_source, not list_documents.
+            assert source_type not in source_service.SOURCE_TABLE, source_type
+            assert source_type not in source_tasks.INDEXERS, source_type
+            continue
         assert source_type in source_service.SOURCE_TABLE, source_type
         assert source_type in source_tasks.INDEXERS, source_type
 
     # Every document table is exactly one storage strategy.
     for source_type, table in source_service.SOURCE_TABLE.items():
-        assert source_type in capability_types, source_type
+        assert source_type in source_service.SOURCE_CAPABILITY, source_type
         # content tables hold the body; index-only tables fetch it lazily — a
         # table that's in neither set would break read_document.
         is_content = table in source_service.CONTENT_TABLES
@@ -159,3 +164,58 @@ def test_gong_is_api_key_searchable_source():
 async def test_gong_rejects_missing_credentials():
     with pytest.raises(ValueError):
         await GongIntegration().connect_with_credentials({"access_key": "", "access_key_secret": ""})
+
+
+# --- Snowflake (queryable source) -------------------------------------------
+
+
+def test_read_only_guard_allows_selects():
+    # Allowed leading keywords pass; a trailing semicolon is stripped.
+    for sql in ("SELECT 1", "  with x as (select 1) select * from x  ", "SHOW TABLES;", "DESCRIBE TABLE t"):
+        assert _assert_read_only(sql)
+
+
+def test_read_only_guard_blocks_writes_and_multi_statements():
+    for sql in (
+        "DELETE FROM t",
+        "UPDATE t SET x = 1",
+        "INSERT INTO t VALUES (1)",
+        "DROP TABLE t",
+        "CREATE TABLE t (id int)",
+        "GRANT SELECT ON t TO r",
+        "SELECT 1; DROP TABLE t",  # piggybacked statement
+        "",
+    ):
+        with pytest.raises(ValueError):
+            _assert_read_only(sql)
+
+
+def test_validate_identifier_rejects_injection():
+    assert _validate_identifier("DB.SCHEMA.TABLE") == "DB.SCHEMA.TABLE"
+    for bad in ("t; drop table u", "t where 1=1", "t--", "t)"):
+        with pytest.raises(ValueError):
+            _validate_identifier(bad)
+
+
+def test_snowflake_is_queryable_api_key_source():
+    sf = SnowflakeIntegration()
+    assert sf.auth_kind == "api_key"
+    assert sf.credential_fields[0].name == "account"
+    assert source_service.SOURCE_CAPABILITY["snowflake"] == "queryable"
+    # Queryable sources intentionally have no document table or indexer.
+    assert "snowflake" not in source_service.SOURCE_TABLE
+    assert "snowflake" not in source_tasks.INDEXERS
+
+
+@pytest.mark.asyncio
+async def test_snowflake_rejects_incomplete_credentials():
+    with pytest.raises(ValueError):
+        await SnowflakeIntegration().connect_with_credentials({"account": "a"})  # no user/key
+
+
+def test_query_source_tool_is_registered_and_in_tool_sets():
+    # The catalog and the advertised tool sets must agree, or the agent would
+    # be offered a tool that doesn't exist (or vice-versa).
+    assert "query_source" in agent_runtime._TOOLS_BY_NAME
+    assert "query_source" in prompts.STASH_TOOL_SET
+    assert "query_source" in prompts.ASK_TOOL_SET

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -1,17 +1,21 @@
-"""Jira + Asana source unit tests.
+"""Jira + Asana + Gong source unit tests.
 
 Two things worth pinning that don't need a DB or live OAuth:
 
-1. The rendering helpers decide what text the agent actually reads for an issue
-   or task — so we assert the human-meaningful fields (status, assignee, body,
-   comments) survive into the document.
+1. The rendering helpers decide what text the agent actually reads for an issue,
+   task, or call — so we assert the human-meaningful fields (status, assignee,
+   body, comments, transcript) survive into the document.
 2. A connected source type is only usable if it's wired into EVERY map at once
    (capability, table, content-vs-index, indexer, sync interval). The
    consistency test fails loudly if a future integration wires only some of
    them — the exact bug that makes a source silently un-syncable.
 """
 
+import pytest
+
 from backend.integrations.asana.indexer import _render_task
+from backend.integrations.gong.indexer import _render_call
+from backend.integrations.gong.provider import GongIntegration
 from backend.integrations.jira.indexer import _adf_to_text, _render_issue
 from backend.services import source_service
 from backend.tasks import sources as source_tasks
@@ -122,3 +126,36 @@ def test_jira_and_asana_are_searchable_content_sources():
     assert "asana_documents" in source_service.CONTENT_TABLES
     assert source_service.SOURCE_CAPABILITY["jira_project"] == "searchable"
     assert source_service.SOURCE_CAPABILITY["asana_project"] == "navigable"
+
+
+def test_render_call_labels_speakers_and_keeps_transcript():
+    text = _render_call(
+        {"title": "Q3 sync", "started": "2026-06-01T10:00:00Z"},
+        [
+            {"speakerId": "a", "sentences": [{"text": "hello there"}]},
+            {"speakerId": "b", "sentences": [{"text": "hi"}, {"text": "good to meet you"}]},
+            {"speakerId": "a", "sentences": [{"text": "likewise"}]},
+        ],
+    )
+    assert "# Q3 sync" in text
+    assert "Date: 2026-06-01T10:00:00Z" in text
+    # Stable per-call speaker numbering: first speaker is 1, second is 2.
+    assert "[Speaker 1]: hello there" in text
+    assert "[Speaker 2]: hi good to meet you" in text
+    assert "[Speaker 1]: likewise" in text
+
+
+def test_gong_is_api_key_searchable_source():
+    gong = GongIntegration()
+    assert gong.auth_kind == "api_key"
+    assert [f.name for f in gong.credential_fields] == ["access_key", "access_key_secret"]
+    assert all(f.secret for f in gong.credential_fields)
+    assert source_service.SOURCE_TABLE["gong_calls"] == "gong_documents"
+    assert "gong_documents" in source_service.CONTENT_TABLES
+    assert source_service.SOURCE_CAPABILITY["gong_calls"] == "searchable"
+
+
+@pytest.mark.asyncio
+async def test_gong_rejects_missing_credentials():
+    with pytest.raises(ValueError):
+        await GongIntegration().connect_with_credentials({"access_key": "", "access_key_secret": ""})

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -83,6 +83,23 @@ export function NotionIcon({ className, size = defaultSize }: Props) {
   );
 }
 
+export function GongIcon({ className, size = defaultSize }: Props) {
+  // Gong mark — a purple ring with a centered dot.
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="9.2" stroke="#8039DF" strokeWidth="2.2" />
+      <circle cx="12" cy="12" r="3.4" fill="#8039DF" />
+    </svg>
+  );
+}
+
 export function JiraIcon({ className, size = defaultSize }: Props) {
   // Official Jira mark — interlocking chevrons in Jira blue.
   return (

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -83,6 +83,32 @@ export function NotionIcon({ className, size = defaultSize }: Props) {
   );
 }
 
+export function SnowflakeIcon({ className, size = defaultSize }: Props) {
+  // Snowflake mark — a six-spoke flake in Snowflake blue.
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      stroke="#29B5E8"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      fill="none"
+      aria-hidden
+    >
+      <g>
+        <line x1="12" y1="3" x2="12" y2="21" />
+        <line x1="4.2" y1="7.5" x2="19.8" y2="16.5" />
+        <line x1="4.2" y1="16.5" x2="19.8" y2="7.5" />
+        <path d="M12 6.4l-1.8-1.8M12 6.4l1.8-1.8M12 17.6l-1.8 1.8M12 17.6l1.8 1.8" />
+        <path d="M6.6 9.5l-2.5.1M6.6 9.5l-.7-2.4M17.4 14.5l2.5-.1M17.4 14.5l.7 2.4" />
+        <path d="M6.6 14.5l-.7 2.4M6.6 14.5l-2.5-.1M17.4 9.5l.7-2.4M17.4 9.5l2.5.1" />
+      </g>
+    </svg>
+  );
+}
+
 export function GongIcon({ className, size = defaultSize }: Props) {
   // Gong mark — a purple ring with a centered dot.
   return (

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -37,6 +37,7 @@ import {
   NotionIcon,
   ObsidianIcon,
   SlackIcon,
+  SnowflakeIcon,
 } from "./BrandIcons";
 import ObsidianVaultDropZone from "./ObsidianVaultDropZone";
 
@@ -123,6 +124,14 @@ const CONNECTORS: Connector[] = [
     icon: <GongIcon />,
     kind: "auto",
     blurb: "Call transcripts, kept in sync.",
+  },
+  {
+    provider: "snowflake",
+    label: "Snowflake",
+    sourceType: "snowflake",
+    icon: <SnowflakeIcon />,
+    kind: "auto",
+    blurb: "Run read-only SQL against your warehouse.",
   },
 ];
 
@@ -848,6 +857,7 @@ function labelForSourceType(type: string): string {
   if (type === "jira_project") return "Jira";
   if (type === "asana_project") return "Asana";
   if (type === "gong_calls") return "Gong";
+  if (type === "snowflake") return "Snowflake";
   return type;
 }
 

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -17,7 +17,9 @@ import {
   listJiraProjects,
   listNotionPages,
   startConnect,
+  submitCredentials,
   type AsanaProjectSummary,
+  type CredentialField,
   type GitHubRepoSummary,
   type IntegrationProvider,
   type IntegrationStatus,
@@ -28,6 +30,7 @@ import {
 import {
   AsanaIcon,
   GitHubIcon,
+  GongIcon,
   GoogleDriveIcon,
   GranolaIcon,
   JiraIcon,
@@ -113,6 +116,14 @@ const CONNECTORS: Connector[] = [
     kind: "auto",
     blurb: "Meeting notes and transcripts.",
   },
+  {
+    provider: "gong",
+    label: "Gong",
+    sourceType: "gong_calls",
+    icon: <GongIcon />,
+    kind: "auto",
+    blurb: "Call transcripts, kept in sync.",
+  },
 ];
 
 export default function SourceConnectorList({
@@ -192,6 +203,22 @@ export default function SourceConnectorList({
     }
   }
 
+  async function submitCreds(connector: Connector, values: Record<string, string>) {
+    setBusy(connector.provider);
+    setError(null);
+    try {
+      await submitCredentials(connector.provider, values);
+      setExpanded(null);
+      await refresh();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not connect");
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function syncSource(source: WorkspaceSource) {
     if (!workspaceId) return;
     setBusy(`sync:${source.source}`);
@@ -256,6 +283,7 @@ export default function SourceConnectorList({
                 connector={connector}
                 connected={connected}
                 enabled={enabled}
+                authKind={status?.auth_kind ?? "oauth"}
                 disabledReason={status?.disabled_reason ?? null}
                 busy={busy === connector.provider}
                 workspaceReady={!!workspaceId}
@@ -305,6 +333,16 @@ export default function SourceConnectorList({
                 })}
               />
             )}
+            {expanded === connector.provider &&
+              !connected &&
+              status?.auth_kind === "api_key" &&
+              status.credential_fields && (
+                <CredentialForm
+                  fields={status.credential_fields}
+                  busy={busy === connector.provider}
+                  onSubmit={(values) => submitCreds(connector, values)}
+                />
+              )}
           </div>
         );
       })}
@@ -358,6 +396,7 @@ function ConnectorAction({
   connector,
   connected,
   enabled,
+  authKind,
   disabledReason,
   busy,
   workspaceReady,
@@ -369,6 +408,7 @@ function ConnectorAction({
   connector: Connector;
   connected: boolean;
   enabled: boolean;
+  authKind: IntegrationStatus["auth_kind"];
   disabledReason: string | null;
   busy: boolean;
   workspaceReady: boolean;
@@ -385,6 +425,15 @@ function ConnectorAction({
     );
   }
   if (!connected) {
+    // api_key providers (Gong) reveal an inline credential form instead of
+    // redirecting to an OAuth consent screen.
+    if (authKind === "api_key") {
+      return (
+        <button type="button" onClick={onExpand} disabled={busy} className={primaryButton()}>
+          {expanded ? "Cancel" : "Connect"}
+        </button>
+      );
+    }
     return (
       <button type="button" onClick={onConnect} disabled={busy} className={primaryButton()}>
         {busy ? "Connecting..." : "Connect"}
@@ -679,6 +728,46 @@ function AsanaProjectPicker({
   );
 }
 
+function CredentialForm({
+  fields,
+  busy,
+  onSubmit,
+}: {
+  fields: CredentialField[];
+  busy: boolean;
+  onSubmit: (values: Record<string, string>) => Promise<boolean>;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const complete = fields.every((f) => (values[f.name] ?? "").trim().length > 0);
+
+  return (
+    <form
+      className="mt-2.5 space-y-2 rounded-md border border-border bg-base p-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (complete) void onSubmit(values);
+      }}
+    >
+      {fields.map((field) => (
+        <label key={field.name} className="block">
+          <span className="mb-1 block text-[11.5px] text-muted">{field.label}</span>
+          <input
+            type={field.secret ? "password" : "text"}
+            value={values[field.name] ?? ""}
+            placeholder={field.placeholder}
+            autoComplete="off"
+            onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
+            className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+          />
+        </label>
+      ))}
+      <button type="submit" disabled={!complete || busy} className={primaryButton()}>
+        {busy ? "Connecting..." : "Connect"}
+      </button>
+    </form>
+  );
+}
+
 function PickerShell({
   error,
   loading,
@@ -758,6 +847,7 @@ function labelForSourceType(type: string): string {
   if (type === "granola") return "Granola";
   if (type === "jira_project") return "Jira";
   if (type === "asana_project") return "Asana";
+  if (type === "gong_calls") return "Gong";
   return type;
 }
 

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -15,7 +15,15 @@ export type IntegrationProvider =
   | "slack"
   | "granola"
   | "jira"
-  | "asana";
+  | "asana"
+  | "gong";
+
+export type CredentialField = {
+  name: string;
+  label: string;
+  secret: boolean;
+  placeholder: string;
+};
 
 export type IntegrationStatus = {
   provider: string;
@@ -28,8 +36,11 @@ export type IntegrationStatus = {
   account_display_name: string | null;
   expires_at: string | null;
   connected_at: string | null;
-  // "oauth" (redirect flow) or "mcp_oauth" (DCR+PKCE via an MCP server, e.g. Granola).
-  auth_kind: "oauth" | "mcp_oauth";
+  // "oauth" (redirect flow), "mcp_oauth" (DCR+PKCE via an MCP server, e.g.
+  // Granola), or "api_key" (pasted credentials, e.g. Gong).
+  auth_kind: "oauth" | "mcp_oauth" | "api_key";
+  // Present only for api_key providers — the fields to render in the connect form.
+  credential_fields: CredentialField[] | null;
 };
 
 export type IntegrationsList = {
@@ -62,6 +73,20 @@ export async function startConnect(
 
 export async function disconnectIntegration(provider: IntegrationProvider): Promise<void> {
   await apiFetch(`/api/v1/integrations/${provider}/disconnect`, { method: "POST" });
+}
+
+/**
+ * Connect an api_key provider (e.g. Gong) by POSTing the pasted credential
+ * values. The backend validates them upstream and stores them encrypted.
+ */
+export async function submitCredentials(
+  provider: IntegrationProvider,
+  values: Record<string, string>,
+): Promise<void> {
+  await apiFetch(`/api/v1/integrations/${provider}/credentials`, {
+    method: "POST",
+    body: JSON.stringify(values),
+  });
 }
 
 export type GitHubRepoSummary = {

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -16,7 +16,8 @@ export type IntegrationProvider =
   | "granola"
   | "jira"
   | "asana"
-  | "gong";
+  | "gong"
+  | "snowflake";
 
 export type CredentialField = {
   name: string;


### PR DESCRIPTION
## What

**PR 3 of 3.** Adds **Snowflake** as a new **`queryable`** source — the agent runs live read-only SQL against the warehouse instead of crawling it into full-text search.

> Stacked on #506 (api_key + Gong), which is stacked on #505 (Jira/Asana). Base is `integrations-apikey-gong`; merge #505 → #506 → this. GitHub retargets automatically as each base merges.

## Why a new source shape

Snowflake is a SQL warehouse, not a document store — you don't crawl it into FTS. So instead of an indexer + document table, it's a `queryable` source the agent queries on demand. It reuses PR 2's `api_key` credential path for auth.

## How

- **Provider (`api_key`)**: pasted credentials (key-pair recommended — Snowflake is phasing out single-factor passwords for service accounts; a password field is accepted as an alternative), validated with `SELECT CURRENT_USER()` at connect time. One connection = one source (`source_type='snowflake'`, `capability='queryable'`, `external_ref=account`).
- **`client.py` — read-only by construction**: `_assert_read_only` allowlists the leading keyword (`SELECT/WITH/SHOW/DESCRIBE/EXPLAIN`), rejects multiple statements (no piggybacked `; DROP …`), and caps rows; table identifiers for `DESCRIBE` are validated against injection. The blocking driver runs in `asyncio.to_thread`, and `snowflake.connector` is imported **lazily** so the app loads (and PR 1/2 tests run) without the driver installed.
- **`source_service`**: a `queryable` branch in `source_entries` (list tables via `SHOW TERSE TABLES`) and `source_document` (`DESCRIBE` a table), plus `query_source()`.
- **Agent**: new `query_source` tool (added to `STASH_TOOL_SET` + read-only `ASK_TOOL_SET`) and a `POST .../sources/{source}/query` endpoint. The agent discovers the source via `list_sources`, browses tables with `list_source`/`read_source`, and runs SELECTs via `query_source`.
- **Frontend**: Snowflake connector reuses the api_key credential form; icon + label.
- **Dependency**: `snowflake-connector-python`.

## Verification

- `ruff` + `pytest` (`test_integration_sources.py`: read-only guard allows reads / blocks writes + piggybacked statements, identifier-injection rejection, api_key + queryable wiring; `test_agent_runtime.py`: `query_source` registered and matches the advertised tool set) — green. Full source suite (37 tests) green.
- Frontend `tsc --noEmit` + `eslint` — green.
- Throwaway backend confirmed: Snowflake lists `enabled` with `auth_kind=api_key` and 7 credential fields; with the driver absent, a connect attempt degrades to a clean **400** rather than a 500; the query route 404s for an unknown source.
- UI: the Snowflake connector card renders in Settings → Sources (screenshot in thread). The api_key credential form is shared with Gong and verified via tests/API.

A live query needs `snowflake-connector-python` installed (in `requirements.txt`) and a real Snowflake account/role. Read-only is enforced in-process; pairing it with a read-only Snowflake role is recommended defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)