### PR TITLE
Support multiple Gmail accounts

### DIFF
--- a/backend/integrations/gmail/indexer.py
+++ b/backend/integrations/gmail/indexer.py
@@ -113,7 +113,7 @@ async def _upsert_message_metadata(source: dict, message: dict) -> str | None:
 async def index_gmail(source: dict) -> str | None:
     source_id = UUID(source["id"])
     owner_user_id = UUID(source["owner_user_id"])
-    token = await get_valid_token(owner_user_id, "gmail")
+    token = await get_valid_token(owner_user_id, "gmail", source["external_ref"])
 
     present: list[str] = []
     async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
@@ -133,7 +133,7 @@ async def index_gmail(source: dict) -> str | None:
 
 async def search_gmail(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
     owner_user_id = UUID(source["owner_user_id"])
-    token = await get_valid_token(owner_user_id, "gmail")
+    token = await get_valid_token(owner_user_id, "gmail", source["external_ref"])
 
     async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
         refs = await _list_message_refs(client, query, min(limit, SEARCH_LIMIT))
@@ -207,8 +207,8 @@ def _render_message(message: dict) -> str:
     return "\n".join(parts)
 
 
-async def fetch_gmail_content(owner_user_id: UUID, message_id: str) -> str:
-    token = await get_valid_token(owner_user_id, "gmail")
+async def fetch_gmail_content(owner_user_id: UUID, account_key: str, message_id: str) -> str:
+    token = await get_valid_token(owner_user_id, "gmail", account_key)
     async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
         resp = await client.get(
             MESSAGE_URL.format(message_id=message_id),

--- a/backend/integrations/granola/oauth.py
+++ b/backend/integrations/granola/oauth.py
@@ -220,12 +220,12 @@ async def _store_connection(user_id: UUID, token: dict, client: dict, account: d
     await pool.execute(
         """
         INSERT INTO user_integrations (
-            user_id, provider, access_token_encrypted, refresh_token_encrypted,
+            user_id, provider, account_key, access_token_encrypted, refresh_token_encrypted,
             scopes, expires_at, account_email, account_display_name,
             client_info, updated_at
         )
-        VALUES ($1, 'granola', $2, $3, $4, $5, $6, $7, $8, now())
-        ON CONFLICT (user_id, provider) DO UPDATE SET
+        VALUES ($1, 'granola', 'default', $2, $3, $4, $5, $6, $7, $8, now())
+        ON CONFLICT (user_id, provider, account_key) DO UPDATE SET
             access_token_encrypted = EXCLUDED.access_token_encrypted,
             refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, user_integrations.refresh_token_encrypted),
             scopes = EXCLUDED.scopes,
@@ -253,7 +253,8 @@ async def get_valid_access_token(user_id: UUID) -> str:
     row = await pool.fetchrow(
         """
         SELECT access_token_encrypted, refresh_token_encrypted, expires_at, client_info
-        FROM user_integrations WHERE user_id = $1 AND provider = 'granola'
+        FROM user_integrations
+        WHERE user_id = $1 AND provider = 'granola' AND account_key = 'default'
         """,
         user_id,
     )
@@ -291,6 +292,7 @@ async def get_valid_access_token(user_id: UUID) -> str:
             expires_at = $4,
             updated_at = now()
         WHERE user_id = $1 AND provider = 'granola'
+          AND account_key = 'default'
         """,
         user_id,
         f.encrypt(token["access_token"].encode()),

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -23,7 +23,7 @@ from uuid import UUID
 from cryptography.fernet import Fernet, InvalidToken
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
 from ..config import settings
@@ -79,6 +79,15 @@ def _safe_return_to(return_to: str | None) -> str | None:
     return return_to
 
 
+class IntegrationAccountItem(BaseModel):
+    account_key: str
+    account_email: str | None = None
+    account_display_name: str | None = None
+    scopes: list[str]
+    expires_at: str | None = None
+    connected_at: str | None = None
+
+
 class ProviderListItem(BaseModel):
     provider: str
     display_name: str
@@ -95,6 +104,7 @@ class ProviderListItem(BaseModel):
     account_display_name: str | None = None
     expires_at: str | None = None
     connected_at: str | None = None
+    accounts: list[IntegrationAccountItem] = Field(default_factory=list)
 
 
 class IntegrationsListResponse(BaseModel):
@@ -206,6 +216,7 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
                 account_display_name=conn["account_display_name"] if conn else None,
                 expires_at=conn["expires_at"] if conn else None,
                 connected_at=conn["connected_at"] if conn else None,
+                accounts=conn["accounts"] if conn else [],
             )
         )
     return IntegrationsListResponse(providers=items)

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -24,6 +24,7 @@ from .base import AccountInfo, TokenSet
 from .registry import get_provider
 
 _fernet: Fernet | None = None
+DEFAULT_ACCOUNT_KEY = "default"
 
 
 def _get_fernet() -> Fernet:
@@ -51,6 +52,25 @@ def _decrypt(ciphertext: bytes | None) -> str | None:
     return _get_fernet().decrypt(bytes(ciphertext)).decode()
 
 
+def _account_key_for(provider: str, account: AccountInfo) -> str:
+    if provider == "gmail":
+        if not account.email:
+            raise ValueError("Gmail account email is required")
+        return account.email.strip().lower()
+    return DEFAULT_ACCOUNT_KEY
+
+
+def _account_row(row) -> dict:
+    return {
+        "account_key": row["account_key"],
+        "account_email": row["account_email"],
+        "account_display_name": row["account_display_name"],
+        "scopes": list(row["scopes"] or []),
+        "expires_at": row["expires_at"].isoformat() if row["expires_at"] else None,
+        "connected_at": row["created_at"].isoformat() if row["created_at"] else None,
+    }
+
+
 async def store_token(
     user_id: UUID,
     provider: str,
@@ -58,17 +78,18 @@ async def store_token(
     account: AccountInfo,
 ) -> None:
     pool = get_pool()
+    account_key = _account_key_for(provider, account)
     await pool.execute(
         """
         INSERT INTO user_integrations (
-            user_id, provider,
+            user_id, provider, account_key,
             access_token_encrypted, refresh_token_encrypted,
             scopes, expires_at,
             account_email, account_display_name,
             updated_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
-        ON CONFLICT (user_id, provider) DO UPDATE SET
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+        ON CONFLICT (user_id, provider, account_key) DO UPDATE SET
             access_token_encrypted = EXCLUDED.access_token_encrypted,
             refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, user_integrations.refresh_token_encrypted),
             scopes = EXCLUDED.scopes,
@@ -79,6 +100,7 @@ async def store_token(
         """,
         user_id,
         provider,
+        account_key,
         _encrypt(token.access_token),
         _encrypt(token.refresh_token),
         token.scopes,
@@ -88,16 +110,22 @@ async def store_token(
     )
 
 
-async def get_valid_token(user_id: UUID, provider: str) -> str:
+async def get_valid_token(
+    user_id: UUID,
+    provider: str,
+    account_key: str = DEFAULT_ACCOUNT_KEY,
+) -> str:
     """Return a usable access token, refreshing if expired."""
     pool = get_pool()
     row = await pool.fetchrow(
         """
         SELECT access_token_encrypted, refresh_token_encrypted, expires_at, scopes
-        FROM user_integrations WHERE user_id = $1 AND provider = $2
+        FROM user_integrations
+        WHERE user_id = $1 AND provider = $2 AND account_key = $3
         """,
         user_id,
         provider,
+        account_key,
     )
     if row is None:
         raise HTTPException(
@@ -130,61 +158,76 @@ async def get_valid_token(user_id: UUID, provider: str) -> str:
             expires_at = $5,
             updated_at = now()
         WHERE user_id = $1 AND provider = $2
+          AND account_key = $6
         """,
         user_id,
         provider,
         _encrypt(new_token.access_token),
         _encrypt(new_token.refresh_token),
         new_token.expires_at,
+        account_key,
     )
     return new_token.access_token
 
 
-async def revoke_stored(user_id: UUID, provider: str) -> None:
+async def revoke_stored(
+    user_id: UUID,
+    provider: str,
+    account_key: str | None = None,
+) -> None:
     pool = get_pool()
-    row = await pool.fetchrow(
+    rows = await pool.fetch(
         "SELECT access_token_encrypted FROM user_integrations "
-        "WHERE user_id = $1 AND provider = $2",
+        "WHERE user_id = $1 AND provider = $2 "
+        "AND ($3::text IS NULL OR account_key = $3)",
         user_id,
         provider,
+        account_key,
     )
-    if row is None:
+    if not rows:
         return
-    access_token = _decrypt(row["access_token_encrypted"])
     provider_impl = get_provider(provider)
-    if access_token:
-        try:
-            await provider_impl.revoke(access_token)
-        except Exception:
-            # Provider may already consider the token invalid; we still
-            # delete our local copy so the user can reconnect cleanly.
-            pass
+    for row in rows:
+        access_token = _decrypt(row["access_token_encrypted"])
+        if access_token:
+            try:
+                await provider_impl.revoke(access_token)
+            except Exception:
+                # Provider may already consider the token invalid; we still
+                # delete our local copy so the user can reconnect cleanly.
+                pass
     await pool.execute(
-        "DELETE FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        "DELETE FROM user_integrations WHERE user_id = $1 AND provider = $2 "
+        "AND ($3::text IS NULL OR account_key = $3)",
         user_id,
         provider,
+        account_key,
     )
 
 
 async def status(user_id: UUID, provider: str) -> dict:
     pool = get_pool()
-    row = await pool.fetchrow(
+    rows = await pool.fetch(
         """
-        SELECT scopes, expires_at, account_email, account_display_name, created_at
+        SELECT account_key, scopes, expires_at, account_email, account_display_name, created_at
         FROM user_integrations WHERE user_id = $1 AND provider = $2
+        ORDER BY account_email NULLS LAST, account_display_name NULLS LAST, account_key
         """,
         user_id,
         provider,
     )
-    if row is None:
-        return {"connected": False}
+    if not rows:
+        return {"connected": False, "accounts": []}
+    accounts = [_account_row(row) for row in rows]
+    first = accounts[0]
     return {
         "connected": True,
-        "scopes": list(row["scopes"] or []),
-        "expires_at": row["expires_at"].isoformat() if row["expires_at"] else None,
-        "account_email": row["account_email"],
-        "account_display_name": row["account_display_name"],
-        "connected_at": row["created_at"].isoformat() if row["created_at"] else None,
+        "scopes": first["scopes"],
+        "expires_at": first["expires_at"],
+        "account_email": first["account_email"],
+        "account_display_name": first["account_display_name"],
+        "connected_at": first["connected_at"],
+        "accounts": accounts,
     }
 
 
@@ -192,20 +235,26 @@ async def list_connections(user_id: UUID) -> list[dict]:
     pool = get_pool()
     rows = await pool.fetch(
         """
-        SELECT provider, scopes, expires_at, account_email, account_display_name, created_at
+        SELECT provider, account_key, scopes, expires_at,
+               account_email, account_display_name, created_at
         FROM user_integrations WHERE user_id = $1
-        ORDER BY provider
+        ORDER BY provider, account_email NULLS LAST, account_display_name NULLS LAST, account_key
         """,
         user_id,
     )
-    return [
-        {
-            "provider": r["provider"],
-            "scopes": list(r["scopes"] or []),
-            "expires_at": r["expires_at"].isoformat() if r["expires_at"] else None,
-            "account_email": r["account_email"],
-            "account_display_name": r["account_display_name"],
-            "connected_at": r["created_at"].isoformat() if r["created_at"] else None,
-        }
-        for r in rows
-    ]
+    connections: dict[str, dict] = {}
+    for row in rows:
+        provider = row["provider"]
+        account = _account_row(row)
+        if provider not in connections:
+            connections[provider] = {
+                "provider": provider,
+                "scopes": account["scopes"],
+                "expires_at": account["expires_at"],
+                "account_email": account["account_email"],
+                "account_display_name": account["account_display_name"],
+                "connected_at": account["connected_at"],
+                "accounts": [],
+            }
+        connections[provider]["accounts"].append(account)
+    return list(connections.values())

--- a/backend/migrations/versions/0094_multi_account_integrations.py
+++ b/backend/migrations/versions/0094_multi_account_integrations.py
@@ -1,0 +1,55 @@
+"""Multi-account integration tokens.
+
+Revision ID: 0094
+Revises: 0093
+"""
+
+from alembic import op
+
+revision = "0094"
+down_revision = "0093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE user_integrations ADD COLUMN account_key text")
+    op.execute("""
+        UPDATE user_integrations
+        SET account_key = CASE
+            WHEN provider = 'gmail' THEN lower(account_email)
+            ELSE 'default'
+        END
+        """)
+    op.execute("ALTER TABLE user_integrations ALTER COLUMN account_key SET NOT NULL")
+
+    op.execute("""
+        UPDATE workspace_sources ws
+        SET external_ref = lower(ui.account_email),
+            display_name = 'Gmail (' || lower(ui.account_email) || ')',
+            updated_at = now()
+        FROM user_integrations ui
+        WHERE ws.owner_user_id = ui.user_id
+          AND ws.source_type = 'gmail'
+          AND ui.provider = 'gmail'
+        """)
+
+    op.execute("ALTER TABLE user_integrations DROP CONSTRAINT user_integrations_pkey")
+    op.execute("""
+        ALTER TABLE user_integrations
+        ADD PRIMARY KEY (user_id, provider, account_key)
+        """)
+    op.execute(
+        "CREATE INDEX user_integrations_user_provider_idx "
+        "ON user_integrations (user_id, provider)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS user_integrations_user_provider_idx")
+    op.execute("ALTER TABLE user_integrations DROP CONSTRAINT user_integrations_pkey")
+    op.execute("""
+        ALTER TABLE user_integrations
+        ADD PRIMARY KEY (user_id, provider)
+        """)
+    op.execute("ALTER TABLE user_integrations DROP COLUMN account_key")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -30,8 +30,8 @@ async def _require_member(workspace_id: UUID, user_id: UUID) -> None:
 
 class AddSourceRequest(BaseModel):
     source_type: str
-    # Optional for Slack/Granola — their workspace id + name are resolved from
-    # the connected token (the user can't easily supply them).
+    # Optional for sources where the connected account resolves the target. For
+    # Gmail, pass the account email when more than one mailbox is connected.
     external_ref: str | None = None
     display_name: str | None = None
 
@@ -54,12 +54,33 @@ async def _resolve_granola_source(user_id) -> tuple[str, str]:
     return "granola", "Granola"
 
 
-async def _resolve_gmail_source(user_id) -> tuple[str, str]:
-    """Gmail is one mailbox source per connected user."""
-    await integration_storage.get_valid_token(user_id, "gmail")
+async def _resolve_gmail_source(user_id, account_key: str | None) -> tuple[str, str]:
+    """Gmail source external_ref = the connected mailbox email."""
     status = await integration_storage.status(user_id, "gmail")
-    email = status.get("account_email")
-    return "me", f"Gmail ({email})" if email else "Gmail"
+    accounts = status.get("accounts", [])
+    if not accounts:
+        raise HTTPException(status_code=401, detail="not connected to gmail")
+
+    if not account_key:
+        if len(accounts) != 1:
+            raise HTTPException(status_code=400, detail="Choose a Gmail account to add.")
+        account = accounts[0]
+    else:
+        key = account_key.strip().lower()
+        account = next(
+            (
+                a
+                for a in accounts
+                if a["account_key"] == key or (a.get("account_email") or "").lower() == key
+            ),
+            None,
+        )
+        if account is None:
+            raise HTTPException(status_code=400, detail="Gmail account is not connected.")
+
+    email = account.get("account_email") or account["account_key"]
+    await integration_storage.get_valid_token(user_id, "gmail", account["account_key"])
+    return account["account_key"], f"Gmail ({email})"
 
 
 async def _resolve_gong_source(user_id) -> tuple[str, str]:
@@ -223,8 +244,8 @@ async def add_source(
     elif body.source_type == "granola" and not external_ref:
         external_ref, resolved_name = await _resolve_granola_source(current_user["id"])
         display_name = display_name or resolved_name
-    elif body.source_type == "gmail" and not external_ref:
-        external_ref, resolved_name = await _resolve_gmail_source(current_user["id"])
+    elif body.source_type == "gmail":
+        external_ref, resolved_name = await _resolve_gmail_source(current_user["id"], external_ref)
         display_name = display_name or resolved_name
     elif body.source_type == "gong_calls" and not external_ref:
         external_ref, resolved_name = await _resolve_gong_source(current_user["id"])

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -507,7 +507,7 @@ async def _delete_cartridge(args: dict) -> dict:
 #
 # One surface over every source: the two native sources (files, session
 # transcripts — workspace-scoped) and the user's own connected sources
-# (GitHub/Drive/Notion/Slack/Granola — user-scoped). Connected-source access
+# (GitHub/Drive/Gmail/Notion/Slack/Granola — user-scoped). Connected-source access
 # always goes through source_service.get_owned_source, which is the single
 # user-scoping guard.
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+from urllib.parse import quote
 from uuid import UUID
 
 from ..database import get_pool
@@ -443,9 +444,7 @@ async def read_document(source: dict, path: str) -> dict | None:
     )
     if not row:
         return None
-    content = await _lazy_fetch(
-        source["source_type"], UUID(source["owner_user_id"]), row["external_ref"]
-    )
+    content = await _lazy_fetch(source, row["external_ref"])
     return {
         "path": row["path"],
         "name": row["name"],
@@ -455,11 +454,13 @@ async def read_document(source: dict, path: str) -> dict | None:
     }
 
 
-async def _lazy_fetch(source_type: str, owner_user_id: UUID, external_ref: str | None) -> str:
+async def _lazy_fetch(source: dict, external_ref: str | None) -> str:
     """Fetch an index-only document's body from the provider. Local import keeps
     the integration indexers (which import this module) free of a cycle."""
     if not external_ref:
         return ""
+    source_type = source["source_type"]
+    owner_user_id = UUID(source["owner_user_id"])
     if source_type == "google_drive":
         from ..integrations.google.indexer import fetch_drive_content
 
@@ -467,7 +468,7 @@ async def _lazy_fetch(source_type: str, owner_user_id: UUID, external_ref: str |
     if source_type == "gmail":
         from ..integrations.gmail.indexer import fetch_gmail_content
 
-        return await fetch_gmail_content(owner_user_id, external_ref)
+        return await fetch_gmail_content(owner_user_id, source["external_ref"], external_ref)
     if source_type == "jira_project":
         from ..integrations.jira.indexer import fetch_jira_content
 
@@ -707,7 +708,8 @@ def source_document_url(
             return link
         return f"https://drive.google.com/file/d/{path}/view"
     if source_type == "gmail":
-        return f"https://mail.google.com/mail/u/0/#all/{path}"
+        mailbox = quote(external_ref or "0", safe="")
+        return f"https://mail.google.com/mail/u/{mailbox}/#all/{path}"
     # slack, granola, gong_calls: deep link TODO — needs team domain / note url / gong subdomain.
     return None
 
@@ -766,9 +768,11 @@ async def _deep_link(source: dict, doc: dict) -> str | None:
         return source_document_url("github_repo", source["external_ref"], doc["path"])
     if source_type == "asana_project":
         return source_document_url("asana_project", None, doc["path"])
-    if source_type in ("notion", "google_drive", "gmail"):
+    if source_type in ("notion", "google_drive"):
         # The page/file id lives on the document row, not the source row.
         return source_document_url(source_type, None, doc_ref or doc["path"])
+    if source_type == "gmail":
+        return source_document_url(source_type, source["external_ref"], doc_ref or doc["path"])
     if source_type == "jira_project":
         from ..integrations.jira.indexer import site_url
 

--- a/backend/tests/test_gmail_multi_account.py
+++ b/backend/tests/test_gmail_multi_account.py
@@ -1,0 +1,109 @@
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.integrations import storage
+from backend.integrations.base import AccountInfo, TokenSet
+
+from .conftest import unique_name
+
+TEST_FERNET_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("gmail"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _create_workspace(client: AsyncClient, api_key: str) -> UUID:
+    resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": unique_name("gmail_ws")},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return UUID(resp.json()["id"])
+
+
+async def _store_gmail(user_id: UUID, email: str, access_token: str) -> None:
+    await storage.store_token(
+        user_id,
+        "gmail",
+        TokenSet(
+            access_token=access_token,
+            refresh_token=f"refresh-{access_token}",
+            expires_at=None,
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        ),
+        AccountInfo(email=email, display_name=email),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _integration_encryption(monkeypatch):
+    monkeypatch.setattr(storage.settings, "INTEGRATIONS_ENCRYPTION_KEY", TEST_FERNET_KEY)
+    monkeypatch.setattr(storage, "_fernet", None)
+
+
+@pytest.mark.asyncio
+async def test_gmail_tokens_are_keyed_by_mailbox(client: AsyncClient):
+    _, user_id = await _register(client)
+
+    await _store_gmail(user_id, "htdowling@gmail.com", "token-personal")
+    await _store_gmail(user_id, "henry@joinstash.ai", "token-work")
+
+    status = await storage.status(user_id, "gmail")
+
+    assert status["connected"]
+    assert {a["account_key"] for a in status["accounts"]} == {
+        "htdowling@gmail.com",
+        "henry@joinstash.ai",
+    }
+    assert (
+        await storage.get_valid_token(user_id, "gmail", "htdowling@gmail.com") == "token-personal"
+    )
+    assert await storage.get_valid_token(user_id, "gmail", "henry@joinstash.ai") == "token-work"
+
+
+@pytest.mark.asyncio
+async def test_gmail_sources_target_specific_mailboxes(client: AsyncClient):
+    api_key, user_id = await _register(client)
+    workspace_id = await _create_workspace(client, api_key)
+    await _store_gmail(user_id, "htdowling@gmail.com", "token-personal")
+    await _store_gmail(user_id, "henry@joinstash.ai", "token-work")
+
+    ambiguous = await client.post(
+        f"/api/v1/workspaces/{workspace_id}/sources",
+        json={"source_type": "gmail"},
+        headers=_auth(api_key),
+    )
+    assert ambiguous.status_code == 400
+    assert ambiguous.json()["detail"] == "Choose a Gmail account to add."
+
+    for email in ("htdowling@gmail.com", "henry@joinstash.ai"):
+        added = await client.post(
+            f"/api/v1/workspaces/{workspace_id}/sources",
+            json={"source_type": "gmail", "external_ref": email},
+            headers=_auth(api_key),
+        )
+        assert added.status_code == 200
+        assert added.json()["external_ref"] == email
+        assert added.json()["display_name"] == f"Gmail ({email})"
+
+    listing = await client.get(f"/api/v1/workspaces/{workspace_id}/sources", headers=_auth(api_key))
+    gmail_sources = [s for s in listing.json()["sources"] if s["type"] == "gmail"]
+
+    assert {s["external_ref"] for s in gmail_sources} == {
+        "htdowling@gmail.com",
+        "henry@joinstash.ai",
+    }

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -150,8 +150,8 @@ def test_gmail_is_readonly_searchable_source():
     assert source_service.SOURCE_TABLE["gmail"] == "gmail_index"
     assert "gmail" in source_tasks.INDEXERS
     assert (
-        source_service.source_document_url("gmail", None, "msg-123")
-        == "https://mail.google.com/mail/u/0/#all/msg-123"
+        source_service.source_document_url("gmail", "henry@joinstash.ai", "msg-123")
+        == "https://mail.google.com/mail/u/henry%40joinstash.ai/#all/msg-123"
     )
 
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2870,9 +2870,11 @@ def sources_ls(
 @sources_app.command("add")
 def sources_add(
     source_type: str = typer.Argument(
-        ..., help="github_repo | google_drive | notion | slack | granola"
+        ..., help="github_repo | google_drive | gmail | notion | slack | granola"
     ),
-    ref: str = typer.Option("", "--ref", help="external_ref, e.g. a repo 'owner/name'."),
+    ref: str = typer.Option(
+        "", "--ref", help="external_ref, e.g. a repo 'owner/name' or Gmail address."
+    ),
     name: str = typer.Option("", "--name", help="Display name."),
     workspace_id: str = typer.Option(None, "--ws"),
     as_json: bool = typer.Option(False, "--json"),

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -35,7 +35,7 @@ def _json(obj: object) -> str:
 @mcp.tool()
 def stash_search(query: str, source: str = "", limit: int = 20, workspace_id: str = "") -> str:
     """Search across all your sources — native files + session transcripts +
-    connected sources (GitHub/Drive/Notion/Slack/Granola).
+    connected sources (GitHub/Drive/Gmail/Notion/Slack/Granola).
 
     Pass `source` to scope to one (a handle from stash_list_sources: 'files',
     'sessions', or a connected-source id); omit it to search everything.
@@ -80,9 +80,9 @@ def stash_add_source(
     display_name: str = "",
     workspace_id: str = "",
 ) -> str:
-    """Connect a source. source_type: github_repo | google_drive | notion |
-    slack | granola. Slack/Granola resolve external_ref from your connected
-    token; the rest need an external_ref (e.g. a repo 'owner/name')."""
+    """Connect a source. source_type: github_repo | google_drive | gmail |
+    notion | slack | granola. Slack/Granola resolve external_ref from your
+    connected token; Gmail uses the mailbox email as external_ref."""
     client, default_ws = _client()
     ws = _require_ws(workspace_id or default_ws)
     return _json(

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
@@ -100,7 +100,8 @@ export default function IntegrationPage() {
   }
 
   const connected = !!status?.connected;
-  const account = status?.account_email || status?.account_display_name;
+  const account = connectedAccountLabel(status);
+  const canConnectAnother = connected && connector.provider === "gmail" && status?.auth_kind !== "api_key";
 
   async function connect() {
     setBusy("connect");
@@ -192,18 +193,29 @@ export default function IntegrationPage() {
           <div className="ml-auto flex items-center gap-3.5">
             {connected && account && (
               <span className="text-[12.5px] text-muted">
-                Connected as <b className="font-semibold text-foreground">{account}</b>
+                {account}
               </span>
             )}
             {connected ? (
-              <button
-                type="button"
-                onClick={() => void disconnect()}
-                disabled={busy === "disconnect"}
-                className="rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-foreground disabled:opacity-60"
-              >
-                {busy === "disconnect" ? "Disconnecting..." : "Disconnect"}
-              </button>
+              <>
+                {canConnectAnother && (
+                  <button type="button" onClick={() => void connect()} disabled={busy === "connect"} className={secondaryButton()}>
+                    {busy === "connect" ? "Connecting..." : "Connect another"}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void disconnect()}
+                  disabled={busy === "disconnect"}
+                  className="rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-foreground disabled:opacity-60"
+                >
+                  {busy === "disconnect"
+                    ? "Disconnecting..."
+                    : connector.provider === "gmail" && (status?.accounts.length ?? 0) > 1
+                    ? "Disconnect all"
+                    : "Disconnect"}
+                </button>
+              </>
             ) : status?.auth_kind === "api_key" ? (
               <button
                 type="button"
@@ -251,6 +263,8 @@ export default function IntegrationPage() {
               connector={connector}
               workspaceId={workspaceId}
               connected={connected}
+              accounts={status?.accounts ?? []}
+              existingRefs={sources.map((source) => source.external_ref).filter((ref): ref is string => Boolean(ref))}
               onAdded={() => void refresh()}
             />
           </section>
@@ -298,6 +312,13 @@ export default function IntegrationPage() {
       </div>
     </div>
   );
+}
+
+function connectedAccountLabel(status: IntegrationStatus | null): string | null {
+  if (!status?.connected) return null;
+  if (status.accounts.length > 1) return `${status.accounts.length} accounts connected`;
+  const account = status.account_email || status.account_display_name;
+  return account ? `Connected as ${account}` : "Connected";
 }
 
 // The uppercase section label that runs above each block, per the mock.

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -156,7 +156,7 @@ export default function AppSidebar({
   const [spines, setSpines] = useState<Record<string, WorkspaceSidebar>>(() =>
     readCachedSidebars()
   );
-  // Connected sources (GitHub/Drive/Notion/Slack/Granola) for the active
+  // Connected sources (GitHub/Drive/Gmail/Notion/Slack/Granola) for the active
   // workspace, keyed by workspace id. User-scoped — only the viewer's own.
   const [sourceMap, setSourceMap] = useState<Record<string, WorkspaceSource[]>>({});
 

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -110,9 +110,7 @@ export default function SourceConnectorList({
               <div className="min-w-0 flex-1">
                 <div className="text-[13.5px] font-medium text-foreground">{connector.label}</div>
                 <div className="truncate text-[11.5px] text-muted">
-                  {connected && (status?.account_email || status?.account_display_name)
-                    ? `Connected as ${status.account_email || status.account_display_name}`
-                    : connector.blurb}
+                  {connected ? connectedLabel(status) : connector.blurb}
                 </div>
               </div>
               <div className="flex shrink-0 items-center gap-2">
@@ -158,6 +156,14 @@ export default function SourceConnectorList({
       )}
     </div>
   );
+}
+
+function connectedLabel(status: IntegrationStatus | undefined): string {
+  const accounts = status?.accounts ?? [];
+  if (accounts.length > 1) return `${accounts.length} accounts connected`;
+  const account = status?.account_email || status?.account_display_name;
+  if (account) return `Connected as ${account}`;
+  return "Connected";
 }
 
 function ConnectorAction({

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 
 import { addWorkspaceSource } from "@/lib/api";
 import {
+  type IntegrationAccount,
   listAsanaProjects,
   listGitHubRepos,
   listJiraProjects,
@@ -33,11 +34,15 @@ export function AddSourceControls({
   connector,
   workspaceId,
   connected,
+  accounts = [],
+  existingRefs = [],
   onAdded,
 }: {
   connector: Connector;
   workspaceId: string;
   connected: boolean;
+  accounts?: IntegrationAccount[];
+  existingRefs?: string[];
   onAdded: () => void;
 }) {
   const [busy, setBusy] = useState(false);
@@ -131,7 +136,39 @@ export function AddSourceControls({
     );
   }
 
-  // kind "auto" — gmail/slack/granola/gong/snowflake. The backend resolves the ref.
+  if (connector.provider === "gmail") {
+    return (
+      <div className="space-y-2">
+        {accounts.length === 0 ? (
+          <div className="text-[11.5px] text-muted">Connect Gmail first to add a mailbox.</div>
+        ) : (
+          accounts.map((account) => {
+            const label = account.account_email || account.account_display_name || account.account_key;
+            const added = existingRefs.includes(account.account_key);
+            return (
+              <div key={account.account_key} className="flex items-center gap-3 rounded-lg border border-border px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium text-foreground">{label}</div>
+                  <div className="text-[11.5px] text-muted">Mailbox</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void add({ external_ref: account.account_key, display_name: `Gmail (${label})` })}
+                  disabled={busy || added}
+                  className={secondaryButton()}
+                >
+                  {added ? "Added" : busy ? "Adding..." : "Add"}
+                </button>
+              </div>
+            );
+          })
+        )}
+        {errorRow}
+      </div>
+    );
+  }
+
+  // kind "auto" — slack/granola/gong/snowflake. The backend resolves the ref.
   return (
     <div className="space-y-2">
       {!connected && (

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -29,6 +29,15 @@ export type CredentialField = {
   help?: string;
 };
 
+export type IntegrationAccount = {
+  account_key: string;
+  account_email: string | null;
+  account_display_name: string | null;
+  scopes: string[];
+  expires_at: string | null;
+  connected_at: string | null;
+};
+
 export type IntegrationStatus = {
   provider: string;
   display_name: string;
@@ -40,6 +49,7 @@ export type IntegrationStatus = {
   account_display_name: string | null;
   expires_at: string | null;
   connected_at: string | null;
+  accounts: IntegrationAccount[];
   // "oauth" (redirect flow), "mcp_oauth" (DCR+PKCE via an MCP server, e.g.
   // Granola), or "api_key" (pasted credentials, e.g. Gong).
   auth_kind: "oauth" | "mcp_oauth" | "api_key";

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -348,10 +348,10 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       <CommandRef
         command="stash sources add"
         args="<source_type> [--ref REF] [--name NAME]"
-        description="Connect a source. Slack and Granola resolve their reference from your connected token; the others need a --ref (e.g. a repo 'owner/name')."
+        description="Connect a source. Slack and Granola resolve their reference from your connected token; Gmail uses the mailbox email as --ref; the others need a --ref (e.g. a repo 'owner/name')."
         params={[
-          { name: "<source_type>", type: "string", desc: "github_repo | google_drive | notion | slack | granola.", required: true },
-          { name: "--ref", type: "string", desc: "External reference, e.g. a repo 'owner/name'." },
+          { name: "<source_type>", type: "string", desc: "github_repo | google_drive | gmail | notion | slack | granola.", required: true },
+          { name: "--ref", type: "string", desc: "External reference, e.g. a repo 'owner/name' or Gmail address." },
           { name: "--name", type: "string", desc: "Display name for the source." },
           { name: "--ws", type: "string", desc: "Workspace ID override." },
         ]}


### PR DESCRIPTION
## Summary
- Add `account_key` to integration token storage so Gmail can store one OAuth token per mailbox.
- Key Gmail workspace sources by mailbox email instead of the old `me` ref, so multiple Gmail accounts can be added to the same workspace.
- Update Gmail search/read/sync to use the mailbox-specific token and Gmail deep links to point at the matching mailbox.
- Update the Gmail integration UI to show multiple connected accounts, allow connecting another Gmail account, and add each mailbox separately.
- Update CLI/MCP/docs help to include Gmail source refs.

## Visual Check
- Gmail multi-account UI: https://app.joinstash.ai/workspaces/24a2d68b-a549-436b-9091-96c0a32acc56/f/f053f3ac-8974-431b-9544-a23344a9d8a3

## Verification
- `ruff check backend cli`
- `black --check backend/integrations/storage.py backend/integrations/router.py backend/routers/sources.py backend/integrations/gmail/indexer.py backend/integrations/granola/oauth.py backend/services/source_service.py backend/tests/test_gmail_multi_account.py`
- `pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm test -- --run`
- `cd frontend && BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- `cd www && npm run lint` (passes with existing warnings)
- `cd www && npm run build`

## Notes
- `ruff check .` still reports unrelated pre-existing lint in `powerpoint-mcp/` and `plugins/tests/`; the changed backend/CLI files pass `ruff check backend cli`.
