### PR TITLE
Fidelity fixes: Notion tables, Jira fields, Drive non-Doc files, .docx/.pptx extraction

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -30,6 +30,7 @@ MIME_FOLDER = "application/vnd.google-apps.folder"
 MIME_GOOGLE_DOC = "application/vnd.google-apps.document"
 MIME_GOOGLE_SHEET = "application/vnd.google-apps.spreadsheet"
 MIME_GOOGLE_SLIDE = "application/vnd.google-apps.presentation"
+_XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 MAX_FOLDER_DEPTH = 8
 # Native (non-Google) files can be massive (terabyte videos). Cap downloads so
 # a stray click doesn't drag a huge file into the agent's response.
@@ -169,8 +170,15 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
         if mime == MIME_GOOGLE_DOC:
             return await _export(client, file_id, "text/markdown")
         if mime == MIME_GOOGLE_SHEET:
-            csv = await _export(client, file_id, "text/csv")
-            return _csv_to_markdown_table(csv) if csv else ""
+            # XLSX export keeps every visible sheet (Drive's CSV export drops
+            # everything except the first). file_extraction renders one TSV
+            # block per sheet.
+            xlsx = await _export_bytes(client, file_id, _XLSX_MIME)
+            if not xlsx:
+                return ""
+            from ...services.file_extraction import extract_text
+
+            return extract_text(xlsx, _XLSX_MIME) or ""
         if mime == MIME_GOOGLE_SLIDE:
             return await _export(client, file_id, "text/plain")
 
@@ -205,32 +213,10 @@ async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:
     return resp.text if resp.status_code == 200 else ""
 
 
-def _csv_to_markdown_table(csv_text: str) -> str:
-    """First-sheet CSV → a markdown table (header row + body).
+async def _export_bytes(client: httpx.AsyncClient, file_id: str, mime: str) -> bytes:
+    resp = await client.get(
+        DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime}
+    )
+    return resp.content if resp.status_code == 200 else b""
 
-    Cap is the row count, not byte count — the Sheet might have 100k rows
-    that the agent can't reasonably scan; the federated search step has
-    already narrowed to a specific sheet, so the agent expects a summary.
-    """
-    import csv as csv_mod
-    import io
 
-    rows = list(csv_mod.reader(io.StringIO(csv_text)))
-    if not rows:
-        return ""
-    max_rows = 200
-    truncated = len(rows) > max_rows + 1  # +1 for header
-    rows = rows[: max_rows + 1]
-    cols = max(len(r) for r in rows)
-    rows = [r + [""] * (cols - len(r)) for r in rows]
-    header = rows[0]
-    body = rows[1:]
-    out = [
-        "| " + " | ".join(c.replace("|", "\\|") for c in header) + " |",
-        "| " + " | ".join(["---"] * cols) + " |",
-    ]
-    for row in body:
-        out.append("| " + " | ".join(c.replace("|", "\\|") for c in row) + " |")
-    if truncated:
-        out.append(f"_(showing first {max_rows} rows of {len(rows) + max_rows - 1}+)_")
-    return "\n".join(out)

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -24,10 +24,16 @@ from ..storage import get_valid_token
 logger = logging.getLogger(__name__)
 
 DRIVE_LIST_URL = "https://www.googleapis.com/drive/v3/files"
+DRIVE_FILE_URL = "https://www.googleapis.com/drive/v3/files/{file_id}"
 DRIVE_EXPORT_URL = "https://www.googleapis.com/drive/v3/files/{file_id}/export"
 MIME_FOLDER = "application/vnd.google-apps.folder"
 MIME_GOOGLE_DOC = "application/vnd.google-apps.document"
+MIME_GOOGLE_SHEET = "application/vnd.google-apps.spreadsheet"
+MIME_GOOGLE_SLIDE = "application/vnd.google-apps.presentation"
 MAX_FOLDER_DEPTH = 8
+# Native (non-Google) files can be massive (terabyte videos). Cap downloads so
+# a stray click doesn't drag a huge file into the agent's response.
+MAX_NATIVE_DOWNLOAD_BYTES = 25 * 1024 * 1024
 
 
 def _parse_time(value: str | None) -> datetime | None:
