### PR TITLE
Fix stale table workspace links

### DIFF
--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -423,8 +423,21 @@ function TableEditorPageInner() {
         return;
       }
       if (resolvedWorkspaceId) {
-        setTable(await getTable(resolvedWorkspaceId, tableId));
-        return;
+        try {
+          setTable(await getTable(resolvedWorkspaceId, tableId));
+          return;
+        } catch {
+          const all = await listAllTables();
+          const match = all?.tables?.find((t) => t.id === tableId);
+          if (match?.workspace_id && match.workspace_id !== resolvedWorkspaceId) {
+            setResolvedWorkspaceId(match.workspace_id);
+            router.push(`/tables/${tableId}?workspaceId=${match.workspace_id}`);
+            setTable(await getTable(match.workspace_id, tableId));
+            return;
+          }
+          setError("Table not found");
+          return;
+        }
       }
       try {
         setTable(await getTable(null, tableId));
@@ -439,7 +452,7 @@ function TableEditorPageInner() {
         }
       }
     } catch { setError("Table not found"); }
-  }, [tableId, resolvedWorkspaceId, stashSlug]);
+  }, [tableId, resolvedWorkspaceId, stashSlug, router]);
 
   const buildRowParams = useCallback((pageOffset: number) => {
     const p: { sort_by?: string; sort_order?: string; limit?: number; offset?: number; filters?: object[] } = {

--- a/frontend/src/app/tables/[tableId]/page.test.tsx
+++ b/frontend/src/app/tables/[tableId]/page.test.tsx
@@ -219,6 +219,29 @@ describe("TableEditorPage row creation", () => {
     expect(api.getTable).not.toHaveBeenCalled();
   });
 
+  it("recovers stale workspace links with the canonical table workspace", async () => {
+    route.search = "workspaceId=stale-ws";
+    const canonicalTable = { ...table, workspace_id: "ws-2" };
+    api.getTable.mockImplementation(async (workspaceId: string | null) => {
+      if (workspaceId === "stale-ws") throw new Error("Table not found");
+      if (workspaceId === "ws-2") return canonicalTable;
+      throw new Error("Table not found");
+    });
+    api.listAllTables.mockResolvedValue({
+      tables: [{ ...canonicalTable, workspace_name: "Henry's Workspace" }],
+    });
+
+    render(<TableEditorPage />);
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(route.push).toHaveBeenCalledWith("/tables/table-1?workspaceId=ws-2");
+    expect(api.listTableRows).toHaveBeenCalledWith(
+      "ws-2",
+      "table-1",
+      expect.objectContaining({ offset: 0 }),
+    );
+  });
+
   it("undoes a committed cell edit with command-z", async () => {
     const editedRow = {
       ...existingRows[0],


### PR DESCRIPTION
## Summary

- Recover stale `/tables/[tableId]?workspaceId=...` links by checking the authenticated cross-workspace table index after the scoped lookup fails.
- Redirect the URL to the table's canonical workspace and load rows from that workspace.
- Add a regression for stale workspace links resolving to the canonical table workspace.

## Root Cause

The table page trusted the `workspaceId` query param. If that workspace was stale or no longer accessible, the first scoped table lookup failed and the UI showed `Table not found`, even when the same table was still visible to the user in another workspace.

## Product Impact

Old table links now self-heal instead of looking like data loss. This covers the `Hiring Outreach CRM` failure mode we just debugged.

## Screenshots

No screenshot attached: this is a route-resolution fix with no visual UI change. The user-facing result is the existing table page loading instead of the existing `Table not found` error.

## Validation

- `npm test -- --run 'src/app/tables/[tableId]/page.test.tsx'`
- `npx eslint 'src/app/tables/[tableId]/TableClient.tsx' 'src/app/tables/[tableId]/page.test.tsx'`
- `git diff --check -- 'frontend/src/app/tables/[tableId]/TableClient.tsx' 'frontend/src/app/tables/[tableId]/page.test.tsx'`
