### PR TITLE
Add Slack agent (talk-to-Stash bot)

### DIFF
--- a/backend/integrations/slack/agent.py
+++ b/backend/integrations/slack/agent.py
@@ -1,0 +1,75 @@
+"""Slack agent (talk-to-Stash bot) — turn a Slack mention/DM into an agent run.
+
+This is the seam where the Slack surface meets the existing agent: it resolves
+the Slack user to a Stash account, runs the workspace agent in that user's
+single continuous Slack session, and posts the reply back. Everything agent-
+side (tool_loop, tools, memory, scoping) is reused unchanged.
+
+REMOVAL: this module + installs.py + client.py + the provider bot-token
+capture + the webhook agent branch + the respond_to_slack_mention Celery task
++ the slack_bot_installs table are the whole feature. Delete them to drop it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from ...services import ask_service, user_service, workspace_service
+from . import client, installs
+
+logger = logging.getLogger(__name__)
+
+# Slack renders mentions as <@U123>; strip the bot's own token from the prompt.
+_MENTION_RE = re.compile(r"<@[A-Z0-9]+>")
+
+_NO_ACCOUNT_MSG = (
+    "I couldn't match your Slack email to a Stash account. "
+    "Make sure your Stash account uses the same email as Slack."
+)
+
+
+def _strip_mentions(text: str) -> str:
+    return _MENTION_RE.sub("", text).strip()
+
+
+async def respond_to_mention(team_id: str, event: dict) -> None:
+    install = await installs.get_install(team_id)
+    if install is None:
+        logger.info("slack agent: no bot install for team %s", team_id)
+        return
+
+    bot_token = install["bot_token"]
+    slack_user_id = event.get("user")
+    channel = event.get("channel")
+    # Keep the conversation in-thread (fall back to the message ts itself).
+    thread_ts = event.get("thread_ts") or event.get("ts")
+    text = _strip_mentions(event.get("text") or "")
+    if not slack_user_id or not channel or not text:
+        return
+
+    email = await client.get_user_email(bot_token, slack_user_id)
+    user = await user_service.get_user_by_email(email) if email else None
+    if user is None:
+        await client.post_message(bot_token, channel, _NO_ACCOUNT_MSG, thread_ts)
+        return
+
+    workspace_id = await workspace_service.get_primary_for_user(user["id"])
+    if workspace_id is None:
+        spaces = await workspace_service.list_user_workspaces(user["id"])
+        workspace_id = spaces[0]["id"] if spaces else None
+    if workspace_id is None:
+        await client.post_message(
+            bot_token, channel, "You don't have a Stash workspace yet.", thread_ts
+        )
+        return
+
+    workspace = await workspace_service.get_workspace(workspace_id)
+    # One continuous session per user → memory accumulates across DMs/channels/time.
+    session_id = f"slack-agent-{user['id']}"
+    answer = await ask_service.run_chat(
+        workspace_id, workspace["name"], user["id"], session_id, text
+    )
+    await client.post_message(
+        bot_token, channel, answer or "(I didn't produce a response.)", thread_ts
+    )

--- a/backend/integrations/slack/client.py
+++ b/backend/integrations/slack/client.py
@@ -1,0 +1,44 @@
+"""Slack agent (talk-to-Stash bot) — outbound Slack Web API calls.
+
+Mirrors the httpx pattern in indexer.py but for the bot token: post replies
+and resolve a Slack user's email. Part of the removable Slack-agent feature.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+USERS_INFO_URL = "https://slack.com/api/users.info"
+
+
+async def post_message(
+    bot_token: str, channel: str, text: str, thread_ts: str | None = None
+) -> None:
+    payload: dict = {"channel": channel, "text": text}
+    if thread_ts:
+        payload["thread_ts"] = thread_ts
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(
+            POST_MESSAGE_URL,
+            headers={"Authorization": f"Bearer {bot_token}"},
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"Slack chat.postMessage error: {data.get('error')}")
+
+
+async def get_user_email(bot_token: str, slack_user_id: str) -> str | None:
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            USERS_INFO_URL,
+            headers={"Authorization": f"Bearer {bot_token}"},
+            params={"user": slack_user_id},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"Slack users.info error: {data.get('error')}")
+    return ((data.get("user") or {}).get("profile") or {}).get("email")

