### PR TITLE
Slack agent: robust identity linking (Slack user-id + self-serve)

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -294,6 +294,19 @@ async def integration_callback(
                 )
                 account = AccountInfo(email=None, display_name=None)
             await storage.store_token(user_id, provider, token, account)
+
+            # --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
+            # Capture the connecting user's Slack identity so the bot can map
+            # inbound mentions to this Stash user without relying on email.
+            # Best-effort: a failure here must not break the connection.
+            if provider == "slack":
+                from .slack import links
+
+                try:
+                    await links.capture_from_user_token(user_id, token.access_token)
+                except Exception:
+                    logger.warning("slack: failed to capture user link", exc_info=True)
+            # --- END Slack agent ---
     except HTTPException:
         raise  # already a clean client error (e.g. invalid/expired state → 400)
     except Exception as e:

--- a/backend/integrations/slack/agent.py
+++ b/backend/integrations/slack/agent.py
@@ -5,9 +5,10 @@ the Slack user to a Stash account, runs the workspace agent in that user's
 single continuous Slack session, and posts the reply back. Everything agent-
 side (tool_loop, tools, memory, scoping) is reused unchanged.
 
-REMOVAL: this module + installs.py + client.py + the provider bot-token
-capture + the webhook agent branch + the respond_to_slack_mention Celery task
-+ the slack_bot_installs table are the whole feature. Delete them to drop it.
+REMOVAL: this module + installs.py + client.py + links.py + the provider
+bot-token capture + the router link capture + the webhook agent branch + the
+respond_to_slack_mention Celery task + the slack_bot_installs / slack_user_links
+tables are the whole feature. Delete them to drop it.
 """
 
 from __future__ import annotations
@@ -15,22 +16,43 @@ from __future__ import annotations
 import logging
 import re
 
+from ...config import settings
 from ...services import ask_service, user_service, workspace_service
-from . import client, installs
+from . import client, installs, links
 
 logger = logging.getLogger(__name__)
 
 # Slack renders mentions as <@U123>; strip the bot's own token from the prompt.
 _MENTION_RE = re.compile(r"<@[A-Z0-9]+>")
 
-_NO_ACCOUNT_MSG = (
-    "I couldn't match your Slack email to a Stash account. "
-    "Make sure your Stash account uses the same email as Slack."
-)
-
 
 def _strip_mentions(text: str) -> str:
     return _MENTION_RE.sub("", text).strip()
+
+
+def _connect_prompt() -> str:
+    """Shown when we can't map the Slack user to a Stash account — points them
+    at the in-product Slack connect, which captures the link (and wires up their
+    Slack source)."""
+    url = f"{settings.PUBLIC_URL.rstrip('/')}/settings"
+    return (
+        "I don't know who you are in Stash yet. Connect Slack from your Stash "
+        f"settings and I'll link you automatically: {url}"
+    )
+
+
+async def _resolve_stash_user(team_id: str, slack_user_id: str, bot_token: str) -> dict | None:
+    """Map a Slack user to a Stash account. Primary: the link captured at connect
+    time. Fallback: email match, which then self-heals by writing the link."""
+    user_id = await links.get_linked_user_id(team_id, slack_user_id)
+    if user_id is not None:
+        return await user_service.get_user_by_id(user_id)
+
+    email = await client.get_user_email(bot_token, slack_user_id)
+    user = await user_service.get_user_by_email(email) if email else None
+    if user is not None:
+        await links.store_link(team_id, slack_user_id, user["id"])
+    return user
 
 
 async def respond_to_mention(team_id: str, event: dict) -> None:
@@ -48,10 +70,9 @@ async def respond_to_mention(team_id: str, event: dict) -> None:
     if not slack_user_id or not channel or not text:
         return
 
-    email = await client.get_user_email(bot_token, slack_user_id)
-    user = await user_service.get_user_by_email(email) if email else None
+    user = await _resolve_stash_user(team_id, slack_user_id, bot_token)
     if user is None:
-        await client.post_message(bot_token, channel, _NO_ACCOUNT_MSG, thread_ts)
+        await client.post_message(bot_token, channel, _connect_prompt(), thread_ts)
         return
 
     workspace_id = await workspace_service.get_primary_for_user(user["id"])

--- a/backend/integrations/slack/links.py
+++ b/backend/integrations/slack/links.py
@@ -1,0 +1,48 @@
+"""Slack agent (talk-to-Stash bot) — Slack user ↔ Stash user linking.
+
+The robust identity map: when a Stash user connects Slack, we capture their
+Slack user_id (from auth.test on the user token) and store
+(team_id, slack_user_id) → stash_user_id. Inbound mentions then resolve by
+that id, no email matching required. Part of the removable Slack-agent feature.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ...database import get_pool
+from .provider import SlackIntegration
+
+
+async def store_link(team_id: str, slack_user_id: str, user_id: UUID) -> None:
+    pool = get_pool()
+    await pool.execute(
+        """
+        INSERT INTO slack_user_links (team_id, slack_user_id, user_id)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (team_id, slack_user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+        """,
+        team_id,
+        slack_user_id,
+        user_id,
+    )
+
+
+async def get_linked_user_id(team_id: str, slack_user_id: str) -> UUID | None:
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT user_id FROM slack_user_links WHERE team_id = $1 AND slack_user_id = $2",
+        team_id,
+        slack_user_id,
+    )
+    return row["user_id"] if row else None
+
+
+async def capture_from_user_token(user_id: UUID, user_token: str) -> None:
+    """Called at connect time: resolve the connecting user's Slack identity from
+    their user token (auth.test → team_id, user_id) and persist the link."""
+    info = await SlackIntegration().team_info(user_token)
+    team_id = info.get("team_id")
+    slack_user_id = info.get("user_id")
+    if team_id and slack_user_id:
+        await store_link(team_id, slack_user_id, user_id)

