### PR TITLE
fix(release): version the GHCR images and pin them in the self-host compose

### DIFF
--- a/.github/workflows/bump-plugin-version.yml
+++ b/.github/workflows/bump-plugin-version.yml
@@ -10,12 +10,18 @@ on:
       - 'plugins/codex-plugin/**'
       - 'plugins/cursor-plugin/**'
       - 'plugins/opencode-plugin/**'
+      # Server code ships as versioned GHCR images pinned in
+      # docker-compose.prod.yml, so server changes must also cut a release.
+      - 'backend/**'
+      - 'frontend/**'
+      - 'collab/**'
 
 jobs:
   bump:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write    # required to dispatch publish.yml after the bump
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,6 +75,16 @@ jobs:
           marketplace["plugins"][0]["version"] = plugin_new
           marketplace_path.write_text(json.dumps(marketplace, indent=2) + "\n")
 
+          compose_path = pathlib.Path("docker-compose.prod.yml")
+          compose_text = compose_path.read_text()
+          compose_path.write_text(
+              re.sub(
+                  r"(ghcr\.io/fergana-labs/stash-[a-z]+):\S+",
+                  rf"\g<1>:{package_new}",
+                  compose_text,
+              )
+          )
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
               print(f"package_version={package_new}", file=output)
               print(f"plugin_version={plugin_new}", file=output)
@@ -82,7 +98,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml plugins/claude-plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git add pyproject.toml plugins/claude-plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json docker-compose.prod.yml
           git diff --cached --quiet && echo "No change" && exit 0
           git commit -m "chore: bump stash release to ${{ steps.bump.outputs.package_version }} and plugin to ${{ steps.bump.outputs.plugin_version }}"
           git push
+
+      # The bump commit is pushed with GITHUB_TOKEN, which never fires
+      # publish.yml's `on: push` trigger (GitHub's recursion guard), so the
+      # release would otherwise wait for the next human push to main.
+      # workflow_dispatch is exempt from the guard.
+      - name: Publish release
+        if: steps.trigger.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run publish.yml --ref main

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,12 @@
 name: Publish Docker images to GHCR
 
+# Images are published per release only. The normal path is publish.yml
+# dispatching this workflow on the v* tag it creates (tag pushes made with
+# GITHUB_TOKEN never fire the push trigger — GitHub's recursion guard); the
+# push trigger covers hand-pushed tags.
 on:
   push:
     tags: ["v*"]
-    branches: [main]
   workflow_dispatch:
 
 env:
@@ -45,10 +48,10 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/fergana-labs/${{ matrix.image }}
+          # latest=auto also moves `latest` to each release.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
 
       - uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       id-token: write    # required for PyPI trusted publishing (OIDC)
       contents: write    # required to push the release tag
+      actions: write     # required to dispatch docker-publish on the tag
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,6 +51,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "$TAG"
           git push origin "$TAG"
+
+      # Tag pushes made with GITHUB_TOKEN never fire docker-publish's
+      # `on: push: tags` trigger (GitHub's recursion guard), so dispatch it
+      # explicitly — workflow_dispatch is exempt from that guard.
+      - name: Build release images
+        if: steps.check.outputs.release == 'true'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docker-publish.yml --ref "$TAG"
 
       - name: Install build tooling
         if: steps.check.outputs.release == 'true'

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health
 ```
 
+`docker-compose.prod.yml` pins the image versions it was tested with. To
+upgrade, pull the latest compose file and restart:
+
+```bash
+git pull
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml pull
+docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+```
+
 Then install the CLI:
 
 ```bash

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,7 +55,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/fergana-labs/stash-backend:latest
+    image: ghcr.io/fergana-labs/stash-backend:0.1.26
     restart: always
     expose:
       - "3456"
@@ -78,7 +78,7 @@ services:
       start_period: 30s
 
   worker:
-    image: ghcr.io/fergana-labs/stash-backend:latest
+    image: ghcr.io/fergana-labs/stash-backend:0.1.26
     restart: always
     depends_on:
       postgres:
@@ -96,7 +96,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
-    image: ghcr.io/fergana-labs/stash-backend:latest
+    image: ghcr.io/fergana-labs/stash-backend:0.1.26
     restart: always
     depends_on:
       redis:
@@ -112,7 +112,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    image: ghcr.io/fergana-labs/stash-frontend:latest
+    image: ghcr.io/fergana-labs/stash-frontend:0.1.26
     restart: always
     expose:
       - "3457"
@@ -122,7 +122,7 @@ services:
       BACKEND_INTERNAL_URL: http://backend:3456
 
   collab:
-    image: ghcr.io/fergana-labs/stash-collab:latest
+    image: ghcr.io/fergana-labs/stash-collab:0.1.26
     restart: always
     expose:
       - "3458"