@@ -136,13 +142,95 @@ async def search_drive(source: dict, query: str, limit: int = 25) -> list[dict]:
 
 
 async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
-    """Lazy read: export a Drive file to markdown with the owner's token.
-    Non-Doc files have no markdown export and come back empty."""
+    """Lazy read: route by Drive MIME type.
+
+    - Google Doc       → markdown export
+    - Google Sheet     → CSV export, rendered as a markdown table (first sheet)
+    - Google Slides    → text/plain export
+    - PDF              → bytes + pypdf extraction
+    - Office formats (docx/pptx/xlsx) and text/* → bytes + file_extraction
+    - Anything else    → empty string
+
+    The metadata lookup costs one extra round-trip per read but avoids storing
+    mime types on every index row (and avoids drift if a file is converted).
+    """
     token = await get_valid_token(owner_user_id, "google")
     headers = {"Authorization": f"Bearer {token}"}
     async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
-        export = await client.get(
-            DRIVE_EXPORT_URL.format(file_id=file_id),
-            params={"mimeType": "text/markdown"},
+        meta = await client.get(
+            DRIVE_FILE_URL.format(file_id=file_id),
+            params={"fields": "mimeType,name,size"},
         )
-        return export.text if export.status_code == 200 else ""
+        if meta.status_code != 200:
+            return ""
+        info = meta.json()
+        mime = info.get("mimeType") or ""
+
+        if mime == MIME_GOOGLE_DOC:
+            return await _export(client, file_id, "text/markdown")
+        if mime == MIME_GOOGLE_SHEET:
+            csv = await _export(client, file_id, "text/csv")
+            return _csv_to_markdown_table(csv) if csv else ""
+        if mime == MIME_GOOGLE_SLIDE:
+            return await _export(client, file_id, "text/plain")
+
+        # Native files: cap by size, download bytes, route by mime to a text
+        # extractor.
+        size = int(info.get("size") or 0)
+        if size and size > MAX_NATIVE_DOWNLOAD_BYTES:
+            return f"_(file too large to inline: {size // (1024 * 1024)} MB)_"
+
+        media = await client.get(
+            DRIVE_FILE_URL.format(file_id=file_id),
+            params={"alt": "media"},
+        )
+        if media.status_code != 200:
+            return ""
+        content = media.content
+        if len(content) > MAX_NATIVE_DOWNLOAD_BYTES:
+            return f"_(file too large to inline: {len(content) // (1024 * 1024)} MB)_"
+
+        # Defer to the file-extraction service so docx/pptx/xlsx/pdf/text/*
+        # share the same handler set as the direct-upload extraction queue.
+        from ...services.file_extraction import extract_text
+
+        text = extract_text(content, mime)
+        return text or ""
+
+
+async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:
+    resp = await client.get(
+        DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime}
+    )
+    return resp.text if resp.status_code == 200 else ""
+
+
+def _csv_to_markdown_table(csv_text: str) -> str:
+    """First-sheet CSV → a markdown table (header row + body).
+
+    Cap is the row count, not byte count — the Sheet might have 100k rows
+    that the agent can't reasonably scan; the federated search step has
+    already narrowed to a specific sheet, so the agent expects a summary.
+    """
+    import csv as csv_mod
+    import io
+
+    rows = list(csv_mod.reader(io.StringIO(csv_text)))
+    if not rows:
+        return ""
+    max_rows = 200
+    truncated = len(rows) > max_rows + 1  # +1 for header
+    rows = rows[: max_rows + 1]
+    cols = max(len(r) for r in rows)
+    rows = [r + [""] * (cols - len(r)) for r in rows]
+    header = rows[0]
+    body = rows[1:]
+    out = [
+        "| " + " | ".join(c.replace("|", "\\|") for c in header) + " |",
+        "| " + " | ".join(["---"] * cols) + " |",
+    ]
+    for row in body:
+        out.append("| " + " | ".join(c.replace("|", "\\|") for c in row) + " |")
+    if truncated:
+        out.append(f"_(showing first {max_rows} rows of {len(rows) + max_rows - 1}+)_")
+    return "\n".join(out)

