### PR TITLE
Harden OAuth callback: surface provider errors instead of bare 500

### DIFF
--- a/backend/integrations/asana/provider.py
+++ b/backend/integrations/asana/provider.py
@@ -56,7 +56,10 @@ class AsanaIntegration(Integration):
     async def _token_request(self, payload: dict) -> TokenSet:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(TOKEN_URL, data=payload)
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Asana token endpoint returned {resp.status_code}: {resp.text[:300]}"
+                )
             data = resp.json()
         expires_in = data.get("expires_in")
         expires_at = (

--- a/backend/integrations/jira/provider.py
+++ b/backend/integrations/jira/provider.py
@@ -62,7 +62,12 @@ class JiraIntegration(Integration):
     async def _token_request(self, payload: dict) -> TokenSet:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(TOKEN_URL, json=payload)
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                # Surface Atlassian's reason (invalid_client, redirect_uri_mismatch,
+                # invalid_grant, …) instead of an opaque HTTP error.
+                raise RuntimeError(
+                    f"Atlassian token endpoint returned {resp.status_code}: {resp.text[:300]}"
+                )
             data = resp.json()
         expires_in = data.get("expires_in")
         expires_at = (

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -245,14 +245,28 @@ async def integration_callback(
     state: str = Query(...),
 ):
     p = get_provider(provider)
-    if getattr(p, "auth_kind", "oauth") == "mcp_oauth":
-        # The provider owns the exchange + storage and returns where to land.
-        return_to = await p.finish_authorization(code, state)
-    else:
-        user_id, return_to = _decode_state(state, expected_provider=provider)
-        token = await p.exchange_code(code)
-        account = await p.fetch_account(token.access_token)
-        await storage.store_token(user_id, provider, token, account)
+    # The token exchange / account fetch talks to the provider — it can fail for
+    # reasons outside our control (bad client secret, provider error, expired
+    # code). Surface those as a clean redirect back to the UI with an error flag
+    # instead of a bare 500, and log the real cause for debugging.
+    try:
+        if getattr(p, "auth_kind", "oauth") == "mcp_oauth":
+            # The provider owns the exchange + storage and returns where to land.
+            return_to = await p.finish_authorization(code, state)
+        else:
+            user_id, return_to = _decode_state(state, expected_provider=provider)
+            token = await p.exchange_code(code)
+            account = await p.fetch_account(token.access_token)
+            await storage.store_token(user_id, provider, token, account)
+    except HTTPException:
+        raise  # already a clean client error (e.g. invalid/expired state → 400)
+    except Exception:
+        logger.exception("OAuth callback failed for provider %s", provider)
+        base = settings.PUBLIC_URL.rstrip("/")
+        return RedirectResponse(
+            url=f"{base}/settings?{urlencode({'integration_error': provider})}",
+            status_code=302,
+        )
 
     base = settings.PUBLIC_URL.rstrip("/")
     target = _safe_return_to(return_to) or "/settings"


### PR DESCRIPTION
## Why
Jira's prod callback returns a bare **500** (confirmed in Render logs: `GET /api/v1/integrations/jira/callback -> 500`, ~200ms, no traceback because this app's logging swallows them). The state-decode is fine (dummy-state probe returns a clean 400 like Notion), so the failure is in the **token exchange / account fetch** — i.e. the provider rejecting us. Almost certainly a `JIRA_OAUTH_CLIENT_SECRET` mismatch or Atlassian app misconfig.

## What
- **Generic OAuth callback hardening** (`router.py`): wrap the exchange/fetch/store in try/except. On a provider error, log the real cause and **redirect to `/settings?integration_error=<provider>`** instead of a 500. `HTTPException` (e.g. invalid/expired state → 400) still passes through. Applies to every OAuth provider.
- **Diagnostic provider errors** (Jira + Asana `_token_request`): on a 4xx/5xx from the token endpoint, raise with the provider's **actual error body** (`invalid_client`, `redirect_uri_mismatch`, `invalid_grant`, …) so the logged reason is useful.

After deploy, retrying Jira will (a) no longer 500 — it redirects back with an error flag, and (b) log the precise Atlassian rejection so the root cause is unambiguous.

`ruff` clean; imports verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)