### PR TITLE
Federate search for Jira/Asana/Drive; stop copying their content

### DIFF
--- a/backend/integrations/asana/indexer.py
+++ b/backend/integrations/asana/indexer.py
@@ -1,9 +1,9 @@
-"""Asana project → asana_documents indexer (copied content; navigable).
+"""Asana project → asana_documents indexer (index only; search federated).
 
-An Asana source's external_ref is a project gid. We page through the project's
-tasks and copy each into asana_documents as a text document keyed by the task
-gid (names aren't unique). Idempotent re-sync via source_service (content-hash
-dedupe + soft-delete of tasks that vanished).
+An Asana source's external_ref is a project gid. We don't copy task bodies —
+Asana's own search (`/tasks/search`, paid tiers) is used live (see `search_asana`)
+and the body is fetched lazily on read (`fetch_asana_content`). The sync only
+builds the navigable index: one row per task keyed by its gid.
 """
 
 from __future__ import annotations
@@ -18,10 +18,13 @@ from ..storage import get_valid_token
 
 logger = logging.getLogger(__name__)
 
-TASKS_URL = "https://app.asana.com/api/1.0/projects/{project_gid}/tasks"
+API_BASE = "https://app.asana.com/api/1.0"
+TASKS_URL = API_BASE + "/projects/{project_gid}/tasks"
+# Fields rendered for a full read (lazy fetch).
 TASK_FIELDS = "name,notes,completed,assignee.name,due_on,permalink_url"
 PAGE_SIZE = 100
 MAX_TASKS = 2000
+SEARCH_LIMIT = 25
 
 
 def _render_task(task: dict) -> str:
@@ -41,21 +44,25 @@ def _render_task(task: dict) -> str:
     return "\n".join(parts)
 
 
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
 async def index_asana(source: dict) -> str | None:
+    """Build the navigable index only — one row per task (gid + name), no body."""
     source_id = UUID(source["id"])
     workspace_id = UUID(source["workspace_id"])
     owner_user_id = UUID(source["owner_user_id"])
     project_gid = source["external_ref"]
 
     token = await get_valid_token(owner_user_id, "asana")
-    headers = {"Authorization": f"Bearer {token}"}
     url = TASKS_URL.format(project_gid=project_gid)
 
     present: list[str] = []
     offset: str | None = None
-    async with httpx.AsyncClient(timeout=60.0, headers=headers) as client:
+    async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
         while len(present) < MAX_TASKS:
-            params = {"opt_fields": TASK_FIELDS, "limit": PAGE_SIZE}
+            params = {"opt_fields": "name", "limit": PAGE_SIZE}
             if offset:
                 params["offset"] = offset
             resp = await client.get(url, params=params)
@@ -65,14 +72,13 @@ async def index_asana(source: dict) -> str | None:
                 gid = task.get("gid")
                 if not gid:
                     continue
-                await source_service.upsert_content_document(
+                await source_service.upsert_index_row(
                     table="asana_documents",
                     source_id=source_id,
                     workspace_id=workspace_id,
                     path=gid,
                     name=task.get("name") or "(untitled task)",
                     kind="task",
-                    content=_render_task(task),
                     external_ref=gid,
                 )
                 present.append(gid)
@@ -84,3 +90,38 @@ async def index_asana(source: dict) -> str | None:
     await source_service.soft_delete_missing("asana_documents", source_id, present)
     logger.info("asana source %s: indexed %d task(s)", project_gid, len(present))
     return None
+
+
+async def search_asana(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
+    """Federated search via Asana's `/tasks/search` (paid tiers only). Scoped to
+    the project; returns hits keyed by task gid (the index path)."""
+    owner_user_id = UUID(source["owner_user_id"])
+    project_gid = source["external_ref"]
+    token = await get_valid_token(owner_user_id, "asana")
+    async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
+        # The search endpoint is workspace-scoped; resolve the project's workspace.
+        proj = await client.get(
+            f"{API_BASE}/projects/{project_gid}", params={"opt_fields": "workspace"}
+        )
+        proj.raise_for_status()
+        workspace_gid = proj.json()["data"]["workspace"]["gid"]
+        resp = await client.get(
+            f"{API_BASE}/workspaces/{workspace_gid}/tasks/search",
+            params={"text": query, "projects.any": project_gid, "opt_fields": "name", "limit": min(limit, 100)},
+        )
+        resp.raise_for_status()
+        tasks = resp.json().get("data", [])
+    return [
+        {"ref": t["gid"], "name": t.get("name") or t["gid"], "snippet": t.get("name") or ""}
+        for t in tasks
+        if t.get("gid")
+    ]
+
+
+async def fetch_asana_content(owner_user_id: UUID, gid: str) -> str:
+    """Lazy read: render a single task. `external_ref` is the task gid."""
+    token = await get_valid_token(owner_user_id, "asana")
+    async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
+        resp = await client.get(f"{API_BASE}/tasks/{gid}", params={"opt_fields": TASK_FIELDS})
+        resp.raise_for_status()
+        return _render_task(resp.json().get("data", {}))

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -98,6 +98,43 @@ async def index_google_drive(source: dict) -> str | None:
     return None
 
 
+def _drive_q_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("'", "\\'")
+
+
+async def search_drive(source: dict, query: str, limit: int = 25) -> list[dict]:
+    """Federated search via Drive's `fullText contains` — Google full-text-indexes
+    file contents server-side, so we never copy them. Maps the matched file ids
+    back to our index paths (so read_source resolves them) and only returns files
+    we've indexed for this source."""
+    owner_user_id = UUID(source["owner_user_id"])
+    source_id = UUID(source["id"])
+    token = await get_valid_token(owner_user_id, "google")
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        resp = await client.get(
+            DRIVE_LIST_URL,
+            params={
+                "q": f"fullText contains '{_drive_q_escape(query)}' and trashed = false",
+                "fields": "files(id, name)",
+                "pageSize": min(limit, 50),
+            },
+        )
+        resp.raise_for_status()
+        files = resp.json().get("files", [])
+
+    file_ids = [f["id"] for f in files]
+    paths = await source_service.index_paths_for_refs("drive_index", source_id, file_ids)
+    hits = []
+    for f in files:
+        entry = paths.get(f["id"])
+        if entry is None:
+            continue  # outside the indexed scope of this source
+        path, name = entry
+        hits.append({"ref": path, "name": name, "snippet": ""})
+    return hits
+
+
 async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
     """Lazy read: export a Drive file to markdown with the owner's token.
     Non-Doc files have no markdown export and come back empty."""