--- a/backend/integrations/jira/indexer.py
+++ b/backend/integrations/jira/indexer.py
@@ -24,8 +24,24 @@ ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-res
 # cloud_id -> site base url (e.g. https://acme.atlassian.net). Cached because the
 # site url never changes for a cloud and the lookup costs a network round-trip.
 _SITE_URL_CACHE: dict[str, str] = {}
-# Fields rendered for a full read (lazy fetch).
-ISSUE_FIELDS = "summary,status,assignee,updated,description,comment"
+# Fields rendered for a full read (lazy fetch). Keep this in sync with
+# `_render_issue` — every field here should have a corresponding render
+# branch, or the network round-trip is wasted.
+ISSUE_FIELDS = ",".join(
+    [
+        # core
+        "summary", "status", "priority", "issuetype",
+        "assignee", "reporter", "created", "updated", "duedate",
+        # body + activity
+        "description", "comment",
+        # taxonomy
+        "labels", "components", "fixVersions",
+        # graph (links + hierarchy)
+        "issuelinks", "subtasks", "parent",
+        # files
+        "attachment",
+    ]
+)
 PAGE_SIZE = 100
 MAX_ISSUES = 2000
 SEARCH_LIMIT = 25
@@ -55,31 +71,104 @@ def _adf_to_text(node: dict | None) -> str:
     return "".join(out).strip()
 
 
+def _name(obj: dict | None) -> str:
+    """Pull `.name` out of a nullable Jira reference (status, priority, etc)."""
+    return (obj or {}).get("name") or ""
+
+
+def _display_name(obj: dict | None) -> str:
+    return (obj or {}).get("displayName") or ""
+
+
 def _render_issue(issue: dict) -> str:
     fields = issue.get("fields", {})
     key = issue.get("key", "")
     summary = fields.get("summary") or ""
-    status = (fields.get("status") or {}).get("name") or ""
-    assignee = (fields.get("assignee") or {}).get("displayName") or "Unassigned"
-    description = _adf_to_text(fields.get("description"))
 
+    # Header metadata block.
+    meta_lines = [
+        f"Status: {_name(fields.get('status'))}",
+        f"Type: {_name(fields.get('issuetype'))}",
+        f"Priority: {_name(fields.get('priority'))}",
+        f"Assignee: {_display_name(fields.get('assignee')) or 'Unassigned'}",
+        f"Reporter: {_display_name(fields.get('reporter')) or 'Unknown'}",
+    ]
+    for field, label in (("created", "Created"), ("updated", "Updated"), ("duedate", "Due")):
+        value = fields.get(field)
+        if value:
+            meta_lines.append(f"{label}: {value}")
+
+    labels = fields.get("labels") or []
+    if labels:
+        meta_lines.append("Labels: " + ", ".join(labels))
+    components = [c.get("name", "") for c in (fields.get("components") or [])]
+    if components:
+        meta_lines.append("Components: " + ", ".join(components))
+    fix_versions = [v.get("name", "") for v in (fields.get("fixVersions") or [])]
+    if fix_versions:
+        meta_lines.append("Fix versions: " + ", ".join(fix_versions))
+
+    parent = fields.get("parent")
+    if parent:
+        parent_key = parent.get("key", "")
+        parent_summary = (parent.get("fields") or {}).get("summary", "")
+        meta_lines.append(f"Parent: {parent_key} {parent_summary}".rstrip())
+
+    parts = [f"# {key}: {summary}", "\n".join(meta_lines)]
+
+    description = _adf_to_text(fields.get("description"))
+    if description:
+        parts.append(f"\n{description}")
+
+    # Issue links: "blocks", "is blocked by", "relates to", etc.
+    link_lines: list[str] = []
+    for link in fields.get("issuelinks") or []:
+        link_type = link.get("type") or {}
+        if "outwardIssue" in link:
+            other = link["outwardIssue"]
+            relation = link_type.get("outward") or "links to"
+        elif "inwardIssue" in link:
+            other = link["inwardIssue"]
+            relation = link_type.get("inward") or "linked from"
+        else:
+            continue
+        other_key = other.get("key", "")
+        other_summary = (other.get("fields") or {}).get("summary", "")
+        link_lines.append(f"- {relation} {other_key}: {other_summary}")
+    if link_lines:
+        parts.append("\n## Links\n" + "\n".join(link_lines))
+
+    # Subtasks: key + summary + status.
+    subtask_lines: list[str] = []
+    for sub in fields.get("subtasks") or []:
+        sub_key = sub.get("key", "")
+        sub_fields = sub.get("fields") or {}
+        sub_summary = sub_fields.get("summary", "")
+        sub_status = _name(sub_fields.get("status"))
+        subtask_lines.append(f"- {sub_key} ({sub_status}): {sub_summary}")
+    if subtask_lines:
+        parts.append("\n## Subtasks\n" + "\n".join(subtask_lines))
+
+    # Attachments: filename + content URL (so the agent can fetch them).
+    attach_lines: list[str] = []
+    for att in fields.get("attachment") or []:
+        filename = att.get("filename", "")
+        url = att.get("content", "")
+        attach_lines.append(f"- [{filename}]({url})" if url else f"- {filename}")
+    if attach_lines:
+        parts.append("\n## Attachments\n" + "\n".join(attach_lines))
+
+    # Comments stay last — they tend to be the most verbose section.
     comments = (fields.get("comment") or {}).get("comments", []) or []
     rendered_comments = []
     for c in comments:
