### PR TITLE
Refresh two-pillar messaging + onboarding (about-step + collab-docs path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 <h3 align="center">Knowledge bases for the agent era.</h3>
 
 <p align="center">
-  Built for the era where your agents write more than your team does. <br>
-  Sessions, files, and Stashes — a company brain humans and agents both <br>
-  write into, query semantically, and publish from.
+  The one place your agents connect to all your data — GitHub, Drive, Gmail, <br>
+  Notion, Slack and more — plus an agent-native Drive in Markdown and HTML <br>
+  where their sessions, files, and pages all land.
 </p>
 
 
@@ -57,7 +57,7 @@ With Stash, every agent on the repo has context about every session created from
 >
 > — Andrej Karpathy, *LLM Knowledge Bases*
 
-**Stash is that product.** A company brain humans and agents both write into — not a stack of shell scripts wrapped around a folder of markdown.
+**Stash is that product.** The one place your agents connect to all your data, with an agent-native Drive they write it back into — not a stack of shell scripts wrapped around a folder of markdown.
 
 Built for —
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -82,7 +82,8 @@ async def _get_user_from_api_key(token: str) -> dict:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT u.id, u.name, u.display_name, u.email, u.description, "
-        "       u.created_at, u.last_seen, k.id AS key_id "
+        "       u.created_at, u.last_seen, u.role, u.referral_source, u.use_case, "
+        "       k.id AS key_id "
         "FROM user_api_keys k JOIN users u ON u.id = k.user_id "
         "WHERE k.key_hash = $1 AND k.revoked_at IS NULL",
         key_hash,
@@ -108,7 +109,8 @@ async def _get_user_from_jwt(token: str) -> dict:
     claims = await validate_auth0_token(token)
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, email, description, created_at, last_seen "
+        "SELECT id, name, display_name, email, description, created_at, last_seen, "
+        "       role, referral_source, use_case "
         "FROM users WHERE auth0_sub = $1",
         claims["sub"],
     )

--- a/backend/migrations/versions/0097_user_onboarding_fields.py
+++ b/backend/migrations/versions/0097_user_onboarding_fields.py
@@ -1,0 +1,33 @@
+"""Add onboarding profile fields to users — role, referral_source, use_case.
+
+Captured in the first onboarding step so we know who's signing up, how they
+found us, and what they want to build. Nullable: older accounts never answered.
+
+Revision ID: 0097
+Revises: 0096
+"""
+
+from alembic import op
+
+revision = "0097"
+down_revision = "0096"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE users
+            ADD COLUMN role            text,
+            ADD COLUMN referral_source text,
+            ADD COLUMN use_case        text
+        """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE users
+            DROP COLUMN IF EXISTS role,
+            DROP COLUMN IF EXISTS referral_source,
+            DROP COLUMN IF EXISTS use_case
+        """)

--- a/backend/models.py
+++ b/backend/models.py
@@ -33,6 +33,9 @@ class UserProfile(BaseModel):
     description: str
     created_at: datetime
     last_seen: datetime
+    role: str | None = None
+    referral_source: str | None = None
+    use_case: str | None = None
 
 
 class UserUpdateRequest(BaseModel):
@@ -42,6 +45,10 @@ class UserUpdateRequest(BaseModel):
     # Required whenever `password` is set — stops a stolen session key from
     # being enough to permanently take over the account.
     current_password: str | None = Field(None, max_length=128)
