### PR TITLE
[codex] Cap embedding text for worker stability

### DIFF
--- a/backend/services/embeddings/__init__.py
+++ b/backend/services/embeddings/__init__.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "BaseEmbedder",
+    "MAX_TEXT_CHARS",
+    "clip_text",
     "get_embedder",
     "set_embedder",
     "embed_text",
@@ -51,8 +53,13 @@ __all__ = [
 _MAX_ATTEMPTS = int(os.getenv("EMBEDDING_MAX_ATTEMPTS", "3"))
 _BASE_DELAY = float(os.getenv("EMBEDDING_RETRY_BASE_DELAY", "0.5"))
 _MAX_DELAY = float(os.getenv("EMBEDDING_RETRY_MAX_DELAY", "10.0"))
+MAX_TEXT_CHARS = 6_000
 
 _semaphore: asyncio.Semaphore | None = None
+
+
+def clip_text(text: str) -> str:
+    return text[:MAX_TEXT_CHARS]
 
 
 def _get_semaphore() -> asyncio.Semaphore:
@@ -104,6 +111,7 @@ async def _with_retry(coro_factory):
 async def embed_text(text: str) -> np.ndarray | None:
     """Embed a single text string."""
     embedder = get_embedder()
+    text = clip_text(text)
     try:
         return await _with_retry(lambda: embedder.embed_text(text))
     except TransientEmbeddingError:
@@ -140,6 +148,7 @@ async def embed_batch(texts: list[str]) -> list[np.ndarray] | None:
     don't blow up the embedding API."""
     if not texts:
         return []
+    texts = [clip_text(text) for text in texts]
     embedder = get_embedder()
     shards = _shard_by_chars(texts, _SHARD_CHAR_BUDGET)
     out: list[np.ndarray | None] = [None] * len(texts)

--- a/backend/services/embeddings/openai_compat.py
+++ b/backend/services/embeddings/openai_compat.py
@@ -14,10 +14,9 @@ from .base import BaseEmbedder, TransientEmbeddingError
 
 logger = logging.getLogger(__name__)
 
-# OpenAI-compatible endpoints cap each input at 8192 tokens. We approximate
-# ~4 chars/token (matching the batch-sharding budget) and clip at 30k chars
-# (~7500 tokens) so one oversize transcript doesn't fail the whole batch.
-_PER_INPUT_CHAR_CAP = 30_000
+# OpenAI-compatible endpoints cap each input at 8192 tokens. Logs, code, and
+# IDs can get close to one token per char, so keep a real margin.
+_PER_INPUT_CHAR_CAP = 6_000
 
 
 class OpenAICompatEmbedder(BaseEmbedder):

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -23,6 +23,7 @@ from ._celery_helpers import run_async
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 32
+TEXT_LIMIT = embedding_service.MAX_TEXT_CHARS
 
 
 def _text_hash(text: str) -> str:
@@ -32,9 +33,10 @@ def _text_hash(text: str) -> str:
 async def _reconcile_pages() -> int:
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT id, content_markdown FROM pages "
+        "SELECT id, LEFT(content_markdown, $2) AS content_markdown FROM pages "
         "WHERE embed_stale AND deleted_at IS NULL LIMIT $1",
         BATCH_SIZE,
+        TEXT_LIMIT,
     )
     if not rows:
         return 0
@@ -66,7 +68,9 @@ async def _reconcile_table_rows() -> int:
     texts = []
     hashes = []
     for r in rows:
-        text = _build_embedding_text(r["data"], r["embedding_config"], r["columns"])
+        text = embedding_service.clip_text(
+            _build_embedding_text(r["data"], r["embedding_config"], r["columns"])
+        )
         ids.append(r["id"])
         texts.append(text)
         hashes.append(_text_hash(text))
@@ -83,8 +87,9 @@ async def _reconcile_table_rows() -> int:
 async def _reconcile_history_events() -> int:
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT id, content FROM history_events WHERE embed_stale LIMIT $1",
+        "SELECT id, LEFT(content, $2) AS content FROM history_events WHERE embed_stale LIMIT $1",
         BATCH_SIZE,
