### PR TITLE
Add fetch_history: reach past the cached window (Slack/Gong)

### DIFF
--- a/backend/integrations/gong/indexer.py
+++ b/backend/integrations/gong/indexer.py
@@ -114,3 +114,42 @@ async def index_gong(source: dict) -> str | None:
     await source_service.soft_delete_missing("gong_documents", source_id, present)
     logger.info("gong source: indexed %d call(s)", len(present))
     return None
+
+
+async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
+    """On-demand: pull calls in [since, until] — older than the rolling window
+    the scheduled sync keeps. Caches them (upsert) so they're searchable
+    afterward, and returns the call ids found. No soft-delete: this adds to the
+    cache, it doesn't define the live set."""
+    source_id = UUID(source["id"])
+    workspace_id = UUID(source["workspace_id"])
+    owner_user_id = UUID(source["owner_user_id"])
+    creds = json.loads(await get_valid_token(owner_user_id, "gong"))
+    headers = {"Authorization": basic_auth_header(creds["access_key"], creds["access_key_secret"])}
+    from_dt = since.isoformat()
+    to_dt = (until or datetime.now(UTC)).isoformat()
+
+    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+        meta_by_id = await _fetch_call_meta(client, from_dt, to_dt)
+        transcript_by_id = await _fetch_transcripts(client, from_dt, to_dt)
+
+    refs: list[str] = []
+    for call_id, meta in list(meta_by_id.items())[:limit]:
+        await source_service.upsert_content_document(
+            table="gong_documents",
+            source_id=source_id,
+            workspace_id=workspace_id,
+            path=call_id,
+            name=meta.get("title") or call_id,
+            kind="call",
+            content=_render_call(meta, transcript_by_id.get(call_id, [])),
+            external_ref=call_id,
+        )
+        refs.append(call_id)
+
+    return {
+        "fetched": len(refs),
+        "since": since.isoformat(),
+        "until": until.isoformat() if until else None,
+        "results": [{"ref": r} for r in refs[:25]],
+    }

--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -82,6 +82,59 @@ async def index_slack(source: dict) -> str | None:
     return None
 
 