+    # Captured during onboarding's first step.
+    role: str | None = Field(None, max_length=128)
+    referral_source: str | None = Field(None, max_length=128)
+    use_case: str | None = Field(None, max_length=2000)
 
 
 class LoginRequest(BaseModel):

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -108,6 +108,9 @@ async def update_me(req: UserUpdateRequest, current_user: dict = Depends(get_cur
             password=req.password,
             current_password=req.current_password,
             current_key_id=current_user.get("key_id"),
+            role=req.role,
+            referral_source=req.referral_source,
+            use_case=req.use_case,
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -48,9 +48,14 @@ def send_welcome_email(user_email: str, first_name: str | None = None) -> None:
     html = f"""
 <p>{greeting}</p>
 
-<p>Thanks for signing up for Stash. Your workspace is a shared hopper for everything your agents produce or consume &mdash; session transcripts, markdown docs, HTML pages, images, tables, raw files. Structured or not.</p>
+<p>Thanks for signing up for Stash. Two things it does for your agents:</p>
 
-<p>It&rsquo;s organized into three things:</p>
+<ul>
+  <li><strong>One place to connect to all your data</strong> &mdash; GitHub, Google Drive, Gmail, Notion, Slack, Granola. Your agent reads and searches across everything you connect, from day one.</li>
+  <li><strong>An agent-native Drive</strong> &mdash; Markdown and HTML pages, files, and session transcripts your agents read and write natively through the CLI, MCP, and API.</li>
+</ul>
+
+<p>Under the hood, your workspace is organized into three things:</p>
 
 <ul>
   <li><strong>Cartridges</strong> &mdash; virtual sub-workspaces. Bundle any subset of your workspace into a Stash, share it publicly, or keep it private. Use them for teams, workstreams, or projects (LinkedIn marketing, backend infra, kernel reading group).</li>
@@ -87,7 +92,7 @@ def send_welcome_email(user_email: str, first_name: str | None = None) -> None:
             "From": FOUNDER_FROM,
             "To": user_email,
             "ReplyTo": "sam@joinstash.ai",
-            "Subject": "Welcome to Stash — your knowledge base is ready",
+            "Subject": "Welcome to Stash — connect your data and start writing",
             "HtmlBody": html,
         }
     )

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -55,7 +55,8 @@ async def register_user(
 async def get_user_by_id(user_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, name, display_name, email, description, created_at, last_seen "
+        "SELECT id, name, display_name, email, description, created_at, last_seen, "
+        "       role, referral_source, use_case "
         "FROM users WHERE id = $1",
         user_id,
     )
@@ -81,6 +82,9 @@ async def update_user(
     password: str | None = None,
     current_password: str | None = None,
     current_key_id: UUID | None = None,
+    role: str | None = None,
+    referral_source: str | None = None,
+    use_case: str | None = None,
 ) -> dict:
     """Update profile fields. Password changes must present `current_password`,
     and revoke every other API key so a stolen session can't outlive the rotation.
@@ -113,9 +117,22 @@ async def update_user(
         sets.append(f"password_hash = ${idx}")
         args.append(hash_password(password))
         idx += 1
+    if role is not None:
+        sets.append(f"role = ${idx}")
+        args.append(role)
+        idx += 1
+    if referral_source is not None:
+        sets.append(f"referral_source = ${idx}")
+        args.append(referral_source)
+        idx += 1
+    if use_case is not None:
+        sets.append(f"use_case = ${idx}")
+        args.append(use_case)
+        idx += 1
     if not sets:
         row = await pool.fetchrow(
-            "SELECT id, name, display_name, email, description, created_at, last_seen "
+            "SELECT id, name, display_name, email, description, created_at, last_seen, "
+            "       role, referral_source, use_case "
             "FROM users WHERE id = $1",
             user_id,
         )
@@ -123,7 +140,8 @@ async def update_user(
     args.append(user_id)
     row = await pool.fetchrow(
         f"UPDATE users SET {', '.join(sets)} WHERE id = ${idx} "
-        "RETURNING id, name, display_name, email, description, created_at, last_seen",
+        "RETURNING id, name, display_name, email, description, created_at, last_seen, "
+        "          role, referral_source, use_case",
         *args,
     )
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -23,7 +23,8 @@ const spaceGrotesk = Space_Grotesk({
 
 export const metadata: Metadata = {
   title: "Stash",
-  description: "A shared memory for your AI agent team",
+  description:
+    "One place for your agents to connect to all your data, plus an agent-native Drive in Markdown and HTML.",
   icons: {
     icon: [
       { url: "/icon.svg", type: "image/svg+xml" },

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -6,15 +6,35 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../../components/Header";
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
-import { getToken, listMyWorkspaces } from "../../lib/api";
+import { createPage, getToken, listMyWorkspaces, updateMe } from "../../lib/api";
+import { generateCollabIntroMarkdown } from "../../lib/onboarding/collabIntro";
 import { seedWelcomePage } from "../../lib/onboarding/seedWelcome";
 import SourceConnectorList from "../../components/integrations/SourceConnectorList";
 
 import MemoryAskStep from "./paths/memory/MemoryAskStep";
 
-// The linear flow: explain Stash, connect a source, then ask the agent a real
-// question over your data, then launch into the workspace.
-const STEP_NAMES = ["intro", "connect", "ask"] as const;
+// The linear flow: a few questions about the user, explain Stash, connect a
+// source, then ask the agent a real question over your data, then launch.
+const STEP_NAMES = ["about", "intro", "connect", "ask"] as const;
+
+const ROLE_OPTIONS = [
+  "Engineer",
+  "Eng Manager",
+  "Founder / Exec",
+  "Product",
+  "Designer",
+  "Researcher",
+  "Other",
+];
+
+const REFERRAL_OPTIONS = [
+  "Search",
+  "X / Twitter",
+  "Friend or colleague",
+  "GitHub",
+  "LinkedIn",
+  "Other",
+];
 
 function useStashToken(): string | null {
   return useSyncExternalStore(
@@ -48,6 +68,9 @@ function OnboardingInner() {
   const [sourceCount, setSourceCount] = useState(0);
   const [obsidianAdded, setObsidianAdded] = useState(false);
   const [answered, setAnswered] = useState(false);
+  const [role, setRole] = useState("");
+  const [referralSource, setReferralSource] = useState("");
+  const [useCase, setUseCase] = useState("");
 
   const stepIdx = useMemo(() => {
     const raw = searchParams.get("step");
@@ -113,21 +136,53 @@ function OnboardingInner() {
     exitToWorkspace();
   }, [exitToWorkspace, stepIdx]);
 
+  // The "I just want to write with my agent" path: skip connecting sources,
+  // seed a starter page, and drop the user straight into the collaborative
+  // editor. This is the Google-Docs-for-agents wedge, so it bypasses the ask step.
+  const finishToCollabDoc = useCallback(async () => {
+    if (!workspaceId) return;
+    track("onboarding.collab_path_chosen", {});
+    const content = generateCollabIntroMarkdown(user?.display_name || user?.name || "");
+    const page = await createPage(workspaceId, "Welcome to your Drive", undefined, content);
+    router.push(`/workspaces/${workspaceId}/p/${page.id}`);
+  }, [workspaceId, user, router]);
+
   if (loading || !apiKey) {
     return (
       <div className="min-h-screen flex items-center justify-center text-muted">Loading…</div>
     );
   }
 
-  // 0 = intro, 1 = connect, 2 = ask.
-  const isIntro = stepIdx <= 0;
-  const isConnect = stepIdx === 1;
-  const isAsk = stepIdx >= 2;
+  // 0 = about, 1 = intro, 2 = connect, 3 = ask.
+  const isAbout = stepIdx <= 0;
+  const isIntro = stepIdx === 1;
+  const isConnect = stepIdx === 2;
+  const isAsk = stepIdx >= 3;
 
-  const continueLabel = isIntro ? "Get started" : isAsk ? "Launch workspace" : "Continue";
-  // On the ask step, only let them launch once the agent has actually replied.
-  const canContinue = isIntro || (isAsk ? answered : sourceCount > 0 || obsidianAdded);
-  const onContinue = () => {
+  const continueLabel = isIntro
+    ? "Get started"
+    : isAsk
+      ? "Launch workspace"
+      : "Continue";
+  // About: role + referral are required (use-case is optional). Ask: only let
+  // them launch once the agent has actually replied.
+  const canContinue = isAbout
+    ? Boolean(role && referralSource)
+    : isIntro || (isAsk ? answered : sourceCount > 0 || obsidianAdded);
+  const onContinue = async () => {
+    if (isAbout) {
+      try {
+        await updateMe({
+          role,
+          referral_source: referralSource,
+          use_case: useCase || undefined,
+        });
+      } catch {
+        // Best-effort — don't block onboarding on a profile write.
+      }
+      track("onboarding.about_submitted", { role, referral_source: referralSource });
+      return goToStep(stepIdx + 1);
+    }
     if (isAsk) return void finishAndExit();
     goToStep(stepIdx + 1);
   };
@@ -138,12 +193,23 @@ function OnboardingInner() {
       <main className="flex-1 px-4 py-10">
         <div className="mx-auto w-full max-w-2xl space-y-8">
           <ProgressBar stepIdx={stepIdx} />
+          {isAbout && (
+            <AboutStep
+              role={role}
+              referralSource={referralSource}
+              useCase={useCase}
+              onRole={setRole}
+              onReferral={setReferralSource}
+              onUseCase={setUseCase}
+            />
+          )}
           {isIntro && <IntroStep />}
           {isConnect && (
             <ConnectStep
               workspaceId={workspaceId}
               onSourceCountChange={setSourceCount}
               onObsidianAdded={() => setObsidianAdded(true)}
+              onCollabDoc={finishToCollabDoc}
             />
           )}
           {isAsk && (
@@ -157,6 +223,103 @@ function OnboardingInner() {
           />
         </div>
       </main>
+    </div>
+  );
+}
+
+function AboutStep({
+  role,
+  referralSource,
+  useCase,
+  onRole,
+  onReferral,
+  onUseCase,
+}: {
+  role: string;
+  referralSource: string;
+  useCase: string;
+  onRole: (v: string) => void;
+  onReferral: (v: string) => void;
+  onUseCase: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          First, tell us about you
+        </h1>
+        <p className="text-sm text-dim max-w-lg">
+          Three quick questions so we can tailor Stash to how you&rsquo;ll use it.
+        </p>
+      </div>
+      <Field label="What's your role?">
+        <PillGroup options={ROLE_OPTIONS} value={role} onChange={onRole} />
+      </Field>
+      <Field label="How did you hear about us?">
+        <PillGroup options={REFERRAL_OPTIONS} value={referralSource} onChange={onReferral} />
+      </Field>
+      <Field label="What do you want to use Stash for?" optional>
+        <textarea
+          value={useCase}
+          onChange={(e) => onUseCase(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          placeholder="e.g. give my coding agents a shared knowledge base across our repos"
+          className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-[13.5px] text-foreground placeholder:text-muted/70 focus:border-brand focus:outline-none"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  optional,
+  children,
+}: {
+  label: string;
+  optional?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="text-[13px] font-medium text-foreground">
+        {label}
+        {optional && <span className="ml-1.5 text-[11px] font-normal text-muted">optional</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function PillGroup({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const selected = value === option;
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            className={`rounded-full border px-3 py-1.5 text-[12.5px] transition-colors ${
+              selected
+                ? "border-brand bg-brand text-white"
+                : "border-border bg-surface text-dim hover:border-foreground/40 hover:text-foreground"
+            }`}
+          >
+            {option}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -213,10 +376,12 @@ function ConnectStep({
   workspaceId,
   onSourceCountChange,
   onObsidianAdded,
+  onCollabDoc,
 }: {
   workspaceId: string | null;
   onSourceCountChange: (n: number) => void;
   onObsidianAdded: () => void;
+  onCollabDoc: () => void;
 }) {
   return (
     <div className="space-y-6">
@@ -231,10 +396,25 @@ function ConnectStep({
       </div>
       <SourceConnectorList
         workspaceId={workspaceId}
-        returnTo="/onboarding?step=2"
+        returnTo="/onboarding?step=3"
         onSourceCountChange={onSourceCountChange}
         onObsidianUploaded={onObsidianAdded}
       />
+      <button
+        type="button"
+        onClick={onCollabDoc}
+        className="group flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
+      >
+        <div>
+          <div className="text-[13.5px] font-medium text-foreground">
+            Just want a place to write with your agent?
+          </div>
+          <div className="text-[12px] text-muted">
+            Skip connecting sources — start a collaborative doc instead.
+          </div>
+        </div>
+        <span className="text-muted transition-colors group-hover:text-brand">&rarr;</span>
+      </button>
     </div>
   );
 }
@@ -262,7 +442,7 @@ function AskStep({
 }
 
 function ProgressBar({ stepIdx }: { stepIdx: number }) {
-  const labels = ["Welcome", "Connect", "Ask"];
+  const labels = ["About you", "Welcome", "Connect", "Ask"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, i) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -149,6 +149,9 @@ export async function updateMe(data: {
   description?: string;
   password?: string;
   current_password?: string;
+  role?: string;
+  referral_source?: string;
+  use_case?: string;
 }): Promise<User> {
   return apiFetch("/api/v1/users/me", {
     method: "PATCH",

--- a/frontend/src/lib/onboarding/collabIntro.ts
+++ b/frontend/src/lib/onboarding/collabIntro.ts
@@ -1,0 +1,29 @@
+// The starter page seeded when a user picks the "just write with my agent"
+// onboarding path. It's a real Markdown page in their Drive — editable and
+// deletable — that doubles as an explainer for how the agent-native Drive works.
+
+export function generateCollabIntroMarkdown(displayName: string): string {
+  const name = displayName.trim() || "there";
+  return `# Welcome to your agent-native Drive, ${name}
+
+This is a real page in your Stash — start typing to make it yours, or delete it. Edits save automatically, and you and your agent can edit the same page at the same time (two cursors at once).
+
+## What lives here
+
+- **Markdown & HTML pages** — like this one. The formats your agent already reads and writes.
+- **Files** — drop in PDFs, CSVs, images; your agent can open them too.
+- **Agent session transcripts** — every conversation with your coding agent, pushed in automatically.
+
+## How your agent reaches it
+
+Your whole Drive mounts as a virtual filesystem your agent can navigate and edit:
+
+- **CLI** — \`pip install stashai\`, then your coding agent can \`ls\`, \`find\`, and \`rg\` across everything.
+- **MCP** — point Claude Code, Cursor, Codex, or OpenCode at the Stash MCP server and they read and write pages directly.
+- **API** — the same surface over HTTP for anything custom.
+
+## Share it
+
+Bundle any set of pages into a Cartridge with a link, or share a folder with specific people — so teammates and their agents work from the same docs.
+`;
+}

--- a/www/app/_components/Logo.tsx
+++ b/www/app/_components/Logo.tsx
@@ -1,0 +1,22 @@
+export default function Logo({ size = 28 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 64 72"
+      width={size}
+      height={(size * 72) / 64}
+      aria-hidden="true"
+    >
+      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
+      <circle cx="25" cy="22" r="4" fill="#fff" />
+      <circle cx="39" cy="22" r="4" fill="#fff" />
+      <circle cx="26" cy="22" r="2" fill="#0F172A" />
+      <circle cx="40" cy="22" r="2" fill="#0F172A" />
+      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+
+import Logo from "./Logo";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+// Shared top nav for the landing page and the use-case pages, so the two
+// primary use-case links stay identical everywhere they appear.
+export default function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-border-subtle bg-background/80 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-7 sm:px-7">
+        <Link
+          href="/"
+          className="flex items-center gap-2.5 font-display text-[20px] font-black tracking-[-0.03em] text-ink"
+        >
+          <Logo size={28} />
+          stash
+        </Link>
+        <nav className="flex items-center gap-2 text-[14px] text-dim">
+          <Link
+            href="/connect-your-data"
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
+          >
+            Connect your data
+          </Link>
+          <Link
+            href="/agent-native-drive"
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
+          >
+            Agent-native Drive
+          </Link>
+          <Link
+            href="/docs"
+            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
+          >
+            Docs
+          </Link>
+          <Link
+            href="/blog"
+            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
+          >
+            Blog
+          </Link>
+          <Link
+            href="/contact-sales"
+            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
+          >
+            Contact sales
+          </Link>
+          <Link
+            href="https://github.com/Fergana-Labs/stash"
+            className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
+            aria-label="Stash on GitHub"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 0 0 7.86 10.92c.57.11.78-.25.78-.55v-1.94c-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.07 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.6.23 2.78.12 3.07.74.81 1.19 1.84 1.19 3.1 0 4.41-2.69 5.38-5.26 5.67.41.35.77 1.05.77 2.12v3.14c0 .3.21.67.79.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+            </svg>
+            <span className="hidden sm:inline">GitHub</span>
+          </Link>
+          <Link
+            href="/login"
+            className="hidden h-10 items-center rounded-lg border border-border bg-background px-[18px] text-[14px] font-medium text-ink transition hover:border-ink sm:inline-flex"
+          >
+            Sign in
+          </Link>
+          <Link
+            href={APP_URL}
+            className="hidden h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover sm:inline-flex"
+          >
+            Start free
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/www/app/agent-native-drive/page.tsx
+++ b/www/app/agent-native-drive/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import SiteHeader from "../_components/SiteHeader";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export const metadata: Metadata = {
+  title: "Agent-native Drive · Stash",
+  description:
+    "An agent-native Google Drive in Markdown and HTML. Real-time collaborative editing for you and your agents, reachable through the CLI, MCP, and API.",
+};
+
+const FEATURES = [
+  [
+    "Markdown & HTML, natively",
+    "Pages are real Markdown and HTML — plus CSV, PDF, and images. The formats your agent already reads and writes, not a proprietary block format.",
+  ],
+  [
+    "Real-time collaboration",
+    "You and your agent edit the same page at the same time — two cursors at once. Edits save automatically.",
+  ],
+  [
+    "A virtual filesystem",
+    "The whole Drive mounts as a filesystem your agent can ls, find, and rg — pages, files, and session transcripts side by side.",
+  ],
+  [
+    "Reachable everywhere",
+    "Through the CLI, the Stash MCP server, or the HTTP API. Point Claude Code, Cursor, Codex, or OpenCode at it and they read and write directly.",
+  ],
+  [
+    "Sessions land here too",
+    "Every coding-agent session streams in automatically, indexed alongside your docs — no manual upload, no copy-paste.",
+  ],
+  [
+    "Share a slice",
+    "Bundle any set of pages into a Cartridge with a link, or share a folder with specific people — teammates and their agents work from the same docs.",
+  ],
+];
+
+export default function AgentNativeDrivePage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+
+      <section className="border-b border-border-subtle py-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Agent-native Drive
+          </p>
+          <h1 className="mt-5 max-w-[900px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
+            A Google Drive your{" "}
+            <span className="text-brand">agents can actually use.</span>
+          </h1>
+          <p className="mt-7 max-w-[620px] text-[18px] leading-[1.55] text-foreground">
+            Write with your agent in real time on pages that are real Markdown and
+            HTML. The whole Drive — pages, files, and session transcripts — is
+            reachable through the CLI, MCP, and API, so your agent reads and writes
+            it as naturally as you do.
+          </p>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/docs/quickstart"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Quickstart →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Built for the way agents read and write.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map(([name, blurb]) => (
+              <div
+                key={name}
+                className="rounded-[12px] border border-border bg-background p-5 transition-colors hover:border-brand"
+              >
+                <div className="font-display text-[17px] font-bold tracking-[-0.01em] text-ink">
+                  {name}
+                </div>
+                <p className="mt-1.5 text-[14px] leading-[1.55] text-dim">{blurb}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-surface py-28 text-center">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-black leading-[1.0] tracking-[-0.04em] text-ink">
+            Give your agents somewhere to write.
+          </h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/connect-your-data"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Connect your data →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/www/app/connect-your-data/page.tsx
+++ b/www/app/connect-your-data/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import SiteHeader from "../_components/SiteHeader";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export const metadata: Metadata = {
+  title: "Connect your data · Stash",
+  description:
+    "The one place your agents connect to all your data — GitHub, Drive, Gmail, Notion, Slack, and more. Read and search across everything from day one.",
+};
+
+const SOURCES = [
+  ["GitHub", "Pick repos your agent can navigate like a filesystem."],
+  ["Google Drive", "Index My Drive and read docs on demand."],
+  ["Gmail", "Search messages and read email on demand."],
+  ["Notion", "Pages and databases you share with Stash."],
+  ["Slack", "Channel history, kept in sync."],
+  ["Granola", "Meeting notes and transcripts."],
+  ["Jira", "Search issues across a project."],
+  ["Asana", "Navigate tasks from a project."],
+  ["Gong", "Call transcripts, kept in sync."],
+  ["Snowflake", "Run read-only SQL against your warehouse."],
+];
+
+export default function ConnectYourDataPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+
+      <section className="border-b border-border-subtle py-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Connect your data
+          </p>
+          <h1 className="mt-5 max-w-[900px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
+            One place your agents connect to{" "}
+            <span className="text-brand">all your data.</span>
+          </h1>
+          <p className="mt-7 max-w-[620px] text-[18px] leading-[1.55] text-foreground">
+            Connect GitHub, Drive, Gmail, Notion, Slack and more in a couple of
+            clicks. Your agent reads and searches across everything you connect —
+            grounded on your real work from day one instead of starting empty.
+          </p>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/contact-sales"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Talk to us
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Connect once. Your agent reads it all.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {SOURCES.map(([name, blurb]) => (
+              <div
+                key={name}
+                className="rounded-[12px] border border-border bg-background p-5 transition-colors hover:border-brand"
+              >
+                <div className="font-display text-[17px] font-bold tracking-[-0.01em] text-ink">
+                  {name}
+                </div>
+                <p className="mt-1.5 text-[14px] leading-[1.55] text-dim">{blurb}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle py-20 md:py-28">
+        <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-7 md:grid-cols-3 md:gap-12">
+          <Point title="OAuth in two clicks">
+            Connect a source from settings — no tokens to paste, no scripts to
+            run. Access stays scoped to what you grant.
+          </Point>
+          <Point title="Kept in sync">
+            Stash keeps connected sources fresh, so your agent reasons over the
+            current state of your data, not a one-time export.
+          </Point>
+          <Point title="Search and ask across everything">
+            Ask one question and your agent answers across every source at once —
+            grounded on your stuff, with citations back to where it came from.
+          </Point>
+        </div>
+      </section>
+
+      <section className="bg-surface py-28 text-center">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-black leading-[1.0] tracking-[-0.04em] text-ink">
+            Give your agents everything you know.
+          </h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/agent-native-drive"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              See the agent-native Drive →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Point({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="font-display text-[19px] font-bold tracking-[-0.01em] text-ink">{title}</h3>
+      <p className="mt-2.5 text-[15px] leading-[1.6] text-dim">{children}</p>
+    </div>
+  );
+}

--- a/www/app/contact-sales/page.tsx
+++ b/www/app/contact-sales/page.tsx
@@ -44,9 +44,9 @@ export default function ContactSalesPage() {
           </h1>
           <p className="mt-6 max-w-[440px] text-[17px] leading-[1.6] text-foreground">
             Tell us a bit about your team and we&apos;ll set up a 30-minute
-            walkthrough. We&apos;ll cover how Stash captures every agent run,
-            keeps a shared files, and answers questions across your team&apos;s
-            history.
+            walkthrough. We&apos;ll cover how Stash connects your agents to all
+            your data and gives them an agent-native Drive to write the work
+            back into.
           </p>
 
           <ul className="mt-8 flex flex-col gap-3 text-[14px] text-dim">

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -5,7 +5,7 @@ export default function DocsOverview() {
   return (
     <>
       <Title>Stash Overview</Title>
-      <Subtitle> Stash is shared memory for your repositories. Agents push in their work automatically. Stash indexes it into a shared, searchable knowledge base. </Subtitle>
+      <Subtitle> Stash is the one place your agents connect to all your data — GitHub, Drive, Gmail, Notion, Slack and more — plus an agent-native Drive in Markdown and HTML where their sessions, files, and pages all land. </Subtitle>
 
       <Callout type="tip">
         <strong>Ready to get started?</strong> Go straight to the{" "}

--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -13,9 +13,9 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Stash · Your team's AI work, compounding",
+  title: "Stash · One place your agents connect to all your data",
   description:
-    "Stash turns every coding-agent session into a shared, evolving asset, so your team stops running AI individually and starts compounding the work.",
+    "The one place your agents connect to all your data — GitHub, Drive, Gmail, Notion, Slack and more — plus an agent-native Drive in Markdown and HTML to write the work back into.",
 };
 
 export default function RootLayout({

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -3,7 +3,9 @@ import type { ReactNode } from "react";
 
 import AppRedirectForSignedInUsers from "./_components/AppRedirectForSignedInUsers";
 import LiveDemo from "./_components/LiveDemo";
+import Logo from "./_components/Logo";
 import ScrollLink from "./_components/ScrollLink";
+import SiteHeader from "./_components/SiteHeader";
 import VisualizationsShowcase from "./_components/VisualizationsShowcase";
 
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
@@ -12,7 +14,7 @@ export default function Page() {
   return (
     <main className="min-h-screen bg-background text-foreground">
       <AppRedirectForSignedInUsers appUrl={APP_URL} />
-      <Nav />
+      <SiteHeader />
       <Hero />
       <Logos />
       <Problem />
@@ -29,111 +31,12 @@ export default function Page() {
   );
 }
 
-function Logo({ size = 28 }: { size?: number }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 64 72"
-      width={size}
-      height={(size * 72) / 64}
-      aria-hidden="true"
-    >
-      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
-      <circle cx="25" cy="22" r="4" fill="#fff" />
-      <circle cx="39" cy="22" r="4" fill="#fff" />
-      <circle cx="26" cy="22" r="2" fill="#0F172A" />
-      <circle cx="40" cy="22" r="2" fill="#0F172A" />
-      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
-    </svg>
-  );
-}
-
 function EyebrowDot({ children }: { children: ReactNode }) {
   return (
     <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
       <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
       {children}
     </p>
-  );
-}
-
-function Nav() {
-  return (
-    <header className="sticky top-0 z-50 border-b border-border-subtle bg-background/80 backdrop-blur">
-      <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-7 sm:px-7">
-        <Link
-          href="/"
-          className="flex items-center gap-2.5 font-display text-[20px] font-black tracking-[-0.03em] text-ink"
-        >
-          <Logo size={28} />
-          stash
-        </Link>
-        <nav className="flex items-center gap-2 text-[14px] text-dim">
-          <ScrollLink
-            to="#how"
-            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
-          >
-            How it works
-          </ScrollLink>
-          <ScrollLink
-            to="#features"
-            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
-          >
-            Features
-          </ScrollLink>
-          <Link
-            href="/discover"
-            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-          >
-            Discover
-          </Link>
-          <Link
-            href="/docs"
-            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-          >
-            Docs
-          </Link>
-          <Link
-            href="/blog"
-            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-          >
-            Blog
-          </Link>
-          <Link
-            href="/contact-sales"
-            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-          >
-            Contact sales
-          </Link>
-          <Link
-            href="https://github.com/Fergana-Labs/stash"
-            className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-            aria-label="Stash on GitHub"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-              <path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 0 0 7.86 10.92c.57.11.78-.25.78-.55v-1.94c-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.07 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.6.23 2.78.12 3.07.74.81 1.19 1.84 1.19 3.1 0 4.41-2.69 5.38-5.26 5.67.41.35.77 1.05.77 2.12v3.14c0 .3.21.67.79.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
-            </svg>
-            <span className="hidden sm:inline">GitHub</span>
-          </Link>
-          <Link
-            href="/login"
-            className="hidden h-10 items-center rounded-lg border border-border bg-background px-[18px] text-[14px] font-medium text-ink transition hover:border-ink sm:inline-flex"
-          >
-            Sign in
-          </Link>
-          <Link
-            href={APP_URL}
-            className="hidden h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover sm:inline-flex"
-          >
-            Start free
-          </Link>
-        </nav>
-      </div>
-    </header>
   );
 }
 
@@ -239,9 +142,9 @@ function Hero() {
             </h1>
 
             <p className="mt-7 max-w-[540px] text-[18px] leading-[1.55] text-foreground">
-              Built for the era where your agents write more than your team does.
-              Files, sessions, and Stashes. A company brain agents and humans
-              both write into.
+              The one place your agents connect to all your data — GitHub, Drive,
+              Gmail, Notion, Slack and more. Plus an agent-native Drive in Markdown
+              and HTML to write the work back into.
             </p>
 
             <div className="mt-9 flex flex-wrap items-center gap-3">
@@ -333,10 +236,10 @@ function Problem() {
             evaporates the moment the session closes.
           </p>
           <p>
-            Stash is the company brain built for that flow. Sessions stream in as they happen. Files give
-            your team and your agents a real filesystem to write into. Stashes
-            turn any slice of that work into a link you can publish or fork
-            into another workspace.
+            Stash is built for that flow. It&rsquo;s the one place your agents
+            connect to all your data — GitHub, Drive, Gmail, Notion, Slack — and
+            an agent-native Drive in Markdown and HTML where sessions, files, and
+            pages all land. Bundle any slice into a link you can publish or fork.
           </p>
         </div>
       </div>
@@ -1000,9 +903,10 @@ function ClosingCTA() {
           <br />
           <span className="text-brand">to put their work.</span>
         </h2>
-        <p className="mx-auto mt-6 max-w-[540px] text-[17px] text-dim">
-          Start free in the managed app, or run the whole thing on your own
-          Postgres. Open source, MIT licensed.
+        <p className="mx-auto mt-6 max-w-[560px] text-[17px] text-dim">
+          Connect your agents to all your data, and give them an agent-native
+          Drive to write it back into. Start free in the managed app, or run the
+          whole thing on your own Postgres. Open source, MIT licensed.
         </p>
         <div className="mt-9 flex flex-wrap justify-center gap-3">
           <Link
@@ -1031,7 +935,8 @@ function Footer() {
     {
       h: "Product",
       links: [
-        ["How it works", "#how"],
+        ["Connect your data", "/connect-your-data"],
+        ["Agent-native Drive", "/agent-native-drive"],
         ["Discover", "/discover"],
         ["Docs", "/docs"],
       ],
@@ -1070,7 +975,8 @@ function Footer() {
             stash
           </div>
           <p className="mt-3 max-w-[320px] text-[13.5px] leading-[1.55] text-dim">
-            The knowledge base for the agent era. Open source, MIT licensed,
+            The one place your agents connect to all your data — plus an
+            agent-native Drive in Markdown and HTML. Open source, MIT licensed,
             self-hostable.
           </p>
         </div>


### PR DESCRIPTION
## What & why

The product narrative is now **two pillars**, in priority order:

1. **One place for your agents to connect to all your data** (primary) — GitHub, Drive, Gmail, Notion, Slack, and more.
2. **An agent-native Drive** (secondary) — Markdown/HTML pages, files, and session transcripts agents read/write via the CLI, MCP, and API.

This PR aligns messaging to that story and reshapes onboarding around it.

## Messaging refresh

- **Landing** (`www/app/page.tsx`): kept the `Knowledge bases for the agent era.` headline; rewrote the hero subhead, problem paragraph, closing CTA, and footer to lead with connect-your-data.
- **Meta/SEO**: `www/app/layout.tsx` + `frontend/src/app/layout.tsx` descriptions.
- **Docs** overview, **contact-sales** page copy (also fixed a "keeps a shared files" grammar bug) + confirmation email, **README** value-prop and tagline paragraph.
- **Welcome email** (`backend/services/email_service.py`): re-ordered so the two pillars lead, subject updated.

## Landing nav + two new pages

- Removed **How it works**, **Features**, **Discover** from the top nav.
- Added **Connect your data** → `/connect-your-data` and **Agent-native Drive** → `/agent-native-drive`, each a new dedicated use-case page explaining that pillar in detail.
- Extracted a shared `SiteHeader` (+ `Logo`) so the nav is identical across the landing page and both new pages. Surfaced the two pages in the footer Product column.

## Onboarding

- **New required "About you" step** *before* the intro: role + how-did-you-hear (required, pill selectors) and an optional "what do you want to use Stash for" textarea. Persisted to three new nullable `users` columns (`role`, `referral_source`, `use_case`; Alembic `0097`) via `PATCH /me`, plus an `onboarding.about_submitted` analytics event. Continue is gated until role + how-heard are set.
- **"Just want to write with your agent?" option** on the connect step: seeds a Markdown explainer page (how the agent-native Drive works — Markdown/HTML, transcripts, CLI/MCP/API) and drops the user straight into the collaborative editor, bypassing the ask step.

## Verification

- `ruff check backend/` ✓ · `www` + `frontend` eslint ✓ (only pre-existing warnings) · `frontend` + `www` `tsc` ✓ (only pre-existing test-runner-global errors) · `www` `next build` ✓ (both new routes prerender).
- Backend `test_auth.py` green; migration `0097` applied to the test DB; `PATCH`/`GET /me` round-trips `role`/`referral_source`/`use_case`.
- Browser-walked the full onboarding flow (About → Welcome → Connect → collab-doc → editor) and confirmed the seeded explainer renders live in the collaborative editor, plus the new landing nav and both use-case pages. Screenshots below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
