### PR TITLE
Bootstrap recent content on Slack/Granola sync

### DIFF
--- a/backend/integrations/granola/client.py
+++ b/backend/integrations/granola/client.py
@@ -50,6 +50,26 @@ async def call_tool_json(
     return json.loads(text) if text else None
 
 
+async def call_tool_data(
+    session: ClientSession, name: str, arguments: dict[str, Any] | None = None
+) -> Any:
+    """Call a tool and return its data, tolerant of result shape: prefer
+    structuredContent, then JSON text, then the raw text. Never raises on a
+    non-JSON body (Granola tools may return markdown) — only on an MCP error."""
+    result = await session.call_tool(name, arguments or {})
+    if result.isError:
+        raise RuntimeError(f"granola tool {name} failed: {_first_text(result.content)}")
+    if result.structuredContent is not None:
+        return result.structuredContent
+    text = _first_text(result.content)
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text  # markdown / plain text — caller handles it
+
+
 def _first_text(content: list) -> str:
     for block in content:
         if getattr(block, "type", None) == "text":

--- a/backend/integrations/granola/indexer.py
+++ b/backend/integrations/granola/indexer.py
@@ -18,13 +18,27 @@ import logging
 from uuid import UUID
 
 from ...services import source_service
-from .client import call_tool_json, granola_session
+from .client import call_tool_data, granola_session
 from .oauth import get_valid_access_token
 
 logger = logging.getLogger(__name__)
 
 # Granola rate-limits; a transcript fetch per meeting can add up, so cap a sync.
 MAX_MEETINGS = 1000
+
+# Granola's MCP tool names aren't a stable public contract, so we discover them
+# at runtime (tools/list) and match by intent rather than hardcoding a guess.
+_LIST_HINTS = ("list_meeting", "list_document", "list_note", "recent", "meeting", "document", "search")
+_TRANSCRIPT_HINTS = ("transcript", "get_meeting", "get_document", "get_note", "detail", "content")
+
+
+def _pick_tool(names: list[str], hints: tuple[str, ...]) -> str | None:
+    lower = {n.lower(): n for n in names}
+    for hint in hints:
+        for low, original in lower.items():
+            if hint in low:
+                return original
+    return None
 
 
 def _as_list(result, *keys) -> list:
@@ -86,17 +100,40 @@ async def index_granola(source: dict) -> str | None:
     present: list[str] = []
 
     async with granola_session(access_token) as session:
-        meetings_result = await call_tool_json(session, "list_meetings")
-        meetings = _as_list(meetings_result, "meetings", "results", "items")
+        tools = (await session.list_tools()).tools
+        names = [t.name for t in tools]
+        # Log the real tool surface — names aren't documented, so this is how we
+        # learn (and adjust) what Granola actually exposes.
+        logger.info("granola MCP tools: %s", names)
+
+        list_tool = _pick_tool(names, _LIST_HINTS)
+        if not list_tool:
+            logger.warning("granola: no meetings-list tool among %s", names)
+            return None
+        transcript_tool = _pick_tool([n for n in names if n != list_tool], _TRANSCRIPT_HINTS)
+
+        data = await call_tool_data(session, list_tool)
+        meetings = _as_list(data, "meetings", "results", "items", "documents", "notes")
+        logger.info(
+            "granola: '%s' returned %d meeting(s); transcript tool=%s",
+            list_tool,
+            len(meetings),
+            transcript_tool,
+        )
 
         for meeting in meetings[:MAX_MEETINGS]:
+            if not isinstance(meeting, dict):
+                continue
             meeting_id = _meeting_id(meeting)
             if not meeting_id:
                 continue
-            transcript_result = await call_tool_json(
-                session, "get_meeting_transcript", {"meeting_id": meeting_id}
-            )
-            transcript = _as_list(transcript_result, "transcript", "segments", "entries")
+            transcript: list = []
+            if transcript_tool:
+                try:
+                    td = await call_tool_data(session, transcript_tool, {"meeting_id": meeting_id})
+                    transcript = _as_list(td, "transcript", "segments", "entries")
+                except Exception:
+                    logger.info("granola: transcript fetch failed for %s", meeting_id)
             await source_service.upsert_content_document(
                 table="granola_notes",
                 source_id=source_id,

--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -54,11 +54,18 @@ async def index_slack(source: dict) -> str | None:
         for channel in channels_payload.get("channels", []):
             channel_id = channel["id"]
             channel_name = channel.get("name") or channel_id
-            history = await _slack_get(
-                client,
-                CONVERSATIONS_HISTORY_URL,
-                {"channel": channel_id, "limit": MAX_MESSAGES_PER_CHANNEL},
-            )
+            # A channel we can't read (not a member, archived, …) must not abort
+            # the whole backfill — skip it and continue. conversations.history
+            # returns most-recent-first, so this bootstraps recent messages.
+            try:
+                history = await _slack_get(
+                    client,
+                    CONVERSATIONS_HISTORY_URL,
+                    {"channel": channel_id, "limit": MAX_MESSAGES_PER_CHANNEL},
+                )
+            except RuntimeError as e:
+                logger.info("slack: skipping channel %s (%s)", channel_name, e)
+                continue
             for msg in history.get("messages", []):
                 if msg.get("type") != "message" or not msg.get("ts"):
                     continue

--- a/backend/integrations/slack/provider.py
+++ b/backend/integrations/slack/provider.py
@@ -20,9 +20,21 @@ TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 AUTH_TEST_URL = "https://slack.com/api/auth.test"
 REVOKE_URL = "https://slack.com/api/auth.revoke"
 
-# User-token scopes: read channel/group history + resolve user names. We index
-# rather than search live, so search:read is not required.
-USER_SCOPES = ["channels:history", "groups:history", "im:history", "users:read"]
+# User-token scopes: list conversations + read their history + resolve user
+# names. The `*:read` scopes are required by conversations.list (the backfill
+# enumerates channels); `*:history` lets us read messages. We index rather than
+# search live, so search:read is not required.
+USER_SCOPES = [
+    "channels:read",
+    "channels:history",
+    "groups:read",
+    "groups:history",
+    "im:read",
+    "im:history",
+    "mpim:read",
+    "mpim:history",
+    "users:read",
+]
 
 
 class SlackIntegration(Integration):


### PR DESCRIPTION
Both indexed 0 docs (nothing to search). Root causes from the celery-worker logs:

- **Slack**: `conversations.list` → `missing_scope` — the user token only had `*:history`, but listing channels needs `*:read`. Added `channels:read`/`groups:read`/`im:read`/`mpim:read` (+ `mpim:history`), and made per-channel history non-fatal so one unreadable channel can't abort the backfill. `conversations.history` is most-recent-first → bootstraps recent messages. **Requires re-consent** (add scopes in the Slack app + reconnect).
- **Granola**: the MCP call used a guessed tool name (`list_meetings`) → non-JSON → `JSONDecodeError`. Now we **discover tools at runtime** (`tools/list`), log the real surface, match list/transcript tools by intent, and parse tolerantly (structured → JSON → raw text).

ruff + imports clean.