### PR TITLE
dev: document uv-based local CLI development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,6 @@ By default `stash` is the released PyPI build (`uv tool` install, self-updating)
 1. Once per checkout: `uv venv -p 3.12 && uv pip install -e .`
 2. Per terminal: `source .venv/bin/activate` — your prompt shows `(.venv)` and `stash` now runs this checkout's working tree. New terminals default back to the released CLI.
 
-Use uv for all Python installs — never a bare interpreter's pip (a bare `pip install -e .` under pyenv leaves a stale `stash` binary on PATH that shadows the real install).
-
 ### Backend
 - Install deps: `uv pip install -r backend/requirements.txt -r backend/requirements-dev.txt`
 - Migrate DB: `alembic upgrade head`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,15 @@ Two model tiers, configured in `backend/.env`:
 
 ## Commands
 
+### Developing the stash CLI
+By default `stash` is the released PyPI build (`uv tool` install, self-updating). To develop against this checkout's code instead:
+1. Once per checkout: `uv venv -p 3.12 && uv pip install -e .`
+2. Per terminal: `source .venv/bin/activate` — your prompt shows `(.venv)` and `stash` now runs this checkout's working tree. New terminals default back to the released CLI.
+
+Use uv for all Python installs — never a bare interpreter's pip (a bare `pip install -e .` under pyenv leaves a stale `stash` binary on PATH that shadows the real install).
+
 ### Backend
-- Install deps: `pip install -r backend/requirements.txt -r backend/requirements-dev.txt && pip install -e .`
+- Install deps: `uv pip install -r backend/requirements.txt -r backend/requirements-dev.txt`
 - Migrate DB: `alembic upgrade head`
 - Run server: `uvicorn backend.main:app --host 0.0.0.0 --port 3456 --proxy-headers --forwarded-allow-ips '*'`
 - Tests: `pytest`


### PR DESCRIPTION
## What

Documents the local-CLI dev workflow and standardizes all Python installs on uv:

- By default `stash` is the released PyPI build (`uv tool` install, self-updating via the plugin's session-start hook).
- To develop the CLI in a checkout (main repo or any worktree): `uv venv -p 3.12 && uv pip install -e .` once, then `source .venv/bin/activate` per terminal. The `(.venv)` prompt badge shows dev mode is on; new terminals default back to the released CLI.
- Backend dep install now targets `.venv` via `uv pip` instead of bare `pip`.

## Why

A bare `pip install -e .` under a pyenv interpreter is exactly what left the stale `stash` binary on PATH that #560 had to defend against. This makes the venv path the documented default with the simplest possible mental model: activate = this checkout's code, otherwise = released CLI.

(Earlier revisions of this PR shipped a committed `.envrc` + direnv for automatic per-directory switching; dropped deliberately — one more tool and invisible PATH state wasn't worth it vs `source .venv/bin/activate`.)

## Verification

- `source .venv/bin/activate` → `command -v stash` → `.venv/bin/stash`, `import cli` resolves to the working tree
- `deactivate` → `command -v stash` → `~/.local/bin/stash` (uv release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)