### PR TITLE
Snowflake: Programmatic Access Token auth + fix optional connect fields

### DIFF
--- a/backend/integrations/base.py
+++ b/backend/integrations/base.py
@@ -38,6 +38,8 @@ class CredentialField:
     label: str
     secret: bool = False  # render as a password field + never echo back
     placeholder: str = ""
+    optional: bool = False  # not required to submit the form
+    help: str = ""  # one-line hint shown under the field
 
 
 class Integration(Protocol):

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -185,7 +185,14 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
                 disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
                 credential_fields=[
-                    {"name": f.name, "label": f.label, "secret": f.secret, "placeholder": f.placeholder}
+                    {
+                        "name": f.name,
+                        "label": f.label,
+                        "secret": f.secret,
+                        "placeholder": f.placeholder,
+                        "optional": f.optional,
+                        "help": f.help,
+                    }
                     for f in getattr(p, "credential_fields", [])
                 ]
                 or None,

--- a/backend/integrations/snowflake/client.py
+++ b/backend/integrations/snowflake/client.py
@@ -65,7 +65,10 @@ def _connect(creds: dict):
             kwargs[key] = creds[key]
 
     private_key = creds.get("private_key")
-    if private_key:
+    if creds.get("token"):
+        # A Programmatic Access Token authenticates in place of a password.
+        kwargs["password"] = creds["token"]
+    elif private_key:
         from cryptography.hazmat.primitives import serialization
 
         passphrase = creds.get("private_key_passphrase") or None
@@ -81,7 +84,7 @@ def _connect(creds: dict):
     elif creds.get("password"):
         kwargs["password"] = creds["password"]
     else:
-        raise ValueError("Snowflake credentials need a private key or password")
+        raise ValueError("Snowflake credentials need a token, private key, or password")
 
     return snowflake.connector.connect(**kwargs)
 

--- a/backend/integrations/snowflake/provider.py
+++ b/backend/integrations/snowflake/provider.py
@@ -1,10 +1,12 @@
 """Snowflake api_key provider.
 
 Snowflake is a SQL warehouse, exposed to the agent as a read-only *query*
-source rather than a crawled document source. Credentials are pasted (key-pair
-auth recommended — Snowflake is phasing out single-factor passwords for service
-accounts; a password field is accepted as an alternative). See client.py for
-the read-only query path and integrations/base.py for the api_key contract.
+source rather than a crawled document source. Credentials are pasted: a
+**Programmatic Access Token** (a single token string — easiest, but needs a
+network policy on the account) or **key-pair** auth as the alternative. Both
+authenticate in place of a password (Snowflake is phasing out single-factor
+passwords for service accounts). See client.py for the read-only query path and
+integrations/base.py for the api_key contract.
 """
 
 from __future__ import annotations
