### PR TITLE
Agent: create_page + update_page tools (markdown + HTML)

### DIFF
--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -662,9 +662,85 @@ async def _fetch_history(args: dict) -> dict:
     return _text_result(json.dumps(result))
 
 
+@tool(
+    "create_page",
+    "Create a new page in the workspace. Use content_type 'markdown' with `content`, "
+    "or 'html' with `content_html`. Returns the new page id.",
+    {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "content_type": {
+                "type": "string",
+                "enum": ["markdown", "html"],
+                "default": "markdown",
+            },
+            "content": {"type": "string", "default": ""},
+            "content_html": {"type": "string", "default": ""},
+            "folder_id": {"type": "string"},
+        },
+        "required": ["name"],
+    },
+)
+async def _create_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    folder_id = UUID(args["folder_id"]) if args.get("folder_id") else None
+    try:
+        page = await files_tree_service.create_page(
+            workspace_id=workspace_id,
+            name=args["name"],
+            created_by=user_id,
+            folder_id=folder_id,
+            content=args.get("content") or "",
+            content_type=args.get("content_type") or "markdown",
+            content_html=args.get("content_html") or "",
+        )
+    except files_tree_service.DuplicatePageName:
+        return _text_result(json.dumps({"error": "a page with that name already exists here"}))
+    except ValueError as e:
+        return _text_result(json.dumps({"error": str(e)}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
+@tool(
+    "update_page",
+    "Update an existing page's content or name by id. Pass content_type 'markdown' with "
+    "`content`, or 'html' with `content_html`. Omit a field to leave it unchanged.",
+    {
+        "type": "object",
+        "properties": {
+            "page_id": {"type": "string"},
+            "name": {"type": "string"},
+            "content_type": {"type": "string", "enum": ["markdown", "html"]},
+            "content": {"type": "string"},
+            "content_html": {"type": "string"},
+        },
+        "required": ["page_id"],
+    },
+)
+async def _update_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    page = await files_tree_service.update_page(
+        page_id=UUID(args["page_id"]),
+        workspace_id=workspace_id,
+        updated_by=user_id,
+        name=args.get("name"),
+        content=args.get("content"),
+        content_type=args.get("content_type"),
+        content_html=args.get("content_html"),
+    )
+    if page is None:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
+    "create_page": _create_page,
+    "update_page": _update_page,
     "grep_pages": _grep_pages,
     "list_files": _list_files,
     "read_file": _read_file,

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -41,6 +41,8 @@ def render_ask_system(stash_name: str, sources: list[dict] | None = None) -> str
 STASH_TOOL_SET = (
     "search_history",
     "read_page",
+    "create_page",
+    "update_page",
     "grep_pages",
     "list_files",
     "read_file",

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -136,6 +136,54 @@ async def test_cartridge_tools_create_list_and_delete(workspace: UUID, _db_pool)
     assert deleted == {"deleted": True, "cartridge_id": created["id"]}
 
 
+def test_page_tools_are_writable_surfaces_only():
+    """create_page/update_page are mutations: offered to the agent + Slack
+    surfaces (STASH_TOOL_SET), but withheld from the read-only ask surface so a
+    prompt-injected ask can't author pages."""
+    for name in ("create_page", "update_page"):
+        assert name in agent_runtime._TOOLS_BY_NAME
+        assert name in prompts.STASH_TOOL_SET
+        assert name in prompts.SLACK_TOOL_SET
+        assert name not in prompts.ASK_TOOL_SET
+
+
+@pytest.mark.asyncio
+async def test_create_and_update_page_round_trip(workspace: UUID, _db_pool):
+    """create_page persists markdown + html; update_page edits an existing page
+    by id. Both must bind to the active workspace context."""
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        md = await agent_runtime._create_page.handler(
+            {"name": "Notes", "content_type": "markdown", "content": "# Hello"}
+        )
+        html = await agent_runtime._create_page.handler(
+            {"name": "Dashboard", "content_type": "html", "content_html": "<h1>Live</h1>"}
+        )
+        md_page = json.loads(md["content"][0]["text"])
+        await agent_runtime._update_page.handler(
+            {"page_id": md_page["id"], "content": "# Hello again"}
+        )
+        read_back = await agent_runtime._read_page.handler({"page_id": md_page["id"]})
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+
+    html_page = json.loads(html["content"][0]["text"])
+    assert md_page["name"] == "Notes" and "id" in md_page
+    assert html_page["name"] == "Dashboard"
+    # Persisted to this workspace, scoped by context.
+    stored = await _db_pool.fetchrow(
+        "SELECT workspace_id, content_html FROM pages WHERE id = $1", UUID(html_page["id"])
+    )
+    assert stored["workspace_id"] == workspace
+    assert "<h1>Live</h1>" in (stored["content_html"] or "")
+    # update_page edited the markdown body in place.
+    assert "Hello again" in json.loads(read_back["content"][0]["text"])["content"]
+
+
 @pytest.mark.asyncio
 async def test_external_cartridge_is_workspace_fork(workspace: UUID, _db_pool):
     owner_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)


### PR DESCRIPTION
## Why

The agent could **read** pages (`read_page`, `grep_pages`) but had no way to **author** one — its only writes were Cartridges, which just bundle *existing* items. So "draft a one-pager and save it as a page" or "build an HTML dashboard from my Snowflake numbers" couldn't persist anything; the content only lived in the chat reply.

## What

Two new tools wired to the existing `files_tree_service` (which already supports markdown + HTML bodies):

- **`create_page`** — `name`, `content_type` (`markdown`|`html`), `content` / `content_html`, optional `folder_id`.
- **`update_page`** — edit an existing page by id (name/body); omit a field to leave it unchanged.

Both run under the active workspace/user context like every other tool, so they're per-user scoped exactly like the reads.

## Where they're exposed

- Added to **`STASH_TOOL_SET`** → the SDK agent and, by derivation, the **Slack bot** (`SLACK_TOOL_SET`) get them.
- **Deliberately kept out of `ASK_TOOL_SET`** — that's the read-only web "ask" surface; keeping page-authoring off it preserves the existing "a prompt-injected ask can't trigger mutations" posture.
- Non-destructive (additive), consistent with allowing `create_cartridge` while withholding `delete_cartridge` on Slack.

## Tests

- `test_page_tools_are_writable_surfaces_only` — encodes the intent: present in STASH/SLACK, absent from ASK.
- `test_create_and_update_page_round_trip` — creates a markdown page + an HTML page, edits the markdown, asserts content persists to the right workspace.
- Existing `test_tool_catalog_matches_prompts_set` still green (catalog ↔ tool-set invariant).

Local: `ruff` + `black` clean; `test_agent_runtime`, `test_integration_sources`, `test_cartridge_agent_read` all pass.

Backend-only; no GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)