### PR TITLE
fix(plugins): resolve stash binary with bash PATH, not shutil.which

### DIFF
--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -22,7 +22,12 @@ fi
 
 PY=""
 if command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  # Resolve with bash's own PATH lookup, then only use python to follow the
+  # symlink. shutil.which inside python3 is wrong here: when python3 is a
+  # pyenv shim, pyenv prepends its version's bin dir to PATH, so a stale
+  # pip-installed `stash` in that dir shadows the real pipx/uv install.
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then

--- a/plugins/openclaw-plugin/scripts/_run.sh
+++ b/plugins/openclaw-plugin/scripts/_run.sh
@@ -16,7 +16,12 @@ fi
 
 PY="${STASH_PYTHON:-}"
 if [ -z "$PY" ] && command -v stash >/dev/null 2>&1; then
-  STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" 2>/dev/null || true)"
+  # Resolve with bash's own PATH lookup, then only use python to follow the
+  # symlink. shutil.which inside python3 is wrong here: when python3 is a
+  # pyenv shim, pyenv prepends its version's bin dir to PATH, so a stale
+  # pip-installed `stash` in that dir shadows the real pipx/uv install.
+  STASH_BIN="$(command -v stash)"
+  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
   if [ -n "$STASH_REAL" ]; then
     CANDIDATE="$(dirname "$STASH_REAL")/python"
     if [ -x "$CANDIDATE" ]; then


### PR DESCRIPTION
fixes this subtle bug where when we call python3, and we have pyenv installed, we used a different PATH than if pyenv *isnt* installed. A different PATH means we could find a different installation of `stash` than the one we're actually using. So, we fix this by just using bash to do `which stash` so our result does not depend on whether or not pyenv happens to be in use.


# slop version

....
## Problem

Every Claude Code hook (Stop, UserPromptSubmit, …) was failing with:

```
ModuleNotFoundError: No module named 'stashai.plugin.event'
```

## Root cause

`plugins/claude-plugin/scripts/_run.sh` (and the openclaw variant) located the right Python by asking `python3` to resolve the `stash` binary:

```bash
STASH_REAL="$(python3 -c "import os, shutil; print(os.path.realpath(shutil.which('stash')))" ...)"
```

When `python3` is a **pyenv shim**, pyenv prepends `~/.pyenv/versions/<v>/bin` to the child process PATH. If that dir contains a stale pip-installed `stash` (e.g. stashai 0.1.23 from an old `pip install`), `shutil.which` finds it instead of the real pipx/uv install that bash's own PATH would find. The hook then re-execs under the stale venv's python, whose ancient stashai has no `stashai.plugin.event` module, and every hook errors.

## Fix

Resolve the binary with bash's own `command -v` (caller PATH, unmodified) and only use python to follow the symlink — the same pattern the codex/cursor/opencode `_run.sh` variants already use:

```bash
STASH_BIN="$(command -v stash)"
STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" ...)"
```

Any pyenv user with an old pip install lying around would hit this; resolution now matches what their shell sees.

## Verification

- Reproduced the failure: inside a pyenv-shimmed python3, `shutil.which('stash')` returned the stale `~/.pyenv/versions/3.12.0/bin/stash` while `command -v stash` correctly returned `~/.local/bin/stash` → uv tool venv.
- After the fix, `echo '{...}' | bash _run.sh on_prompt` and `on_stop` both exit 0.
- `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)