### PR TITLE
Make Notion full-text searchable

### DIFF
--- a/backend/integrations/notion/indexer.py
+++ b/backend/integrations/notion/indexer.py
@@ -1,15 +1,11 @@
-"""Notion → notion_index indexer (index only; body fetched lazily).
+"""Notion → notion_index indexer (copied content; FTS-searchable).
 
 A Notion source's `external_ref` is a page or database id (auto-detected). We
-walk the page tree (and database rows) to build the navigable path index — each
-page/row becomes an INDEX ROW storing its title-based path and the Notion id
-(`external_ref`). We never store the body; `read_source` calls
-`fetch_notion_content` at read time, rendering the page's blocks to markdown
-with the owner's token.
-
-The walk still has to read each page's child blocks to discover sub-pages, so a
-traversal hits the API; index-only refers to what we *store*, not how few calls
-the crawl makes.
+walk the page tree (and database rows) and copy each one into notion_index as a
+document keyed by its title-based path. The walk already has to render each
+page's blocks to markdown to discover sub-pages — so we store that rendered text
+as the document body, which makes Notion full-text searchable for nearly free
+(the API calls happen either way). Idempotent re-sync via source_service.
 """
 
 from __future__ import annotations
@@ -66,16 +62,18 @@ async def _index_page(
     if meta_resp.status_code != 200:
         return
     title = _safe(_extract_title(meta_resp.json()))
-    # Read child blocks only to discover sub-pages; the body isn't stored.
-    _, child_ids = await fetch_block_tree(client, page_id)
+    # Render the blocks to markdown — both to discover sub-pages and to store
+    # the body for full-text search.
+    lines, child_ids = await fetch_block_tree(client, page_id)
     path = f"{prefix}{title}"
-    await source_service.upsert_index_row(
+    await source_service.upsert_content_document(
         table="notion_index",
         source_id=source_id,
         workspace_id=workspace_id,
         path=path,
         name=title,
         kind="note",
+        content="\n".join(lines),
         external_ref=page_id,
     )
     present.append(path)
@@ -115,13 +113,17 @@ async def _index_database(
             props = row.get("properties", {}) or {}
             title = _safe(_row_title(props))
             path = f"{db_title}/{title}"
-            await source_service.upsert_index_row(
+            # Database rows are indexed by their title (the property values are
+            # the searchable text); we don't fetch each row's blocks to keep the
+            # crawl cheap.
+            await source_service.upsert_content_document(
                 table="notion_index",
                 source_id=source_id,
                 workspace_id=workspace_id,
                 path=path,
                 name=title,
                 kind="note",
+                content=title,
                 external_ref=row.get("id"),
             )
             present.append(path)
@@ -172,12 +174,3 @@ async def index_notion(source: dict) -> str | None:
     await source_service.soft_delete_missing("notion_index", source_id, present)
     logger.info("notion source %s: indexed %d document(s)", resource_id, len(present))
     return None
-
-
-async def fetch_notion_content(owner_user_id: UUID, page_id: str) -> str:
-    """Lazy read: render a Notion page's blocks to markdown with the owner's
-    token."""
-    token = await get_valid_token(owner_user_id, "notion")
-    async with _notion_client(token) as client:
-        lines, _ = await fetch_block_tree(client, page_id)
-    return "\n".join(lines)

--- a/backend/migrations/versions/0090_notion_searchable.py
+++ b/backend/migrations/versions/0090_notion_searchable.py
@@ -1,0 +1,45 @@
+"""Make Notion full-text searchable.
+
+notion_index was index-only (no body stored). Notion's crawl already renders
+each page's blocks to markdown to discover sub-pages, so we now store that text
+and treat notion_index as a copied-content table — adding the content/embedding
+columns + the FTS index the other content tables have (migration 0084). Existing
+rows get NULL content until the next sync re-populates them.
+
+Revision ID: 0090
+Revises: 0089
+"""
+
+from alembic import op
+
+revision = "0090"
+down_revision = "0089"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE notion_index
+            ADD COLUMN content      text,
+            ADD COLUMN content_hash text,
+            ADD COLUMN embedding    vector(384),
+            ADD COLUMN embed_stale  boolean NOT NULL DEFAULT FALSE
+        """
+    )
+    op.execute(
+        "CREATE INDEX notion_index_fts_idx ON notion_index "
+        "USING gin (to_tsvector('english', coalesce(content, '')))"
+    )
+    op.execute("CREATE INDEX notion_index_embed_stale_idx ON notion_index (id) WHERE embed_stale")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS notion_index_embed_stale_idx")
+    op.execute("DROP INDEX IF EXISTS notion_index_fts_idx")
+    op.execute(
+        "ALTER TABLE notion_index "
+        "DROP COLUMN content, DROP COLUMN content_hash, "
+        "DROP COLUMN embedding, DROP COLUMN embed_stale"
+    )

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -9,10 +9,11 @@ owner sees them.
 This module owns:
 - the `workspace_sources` registry (CRUD + sync bookkeeping),
 - the per-integration document store. Each source type has its own table
