### PR TITLE
www: focus /m/[variant] message tests into minimal painted-door pages

### DIFF
--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import VariantSurvey from "../m/_components/VariantSurvey";
 import AppRedirectForSignedInUsers from "./AppRedirectForSignedInUsers";
 import { INTEGRATIONS, integrationIcon } from "./BrandIcons";
 import Logo from "./Logo";
@@ -11,23 +10,12 @@ import VisualizationsShowcase from "./VisualizationsShowcase";
 
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
 
-export type HeroCopy = { headline: string; subhead?: string };
-
-// The full landing page. Message-test variant pages (`/m/[variant]`) reuse it
-// with overridden hero copy and every signup CTA routed to the lead survey.
-export default function HomePage({
-  heroOverride,
-  surveyVariant,
-}: {
-  heroOverride?: HeroCopy;
-  surveyVariant?: string;
-}) {
-  const ctaHref = surveyVariant ? "#survey" : APP_URL;
+export default function HomePage() {
   return (
     <main className="min-h-screen bg-background text-foreground">
       <AppRedirectForSignedInUsers appUrl={APP_URL} />
-      <SiteHeader ctaHref={ctaHref} />
-      <Hero override={heroOverride} ctaHref={ctaHref} />
+      <SiteHeader />
+      <Hero />
       <Logos />
       <Problem />
       <HowItWorks />
@@ -37,34 +25,9 @@ export default function HomePage({
       <Features />
       <DiscoverGrid />
       <CliAndPlugin />
-      <ClosingCTA ctaHref={ctaHref} />
-      {surveyVariant ? <VariantSurvey variant={surveyVariant} appUrl={APP_URL} /> : null}
+      <ClosingCTA />
       <Footer />
     </main>
-  );
-}
-
-// Signup CTAs become in-page anchors to the survey on variant pages.
-function CtaLink({
-  href,
-  className,
-  children,
-}: {
-  href: string;
-  className: string;
-  children: ReactNode;
-}) {
-  if (href.startsWith("#")) {
-    return (
-      <ScrollLink to={href} className={className}>
-        {children}
-      </ScrollLink>
-    );
-  }
-  return (
-    <Link href={href} className={className}>
-      {children}
-    </Link>
   );
 }
 
@@ -158,7 +121,7 @@ function HeroFunnel() {
   );
 }
 
-function Hero({ override, ctaHref }: { override?: HeroCopy; ctaHref: string }) {
+function Hero() {
   return (
     <section className="relative overflow-hidden">
       <div
@@ -172,39 +135,25 @@ function Hero({ override, ctaHref }: { override?: HeroCopy; ctaHref: string }) {
       <div className="relative z-10 mx-auto max-w-[1200px] px-7 pb-12 pt-20 lg:pb-20 lg:pt-28">
         <div className="grid grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:gap-16">
           <div>
-            {override ? (
-              <h1 className="text-balance font-display text-[clamp(38px,5vw,64px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
-                {override.headline}
-              </h1>
-            ) : (
-              <h1 className="text-balance font-display text-[clamp(44px,6.2vw,80px)] font-black leading-[0.95] tracking-[-0.045em] text-ink">
-                Knowledge bases for
-                <br />
-                the <span className="text-brand">agent era.</span>
-              </h1>
-            )}
+            <h1 className="text-balance font-display text-[clamp(44px,6.2vw,80px)] font-black leading-[0.95] tracking-[-0.045em] text-ink">
+              Knowledge bases for
+              <br />
+              the <span className="text-brand">agent era.</span>
+            </h1>
 
-            {override ? (
-              override.subhead ? (
-                <p className="mt-7 max-w-[540px] text-[18px] leading-[1.55] text-foreground">
-                  {override.subhead}
-                </p>
-              ) : null
-            ) : (
-              <p className="mt-7 max-w-[540px] text-[18px] leading-[1.55] text-foreground">
-                The one place your agents connect to all your data — GitHub, Drive,
-                Gmail, Notion, Slack and more. Plus an agent-native Drive to store
-                your agent-generated docs and data in.
-              </p>
-            )}
+            <p className="mt-7 max-w-[540px] text-[18px] leading-[1.55] text-foreground">
+              The one place your agents connect to all your data — GitHub, Drive,
+              Gmail, Notion, Slack and more. Plus an agent-native Drive to store
+              your agent-generated docs and data in.
+            </p>
 
             <div className="mt-9 flex flex-wrap items-center gap-3">
-              <CtaLink
-                href={ctaHref}
+              <Link
+                href={APP_URL}
                 className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
               >
                 Start free →
-              </CtaLink>
+              </Link>
               <Link
                 href="/contact-sales"
                 className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
@@ -962,7 +911,7 @@ function CliAndPlugin() {
   );
 }
 
-function ClosingCTA({ ctaHref }: { ctaHref: string }) {
+function ClosingCTA() {
   return (
     <section className="border-b border-border-subtle bg-surface py-32 text-center">
       <div className="mx-auto max-w-[1200px] px-7">
@@ -977,12 +926,12 @@ function ClosingCTA({ ctaHref }: { ctaHref: string }) {
           whole thing on your own Postgres. Open source, MIT licensed.
         </p>
         <div className="mt-9 flex flex-wrap justify-center gap-3">
-          <CtaLink
-            href={ctaHref}
+          <Link
+            href={APP_URL}
             className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
           >
             Start free →
-          </CtaLink>
+          </Link>
           <Link
             href="/contact-sales"
             className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -1,17 +1,12 @@
 import Link from "next/link";
 
 import Logo from "./Logo";
-import ScrollLink from "./ScrollLink";
 
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
 
 // Shared top nav for the landing page and the use-case pages, so the two
 // primary use-case links stay identical everywhere they appear.
-// Message-test variant pages pass ctaHref="#survey" to route signups
-// into the lead survey instead of the app.
-export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) {
-  const ctaClassName =
-    "hidden h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover sm:inline-flex";
+export default function SiteHeader() {
   return (
     <header className="sticky top-0 z-50 border-b border-border-subtle bg-background/80 backdrop-blur">
       <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-7 sm:px-7">
@@ -69,15 +64,12 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
           >
             Sign in
           </Link>
-          {ctaHref.startsWith("#") ? (
-            <ScrollLink to={ctaHref} className={ctaClassName}>
-              Start free
-            </ScrollLink>
-          ) : (
-            <Link href={ctaHref} className={ctaClassName}>
-              Start free
-            </Link>
-          )}
+          <Link
+            href={APP_URL}
+            className="hidden h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover sm:inline-flex"
+          >
+            Start free
+          </Link>
         </nav>
       </div>
     </header>

--- a/www/app/m/[variant]/page.tsx
+++ b/www/app/m/[variant]/page.tsx
@@ -1,25 +1,90 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import HomePage, { type HeroCopy } from "../../_components/HomePage";
+import PaintedDoorPage, {
+  type PaintedDoorCopy,
+} from "../_components/PaintedDoorPage";
 
-// Message-test landing pages: the homepage with one variable changed (hero
-// copy), every signup CTA routed into the lead survey. One X ad points at
-// each slug; survey submissions arrive tagged with it.
-const VARIANTS: Record<string, HeroCopy> = {
+// Painted-door message test: one X ad per slug points here. Each page is
+// built around the single message under test — hero, three proof points
+// written for that message, and the lead survey. Submissions email the team
+// tagged with the slug; submissions ÷ ad clicks ranks the messages.
+const VARIANTS: Record<string, PaintedDoorCopy> = {
   drive: {
     headline: "The Drive for your AI agents.",
     subhead:
       "Markdown, HTML, sessions, and skills — a virtual file system your agents work in.",
+    bullets: [
+      {
+        title: "Everything lands in one place",
+        body: "Every doc, transcript, and artifact your agents produce is saved automatically. Nothing evaporates when the session closes.",
+      },
+      {
+        title: "A real file system for agents",
+        body: "Agents ls, find, and rg the whole workspace through the CLI and MCP server. One addressable tree of pages, sessions, and tables.",
+      },
+      {
+        title: "Humans see everything",
+        body: "Browse and edit your agents' files in the browser, in real time. No black-box memory, no export step.",
+      },
+    ],
   },
   wiki: {
     headline: "A wiki your agents read and write.",
+    subhead:
+      "Shared pages your team and your agents keep current — together, in real time.",
+    bullets: [
+      {
+        title: "Agents write pages, not black-box memory",
+        body: "Plans, ADRs, runbooks, and research notes that stay current because the agents doing the work update them.",
+      },
+      {
+        title: "Your team edits alongside",
+        body: "Humans and agents edit the same pages at the same time. When an agent writes, your teammate sees it appear.",
+      },
+      {
+        title: "Every agent reads the same wiki",
+        body: "Shared context across teammates and tools — your agent already knows what mine figured out yesterday.",
+      },
+    ],
   },
   connect: {
     headline: "Connect your agents to all your data sources.",
+    subhead:
+      "GitHub, Drive, Gmail, Notion, Slack, Gong and more — one place your agents can query everything.",
+    bullets: [
+      {
+        title: "One connection, every source",
+        body: "Connect a source once and every agent you run can read it. No per-tool plumbing, no copy-paste context.",
+      },
+      {
+        title: "Works with the agents you already use",
+        body: "Claude Code, Cursor, Codex, and anything that speaks MCP. Plugins stream sessions in automatically.",
+      },
+      {
+        title: "Search by meaning",
+        body: "Semantic and keyword search across everything connected — your agent finds the Gong call, the PR, and the doc in one query.",
+      },
+    ],
   },
   assistant: {
     headline: "An AI assistant that lives in Slack and email.",
+    subhead:
+      "Ask it anything, right where you work — it knows everything your company has connected.",
+    bullets: [
+      {
+        title: "Answers in Slack",
+        body: "Mention it in any channel and it answers from your company's actual data — docs, code, calls, and past conversations.",
+      },
+      {
+        title: "Backed by everything you've connected",
+        body: "GitHub, Drive, Gmail, Notion, Gong and more. One assistant with the full picture, not another silo.",
+      },
+      {
+        title: "It remembers",
+        body: "Every question, answer, and doc adds to a shared brain your whole team — and all your agents — can use.",
+      },
+    ],
   },
 };
 
@@ -49,5 +114,5 @@ export default async function VariantPage({
   const { variant } = await params;
   const copy = VARIANTS[variant];
   if (!copy) notFound();
-  return <HomePage heroOverride={copy} surveyVariant={variant} />;
+  return <PaintedDoorPage variant={variant} copy={copy} />;
 }

--- a/www/app/m/_components/PaintedDoorPage.tsx
+++ b/www/app/m/_components/PaintedDoorPage.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+
+import Logo from "../../_components/Logo";
+import ScrollLink from "../../_components/ScrollLink";
+import VariantSurvey from "./VariantSurvey";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export type PaintedDoorCopy = {
+  headline: string;
+  subhead: string;
+  bullets: { title: string; body: string }[];
+};
+
+// Minimal painted-door page for the message test: one message, three proof
+// points written for that message, and the lead survey. No site nav — the
+// only paths are the survey or leaving, so clicks measure the message.
+export default function PaintedDoorPage({
+  variant,
+  copy,
+}: {
+  variant: string;
+  copy: PaintedDoorCopy;
+}) {
+  const ctaClassName =
+    "inline-flex h-11 items-center rounded-lg bg-brand px-6 text-[14.5px] font-medium text-white shadow-sm transition hover:bg-brand-hover";
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border-subtle">
+        <div className="mx-auto flex h-16 max-w-[1080px] items-center justify-between px-7">
+          <Link
+            href="/"
+            className="flex items-center gap-2.5 font-display text-[20px] font-black tracking-[-0.03em] text-ink"
+          >
+            <Logo size={28} />
+            stash
+          </Link>
+          <ScrollLink
+            to="#survey"
+            className="inline-flex h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+          >
+            Get early access
+          </ScrollLink>
+        </div>
+      </header>
+
+      <section className="relative overflow-hidden">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[480px]"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(249,115,22,0.08), transparent 60%)",
+          }}
+        />
+        <div className="relative z-10 mx-auto max-w-[860px] px-7 pb-20 pt-20 text-center md:pt-28">
+          <p className="flex items-center justify-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Private beta
+          </p>
+          <h1 className="mt-5 text-balance font-display text-[clamp(40px,5.6vw,72px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
+            {copy.headline}
+          </h1>
+          <p className="mx-auto mt-6 max-w-[600px] text-[18px] leading-[1.55] text-foreground">
+            {copy.subhead}
+          </p>
+          <div className="mt-9 flex justify-center">
+            <ScrollLink to="#survey" className={ctaClassName}>
+              Get early access →
+            </ScrollLink>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-border-subtle bg-surface py-16 md:py-20">
+        <div className="mx-auto grid max-w-[1080px] grid-cols-1 gap-10 px-7 md:grid-cols-3 md:gap-12">
+          {copy.bullets.map((b) => (
+            <div key={b.title}>
+              <h3 className="font-display text-[18px] font-bold tracking-[-0.015em] text-ink">
+                {b.title}
+              </h3>
+              <p className="mt-2.5 text-[14.5px] leading-[1.6] text-dim">{b.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <VariantSurvey variant={variant} appUrl={APP_URL} />
+
+      <footer className="border-t border-border-subtle">
+        <div className="mx-auto flex max-w-[1080px] flex-wrap items-center justify-between gap-3 px-7 py-5 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">
+          <span>© 2026 Fergana Labs</span>
+          <span className="flex gap-5">
+            <Link href="/privacy" className="transition hover:text-ink">
+              Privacy
+            </Link>
+            <Link href="/terms" className="transition hover:text-ink">
+              Terms
+            </Link>
+          </span>
+        </div>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
## What

Follow-up to #558. Each message-test page is now a minimal painted-door page built around only the message under test — logo-only header, headline + subhead, three proof points written for that specific message, then the lead survey. No site nav, no homepage body.

## Why

The full homepage body under every headline contaminated the test: it's knowledge-base-themed (worst under the assistant headline) and gave visitors paths around the survey. Now the only choices are the survey or leaving, so clicks measure the message.

## Changes

- New `app/m/_components/PaintedDoorPage.tsx`; per-variant copy (subhead + 3 bullets) lives in the `VARIANTS` map in `/m/[variant]/page.tsx`
- `HomePage`/`SiteHeader` revert to plain homepage components (heroOverride/ctaHref threading removed)
- Survey, Postmark action, noindex, 404-on-unknown all unchanged

## Verified

lint (0 errors) · build (4 variants SSG'd) · browser: CTA anchor-scroll, full survey submit → success card, `/m/unknown` 404, homepage hero/CTAs unchanged.

## Screenshots

[drive](https://app.joinstash.ai/workspaces/3bf47bc3-778c-4fd7-ad71-07c454259de5/f/b0db0d2b-3918-424d-919e-922fc11d6e10) · [wiki](https://app.joinstash.ai/workspaces/3bf47bc3-778c-4fd7-ad71-07c454259de5/f/2cde4123-b777-43cf-9724-a6dc1adcd739) · [connect](https://app.joinstash.ai/workspaces/3bf47bc3-778c-4fd7-ad71-07c454259de5/f/08ed94b7-ab65-4f35-9783-a6279385939a) · [assistant](https://app.joinstash.ai/workspaces/3bf47bc3-778c-4fd7-ad71-07c454259de5/f/12977ecc-8715-459d-bc0b-65b4feef8a72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)