### PR TITLE
[codex] Remove onboarding about-page copy

### DIFF
--- a/frontend/src/lib/onboarding/welcomeContent.test.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { generateWelcomeHtml } from "./welcomeContent";
+
+describe("generateWelcomeHtml", () => {
+  it("omits the explanatory About-page copy from new workspaces", () => {
+    const html = generateWelcomeHtml({
+      displayName: "Ada",
+      inviteLink: null,
+      counts: {
+        pages: 0,
+        files: 0,
+        sessions: 0,
+      },
+    });
+
+    expect(html).toContain("<h1>Welcome to Stash, Ada</h1>");
+    expect(html).toContain("<h2>What to try next</h2>");
+    expect(html).not.toContain("This is your About page");
+  });
+});

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -22,9 +22,6 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
   parts.push(
     `<h1>Welcome to Stash, ${escapeHtml(displayName)}</h1>`,
   );
-  parts.push(
-    `<p><em>This is your About page. It&rsquo;s editable like any other doc — keep what&rsquo;s useful, delete the rest.</em></p>`,
-  );
 
   if (counts.sessions > 0) {
     parts.push(`<h2>What you just did</h2>`);


### PR DESCRIPTION
## Summary
- Remove the italic About-page explainer from generated new-workspace welcome content.
- Add Vitest coverage so the starter content does not reintroduce that sentence.

## Validation
- `npm test -- src/lib/onboarding/welcomeContent.test.ts`
- `npm run lint`
- Browser QA: registered a disposable local user, skipped onboarding, opened the seeded workspace, and verified the sentence is absent.

## Screenshot
- [Seeded workspace without the About-page sentence](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/84e3b9a0-27e2-47ea-89f5-3eed550ba61a)