-  (migration 0084): github/slack/granola COPY content (FTS + embeddings live in
-  the table), drive/notion store an INDEX ONLY and fetch the body lazily from
-  the provider at read time. Every table shares the navigation shape
-  (path/name/kind/deleted_at) so the agent's list/read tools stay uniform.
+  (migration 0084): most COPY content (FTS + embeddings live in the table —
+  github/slack/granola/jira/asana/gong/notion), while drive stores an INDEX ONLY
+  and fetches the body lazily from the provider at read time. Every table shares
+  the navigation shape (path/name/kind/deleted_at) so the agent's list/read tools
+  stay uniform.
 
 This module also owns the unified VFS surface (`source_entries`, `source_document`,
 `search_all`) over BOTH native and connected sources — the single codepath the
@@ -236,6 +237,8 @@ SOURCE_TABLE = {
 
 # Tables that COPY content (FTS + embeddings live in them). The rest are
 # index-only and fetch their body lazily from the provider at read time.
+# Notion copies content too — its crawl already renders each page's text to
+# discover sub-pages, so storing it for FTS is nearly free.
 CONTENT_TABLES = {
     "github_documents",
     "slack_messages",
@@ -243,6 +246,7 @@ CONTENT_TABLES = {
     "jira_documents",
     "asana_documents",
     "gong_documents",
+    "notion_index",
 }
 
 
@@ -435,10 +439,6 @@ async def _lazy_fetch(source_type: str, owner_user_id: UUID, external_ref: str |
         from ..integrations.google.indexer import fetch_drive_content
 
         return await fetch_drive_content(owner_user_id, external_ref)
-    if source_type == "notion":
-        from ..integrations.notion.indexer import fetch_notion_content
-
-        return await fetch_notion_content(owner_user_id, external_ref)
     return ""
 
 

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -16,6 +16,7 @@ import logging
 from ..celery_app import celery
 from ..database import get_pool
 from ..services import embeddings as embedding_service
+from ..services.source_service import CONTENT_TABLES as _SOURCE_CONTENT_TABLES
 from ..services.table_service import _build_embedding_text
 from ._celery_helpers import run_async
 
@@ -128,9 +129,9 @@ async def _reconcile_files() -> int:
 
 
 # Copied-content source tables get embedded after each sync flips embed_stale
-# TRUE on changed rows. Index-only tables (drive/notion) hold no content here —
-# their bodies are fetched lazily at read time, so they aren't embedded.
-_SOURCE_CONTENT_TABLES = ("github_documents", "slack_messages", "granola_notes")
+# TRUE on changed rows. We embed exactly source_service.CONTENT_TABLES (imported
+# above) so a new content source is picked up automatically; index-only tables
+# (drive) hold no content here — their bodies are fetched lazily at read time.
 
 
 async def _reconcile_source_table(table: str) -> int:

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -120,8 +120,16 @@ def test_connected_source_types_are_fully_wired():
         # content tables hold the body; index-only tables fetch it lazily — a
         # table that's in neither set would break read_document.
         is_content = table in source_service.CONTENT_TABLES
-        is_index_only = source_type in ("google_drive", "notion")
+        is_index_only = source_type in ("google_drive",)
         assert is_content or is_index_only, table
+
+
+def test_notion_is_searchable_content_source():
+    # Notion moved from index-only to copied-content so it's full-text searchable;
+    # Drive is now the only remaining lazy-fetch index-only source.
+    assert source_service.SOURCE_TABLE["notion"] == "notion_index"
+    assert "notion_index" in source_service.CONTENT_TABLES
+    assert source_service.SOURCE_CAPABILITY["notion"] == "navigable"
 
 
 def test_jira_and_asana_are_searchable_content_sources():

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -2,7 +2,7 @@
 
 Covers the user-scoping invariant (a connected source is visible only to its
 owner), idempotent re-sync of the per-integration tables, lazy reads for the
-index-only sources (drive/notion), and the agent tools that span native (files,
+index-only source (drive), and the agent tools that span native (files,
 sessions) + connected sources.
 """
 
@@ -437,14 +437,53 @@ async def test_slack_event_ingest_fans_out_per_owner(client: AsyncClient):
     assert all(h["source_id"] != src_b["id"] for h in a_hits)
 
 
-# --- index-only sources (drive/notion): lazy read ---------------------------
+# --- index-only sources (drive): lazy read ----------------------------------
 
 
 @pytest.mark.asyncio
-async def test_notion_index_only_reads_lazily(client: AsyncClient, monkeypatch):
-    """Notion stores an index row only; reading triggers a lazy provider fetch."""
-    from backend.integrations.notion import indexer
+async def test_drive_index_only_reads_lazily(client: AsyncClient, monkeypatch):
+    """Google Drive stores an index row only; reading triggers a lazy provider fetch.
+    (Notion used to work this way too, but it now copies content for FTS — Drive is
+    the sole remaining index-only source.)"""
+    from backend.integrations.google import indexer
 
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await source_service.create_source(
+        workspace_id=ws,
+        owner_user_id=owner_id,
+        source_type="google_drive",
+        external_ref="root",
+        display_name="My Drive",
+    )
+    # Index row: path + provider id, no body stored.
+    await source_service.upsert_index_row(
+        table="drive_index",
+        source_id=UUID(src["id"]),
+        workspace_id=ws,
+        path="Auth",
+        name="Auth",
+        kind="file",
+        external_ref="file-123",
+    )
+
+    fetched: list[str] = []
+
+    async def fake_fetch(owner, file_id):
+        fetched.append(file_id)
+        return "rotate tokens hourly"
+
+    monkeypatch.setattr(indexer, "fetch_drive_content", fake_fetch)
+
+    doc = await source_service.read_document(src, "Auth")
+    assert doc["content"] == "rotate tokens hourly"
+    assert fetched == ["file-123"]  # lazily fetched the provider file on read
+
+
+@pytest.mark.asyncio
+async def test_notion_is_full_text_searchable(client: AsyncClient):
+    """Notion now copies content, so its docs are served from the table and show
+    up in full-text search — no lazy provider fetch on read."""
     api_key, owner_id = await _register(client)
     ws = await _create_workspace(client, api_key)
     src = await source_service.create_source(
@@ -454,28 +493,24 @@ async def test_notion_index_only_reads_lazily(client: AsyncClient, monkeypatch):
         external_ref="page-root",
         display_name="Specs",
     )
-    # Index row: path + provider id, no body stored.
-    await source_service.upsert_index_row(
+    await source_service.upsert_content_document(
         table="notion_index",
         source_id=UUID(src["id"]),
         workspace_id=ws,
         path="Auth",
         name="Auth",
         kind="note",
+        content="rotate tokens hourly",
         external_ref="page-123",
     )
 
-    fetched: list[str] = []
-
-    async def fake_fetch(owner, page_id):
-        fetched.append(page_id)
-        return "rotate tokens hourly"
-
-    monkeypatch.setattr(indexer, "fetch_notion_content", fake_fetch)
-
+    # Read serves the stored body directly (no fetch_notion_content anymore).
     doc = await source_service.read_document(src, "Auth")
     assert doc["content"] == "rotate tokens hourly"
-    assert fetched == ["page-123"]  # lazily fetched the provider page on read
+
+    # And it's full-text searchable, scoped to the Notion source.
+    hits = await source_service.search_all(ws, owner_id, "rotate tokens", source=src["id"])
+    assert any(h["ref"] == "Auth" for h in hits)
 
 
 @pytest.mark.asyncio
@@ -517,9 +552,9 @@ async def test_read_source_rejects_unowned_connected_source(client: AsyncClient)
 
 @pytest.mark.asyncio
 async def test_snapshot_source_into_cartridge_copies_lazy_content(client: AsyncClient, monkeypatch):
-    """Adding an index-only (Notion) source doc to a cartridge fetches its body
-    at add time and copies it in as a page, so the bundle is self-contained."""
-    from backend.integrations.notion import indexer
+    """Adding an index-only (Google Drive) source doc to a cartridge fetches its
+    body at add time and copies it in as a page, so the bundle is self-contained."""
+    from backend.integrations.google import indexer
 
     api_key, owner_id = await _register(client)
     ws = await _create_workspace(client, api_key)
@@ -527,24 +562,24 @@ async def test_snapshot_source_into_cartridge_copies_lazy_content(client: AsyncC
     src = await source_service.create_source(
         workspace_id=ws,
         owner_user_id=owner_id,
-        source_type="notion",
-        external_ref="page-root",
-        display_name="Specs",
+        source_type="google_drive",
+        external_ref="root",
+        display_name="My Drive",
     )
     await source_service.upsert_index_row(
-        table="notion_index",
+        table="drive_index",
         source_id=UUID(src["id"]),
         workspace_id=ws,
         path="Auth",
         name="Auth",
-        kind="note",
-        external_ref="page-abc",
+        kind="file",
+        external_ref="file-abc",
     )
 
-    async def fake_fetch(owner, page_id):
-        return f"snapshot body for {page_id}"
+    async def fake_fetch(owner, file_id):
+        return f"snapshot body for {file_id}"
 
-    monkeypatch.setattr(indexer, "fetch_notion_content", fake_fetch)
+    monkeypatch.setattr(indexer, "fetch_drive_content", fake_fetch)
 
     cartridge = await client.post(
         f"/api/v1/workspaces/{ws}/cartridges",
@@ -563,7 +598,7 @@ async def test_snapshot_source_into_cartridge_copies_lazy_content(client: AsyncC
     page = snap.json()
     assert page["name"] == "Auth"
     # The body was copied in (a point-in-time snapshot), not left as a live ref.
-    assert "snapshot body for page-abc" in page["content_markdown"]
+    assert "snapshot body for file-abc" in page["content_markdown"]
 
     # And the page is now an item in the cartridge.
     public = await client.get(f"/api/v1/cartridges/{cartridge.json()['slug']}")


### PR DESCRIPTION
## What

Makes **Notion** full-text searchable. It was the index-only odd-one-out: its body was lazy-fetched at read time and it didn't appear in `search` at all.

## Why this is the right shape (we considered the alternatives)

- **MCP (`notion-search`)** — Notion's MCP server has a real AI search, but it requires a **second OAuth handshake** (DCR+PKCE into the MCP server) *and* a **paid Notion AI plan** for anything beyond title search. Too many dependencies for a core capability.
- **REST `/v1/search`** — title-only, no body search.
- **Copied-content FTS (this PR)** — works for everyone, no paid dependency, and is nearly free here because Notion's crawl **already renders each page's blocks to markdown** (to discover sub-pages) and then discarded that text. We just store it.

Jira/Asana already copy content (already searchable) and are untouched. **Google Drive stays index-only** — converting it would mean downloading + extracting every file on each sync; that's a separate decision.

## How

- **Migration 0090**: `notion_index` gains `content / content_hash / embedding / embed_stale` + the FTS gin index — same shape as the other content tables. (Additive; existing rows backfill on the next sync.)
- **Indexer**: stores the page text it already fetches (`upsert_content_document`); the now-dead `fetch_notion_content` lazy path is removed. Reads serve the stored body.
- **Embedding reconciler**: now derives its table list from `source_service.CONTENT_TABLES` instead of a stale hardcoded tuple. This also **fixes a latent gap** — `jira_documents`, `asana_documents`, and `gong_documents` (from the earlier integration PRs) were never being embedded.

## Verification

- `ruff` (whole backend) + `pytest` green (39 tests across `test_sources`, `test_integration_sources`, `test_agent_runtime`).
- New behavioral test proves Notion now serves stored content **and** shows up in full-text `search`; the lazy-read + cartridge-snapshot tests are repointed to Google Drive (the remaining index-only source); the wiring invariant updated.
- Migration 0090 applies; `notion_index` has the new columns + FTS index; the embedding reconciler now enumerates all seven content tables including `notion_index`.

Net effect for users: Notion pages become searchable by content (not just navigable), with no new auth and no paid-plan requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)