### PR TITLE
style: black-format files touched by #550

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -207,16 +207,10 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
 
 
 async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:
-    resp = await client.get(
-        DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime}
-    )
+    resp = await client.get(DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime})
     return resp.text if resp.status_code == 200 else ""
 
 
 async def _export_bytes(client: httpx.AsyncClient, file_id: str, mime: str) -> bytes:
-    resp = await client.get(
-        DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime}
-    )
+    resp = await client.get(DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime})
     return resp.content if resp.status_code == 200 else b""
-
-

--- a/backend/integrations/jira/indexer.py
+++ b/backend/integrations/jira/indexer.py
@@ -30,14 +30,26 @@ _SITE_URL_CACHE: dict[str, str] = {}
 ISSUE_FIELDS = ",".join(
     [
         # core
-        "summary", "status", "priority", "issuetype",
-        "assignee", "reporter", "created", "updated", "duedate",
+        "summary",
+        "status",
+        "priority",
+        "issuetype",
+        "assignee",
+        "reporter",
+        "created",
+        "updated",
+        "duedate",
         # body + activity
-        "description", "comment",
+        "description",
+        "comment",
         # taxonomy
-        "labels", "components", "fixVersions",
+        "labels",
+        "components",
+        "fixVersions",
         # graph (links + hierarchy)
-        "issuelinks", "subtasks", "parent",
+        "issuelinks",
+        "subtasks",
+        "parent",
         # files
         "attachment",
     ]

--- a/backend/integrations/notion/importers/page.py
+++ b/backend/integrations/notion/importers/page.py
@@ -188,9 +188,7 @@ def _cell_to_md(cell: list[dict]) -> str:
     return text.replace("|", "\\|").replace("\n", " ")
 
 
-async def _render_table_block(
-    client: httpx.AsyncClient, block: dict, depth: int
-) -> list[str]:
+async def _render_table_block(client: httpx.AsyncClient, block: dict, depth: int) -> list[str]:
     """Render a Notion `table` block as a markdown table.
 
     Notion's `table` block has `table_width` + `has_column_header`. The rows


### PR DESCRIPTION
Follow-up to #550. Backend lint job caught formatting drift on the three files I edited; this just runs black --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)