--- a/backend/integrations/slack/installs.py
+++ b/backend/integrations/slack/installs.py
@@ -1,0 +1,56 @@
+"""Slack agent (talk-to-Stash bot) — team bot-token storage.
+
+One row per Slack team in `slack_bot_installs`. The bot token lets the agent
+post replies (chat.postMessage) and resolve user emails (users.info). Tokens
+are encrypted at rest with the same Fernet key as user_integrations.
+
+This module is part of the removable Slack-agent feature: delete the
+slack/ agent files + the slack_bot_installs table to drop it entirely.
+"""
+
+from __future__ import annotations
+
+from ...database import get_pool
+from ..storage import _decrypt, _encrypt
+
+
+async def store_install(
+    *,
+    team_id: str,
+    bot_token: str,
+    bot_user_id: str | None = None,
+    installed_by_user_id=None,
+) -> None:
+    pool = get_pool()
+    await pool.execute(
+        """
+        INSERT INTO slack_bot_installs (
+            team_id, bot_token_encrypted, bot_user_id, installed_by_user_id, updated_at
+        )
+        VALUES ($1, $2, $3, $4, now())
+        ON CONFLICT (team_id) DO UPDATE SET
+            bot_token_encrypted = EXCLUDED.bot_token_encrypted,
+            bot_user_id = EXCLUDED.bot_user_id,
+            installed_by_user_id = COALESCE(EXCLUDED.installed_by_user_id, slack_bot_installs.installed_by_user_id),
+            updated_at = now()
+        """,
+        team_id,
+        _encrypt(bot_token),
+        bot_user_id,
+        installed_by_user_id,
+    )
+
+
+async def get_install(team_id: str) -> dict | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT team_id, bot_token_encrypted, bot_user_id FROM slack_bot_installs WHERE team_id = $1",
+        team_id,
+    )
+    if row is None:
+        return None
+    return {
+        "team_id": row["team_id"],
+        "bot_token": _decrypt(row["bot_token_encrypted"]),
+        "bot_user_id": row["bot_user_id"],
+    }

--- a/backend/integrations/slack/provider.py
+++ b/backend/integrations/slack/provider.py
@@ -36,6 +36,23 @@ USER_SCOPES = [
     "users:read",
 ]
 
+# --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+# Bot scopes requested in the same install so we also receive a team bot
+# token. They power the conversational agent (mentions/DMs → reply), separate
+# from the user-token ingest above. To drop the Slack agent: remove these
+# scopes, the `scope=` param in authorize_url, and the install capture in
+# exchange_code (plus integrations/slack/{installs,client,agent}.py).
+BOT_SCOPES = [
+    "app_mentions:read",  # receive @mentions
+    "chat:write",  # post replies
+    "im:history",  # read DMs to the bot
+    "im:read",
+    "im:write",  # open/post DMs
+    "users:read",
+    "users:read.email",  # resolve Slack user → email → Stash account
+]
+# --- END Slack agent ---
+
 
 class SlackIntegration(Integration):
     name = "slack"
@@ -62,6 +79,8 @@ class SlackIntegration(Integration):
         params = {
             "client_id": self._client_id(),
             "user_scope": " ".join(self.scopes),
+            # Slack agent: `scope` requests bot scopes → install yields a bot token too.
+            "scope": " ".join(BOT_SCOPES),
             "redirect_uri": self._redirect_uri(),
             "state": state,
         }
@@ -82,6 +101,23 @@ class SlackIntegration(Integration):
             payload = resp.json()
         if not payload.get("ok"):
             raise RuntimeError(f"Slack OAuth error: {payload.get('error')}")
+
+        # --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+        # The same install yields a team bot token at top-level `access_token`
+        # (present only because we request bot `scope`). Store it so the agent
+        # can post replies. Failure here must not block the user-token connect.
+        from . import installs
+
+        bot_token = payload.get("access_token")
+        team_id = (payload.get("team") or {}).get("id")
+        if bot_token and team_id:
+            await installs.store_install(
+                team_id=team_id,
+                bot_token=bot_token,
+                bot_user_id=payload.get("bot_user_id"),
+            )
+        # --- END Slack agent ---
+
         authed_user = payload.get("authed_user") or {}
         user_token = authed_user.get("access_token")
         if not user_token:

