### PR TITLE
feat(doctor): warn automatically when duplicate stash installs shadow each other

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from stashai.plugin.doctor import shadow_install_warning
 from stashai.plugin.upload_status import read_upload_status
 
 from . import __version__, telemetry
@@ -4704,6 +4705,11 @@ def _show_setup_complete_splash() -> None:
         )
     )
     console.print()
+
+    warning = shadow_install_warning()
+    if warning:
+        console.print(Text(warning, style="yellow"))
+        console.print()
 
 
 @app.command("welcome")

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -9,6 +9,15 @@ import sys
 from adapt import adapt_session_start
 from config import DATA_DIR, get_config, get_stdin_data
 
+try:
+    from stashai.plugin.doctor import shadow_install_warning
+except ImportError:
+    # Plugin scripts can refresh a session before the stashai package
+    # auto-updates; skip the check until the package catches up.
+    def shadow_install_warning() -> None:
+        return None
+
+
 from stashai.plugin.hooks import (
     create_session_record,
     reset_session_record_state,
@@ -65,8 +74,9 @@ def main():
     state = load_state(DATA_DIR)
     if not uploads_enabled(cfg, event):
         warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
-        if warning:
-            json.dump({"systemMessage": warning}, sys.stdout)
+        messages = [m for m in (warning, shadow_install_warning()) if m]
+        if messages:
+            json.dump({"systemMessage": "\n\n".join(messages)}, sys.stdout)
         return
 
     reset_session_record_state(state)
@@ -98,15 +108,16 @@ def main():
             session_row_id=state.get("session_row_id", ""),
         )
 
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "SessionStart",
-                "additionalContext": CONTEXT + session_context,
-            }
-        },
-        sys.stdout,
-    )
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": CONTEXT + session_context,
+        }
+    }
+    shadow_warning = shadow_install_warning()
+    if shadow_warning:
+        output["systemMessage"] = shadow_warning
+    json.dump(output, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/plugins/tests/test_shadow_installs.py
+++ b/plugins/tests/test_shadow_installs.py
@@ -1,0 +1,58 @@
+"""The shadow-install warning exists because a bare pip install leaves a
+second, never-updating `stash` on PATH that wins in some contexts (pyenv
+shims prepend their bin dir) — hooks then run stale code long after the
+install that caused it. These tests pin the triggering conditions."""
+
+import os
+from pathlib import Path
+
+from stashai.plugin.doctor import find_stash_installs, shadow_install_warning
+
+
+def _make_stash(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    exe = directory / "stash"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    return exe
+
+
+def test_single_install_is_quiet(tmp_path, monkeypatch):
+    _make_stash(tmp_path / "bin")
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    assert shadow_install_warning() is None
+
+
+def test_symlinked_duplicate_counts_as_one_install(tmp_path, monkeypatch):
+    # uv setups expose the same binary twice (~/.local/bin symlink + the tool
+    # venv's bin). That is one install, not a shadow.
+    real = _make_stash(tmp_path / "venv" / "bin")
+    link_dir = tmp_path / "local"
+    link_dir.mkdir()
+    (link_dir / "stash").symlink_to(real)
+    monkeypatch.setenv("PATH", f"{link_dir}{os.pathsep}{real.parent}")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    assert len(find_stash_installs()) == 1
+    assert shadow_install_warning() is None
+
+
+def test_two_distinct_installs_warn_with_both_paths(tmp_path, monkeypatch):
+    first = _make_stash(tmp_path / "local" / "bin")
+    stale = _make_stash(tmp_path / "pyenv" / "shims")
+    monkeypatch.setenv("PATH", f"{first.parent}{os.pathsep}{stale.parent}")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    warning = shadow_install_warning()
+    assert warning is not None
+    assert str(first) in warning
+    assert str(stale) in warning
+
+
+def test_activated_dev_venv_suppresses_warning(tmp_path, monkeypatch):
+    # Dev mode (`source .venv/bin/activate`) intentionally puts a second
+    # stash on PATH; warning would otherwise fire on every dev session.
+    venv_stash = _make_stash(tmp_path / ".venv" / "bin")
+    release = _make_stash(tmp_path / "local" / "bin")
+    monkeypatch.setenv("PATH", f"{venv_stash.parent}{os.pathsep}{release.parent}")
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+    assert shadow_install_warning() is None

--- a/stashai/plugin/doctor.py
+++ b/stashai/plugin/doctor.py
@@ -1,0 +1,55 @@
+"""Detect duplicate `stash` installs that shadow each other.
+
+A bare `pip install stashai` under a pyenv or system interpreter leaves a
+second `stash` entry point on PATH. It never auto-updates (only the uv/pipx
+install does), and which copy wins differs by context — pyenv shims prepend
+their version's bin dir, so a hook can resolve a stale copy the shell never
+sees. The result is months-old code failing long after the install that
+caused it. Warn the moment more than one install is visible.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def find_stash_installs() -> list[Path]:
+    """Distinct `stash` executables on PATH, in PATH order, deduped by realpath."""
+    seen: set[Path] = set()
+    installs: list[Path] = []
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        candidate = Path(entry) / "stash"
+        if not (candidate.is_file() and os.access(candidate, os.X_OK)):
+            continue
+        real = candidate.resolve()
+        if real in seen:
+            continue
+        seen.add(real)
+        installs.append(candidate)
+    return installs
+
+
+def shadow_install_warning() -> str | None:
+    """Warning text when multiple `stash` installs can shadow each other, else None.
+
+    An activated virtualenv (VIRTUAL_ENV set) is the documented dev-mode
+    setup — its `stash` deliberately coexists with the released one — so the
+    check is skipped entirely rather than special-cased per install.
+    """
+    if os.environ.get("VIRTUAL_ENV"):
+        return None
+    installs = find_stash_installs()
+    if len(installs) <= 1:
+        return None
+    listing = "\n".join(f"  {path} -> {path.resolve()}" for path in installs)
+    return (
+        "Multiple `stash` installs found on PATH. The extras never "
+        "auto-update and can shadow the active one in some contexts "
+        "(pyenv shims, agent hooks), eventually breaking with stale code:\n"
+        f"{listing}\n"
+        "Keep one (`uv tool install stashai`) and remove the rest — for a "
+        "pip install under pyenv: `pip uninstall stashai`, then `pyenv rehash`."
+    )


### PR DESCRIPTION
## Problem

A bare `pip install stashai` (or `pip install -e .`) under a pyenv/system interpreter plants a second `stash` entry point on PATH. It never auto-updates — only the uv/pipx install does — and which copy wins differs by context, because pyenv shims prepend their version's bin dir. The observed failure mode: every plugin hook dying with `ModuleNotFoundError: No module named 'stashai.plugin.event'` weeks after the stray install, from a stale 0.1.23 shadowing the real 0.1.26.

#564 documents the right workflow, but a prose rule that every human and coding agent must remember forever is brittle. This makes the failure state self-announcing instead.

## What

New `stashai/plugin/doctor.py`:
- `find_stash_installs()` — distinct `stash` executables on PATH, in PATH order, deduped by realpath (so the uv symlink + its target count as one install).
- `shadow_install_warning()` — warning text when more than one distinct install is visible, naming each copy and its realpath with the removal command. Skipped entirely when `VIRTUAL_ENV` is set: an activated dev venv (the #564 workflow) intentionally coexists with the released CLI.

Surfaced at the two checkpoints that cover every machine:
- **Claude session-start hook** — as a `systemMessage`, on both the connected-repo path and the uploads-disabled early return. The import is guarded for the one-session window where refreshed plugin scripts run against a not-yet-auto-updated package (the same skew class this whole saga is about).
- **`stash login` / `stash welcome`** — printed after the setup-complete splash, catching it at install time.

The detection lives in the package, so it ships to every existing machine via the daily PyPI auto-update once the plugin scripts refresh.

## Verification

- 4 new tests in `plugins/tests/test_shadow_installs.py`: single install quiet, symlinked duplicate counts as one, two distinct installs warn with both paths named, activated dev venv suppresses.
- E2E: ran the actual hook script with two fake `stash` binaries on PATH → `systemMessage` emitted with both paths; with one binary → no output. 
- `plugins/tests` + `cli/tests`: 153 passed; the 1 failure (`test_shares_add_and_remove`) and the coverage-gate notice reproduce on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)