--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -13,10 +13,11 @@ SCRIPT="$1"
 shift
 TARGET="$(dirname "$0")/$SCRIPT.py"
 
-# On session start, pull the latest plugin code in the background so the
-# plugin cache never drifts from the source repo.
-if [ "$SCRIPT" = "on_session_start" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  git -C "$CLAUDE_PLUGIN_ROOT" pull --ff-only origin main >/dev/null 2>&1 &
+# On session start, upgrade the stashai package in the background. The hook
+# scripts themselves only update through Claude Code's marketplace refresh
+# (keyed off the plugin version bump) — the cache is a plain copy, not a git
+# checkout, so there is nothing to pull here.
+if [ "$SCRIPT" = "on_session_start" ]; then
   command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
 fi
 


### PR DESCRIPTION
Makes publishing less vibe coded and easier to debug

1. Self-hosters previously asked for the *latest* version of GHCR images when they ran `docker-compose.prod.yml`. Now they ask for a *specific* GHCR image version number, which is the one that we pin in `docker-compose.prod.yml`.
2. We used to have this idea of an "latest" version of a GHCR image, which was based on the latest commit, as opposed to a "numbered" version, which was based on the latest PR (wait isn't that essentially the same thing?). We got rid of the "edge" version because nobody was using it.
3. We also made a change to PyPI so that every PyPI release and git tag are not one commit late due to githubs anti recursion rules any more.

# slop version

## Problem

A self-hosted Stash server has no version. Three compounding causes:

1. `docker-publish.yml` built on **every push to main** and repointed `:latest` each time, so `:latest` meant "last merged commit", not "last release".
2. Its `on: push: tags: [v*]` trigger has **never fired**: `publish.yml` pushes release tags with `GITHUB_TOKEN`, and GitHub's recursion guard suppresses workflow runs for token-created push events. GHCR confirms it — every image carries only `latest`.
3. `docker-compose.prod.yml` pulled `:latest`, so self-hosters deploy an arbitrary main snapshot, can't say what version they run, can't roll back, and re-pulls blindly run Alembic migrations forward.

## Fix

**Images are published per release, and only per release.** `publish.yml` already tags `v<version>` on every release; now it also dispatches `docker-publish.yml` on that tag (`workflow_dispatch` is exempt from the recursion guard). Release refs produce `0.1.X` / `0.1` / `latest` image tags — `latest` now means *latest release*. The per-merge main build is deleted entirely: after this PR, every merge touching image contents cuts a release anyway (see below), so continuous `latest`/`edge` builds were pure duplicate work with a footgun attached.

**Pinned compose.** `docker-compose.prod.yml` pins all three Stash images to the release version. The auto-bump workflow now bumps those pins alongside `pyproject.toml` and the plugin version, and also triggers on `backend/`, `frontend/`, `collab/` changes so server code cuts releases too. Upgrading a self-host install becomes explicit: `git pull && docker compose pull && up -d` (README updated); rollback is editing the pin back.

**Faster releases.** The bump commit is also a `GITHUB_TOKEN` push, so `publish.yml` previously waited for the *next human push* to publish. The bump workflow now dispatches it immediately.

**Dead code removal.** The claude-plugin `_run.sh` "self-update" `git pull` has always silently no-opped — the plugin cache is a plain copy, not a git checkout. Removed; hook scripts update via Claude Code's marketplace refresh, keyed off the plugin version bump.

## Rollout note

No versioned images exist yet — including for `v0.1.27`, which was released 2026-06-09 (after this PR was opened) and demonstrated the bug live: the #565 merge bumped the version, the bot commit couldn't trigger publish (recursion guard), the #564 merge 22 seconds later published the tag + PyPI — and docker-publish never saw the tag, so `0.1.27` has a git tag and a PyPI release but no images. The `0.1.26` pin in this diff is equally imageless and that's fine: merging this PR triggers the bump bot, which cuts `0.1.28`, re-pins the compose to it, and runs the new dispatch chain end-to-end, producing the first versioned images ever. There is a window of minutes between merge and that chain completing during which a fresh `compose pull` of main would 404; existing deployments keep running. This is the dispatch chain's maiden run — worth watching the Actions tab on merge.

Self-hosters currently on `latest` may be *ahead* of the pinned release when they next upgrade; the next bump after merge puts the pin ahead again.

## Verification

- All three workflow files parse (`yaml.safe_load`), `_run.sh` passes `bash -n`.
- The new compose-pin regex was run against the real `docker-compose.prod.yml` and rewrites exactly the three `ghcr.io/fergana-labs/stash-*` pins.
- Registry state confirming the diagnosis: `gh api .../stash-backend/versions` shows only `latest`-tagged images; `gh run list --workflow docker-publish.yml` shows only `main` push events, never tag events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