--- a/backend/migrations/versions/0094_slack_bot_installs.py
+++ b/backend/migrations/versions/0094_slack_bot_installs.py
@@ -1,0 +1,34 @@
+"""Add slack_bot_installs — team bot tokens for the Slack agent.
+
+The Slack agent (talk-to-Stash bot) posts replies with a team-scoped bot
+token, captured during OAuth alongside the existing user token. One row per
+Slack team. This whole table belongs to the removable Slack-agent feature.
+
+Revision ID: 0094
+Revises: 0093
+"""
+
+from alembic import op
+
+revision = "0094"
+down_revision = "0093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE slack_bot_installs (
+            team_id              text PRIMARY KEY,
+            bot_token_encrypted  bytea NOT NULL,
+            bot_user_id          text,
+            installed_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+            updated_at           timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS slack_bot_installs")

--- a/backend/migrations/versions/0095_slack_bot_installs.py
+++ b/backend/migrations/versions/0095_slack_bot_installs.py
@@ -4,21 +4,20 @@ The Slack agent (talk-to-Stash bot) posts replies with a team-scoped bot
 token, captured during OAuth alongside the existing user token. One row per
 Slack team. This whole table belongs to the removable Slack-agent feature.
 
-Revision ID: 0094
-Revises: 0093
+Revision ID: 0095
+Revises: 0094
 """
 
 from alembic import op
 
-revision = "0094"
-down_revision = "0093"
+revision = "0095"
+down_revision = "0094"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         CREATE TABLE slack_bot_installs (
             team_id              text PRIMARY KEY,
             bot_token_encrypted  bytea NOT NULL,
@@ -26,8 +25,7 @@ def upgrade() -> None:
             installed_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
             updated_at           timestamptz NOT NULL DEFAULT now()
         )
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -55,6 +55,8 @@ def _is_agent_trigger(event: dict) -> bool:
     if event.get("type") == "app_mention":
         return True
     return event.get("type") == "message" and event.get("channel_type") == "im"
+
+
 # --- END Slack agent ---
 
 

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -11,6 +11,7 @@ import hashlib
 import hmac
 import time
 
+import redis.asyncio as aioredis
 from fastapi import APIRouter, HTTPException, Request
 
 from ..celery_app import celery
@@ -20,6 +21,41 @@ router = APIRouter(prefix="/api/v1/integrations", tags=["webhooks"])
 
 # Reject replays / stale deliveries beyond Slack's recommended 5-minute window.
 SLACK_MAX_SKEW_S = 60 * 5
+
+
+# --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+# Slack delivers events at-least-once (retries on any non-200/slow ack), so we
+# dedupe on event_id before enqueuing an agent reply — otherwise a retry makes
+# the bot answer the same question twice.
+_redis: aioredis.Redis | None = None
+_SLACK_EVENT_TTL_S = 60 * 10
+
+
+def _get_redis() -> aioredis.Redis:
+    global _redis
+    if _redis is None:
+        _redis = aioredis.from_url(settings.REDIS_URL)
+    return _redis
+
+
+async def _already_handled(event_id: str | None) -> bool:
+    if not event_id:
+        return False
+    # SET NX returns True only the first time we see this event_id.
+    first = await _get_redis().set(f"slack:evt:{event_id}", "1", nx=True, ex=_SLACK_EVENT_TTL_S)
+    return not first
+
+
+def _is_agent_trigger(event: dict) -> bool:
+    """True for messages the agent should reply to: @mentions and DMs to the
+    bot. Loop guard: never react to the bot's own posts (bot_id) or to
+    edits/deletes/joins (subtype). Plain channel messages are ingest-only."""
+    if event.get("bot_id") or event.get("subtype"):
+        return False
+    if event.get("type") == "app_mention":
+        return True
+    return event.get("type") == "message" and event.get("channel_type") == "im"
+# --- END Slack agent ---
 
 
 def _verify_slack_signature(timestamp: str, body: bytes, signature: str) -> bool:
@@ -54,9 +90,23 @@ async def slack_events(request: Request):
 
     if payload.get("type") == "event_callback":
         event = payload.get("event") or {}
-        if event.get("type") == "message":
+        team_id = payload.get("team_id")
+
+        # --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+        if _is_agent_trigger(event):
+            if not await _already_handled(payload.get("event_id")):
+                celery.send_task(
+                    "backend.tasks.sources.respond_to_slack_mention",
+                    kwargs={"team_id": team_id, "event": event},
+                )
+            return {"ok": True}
+        # --- END Slack agent ---
+
+        # Plain channel messages → existing search ingest (DMs to the bot and
+        # @mentions are handled by the agent branch above, not indexed).
+        if event.get("type") == "message" and event.get("channel_type") != "im":
             celery.send_task(
                 "backend.tasks.sources.ingest_slack_event",
-                kwargs={"team_id": payload.get("team_id"), "event": event},
+                kwargs={"team_id": team_id, "event": event},
             )
     return {"ok": True}

--- a/backend/services/ask_service.py
+++ b/backend/services/ask_service.py
@@ -46,8 +46,14 @@ async def stream_ask(
         yield _sse(event)
 
 
-async def _load_history(workspace_id: UUID, session_id: str, user_id: UUID) -> list[dict]:
-    """Rebuild the [{role, content}] conversation from stored session events."""
+async def _load_history(
+    workspace_id: UUID, session_id: str, user_id: UUID, limit: int | None = None
+) -> list[dict]:
+    """Rebuild the [{role, content}] conversation from stored session events.
+
+    `limit` caps the replay to the most recent N turns — for the Slack agent's
+    single ever-growing per-user session, older context is recalled via the
+    `search_history` tool rather than replayed verbatim."""
     events = await memory_service.read_session_events(workspace_id, session_id, user_id)
     history: list[dict] = []
     for e in events:
@@ -58,6 +64,8 @@ async def _load_history(workspace_id: UUID, session_id: str, user_id: UUID) -> l
             history.append({"role": "user", "content": content})
         elif e["event_type"] == "assistant_message":
             history.append({"role": "assistant", "content": content})
+    if limit is not None:
+        return history[-limit:]
     return history
 
 
@@ -114,3 +122,53 @@ async def stream_chat(
             user_id,
             session_id=session_id,
         )
+
+
+# --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+# How much of the per-user Slack session to replay each turn. The agent recalls
+# older context via the search_history tool, so this bounds the live window.
+SLACK_HISTORY_REPLAY_LIMIT = 30
+
+
+async def run_chat(
+    workspace_id: UUID,
+    workspace_name: str,
+    user_id: UUID,
+    session_id: str,
+    message: str,
+) -> str:
+    """Non-streaming multi-turn chat for non-SSE surfaces (the Slack agent).
+
+    Same persistence + replay as `stream_chat`, but uses the artifact-creating
+    `SLACK_TOOL_SET` and returns the final answer text instead of streaming
+    (Slack wants one message). The agent core (tool_loop) is untouched."""
+    history = await _load_history(
+        workspace_id, session_id, user_id, limit=SLACK_HISTORY_REPLAY_LIMIT
+    )
+    await memory_service.push_event(
+        workspace_id, AGENT_NAME, "user_message", message, user_id, session_id=session_id
+    )
+    history.append({"role": "user", "content": message})
+
+    sources = await source_service.list_sources(workspace_id, user_id)
+    system = prompts.render_ask_system(workspace_name, sources)
+
+    answer: list[str] = []
+    async for event in tool_loop.stream_tool_loop(
+        tier=llm.ModelTier.QUALITY,
+        system=system,
+        history=history,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_set=prompts.SLACK_TOOL_SET,
+    ):
+        if event.get("type") == "text":
+            answer.append(event.get("delta") or "")
+
+    final = "".join(answer).strip()
+    if final:
+        await memory_service.push_event(
+            workspace_id, AGENT_NAME, "assistant_message", final, user_id, session_id=session_id
+        )
+    return final
+# --- END Slack agent ---

--- a/backend/services/ask_service.py
+++ b/backend/services/ask_service.py
@@ -171,4 +171,6 @@ async def run_chat(
             workspace_id, AGENT_NAME, "assistant_message", final, user_id, session_id=session_id
         )
     return final
+
+
 # --- END Slack agent ---

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -59,6 +59,11 @@ STASH_TOOL_SET = (
     "fetch_history",
 )
 
+# Slack agent (talk-to-Stash bot): can create + update cartridges (artifacts),
+# but NOT delete. Slack is an untrusted surface, so the destructive
+# `delete_cartridge` is held back to limit what a prompt-injected message can do.
+SLACK_TOOL_SET = tuple(t for t in STASH_TOOL_SET if t != "delete_cartridge")
+
 # Read-only subset for ask-the-workspace and other Q&A surfaces. Drops
 # the write tools so a prompt-injected request can't trigger mutations
 # even if the model decides to play along. Service-layer permission

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -62,6 +62,18 @@ async def get_user_by_id(user_id: UUID) -> dict | None:
     return dict(row) if row else None
 
 
+async def get_user_by_email(email: str) -> dict | None:
+    """Case-insensitive lookup. Used by the Slack agent to map a Slack user's
+    email to their Stash account."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, name, display_name, email, description, created_at, last_seen "
+        "FROM users WHERE lower(email) = lower($1)",
+        email,
+    )
+    return dict(row) if row else None
+
+
 async def update_user(
     user_id: UUID,
     display_name: str | None = None,

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -93,3 +93,14 @@ def reconcile_due() -> int:
 def ingest_slack_event(team_id: str, event: dict) -> int:
     """Upsert a single Slack Events-API message (enqueued by the webhook)."""
     return run_async(ingest_slack_message(team_id, event))
+
+
+# --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+@celery.task(name="backend.tasks.sources.respond_to_slack_mention")
+def respond_to_slack_mention(team_id: str, event: dict) -> None:
+    """Run the agent for a Slack @mention / DM and post the reply (enqueued by
+    the webhook). Imported lazily so the agent surface stays self-contained."""
+    from ..integrations.slack.agent import respond_to_mention
+
+    run_async(respond_to_mention(team_id, event))
+# --- END Slack agent ---

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -103,4 +103,6 @@ def respond_to_slack_mention(team_id: str, event: dict) -> None:
     from ..integrations.slack.agent import respond_to_mention
 
     run_async(respond_to_mention(team_id, event))
+
+
 # --- END Slack agent ---


### PR DESCRIPTION
## What

Lets a user **@mention or DM a Slack bot** and have the existing Stash workspace agent do work — answer questions and create artifacts — over everything Stash knows about them (their connected sources + history). Viktor-style "talk to it in Slack."

**The agent brain is reused unchanged.** All the heavy lifting (the `tool_loop` agent, ~18 tools spanning every connected source, memory, user/workspace scoping) already existed behind the web UI. This PR only adds the missing **Slack bot surface**.

## How it works

```
Slack (app_mention / message.im)
 → POST /api/v1/integrations/slack/events   (verify sig, ack <3s)
 → Celery respond_to_slack_mention
     1. team bot token            (slack_bot_installs)
     2. Slack user → email → Stash user
     3. user's primary workspace
     4. ask_service.run_chat(session="slack-agent-{user_id}", text)
     5. chat.postMessage back, in-thread
```

- **Identity:** Slack user email → Stash account → primary workspace (fallback: first workspace). Unknown email gets a friendly "connect with the same email" reply.
- **Memory:** one continuous session per user (`slack-agent-{user_id}`) so context accumulates across DMs, channels, and time. Live replay is capped at 30 turns; older recall comes from the agent's existing `search_history` tool.
- **Scope:** uses `SLACK_TOOL_SET` = the full mutating tool set **minus** `delete_cartridge` (Slack is untrusted; destructive delete is held back).

## Loop hygiene (reply-loop guards)

- Ignore the bot's own posts (`bot_id`) and edits/deletes (`subtype`) → no self-reply loop.
- Respond only to `app_mention` and `message.im`; plain channel messages stay **ingest-only**.
- Redis `event_id` dedup (SET NX, 10-min TTL) against Slack's at-least-once retries → no double-answers.
- Strip the `<@BOT>` mention token before prompting; always reply in-thread (`thread_ts`).

## Modularity / removal

The whole feature lives in `integrations/slack/` and every cross-cutting touch point is wrapped in `BEGIN/END Slack agent` banners. To remove: delete `slack/{client,installs,agent}.py`, the `0094` table, and the banner blocks in `provider.py` / `webhooks.py` / `tasks/sources.py` / `ask_service.py`. `get_user_by_email` and `run_chat` are generic and worth keeping. The agent core is untouched.

## Not in this PR (ops / follow-ups)

- **Slack app config** (one-time): add bot scopes (`app_mentions:read`, `chat:write`, `im:*`, `users:read.email`) + event subscriptions (`app_mention`, `message.im`); existing Slack users re-auth once to grant bot scopes.
- Streaming/"working…" placeholder UX (MVP posts one final message).

## Verification

- `ruff check` clean; `pytest backend/tests/test_sources.py backend/tests/test_integration_sources.py` → 44 passed; `test_migrations.py` → 2 passed (`alembic upgrade head` + linear history, 0093→0094).
- Loop-guard + tool-set logic unit-checked (mention/DM trigger, bot/subtype/channel ignored, create-yes/delete-no).
- End-to-end Slack install + live mention requires the Slack app config above and a running stack — not exercised here.

Backend-only; no GUI changes (no screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)