### PR TITLE
Hide app chrome on Stash item routes

### DIFF
--- a/frontend/src/app/(app)/layout.test.tsx
+++ b/frontend/src/app/(app)/layout.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppGroupLayout from "./layout";
+
+const route = vi.hoisted(() => ({
+  pathname: "/workspaces/ws-1",
+  search: "",
+  push: vi.fn(),
+  auth: {
+    user: null as null | {
+      id: string;
+      name: string;
+      display_name: string;
+      description: string;
+      created_at: string;
+      last_seen: string;
+    },
+    loading: false,
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => route.pathname,
+  useRouter: () => ({ push: route.push }),
+  useSearchParams: () => new URLSearchParams(route.search),
+}));
+
+vi.mock("../../components/AppShell", () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("../../components/SkeletonStates", () => ({
+  AppShellSkeleton: () => <div data-testid="app-shell-skeleton" />,
+  PublicCartridgeSkeleton: () => <div data-testid="public-stash-skeleton" />,
+}));
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => route.auth,
+}));
+
+const user = {
+  id: "user-1",
+  name: "henry",
+  display_name: "Henry",
+  description: "",
+  created_at: "2026-06-08T00:00:00Z",
+  last_seen: "2026-06-08T00:00:00Z",
+};
+
+describe("AppGroupLayout", () => {
+  beforeEach(() => {
+    route.pathname = "/workspaces/ws-1";
+    route.search = "";
+    route.auth = {
+      user,
+      loading: false,
+      logout: vi.fn(),
+    };
+    route.push.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps normal signed-in app routes inside the app shell", () => {
+    render(
+      <AppGroupLayout>
+        <div>Workspace content</div>
+      </AppGroupLayout>,
+    );
+
+    expect(screen.getByTestId("app-shell")).toHaveTextContent("Workspace content");
+  });
+
+  it("renders workspace Stash item routes without app chrome", () => {
+    route.pathname = "/workspaces/ws-1/p/page-1";
+    route.search = "stash=shared-stash";
+
+    render(
+      <AppGroupLayout>
+        <div>Stash item content</div>
+      </AppGroupLayout>,
+    );
+
+    expect(screen.queryByTestId("app-shell")).not.toBeInTheDocument();
+    expect(screen.getByText("Stash item content")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -26,10 +26,12 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { user, loading, logout } = useAuth();
+  const isWorkspaceStashRoute =
+    pathname.startsWith("/workspaces/") && searchParams.has("stash");
   const isPublicCartridgeRoute =
     pathname.startsWith("/cartridges/") ||
     pathname.startsWith("/session-folders/") ||
-    (pathname.startsWith("/workspaces/") && searchParams.has("stash"));
+    isWorkspaceStashRoute;
 
   useEffect(() => {
     if (loading) return;
@@ -40,6 +42,10 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
 
   if (loading) {
     return isPublicCartridgeRoute ? <PublicCartridgeSkeleton /> : <AppShellSkeleton />;
+  }
+
+  if (isWorkspaceStashRoute) {
+    return <main className="min-h-screen bg-background">{children}</main>;
   }
 
   if (!user) {

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.test.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StashPageView from "./PageClient";
+
+const api = vi.hoisted(() => {
+  class ApiError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = "ApiError";
+    }
+  }
+
+  return {
+    ApiError,
+    createCommentThread: vi.fn(),
+    deleteCommentMessage: vi.fn(),
+    deleteCommentThread: vi.fn(),
+    getFolderContents: vi.fn(),
+    getPage: vi.fn(),
+    getPublicCartridge: vi.fn(),
+    listCommentThreads: vi.fn(),
+    listObjectStashes: vi.fn(),
+    reconcileCommentAnchors: vi.fn(),
+    replyToCommentThread: vi.fn(),
+    setCommentResolved: vi.fn(),
+    trashItem: vi.fn(),
+    updatePage: vi.fn(),
+  };
+});
+
+const route = vi.hoisted(() => ({
+  push: vi.fn(),
+  search: "stash=private-stash",
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ workspaceId: "ws-1", pageId: "page-1" }),
+  useRouter: () => ({ push: route.push }),
+  useSearchParams: () => new URLSearchParams(route.search),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../../../../../../components/BreadcrumbContext", () => ({
+  useBreadcrumbs: vi.fn(),
+}));
+
+vi.mock("../../../../../../hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "user-1",
+      name: "henry",
+      display_name: "Henry",
+      email: "henry@example.com",
+      description: "",
+      created_at: "2026-06-08T00:00:00Z",
+      last_seen: "2026-06-08T00:00:00Z",
+    },
+    loading: false,
+  }),
+}));
+
+vi.mock("../../../../../../lib/api", () => api);
+
+vi.mock("../../../../cartridges/[slug]/CartridgeItemBodies", () => ({
+  PageBody: () => <div>Stash page body</div>,
+}));
+
+vi.mock("../../../../../../components/DownloadMenu", () => ({
+  downloadBlob: vi.fn(),
+  downloadRenderedPdf: vi.fn(),
+  htmlToPdfBlocks: vi.fn(),
+  markdownToPdfBlocks: vi.fn(),
+}));
+
+vi.mock("../../../../../../components/SkeletonStates", () => ({
+  DocumentPageSkeleton: () => <div>Loading page</div>,
+}));
+
+vi.mock("../../../../../../components/StashIcons", () => ({
+  StashIcon: () => <span>Stash icon</span>,
+}));
+
+vi.mock("../../../../../../components/workspace/HtmlPageView", () => ({
+  default: () => <div>HTML page view</div>,
+  extractCommentIdsFromHtml: vi.fn(() => []),
+}));
+
+vi.mock("../../../../../../components/export/ExportDeckButton", () => ({
+  default: () => <button>Export</button>,
+}));
+
+vi.mock("../../../../../../components/workspace/FileViewerHeader", () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+vi.mock("../../../../../../components/workspace/MarkdownEditor", () => ({
+  default: () => <div>Markdown editor</div>,
+  extractCommentIdsFromMarkdown: vi.fn(() => []),
+}));
+
+vi.mock("../../../../../../components/workspace/CommentsSidebar", () => ({
+  default: () => <aside>Comments</aside>,
+}));
+
+vi.mock("../../../../../../components/workspace/CommentComposerPopover", () => ({
+  default: () => <div>Comment composer</div>,
+}));
+
+describe("StashPageView access fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    route.search = "stash=private-stash";
+    route.push.mockClear();
+    api.getPage.mockRejectedValue(new api.ApiError(404, "Page not found"));
+    api.getPublicCartridge.mockRejectedValue(new Error("Stash not found"));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a full-screen access denied page when the linked Stash is not readable", async () => {
+    render(<StashPageView />);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You don't have access to this page",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/henry@example\.com/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to home" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+    expect(screen.queryByText("This page is not in a Stash yet.")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
@@ -689,36 +689,36 @@ export default function StashPageView() {
 
 function PageAccessDeniedScreen({ accountLabel }: { accountLabel: string | null }) {
   return (
-    <div className="flex min-h-screen flex-col bg-[#f8fafd] text-[#202124]">
-      <header className="flex h-14 items-center border-b border-[#dadce0] bg-white px-5">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="flex h-14 items-center border-b border-border bg-surface px-5">
         <div className="flex items-center gap-2.5">
-          <span className="text-[#1a73e8]">
+          <span className="text-[var(--color-brand-600)]">
             <AccessPageGlyph />
           </span>
-          <span className="text-[18px] text-[#5f6368]">Stash</span>
+          <span className="font-display text-[18px] font-semibold text-foreground">Stash</span>
         </div>
       </header>
       <main className="flex flex-1 items-center justify-center px-6 py-16">
         <section className="w-full max-w-[520px] text-center">
-          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[#e8f0fe] text-[#1a73e8]">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-lg border border-border bg-brand-100 text-[var(--color-brand-700)] shadow-sm">
             <AccessPageGlyph large />
           </div>
-          <h1 className="mt-6 text-[28px] font-normal leading-tight text-[#202124]">
+          <h1 className="mt-6 font-display text-[28px] font-semibold leading-tight tracking-tight text-foreground">
             You don&apos;t have access to this page
           </h1>
-          <p className="mt-3 text-[14px] leading-6 text-[#5f6368]">
+          <p className="mt-3 text-[14px] leading-6 text-dim">
             If someone sent you this link, ask them to share the Stash with your
             account.
           </p>
           {accountLabel ? (
-            <p className="mt-4 text-[13px] leading-5 text-[#5f6368]">
-              You&apos;re signed in as <span className="font-medium text-[#3c4043]">{accountLabel}</span>.
+            <p className="mt-4 text-[13px] leading-5 text-muted">
+              You&apos;re signed in as <span className="font-medium text-foreground">{accountLabel}</span>.
             </p>
           ) : null}
           <div className="mt-8 flex justify-center">
             <Link
               href="/"
-              className="inline-flex h-9 items-center justify-center rounded-[4px] bg-[#1a73e8] px-6 text-[14px] font-medium text-white hover:bg-[#1765cc]"
+              className="inline-flex h-9 items-center justify-center rounded-md bg-[var(--color-brand-600)] px-6 text-[14px] font-medium text-white hover:bg-[var(--color-brand-700)]"
             >
               Go to home
             </Link>
@@ -737,14 +737,15 @@ function AccessPageGlyph({ large = false }: { large?: boolean }) {
       width={size}
       height={size}
       fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       aria-hidden="true"
     >
-      <path
-        d="M6 3.5h8l4 4V20a.5.5 0 0 1-.5.5h-11A.5.5 0 0 1 6 20V3.5Z"
-        fill="currentColor"
-      />
-      <path d="M14 3.5v4h4" fill="#a8c7fa" />
-      <path d="M9 11h6M9 14h6M9 17h4" stroke="white" strokeWidth="1.2" strokeLinecap="round" />
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+      <path d="M9 13h6M9 17h4" />
     </svg>
   );
 }

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
@@ -105,6 +105,7 @@ export default function StashPageView() {
   const [stashFallback, setStashFallback] = useState<
     { stash: WorkspaceCartridge; item: PublicCartridgeItem } | null
   >(null);
+  const [stashAccessDenied, setStashAccessDenied] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
   const [error, setError] = useState("");
   // Save responses can arrive out of order if a fast save fires while a
@@ -171,15 +172,20 @@ export default function StashPageView() {
         (it) => it.object_type === "page" && it.object_id === pageId,
       );
       if (!item) {
-        setError("This page isn't part of the linked Stash.");
-        return false;
+        setStashFallback(null);
+        setStashAccessDenied(true);
+        setError("");
+        return true;
       }
       setStashFallback({ stash: data.cartridge, item });
+      setStashAccessDenied(false);
       setError("");
       return true;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Stash not found");
-      return false;
+    } catch {
+      setStashFallback(null);
+      setStashAccessDenied(true);
+      setError("");
+      return true;
     }
   }, [stashSlug, pageId]);
 
@@ -207,6 +213,7 @@ export default function StashPageView() {
     // page they were legitimately shared.
     setPage(p);
     setStashFallback(null);
+    setStashAccessDenied(false);
     setError("");
     listObjectStashes(workspaceId, "page", pageId)
       .then(setContainingStashes)
@@ -441,6 +448,9 @@ export default function StashPageView() {
       />
     );
   }
+  if (stashAccessDenied) {
+    return <PageAccessDeniedScreen accountLabel={user?.email ?? user?.name ?? null} />;
+  }
   if (!user) {
     // Login bounce is already firing for the no-stash case.
     if (!stashSlug) return null;
@@ -674,6 +684,68 @@ export default function StashPageView() {
         </div>
       </div>
     </div>
+  );
+}
+
+function PageAccessDeniedScreen({ accountLabel }: { accountLabel: string | null }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-[#f8fafd] text-[#202124]">
+      <header className="flex h-14 items-center border-b border-[#dadce0] bg-white px-5">
+        <div className="flex items-center gap-2.5">
+          <span className="text-[#1a73e8]">
+            <AccessPageGlyph />
+          </span>
+          <span className="text-[18px] text-[#5f6368]">Stash</span>
+        </div>
+      </header>
+      <main className="flex flex-1 items-center justify-center px-6 py-16">
+        <section className="w-full max-w-[520px] text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[#e8f0fe] text-[#1a73e8]">
+            <AccessPageGlyph large />
+          </div>
+          <h1 className="mt-6 text-[28px] font-normal leading-tight text-[#202124]">
+            You don&apos;t have access to this page
+          </h1>
+          <p className="mt-3 text-[14px] leading-6 text-[#5f6368]">
+            If someone sent you this link, ask them to share the Stash with your
+            account.
+          </p>
+          {accountLabel ? (
+            <p className="mt-4 text-[13px] leading-5 text-[#5f6368]">
+              You&apos;re signed in as <span className="font-medium text-[#3c4043]">{accountLabel}</span>.
+            </p>
+          ) : null}
+          <div className="mt-8 flex justify-center">
+            <Link
+              href="/"
+              className="inline-flex h-9 items-center justify-center rounded-[4px] bg-[#1a73e8] px-6 text-[14px] font-medium text-white hover:bg-[#1765cc]"
+            >
+              Go to home
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function AccessPageGlyph({ large = false }: { large?: boolean }) {
+  const size = large ? 34 : 24;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M6 3.5h8l4 4V20a.5.5 0 0 1-.5.5h-11A.5.5 0 0 1 6 20V3.5Z"
+        fill="currentColor"
+      />
+      <path d="M14 3.5v4h4" fill="#a8c7fa" />
+      <path d="M9 11h6M9 14h6M9 17h4" stroke="white" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
   );
 }
 

--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -957,7 +957,7 @@ function TableEditorPageInner() {
   if (loading && !readOnly) return <TableEditorSkeleton />;
   if (!user && !readOnly) return null;
   if (!table && !error) {
-    if (!user) {
+    if (readOnly || !user) {
       return (
         <main className="flex min-h-screen flex-col bg-background">
           <TableEditorSkeleton />
@@ -1507,10 +1507,9 @@ function TableEditorPageInner() {
       </div>
   );
 
-  // Anonymous stash viewers don't have a workspace context to power the
-  // sidebar, so they get the bare table. Signed-in users see the full
-  // AppShell either way.
-  if (!user) {
+  // Stash-mode viewers are reading through the stash, not the workspace, so
+  // keep workspace chrome hidden even when they are signed in.
+  if (readOnly || !user) {
     return <main className="flex min-h-screen flex-col bg-background">{tableContent}</main>;
   }
   return (

--- a/frontend/src/app/tables/[tableId]/page.test.tsx
+++ b/frontend/src/app/tables/[tableId]/page.test.tsx
@@ -36,10 +36,15 @@ const api = vi.hoisted(() => ({
   backfillTableEmbeddings: vi.fn(),
 }));
 
+const route = vi.hoisted(() => ({
+  search: "workspaceId=ws-1",
+  push: vi.fn(),
+}));
+
 vi.mock("next/navigation", () => ({
   useParams: () => ({ tableId: "table-1" }),
-  useRouter: () => ({ push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams("workspaceId=ws-1"),
+  useRouter: () => ({ push: route.push }),
+  useSearchParams: () => new URLSearchParams(route.search),
 }));
 
 vi.mock("../../../hooks/useAuth", () => ({
@@ -58,7 +63,9 @@ vi.mock("../../../hooks/useAuth", () => ({
 }));
 
 vi.mock("../../../components/AppShell", () => ({
-  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
 }));
 
 vi.mock("../../../components/workspace/FileViewerHeader", () => ({
@@ -132,6 +139,8 @@ const createdRow = {
 describe("TableEditorPage row creation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    route.search = "workspaceId=ws-1";
+    route.push.mockClear();
     api.getTable.mockResolvedValue(table);
     api.createTableRow.mockResolvedValue(createdRow);
     api.summarizeTableRows.mockResolvedValue({ total_rows: 2, columns: {} });
@@ -179,6 +188,35 @@ describe("TableEditorPage row creation", () => {
       "table-1",
       expect.objectContaining({ offset: 2 }),
     );
+  });
+
+  it("renders stash-mode tables without the app shell for signed-in users", async () => {
+    route.search = "workspaceId=ws-1&stash=shared-stash";
+    api.getPublicCartridge.mockResolvedValue({
+      cartridge: {
+        id: "stash-1",
+        title: "Shared Stash",
+        workspace_id: "ws-1",
+      },
+      items: [
+        {
+          object_type: "table",
+          object_id: "table-1",
+          label: "Prospects",
+          inline: {
+            description: "",
+            columns: table.columns,
+            rows: [{ data: { name: "Alice" }, row_order: 0 }],
+          },
+        },
+      ],
+    });
+
+    render(<TableEditorPage />);
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-shell")).not.toBeInTheDocument();
+    expect(api.getTable).not.toHaveBeenCalled();
   });
 
   it("undoes a committed cell edit with command-z", async () => {


### PR DESCRIPTION
## Summary
- Render workspace item routes opened with `?stash=` without the signed-in app shell, so inaccessible Stash views do not show the sidebar or top-bar Share button.
- Show a full-screen “You don't have access to this page” state when the linked Stash cannot be read, using Stash design-system tokens while keeping the document-access-page structure.
- Apply bare-reader behavior to table Stash mode for signed-in viewers.
- Add regression coverage for app-group layout chrome, table Stash-mode rendering, and unreadable Stash page fallback.

## Validation
- `npm test -- PageClient.test.tsx`
- `npm test -- PageClient.test.tsx layout.test.tsx page.test.tsx`
- `npm test -- layout.test.tsx page.test.tsx Header.test.tsx AppShell.test.tsx`
- `npm run lint -- src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.test.tsx`
- Browser QA with local mock backend; opened a signed-in `/workspaces/ws-1/p/page-1?stash=private-stash` route and verified the full-screen access page rendered with no old page error, Stash aside, Share button, or sidebar.

## Screenshots
- [Stash-styled full-screen access denied page](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/f9e10a13-e702-4b86-baf4-a123f7def85b)
- [Previous bare reader chrome check](https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/8ea8334d-8336-4f0d-ba36-c97a6b09e4df)