### PR TITLE
Make connected sources first-class: per-integration pages

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -136,6 +136,21 @@ async def read_source_doc(
     return doc
 
 
+@router.get("/{source_id}/status")
+async def source_status(
+    workspace_id: UUID,
+    source_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    """Sync/index status for one connected source (for the integration page):
+    sync_status, last_synced_at, sync_error, and how many items are indexed."""
+    await _require_member(workspace_id, current_user["id"])
+    source = await source_service.get_owned_source(source_id, current_user["id"])
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return {**source, "item_count": await source_service.source_item_count(source)}
+
+
 class QuerySourceRequest(BaseModel):
     sql: str
     limit: int = 200

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -594,9 +594,28 @@ async def list_sources(workspace_id: UUID, user_id: UUID) -> list[dict]:
                 "type": s["source_type"],
                 "capability": s["capability"],
                 "display_name": s["display_name"],
+                # Sync bookkeeping for the per-integration page (the sidebar
+                # ignores these). Already on the row — no extra query.
+                "external_ref": s["external_ref"],
+                "sync_status": s["sync_status"],
+                "sync_error": s["sync_error"],
+                "last_synced_at": s["last_synced_at"],
             }
         )
     return sources
+
+
+async def source_item_count(source: dict) -> int | None:
+    """How many live documents a source has indexed. None for queryable sources
+    (Snowflake) — they have no document table."""
+    table = SOURCE_TABLE.get(source["source_type"])
+    if table is None:
+        return None
+    row = await get_pool().fetchrow(
+        f"SELECT count(*) AS n FROM {table} WHERE source_id = $1 AND deleted_at IS NULL",
+        UUID(source["id"]),
+    )
+    return int(row["n"]) if row else 0
 
 
 # --- unified VFS over native + connected sources ----------------------------

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -595,6 +595,43 @@ async def test_fetch_history_routes_to_provider_and_rejects_unsupported(client, 
 
 
 @pytest.mark.asyncio
+async def test_list_sources_carries_status_and_status_endpoint_counts(client: AsyncClient):
+    """The per-integration page needs sync status + item counts: list_sources now
+    carries the status fields, and /status reports the indexed-doc count (None for
+    queryable sources with no table)."""
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await source_service.create_source(
+        workspace_id=ws, owner_user_id=owner_id, source_type="github_repo",
+        external_ref="acme/widgets", display_name="acme/widgets",
+    )
+    await source_service.upsert_content_document(
+        table="github_documents", source_id=UUID(src["id"]), workspace_id=ws,
+        path="README.md", name="README.md", content="hi",
+    )
+
+    listing = await client.get(f"/api/v1/workspaces/{ws}/sources", headers=_auth(api_key))
+    connected = next(s for s in listing.json()["sources"] if s["source"] == src["id"])
+    assert "sync_status" in connected and "last_synced_at" in connected
+
+    status = await client.get(
+        f"/api/v1/workspaces/{ws}/sources/{src['id']}/status", headers=_auth(api_key)
+    )
+    assert status.status_code == 200
+    assert status.json()["item_count"] == 1
+
+    # A queryable source (snowflake) has no document table → count is None.
+    sf = await source_service.create_source(
+        workspace_id=ws, owner_user_id=owner_id, source_type="snowflake",
+        external_ref="acct", display_name="Snowflake",
+    )
+    sf_status = await client.get(
+        f"/api/v1/workspaces/{ws}/sources/{sf['id']}/status", headers=_auth(api_key)
+    )
+    assert sf_status.json()["item_count"] is None
+
+
+@pytest.mark.asyncio
 async def test_read_source_rejects_unowned_connected_source(client: AsyncClient):
     owner_key, owner_id = await _register(client, "owner")
     _, other_id = await _register(client, "other")

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
@@ -1,0 +1,897 @@
+"use client";
+
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
+import { useAuth } from "../../../../../../hooks/useAuth";
+import {
+  deleteWorkspaceSource,
+  fetchSourceHistory,
+  getSourceEntries,
+  getSourceStatus,
+  listWorkspaceSources,
+  querySource,
+  readSourceDoc,
+  searchSource,
+  syncWorkspaceSource,
+  type SourceEntry,
+  type SourceSearchHit,
+  type WorkspaceSource,
+} from "../../../../../../lib/api";
+import {
+  disconnectIntegration,
+  listIntegrations,
+  startConnect,
+  submitCredentials,
+  type IntegrationStatus,
+} from "../../../../../../lib/integrations";
+import { connectorForProvider, connectorIcon } from "../../../../../../components/integrations/connectors";
+import {
+  AddSourceControls,
+  CredentialForm,
+  primaryButton,
+  secondaryButton,
+} from "../../../../../../components/integrations/pickers";
+
+// One-line "how it's indexed" descriptor per source type.
+const INDEX_DESCRIPTOR: Record<string, string> = {
+  github_repo: "Full repo copied + searchable",
+  google_drive: "Indexed; searched live (Drive full-text)",
+  notion: "Pages copied + full-text search",
+  jira_project: "Searched live via Jira (federated)",
+  asana_project: "Searched live via Asana (federated)",
+  slack: "Messages copied + searchable",
+  granola: "Meeting notes copied + searchable",
+  gong_calls: "Call transcripts copied + searchable",
+  snowflake: "Live read-only SQL",
+};
+
+export default function IntegrationPage() {
+  const params = useParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const workspaceId = params.workspaceId as string;
+  const provider = params.provider as string;
+  const highlightSourceId = searchParams.get("source");
+  const { user, loading } = useAuth();
+
+  const connector = connectorForProvider(provider);
+
+  const [status, setStatus] = useState<IntegrationStatus | null>(null);
+  const [sources, setSources] = useState<WorkspaceSource[]>([]);
+  const [openSourceId, setOpenSourceId] = useState<string | null>(highlightSourceId);
+  const [showCreds, setShowCreds] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useBreadcrumbs(
+    [{ label: connector?.label ?? "Integration" }],
+    `${workspaceId}/integrations/${provider}`,
+  );
+
+  const refresh = useCallback(async () => {
+    if (!connector) return;
+    setError("");
+    const [integrations, allSources] = await Promise.all([
+      listIntegrations(),
+      listWorkspaceSources(workspaceId),
+    ]);
+    setStatus(integrations.providers.find((p) => p.provider === provider) ?? null);
+    setSources(allSources.filter((s) => s.type === connector.sourceType));
+  }, [connector, provider, workspaceId]);
+
+  useEffect(() => {
+    if (!user) return;
+    refresh().catch((e) => setError(e instanceof Error ? e.message : "Could not load integration"));
+  }, [user, refresh]);
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  if (loading) return null;
+  if (!user) return null;
+
+  if (!connector) {
+    return (
+      <div className="scroll-thin flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-12 py-8">
+          <h1 className="font-display text-[20px] font-semibold text-foreground">Unknown integration</h1>
+          <p className="mt-2 text-[13px] text-muted">
+            No integration matches “{provider}”.{" "}
+            <Link href="/settings" className="text-brand hover:underline">
+              Manage in Settings
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const connected = !!status?.connected;
+  const account = status?.account_email || status?.account_display_name;
+
+  async function connect() {
+    setBusy("connect");
+    setError("");
+    try {
+      await startConnect(connector!.provider, pathname);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not start connection");
+      setBusy(null);
+    }
+  }
+
+  async function submitCreds(values: Record<string, string>) {
+    setBusy("connect");
+    setError("");
+    try {
+      await submitCredentials(connector!.provider, values);
+      setShowCreds(false);
+      await refresh();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not connect");
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function disconnect() {
+    if (!confirm(`Disconnect ${connector!.label}? You'll need to reconnect to sync its sources again.`)) {
+      return;
+    }
+    setBusy("disconnect");
+    setError("");
+    try {
+      await disconnectIntegration(connector!.provider);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not disconnect");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function syncSource(source: WorkspaceSource) {
+    setBusy(`sync:${source.source}`);
+    setError("");
+    try {
+      await syncWorkspaceSource(workspaceId, source.source);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not start sync");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function removeSource(source: WorkspaceSource) {
+    if (!confirm(`Remove ${source.display_name}?`)) return;
+    setBusy(`delete:${source.source}`);
+    setError("");
+    try {
+      await deleteWorkspaceSource(workspaceId, source.source);
+      if (openSourceId === source.source) setOpenSourceId(null);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not remove source");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const openSource = sources.find((s) => s.source === openSourceId) ?? null;
+
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-3xl px-12 py-8">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+            {connectorIcon(connector.provider)}
+          </span>
+          <div className="min-w-0 flex-1">
+            <h1 className="font-display text-[20px] font-semibold text-foreground">{connector.label}</h1>
+            <div className="text-[12.5px] text-muted">
+              {connected && account ? `Connected as ${account}` : connector.blurb}
+            </div>
+          </div>
+          <Link href="/settings" className="shrink-0 text-[12px] text-muted hover:text-foreground hover:underline">
+            Manage in Settings
+          </Link>
+        </div>
+
+        <div className="mt-3 flex items-center gap-2">
+          {!connected && status?.auth_kind === "api_key" ? (
+            <button
+              type="button"
+              onClick={() => setShowCreds((v) => !v)}
+              disabled={busy === "connect"}
+              className={primaryButton()}
+            >
+              {showCreds ? "Cancel" : "Connect"}
+            </button>
+          ) : !connected ? (
+            <button type="button" onClick={() => void connect()} disabled={busy === "connect"} className={primaryButton()}>
+              {busy === "connect" ? "Connecting..." : "Connect"}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void disconnect()}
+              disabled={busy === "disconnect"}
+              className="shrink-0 rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-muted hover:border-error/40 hover:text-error disabled:opacity-60"
+            >
+              {busy === "disconnect" ? "Disconnecting..." : "Disconnect"}
+            </button>
+          )}
+        </div>
+
+        {showCreds && !connected && status?.auth_kind === "api_key" && status.credential_fields && (
+          <CredentialForm
+            fields={status.credential_fields}
+            busy={busy === "connect"}
+            onSubmit={submitCreds}
+          />
+        )}
+
+        {error && (
+          <div className="mt-4 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
+            {error}
+          </div>
+        )}
+
+        {/* Add */}
+        {connected && (
+          <section className="mt-6">
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">Add</h2>
+            <div className="rounded-lg border border-border bg-surface px-3 py-3">
+              <AddSourceControls
+                connector={connector}
+                workspaceId={workspaceId}
+                connected={connected}
+                onAdded={() => void refresh()}
+              />
+            </div>
+          </section>
+        )}
+
+        {/* Added sources */}
+        <section className="mt-6">
+          <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">Added sources</h2>
+          {sources.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
+              {connected ? "Nothing added yet." : "Connect to add sources."}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {sources.map((source) => (
+                <SourceRow
+                  key={source.source}
+                  workspaceId={workspaceId}
+                  source={source}
+                  highlighted={source.source === highlightSourceId}
+                  open={source.source === openSourceId}
+                  busySync={busy === `sync:${source.source}`}
+                  busyDelete={busy === `delete:${source.source}`}
+                  onOpen={() => setOpenSourceId((v) => (v === source.source ? null : source.source))}
+                  onSync={() => void syncSource(source)}
+                  onRemove={() => void removeSource(source)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Browse */}
+        {openSource && (
+          <section className="mt-6">
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
+              Browse · {openSource.display_name}
+            </h2>
+            <BrowsePanel workspaceId={workspaceId} source={openSource} onRefresh={() => void refresh()} />
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "never synced";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "never synced";
+  const diffMin = Math.round((Date.now() - then) / 60000);
+  if (diffMin < 1) return "synced just now";
+  if (diffMin < 60) return `synced ${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `synced ${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 7) return `synced ${diffD}d ago`;
+  return `synced ${new Date(iso).toLocaleDateString()}`;
+}
+
+function SyncPill({ syncStatus }: { syncStatus: string | null | undefined }) {
+  const s = syncStatus ?? "idle";
+  const cls =
+    s === "syncing"
+      ? "border-blue-300/50 bg-blue-500/10 text-blue-600"
+      : s === "failed"
+      ? "border-error/40 bg-error/10 text-error"
+      : "border-border bg-base text-muted";
+  return (
+    <span className={"inline-flex items-center rounded-full border px-2 py-0.5 text-[10.5px] font-medium " + cls}>
+      {s}
+    </span>
+  );
+}
+
+function SourceRow({
+  workspaceId,
+  source,
+  highlighted,
+  open,
+  busySync,
+  busyDelete,
+  onOpen,
+  onSync,
+  onRemove,
+}: {
+  workspaceId: string;
+  source: WorkspaceSource;
+  highlighted: boolean;
+  open: boolean;
+  busySync: boolean;
+  busyDelete: boolean;
+  onOpen: () => void;
+  onSync: () => void;
+  onRemove: () => void;
+}) {
+  const [itemCount, setItemCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSourceStatus(workspaceId, source.source)
+      .then((s) => {
+        if (!cancelled) setItemCount(s.item_count);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, source.source]);
+
+  return (
+    <div
+      className={
+        "rounded-lg border bg-surface px-3 py-2.5 " +
+        (highlighted ? "border-brand/50 ring-1 ring-brand/30" : "border-border")
+      }
+    >
+      <div className="flex items-center gap-3">
+        <button type="button" onClick={onOpen} className="min-w-0 flex-1 text-left">
+          <div className="truncate text-[13.5px] font-medium text-foreground">{source.display_name}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11.5px] text-muted">
+            <SyncPill syncStatus={source.sync_status} />
+            <span>{relativeTime(source.last_synced_at)}</span>
+            {itemCount !== null && <span>· {itemCount} items</span>}
+            <span>· {INDEX_DESCRIPTOR[source.type] ?? source.type}</span>
+          </div>
+          {source.sync_error && (
+            <div className="mt-1 truncate text-[11px] text-error">{source.sync_error}</div>
+          )}
+        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={onOpen}
+            className="rounded-md border border-border px-2 py-1 text-[11.5px] text-muted hover:text-foreground"
+          >
+            {open ? "Close" : "Browse"}
+          </button>
+          <button
+            type="button"
+            disabled={busySync}
+            onClick={onSync}
+            className="rounded-md border border-border px-2 py-1 text-[11.5px] text-muted hover:text-foreground disabled:opacity-60"
+          >
+            {busySync ? "Syncing..." : "Sync"}
+          </button>
+          <button
+            type="button"
+            disabled={busyDelete}
+            onClick={onRemove}
+            className="rounded-md border border-border px-2 py-1 text-[11.5px] text-muted hover:text-error disabled:opacity-60"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BrowsePanel({
+  workspaceId,
+  source,
+  onRefresh,
+}: {
+  workspaceId: string;
+  source: WorkspaceSource;
+  onRefresh: () => void;
+}) {
+  if (source.capability === "queryable") {
+    return <QueryablePanel workspaceId={workspaceId} source={source} />;
+  }
+  if (source.capability === "searchable") {
+    return <SearchablePanel workspaceId={workspaceId} source={source} onRefresh={onRefresh} />;
+  }
+  return <NavigablePanel workspaceId={workspaceId} source={source} onRefresh={onRefresh} />;
+}
+
+// Shows the full content of one document/entry inside a browse panel.
+function DocViewer({
+  workspaceId,
+  source,
+  refValue,
+  name,
+  onClose,
+}: {
+  workspaceId: string;
+  source: string;
+  refValue: string;
+  name?: string;
+  onClose: () => void;
+}) {
+  const [content, setContent] = useState<string | null>(null);
+  const [title, setTitle] = useState(name ?? "");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    setError("");
+    readSourceDoc(workspaceId, source, refValue)
+      .then((doc) => {
+        if (cancelled) return;
+        setContent(doc.content ?? "");
+        if (doc.name) setTitle(doc.name);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not read document");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, source, refValue]);
+
+  return (
+    <div className="mt-3 rounded-lg border border-border bg-base p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="min-w-0 truncate text-[12.5px] font-medium text-foreground">{title || refValue}</div>
+        <button type="button" onClick={onClose} className="shrink-0 text-[12px] text-muted hover:text-foreground">
+          Close
+        </button>
+      </div>
+      {error ? (
+        <div className="text-[12px] text-error">{error}</div>
+      ) : content === null ? (
+        <div className="text-[12px] text-muted">Loading…</div>
+      ) : (
+        <pre className="scroll-thin max-h-96 overflow-auto whitespace-pre-wrap break-words text-[12px] text-foreground">
+          {content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function QueryablePanel({ workspaceId, source }: { workspaceId: string; source: WorkspaceSource }) {
+  const [tables, setTables] = useState<SourceEntry[] | null>(null);
+  const [sql, setSql] = useState("");
+  const [result, setResult] = useState<{ columns?: string[]; rows?: unknown[][]; error?: string } | null>(null);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSourceEntries(workspaceId, source.source)
+      .then((entries) => {
+        if (!cancelled) setTables(entries);
+      })
+      .catch(() => {
+        if (!cancelled) setTables([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, source.source]);
+
+  async function run() {
+    if (!sql.trim()) return;
+    setRunning(true);
+    try {
+      setResult(await querySource(workspaceId, source.source, sql));
+    } catch (e) {
+      setResult({ error: e instanceof Error ? e.message : "Query failed" });
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3">
+      <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">Tables</div>
+      {tables === null ? (
+        <div className="text-[12px] text-muted">Loading…</div>
+      ) : tables.length === 0 ? (
+        <div className="text-[12px] text-muted">No tables found.</div>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {tables.map((t) => (
+            <button
+              key={t.name}
+              type="button"
+              onClick={() => setSql(`SELECT * FROM ${t.name} LIMIT 100`)}
+              className="rounded-md border border-border bg-base px-2 py-1 text-[11.5px] text-foreground hover:bg-raised"
+            >
+              {t.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <textarea
+        value={sql}
+        onChange={(e) => setSql(e.target.value)}
+        placeholder="SELECT * FROM ... LIMIT 100"
+        rows={4}
+        className="mt-3 w-full rounded-md border border-border bg-base px-2 py-1.5 font-mono text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+      />
+      <button type="button" onClick={() => void run()} disabled={running || !sql.trim()} className={primaryButton() + " mt-2"}>
+        {running ? "Running..." : "Run"}
+      </button>
+
+      {result?.error && (
+        <div className="mt-3 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
+          {result.error}
+        </div>
+      )}
+      {result && !result.error && result.columns && (
+        <div className="scroll-thin mt-3 overflow-auto rounded-md border border-border">
+          <table className="w-full text-left text-[12px]">
+            <thead className="bg-base/70">
+              <tr>
+                {result.columns.map((col) => (
+                  <th key={col} className="whitespace-nowrap px-2 py-1.5 font-medium text-muted">
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(result.rows ?? []).map((row, i) => (
+                <tr key={i} className="border-t border-border">
+                  {row.map((cell, j) => (
+                    <td key={j} className="whitespace-nowrap px-2 py-1.5 text-foreground">
+                      {cell === null ? "" : String(cell)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SearchablePanel({
+  workspaceId,
+  source,
+  onRefresh,
+}: {
+  workspaceId: string;
+  source: WorkspaceSource;
+  onRefresh: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SourceSearchHit[] | null>(null);
+  const [recent, setRecent] = useState<SourceEntry[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
+
+  const showHistory = source.type === "slack" || source.type === "gong_calls";
+
+  useEffect(() => {
+    let cancelled = false;
+    getSourceEntries(workspaceId, source.source)
+      .then((entries) => {
+        if (!cancelled) setRecent(entries);
+      })
+      .catch(() => {
+        if (!cancelled) setRecent([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, source.source]);
+
+  async function search() {
+    if (!query.trim()) return;
+    setSearching(true);
+    try {
+      setHits(await searchSource(workspaceId, query, source.source));
+    } catch {
+      setHits([]);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void search();
+        }}
+        className="flex gap-2"
+      >
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Search ${source.display_name}...`}
+          className="flex-1 rounded-md border border-border bg-base px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+        />
+        <button type="submit" disabled={searching || !query.trim()} className={primaryButton()}>
+          {searching ? "Searching..." : "Search"}
+        </button>
+      </form>
+
+      {hits !== null && (
+        <div className="mt-3">
+          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted">Results</div>
+          {hits.length === 0 ? (
+            <div className="text-[12px] text-muted">No matches.</div>
+          ) : (
+            <div className="space-y-1">
+              {hits.map((hit) => (
+                <button
+                  key={hit.ref}
+                  type="button"
+                  onClick={() => setOpenDoc({ ref: hit.ref, name: hit.name })}
+                  className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-raised"
+                >
+                  <div className="truncate text-[12.5px] font-medium text-foreground">{hit.name || hit.ref}</div>
+                  {hit.snippet && <div className="truncate text-[11.5px] text-muted">{hit.snippet}</div>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {recent && recent.length > 0 && (
+        <div className="mt-3">
+          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted">Recent</div>
+          <div className="space-y-1">
+            {recent.map((entry) => {
+              const ref = entry.id ?? entry.path ?? entry.name;
+              return (
+                <button
+                  key={ref}
+                  type="button"
+                  onClick={() => setOpenDoc({ ref, name: entry.name })}
+                  className="block w-full truncate rounded-md px-2 py-1.5 text-left text-[12.5px] text-foreground hover:bg-raised"
+                >
+                  {entry.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {openDoc && (
+        <DocViewer
+          workspaceId={workspaceId}
+          source={source.source}
+          refValue={openDoc.ref}
+          name={openDoc.name}
+          onClose={() => setOpenDoc(null)}
+        />
+      )}
+
+      {showHistory && (
+        <HistoryControl workspaceId={workspaceId} source={source} onFetched={onRefresh} />
+      )}
+    </div>
+  );
+}
+
+function NavigablePanel({
+  workspaceId,
+  source,
+  onRefresh,
+}: {
+  workspaceId: string;
+  source: WorkspaceSource;
+  onRefresh: () => void;
+}) {
+  const [path, setPath] = useState("");
+  const [entries, setEntries] = useState<SourceEntry[] | null>(null);
+  const [crumbs, setCrumbs] = useState<{ label: string; path: string }[]>([{ label: source.display_name, path: "" }]);
+  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setEntries(null);
+    setError("");
+    getSourceEntries(workspaceId, source.source, path)
+      .then((next) => {
+        if (!cancelled) setEntries(next);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setEntries([]);
+          setError(e instanceof Error ? e.message : "Could not list entries");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, source.source, path]);
+
+  // Folder-like entries (have a `path` and are a container) drill in; leaves open a doc.
+  function isFolder(entry: SourceEntry): boolean {
+    return entry.kind === "dir" || entry.kind === "folder" || entry.kind === "prefix" || entry.kind === "tree";
+  }
+
+  function openEntry(entry: SourceEntry) {
+    if (isFolder(entry) && entry.path !== undefined) {
+      setPath(entry.path);
+      setCrumbs((c) => [...c, { label: entry.name, path: entry.path ?? "" }]);
+      setOpenDoc(null);
+      return;
+    }
+    const ref = entry.id ?? entry.path ?? entry.name;
+    setOpenDoc({ ref, name: entry.name });
+  }
+
+  function goCrumb(index: number) {
+    const target = crumbs[index];
+    setPath(target.path);
+    setCrumbs(crumbs.slice(0, index + 1));
+    setOpenDoc(null);
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3">
+      <div className="mb-2 flex flex-wrap items-center gap-1 text-[12px] text-muted">
+        {crumbs.map((c, i) => (
+          <span key={c.path + i} className="flex items-center gap-1">
+            {i > 0 && <span className="text-muted/60">/</span>}
+            <button
+              type="button"
+              onClick={() => goCrumb(i)}
+              className={i === crumbs.length - 1 ? "text-foreground" : "hover:text-foreground hover:underline"}
+            >
+              {c.label}
+            </button>
+          </span>
+        ))}
+      </div>
+
+      {error && <div className="mb-2 text-[12px] text-error">{error}</div>}
+
+      {entries === null ? (
+        <div className="text-[12px] text-muted">Loading…</div>
+      ) : entries.length === 0 ? (
+        <div className="text-[12px] text-muted">Empty.</div>
+      ) : (
+        <div className="space-y-0.5">
+          {entries.map((entry) => {
+            const key = entry.id ?? entry.path ?? entry.name;
+            const folder = isFolder(entry);
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => openEntry(entry)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised"
+              >
+                <span aria-hidden className="text-[13px]">
+                  {folder ? "📁" : "📄"}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[12.5px] text-foreground">{entry.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {openDoc && (
+        <DocViewer
+          workspaceId={workspaceId}
+          source={source.source}
+          refValue={openDoc.ref}
+          name={openDoc.name}
+          onClose={() => setOpenDoc(null)}
+        />
+      )}
+
+      {source.type === "slack" || source.type === "gong_calls" ? (
+        <HistoryControl workspaceId={workspaceId} source={source} onFetched={onRefresh} />
+      ) : null}
+    </div>
+  );
+}
+
+function HistoryControl({
+  workspaceId,
+  source,
+  onFetched,
+}: {
+  workspaceId: string;
+  source: WorkspaceSource;
+  onFetched: () => void;
+}) {
+  const [since, setSince] = useState("");
+  const [until, setUntil] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+
+  async function run() {
+    if (!since) return;
+    setBusy(true);
+    setMessage("");
+    try {
+      const result = await fetchSourceHistory(workspaceId, source.source, since, until || undefined);
+      setMessage(`Fetched ${result.fetched}`);
+      onFetched();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "Could not fetch history");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded-md border border-border bg-base p-2.5">
+      <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">Fetch older history</div>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-[11.5px] text-muted">
+          Since
+          <input
+            type="date"
+            value={since}
+            onChange={(e) => setSince(e.target.value)}
+            className="ml-1 rounded-md border border-border bg-surface px-2 py-1 text-[12px] text-foreground focus:border-brand focus:outline-none"
+          />
+        </label>
+        <label className="text-[11.5px] text-muted">
+          Until
+          <input
+            type="date"
+            value={until}
+            onChange={(e) => setUntil(e.target.value)}
+            className="ml-1 rounded-md border border-border bg-surface px-2 py-1 text-[12px] text-foreground focus:border-brand focus:outline-none"
+          />
+        </label>
+        <button type="button" onClick={() => void run()} disabled={busy || !since} className={secondaryButton()}>
+          {busy ? "Fetching..." : "Fetch"}
+        </button>
+        {message && <span className="text-[11.5px] text-muted">{message}</span>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -23,6 +23,7 @@ import {
 } from "../lib/api";
 import type { User, Workspace } from "../lib/types";
 import AddSourceModal from "./integrations/AddSourceModal";
+import { providerForSourceType } from "./integrations/connectors";
 import {
   ActivityIcon,
   FileIcon,
@@ -235,13 +236,16 @@ export default function AppSidebar({
         active: filesActive,
       },
     ];
-    const connected = (sourceMap[ws] ?? []).map((s) => ({
-      key: s.source,
-      href: "/settings/integrations",
-      label: s.display_name,
-      icon: <SourceDot color={SOURCE_DOT[s.type] ?? "rgba(0,0,0,0.4)"} />,
-      active: false,
-    }));
+    const connected = (sourceMap[ws] ?? []).map((s) => {
+      const provider = providerForSourceType[s.type] ?? s.type;
+      return {
+        key: s.source,
+        href: `/workspaces/${ws}/integrations/${provider}?source=${s.source}`,
+        label: s.display_name,
+        icon: <SourceDot color={SOURCE_DOT[s.type] ?? "rgba(0,0,0,0.4)"} />,
+        active: pathname.startsWith(`/workspaces/${ws}/integrations/${provider}`),
+      };
+    });
     return [...native, ...connected];
   }, [activeWorkspaceKey, sourceMap, pathname]);
 

--- a/frontend/src/components/integrations/AddSourceModal.tsx
+++ b/frontend/src/components/integrations/AddSourceModal.tsx
@@ -32,9 +32,9 @@ export default function AddSourceModal({
       >
         <div className="mb-4 flex items-start justify-between">
           <div>
-            <h2 className="font-display text-[18px] font-bold text-foreground">Add a source</h2>
+            <h2 className="font-display text-[18px] font-bold text-foreground">Connect a source</h2>
             <p className="mt-0.5 text-[12.5px] text-muted">
-              Connect a source and your agent can read across it.
+              Connect an account; add specific projects from its page.
             </p>
           </div>
           <button

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -1,57 +1,20 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { ReactNode } from "react";
 
 import {
-  addWorkspaceSource,
-  deleteWorkspaceSource,
-  listWorkspaceSources,
-  syncWorkspaceSource,
-  type WorkspaceSource,
-} from "@/lib/api";
-import {
-  listAsanaProjects,
-  listGitHubRepos,
   listIntegrations,
-  disconnectIntegration,
-  listJiraProjects,
-  listNotionPages,
   startConnect,
   submitCredentials,
-  type AsanaProjectSummary,
-  type CredentialField,
-  type GitHubRepoSummary,
   type IntegrationProvider,
   type IntegrationStatus,
-  type JiraProjectSummary,
-  type NotionPageSummary,
 } from "@/lib/integrations";
 
-import {
-  AsanaIcon,
-  GitHubIcon,
-  GongIcon,
-  GoogleDriveIcon,
-  GranolaIcon,
-  JiraIcon,
-  NotionIcon,
-  ObsidianIcon,
-  SlackIcon,
-  SnowflakeIcon,
-} from "./BrandIcons";
+import { ObsidianIcon } from "./BrandIcons";
+import { CONNECTORS, connectorIcon, type Connector } from "./connectors";
+import { CredentialForm, primaryButton, secondaryButton } from "./pickers";
 import ObsidianVaultDropZone from "./ObsidianVaultDropZone";
-
-type ConnectorKind = "github" | "drive" | "notion" | "jira" | "asana" | "auto";
-
-type Connector = {
-  provider: IntegrationProvider;
-  label: string;
-  sourceType: string;
-  icon: ReactNode;
-  kind: ConnectorKind;
-  blurb: string;
-};
 
 type Props = {
   workspaceId: string | null;
@@ -61,90 +24,15 @@ type Props = {
   onObsidianUploaded?: () => void;
 };
 
-const CONNECTORS: Connector[] = [
-  {
-    provider: "github",
-    label: "GitHub",
-    sourceType: "github_repo",
-    icon: <GitHubIcon />,
-    kind: "github",
-    blurb: "Pick repos your agent can navigate.",
-  },
-  {
-    provider: "google",
-    label: "Google Drive",
-    sourceType: "google_drive",
-    icon: <GoogleDriveIcon />,
-    kind: "drive",
-    blurb: "Index My Drive and read docs on demand.",
-  },
-  {
-    provider: "notion",
-    label: "Notion",
-    sourceType: "notion",
-    icon: <NotionIcon />,
-    kind: "notion",
-    blurb: "Pick pages or databases shared with Stash.",
-  },
-  {
-    provider: "jira",
-    label: "Jira",
-    sourceType: "jira_project",
-    icon: <JiraIcon />,
-    kind: "jira",
-    blurb: "Search issues from a project.",
-  },
-  {
-    provider: "asana",
-    label: "Asana",
-    sourceType: "asana_project",
-    icon: <AsanaIcon />,
-    kind: "asana",
-    blurb: "Navigate tasks from a project.",
-  },
-  {
-    provider: "slack",
-    label: "Slack",
-    sourceType: "slack",
-    icon: <SlackIcon />,
-    kind: "auto",
-    blurb: "Channel history, kept in sync.",
-  },
-  {
-    provider: "granola",
-    label: "Granola",
-    sourceType: "granola",
-    icon: <GranolaIcon />,
-    kind: "auto",
-    blurb: "Meeting notes and transcripts.",
-  },
-  {
-    provider: "gong",
-    label: "Gong",
-    sourceType: "gong_calls",
-    icon: <GongIcon />,
-    kind: "auto",
-    blurb: "Call transcripts, kept in sync.",
-  },
-  {
-    provider: "snowflake",
-    label: "Snowflake",
-    sourceType: "snowflake",
-    icon: <SnowflakeIcon />,
-    kind: "auto",
-    blurb: "Run read-only SQL against your warehouse.",
-  },
-];
-
+// Connect-only surface. Connecting an account is done here; adding specific
+// projects/repos/pages happens on each integration's dedicated page.
 export default function SourceConnectorList({
   workspaceId,
   returnTo,
   includeObsidian = true,
-  onSourceCountChange,
   onObsidianUploaded,
 }: Props) {
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus>>({});
-  const [sources, setSources] = useState<WorkspaceSource[]>([]);
   const [expanded, setExpanded] = useState<IntegrationProvider | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -157,13 +45,7 @@ export default function SourceConnectorList({
       nextStatuses[provider.provider] = provider;
     }
     setStatuses(nextStatuses);
-
-    if (!workspaceId) {
-      setSources([]);
-      return;
-    }
-    setSources(await listWorkspaceSources(workspaceId));
-  }, [workspaceId]);
+  }, []);
 
   useEffect(() => {
     refresh().catch((e) => {
@@ -171,36 +53,12 @@ export default function SourceConnectorList({
     });
   }, [refresh]);
 
-  useEffect(() => {
-    onSourceCountChange?.(sources.length);
-  }, [onSourceCountChange, sources.length]);
-
   const disabledReasons = useMemo(() => {
     const reasons = Object.values(statuses)
       .map((status) => status.disabled_reason)
       .filter((reason): reason is string => Boolean(reason));
     return Array.from(new Set(reasons));
   }, [statuses]);
-
-  async function addSource(connector: Connector, body?: { external_ref?: string; display_name?: string }) {
-    if (!workspaceId) return false;
-    setBusy(connector.provider);
-    setError(null);
-    try {
-      await addWorkspaceSource(workspaceId, {
-        source_type: connector.sourceType,
-        ...body,
-      });
-      setExpanded(null);
-      await refresh();
-      return true;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not add source");
-      return false;
-    } finally {
-      setBusy(null);
-    }
-  }
 
   async function connect(connector: Connector) {
     setBusy(connector.provider);
@@ -229,50 +87,6 @@ export default function SourceConnectorList({
     }
   }
 
-  async function disconnect(connector: Connector) {
-    if (!confirm(`Disconnect ${connector.label}? You'll need to reconnect to sync its sources again.`)) {
-      return;
-    }
-    setBusy(connector.provider);
-    setError(null);
-    try {
-      await disconnectIntegration(connector.provider);
-      await refresh();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not disconnect");
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function syncSource(source: WorkspaceSource) {
-    if (!workspaceId) return;
-    setBusy(`sync:${source.source}`);
-    setError(null);
-    try {
-      await syncWorkspaceSource(workspaceId, source.source);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not start sync");
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function removeSource(source: WorkspaceSource) {
-    if (!workspaceId) return;
-    if (!confirm(`Remove ${source.display_name}?`)) return;
-    setBusy(`delete:${source.source}`);
-    setError(null);
-    try {
-      await deleteWorkspaceSource(workspaceId, source.source);
-      await refresh();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not remove source");
-    } finally {
-      setBusy(null);
-    }
-  }
-
   return (
     <div className="space-y-2">
       {disabledReasons.length > 0 && (
@@ -287,22 +101,14 @@ export default function SourceConnectorList({
         const status = statuses[connector.provider];
         const connected = !!status?.connected;
         const enabled = status?.enabled ?? true;
-        const count = sources.filter((source) => source.type === connector.sourceType).length;
         return (
           <div key={connector.provider} className="rounded-lg border border-border bg-surface px-3 py-2.5">
             <div className="flex items-center gap-3">
               <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-                {connector.icon}
+                {connectorIcon(connector.provider)}
               </span>
               <div className="min-w-0 flex-1">
-                <div className="text-[13.5px] font-medium text-foreground">
-                  {connector.label}
-                  {count > 0 && (
-                    <span className="ml-1.5 text-[11px] font-normal text-muted">
-                      · {count} added
-                    </span>
-                  )}
-                </div>
+                <div className="text-[13.5px] font-medium text-foreground">{connector.label}</div>
                 <div className="truncate text-[11.5px] text-muted">
                   {connected && (status?.account_email || status?.account_display_name)
                     ? `Connected as ${status.account_email || status.account_display_name}`
@@ -317,65 +123,16 @@ export default function SourceConnectorList({
                   authKind={status?.auth_kind ?? "oauth"}
                   disabledReason={status?.disabled_reason ?? null}
                   busy={busy === connector.provider}
-                  workspaceReady={!!workspaceId}
+                  workspaceId={workspaceId}
                   expanded={expanded === connector.provider}
                   onConnect={() => void connect(connector)}
-                  onExpand={() => setExpanded((value) => value === connector.provider ? null : connector.provider)}
-                  onAdd={() => void addSource(connector, connector.kind === "drive" ? {
-                    external_ref: "root",
-                    display_name: "Google Drive",
-                  } : undefined)}
+                  onExpand={() =>
+                    setExpanded((value) => (value === connector.provider ? null : connector.provider))
+                  }
                 />
-                {connected && (
-                  <button
-                    type="button"
-                    onClick={() => void disconnect(connector)}
-                    disabled={busy === connector.provider}
-                    title="Disconnect"
-                    className="shrink-0 rounded-md border border-border px-2 py-1.5 text-[12px] font-medium text-muted hover:text-error hover:border-error/40 disabled:opacity-60"
-                  >
-                    Disconnect
-                  </button>
-                )}
               </div>
             </div>
 
-            {expanded === connector.provider && connector.kind === "github" && workspaceId && (
-              <GitHubRepoPicker
-                busy={busy}
-                onAdd={(repo) => addSource(connector, {
-                  external_ref: repo.full_name,
-                  display_name: repo.full_name,
-                })}
-              />
-            )}
-            {expanded === connector.provider && connector.kind === "notion" && workspaceId && (
-              <NotionPagePicker
-                busy={busy}
-                onAdd={(page) => addSource(connector, {
-                  external_ref: page.id,
-                  display_name: page.title || page.id,
-                })}
-              />
-            )}
-            {expanded === connector.provider && connector.kind === "jira" && workspaceId && (
-              <JiraProjectPicker
-                busy={busy}
-                onAdd={(project) => addSource(connector, {
-                  external_ref: project.external_ref,
-                  display_name: `${project.name} (${project.key})`,
-                })}
-              />
-            )}
-            {expanded === connector.provider && connector.kind === "asana" && workspaceId && (
-              <AsanaProjectPicker
-                busy={busy}
-                onAdd={(project) => addSource(connector, {
-                  external_ref: project.gid,
-                  display_name: project.name,
-                })}
-              />
-            )}
             {expanded === connector.provider &&
               !connected &&
               status?.auth_kind === "api_key" &&
@@ -389,38 +146,6 @@ export default function SourceConnectorList({
           </div>
         );
       })}
-
-      {sources.length > 0 && (
-        <div className="rounded-lg border border-border bg-surface px-3 py-2.5">
-          <div className="mb-2 text-[12px] font-medium text-foreground">Connected sources</div>
-          <div className="space-y-1">
-            {sources.map((source) => (
-              <div key={source.source} className="flex items-center gap-2 rounded-md bg-base px-2 py-1.5">
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-[12.5px] text-foreground">{source.display_name}</div>
-                  <div className="text-[11px] text-muted">{labelForSourceType(source.type)}</div>
-                </div>
-                <button
-                  type="button"
-                  disabled={busy === `sync:${source.source}`}
-                  onClick={() => void syncSource(source)}
-                  className="rounded-md border border-border px-2 py-1 text-[11.5px] text-muted hover:text-foreground disabled:opacity-60"
-                >
-                  {busy === `sync:${source.source}` ? "Syncing..." : "Sync"}
-                </button>
-                <button
-                  type="button"
-                  disabled={busy === `delete:${source.source}`}
-                  onClick={() => void removeSource(source)}
-                  className="rounded-md border border-border px-2 py-1 text-[11.5px] text-muted hover:text-error disabled:opacity-60"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
 
       {includeObsidian && workspaceId && (
         <ObsidianSourceCard workspaceId={workspaceId} onUploaded={onObsidianUploaded} />
@@ -442,11 +167,10 @@ function ConnectorAction({
   authKind,
   disabledReason,
   busy,
-  workspaceReady,
+  workspaceId,
   expanded,
   onConnect,
   onExpand,
-  onAdd,
 }: {
   connector: Connector;
   connected: boolean;
@@ -454,11 +178,10 @@ function ConnectorAction({
   authKind: IntegrationStatus["auth_kind"];
   disabledReason: string | null;
   busy: boolean;
-  workspaceReady: boolean;
+  workspaceId: string | null;
   expanded: boolean;
   onConnect: () => void;
   onExpand: () => void;
-  onAdd: () => void;
 }) {
   if (!enabled) {
     return (
@@ -483,372 +206,14 @@ function ConnectorAction({
       </button>
     );
   }
-  if (connector.kind === "github") {
+  if (workspaceId) {
     return (
-      <button type="button" onClick={onExpand} disabled={!workspaceReady} className={secondaryButton()}>
-        {expanded ? "Hide repos" : "Add repo"}
-      </button>
+      <Link href={`/workspaces/${workspaceId}/integrations/${connector.provider}`} className={secondaryButton()}>
+        Open
+      </Link>
     );
   }
-  if (connector.kind === "notion") {
-    return (
-      <button type="button" onClick={onExpand} disabled={!workspaceReady} className={secondaryButton()}>
-        {expanded ? "Hide pages" : "Add page"}
-      </button>
-    );
-  }
-  if (connector.kind === "jira" || connector.kind === "asana") {
-    return (
-      <button type="button" onClick={onExpand} disabled={!workspaceReady} className={secondaryButton()}>
-        {expanded ? "Hide projects" : "Add project"}
-      </button>
-    );
-  }
-  if (connector.kind === "drive") {
-    return (
-      <button type="button" onClick={onAdd} disabled={!workspaceReady || busy} className={secondaryButton()}>
-        {busy ? "Adding..." : "Add My Drive"}
-      </button>
-    );
-  }
-  return (
-    <button type="button" onClick={onAdd} disabled={!workspaceReady || busy} className={secondaryButton()}>
-      {busy ? "Adding..." : "Add"}
-    </button>
-  );
-}
-
-function GitHubRepoPicker({
-  busy,
-  onAdd,
-}: {
-  busy: string | null;
-  onAdd: (repo: GitHubRepoSummary) => Promise<boolean>;
-}) {
-  const [repos, setRepos] = useState<GitHubRepoSummary[] | null>(null);
-  const [query, setQuery] = useState("");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-    listGitHubRepos()
-      .then((next) => {
-        if (!cancelled) setRepos(next);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load repos");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return repos ?? [];
-    return (repos ?? []).filter((repo) =>
-      repo.full_name.toLowerCase().includes(q) ||
-      (repo.description ?? "").toLowerCase().includes(q)
-    );
-  }, [query, repos]);
-
-  return (
-    <PickerShell
-      error={error}
-      loading={repos === null && !error}
-      query={query}
-      placeholder="Search repositories..."
-      onQuery={setQuery}
-      empty="No repositories found."
-    >
-      {filtered.map((repo) => (
-        <button
-          key={repo.full_name}
-          type="button"
-          disabled={busy === "github"}
-          onClick={() => void onAdd(repo)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
-        >
-          <GitHubIcon className="mt-0.5 text-muted" size={14} />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-[12.5px] font-medium text-foreground">
-              {repo.full_name}
-            </span>
-            {repo.description && (
-              <span className="block truncate text-[11.5px] text-muted">{repo.description}</span>
-            )}
-          </span>
-        </button>
-      ))}
-    </PickerShell>
-  );
-}
-
-function NotionPagePicker({
-  busy,
-  onAdd,
-}: {
-  busy: string | null;
-  onAdd: (page: NotionPageSummary) => Promise<boolean>;
-}) {
-  const [pages, setPages] = useState<NotionPageSummary[] | null>(null);
-  const [query, setQuery] = useState("");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-    listNotionPages()
-      .then((next) => {
-        if (!cancelled) setPages(next);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load pages");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return pages ?? [];
-    return (pages ?? []).filter((page) => page.title.toLowerCase().includes(q));
-  }, [query, pages]);
-
-  return (
-    <PickerShell
-      error={error}
-      loading={pages === null && !error}
-      query={query}
-      placeholder="Search Notion pages..."
-      onQuery={setQuery}
-      empty="No shared Notion pages found."
-    >
-      {filtered.map((page) => (
-        <button
-          key={page.id}
-          type="button"
-          disabled={busy === "notion"}
-          onClick={() => void onAdd(page)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
-        >
-          <NotionIcon className="mt-0.5 text-muted" size={14} />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-[12.5px] font-medium text-foreground">
-              {page.title || "Untitled"}
-            </span>
-            <span className="block truncate text-[11.5px] text-muted">{page.url}</span>
-          </span>
-        </button>
-      ))}
-    </PickerShell>
-  );
-}
-
-function JiraProjectPicker({
-  busy,
-  onAdd,
-}: {
-  busy: string | null;
-  onAdd: (project: JiraProjectSummary) => Promise<boolean>;
-}) {
-  const [projects, setProjects] = useState<JiraProjectSummary[] | null>(null);
-  const [query, setQuery] = useState("");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-    listJiraProjects()
-      .then((next) => {
-        if (!cancelled) setProjects(next);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load projects");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return projects ?? [];
-    return (projects ?? []).filter(
-      (p) => p.name.toLowerCase().includes(q) || p.key.toLowerCase().includes(q),
-    );
-  }, [query, projects]);
-
-  return (
-    <PickerShell
-      error={error}
-      loading={projects === null && !error}
-      query={query}
-      placeholder="Search projects..."
-      onQuery={setQuery}
-      empty="No Jira projects found."
-    >
-      {filtered.map((project) => (
-        <button
-          key={project.external_ref}
-          type="button"
-          disabled={busy === "jira"}
-          onClick={() => void onAdd(project)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
-        >
-          <JiraIcon className="mt-0.5" size={14} />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-[12.5px] font-medium text-foreground">
-              {project.name} <span className="text-muted">({project.key})</span>
-            </span>
-            <span className="block truncate text-[11.5px] text-muted">{project.site_name}</span>
-          </span>
-        </button>
-      ))}
-    </PickerShell>
-  );
-}
-
-function AsanaProjectPicker({
-  busy,
-  onAdd,
-}: {
-  busy: string | null;
-  onAdd: (project: AsanaProjectSummary) => Promise<boolean>;
-}) {
-  const [projects, setProjects] = useState<AsanaProjectSummary[] | null>(null);
-  const [query, setQuery] = useState("");
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-    listAsanaProjects()
-      .then((next) => {
-        if (!cancelled) setProjects(next);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load projects");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return projects ?? [];
-    return (projects ?? []).filter((p) => p.name.toLowerCase().includes(q));
-  }, [query, projects]);
-
-  return (
-    <PickerShell
-      error={error}
-      loading={projects === null && !error}
-      query={query}
-      placeholder="Search projects..."
-      onQuery={setQuery}
-      empty="No Asana projects found."
-    >
-      {filtered.map((project) => (
-        <button
-          key={project.gid}
-          type="button"
-          disabled={busy === "asana"}
-          onClick={() => void onAdd(project)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
-        >
-          <AsanaIcon className="mt-0.5" size={14} />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-[12.5px] font-medium text-foreground">
-              {project.name}
-            </span>
-            <span className="block truncate text-[11.5px] text-muted">
-              {project.workspace_name}
-            </span>
-          </span>
-        </button>
-      ))}
-    </PickerShell>
-  );
-}
-
-function CredentialForm({
-  fields,
-  busy,
-  onSubmit,
-}: {
-  fields: CredentialField[];
-  busy: boolean;
-  onSubmit: (values: Record<string, string>) => Promise<boolean>;
-}) {
-  const [values, setValues] = useState<Record<string, string>>({});
-  const complete = fields.every((f) => (values[f.name] ?? "").trim().length > 0);
-
-  return (
-    <form
-      className="mt-2.5 space-y-2 rounded-md border border-border bg-base p-2"
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (complete) void onSubmit(values);
-      }}
-    >
-      {fields.map((field) => (
-        <label key={field.name} className="block">
-          <span className="mb-1 block text-[11.5px] text-muted">{field.label}</span>
-          <input
-            type={field.secret ? "password" : "text"}
-            value={values[field.name] ?? ""}
-            placeholder={field.placeholder}
-            autoComplete="off"
-            onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
-            className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
-          />
-        </label>
-      ))}
-      <button type="submit" disabled={!complete || busy} className={primaryButton()}>
-        {busy ? "Connecting..." : "Connect"}
-      </button>
-    </form>
-  );
-}
-
-function PickerShell({
-  error,
-  loading,
-  query,
-  placeholder,
-  empty,
-  onQuery,
-  children,
-}: {
-  error: string;
-  loading: boolean;
-  query: string;
-  placeholder: string;
-  empty: string;
-  onQuery: (value: string) => void;
-  children: ReactNode;
-}) {
-  const hasChildren = Array.isArray(children) ? children.length > 0 : !!children;
-  return (
-    <div className="mt-2.5 rounded-md border border-border bg-base p-2">
-      <input
-        type="search"
-        value={query}
-        onChange={(e) => onQuery(e.target.value)}
-        placeholder={placeholder}
-        className="mb-2 w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
-      />
-      {error ? (
-        <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
-      ) : loading ? (
-        <div className="px-2 py-3 text-[12px] text-muted">Loading...</div>
-      ) : hasChildren ? (
-        <div className="max-h-48 overflow-y-auto">{children}</div>
-      ) : (
-        <div className="px-2 py-3 text-[12px] text-muted">{empty}</div>
-      )}
-    </div>
-  );
+  return <span className="text-[12px] font-medium text-muted">Connected</span>;
 }
 
 function ObsidianSourceCard({
@@ -880,25 +245,4 @@ function ObsidianSourceCard({
       )}
     </div>
   );
-}
-
-function labelForSourceType(type: string): string {
-  if (type === "github_repo") return "GitHub";
-  if (type === "google_drive") return "Google Drive";
-  if (type === "notion") return "Notion";
-  if (type === "slack") return "Slack";
-  if (type === "granola") return "Granola";
-  if (type === "jira_project") return "Jira";
-  if (type === "asana_project") return "Asana";
-  if (type === "gong_calls") return "Gong";
-  if (type === "snowflake") return "Snowflake";
-  return type;
-}
-
-function primaryButton(): string {
-  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
-}
-
-function secondaryButton(): string {
-  return "shrink-0 rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60";
 }

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode } from "react";
+
+import type { IntegrationProvider } from "@/lib/integrations";
+
+import {
+  AsanaIcon,
+  GitHubIcon,
+  GongIcon,
+  GoogleDriveIcon,
+  GranolaIcon,
+  JiraIcon,
+  NotionIcon,
+  SlackIcon,
+  SnowflakeIcon,
+} from "./BrandIcons";
+
+export type ConnectorKind = "github" | "drive" | "notion" | "jira" | "asana" | "auto";
+
+export type Connector = {
+  provider: IntegrationProvider;
+  label: string;
+  sourceType: string;
+  kind: ConnectorKind;
+  blurb: string;
+};
+
+export const CONNECTORS: Connector[] = [
+  {
+    provider: "github",
+    label: "GitHub",
+    sourceType: "github_repo",
+    kind: "github",
+    blurb: "Pick repos your agent can navigate.",
+  },
+  {
+    provider: "google",
+    label: "Google Drive",
+    sourceType: "google_drive",
+    kind: "drive",
+    blurb: "Index My Drive and read docs on demand.",
+  },
+  {
+    provider: "notion",
+    label: "Notion",
+    sourceType: "notion",
+    kind: "notion",
+    blurb: "Pick pages or databases shared with Stash.",
+  },
+  {
+    provider: "jira",
+    label: "Jira",
+    sourceType: "jira_project",
+    kind: "jira",
+    blurb: "Search issues from a project.",
+  },
+  {
+    provider: "asana",
+    label: "Asana",
+    sourceType: "asana_project",
+    kind: "asana",
+    blurb: "Navigate tasks from a project.",
+  },
+  {
+    provider: "slack",
+    label: "Slack",
+    sourceType: "slack",
+    kind: "auto",
+    blurb: "Channel history, kept in sync.",
+  },
+  {
+    provider: "granola",
+    label: "Granola",
+    sourceType: "granola",
+    kind: "auto",
+    blurb: "Meeting notes and transcripts.",
+  },
+  {
+    provider: "gong",
+    label: "Gong",
+    sourceType: "gong_calls",
+    kind: "auto",
+    blurb: "Call transcripts, kept in sync.",
+  },
+  {
+    provider: "snowflake",
+    label: "Snowflake",
+    sourceType: "snowflake",
+    kind: "auto",
+    blurb: "Run read-only SQL against your warehouse.",
+  },
+];
+
+// Maps a connected-source row's `type` back to the integration provider that
+// owns it — used by the sidebar and the per-integration page routing.
+export const providerForSourceType: Record<string, string> = {
+  github_repo: "github",
+  google_drive: "google",
+  notion: "notion",
+  jira_project: "jira",
+  asana_project: "asana",
+  slack: "slack",
+  granola: "granola",
+  gong_calls: "gong",
+  snowflake: "snowflake",
+};
+
+export function connectorForProvider(provider: string): Connector | undefined {
+  return CONNECTORS.find((connector) => connector.provider === provider);
+}
+
+export function connectorIcon(provider: string): ReactNode {
+  switch (provider) {
+    case "github":
+      return <GitHubIcon />;
+    case "google":
+      return <GoogleDriveIcon />;
+    case "notion":
+      return <NotionIcon />;
+    case "jira":
+      return <JiraIcon />;
+    case "asana":
+      return <AsanaIcon />;
+    case "slack":
+      return <SlackIcon />;
+    case "granola":
+      return <GranolaIcon />;
+    case "gong":
+      return <GongIcon />;
+    case "snowflake":
+      return <SnowflakeIcon />;
+    default:
+      return null;
+  }
+}
+
+export function labelForSourceType(type: string): string {
+  if (type === "github_repo") return "GitHub";
+  if (type === "google_drive") return "Google Drive";
+  if (type === "notion") return "Notion";
+  if (type === "slack") return "Slack";
+  if (type === "granola") return "Granola";
+  if (type === "jira_project") return "Jira";
+  if (type === "asana_project") return "Asana";
+  if (type === "gong_calls") return "Gong";
+  if (type === "snowflake") return "Snowflake";
+  return type;
+}

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import { addWorkspaceSource } from "@/lib/api";
+import {
+  listAsanaProjects,
+  listGitHubRepos,
+  listJiraProjects,
+  listNotionPages,
+  type AsanaProjectSummary,
+  type CredentialField,
+  type GitHubRepoSummary,
+  type JiraProjectSummary,
+  type NotionPageSummary,
+} from "@/lib/integrations";
+
+import { AsanaIcon, GitHubIcon, JiraIcon, NotionIcon } from "./BrandIcons";
+import type { Connector } from "./connectors";
+
+export function primaryButton(): string {
+  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
+}
+
+export function secondaryButton(): string {
+  return "shrink-0 rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60";
+}
+
+// Renders the right "add a specific project/page/repo" UI for a connector and
+// calls addWorkspaceSource, then onAdded(). Connected-only — callers gate on it.
+export function AddSourceControls({
+  connector,
+  workspaceId,
+  connected,
+  onAdded,
+}: {
+  connector: Connector;
+  workspaceId: string;
+  connected: boolean;
+  onAdded: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function add(body?: { external_ref?: string; display_name?: string }) {
+    setBusy(true);
+    setError("");
+    try {
+      await addWorkspaceSource(workspaceId, {
+        source_type: connector.sourceType,
+        ...body,
+      });
+      onAdded();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add source");
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const errorRow = error ? (
+    <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
+  ) : null;
+
+  if (connector.kind === "github") {
+    return (
+      <div className="space-y-2">
+        <GitHubRepoPicker
+          busy={busy}
+          onAdd={(repo) => add({ external_ref: repo.full_name, display_name: repo.full_name })}
+        />
+        {errorRow}
+      </div>
+    );
+  }
+
+  if (connector.kind === "notion") {
+    return (
+      <div className="space-y-2">
+        <NotionPagePicker
+          busy={busy}
+          onAdd={(page) => add({ external_ref: page.id, display_name: page.title || page.id })}
+        />
+        {errorRow}
+      </div>
+    );
+  }
+
+  if (connector.kind === "jira") {
+    return (
+      <div className="space-y-2">
+        <JiraProjectPicker
+          busy={busy}
+          onAdd={(project) =>
+            add({ external_ref: project.external_ref, display_name: `${project.name} (${project.key})` })
+          }
+        />
+        {errorRow}
+      </div>
+    );
+  }
+
+  if (connector.kind === "asana") {
+    return (
+      <div className="space-y-2">
+        <AsanaProjectPicker
+          busy={busy}
+          onAdd={(project) => add({ external_ref: project.gid, display_name: project.name })}
+        />
+        {errorRow}
+      </div>
+    );
+  }
+
+  if (connector.kind === "drive") {
+    return (
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={() => void add({ external_ref: "root", display_name: "Google Drive" })}
+          disabled={busy}
+          className={secondaryButton()}
+        >
+          {busy ? "Adding..." : "Add My Drive"}
+        </button>
+        {errorRow}
+      </div>
+    );
+  }
+
+  // kind "auto" — slack/granola/gong/snowflake. The backend resolves the ref.
+  return (
+    <div className="space-y-2">
+      {!connected && (
+        <div className="text-[11.5px] text-muted">Connect {connector.label} first to add it.</div>
+      )}
+      <button type="button" onClick={() => void add()} disabled={busy || !connected} className={secondaryButton()}>
+        {busy ? "Adding..." : "Add"}
+      </button>
+      {errorRow}
+    </div>
+  );
+}
+
+export function GitHubRepoPicker({
+  busy,
+  onAdd,
+}: {
+  busy: boolean;
+  onAdd: (repo: GitHubRepoSummary) => Promise<boolean>;
+}) {
+  const [repos, setRepos] = useState<GitHubRepoSummary[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    listGitHubRepos()
+      .then((next) => {
+        if (!cancelled) setRepos(next);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load repos");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return repos ?? [];
+    return (repos ?? []).filter(
+      (repo) =>
+        repo.full_name.toLowerCase().includes(q) ||
+        (repo.description ?? "").toLowerCase().includes(q),
+    );
+  }, [query, repos]);
+
+  return (
+    <PickerShell
+      error={error}
+      loading={repos === null && !error}
+      query={query}
+      placeholder="Search repositories..."
+      onQuery={setQuery}
+      empty="No repositories found."
+    >
+      {filtered.map((repo) => (
+        <button
+          key={repo.full_name}
+          type="button"
+          disabled={busy}
+          onClick={() => void onAdd(repo)}
+          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+        >
+          <GitHubIcon className="mt-0.5 text-muted" size={14} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[12.5px] font-medium text-foreground">
+              {repo.full_name}
+            </span>
+            {repo.description && (
+              <span className="block truncate text-[11.5px] text-muted">{repo.description}</span>
+            )}
+          </span>
+        </button>
+      ))}
+    </PickerShell>
+  );
+}
+
+export function NotionPagePicker({
+  busy,
+  onAdd,
+}: {
+  busy: boolean;
+  onAdd: (page: NotionPageSummary) => Promise<boolean>;
+}) {
+  const [pages, setPages] = useState<NotionPageSummary[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    listNotionPages()
+      .then((next) => {
+        if (!cancelled) setPages(next);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load pages");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return pages ?? [];
+    return (pages ?? []).filter((page) => page.title.toLowerCase().includes(q));
+  }, [query, pages]);
+
+  return (
+    <PickerShell
+      error={error}
+      loading={pages === null && !error}
+      query={query}
+      placeholder="Search Notion pages..."
+      onQuery={setQuery}
+      empty="No shared Notion pages found."
+    >
+      {filtered.map((page) => (
+        <button
+          key={page.id}
+          type="button"
+          disabled={busy}
+          onClick={() => void onAdd(page)}
+          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+        >
+          <NotionIcon className="mt-0.5 text-muted" size={14} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[12.5px] font-medium text-foreground">
+              {page.title || "Untitled"}
+            </span>
+            <span className="block truncate text-[11.5px] text-muted">{page.url}</span>
+          </span>
+        </button>
+      ))}
+    </PickerShell>
+  );
+}
+
+export function JiraProjectPicker({
+  busy,
+  onAdd,
+}: {
+  busy: boolean;
+  onAdd: (project: JiraProjectSummary) => Promise<boolean>;
+}) {
+  const [projects, setProjects] = useState<JiraProjectSummary[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    listJiraProjects()
+      .then((next) => {
+        if (!cancelled) setProjects(next);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load projects");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects ?? [];
+    return (projects ?? []).filter(
+      (p) => p.name.toLowerCase().includes(q) || p.key.toLowerCase().includes(q),
+    );
+  }, [query, projects]);
+
+  return (
+    <PickerShell
+      error={error}
+      loading={projects === null && !error}
+      query={query}
+      placeholder="Search projects..."
+      onQuery={setQuery}
+      empty="No Jira projects found."
+    >
+      {filtered.map((project) => (
+        <button
+          key={project.external_ref}
+          type="button"
+          disabled={busy}
+          onClick={() => void onAdd(project)}
+          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+        >
+          <JiraIcon className="mt-0.5" size={14} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[12.5px] font-medium text-foreground">
+              {project.name} <span className="text-muted">({project.key})</span>
+            </span>
+            <span className="block truncate text-[11.5px] text-muted">{project.site_name}</span>
+          </span>
+        </button>
+      ))}
+    </PickerShell>
+  );
+}
+
+export function AsanaProjectPicker({
+  busy,
+  onAdd,
+}: {
+  busy: boolean;
+  onAdd: (project: AsanaProjectSummary) => Promise<boolean>;
+}) {
+  const [projects, setProjects] = useState<AsanaProjectSummary[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    listAsanaProjects()
+      .then((next) => {
+        if (!cancelled) setProjects(next);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load projects");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects ?? [];
+    return (projects ?? []).filter((p) => p.name.toLowerCase().includes(q));
+  }, [query, projects]);
+
+  return (
+    <PickerShell
+      error={error}
+      loading={projects === null && !error}
+      query={query}
+      placeholder="Search projects..."
+      onQuery={setQuery}
+      empty="No Asana projects found."
+    >
+      {filtered.map((project) => (
+        <button
+          key={project.gid}
+          type="button"
+          disabled={busy}
+          onClick={() => void onAdd(project)}
+          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+        >
+          <AsanaIcon className="mt-0.5" size={14} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[12.5px] font-medium text-foreground">
+              {project.name}
+            </span>
+            <span className="block truncate text-[11.5px] text-muted">{project.workspace_name}</span>
+          </span>
+        </button>
+      ))}
+    </PickerShell>
+  );
+}
+
+export function CredentialForm({
+  fields,
+  busy,
+  onSubmit,
+}: {
+  fields: CredentialField[];
+  busy: boolean;
+  onSubmit: (values: Record<string, string>) => Promise<boolean>;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const complete = fields.every((f) => (values[f.name] ?? "").trim().length > 0);
+
+  return (
+    <form
+      className="mt-2.5 space-y-2 rounded-md border border-border bg-base p-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (complete) void onSubmit(values);
+      }}
+    >
+      {fields.map((field) => (
+        <label key={field.name} className="block">
+          <span className="mb-1 block text-[11.5px] text-muted">{field.label}</span>
+          <input
+            type={field.secret ? "password" : "text"}
+            value={values[field.name] ?? ""}
+            placeholder={field.placeholder}
+            autoComplete="off"
+            onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
+            className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+          />
+        </label>
+      ))}
+      <button type="submit" disabled={!complete || busy} className={primaryButton()}>
+        {busy ? "Connecting..." : "Connect"}
+      </button>
+    </form>
+  );
+}
+
+export function PickerShell({
+  error,
+  loading,
+  query,
+  placeholder,
+  empty,
+  onQuery,
+  children,
+}: {
+  error: string;
+  loading: boolean;
+  query: string;
+  placeholder: string;
+  empty: string;
+  onQuery: (value: string) => void;
+  children: ReactNode;
+}) {
+  const hasChildren = Array.isArray(children) ? children.length > 0 : !!children;
+  return (
+    <div className="mt-2.5 rounded-md border border-border bg-base p-2">
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => onQuery(e.target.value)}
+        placeholder={placeholder}
+        className="mb-2 w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
+      />
+      {error ? (
+        <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
+      ) : loading ? (
+        <div className="px-2 py-3 text-[12px] text-muted">Loading...</div>
+      ) : hasChildren ? (
+        <div className="max-h-48 overflow-y-auto">{children}</div>
+      ) : (
+        <div className="px-2 py-3 text-[12px] text-muted">{empty}</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -212,8 +212,24 @@ export async function getWorkspace(workspaceId: string): Promise<Workspace> {
 export interface WorkspaceSource {
   source: string; // native handle ("files"/"sessions") or connected-source id
   type: string; // 'native_files' | 'native_sessions' | 'github_repo' | ...
-  capability: string; // 'navigable' | 'searchable'
+  capability: string; // 'navigable' | 'searchable' | 'queryable'
   display_name: string;
+  // Present for connected sources (the integration page uses these).
+  external_ref?: string | null;
+  sync_status?: string | null; // 'idle' | 'syncing' | 'failed'
+  sync_error?: string | null;
+  last_synced_at?: string | null;
+}
+
+export interface SourceStatus extends WorkspaceSource {
+  item_count: number | null; // null for queryable sources (no document table)
+}
+
+export interface SourceEntry {
+  path?: string;
+  id?: string;
+  name: string;
+  kind: string;
 }
 
 const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);
@@ -254,6 +270,81 @@ export async function deleteWorkspaceSource(
 ): Promise<void> {
   await apiFetch(`/api/v1/workspaces/${workspaceId}/sources/${sourceId}`, {
     method: "DELETE",
+  });
+}
+
+// --- per-integration page: status + content browsing ---
+
+export async function getSourceStatus(
+  workspaceId: string,
+  sourceId: string,
+): Promise<SourceStatus> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/sources/${sourceId}/status`);
+}
+
+export async function getSourceEntries(
+  workspaceId: string,
+  source: string,
+  path = "",
+): Promise<SourceEntry[]> {
+  const q = path ? `?path=${encodeURIComponent(path)}` : "";
+  const data = await apiFetch<{ entries: SourceEntry[] }>(
+    `/api/v1/workspaces/${workspaceId}/sources/${source}/entries${q}`,
+  );
+  return data.entries;
+}
+
+export async function readSourceDoc(
+  workspaceId: string,
+  source: string,
+  ref: string,
+): Promise<{ name?: string; content?: string }> {
+  return apiFetch(
+    `/api/v1/workspaces/${workspaceId}/sources/${source}/doc?ref=${encodeURIComponent(ref)}`,
+  );
+}
+
+export interface SourceSearchHit {
+  source: string;
+  source_name?: string;
+  ref: string;
+  name?: string;
+  snippet?: string;
+}
+
+export async function searchSource(
+  workspaceId: string,
+  query: string,
+  source?: string,
+): Promise<SourceSearchHit[]> {
+  const params = new URLSearchParams({ q: query });
+  if (source) params.set("source", source);
+  const data = await apiFetch<{ results: SourceSearchHit[] }>(
+    `/api/v1/workspaces/${workspaceId}/sources/search?${params.toString()}`,
+  );
+  return data.results;
+}
+
+export async function querySource(
+  workspaceId: string,
+  source: string,
+  sql: string,
+): Promise<{ columns?: string[]; rows?: unknown[][]; error?: string }> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/sources/${source}/query`, {
+    method: "POST",
+    body: JSON.stringify({ sql }),
+  });
+}
+
+export async function fetchSourceHistory(
+  workspaceId: string,
+  source: string,
+  since: string,
+  until?: string,
+): Promise<{ fetched: number; since: string; until: string | null }> {
+  return apiFetch(`/api/v1/workspaces/${workspaceId}/sources/${source}/history`, {
+    method: "POST",
+    body: JSON.stringify({ since, until }),
   });
 }
 


### PR DESCRIPTION
## What

Connected sources felt bolted-on — the sidebar listed them but every row bounced to `/settings`, and adding/managing lived only in a modal. Now each integration is a **first-class object with its own page in the workspace**.

## The integration page
New route **`/workspaces/[id]/integrations/[provider]`**:
- **Header** — brand icon, connected account ("Connected as …"), Connect / Disconnect (or the api-key credential form), and a "Manage in Settings" link.
- **Add** — the project/page/repo picker, **moved off the modal** onto the page.
- **Added sources** — each with a sync-status pill (idle/syncing/failed), relative last-synced, **item count**, and a one-line *"how it's indexed"* descriptor (copied vs federated vs live SQL), plus Sync / Remove. The `?source=` row is highlighted.
- **Browse** (the first-class part) — reuses the existing source endpoints: entries/doc for navigable sources, a scoped search box for searchable ones, a SQL box + results table for Snowflake, and a **"fetch older history"** control for Slack/Gong.

## Sidebar + connect surfaces
- Sidebar connected-source rows now link to their integration page (not `/settings`).
- **`SourceConnectorList` is now connect-only** (Connect / Open / Unavailable + the api-key form). The inline pickers and the connected-sources list moved to the page. The "+ Add a new source" modal, Settings, and onboarding all use this connect-only surface; the modal is retitled "Connect a source."

## Refactor + backend
- Extracted shared `connectors.tsx` (CONNECTORS, `providerForSourceType`, `connectorIcon`, `labelForSourceType`) and `pickers.tsx` (pickers, `CredentialForm`, `AddSourceControls`).
- `list_sources` now carries `sync_status`/`last_synced_at`/`sync_error`/`external_ref` (already on the row — no extra query); new `GET /sources/{id}/status` returns those + `item_count` (null for queryable Snowflake).

## Verification
- `pytest` (status fields + item counts for copied vs queryable) + whole-backend `ruff` — green.
- Frontend `tsc --noEmit` + `eslint` + **production `next build`** — green; new route registered.
- Page render verified locally (header, Connect, empty-state) — screenshot in thread. Full populated experience (real connections, status, browse) verifies after deploy against prod where the accounts are connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)