### PR TITLE
Sidebar: Your brain · Agents · Cartridges (fold in Discover + Activity)

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
@@ -3,17 +3,26 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
-import { StashesGridSkeleton } from "../../../../../components/SkeletonStates";
+import {
+  CardGridSkeleton,
+  StashesGridSkeleton,
+} from "../../../../../components/SkeletonStates";
 import { PinIcon, StashIcon } from "../../../../../components/StashIcons";
 import CartridgeCard from "../../../../../components/cartridge/CartridgeCard";
+import ForkCartridgeCardButton from "../../../../../components/cartridge/ForkCartridgeCardButton";
 import { SelectBox } from "../../../../../components/workspace/file-browser/ItemsList";
 import { useShareModal } from "../../../../../lib/shareModalContext";
 import {
   addExternalCartridge,
   ApiError,
+  API_BASE,
   deleteCartridge,
+  dismissCartridgeInvite,
   displayVisibility,
+  listCartridgeInvites,
   listStashes,
+  type CartridgeInvite,
+  type PublicCartridgeCard,
   type WorkspaceCartridge,
 } from "../../../../../lib/api";
 import { usePins } from "../../../../../lib/pins";
@@ -49,6 +58,8 @@ export default function WorkspaceStashesPage() {
   const pins = usePins("cartridges", workspaceId);
 
   const [cartridges, setStashes] = useState<WorkspaceCartridge[] | null>(null);
+  const [invites, setInvites] = useState<CartridgeInvite[]>([]);
+  const [busyInviteId, setBusyInviteId] = useState<string | null>(null);
   const [visibility, setVisibility] = useState<Visibility>("all");
   const [view, setView] = useState<ViewKey>("grid");
   const [error, setError] = useState("");
@@ -94,6 +105,24 @@ export default function WorkspaceStashesPage() {
   useEffect(() => {
     load();
   }, [load, shareVersion]);
+
+  // Pending invites are Cartridges others shared directly with you — surfaced in
+  // the "Shared with you" section. Non-critical: failure leaves the list empty.
+  useEffect(() => {
+    listCartridgeInvites()
+      .then(setInvites)
+      .catch(() => setInvites([]));
+  }, [shareVersion]);
+
+  async function dismissInvite(invite: CartridgeInvite) {
+    setBusyInviteId(invite.id);
+    try {
+      await dismissCartridgeInvite(invite.id);
+      setInvites((current) => current.filter((item) => item.id !== invite.id));
+    } finally {
+      setBusyInviteId(null);
+    }
+  }
 
   // Visibility filter applies across both axes; the section split (yours vs
   // forked) is the origin axis, kept independent of it.
@@ -163,11 +192,7 @@ export default function WorkspaceStashesPage() {
               Cartridges
             </h1>
             <p className="mt-0.5 text-[12.5px] text-muted">
-              Publishable bundles you own. Browse public ones in{" "}
-              <Link href="/discover" className="text-[var(--color-brand-600)] hover:underline">
-                Discover
-              </Link>
-              .
+              Your knowledge bundles — yours, shared with you, and the public library.
             </p>
           </div>
           <button
@@ -204,55 +229,62 @@ export default function WorkspaceStashesPage() {
           <CartridgeViewToggle view={view} onChange={setViewPersisted} />
         </div>
 
-        {cartridges.length === 0 ? (
-          <div className="mt-12 rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[12.5px] text-muted">
-            No Cartridges yet.
-          </div>
-        ) : (
-          <>
-            <CartridgeSection
-              title="Your Cartridges"
-              count={native.length}
-              emptyHint="None match this visibility."
-            >
-              <CartridgeCollection
-                cartridges={native}
-                startIndex={0}
-                view={view}
-                isPinned={isPinned}
-                onTogglePin={(s) => pins.toggle(s.id)}
-                selectedIds={selectedIds}
-                onToggleSelect={toggleSelect}
-                embedded
-              />
-            </CartridgeSection>
+        <CartridgeSection
+          title="Your cartridges"
+          count={native.length}
+          emptyHint={cartridges.length === 0 ? "No cartridges yet." : "None match this visibility."}
+        >
+          <CartridgeCollection
+            cartridges={native}
+            startIndex={0}
+            view={view}
+            isPinned={isPinned}
+            onTogglePin={(s) => pins.toggle(s.id)}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelect}
+            embedded
+          />
+        </CartridgeSection>
 
-            {/* Origin axis: Cartridges forked in from other workspaces. Kept a
-                separate section (not a peer filter) and always shown so the
-                add-by-link entry point stays reachable. */}
-            <CartridgeSection
-              title="Forked from others"
-              count={forked.length}
-              emptyHint={visibility === "all" ? null : "None match this visibility."}
-              action={
-                <ExternalCartridgeLinkForm workspaceId={workspaceId} onAdded={() => void load()} />
-              }
-            >
-              {forked.length > 0 && (
-                <CartridgeCollection
-                  cartridges={forked}
-                  startIndex={native.length}
-                  view={view}
-                  isPinned={isPinned}
-                  onTogglePin={(s) => pins.toggle(s.id)}
-                  selectedIds={selectedIds}
-                  onToggleSelect={toggleSelect}
-                  embedded
+        {/* Cartridges others gave you: forked-in copies plus pending invites
+            (view access shared directly with you). The add-by-link entry point
+            lives here too. */}
+        <CartridgeSection
+          title="Shared with you"
+          count={forked.length + invites.length}
+          emptyHint={visibility === "all" ? null : "None match this visibility."}
+          action={
+            <ExternalCartridgeLinkForm workspaceId={workspaceId} onAdded={() => void load()} />
+          }
+        >
+          {invites.length > 0 && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {invites.map((invite) => (
+                <SharedInviteCard
+                  key={invite.id}
+                  invite={invite}
+                  busy={busyInviteId === invite.id}
+                  onDismiss={() => void dismissInvite(invite)}
                 />
-              )}
-            </CartridgeSection>
-          </>
-        )}
+              ))}
+            </div>
+          )}
+          {forked.length > 0 && (
+            <CartridgeCollection
+              cartridges={forked}
+              startIndex={native.length}
+              view={view}
+              isPinned={isPinned}
+              onTogglePin={(s) => pins.toggle(s.id)}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
+              embedded
+              className={invites.length > 0 ? "mt-3" : undefined}
+            />
+          )}
+        </CartridgeSection>
+
+        <DiscoverSection workspaceId={workspaceId} />
       </div>
 
       {selectedStashes.length > 0 && (
@@ -444,6 +476,222 @@ function PlusGlyph() {
   );
 }
 
+// A pending invite rendered as a grid peer of the Cartridge cards. View opens
+// the Cartridge; Dismiss removes the invite (the access stays — it can still be
+// reached by link). Mirrors the dismiss logic in CartridgeInviteCenter.
+function SharedInviteCard({
+  invite,
+  busy,
+  onDismiss,
+}: {
+  invite: CartridgeInvite;
+  busy: boolean;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex flex-col rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2">
+        <span className="text-[var(--color-brand-600)]">
+          <StashIcon className="text-[18px]" />
+        </span>
+        <h3 className="min-w-0 flex-1 truncate font-display text-[14px] font-semibold text-foreground">
+          {invite.cartridge_title}
+        </h3>
+        <span className="shrink-0 rounded-full border border-border bg-base px-1.5 py-0.5 font-mono text-[9.5px] text-muted">
+          INVITE
+        </span>
+      </div>
+      <p className="mt-2 line-clamp-2 flex-1 text-[12px] leading-relaxed text-muted">
+        {invite.cartridge_description || "No description."}
+      </p>
+      <p className="mt-2 text-[11px] text-muted">
+        Shared by {invite.invited_by_display_name} · from {invite.source_workspace_name}
+      </p>
+      <div className="mt-3 flex justify-end gap-1.5">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onDismiss}
+          className="rounded-md border border-border-subtle px-2.5 py-1.5 text-[12px] text-muted hover:text-foreground disabled:opacity-50"
+        >
+          Dismiss
+        </button>
+        <Link
+          href={`/cartridges/${invite.cartridge_slug}`}
+          className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+        >
+          View
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// --- Discover (public library), inline ---
+
+const DISCOVER_SORTS = ["trending", "newest", "popular"] as const;
+type DiscoverSort = (typeof DISCOVER_SORTS)[number];
+
+function discoverSortLabel(sort: DiscoverSort): string {
+  if (sort === "popular") return "Most viewed";
+  if (sort === "trending") return "Trending";
+  return "Newest";
+}
+
+async function fetchPublicCartridges(params: {
+  q?: string;
+  sort: DiscoverSort;
+}): Promise<PublicCartridgeCard[]> {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) qs.set(key, value);
+  }
+  const res = await fetch(`${API_BASE}/api/v1/discover/cartridges${qs.size ? `?${qs}` : ""}`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.cartridges ?? [];
+}
+
+// The public marketplace as a section of the Cartridges page. Self-contained:
+// owns its own search/sort/fetch and isn't touched by the page's visibility
+// filter, view toggle, pins, or selection (those are for Cartridges you hold).
+function DiscoverSection({ workspaceId }: { workspaceId: string }) {
+  const [sort, setSort] = useState<DiscoverSort>("trending");
+  const [query, setQuery] = useState("");
+  const [cartridges, setCartridges] = useState<PublicCartridgeCard[]>([]);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFetching(true);
+    const handle = setTimeout(() => {
+      fetchPublicCartridges({ q: query || undefined, sort })
+        .then((list) => {
+          if (!cancelled) setCartridges(list);
+        })
+        .finally(() => {
+          if (!cancelled) setFetching(false);
+        });
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, sort]);
+
+  return (
+    <section className="mt-8">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <h2 className="m-0 font-display text-[14px] font-semibold">Discover</h2>
+          <span className="sys-label" style={{ fontSize: 10.5 }}>
+            public library
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex w-[220px] items-center gap-2 rounded-lg border border-border bg-base px-2.5 py-1.5">
+            <SearchGlyph />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search public Cartridges…"
+              className="min-w-0 flex-1 border-0 bg-transparent text-[12.5px] text-foreground placeholder:text-muted focus:outline-none"
+            />
+          </div>
+          <div className="inline-flex gap-0.5 rounded-lg border border-border bg-base p-[3px]">
+            {DISCOVER_SORTS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setSort(option)}
+                className={
+                  "rounded-md px-2.5 py-[3px] text-[12px] " +
+                  (sort === option
+                    ? "bg-raised font-semibold text-foreground"
+                    : "text-muted hover:text-foreground")
+                }
+              >
+                {discoverSortLabel(option)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {fetching ? (
+        <CardGridSkeleton />
+      ) : cartridges.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12px] text-muted">
+          No public Cartridges match.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {cartridges.map((stash, i) => {
+            const trending = sort === "trending" && i < 2;
+            return (
+              <CartridgeCard
+                key={stash.id}
+                stash={{
+                  id: stash.id,
+                  slug: stash.slug,
+                  title: stash.title,
+                  description: stash.description,
+                  cover_image_url: stash.cover_image_url,
+                  access: "public",
+                  item_count: stash.item_count,
+                  updated_at: stash.updated_at,
+                }}
+                cover={COVERS[i % COVERS.length]}
+                badge={
+                  trending ? (
+                    <span className="absolute left-3 top-2.5 inline-flex items-center gap-1 rounded-full bg-black/80 px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.04em] text-white">
+                      ↗ trending
+                    </span>
+                  ) : undefined
+                }
+                cornerAction={
+                  stash.workspace_id === workspaceId ? undefined : (
+                    <ForkCartridgeCardButton
+                      slug={stash.slug}
+                      sourceWorkspaceId={stash.workspace_id}
+                    />
+                  )
+                }
+                footer={
+                  <>
+                    <span className="min-w-0 truncate">
+                      {stash.owner_display_name}
+                      {stash.workspace_name && (
+                        <>
+                          {" · "}
+                          <span className="font-mono text-dim">{stash.workspace_name}</span>
+                        </>
+                      )}
+                    </span>
+                    <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-md border border-border bg-base px-2 py-0.5 text-[11.5px] font-medium text-foreground group-hover:border-[var(--color-brand-300)] group-hover:bg-[var(--color-brand-50)] group-hover:text-[var(--color-brand-700)]">
+                      Open →
+                    </span>
+                  </>
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SearchGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted">
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
 
 function CartridgeCollection({
   cartridges,
@@ -454,6 +702,7 @@ function CartridgeCollection({
   selectedIds,
   onToggleSelect,
   embedded,
+  className,
 }: {
   cartridges: WorkspaceCartridge[];
   startIndex: number;
@@ -463,13 +712,16 @@ function CartridgeCollection({
   selectedIds: Set<string>;
   onToggleSelect: (id: string) => void;
   embedded?: boolean;
+  className?: string;
 }) {
+  const extra = className ? ` ${className}` : "";
   if (view === "list") {
     return (
       <div
         className={
           (embedded ? "" : "mt-4 ") +
-          "overflow-hidden rounded-xl border border-border bg-surface"
+          "overflow-hidden rounded-xl border border-border bg-surface" +
+          extra
         }
       >
         {cartridges.map((stash) => (
@@ -490,7 +742,8 @@ function CartridgeCollection({
     <div
       className={
         (embedded ? "" : "mt-4 ") +
-        "grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+        "grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" +
+        extra
       }
     >
       {cartridges.map((stash, i) => (

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
 import AppShell from "../../components/AppShell";
 import {
   ActivitySkeleton,
@@ -17,17 +17,27 @@ import {
 } from "../../components/StashIcons";
 import ContributorActivityTimeline from "../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../components/viz/EmbeddingSpaceExplorer";
+import KnowledgeDensityMap from "../../components/viz/KnowledgeDensityMap";
 import { useAuth } from "../../hooks/useAuth";
 import {
   getActivityTimeline,
   getEmbeddingProjection,
+  getKnowledgeDensity,
   getWorkspace,
+  getWorkspaceOverview,
   listActivity,
   listMyWorkspaces,
   listWorkspaceActivity,
+  listWorkspaceSources,
   type ActivityEvent,
+  type WorkspaceOverview,
+  type WorkspaceSource,
 } from "../../lib/api";
-import type { ActivityTimeline, EmbeddingProjection } from "../../lib/types";
+import type {
+  ActivityTimeline,
+  EmbeddingProjection,
+  KnowledgeDensity,
+} from "../../lib/types";
 
 type FilterKey = "all" | "sessions" | "pages" | "cartridges";
 
@@ -47,6 +57,10 @@ const AVATAR_CLASSES = [
   "av-teal",
   "av-lime",
 ];
+
+// Native handles ("files"/"sessions") are always present — the Sources vital
+// counts the connected integrations the brain draws from, not these.
+const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);
 
 function avatarClassFor(name: string): string {
   let h = 5381;
@@ -85,6 +99,9 @@ function ActivityPageInner() {
   const [filter, setFilter] = useState<FilterKey>("all");
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
+  const [density, setDensity] = useState<KnowledgeDensity | null>(null);
+  const [overview, setOverview] = useState<WorkspaceOverview | null>(null);
+  const [sources, setSources] = useState<WorkspaceSource[]>([]);
   const [insightsLoaded, setInsightsLoaded] = useState(false);
   // Captured once so the "last 24h" window doesn't drift across re-renders.
   const [nowMs] = useState(() => Date.now());
@@ -113,8 +130,8 @@ function ActivityPageInner() {
     };
   }, [user, workspaceId]);
 
-  // Visualizations of what's been going on. They're workspace-scoped, so for
-  // the global view we resolve the user's own workspace.
+  // The brain's vitals + visualizations. All workspace-scoped, so for the
+  // global view we resolve the user's own workspace once and fan out.
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
@@ -125,13 +142,19 @@ function ActivityPageInner() {
         if (!cancelled) setInsightsLoaded(true);
         return;
       }
-      const [t, p] = await Promise.allSettled([
+      const [t, p, d, o, s] = await Promise.allSettled([
         getActivityTimeline(30, "day", wsId),
         getEmbeddingProjection(500, undefined, wsId),
+        getKnowledgeDensity(12, wsId),
+        getWorkspaceOverview(wsId),
+        listWorkspaceSources(wsId),
       ]);
       if (cancelled) return;
       if (t.status === "fulfilled") setTimeline(t.value);
       if (p.status === "fulfilled") setProjection(p.value);
+      if (d.status === "fulfilled") setDensity(d.value);
+      if (o.status === "fulfilled") setOverview(o.value);
+      if (s.status === "fulfilled") setSources(s.value);
       setInsightsLoaded(true);
     })().catch(() => {
       if (!cancelled) setInsightsLoaded(true);
@@ -150,12 +173,31 @@ function ActivityPageInner() {
     const since = nowMs - dayMs;
     const recent = events.filter((e) => new Date(e.ts).getTime() >= since);
     return {
+      recent24h: recent.length,
       sessions24h: recent.filter((e) => e.kind === "session.uploaded").length,
       pages24h: recent.filter((e) => e.kind === "page.updated").length,
       files24h: recent.filter((e) => e.kind === "file.uploaded").length,
       total: events.length,
     };
   }, [events, nowMs]);
+
+  // Connected integrations the brain learns from, plus their freshness.
+  const sourceVitals = useMemo(() => {
+    const connected = sources.filter((s) => !NATIVE_SOURCE_TYPES.has(s.type));
+    const syncing = connected.filter((s) => s.sync_status === "syncing").length;
+    const syncedAt = connected
+      .map((s) => s.last_synced_at)
+      .filter((v): v is string => !!v)
+      .sort()
+      .at(-1);
+    let hint = "—";
+    if (syncing > 0) hint = `${syncing} syncing`;
+    else if (syncedAt) hint = `synced ${relativeTime(syncedAt)}`;
+    else if (connected.length > 0) hint = "not synced yet";
+    return { count: connected.length, hint };
+  }, [sources]);
+
+  const knowledgePoints = projection?.stats.total_embeddings ?? 0;
 
   const filtered = useMemo(() => {
     if (filter === "all") return events;
@@ -180,59 +222,66 @@ function ActivityPageInner() {
     );
   }
 
+  const title = workspaceId ? workspaceName || "Your brain" : "Your brain";
+
   return (
     <AppShell user={user} onLogout={logout}>
       <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
-        {/* Header — a calm summary line, not a billboard. */}
+        {/* Header — what this brain holds and how fresh it is. */}
         <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
-          {workspaceId ? workspaceName || "Activity" : "Activity"}
+          {title}
         </h1>
         <p className="mt-1 text-[13.5px] text-muted">
-          {`${stats.sessions24h} session${stats.sessions24h === 1 ? "" : "s"}, ${stats.pages24h} page edit${stats.pages24h === 1 ? "" : "s"}, and ${stats.files24h} file upload${stats.files24h === 1 ? "" : "s"} in the last 24 hours.`}
+          {`${knowledgePoints.toLocaleString()} things learned across ${sourceVitals.count} connected source${sourceVitals.count === 1 ? "" : "s"} · ${stats.recent24h} new in the last 24 hours.`}
         </p>
 
-        {/* Stat strip */}
-        <div className="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-          <StatCard label="Sessions today" value={stats.sessions24h} tint="var(--color-agent)" />
-          <StatCard label="Pages edited" value={stats.pages24h} tint="var(--color-human)" />
-          <StatCard label="Files uploaded" value={stats.files24h} tint="#16A34A" />
-          <StatCard label="Total events" value={stats.total} tint="var(--text-muted)" />
+        {/* Brain map — the knowledge the brain holds, laid out in space. The
+            centerpiece visual. (Decorative.) */}
+        <VizCard label="Knowledge map" className="mt-6">
+          {!insightsLoaded ? (
+            <SkeletonBlock className="h-64 w-full" />
+          ) : projection && projection.points.length > 0 ? (
+            <EmbeddingSpaceExplorer data={projection} />
+          ) : (
+            <div className="px-2 py-12 text-center text-[12.5px] text-muted">
+              No embeddings indexed yet. Pages, table rows, and session events get
+              embedded as they&apos;re added.
+            </div>
+          )}
+        </VizCard>
+
+        {/* Vitals — the brain's current size and pulse. */}
+        <div className="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
+          <VitalCard label="Knowledge points" value={knowledgePoints} tint="var(--color-brand-600)" />
+          <VitalCard label="Pages" value={overview?.files.pages.length ?? 0} tint="var(--color-human)" />
+          <VitalCard label="Files" value={overview?.files.files.length ?? 0} tint="#16A34A" />
+          <VitalCard label="Sessions" value={overview?.sessions.length ?? 0} tint="var(--color-agent)" />
+          <VitalCard label="Sources" value={sourceVitals.count} hint={sourceVitals.hint} tint="#7C3AED" />
+          <VitalCard label="Learned today" value={stats.recent24h} tint="var(--text-muted)" />
         </div>
 
-        {/* Visualizations — what's been going on, over time and across the
-            knowledge map. (Decorative; moved here from the workspace home.) */}
-        <section className="mt-7">
-          <div className="sys-label mb-1.5">Human / agent commits — last 30 days</div>
-          <div className="card-soft overflow-x-auto p-3">
-            {!insightsLoaded ? (
-              <SkeletonBlock className="h-40 w-full" />
-            ) : timeline && timeline.contributors.length > 0 ? (
-              <ContributorActivityTimeline data={timeline} />
-            ) : (
-              <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No agent session commits yet. Push a transcript to populate this view.
-              </div>
-            )}
-          </div>
-        </section>
+        {/* What the brain knows — topic clusters. Hidden when there's nothing
+            to show, since it's an optional lens. */}
+        {density && density.clusters.length > 0 && (
+          <VizCard label="What your brain knows" className="mt-7">
+            <KnowledgeDensityMap data={density} />
+          </VizCard>
+        )}
 
-        <section className="mt-5">
-          <div className="sys-label mb-1.5">Embedding space — knowledge map</div>
-          <div className="card-soft p-3">
-            {!insightsLoaded ? (
-              <SkeletonBlock className="h-40 w-full" />
-            ) : projection && projection.points.length > 0 ? (
-              <EmbeddingSpaceExplorer data={projection} />
-            ) : (
-              <div className="px-2 py-6 text-center text-[12.5px] text-muted">
-                No embeddings indexed yet. Pages, table rows, and session events get embedded as
-                they&apos;re added.
-              </div>
-            )}
-          </div>
-        </section>
+        {/* Human / agent commits over time. (Decorative.) */}
+        <VizCard label="Human / agent commits — last 30 days" className="mt-5" scroll>
+          {!insightsLoaded ? (
+            <SkeletonBlock className="h-40 w-full" />
+          ) : timeline && timeline.contributors.length > 0 ? (
+            <ContributorActivityTimeline data={timeline} />
+          ) : (
+            <div className="px-2 py-6 text-center text-[12.5px] text-muted">
+              No agent session commits yet. Push a transcript to populate this view.
+            </div>
+          )}
+        </VizCard>
 
-        {/* Filters */}
+        {/* Newsfeed — what the brain has been learning lately. */}
         <div className="mt-8 flex items-center justify-between border-b border-border pb-2">
           <div className="flex gap-1">
             {FILTERS.map((f) => {
@@ -253,15 +302,14 @@ function ActivityPageInner() {
               );
             })}
           </div>
-          <span className="sys-label">sorted · recent</span>
+          <span className="sys-label">Recent learnings · recent</span>
         </div>
 
-        {/* Feed */}
         <div className="mt-3.5 flex flex-col gap-2.5">
           {filtered.length === 0 ? (
             <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
               {events.length === 0
-                ? "No activity yet. Push a transcript, edit a page, or upload a file."
+                ? "Nothing learned yet. Push a transcript, edit a page, or upload a file."
                 : `No ${filter === "all" ? "" : filter + " "}activity matches this filter.`}
             </div>
           ) : (
@@ -279,13 +327,36 @@ function ActivityPageInner() {
   );
 }
 
-function StatCard({
+// A labeled visualization card — the repeated sys-label + card-soft shell used
+// by the map, topics, and timeline sections.
+function VizCard({
+  label,
+  className,
+  scroll,
+  children,
+}: {
+  label: string;
+  className?: string;
+  scroll?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section className={className}>
+      <div className="sys-label mb-1.5">{label}</div>
+      <div className={`card-soft p-3${scroll ? " overflow-x-auto" : ""}`}>{children}</div>
+    </section>
+  );
+}
+
+function VitalCard({
   label,
   value,
+  hint,
   tint,
 }: {
   label: string;
   value: number;
+  hint?: string;
   tint: string;
 }) {
   return (
@@ -297,6 +368,7 @@ function StatCard({
         {value}
       </div>
       <div className="sys-label mt-0.5">{label}</div>
+      {hint && <div className="mt-0.5 text-[10.5px] text-muted">{hint}</div>}
     </div>
   );
 }

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -26,7 +26,6 @@ import AddSourceModal from "./integrations/AddSourceModal";
 import { labelForProvider, providerForSourceType } from "./integrations/connectors";
 import {
   ActivityIcon,
-  DiscoverIcon,
   FileIcon,
   HelpIcon,
   SessionsIcon,
@@ -295,13 +294,14 @@ export default function AppSidebar({
               : pathname === "/"
           }
         />
-        {/* Discover is global (not workspace-scoped) — the front door to public
-            Cartridges across Stash, so it sits up top next to Home. */}
+        {/* "Your brain" is the revamped activity view — your accumulated
+            knowledge, status, and newsfeed. Global (workspace-resolved within
+            the page), so it sits up top next to Home. */}
         <NavRow
-          href="/discover"
-          icon={<DiscoverIcon />}
-          label="Discover"
-          active={pathname.startsWith("/discover")}
+          href="/activity"
+          icon={<ActivityIcon />}
+          label="Your brain"
+          active={pathname.startsWith("/activity")}
         />
         {activeWorkspace ? (
           <NavRow
@@ -311,12 +311,6 @@ export default function AppSidebar({
             active={pathname.startsWith(`/workspaces/${activeWorkspace.id}/agents`)}
           />
         ) : null}
-        <NavRow
-          href="/activity"
-          icon={<ActivityIcon />}
-          label="Activity"
-          active={pathname.startsWith("/activity")}
-        />
         {activeWorkspace ? (
           <NavRow
             href={`/workspaces/${activeWorkspace.id}/cartridges`}


### PR DESCRIPTION
## What & why

Tightens the product sidebar's top nav under **Home** from five flat items to four intent-driven ones. Today's `Home · Discover · Agents · Activity · Cartridges` has two redundant entries — Discover is just the public slice of Cartridges, and Activity undersells what it represents (your accumulated second brain). New nav:

**Home → Your brain → Agents → Cartridges**

The standalone Discover and Activity rows are removed. Their routes (`/discover`, `/activity`) stay reachable by URL — `/discover` still serves the logged-out public marketplace.

## Changes

**Sidebar** (`AppSidebar.tsx`) — drop the Discover/Activity rows, add a **Your brain** row pointing at `/activity`.

**Your brain** (revamped `/activity`) — reframed from a generic feed into a view of your second brain:
- Brain/embedding **knowledge map** promoted to the centerpiece hero
- A 6-up **vitals strip**: knowledge points, pages, files, sessions, sources (+ sync freshness), learned-today
- **What your brain knows** — the previously-unused `KnowledgeDensityMap` topic treemap
- Commits timeline + the existing newsfeed (filter tabs kept)
- All driven by existing endpoints — no new backend (the visualizations are decorative).

**Cartridges** (combined page) — one page, three stacked sections:
- **Your cartridges** (native)
- **Shared with you** — forked/external cartridges + pending cartridge invites (`listCartridgeInvites`, optimistic dismiss)
- **Discover** — the public library inline, with its own search / sort / fork

Visibility filter, grid/list toggle, pins, and bulk-delete stay scoped to the cartridges you own/hold; Discover is excluded. The logged-out `/discover` page and the topbar invite bell are left untouched as independent entry points.

## Verification

- `npm run lint` clean, `npm test` → 127 passing, `tsc --noEmit` clean on changed files.
- Dogfooded in a headless browser (fresh account): nav reads Home → Your brain → Agents → Cartridges; both pages render with **zero console errors**; brain vitals/topics/map render and degrade cleanly on an empty workspace; Cartridges shows all three sections with section-scoped empty states; inline Discover search/sort/empty-state and grid/list toggle all work.

## Screenshots

_Screenshots attached in the thread below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