--- a/backend/integrations/jira/indexer.py
+++ b/backend/integrations/jira/indexer.py
@@ -1,10 +1,10 @@
-"""Jira project → jira_documents indexer (copied content; FTS-searchable).
+"""Jira project → jira_documents indexer (index only; search federated to JQL).
 
-A Jira source's external_ref is "{cloudId}:{projectKey}". We page through the
-project's issues newest-first and copy each one into jira_documents as a text
-document keyed by its issue key (e.g. PROJ-123), so the agent can search and
-read them like any other source. Idempotent re-sync via source_service
-(content-hash dedupe + soft-delete of issues that vanished).
+A Jira source's external_ref is "{cloudId}:{projectKey}". We don't copy issue
+bodies — Jira's own search (JQL `text ~`) is strong, so search is federated live
+(see `search_jira`) and the body is fetched lazily on read (`fetch_jira_content`).
+The sync only builds the navigable index: one row per issue keyed by its key
+(PROJ-123), storing the cloudId:key in external_ref for lazy fetch.
 """
 
 from __future__ import annotations
@@ -20,10 +20,15 @@ from ..storage import get_valid_token
 logger = logging.getLogger(__name__)
 
 API_BASE = "https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
-# The enhanced JQL search endpoint (token-paginated). Requires explicit fields.
+# Fields rendered for a full read (lazy fetch).
 ISSUE_FIELDS = "summary,status,assignee,updated,description,comment"
 PAGE_SIZE = 100
 MAX_ISSUES = 2000
+SEARCH_LIMIT = 25
+
+
+def _jql_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _adf_to_text(node: dict | None) -> str:
@@ -74,22 +79,27 @@ def _render_issue(issue: dict) -> str:
     return "\n".join(parts)
 
 
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+
 async def index_jira(source: dict) -> str | None:
+    """Build the navigable index only — one row per issue (key + title), no body.
+    The body is fetched lazily on read and search is federated to JQL."""
     source_id = UUID(source["id"])
     workspace_id = UUID(source["workspace_id"])
     owner_user_id = UUID(source["owner_user_id"])
     cloud_id, _, project_key = source["external_ref"].partition(":")
 
     token = await get_valid_token(owner_user_id, "jira")
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
     base = API_BASE.format(cloud_id=cloud_id)
     jql = f"project = {project_key} ORDER BY updated DESC"
 
     present: list[str] = []
     next_page_token: str | None = None
-    async with httpx.AsyncClient(timeout=60.0, headers=headers) as client:
+    async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
         while len(present) < MAX_ISSUES:
-            params = {"jql": jql, "maxResults": PAGE_SIZE, "fields": ISSUE_FIELDS}
+            params = {"jql": jql, "maxResults": PAGE_SIZE, "fields": "summary"}
             if next_page_token:
                 params["nextPageToken"] = next_page_token
             resp = await client.get(f"{base}/search/jql", params=params)
@@ -99,15 +109,15 @@ async def index_jira(source: dict) -> str | None:
                 key = issue.get("key")
                 if not key:
                     continue
-                await source_service.upsert_content_document(
+                summary = (issue.get("fields") or {}).get("summary") or key
+                await source_service.upsert_index_row(
                     table="jira_documents",
                     source_id=source_id,
                     workspace_id=workspace_id,
                     path=key,
-                    name=key,
+                    name=f"{key}: {summary}",
                     kind="issue",
-                    content=_render_issue(issue),
-                    external_ref=key,
+                    external_ref=f"{cloud_id}:{key}",
                 )
                 present.append(key)
             if payload.get("isLast") or not payload.get("nextPageToken"):
@@ -117,3 +127,39 @@ async def index_jira(source: dict) -> str | None:
     await source_service.soft_delete_missing("jira_documents", source_id, present)
     logger.info("jira source %s: indexed %d issue(s)", project_key, len(present))
     return None
+
+
+async def search_jira(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
+    """Federated search: run JQL `text ~` against the project, live. Returns hits
+    keyed by issue key (which is the index path, so read_source resolves them)."""
+    owner_user_id = UUID(source["owner_user_id"])
+    cloud_id, _, project_key = source["external_ref"].partition(":")
+    token = await get_valid_token(owner_user_id, "jira")
+    base = API_BASE.format(cloud_id=cloud_id)
+    jql = f'project = "{project_key}" AND text ~ "{_jql_escape(query)}" ORDER BY updated DESC'
+    async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
+        resp = await client.get(
+            f"{base}/search/jql",
+            params={"jql": jql, "maxResults": min(limit, 50), "fields": "summary"},
+        )
+        resp.raise_for_status()
+        issues = resp.json().get("issues", [])
+    hits = []
+    for issue in issues:
+        key = issue.get("key")
+        if not key:
+            continue
+        summary = (issue.get("fields") or {}).get("summary") or ""
+        hits.append({"ref": key, "name": f"{key}: {summary}", "snippet": summary})
+    return hits
+
+
+async def fetch_jira_content(owner_user_id: UUID, external_ref: str) -> str:
+    """Lazy read: render a single issue. `external_ref` is "{cloudId}:{key}"."""
+    cloud_id, _, key = external_ref.partition(":")
+    token = await get_valid_token(owner_user_id, "jira")
+    base = API_BASE.format(cloud_id=cloud_id)
+    async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
+        resp = await client.get(f"{base}/issue/{key}", params={"fields": ISSUE_FIELDS})
+        resp.raise_for_status()
+        return _render_issue(resp.json())

--- a/backend/migrations/versions/0091_jira_asana_index_only.py
+++ b/backend/migrations/versions/0091_jira_asana_index_only.py
@@ -1,0 +1,46 @@
+"""Jira & Asana become index-only (search federated to the provider).
+
+We stopped copying issue/task bodies: Jira search is federated to JQL and Asana
+to its tasks/search endpoint, with bodies fetched lazily on read. So drop the
+copied-content columns + their FTS/embedding indexes from jira_documents and
+asana_documents, leaving the navigable index (path/name/external_ref). The
+source_idx + UNIQUE(source_id, path) stay.
+
+Revision ID: 0091
+Revises: 0090
+"""
+
+from alembic import op
+
+revision = "0091"
+down_revision = "0090"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("jira_documents", "asana_documents")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"DROP INDEX IF EXISTS {table}_fts_idx")
+        op.execute(f"DROP INDEX IF EXISTS {table}_embed_stale_idx")
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"DROP COLUMN content, DROP COLUMN content_hash, "
+            f"DROP COLUMN embedding, DROP COLUMN embed_stale"
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"ADD COLUMN content text, ADD COLUMN content_hash text, "
+            f"ADD COLUMN embedding vector(384), "
+            f"ADD COLUMN embed_stale boolean NOT NULL DEFAULT FALSE"
+        )
+        op.execute(
+            f"CREATE INDEX {table}_fts_idx ON {table} "
+            f"USING gin (to_tsvector('english', coalesce(content, '')))"
+        )
+        op.execute(f"CREATE INDEX {table}_embed_stale_idx ON {table} (id) WHERE embed_stale")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -23,10 +23,14 @@ files_tree_service / memory_service (imported lazily to avoid an import cycle).
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import logging
 from uuid import UUID
 
 from ..database import get_pool
+
+logger = logging.getLogger(__name__)
 
 # Native source handles. Connected sources use their workspace_sources.id (str).
 NATIVE_FILES = "files"
@@ -238,16 +242,21 @@ SOURCE_TABLE = {
 # Tables that COPY content (FTS + embeddings live in them). The rest are
 # index-only and fetch their body lazily from the provider at read time.
 # Notion copies content too — its crawl already renders each page's text to
-# discover sub-pages, so storing it for FTS is nearly free.
+# discover sub-pages, so storing it for FTS is nearly free. Jira/Asana/Drive do
+# NOT copy: they're index-only and search is federated to the provider's own
+# search API (see FEDERATED_SEARCH_TYPES) so we don't duplicate their content.
 CONTENT_TABLES = {
     "github_documents",
     "slack_messages",
     "granola_notes",
-    "jira_documents",
-    "asana_documents",
     "gong_documents",
     "notion_index",
 }
+
+# Index-only source types whose `search` is federated live to the provider's
+# native search instead of our FTS (no copied content). source_type -> the
+# provider search coroutine, resolved lazily to avoid an import cycle.
+FEDERATED_SEARCH_TYPES = {"google_drive", "jira_project", "asana_project"}
 
 
 def _table_for(source_type: str) -> str:
@@ -439,7 +448,62 @@ async def _lazy_fetch(source_type: str, owner_user_id: UUID, external_ref: str |
         from ..integrations.google.indexer import fetch_drive_content
 
         return await fetch_drive_content(owner_user_id, external_ref)
+    if source_type == "jira_project":
+        from ..integrations.jira.indexer import fetch_jira_content
+
+        return await fetch_jira_content(owner_user_id, external_ref)
+    if source_type == "asana_project":
+        from ..integrations.asana.indexer import fetch_asana_content
+
+        return await fetch_asana_content(owner_user_id, external_ref)
     return ""
+
+
+async def index_paths_for_refs(
+    table: str, source_id: UUID, external_refs: list[str]
+) -> dict[str, tuple[str, str]]:
+    """Map provider external_refs back to (path, name) for a source's live index
+    rows. Federated search returns provider ids; this resolves them to the paths
+    `read_source` understands (and drops anything not in our index)."""
+    if not external_refs:
+        return {}
+    rows = await get_pool().fetch(
+        f"SELECT external_ref, path, name FROM {table} "
+        f"WHERE source_id = $1 AND external_ref = ANY($2) AND deleted_at IS NULL",
+        source_id,
+        external_refs,
+    )
+    return {r["external_ref"]: (r["path"], r["name"]) for r in rows}
+
+
+async def _federated_search(source: dict, query: str, limit: int) -> list[dict]:
+    """Run a federated source's native provider search. Returns unified hits
+    ({source, source_name, ref, name, snippet}); never raises — a provider error
+    (e.g. Asana on a free tier) logs and yields no hits so search stays alive."""
+    source_type = source["source_type"]
+    try:
+        if source_type == "google_drive":
+            from ..integrations.google.indexer import search_drive as fn
+        elif source_type == "jira_project":
+            from ..integrations.jira.indexer import search_jira as fn
+        elif source_type == "asana_project":
+            from ..integrations.asana.indexer import search_asana as fn
+        else:
+            return []
+        hits = await fn(source, query, limit)
+    except Exception:
+        logger.warning("federated search failed for source %s", source["id"], exc_info=True)
+        return []
+    return [
+        {
+            "source": source["id"],
+            "source_name": source["display_name"],
+            "ref": h["ref"],
+            "name": h.get("name", ""),
+            "snippet": h.get("snippet", ""),
+        }
+        for h in hits
+    ]
 
 
 async def search_documents(
@@ -680,6 +744,8 @@ async def search_all(
         if connected is None:
             return None
     if source is None or connected is not None:
+        # Copied-content sources go through our FTS (returns [] for index-only /
+        # federated sources, which have no stored content to match).
         docs = await search_documents(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -697,5 +763,22 @@ async def search_all(
             }
             for d in docs
         ]
+
+        # Federated sources search the provider's native API live. Scoped → the
+        # one source; unscoped → fan out across the user's federated sources
+        # (each call is independent and already swallows its own errors).
+        if connected is not None:
+            if connected["source_type"] in FEDERATED_SEARCH_TYPES:
+                results += await _federated_search(connected, query, limit)
+        else:
+            federated = [
+                s
+                for s in await list_connected_sources(workspace_id, user_id)
+                if s["source_type"] in FEDERATED_SEARCH_TYPES
+            ]
+            for hits in await asyncio.gather(
+                *(_federated_search(s, query, limit) for s in federated)
+            ):
+                results += hits
 
     return results

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -114,31 +114,30 @@ def test_connected_source_types_are_fully_wired():
         assert source_type in source_service.SOURCE_TABLE, source_type
         assert source_type in source_tasks.INDEXERS, source_type
 
-    # Every document table is exactly one storage strategy.
+    # Every document table is exactly one storage strategy: it either copies
+    # content (FTS) or is index-only (lazy read). Index-only sources are either
+    # federated-searchable (drive/jira/asana) or not searchable at all.
     for source_type, table in source_service.SOURCE_TABLE.items():
         assert source_type in source_service.SOURCE_CAPABILITY, source_type
-        # content tables hold the body; index-only tables fetch it lazily — a
-        # table that's in neither set would break read_document.
         is_content = table in source_service.CONTENT_TABLES
-        is_index_only = source_type in ("google_drive",)
+        is_index_only = source_type in source_service.FEDERATED_SEARCH_TYPES
         assert is_content or is_index_only, table
 
 
 def test_notion_is_searchable_content_source():
-    # Notion moved from index-only to copied-content so it's full-text searchable;
-    # Drive is now the only remaining lazy-fetch index-only source.
+    # Notion copies content (its crawl already renders the text), so it's FTS
+    # searchable rather than federated.
     assert source_service.SOURCE_TABLE["notion"] == "notion_index"
     assert "notion_index" in source_service.CONTENT_TABLES
-    assert source_service.SOURCE_CAPABILITY["notion"] == "navigable"
+    assert "notion" not in source_service.FEDERATED_SEARCH_TYPES
 
 
-def test_jira_and_asana_are_searchable_content_sources():
-    assert source_service.SOURCE_TABLE["jira_project"] == "jira_documents"
-    assert source_service.SOURCE_TABLE["asana_project"] == "asana_documents"
-    assert "jira_documents" in source_service.CONTENT_TABLES
-    assert "asana_documents" in source_service.CONTENT_TABLES
-    assert source_service.SOURCE_CAPABILITY["jira_project"] == "searchable"
-    assert source_service.SOURCE_CAPABILITY["asana_project"] == "navigable"
+def test_jira_asana_drive_are_index_only_federated():
+    # Jira/Asana/Drive don't copy content — search is federated to the provider's
+    # own search API and bodies are fetched lazily on read.
+    for st in ("jira_project", "asana_project", "google_drive"):
+        assert st in source_service.FEDERATED_SEARCH_TYPES, st
+        assert source_service.SOURCE_TABLE[st] not in source_service.CONTENT_TABLES, st
 
 
 def test_render_call_labels_speakers_and_keeps_transcript():

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -514,6 +514,52 @@ async def test_notion_is_full_text_searchable(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_jira_is_index_only_with_federated_search(client: AsyncClient, monkeypatch):
+    """Jira doesn't copy content: search is federated to the provider live, and
+    the issue body is fetched lazily on read."""
+    from backend.integrations.jira import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await source_service.create_source(
+        workspace_id=ws,
+        owner_user_id=owner_id,
+        source_type="jira_project",
+        external_ref="cloud-1:PROJ",
+        display_name="PROJ",
+    )
+    # Index row only — no body stored; external_ref carries cloudId:key for read.
+    await source_service.upsert_index_row(
+        table="jira_documents",
+        source_id=UUID(src["id"]),
+        workspace_id=ws,
+        path="PROJ-9",
+        name="PROJ-9: login bug",
+        kind="issue",
+        external_ref="cloud-1:PROJ-9",
+    )
+
+    async def fake_search(source, query, limit):
+        assert source["id"] == src["id"]
+        return [{"ref": "PROJ-9", "name": "PROJ-9: login bug", "snippet": "login is broken"}]
+
+    async def fake_fetch(owner, external_ref):
+        assert external_ref == "cloud-1:PROJ-9"
+        return "full issue body: login is broken"
+
+    monkeypatch.setattr(indexer, "search_jira", fake_search)
+    monkeypatch.setattr(indexer, "fetch_jira_content", fake_fetch)
+
+    # Search is federated (not our FTS — jira_documents holds no content).
+    hits = await source_service.search_all(ws, owner_id, "login", source=src["id"])
+    assert any(h["ref"] == "PROJ-9" for h in hits)
+
+    # Read lazily fetches the body from the provider.
+    doc = await source_service.read_document(src, "PROJ-9")
+    assert "login is broken" in doc["content"]
+
+
+@pytest.mark.asyncio
 async def test_read_source_rejects_unowned_connected_source(client: AsyncClient):
     owner_key, owner_id = await _register(client, "owner")
     _, other_id = await _register(client, "other")


### PR DESCRIPTION
## What

Applies the principle **"don't copy content unless necessary."** Jira, Asana, and Google Drive each have a strong native search, so we now **federate search to the provider live** and stop copying their content. They become index-only (bodies fetched lazily on read).

## Where copying is / isn't necessary

| Source | Native search | Decision |
|---|---|---|
| **Drive** | `fullText contains` (strong) | **Federate** — was already index-only, just added search |
| **Jira** | JQL `text ~` (strong) | **Federate** — converted from copied → index-only |
| **Asana** | `/tasks/search` (paid tiers) | **Federate** — converted; you confirmed paid tier |
| **Notion** | title-only / paid MCP | **Keep copied** (#508) — native search too weak |
| **Slack / Granola / Gong / GitHub** | push / weak APIs | **Keep copied** |

## How

- **Federated-search path** in `source_service`: a source whose type is in `FEDERATED_SEARCH_TYPES` routes `search` to the provider's native API instead of our FTS. Scoped search → one source; unscoped → fans out across the user's federated sources concurrently. Each federated call **swallows its own errors**, so one provider (e.g. Asana on a free tier returning 402) can't break the whole search.
- **Jira** → index-only sync (key + title); `search_jira` (JQL `text ~`); lazy `fetch_jira_content` keyed by `cloudId:key`.
- **Asana** → index-only sync (gid + name); `search_asana` (`/tasks/search`, workspace resolved at query time); lazy `fetch_asana_content` by gid.
- **Drive** → `search_drive` (`fullText contains`), mapping matched file ids back to our index paths so `read_source` resolves them (and only returns indexed-in-scope files).
- **Migration 0091** drops the copied-content columns + FTS/embedding indexes from `jira_documents`/`asana_documents`. They leave `CONTENT_TABLES`, so the embedding reconciler skips them automatically.

## Trade-offs (called out honestly)
- **Reads cost one API call** for Jira/Asana now (lazy fetch) instead of being instant from a local copy — in exchange for zero copied content and always-fresh data.
- **Unscoped search fans out** to live provider APIs (rate-limit exposure); scoped search is a single call.
- **Asana search needs a paid tier** — handled gracefully (errors → no hits, never a 500).

## Verification

- `ruff` (whole backend) + `pytest` green — 40 tests across `test_sources`, `test_integration_sources`, `test_agent_runtime`. New tests: federated search **routes to the provider** (not FTS) and Jira **reads lazily**; wiring invariant updated so every index-only source must be federated-searchable.
- Migration 0091 applies; `jira_documents` confirmed index-only (content columns gone); `app` imports; `CONTENT_TABLES` and the embedding reconciler no longer include Jira/Asana.
- Live provider calls (JQL / `fullText contains` / `/tasks/search`) need real connected accounts to exercise end-to-end — the routing, lazy-read, error-swallowing, and id→path mapping are unit/DB-tested.

Stacked conceptually on #508 (Notion), already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)