### PR TITLE
[codex] Polish sessions segmented controls

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
@@ -521,7 +521,7 @@ function SegmentedControl<T extends string>({
       <span className="sys-label" style={{ fontSize: 10 }}>
         {label}
       </span>
-      <div className="inline-flex gap-0.5 rounded-md border border-border bg-base p-[2px]">
+      <div className="inline-flex gap-1 rounded-full border border-border bg-surface/60 p-1 shadow-sm">
         {options.map((opt) => {
           const active = value === opt.key;
           return (
@@ -530,10 +530,10 @@ function SegmentedControl<T extends string>({
               type="button"
               onClick={() => onChange(opt.key)}
               className={
-                "rounded px-2 py-[3px] text-[12px] " +
+                "rounded-full px-2.5 py-1 text-[12px] leading-none transition-colors " +
                 (active
-                  ? "bg-raised font-semibold text-foreground"
-                  : "text-muted hover:text-foreground")
+                  ? "bg-base font-semibold text-foreground shadow-sm"
+                  : "text-muted hover:bg-raised/70 hover:text-foreground")
               }
             >
               {opt.label}


### PR DESCRIPTION
## Summary
- Update the sessions toolbar segmented controls so the selected option is a rounded pill instead of a rectangular block inside a pill container.
- Add slightly more spacing, a subtle selected surface, and hover states that preserve the rounded geometry.

## Why
The previous active segment used a small rectangle inside a more oval control, which made the selected state look visually mismatched.

## Screenshot
[Sessions segmented control screenshot](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/be5ea7b2-4a2b-4b4f-a406-1818522ec52c)

## Validation
- `npm run lint -- 'src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx'`
- Playwright browser render against local Next dev server with mocked API responses; screenshot captured at `/tmp/stash-sessions-control.png`.
