### PR TITLE
[codex] Redirect signed-in landing visitors to app

### DIFF
--- a/frontend/src/app/landing-auth-check/LandingAuthCheckClient.tsx
+++ b/frontend/src/app/landing-auth-check/LandingAuthCheckClient.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import {
+  allowedLandingParentOrigin,
+  landingAuthStatusMessage,
+} from "@/lib/landingAuthCheck";
+import { API_BASE, getToken } from "@/lib/api";
+
+const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
+
+export default function LandingAuthCheckClient() {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const parentOrigin = allowedLandingParentOrigin(searchParams.get("origin"));
+    if (!parentOrigin) return;
+    const targetOrigin = parentOrigin;
+
+    let cancelled = false;
+
+    async function postStatus() {
+      const signedIn = await hasStashSession();
+      if (cancelled) return;
+
+      window.parent.postMessage(landingAuthStatusMessage(signedIn), targetOrigin);
+    }
+
+    void postStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams]);
+
+  return null;
+}
+
+async function hasStashSession(): Promise<boolean> {
+  if (await hasApiKeySession()) return true;
+  if (await hasAuth0Session()) return true;
+  return false;
+}
+
+async function hasApiKeySession(): Promise<boolean> {
+  let token: string | null;
+  try {
+    token = getToken();
+  } catch {
+    return false;
+  }
+
+  if (!token) return false;
+
+  try {
+    const response = await fetch(`${API_BASE}/api/v1/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function hasAuth0Session(): Promise<boolean> {
+  if (!AUTH0_ENABLED) return false;
+
+  try {
+    const response = await fetch("/auth/profile", { credentials: "include" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/app/landing-auth-check/page.tsx
+++ b/frontend/src/app/landing-auth-check/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import LandingAuthCheckClient from "./LandingAuthCheckClient";
+
+export default function LandingAuthCheckPage() {
+  return (
+    <Suspense fallback={null}>
+      <LandingAuthCheckClient />
+    </Suspense>
+  );
+}

--- a/frontend/src/lib/landingAuthCheck.test.ts
+++ b/frontend/src/lib/landingAuthCheck.test.ts
@@ -1,0 +1,34 @@
+import {
+  allowedLandingParentOrigin,
+  landingAuthStatusMessage,
+  LANDING_AUTH_MESSAGE_TYPE,
+} from "./landingAuthCheck";
+
+describe("landing auth check", () => {
+  it("allows the production marketing origins", () => {
+    expect(allowedLandingParentOrigin("https://joinstash.ai")).toBe("https://joinstash.ai");
+    expect(allowedLandingParentOrigin("https://www.joinstash.ai/path")).toBe(
+      "https://www.joinstash.ai",
+    );
+  });
+
+  it("allows local marketing origins", () => {
+    expect(allowedLandingParentOrigin("http://localhost:3100")).toBe("http://localhost:3100");
+    expect(allowedLandingParentOrigin("http://127.0.0.1:3100")).toBe(
+      "http://127.0.0.1:3100",
+    );
+  });
+
+  it("rejects untrusted origins", () => {
+    expect(allowedLandingParentOrigin("https://evil.example")).toBeNull();
+    expect(allowedLandingParentOrigin("http://joinstash.ai")).toBeNull();
+    expect(allowedLandingParentOrigin("not a url")).toBeNull();
+  });
+
+  it("builds the postMessage payload", () => {
+    expect(landingAuthStatusMessage(true)).toEqual({
+      type: LANDING_AUTH_MESSAGE_TYPE,
+      signedIn: true,
+    });
+  });
+});

--- a/frontend/src/lib/landingAuthCheck.ts
+++ b/frontend/src/lib/landingAuthCheck.ts
@@ -1,0 +1,38 @@
+export const LANDING_AUTH_MESSAGE_TYPE = "stash:landing-auth-status";
+
+const LOCAL_MARKETING_ORIGINS = new Set([
+  "http://localhost:3100",
+  "http://127.0.0.1:3100",
+]);
+
+export function allowedLandingParentOrigin(value: string | null): string | null {
+  if (!value) return null;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (LOCAL_MARKETING_ORIGINS.has(url.origin)) {
+    return url.origin;
+  }
+
+  if (url.protocol !== "https:") {
+    return null;
+  }
+
+  if (url.hostname === "joinstash.ai" || url.hostname === "www.joinstash.ai") {
+    return url.origin;
+  }
+
+  return null;
+}
+
+export function landingAuthStatusMessage(signedIn: boolean) {
+  return {
+    type: LANDING_AUTH_MESSAGE_TYPE,
+    signedIn,
+  };
+}

--- a/www/app/_components/AppRedirectForSignedInUsers.tsx
+++ b/www/app/_components/AppRedirectForSignedInUsers.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+
+const LANDING_AUTH_MESSAGE_TYPE = "stash:landing-auth-status";
+
+type Props = {
+  appUrl: string;
+};
+
+export default function AppRedirectForSignedInUsers({ appUrl }: Props) {
+  useEffect(() => {
+    const check = buildAuthCheck(appUrl, window.location.origin);
+    if (!check) return;
+    const { origin, url } = check;
+
+    const iframe = document.createElement("iframe");
+    iframe.src = url;
+    iframe.hidden = true;
+    iframe.tabIndex = -1;
+    iframe.title = "";
+    iframe.setAttribute("aria-hidden", "true");
+
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== origin) return;
+      if (!isSignedInMessage(event.data)) return;
+
+      window.location.assign(appUrl);
+    }
+
+    window.addEventListener("message", onMessage);
+    document.body.appendChild(iframe);
+
+    return () => {
+      window.removeEventListener("message", onMessage);
+      iframe.remove();
+    };
+  }, [appUrl]);
+
+  return null;
+}
+
+function buildAuthCheck(appUrl: string, parentOrigin: string) {
+  let app: URL;
+  try {
+    app = new URL(appUrl);
+  } catch {
+    return null;
+  }
+
+  const checkUrl = new URL("/landing-auth-check", app.origin);
+  checkUrl.searchParams.set("origin", parentOrigin);
+
+  return {
+    origin: app.origin,
+    url: checkUrl.toString(),
+  };
+}
+
+function isSignedInMessage(data: unknown): boolean {
+  if (!data || typeof data !== "object") return false;
+
+  const message = data as { type?: unknown; signedIn?: unknown };
+  return message.type === LANDING_AUTH_MESSAGE_TYPE && message.signedIn === true;
+}

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
+import AppRedirectForSignedInUsers from "./_components/AppRedirectForSignedInUsers";
 import LiveDemo from "./_components/LiveDemo";
 import ScrollLink from "./_components/ScrollLink";
 import VisualizationsShowcase from "./_components/VisualizationsShowcase";
@@ -10,6 +11,7 @@ const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
 export default function Page() {
   return (
     <main className="min-h-screen bg-background text-foreground">
+      <AppRedirectForSignedInUsers appUrl={APP_URL} />
       <Nav />
       <Hero />
       <Logos />


### PR DESCRIPTION
## Summary
- Add a hidden landing-page auth probe that redirects signed-in visitors to `MANAGED_APP_URL`.
- Add an app-origin `/landing-auth-check` route that checks the existing Stash API key or Auth0 profile session, then posts back a boolean to trusted marketing origins.
- Keep signed-out visitors on the marketing page.

## Validation
- `npm test -- landingAuthCheck.test.ts`
- `npm run lint` in `frontend/`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build` in `frontend/` (passes with existing Next workspace-root warning)
- `npm run lint` in `www/` (passes with existing warnings in admin analytics, docs contributing, and unused landing components)
- `npm run build` in `www/`
- Playwright smoke test: signed-out stays on `localhost:3100`; signed-in app token redirects to app origin.

## Screenshot
- Signed-out landing page, no visible UI change: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/78af8f69-2b2a-419b-9592-21a05e1c4aed
