### PR TITLE
Show username in account menu

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -203,7 +203,7 @@ describe("AppShell sidebar collapse", () => {
     expect(localStorage.getItem("stash_sidebar_width")).toBe("380");
   });
 
-  it("shows the signed-in email and signs out from the account menu", () => {
+  it("shows the signed-in email, username, and signs out from the account menu", () => {
     const onLogout = vi.fn();
 
     render(
@@ -220,6 +220,7 @@ describe("AppShell sidebar collapse", () => {
     fireEvent.click(screen.getByTitle("henry@example.com"));
 
     expect(screen.getByText("henry@example.com")).toBeInTheDocument();
+    expect(screen.getByText("@Henry")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -395,6 +395,7 @@ export default function AppShell({
   const searchScope = inferSearchScope(pathname, activeWorkspace, breadcrumbs);
   const initial = user.display_name[0].toUpperCase();
   const accountLabel = user.email ?? user.name;
+  const usernameLabel = `@${user.name}`;
   const directShareTarget = inferDirectShareTarget(pathname, breadcrumbs);
   const shareInitial = inferShareInitial(pathname);
 
@@ -580,6 +581,7 @@ export default function AppShell({
           <UserMenu
             initial={initial}
             accountLabel={accountLabel}
+            usernameLabel={usernameLabel}
             onLogout={onLogout}
           />
         </div>
@@ -652,10 +654,12 @@ function sessionShareTitle(session: SessionDetail): string {
 function UserMenu({
   initial,
   accountLabel,
+  usernameLabel,
   onLogout,
 }: {
   initial: string;
   accountLabel: string;
+  usernameLabel: string;
   onLogout: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -693,7 +697,12 @@ function UserMenu({
           className="absolute right-0 top-full z-40 mt-1.5 w-64 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
         >
           <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted">
-            Signed in as <span className="break-all text-foreground">{accountLabel}</span>
+            <div>
+              Signed in as <span className="break-all text-foreground">{accountLabel}</span>
+            </div>
+            <div className="mt-0.5">
+              Username <span className="break-all text-foreground">{usernameLabel}</span>
+            </div>
           </div>
           <Link
             href="/settings"

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("Header account menu", () => {
-  it("shows the signed-in email and signs out", () => {
+  it("shows the signed-in email, username, and signs out", () => {
     const onLogout = vi.fn();
 
     render(<Header user={user} onLogout={onLogout} />);
@@ -41,6 +41,7 @@ describe("Header account menu", () => {
     fireEvent.click(screen.getByTitle("henry@example.com"));
 
     expect(screen.getByText("henry@example.com")).toBeInTheDocument();
+    expect(screen.getByText("@henry")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -34,6 +34,7 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
   const containerRef = useRef<HTMLDivElement>(null);
   const label = user.display_name;
   const accountLabel = user.email ?? user.name;
+  const usernameLabel = `@${user.name}`;
   const initial = label[0].toUpperCase();
 
   useEscapeKey(open, () => setOpen(false));
@@ -70,7 +71,12 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
           className="absolute right-0 top-full z-40 mt-1.5 w-64 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg"
         >
           <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted">
-            Signed in as <span className="break-all text-foreground">{accountLabel}</span>
+            <div>
+              Signed in as <span className="break-all text-foreground">{accountLabel}</span>
+            </div>
+            <div className="mt-0.5">
+              Username <span className="break-all text-foreground">{usernameLabel}</span>
+            </div>
           </div>
           <Link
             href="/settings"


### PR DESCRIPTION
## Summary
- Show the user's username as a second line in the account dropdown while keeping the existing signed-in account label.
- Cover both account menu implementations and update their tests.

## Validation
- `npm test -- Header.test.tsx AppShell.test.tsx`
- `npm run lint -- src/components/Header.tsx src/components/AppShell.tsx`
- Browser QA with local mock backend; opened the user menu and verified `@henry` is visible.

## Screenshot
- [Account dropdown with username](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/b31bf810-0419-4040-b1c0-309bdd66eeb9)