@@ -22,13 +24,25 @@ class SnowflakeIntegration:
     supports_refresh = False
     auth_kind = "api_key"
     credential_fields = [
-        CredentialField("account", "Account", placeholder="orgname-account_name"),
+        CredentialField(
+            "account", "Account", placeholder="orgname-account_name",
+            help="Your Snowflake account identifier (Admin → Accounts).",
+        ),
         CredentialField("user", "User", placeholder="SVC_AGENT"),
-        CredentialField("private_key", "Private Key (PEM)", secret=True, placeholder="-----BEGIN PRIVATE KEY-----"),
-        CredentialField("private_key_passphrase", "Private Key Passphrase", secret=True),
-        CredentialField("warehouse", "Warehouse", placeholder="COMPUTE_WH"),
-        CredentialField("role", "Role", placeholder="READ_ONLY"),
-        CredentialField("database", "Database", placeholder="(optional default)"),
+        CredentialField(
+            "token", "Programmatic Access Token", secret=True, optional=True,
+            placeholder="Recommended — a single token string",
+            help="Easiest: ALTER USER <u> ADD PROGRAMMATIC ACCESS TOKEN … (needs a network policy on the account).",
+        ),
+        CredentialField(
+            "private_key", "Private Key (PEM)", secret=True, optional=True,
+            placeholder="-----BEGIN PRIVATE KEY-----",
+            help="Alternative to a token: key-pair auth.",
+        ),
+        CredentialField("private_key_passphrase", "Private Key Passphrase", secret=True, optional=True),
+        CredentialField("warehouse", "Warehouse", optional=True, placeholder="COMPUTE_WH"),
+        CredentialField("role", "Role", optional=True, placeholder="READ_ONLY"),
+        CredentialField("database", "Database", optional=True, placeholder="(optional default)"),
     ]
 
     async def connect_with_credentials(
@@ -37,8 +51,8 @@ class SnowflakeIntegration:
         creds = {k: v.strip() for k, v in values.items() if v and v.strip()}
         if not creds.get("account") or not creds.get("user"):
             raise ValueError("Account and User are required")
-        if not creds.get("private_key") and not creds.get("password"):
-            raise ValueError("A private key (or password) is required")
+        if not creds.get("token") and not creds.get("private_key") and not creds.get("password"):
+            raise ValueError("Provide a Programmatic Access Token or a Private Key")
 
         try:
             display_name = await test_connection(creds)

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -214,10 +214,25 @@ def test_snowflake_is_queryable_api_key_source():
     assert "snowflake" not in source_tasks.INDEXERS
 
 
+def test_snowflake_offers_pat_token_with_optional_alternatives():
+    # PAT (a single token) is the easy auth path; key-pair is the optional
+    # alternative. Only account + user are required so the form doesn't force
+    # users to fill the optional warehouse/role/database/passphrase.
+    fields = {f.name: f for f in SnowflakeIntegration().credential_fields}
+    assert fields["token"].optional and fields["token"].secret
+    assert fields["private_key"].optional
+    assert not fields["account"].optional and not fields["user"].optional
+    for opt in ("warehouse", "role", "database", "private_key_passphrase"):
+        assert fields[opt].optional, opt
+
+
 @pytest.mark.asyncio
 async def test_snowflake_rejects_incomplete_credentials():
     with pytest.raises(ValueError):
         await SnowflakeIntegration().connect_with_credentials({"account": "a"})  # no user/key
+    # account + user but no auth method (token/key/password) is also rejected.
+    with pytest.raises(ValueError):
+        await SnowflakeIntegration().connect_with_credentials({"account": "a", "user": "u"})
 
 
 def test_query_source_tool_is_registered_and_in_tool_sets():

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -407,7 +407,11 @@ export function CredentialForm({
   onSubmit: (values: Record<string, string>) => Promise<boolean>;
 }) {
   const [values, setValues] = useState<Record<string, string>>({});
-  const complete = fields.every((f) => (values[f.name] ?? "").trim().length > 0);
+  // Only the required (non-optional) fields gate submission; "one of" auth
+  // choices are marked optional and validated server-side.
+  const complete = fields
+    .filter((f) => !f.optional)
+    .every((f) => (values[f.name] ?? "").trim().length > 0);
 
   return (
     <form
@@ -419,7 +423,10 @@ export function CredentialForm({
     >
       {fields.map((field) => (
         <label key={field.name} className="block">
-          <span className="mb-1 block text-[11.5px] text-muted">{field.label}</span>
+          <span className="mb-1 block text-[11.5px] text-muted">
+            {field.label}
+            {field.optional && <span className="ml-1 text-dim">(optional)</span>}
+          </span>
           <input
             type={field.secret ? "password" : "text"}
             value={values[field.name] ?? ""}
@@ -428,6 +435,7 @@ export function CredentialForm({
             onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
             className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted focus:border-brand focus:outline-none"
           />
+          {field.help && <span className="mt-1 block text-[11px] text-dim">{field.help}</span>}
         </label>
       ))}
       <button type="submit" disabled={!complete || busy} className={primaryButton()}>

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -24,6 +24,8 @@ export type CredentialField = {
   label: string;
   secret: boolean;
   placeholder: string;
+  optional?: boolean;
+  help?: string;
 };
 
 export type IntegrationStatus = {


### PR DESCRIPTION
## Why
You asked if PATs are easier to set up — they are (a single token string vs generating an RSA keypair and pasting a multi-line PEM). While wiring it up I found the connect form required **every** field, so you literally couldn't connect Snowflake without filling the optional passphrase/warehouse/role/database. This fixes both.

## What
- `CredentialField` gains `optional` + `help`. The connect form now only requires non-optional fields and shows an **(optional)** hint + a one-line help under each field. Other api_key providers (Gong) are unchanged — fields default to required.
- Snowflake offers a **Programmatic Access Token** as the recommended auth (single secret string), with **key-pair** as the optional alternative. A PAT authenticates in place of a password (`client._connect` uses it as the password). Only **account + user** are required; the rest is optional and validated server-side ("provide a token or a private key").

The new form (account + user required; PAT recommended; everything else optional, with help text):

```
Account            Your Snowflake account identifier (Admin → Accounts)
User
Programmatic Access Token (optional)   Easiest: ALTER USER … ADD PROGRAMMATIC ACCESS TOKEN … (needs a network policy)
Private Key (PEM) (optional)           Alternative to a token: key-pair auth
Private Key Passphrase (optional)
Warehouse / Role / Database (optional)
```

> ⚠️ **PATs require an active network policy** on the Snowflake account (surfaced in the field help). Key-pair remains the universal fallback.

## Verification
ruff + pytest (PAT/optional-field contract + auth-required validation), tsc + eslint + production build — all green. Form rendered locally (screenshot shared in chat). **Not exercised:** a live PAT connect against a real Snowflake account (none available) — worth a real connect test before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)