### PR TITLE
CLI: fix `stash sources browse` and `stash join` crashes

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -59,8 +59,10 @@ class CartridgeClient:
             raise CartridgeError(resp.status_code, detail)
         return resp
 
-    def _get(self, path: str, **params) -> dict | list:
-        return self._request("GET", path, params=params).json()
+    # The URL argument is named `url`, not `path`, so callers can pass a query
+    # param literally named "path" (the source VFS does) without a kwarg clash.
+    def _get(self, url: str, **params) -> dict | list:
+        return self._request("GET", url, params=params).json()
 
     def _post(self, path: str, json=None) -> dict:
         resp = self._request("POST", path, json=json)
@@ -75,8 +77,8 @@ class CartridgeClient:
     def _delete(self, path: str) -> None:
         self._request("DELETE", path)
 
-    def _list(self, path: str, key: str, **params) -> list:
-        data = self._get(path, **params)
+    def _list(self, url: str, key: str, **params) -> list:
+        data = self._get(url, **params)
         return data.get(key, data) if isinstance(data, dict) else data
 
     def _upload(self, path: str, file_path: str) -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -4248,7 +4248,7 @@ def connect_cmd():
 @app.command("join")
 def join_cmd():
     """Request to join this repo's workspace."""
-    cfg = _require_auth()
+    _require_auth()
 
     repo_root = _git_toplevel()
     if not repo_root:
@@ -4262,9 +4262,7 @@ def join_cmd():
 
     manifest = json.loads(manifest_path.read_text())
     ws_id = manifest.get("workspace_id", "")
-
-    with CartridgeClient(base_url=cfg["base_url"], api_key=cfg["api_key"]) as c:
-        _handle_not_member(ws_id, c)
+    _handle_not_member(ws_id)
 
 
 @app.command("leave")

--- a/cli/tests/test_join_cmd.py
+++ b/cli/tests/test_join_cmd.py
@@ -1,0 +1,19 @@
+"""`stash join` is the guidance path for non-members: it must print the
+invite-link instructions, not crash. It once passed a client to
+_handle_not_member after the join-request flow (and the extra parameter)
+was removed."""
+
+import json
+
+from cli import main
+
+
+def test_join_prints_invite_guidance(monkeypatch, tmp_path, capsys) -> None:
+    (tmp_path / ".stash").write_text(json.dumps({"workspace_id": "ws-1234567890"}))
+    monkeypatch.setattr(main, "_require_auth", lambda: {"base_url": "http://test", "api_key": "k"})
+    monkeypatch.setattr(main, "_git_toplevel", lambda cwd=None: tmp_path)
+
+    main.join_cmd()
+
+    out = capsys.readouterr().out
+    assert "You're not a member" in out

--- a/cli/tests/test_sources_cli.py
+++ b/cli/tests/test_sources_cli.py
@@ -4,6 +4,7 @@ called with the source-optional arguments, so search-everything and
 search-one-source both reach the server correctly."""
 
 from cli import main
+from cli.client import CartridgeClient
 
 
 class _FakeClient:
@@ -66,3 +67,26 @@ def test_sources_browse_and_read(monkeypatch) -> None:
     main.sources_read("src-9", "specs/auth.md", workspace_id=None, as_json=True)
     assert ("entries", "ws-1", "src-9", "specs/") in calls
     assert ("read", "ws-1", "src-9", "specs/auth.md") in calls
+
+
+def test_list_source_entries_sends_path_as_query_param(monkeypatch) -> None:
+    """The entries endpoint takes a query param literally named "path". The real
+    client method must not collide with the helpers' URL argument (it did once:
+    `_list() got multiple values for argument 'path'`)."""
+    requests: list = []
+
+    class _Resp:
+        def json(self):
+            return {"entries": [{"path": "a.md"}]}
+
+    def fake_request(method, url, **kwargs):
+        requests.append((method, url, kwargs.get("params")))
+        return _Resp()
+
+    client = CartridgeClient("http://test")
+    monkeypatch.setattr(client, "_request", fake_request)
+    entries = client.list_source_entries("ws-1", "src-9", path="specs/")
+    assert entries == [{"path": "a.md"}]
+    assert requests == [
+        ("GET", "/api/v1/workspaces/ws-1/sources/src-9/entries", {"path": "specs/"})
+    ]


### PR DESCRIPTION
## What

Two `stash` CLI commands crashed with TypeErrors:

1. **`stash sources browse <source>`** → `CartridgeClient._list() got multiple values for argument 'path'`. The sources entries endpoint takes a query param literally named `path` (`backend/routers/sources.py:134`), which collided with the URL positional of the same name in the `_get`/`_list` helpers. Renamed the helpers' URL argument to `url` so any query param name is safe. Introduced in b0b29590.

2. **`stash join`** → `_handle_not_member() takes 1 positional argument but 2 were given`. e5a87063 removed the join-request flow and simplified `_handle_not_member` to one argument but missed the call site in `join_cmd`. Dropped the now-dead `CartridgeClient` block there too.

## Tests

Both regression tests reproduce the crash on the parent commit and pass with the fix:
- `test_list_source_entries_sends_path_as_query_param` exercises the real client method (the existing browse test faked the whole client, which is how this slipped through) and asserts the GET carries `params={"path": ...}`.
- `test_join_prints_invite_guidance` runs `join_cmd` end-to-end against a tmp `.stash`.

`cli/tests`: 60 passed. `ruff` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)