-        author = (c.get("author") or {}).get("displayName") or "Unknown"
+        author = _display_name(c.get("author")) or "Unknown"
         body = _adf_to_text(c.get("body"))
         if body:
             rendered_comments.append(f"{author}: {body}")
-
-    parts = [
-        f"# {key}: {summary}",
-        f"Status: {status}",
-        f"Assignee: {assignee}",
-    ]
-    if description:
-        parts.append(f"\n{description}")
     if rendered_comments:
         parts.append("\n## Comments\n" + "\n\n".join(rendered_comments))
+
     return "\n".join(parts)
 
 

--- a/backend/integrations/notion/importers/page.py
+++ b/backend/integrations/notion/importers/page.py
@@ -2,8 +2,8 @@
 
 Covers the block types people actually have in knowledge bases —
 paragraphs, headings, lists, to-do, quotes, callouts, code, dividers,
-toggles, bookmarks, images. Anything fancier falls back to its
-plain-text representation rather than failing.
+toggles, bookmarks, images, tables, child databases. Anything fancier
+falls back to its plain-text representation rather than failing.
 
 Reused by backend/integrations/notion/indexer.py to render connected Notion
 pages into notion_index. (Formerly also held the import-into-the-file-system
@@ -21,9 +21,13 @@ logger = logging.getLogger(__name__)
 
 NOTION_PAGE_URL = "https://api.notion.com/v1/pages/{page_id}"
 NOTION_BLOCKS_URL = "https://api.notion.com/v1/blocks/{block_id}/children"
+NOTION_DATABASE_URL = "https://api.notion.com/v1/databases/{database_id}"
+NOTION_DATABASE_QUERY_URL = "https://api.notion.com/v1/databases/{database_id}/query"
 
 # Cap block nesting so a pathological page can't recurse forever.
 MAX_BLOCK_NESTING = 6
+# Cap child_database inline rendering to keep big tables from blowing up a page.
+CHILD_DATABASE_ROW_LIMIT = 50
 
 
 def _rich_text_to_md(rt: list[dict]) -> str:
@@ -108,11 +112,9 @@ def _render_block(block: dict, depth: int = 0) -> tuple[list[str], list[str]]:
         # Stash pages by the recursive importer. The block id is the
         # page id we need to fetch.
         child_pages.append(block["id"])
-    elif btype == "child_database":
-        # Same idea, but for databases. Not auto-recursed today; surface
-        # as a marker the user can re-import explicitly if they want it.
-        title = body.get("title", "Untitled database")
-        lines.append(f"{indent}- _(database)_ {title}")
+    elif btype in ("table", "child_database"):
+        # Handled inline by fetch_block_tree (needs async children fetch).
+        pass
     else:
         # Unknown block types fall back to whatever text we can extract.
         if text:
@@ -151,6 +153,17 @@ async def fetch_block_tree(
         resp.raise_for_status()
         payload = resp.json()
         for block in payload.get("results", []):
+            btype = block.get("type")
+
+            # Tables and child databases need their own async children
+            # fetch, so they short-circuit the generic walk below.
+            if btype == "table":
+                lines.extend(await _render_table_block(client, block, depth))
+                continue
+            if btype == "child_database":
+                lines.extend(await _render_child_database_block(client, block, depth))
+                continue
+
             block_lines, block_children = _render_block(block, depth)
             lines.extend(block_lines)
             child_pages.extend(block_children)
@@ -160,12 +173,207 @@ async def fetch_block_tree(
                 )
                 lines.extend(child_lines)
                 child_pages.extend(nested_children)
-            if block.get("type") == "toggle":
+            if btype == "toggle":
                 lines.append(f"{'  ' * depth}</details>")
         if not payload.get("has_more"):
             break
         cursor = payload.get("next_cursor")
     return lines, child_pages
+
+
+def _cell_to_md(cell: list[dict]) -> str:
+    """Render one table_row cell (a rich_text array) to markdown, escaping
+    the pipe character so it doesn't break the table syntax."""
+    text = _rich_text_to_md(cell)
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+async def _render_table_block(
+    client: httpx.AsyncClient, block: dict, depth: int
+) -> list[str]:
+    """Render a Notion `table` block as a markdown table.
+
+    Notion's `table` block has `table_width` + `has_column_header`. The rows
+    are its children (`table_row` blocks with `cells: list[list[rich_text]]`).
+    A `table_row` outside a table context would render as plain rich text,
+    but here we fetch them and assemble proper markdown table syntax.
+    """
+    body = block.get("table", {}) or {}
+    width = int(body.get("table_width") or 0)
+    has_header = bool(body.get("has_column_header"))
+    indent = "  " * depth
+
+    rows: list[list[str]] = []
+    cursor: str | None = None
+    while True:
+        params: dict[str, Any] = {"page_size": 100}
+        if cursor:
+            params["start_cursor"] = cursor
+        resp = await client.get(NOTION_BLOCKS_URL.format(block_id=block["id"]), params=params)
+        resp.raise_for_status()
+        payload = resp.json()
+        for child in payload.get("results", []):
+            if child.get("type") != "table_row":
+                continue
+            cells = child.get("table_row", {}).get("cells") or []
+            rendered = [_cell_to_md(c) for c in cells]
+            # Pad short rows so every output row has `width` columns.
+            while width and len(rendered) < width:
+                rendered.append("")
+            rows.append(rendered)
+        if not payload.get("has_more"):
+            break
+        cursor = payload.get("next_cursor")
+
+    if not rows:
+        return []
+
+    col_count = width or max(len(r) for r in rows)
+    out: list[str] = []
+    if has_header:
+        out.append(f"{indent}| {' | '.join(rows[0])} |")
+        out.append(f"{indent}| {' | '.join(['---'] * col_count)} |")
+        body_rows = rows[1:]
+    else:
+        # No header → emit a blank header so the markdown parser still
+        # treats it as a table.
+        out.append(f"{indent}| {' | '.join([''] * col_count)} |")
+        out.append(f"{indent}| {' | '.join(['---'] * col_count)} |")
+        body_rows = rows
+    for row in body_rows:
+        out.append(f"{indent}| {' | '.join(row)} |")
+    return out
+
+
+def _row_title_from_props(props: dict) -> str:
+    """First title-typed property in a database row → plain string."""
+    for value in props.values():
+        if (value or {}).get("type") == "title":
+            runs = value.get("title", []) or []
+            text = "".join(r.get("plain_text", "") for r in runs).strip()
+            if text:
+                return text
+    return "Untitled"
+
+
+def _scalar_prop_to_str(value: dict) -> str:
+    """Render a single property value as a one-line markdown-cell string.
+
+    Handles the common Notion property types we'd want visible in a
+    summary table; falls back to the JSON-y `type` marker for the rest.
+    """
+    if not value:
+        return ""
+    ptype = value.get("type")
+    inner = value.get(ptype) if ptype else None
+    if ptype in ("title", "rich_text"):
+        return _rich_text_to_md(inner or [])
+    if ptype == "number":
+        return "" if inner is None else str(inner)
+    if ptype == "checkbox":
+        return "x" if inner else " "
+    if ptype == "url":
+        return str(inner or "")
+    if ptype == "email":
+        return str(inner or "")
+    if ptype == "phone_number":
+        return str(inner or "")
+    if ptype == "select":
+        return (inner or {}).get("name", "")
+    if ptype == "status":
+        return (inner or {}).get("name", "")
+    if ptype == "multi_select":
+        return ", ".join(item.get("name", "") for item in (inner or []))
+    if ptype == "date":
+        start = (inner or {}).get("start", "")
+        end = (inner or {}).get("end")
+        return f"{start} → {end}" if end else start
+    if ptype == "people":
+        return ", ".join(p.get("name", "") for p in (inner or []))
+    if ptype == "formula":
+        formula_type = (inner or {}).get("type")
+        return str((inner or {}).get(formula_type, ""))
+    if ptype == "rollup":
+        rollup_type = (inner or {}).get("type")
+        if rollup_type == "number":
+            return str((inner or {}).get("number", ""))
+        if rollup_type == "date":
+            return str(((inner or {}).get("date") or {}).get("start", ""))
+        return ""
+    if ptype == "created_time":
+        return str(inner or "")
+    if ptype == "last_edited_time":
+        return str(inner or "")
+    return f"_({ptype})_"
+
+
+async def _render_child_database_block(
+    client: httpx.AsyncClient, block: dict, depth: int
+) -> list[str]:
+    """Inline-render the first N rows of a `child_database` block.
+
+    Without this, the agent never sees the data inside a nested database — the
+    old code emitted only `_(database)_ Title`. We cap row count so a huge
+    database doesn't bloat the parent page beyond what an agent can scan.
+    """
+    body = block.get("child_database", {}) or {}
+    title = body.get("title") or "Untitled database"
+    indent = "  " * depth
+    database_id = block["id"]
+
+    meta_resp = await client.get(NOTION_DATABASE_URL.format(database_id=database_id))
+    if meta_resp.status_code != 200:
+        return [f"{indent}_(child database `{title}` — could not fetch)_"]
+    db_meta = meta_resp.json()
+    db_props = db_meta.get("properties") or {}
+    # Column order: title first (Notion's convention), then everything else
+    # by Notion's stable property order.
+    columns: list[str] = []
+    title_col: str | None = None
+    for name, spec in db_props.items():
+        if (spec or {}).get("type") == "title":
+            title_col = name
+        else:
+            columns.append(name)
+    if title_col is None:
+        title_col = "Name"
+    headers = [title_col, *columns]
+
+    rows: list[list[str]] = []
+    cursor: str | None = None
+    while len(rows) < CHILD_DATABASE_ROW_LIMIT:
+        payload: dict = {"page_size": min(100, CHILD_DATABASE_ROW_LIMIT - len(rows))}
+        if cursor:
+            payload["start_cursor"] = cursor
+        resp = await client.post(
+            NOTION_DATABASE_QUERY_URL.format(database_id=database_id), json=payload
+        )
+        if resp.status_code != 200:
+            break
+        page = resp.json()
+        for row in page.get("results", []):
+            props = row.get("properties") or {}
+            row_cells = [_row_title_from_props(props)]
+            for col in columns:
+                row_cells.append(_scalar_prop_to_str(props.get(col, {}) or {}))
+            rows.append([c.replace("|", "\\|").replace("\n", " ") for c in row_cells])
+            if len(rows) >= CHILD_DATABASE_ROW_LIMIT:
+                break
+        if not page.get("has_more"):
+            break
+        cursor = page.get("next_cursor")
+
+    if not rows:
+        return [f"{indent}_(child database `{title}` — empty)_"]
+
+    out = [f"{indent}**{title}**", ""]
+    out.append(f"{indent}| {' | '.join(headers)} |")
+    out.append(f"{indent}| {' | '.join(['---'] * len(headers))} |")
+    for row in rows:
+        out.append(f"{indent}| {' | '.join(row)} |")
+    if len(rows) == CHILD_DATABASE_ROW_LIMIT:
+        out.append(f"{indent}_(showing first {CHILD_DATABASE_ROW_LIMIT} rows)_")
+    return out
 
 
 def _extract_title(page_meta: dict) -> str:

--- a/backend/services/file_extraction.py
+++ b/backend/services/file_extraction.py
@@ -3,6 +3,8 @@
 Supported:
 - PDFs with embedded text → pypdf (pure Python).
 - Plain-text / JSON / XML → UTF-8 decode.
+- `.docx`, `.pptx` → zipfile + ElementTree walk (no extra deps).
+- `.xlsx` → openpyxl, cells joined into rows.
 - Everything else → None.
 
 `extract_text` never raises. Every failure returns None so uploads
@@ -13,6 +15,8 @@ from __future__ import annotations
 
 import io
 import logging
+import zipfile
+from xml.etree import ElementTree as ET
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +26,17 @@ try:
     _HAS_PYPDF = True
 except ImportError:
     _HAS_PYPDF = False
+
+try:
+    from openpyxl import load_workbook  # type: ignore
+
+    _HAS_OPENPYXL = True
+except ImportError:
+    _HAS_OPENPYXL = False
+
+
+_OOXML_DRAWING_NS = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+_OOXML_WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 
 
 def _extract_pdf_embedded(content: bytes) -> str:
@@ -35,6 +50,74 @@ def _extract_pdf_embedded(content: bytes) -> str:
         except Exception:
             continue
     return "\n\n".join(p for p in parts if p).strip()
+
+
+def _extract_docx(content: bytes) -> str:
+    """Walk the OOXML body, paragraph by paragraph. Tables are rendered with
+    cells separated by tabs so the column structure survives in plain text."""
+    with zipfile.ZipFile(io.BytesIO(content)) as z:
+        if "word/document.xml" not in z.namelist():
+            return ""
+        root = ET.fromstring(z.read("word/document.xml"))
+    paragraphs: list[str] = []
+    for elem in root.iter():
+        if elem.tag == f"{_OOXML_WORD_NS}p":
+            text = "".join(t.text or "" for t in elem.iter(f"{_OOXML_WORD_NS}t"))
+            if text:
+                paragraphs.append(text)
+        elif elem.tag == f"{_OOXML_WORD_NS}tbl":
+            for row in elem.iter(f"{_OOXML_WORD_NS}tr"):
+                cells = []
+                for cell in row.iter(f"{_OOXML_WORD_NS}tc"):
+                    cell_text = "".join(t.text or "" for t in cell.iter(f"{_OOXML_WORD_NS}t"))
+                    cells.append(cell_text)
+                paragraphs.append("\t".join(cells))
+    return "\n".join(paragraphs).strip()
+
+
+def _extract_pptx(content: bytes) -> str:
+    """Slide-by-slide text. The OOXML `<a:t>` element wraps every text run in
+    every shape — that includes titles, body text, table cells, and chart
+    labels — so a single pass over all matching nodes captures the readable
+    content of the deck."""
+    with zipfile.ZipFile(io.BytesIO(content)) as z:
+        slide_names = sorted(
+            n for n in z.namelist() if n.startswith("ppt/slides/slide") and n.endswith(".xml")
+        )
+        slides: list[str] = []
+        for name in slide_names:
+            root = ET.fromstring(z.read(name))
+            runs = [t.text or "" for t in root.iter(f"{_OOXML_DRAWING_NS}t")]
+            slide_text = " ".join(r for r in runs if r)
+            if slide_text.strip():
+                slides.append(slide_text)
+    return "\n\n".join(slides).strip()
+
+
+def _extract_xlsx(content: bytes) -> str:
+    """Every sheet → "## <sheet>\n<row TSV>\n..." block.
+
+    openpyxl is already a dep for xlsx_ingest; reusing it keeps behaviour
+    consistent (same parser → same blind spots → same cells visible).
+    """
+    if not _HAS_OPENPYXL:
+        return ""
+    wb = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+    try:
+        sheets_out: list[str] = []
+        for sheet in wb.worksheets:
+            if sheet.sheet_state != "visible":
+                continue
+            rows_out: list[str] = []
+            for row in sheet.iter_rows(values_only=True):
+                if not any(cell is not None for cell in row):
+                    continue
+                rows_out.append("\t".join("" if c is None else str(c) for c in row))
+            if rows_out:
+                sheets_out.append(f"## {sheet.title}\n" + "\n".join(rows_out))
+        return "\n\n".join(sheets_out).strip()
+    finally:
+        wb.close()
 
 
 def _sanitize_for_postgres(text: str) -> str:
@@ -57,6 +140,13 @@ def _sanitize_for_postgres(text: str) -> str:
     return text
 
 
+_OOXML_TYPES = {
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": _extract_docx,
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": _extract_pptx,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": _extract_xlsx,
+}
+
+
 def extract_text(content: bytes, content_type: str) -> str | None:
     """Return extracted text, or None when extraction is not possible/failed.
 
@@ -71,6 +161,11 @@ def extract_text(content: bytes, content_type: str) -> str | None:
 
         if ct.startswith("text/") or ct in ("application/json", "application/xml"):
             return _sanitize_for_postgres(content.decode("utf-8", errors="replace"))
+
+        extractor = _OOXML_TYPES.get(ct)
+        if extractor is not None:
+            text = extractor(content)
+            return _sanitize_for_postgres(text) if text else None
 
         return None
     except Exception:


### PR DESCRIPTION
Five focused fixes for the gaps the June fidelity sitrep called out.

## What's in here

**Notion** (`backend/integrations/notion/importers/page.py`)
- `table` blocks now render as real markdown tables. Previously dropped silently — `_render_block` had no handler, and the generic children walk rendered each `table_row` as plain rich-text noise.
- `child_database` blocks now inline-render up to 50 rows (was a `_(database)_ Title` placeholder). Property-type coverage: number/checkbox/url/email/select/multi_select/date/people/formula/rollup/created_time/last_edited_time; unknown types fall back to `_(type)_`.

**Jira** (`backend/integrations/jira/indexer.py`)
- Lazy-fetch field whitelist widened from `summary,status,assignee,updated,description,comment` to include `priority,issuetype,reporter,created,duedate,labels,components,fixVersions,issuelinks,subtasks,parent,attachment`.
- `_render_issue` now emits sections for issue links (with relationship strings — "blocks", "is blocked by", etc.), subtasks (key + status + summary), and attachments (filename + content URL so the agent can fetch them).

**Drive** (`backend/integrations/google/indexer.py`)
- `fetch_drive_content` MIME-routes instead of only handling Google Docs:
  - Google Doc → markdown export
  - Google Sheet → XLSX export → multi-sheet TSV via `file_extraction.extract_text`
  - Google Slides → text/plain export
  - PDF / .docx / .pptx / .xlsx native files → `?alt=media` download → file_extraction
  - 25 MB hard cap on native downloads
- Previously Sheets/Slides/native binaries all returned `""`.

**File extraction** (`backend/services/file_extraction.py`)
- Adds .docx (zipfile + ElementTree walk over `word/document.xml`; tables become tab-separated rows), .pptx (every slide's `<a:t>` runs), and .xlsx (openpyxl, one `## <title>` block per visible sheet) to the upload-extraction queue.
- No new dependencies — zipfile + xml.etree are stdlib, openpyxl is already vendored.

**Snowflake** — verified that schema discovery is already wired (`list_source` → `client.list_tables`, `read_source` on a table → `client.describe_table`). No change needed.

## What's NOT in here

- Slack threading / missed-event recovery — out of scope for this batch.
- Drive multi-tab Sheets export via openpyxl is *good*, but cell formatting / formulas still don't make it through.

## Test plan
- [ ] Sync a Notion page that contains a `table` block — verify it renders as a markdown table in `notion_index.content`.
- [ ] Sync a Notion page with a nested `child_database` — verify first 50 rows land in `notion_index`.
- [ ] Read a Jira issue lazily — verify links / subtasks / attachments / parent sections appear.
- [ ] Read a Google Sheet via the agent — verify every visible sheet appears, not just the first.
- [ ] Read a Drive PDF lazily — verify the body extracts.
- [ ] Upload a .docx and .pptx directly — verify text shows up in `files.extracted_text` after the extraction queue runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)