+        TEXT_LIMIT,
     )
     if not rows:
         return 0
@@ -107,12 +112,13 @@ async def _reconcile_files() -> int:
     # off after embedding the text.
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT id, extracted_text FROM files "
+        "SELECT id, LEFT(extracted_text, $2) AS extracted_text FROM files "
         "WHERE embed_stale AND deleted_at IS NULL "
         "AND extraction_status = 'done' "
         "AND extracted_text IS NOT NULL AND extracted_text <> '' "
         "LIMIT $1",
         BATCH_SIZE,
+        TEXT_LIMIT,
     )
     if not rows:
         return 0
@@ -137,10 +143,11 @@ async def _reconcile_files() -> int:
 async def _reconcile_source_table(table: str) -> int:
     pool = get_pool()
     rows = await pool.fetch(
-        f"SELECT id, content FROM {table} "
+        f"SELECT id, LEFT(content, $2) AS content FROM {table} "
         f"WHERE embed_stale AND deleted_at IS NULL "
         f"AND content IS NOT NULL AND content <> '' LIMIT $1",
         BATCH_SIZE,
+        TEXT_LIMIT,
     )
     if not rows:
         return 0

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from backend.services import embeddings as embedding_service
+from backend.services.embeddings.base import BaseEmbedder
+from backend.services.embeddings.openai_compat import OpenAICompatEmbedder
+
+
+class CapturingEmbedder(BaseEmbedder):
+    name = "capturing"
+
+    def __init__(self):
+        self.batches: list[list[str]] = []
+
+    async def embed_batch(self, texts: list[str]) -> list[np.ndarray]:
+        self.batches.append(texts)
+        return [np.array([float(i)], dtype=np.float32) for i, _text in enumerate(texts)]
+
+
+@pytest.mark.asyncio
+async def test_embedding_wrapper_clips_texts_before_provider_call():
+    embedder = CapturingEmbedder()
+    embedding_service.set_embedder(embedder)
+
+    try:
+        vectors = await embedding_service.embed_batch(
+            ["x" * (embedding_service.MAX_TEXT_CHARS + 100), "short"]
+        )
+    finally:
+        await embedding_service.close()
+
+    assert vectors is not None
+    assert [len(text) for text in embedder.batches[0]] == [
+        embedding_service.MAX_TEXT_CHARS,
+        len("short"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedder_clips_inputs_before_http_request():
+    class FakeResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+
+        def json(self):
+            return {"data": [{"index": 0, "embedding": [1.0]}]}
+
+    class FakeClient:
+        def __init__(self):
+            self.payload = None
+
+        async def post(self, _url, *, headers, json):
+            self.payload = json
+            return FakeResponse()
+
+    client = FakeClient()
+    embedder = OpenAICompatEmbedder(api_key="test-key")
+    embedder._get_client = lambda: client
+
+    vectors = await embedder.embed_batch(["x" * (embedding_service.MAX_TEXT_CHARS + 100)])
+
+    assert vectors is not None
+    assert len(client.payload["input"][0]) == embedding_service.MAX_TEXT_CHARS


### PR DESCRIPTION
## What changed
- Cap embedding inputs at 6,000 characters through the shared embedding wrapper.
- Read only that capped prefix from large Celery reconciler text columns before allocating Python strings.
- Keep the OpenAI-compatible provider direct-call cap aligned with the shared wrapper.
- Add focused tests for wrapper and provider clipping.

## Root cause
Render was OOM-killing `stash-celery-worker` at its 512 MiB starter limit. The worker repeatedly ran `backend.tasks.embeddings.reconcile`, retried the same oversized stale rows every minute, and OpenAI rejected them with the 8192-token input limit. Because the rows stayed stale, memory climbed until Render killed the instance.

## Validation
- `pytest backend/tests/test_embeddings.py -q --no-cov`
- `ruff check backend/services/embeddings/__init__.py backend/services/embeddings/openai_compat.py backend/tasks/embeddings.py backend/tests/test_embeddings.py`

Note: `pytest backend/tests/test_embeddings.py -q` also passed the tests but failed the repo-wide coverage threshold because only one focused file was executed.