--- a/backend/migrations/versions/0096_slack_user_links.py
+++ b/backend/migrations/versions/0096_slack_user_links.py
@@ -1,0 +1,32 @@
+"""Add slack_user_links — map a Slack user to a Stash account.
+
+The Slack agent maps an inbound mention/DM to the Stash user who connected
+Slack, by the Slack user_id captured at connect time (email-independent). Part
+of the removable Slack-agent feature.
+
+Revision ID: 0096
+Revises: 0095
+"""
+
+from alembic import op
+
+revision = "0096"
+down_revision = "0095"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE slack_user_links (
+            team_id       text NOT NULL,
+            slack_user_id text NOT NULL,
+            user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at    timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (team_id, slack_user_id)
+        )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS slack_user_links")


### PR DESCRIPTION
## Why

The Slack agent's only identity path was **email matching** (Slack profile email → Stash account email). That breaks the moment the two differ — which is common (Slack on a company domain, Stash on a personal email). Symptom: the bot replies "I couldn't match your Slack email to a Stash account."

## What

Replace email-only matching with a proper link built from data we **already receive** at connect time, plus a self-serve path for unknown users.

**#2 — link by Slack user-id (captured at connect)**
- `0096 slack_user_links`: `(team_id, slack_user_id) → stash user_id`.
- `links.capture_from_user_token`: at Slack connect, `auth.test` on the user token already returns the connecting user's `team_id` + Slack `user_id` — persist the link.
- Router callback captures it after `store_token` (best-effort, slack-guarded, never blocks the connection).
- Responder resolves by this link first — **no email involved**.

**Email fallback, self-healing**
- If there's no link row yet, fall back to email match; on first hit, write the link so it never depends on email again.

**#3 — self-serve for unknown users**
- When the bot still can't map a Slack user, instead of a dead end it DMs a **"connect Slack in Stash"** deep link. Connecting runs the same #2 capture *and* wires up their Slack source (which the agent needs to read their Slack anyway) — so it's more correct than a pure identity link.

## Identity resolution order
1. `slack_user_links` (captured at connect) →
2. email match (self-heals into a link) →
3. DM a connect link.

## Modularity
Still fully contained + banner-wrapped. Removal note updated to include `links.py`, the router capture, and `slack_user_links`.

## Verification
- `ruff` + `black` clean.
- Clean-DB suite: `test_migrations` (alembic upgrade head + linear chain, 0095→0096), `test_integration_sources`, `test_sources` → **46 passed**.
- Post-merge I'll verify on prod: reconnect Slack → `slack_user_links` row appears → `@mention` resolves without email and the agent answers.

Backend-only; no GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)