+async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
+    """On-demand: pull messages in [since, until] across the user's channels —
+    older than the recent backfill window. Caches them (upsert) so they're
+    searchable afterward, and returns the refs found."""
+    source_id = UUID(source["id"])
+    workspace_id = UUID(source["workspace_id"])
+    owner_user_id = UUID(source["owner_user_id"])
+    token = await get_valid_token(owner_user_id, "slack")
+    headers = {"Authorization": f"Bearer {token}"}
+    oldest = f"{since.timestamp():.6f}"
+    latest = f"{until.timestamp():.6f}" if until else None
+
+    refs: list[str] = []
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        channels = (
+            await _slack_get(client, CONVERSATIONS_LIST_URL, {"types": CHANNEL_TYPES, "limit": MAX_CHANNELS})
+        ).get("channels", [])
+        for channel in channels:
+            if len(refs) >= limit:
+                break
+            channel_id = channel["id"]
+            channel_name = channel.get("name") or channel_id
+            params = {"channel": channel_id, "oldest": oldest, "limit": MAX_MESSAGES_PER_CHANNEL}
+            if latest:
+                params["latest"] = latest
+            try:
+                history = await _slack_get(client, CONVERSATIONS_HISTORY_URL, params)
+            except RuntimeError as e:
+                logger.info("slack history: skipping channel %s (%s)", channel_name, e)
+                continue
+            for msg in history.get("messages", []):
+                if msg.get("type") != "message" or not msg.get("ts"):
+                    continue
+                await _upsert_message(
+                    source_id=source_id,
+                    workspace_id=workspace_id,
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                    ts=msg["ts"],
+                    text=msg.get("text") or "",
+                )
+                refs.append(f"{channel_name}/{msg['ts']}")
+                if len(refs) >= limit:
+                    break
+
+    return {
+        "fetched": len(refs),
+        "since": since.isoformat(),
+        "until": until.isoformat() if until else None,
+        "results": [{"ref": r} for r in refs[:25]],
+    }
+
+
 async def _upsert_message(
     *,
     source_id: UUID,

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -158,6 +158,30 @@ async def query_source(
     return result
 
 
+class FetchHistoryRequest(BaseModel):
+    since: str  # ISO-8601 date/datetime
+    until: str | None = None
+    limit: int = 500
+
+
+@router.post("/{source}/history")
+async def fetch_source_history(
+    workspace_id: UUID,
+    source: str,
+    body: FetchHistoryRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Pull older data for a time range from a copied source that supports it
+    (Slack/Gong), caching it so it becomes searchable."""
+    await _require_member(workspace_id, current_user["id"])
+    result = await source_service.fetch_history(
+        workspace_id, current_user["id"], source, body.since, until=body.until, limit=body.limit
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return result
+
+
 @router.post("")
 async def add_source(
     workspace_id: UUID,

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -630,6 +630,38 @@ async def _query_source(args: dict) -> dict:
     return _text_result(json.dumps(result))
 
 
+@tool(
+    "fetch_history",
+    "Pull OLDER data from a source for a time range, beyond what's already "
+    "cached/searchable (Slack messages, Gong calls). Use when the user asks "
+    "about something before the recent window. `since`/`until` are ISO-8601 "
+    "dates (e.g. '2026-01-01'); until defaults to now. Fetched items are cached, "
+    "so afterward you can find them with search/read_source.",
+    {
+        "type": "object",
+        "properties": {
+            "source": {"type": "string"},
+            "since": {"type": "string"},
+            "until": {"type": "string"},
+            "limit": {"type": "integer", "default": 500},
+        },
+        "required": ["source", "since"],
+    },
+)
+async def _fetch_history(args: dict) -> dict:
+    result = await source_service.fetch_history(
+        _current_workspace(),
+        _current_user(),
+        args.get("source", ""),
+        args.get("since", ""),
+        until=args.get("until"),
+        limit=int(args.get("limit", 500)),
+    )
+    if result is None:
+        return _text_result(json.dumps({"error": "source not found"}))
+    return _text_result(json.dumps(result))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
@@ -648,6 +680,7 @@ _TOOLS_BY_NAME = {
     "read_source": _read_source,
     "search": _search,
     "query_source": _query_source,
+    "fetch_history": _fetch_history,
 }
 
 

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -56,6 +56,7 @@ STASH_TOOL_SET = (
     "read_source",
     "search",
     "query_source",
+    "fetch_history",
 )
 
 # Read-only subset for ask-the-workspace and other Q&A surfaces. Drops
@@ -77,4 +78,5 @@ ASK_TOOL_SET = (
     "read_source",
     "search",
     "query_source",
+    "fetch_history",
 )

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -258,6 +258,11 @@ CONTENT_TABLES = {
 # provider search coroutine, resolved lazily to avoid an import cycle.
 FEDERATED_SEARCH_TYPES = {"google_drive", "jira_project", "asana_project"}
 
+# Copied-content sources that only cache a bounded recent window. The agent can
+# pull OLDER data on demand from the provider for an explicit time range — what
+# it fetches is cached (upserted) so it's searchable afterward too.
+HISTORY_FETCH_TYPES = {"slack", "gong_calls"}
+
 
 def _table_for(source_type: str) -> str:
     table = SOURCE_TABLE.get(source_type)
@@ -696,6 +701,49 @@ async def query_source(
         return await run_query(connected, sql, limit)
     except ValueError as e:
         return {"error": str(e)}
+
+
+def _parse_dt(value: str | None):
+    """Parse an ISO-8601 date/datetime (with or without 'Z'). Naive → UTC."""
+    from datetime import UTC, datetime
+
+    if not value or not value.strip():
+        return None
+    dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+async def fetch_history(
+    workspace_id: UUID,
+    user_id: UUID,
+    source: str,
+    since: str,
+    until: str | None = None,
+    limit: int = 500,
+) -> dict | None:
+    """Pull older provider data for a time range, beyond the cached window, for a
+    copied source that supports it (Slack/Gong). Fetched items are upserted into
+    the local table (so they become searchable) and returned. Returns None when
+    the handle is unknown / not owned; an error dict for unsupported sources or
+    bad input."""
+    connected = await _resolve_connected(source, user_id)
+    if connected is None:
+        return None
+    if connected["source_type"] not in HISTORY_FETCH_TYPES:
+        return {"error": "source does not support history fetch"}
+    try:
+        since_dt = _parse_dt(since)
+        until_dt = _parse_dt(until)
+    except ValueError:
+        return {"error": "since/until must be ISO-8601 dates (e.g. 2026-01-01)"}
+    if since_dt is None:
+        return {"error": "since is required"}
+
+    if connected["source_type"] == "slack":
+        from ..integrations.slack.indexer import fetch_history as fn
+    else:
+        from ..integrations.gong.indexer import fetch_history as fn
+    return await fn(connected, since_dt, until_dt, min(limit, 1000))
 
 
 async def search_all(

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -226,3 +226,20 @@ def test_query_source_tool_is_registered_and_in_tool_sets():
     assert "query_source" in agent_runtime._TOOLS_BY_NAME
     assert "query_source" in prompts.STASH_TOOL_SET
     assert "query_source" in prompts.ASK_TOOL_SET
+
+
+def test_fetch_history_wiring():
+    # Copied, time-windowed sources support on-demand history fetch.
+    assert source_service.HISTORY_FETCH_TYPES == {"slack", "gong_calls"}
+    # Both are copied-content (the cache) AND now fetchable for older data.
+    assert source_service.SOURCE_TABLE["slack"] in source_service.CONTENT_TABLES
+    assert source_service.SOURCE_TABLE["gong_calls"] in source_service.CONTENT_TABLES
+    assert "fetch_history" in agent_runtime._TOOLS_BY_NAME
+    assert "fetch_history" in prompts.STASH_TOOL_SET
+    assert "fetch_history" in prompts.ASK_TOOL_SET
+
+
+def test_parse_dt_accepts_iso_dates():
+    assert source_service._parse_dt("2026-01-01").year == 2026
+    assert source_service._parse_dt("2026-01-01T08:00:00Z").hour == 8
+    assert source_service._parse_dt(None) is None

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -560,6 +560,41 @@ async def test_jira_is_index_only_with_federated_search(client: AsyncClient, mon
 
 
 @pytest.mark.asyncio
+async def test_fetch_history_routes_to_provider_and_rejects_unsupported(client, monkeypatch):
+    """fetch_history reaches the provider for a copied, time-windowed source
+    (Slack), and is rejected for sources that don't support it (GitHub)."""
+    from backend.integrations.slack import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    slack = await source_service.create_source(
+        workspace_id=ws, owner_user_id=owner_id, source_type="slack",
+        external_ref="T123", display_name="Slack",
+    )
+    github = await source_service.create_source(
+        workspace_id=ws, owner_user_id=owner_id, source_type="github_repo",
+        external_ref="acme/x", display_name="x",
+    )
+
+    captured = {}
+
+    async def fake_fetch(source, since, until, limit):
+        captured["since"] = since.isoformat()
+        captured["limit"] = limit
+        return {"fetched": 2, "since": since.isoformat(), "results": [{"ref": "general/1"}]}
+
+    monkeypatch.setattr(indexer, "fetch_history", fake_fetch)
+
+    res = await source_service.fetch_history(ws, owner_id, slack["id"], "2026-01-01", until="2026-02-01")
+    assert res["fetched"] == 2
+    assert captured["since"].startswith("2026-01-01")
+
+    # GitHub copies the full tree — no time-window history fetch.
+    bad = await source_service.fetch_history(ws, owner_id, github["id"], "2026-01-01")
+    assert "error" in bad
+
+
+@pytest.mark.asyncio
 async def test_read_source_rejects_unowned_connected_source(client: AsyncClient):
     owner_key, owner_id = await _register(client, "owner")
     _, other_id = await _register(client, "other")


### PR DESCRIPTION
Copied sources cache only a bounded recent window (Slack ~200 msgs/channel, Gong last 90 days), so older data was unreachable. This adds an on-demand history fetch the agent (and API) can call for an explicit time range — and **what it fetches is cached**, so it becomes searchable afterward (the cache deepens on demand).

Only applies to the time-windowed **copied** sources: **Slack** and **Gong**. Federated sources (Jira/Asana/Drive) already reach all data live; Notion copies everything shared; GitHub copies the full current tree.

- `source_service.fetch_history()` — dispatch for `HISTORY_FETCH_TYPES`, ISO-8601 `since`/`until`.
- `slack.fetch_history` — `conversations.history` with `oldest`/`latest` across channels.
- `gong.fetch_history` — calls+transcripts for an arbitrary date range (no 90-day cap), no soft-delete.
- New `fetch_history` agent tool (+ tool sets) and `POST .../sources/{source}/history`.

Tests: provider routing + unsupported-source rejection + wiring + date parsing. 43 source/integration/agent tests green; ruff clean.