### PR TITLE
Fix account menu email and logout

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -81,7 +81,7 @@ async def _get_user_from_api_key(token: str) -> dict:
     key_hash = hash_api_key(token)
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT u.id, u.name, u.display_name, u.description, "
+        "SELECT u.id, u.name, u.display_name, u.email, u.description, "
         "       u.created_at, u.last_seen, k.id AS key_id "
         "FROM user_api_keys k JOIN users u ON u.id = k.user_id "
         "WHERE k.key_hash = $1 AND k.revoked_at IS NULL",
@@ -108,7 +108,7 @@ async def _get_user_from_jwt(token: str) -> dict:
     claims = await validate_auth0_token(token)
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, description, created_at, last_seen "
+        "SELECT id, name, display_name, email, description, created_at, last_seen "
         "FROM users WHERE auth0_sub = $1",
         claims["sub"],
     )

--- a/backend/models.py
+++ b/backend/models.py
@@ -29,6 +29,7 @@ class UserProfile(BaseModel):
     id: UUID
     name: str
     display_name: str
+    email: str | None = None
     description: str
     created_at: datetime
     last_seen: datetime

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -20,7 +20,7 @@ async def register_user(
         row = await pool.fetchrow(
             "INSERT INTO users (name, display_name, password_hash, description, email) "
             "VALUES ($1, $2, $3, $4, $5) "
-            "RETURNING id, name, display_name, description, created_at, last_seen",
+            "RETURNING id, name, display_name, email, description, created_at, last_seen",
             name,
             display_name or name,
             pw_hash,
@@ -55,7 +55,7 @@ async def register_user(
 async def get_user_by_id(user_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, description, created_at, last_seen "
+        "SELECT id, name, display_name, email, description, created_at, last_seen "
         "FROM users WHERE id = $1",
         user_id,
     )
@@ -103,7 +103,7 @@ async def update_user(
         idx += 1
     if not sets:
         row = await pool.fetchrow(
-            "SELECT id, name, display_name, description, created_at, last_seen "
+            "SELECT id, name, display_name, email, description, created_at, last_seen "
             "FROM users WHERE id = $1",
             user_id,
         )
@@ -111,7 +111,7 @@ async def update_user(
     args.append(user_id)
     row = await pool.fetchrow(
         f"UPDATE users SET {', '.join(sets)} WHERE id = ${idx} "
-        "RETURNING id, name, display_name, description, created_at, last_seen",
+        "RETURNING id, name, display_name, email, description, created_at, last_seen",
         *args,
     )
 
@@ -136,7 +136,7 @@ async def authenticate_by_password(name: str, password: str) -> tuple[dict, str]
     """Authenticate by username + password. Returns (user_dict, new_api_key)."""
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, description, created_at, last_seen, password_hash "
+        "SELECT id, name, display_name, email, description, created_at, last_seen, password_hash "
         "FROM users WHERE name = $1",
         name,
     )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -85,6 +85,7 @@ async def test_api_key_auth(client: AsyncClient):
         json={
             "name": name,
             "password": "securepassword1",
+            "email": "henry@example.com",
         },
     )
     api_key = reg.json()["api_key"]
@@ -92,6 +93,29 @@ async def test_api_key_auth(client: AsyncClient):
     me = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {api_key}"})
     assert me.status_code == 200
     assert me.json()["name"] == name
+    assert me.json()["email"] == "henry@example.com"
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_current_api_key(client: AsyncClient):
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": unique_name(),
+            "password": "securepassword1",
+        },
+    )
+    api_key = reg.json()["api_key"]
+
+    logout = await client.post(
+        "/api/v1/users/logout",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+    assert logout.status_code == 204
+
+    me = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {api_key}"})
+    assert me.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { AuthPageSkeleton, SkeletonBlock } from "../../components/SkeletonStates
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
 import { API_BASE, getToken, setToken, listMyWorkspaces } from "../../lib/api";
+import { consumeManualAuth0Logout } from "../../lib/authLogout";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
@@ -316,6 +317,11 @@ function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0Panel
 
   useEffect(() => {
     let cancelled = false;
+    if (consumeManualAuth0Logout()) {
+      setHasSession(false);
+      return;
+    }
+
     (async () => {
       try {
         const res = await fetch("/auth/profile", { credentials: "include" });

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -203,6 +203,29 @@ describe("AppShell sidebar collapse", () => {
     expect(localStorage.getItem("stash_sidebar_width")).toBe("380");
   });
 
+  it("shows the signed-in email and signs out from the account menu", () => {
+    const onLogout = vi.fn();
+
+    render(
+      <ShareModalProvider>
+        <AppShell
+          user={{ ...user, email: "henry@example.com" }}
+          onLogout={onLogout}
+        >
+          <div>Page content</div>
+        </AppShell>
+      </ShareModalProvider>,
+    );
+
+    fireEvent.click(screen.getByTitle("henry@example.com"));
+
+    expect(screen.getByText("henry@example.com")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
   it("opens top-bar search with session scope", () => {
     nav.pathname = "/workspaces/ws-1/sessions/session-123";
     mockWorkspaceCache();

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -394,6 +394,7 @@ export default function AppShell({
   const activeWorkspace = workspaces.find((s) => s.id === activeWorkspaceId);
   const searchScope = inferSearchScope(pathname, activeWorkspace, breadcrumbs);
   const initial = user.display_name[0].toUpperCase();
+  const accountLabel = user.email ?? user.name;
   const directShareTarget = inferDirectShareTarget(pathname, breadcrumbs);
   const shareInitial = inferShareInitial(pathname);
 
@@ -578,7 +579,7 @@ export default function AppShell({
           {shareAction ?? defaultShareAction}
           <UserMenu
             initial={initial}
-            label={user.display_name}
+            accountLabel={accountLabel}
             onLogout={onLogout}
           />
         </div>
@@ -650,11 +651,11 @@ function sessionShareTitle(session: SessionDetail): string {
 
 function UserMenu({
   initial,
-  label,
+  accountLabel,
   onLogout,
 }: {
   initial: string;
-  label: string;
+  accountLabel: string;
   onLogout: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -681,7 +682,7 @@ function UserMenu({
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        title={label}
+        title={accountLabel}
         className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-100 text-[10px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
       >
         {initial}
@@ -689,10 +690,10 @@ function UserMenu({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full z-40 mt-1.5 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
+          className="absolute right-0 top-full z-40 mt-1.5 w-64 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
         >
           <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted">
-            Signed in as <span className="text-foreground">{label}</span>
+            Signed in as <span className="break-all text-foreground">{accountLabel}</span>
           </div>
           <Link
             href="/settings"

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Header from "./Header";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const user = {
+  id: "user-1",
+  name: "henry",
+  display_name: "Henry Dowling",
+  email: "henry@example.com",
+  description: "",
+  created_at: "2026-05-11T00:00:00Z",
+  last_seen: "2026-05-11T00:00:00Z",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Header account menu", () => {
+  it("shows the signed-in email and signs out", () => {
+    const onLogout = vi.fn();
+
+    render(<Header user={user} onLogout={onLogout} />);
+
+    fireEvent.click(screen.getByTitle("henry@example.com"));
+
+    expect(screen.getByText("henry@example.com")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -33,6 +33,7 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const label = user.display_name;
+  const accountLabel = user.email ?? user.name;
   const initial = label[0].toUpperCase();
 
   useEscapeKey(open, () => setOpen(false));
@@ -58,7 +59,7 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="menu"
         aria-expanded={open}
-        title={label}
+        title={accountLabel}
         className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand-100 text-[11px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
       >
         {initial}
@@ -66,10 +67,10 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full z-40 mt-1.5 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
+          className="absolute right-0 top-full z-40 mt-1.5 w-64 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
         >
           <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted">
-            Signed in as <span className="text-foreground">{label}</span>
+            Signed in as <span className="break-all text-foreground">{accountLabel}</span>
           </div>
           <Link
             href="/settings"

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { API_BASE, ApiError, clearToken, getMe, getToken } from "../lib/api";
+import { markManualAuth0Logout } from "../lib/authLogout";
 import { User } from "../lib/types";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
@@ -52,25 +53,25 @@ export function useAuth() {
     return () => window.removeEventListener("storage", onStorage);
   }, [loadUser]);
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    if (AUTH0_ENABLED) {
+      markManualAuth0Logout();
+    }
+
     // Drop local state first so the UI flips to signed-out the moment the
-    // user clicks — don't make them wait on a server round-trip. Revoke the
-    // key in the background; `keepalive` lets the request survive the
-    // navigation we're about to do.
+    // user clicks. Revoke the active key before navigating so the browser
+    // session cannot be restored by a still-valid local API key.
     const token = getToken();
     clearToken();
     setUser(null);
     if (token) {
-      fetch(`${API_BASE}/api/v1/users/logout`, {
+      await fetch(`${API_BASE}/api/v1/users/logout`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
-        keepalive: true,
       }).catch(() => {});
     }
-    // Hard navigation so module-level caches reset. `?federated` makes the
-    // Auth0 SDK kill the tenant SSO cookie too — without it, /login silently
-    // re-auths via the surviving SSO cookie and lands the user back on their
-    // workspace page.
+    // Hard navigation so module-level caches reset. `?federated` asks Auth0 to
+    // clear upstream identity-provider state too.
     window.location.href = AUTH0_ENABLED ? "/auth/logout?federated" : "/login";
   }, []);
 

--- a/frontend/src/lib/authLogout.test.ts
+++ b/frontend/src/lib/authLogout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { consumeManualAuth0Logout, markManualAuth0Logout } from "./authLogout";
+
+describe("Auth0 manual logout marker", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("is consumed once after manual logout", () => {
+    markManualAuth0Logout();
+
+    expect(consumeManualAuth0Logout()).toBe(true);
+    expect(consumeManualAuth0Logout()).toBe(false);
+  });
+});

--- a/frontend/src/lib/authLogout.ts
+++ b/frontend/src/lib/authLogout.ts
@@ -1,0 +1,13 @@
+const AUTH0_MANUAL_LOGOUT_KEY = "stash_auth0_manual_logout";
+
+export function markManualAuth0Logout() {
+  sessionStorage.setItem(AUTH0_MANUAL_LOGOUT_KEY, "1");
+}
+
+export function consumeManualAuth0Logout() {
+  const marked = sessionStorage.getItem(AUTH0_MANUAL_LOGOUT_KEY) === "1";
+  if (marked) {
+    sessionStorage.removeItem(AUTH0_MANUAL_LOGOUT_KEY);
+  }
+  return marked;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2,6 +2,7 @@ export interface User {
   id: string;
   name: string;
   display_name: string;
+  email?: string | null;
   description: string;
   created_at: string;
   last_seen: string;


### PR DESCRIPTION
## Summary
- Expose `email` on `/api/v1/users/me` so the frontend can show the actual signed-in account.
- Update the header and app shell account menus to display the email in a wider dropdown.
- Make logout clear local state immediately, revoke the active API key before navigating, and prevent Auth0 login from silently re-exchanging right after an explicit logout.

## Screenshot
- Account menu with signed-in email: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/fab82280-258e-4532-a8b3-a79e53644747

## Validation
- `pytest backend/tests/test_auth.py --no-cov`
- `npm test -- Header.test.tsx AppShell.test.tsx authLogout.test.ts`
- `npx eslint src/components/Header.tsx src/components/AppShell.tsx src/hooks/useAuth.ts src/app/login/page.tsx src/lib/authLogout.ts`
- `npx eslint src/components/Header.test.tsx src/components/AppShell.test.tsx src/lib/authLogout.test.ts src/lib/authLogout.ts`
- `ruff check backend/auth.py backend/models.py backend/services/user_service.py backend/tests/test_auth.py`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- Playwright browser check against mocked auth/workspace APIs: opened the account menu, captured the screenshot, clicked Sign out, verified `stash_token` cleared and URL reached `/login`.
