### PR TITLE
Brain spans own+shared · Cartridges tabs · sidebar source logos

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -59,11 +59,22 @@ async def list_activity(
     pool = get_pool()
     events = await pool.fetch(
         """
-        WITH accessible_workspaces AS (
+        WITH member_workspaces AS (
           SELECT w.id, w.name
           FROM workspaces w
           JOIN workspace_members wm ON wm.workspace_id = w.id
           WHERE wm.user_id = $1
+          AND ($3::uuid IS NULL OR w.id = $3)
+        ),
+        -- Member workspaces plus any workspace that has shared content with the
+        -- user. Page/file rows still pass readable_content_condition, so a share
+        -- only surfaces the specific shared rows — never the whole workspace.
+        accessible_workspaces AS (
+          SELECT w.id, w.name
+          FROM workspaces w
+          WHERE w.id IN """
+        + permission_service.accessible_workspace_ids_sql(1)
+        + """
           AND ($3::uuid IS NULL OR w.id = $3)
         )
         (
@@ -81,7 +92,7 @@ async def list_activity(
                  aw.id AS workspace_id,
                  aw.name AS workspace_name
           FROM history_events he
-          JOIN accessible_workspaces aw ON aw.id = he.workspace_id
+          JOIN member_workspaces aw ON aw.id = he.workspace_id
           WHERE he.session_id IS NOT NULL
             AND """
         + memory_service.readable_session_event_condition("he", 1)
@@ -131,7 +142,7 @@ async def list_activity(
                  aw.id AS workspace_id,
                  aw.name AS workspace_name
           FROM workspace_members wm
-          JOIN accessible_workspaces aw ON aw.id = wm.workspace_id
+          JOIN member_workspaces aw ON aw.id = wm.workspace_id
         )
         ORDER BY ts DESC LIMIT $2
         """,
@@ -167,6 +178,13 @@ async def list_all_tables(current_user: dict = Depends(get_current_user)):
     """All tables from workspaces + personal."""
     tables = await table_service.list_all_user_tables(current_user["id"])
     return {"tables": tables}
+
+
+@router.get("/overview")
+async def overview_counts(current_user: dict = Depends(get_current_user)):
+    """Page / file / session counts for the 'Your brain' vitals, spanning the
+    user's own content plus everything shared with them."""
+    return await analytics_service.get_overview_counts(current_user["id"])
 
 
 async def _verify_workspace_access(workspace_id: UUID, user_id: UUID) -> None:

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -163,7 +163,7 @@ def _accessible_pages_cte(
     WITH accessible_pages AS (
         SELECT p.id AS page_id
         FROM pages p
-        WHERE p.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
+        WHERE p.workspace_id IN {permission_service.accessible_workspace_ids_sql(1)}
           AND COALESCE(p.metadata->>'shared_in_cartridge_id', '') = ''
           AND {readable_pages}
     )
@@ -201,7 +201,7 @@ def _accessible_tables_cte(
     WITH accessible_tables AS (
         SELECT t.id AS table_id
         FROM tables t
-        WHERE (t.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
+        WHERE (t.workspace_id IN {permission_service.accessible_workspace_ids_sql(1)}
            OR (t.workspace_id IS NULL AND t.created_by = $1))
           AND (t.workspace_id IS NULL OR {readable_tables})
     )
@@ -258,7 +258,7 @@ def _accessible_files_cte(
     WITH accessible_files AS (
         SELECT f.id AS file_id
         FROM files f
-        WHERE f.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
+        WHERE f.workspace_id IN {permission_service.accessible_workspace_ids_sql(1)}
           AND f.deleted_at IS NULL
           AND {readable_files}
     )
@@ -566,6 +566,36 @@ async def _get_source_counts(user_id: UUID, workspace_id: UUID | None = None) ->
             user_id,
         )
     return {"pages": row["pages"], "rows": row["rows"], "events": row["events"]}
+
+
+async def get_overview_counts(user_id: UUID) -> dict:
+    """Counts for the 'Your brain' vitals, spanning the user's own content plus
+    everything shared with them. Pages/files run through readable_content_condition
+    so a share only surfaces the specific shared rows. Sessions stay member-scoped —
+    session sharing isn't reflected in these counts yet."""
+    pool = get_pool()
+    accessible_ws = permission_service.accessible_workspace_ids_sql(1)
+    readable_pages = permission_service.readable_content_condition("page", "p", 1)
+    readable_files = permission_service.readable_content_condition("file", "f", 1)
+    row = await pool.fetchrow(
+        f"""
+        SELECT
+            (SELECT COUNT(*) FROM pages p
+             WHERE p.workspace_id IN {accessible_ws}
+               AND p.deleted_at IS NULL
+               AND COALESCE(p.metadata->>'shared_in_cartridge_id', '') = ''
+               AND {readable_pages}) AS pages,
+            (SELECT COUNT(*) FROM files f
+             WHERE f.workspace_id IN {accessible_ws}
+               AND f.deleted_at IS NULL
+               AND {readable_files}) AS files,
+            (SELECT COUNT(*) FROM sessions s
+             WHERE s.workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = $1)
+               AND s.deleted_at IS NULL) AS sessions
+        """,
+        user_id,
+    )
+    return {"pages": row["pages"], "files": row["files"], "sessions": row["sessions"]}
 
 
 def _signature(counts: dict) -> int:

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -115,6 +115,19 @@ def readable_content_condition(object_type: str, object_alias: str, user_arg: in
     """
 
 
+def accessible_workspace_ids_sql(user_arg: int) -> str:
+    """Subquery: workspace ids whose content user ${user_arg} can possibly see —
+    workspaces they're a member of, plus workspaces that have shared something
+    with them. A coarse prefilter only: `readable_content_condition` still narrows
+    to the specific shared rows, so widening this set never over-exposes."""
+    return f"""(
+        SELECT workspace_id FROM workspace_members WHERE user_id = ${user_arg}
+        UNION
+        SELECT workspace_id FROM shares
+        WHERE principal_type = 'user' AND principal_id = ${user_arg}
+    )"""
+
+
 async def resolve_workspace_id(object_type: str, object_id: UUID) -> UUID | None:
     pool = get_pool()
     if object_type not in _WORKSPACE_LOOKUP:

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -747,3 +747,31 @@ async def test_shared_session_folder_sessions_gated_on_share(pool):
     # A stranger with no share is denied.
     with pytest.raises(HTTPException):
         await share_service.list_shared_session_folder_sessions(sf, stranger)
+
+
+@pytest.mark.asyncio
+async def test_overview_counts_span_shared_not_unshared(pool):
+    """The "Your brain" vitals (analytics_service.get_overview_counts) span the
+    user's own content plus content shared with them — but a share only surfaces
+    the specific shared rows, never the whole sharing workspace, and an unrelated
+    user sees nothing. Guards the widened member∪shared prefilter against leaks."""
+    from backend.services import analytics_service
+
+    owner = await _make_user(pool)
+    friend = await _make_user(pool)  # gets one folder shared
+    stranger = await _make_user(pool)  # gets nothing
+    ws = await _make_workspace(pool, owner)  # friend/stranger are NOT members
+    folder = await _make_folder(pool, ws, owner)
+    await _make_page(pool, ws, owner, folder_id=folder, name="shared-page")
+    await _make_page(pool, ws, owner, name="private-root-page")
+    await _share(pool, ws, "folder", folder, friend, "read", by=owner)
+
+    owner_counts = await analytics_service.get_overview_counts(owner)
+    friend_counts = await analytics_service.get_overview_counts(friend)
+    stranger_counts = await analytics_service.get_overview_counts(stranger)
+
+    # Owner sees both of its pages; friend sees only the page in the shared
+    # folder (not the un-shared root page); stranger sees neither.
+    assert owner_counts["pages"] >= 2
+    assert friend_counts["pages"] == 1
+    assert stranger_counts["pages"] == 0

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
@@ -32,6 +32,10 @@ import { stashSlugFromInput } from "../../../../../lib/cartridgeLinks";
 // axis entirely — where it came from — so it's a section below, not a filter.
 type Visibility = "all" | "private" | "shared" | "public";
 type ViewKey = "grid" | "list";
+// The primary axis: which set of Cartridges you're looking at. Yours and Shared
+// share the visibility filter / view toggle / quick-access; Discover is its own
+// public-library surface.
+type Tab = "yours" | "shared" | "discover";
 
 const VIEW_STORAGE_KEY = "stash_stashes_view";
 
@@ -60,6 +64,7 @@ export default function WorkspaceStashesPage() {
   const [cartridges, setStashes] = useState<WorkspaceCartridge[] | null>(null);
   const [invites, setInvites] = useState<CartridgeInvite[]>([]);
   const [busyInviteId, setBusyInviteId] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("yours");
   const [visibility, setVisibility] = useState<Visibility>("all");
   const [view, setView] = useState<ViewKey>("grid");
   const [error, setError] = useState("");
@@ -210,7 +215,19 @@ export default function WorkspaceStashesPage() {
           </div>
         )}
 
-        {(pinnedStashes.length > 0 || recentStashes.length > 0) && (
+        {/* The primary selector: Yours / Shared with you / Discover. */}
+        <CartridgeTabs
+          tab={tab}
+          onChange={setTab}
+          yoursCount={(cartridges ?? []).filter((s) => !s.is_external).length}
+          sharedCount={
+            (cartridges ?? []).filter((s) => s.is_external).length + invites.length
+          }
+        />
+
+        {/* Quick-access + the visibility/view toolbar belong to your held
+            Cartridges, so they sit under Yours and Shared, not Discover. */}
+        {tab !== "discover" && (pinnedStashes.length > 0 || recentStashes.length > 0) && (
           <CartridgeQuickAccess
             pinned={pinnedStashes}
             recent={recentStashes}
@@ -219,72 +236,78 @@ export default function WorkspaceStashesPage() {
           />
         )}
 
-        {/* Toolbar: one visibility axis (who can see) + the view switch. */}
-        <div className="mt-5 flex flex-wrap items-center justify-between gap-2 border-b border-border pb-2.5">
-          <VisibilityFilter
-            visibility={visibility}
-            counts={counts}
-            onChange={setVisibility}
-          />
-          <CartridgeViewToggle view={view} onChange={setViewPersisted} />
-        </div>
-
-        <CartridgeSection
-          title="Your cartridges"
-          count={native.length}
-          emptyHint={cartridges.length === 0 ? "No cartridges yet." : "None match this visibility."}
-        >
-          <CartridgeCollection
-            cartridges={native}
-            startIndex={0}
-            view={view}
-            isPinned={isPinned}
-            onTogglePin={(s) => pins.toggle(s.id)}
-            selectedIds={selectedIds}
-            onToggleSelect={toggleSelect}
-            embedded
-          />
-        </CartridgeSection>
-
-        {/* Cartridges others gave you: forked-in copies plus pending invites
-            (view access shared directly with you). The add-by-link entry point
-            lives here too. */}
-        <CartridgeSection
-          title="Shared with you"
-          count={forked.length + invites.length}
-          emptyHint={visibility === "all" ? null : "None match this visibility."}
-          action={
-            <ExternalCartridgeLinkForm workspaceId={workspaceId} onAdded={() => void load()} />
-          }
-        >
-          {invites.length > 0 && (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {invites.map((invite) => (
-                <SharedInviteCard
-                  key={invite.id}
-                  invite={invite}
-                  busy={busyInviteId === invite.id}
-                  onDismiss={() => void dismissInvite(invite)}
-                />
-              ))}
-            </div>
-          )}
-          {forked.length > 0 && (
-            <CartridgeCollection
-              cartridges={forked}
-              startIndex={native.length}
-              view={view}
-              isPinned={isPinned}
-              onTogglePin={(s) => pins.toggle(s.id)}
-              selectedIds={selectedIds}
-              onToggleSelect={toggleSelect}
-              embedded
-              className={invites.length > 0 ? "mt-3" : undefined}
+        {tab !== "discover" && (
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <VisibilityFilter
+              visibility={visibility}
+              counts={counts}
+              onChange={setVisibility}
             />
-          )}
-        </CartridgeSection>
+            <CartridgeViewToggle view={view} onChange={setViewPersisted} />
+          </div>
+        )}
 
-        <DiscoverSection workspaceId={workspaceId} />
+        {tab === "yours" && (
+          <div className="mt-4">
+            {native.length > 0 ? (
+              <CartridgeCollection
+                cartridges={native}
+                startIndex={0}
+                view={view}
+                isPinned={isPinned}
+                onTogglePin={(s) => pins.toggle(s.id)}
+                selectedIds={selectedIds}
+                onToggleSelect={toggleSelect}
+                embedded
+              />
+            ) : (
+              <EmptyHint>
+                {cartridges.length === 0 ? "No cartridges yet." : "None match this visibility."}
+              </EmptyHint>
+            )}
+          </div>
+        )}
+
+        {tab === "shared" && (
+          <div className="mt-4">
+            {invites.length > 0 && (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {invites.map((invite) => (
+                  <SharedInviteCard
+                    key={invite.id}
+                    invite={invite}
+                    busy={busyInviteId === invite.id}
+                    onDismiss={() => void dismissInvite(invite)}
+                  />
+                ))}
+              </div>
+            )}
+            {forked.length > 0 ? (
+              <CartridgeCollection
+                cartridges={forked}
+                startIndex={native.length}
+                view={view}
+                isPinned={isPinned}
+                onTogglePin={(s) => pins.toggle(s.id)}
+                selectedIds={selectedIds}
+                onToggleSelect={toggleSelect}
+                embedded
+                className={invites.length > 0 ? "mt-3" : undefined}
+              />
+            ) : (
+              invites.length === 0 && (
+                <EmptyHint>
+                  {visibility === "all"
+                    ? "Nothing shared with you yet."
+                    : "None match this visibility."}
+                </EmptyHint>
+              )
+            )}
+            <ExternalCartridgeLinkForm workspaceId={workspaceId} onAdded={() => void load()} />
+          </div>
+        )}
+
+        {tab === "discover" && <DiscoverSection workspaceId={workspaceId} />}
       </div>
 
       {selectedStashes.length > 0 && (
@@ -430,49 +453,64 @@ function VisibilityFilter({
   );
 }
 
-// A titled block of Cartridges (the origin axis: "Your Cartridges" vs "Forked
-// from others"). Renders its header + count, an optional header action, and a
-// muted hint when the section is empty.
-function CartridgeSection({
-  title,
-  count,
-  emptyHint,
-  action,
-  children,
-}: {
-  title: string;
-  count: number;
-  emptyHint: string | null;
-  action?: React.ReactNode;
-  children?: React.ReactNode;
-}) {
-  return (
-    <section className="mt-6">
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <h2 className="m-0 font-display text-[14px] font-semibold">{title}</h2>
-          <span className="sys-label" style={{ fontSize: 10.5 }}>
-            {count}
-          </span>
-        </div>
-        {action}
-      </div>
-      {count === 0
-        ? emptyHint && (
-            <p className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12px] text-muted">
-              {emptyHint}
-            </p>
-          )
-        : children}
-    </section>
-  );
-}
-
 function PlusGlyph() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
       <path d="M12 5v14M5 12h14" />
     </svg>
+  );
+}
+
+// The primary selector as an underline tab bar. Yours/Shared carry a live count;
+// Discover is the public library (no owned count).
+function CartridgeTabs({
+  tab,
+  onChange,
+  yoursCount,
+  sharedCount,
+}: {
+  tab: Tab;
+  onChange: (next: Tab) => void;
+  yoursCount: number;
+  sharedCount: number;
+}) {
+  const tabs: { key: Tab; label: string; count?: number }[] = [
+    { key: "yours", label: "Yours", count: yoursCount },
+    { key: "shared", label: "Shared with you", count: sharedCount },
+    { key: "discover", label: "Discover" },
+  ];
+  return (
+    <div className="mt-5 flex gap-1 border-b border-border">
+      {tabs.map((t) => {
+        const active = tab === t.key;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            className={
+              "-mb-px border-b-2 px-3 py-2 text-[13px] transition-colors " +
+              (active
+                ? "border-[var(--color-brand-600)] font-semibold text-foreground"
+                : "border-transparent text-muted hover:text-foreground")
+            }
+          >
+            {t.label}
+            {t.count !== undefined && (
+              <span className="ml-1.5 text-[11px] text-muted">{t.count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[12.5px] text-muted">
+      {children}
+    </p>
   );
 }
 
@@ -580,10 +618,9 @@ function DiscoverSection({ workspaceId }: { workspaceId: string }) {
   }, [query, sort]);
 
   return (
-    <section className="mt-8">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <h2 className="m-0 font-display text-[14px] font-semibold">Discover</h2>
+    <section className="mt-4">
+      <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
+        <div className="mr-auto flex items-baseline gap-2">
           <span className="sys-label" style={{ fontSize: 10.5 }}>
             public library
           </span>

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import AppShell from "../../components/AppShell";
 import {
   ActivitySkeleton,
@@ -17,27 +17,16 @@ import {
 } from "../../components/StashIcons";
 import ContributorActivityTimeline from "../../components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "../../components/viz/EmbeddingSpaceExplorer";
-import KnowledgeDensityMap from "../../components/viz/KnowledgeDensityMap";
 import { useAuth } from "../../hooks/useAuth";
 import {
   getActivityTimeline,
   getEmbeddingProjection,
-  getKnowledgeDensity,
-  getWorkspace,
-  getWorkspaceOverview,
+  getMeOverview,
   listActivity,
-  listMyWorkspaces,
-  listWorkspaceActivity,
-  listWorkspaceSources,
   type ActivityEvent,
-  type WorkspaceOverview,
-  type WorkspaceSource,
+  type MeOverview,
 } from "../../lib/api";
-import type {
-  ActivityTimeline,
-  EmbeddingProjection,
-  KnowledgeDensity,
-} from "../../lib/types";
+import type { ActivityTimeline, EmbeddingProjection } from "../../lib/types";
 
 type FilterKey = "all" | "sessions" | "pages" | "cartridges";
 
@@ -58,10 +47,6 @@ const AVATAR_CLASSES = [
   "av-lime",
 ];
 
-// Native handles ("files"/"sessions") are always present — the Sources vital
-// counts the connected integrations the brain draws from, not these.
-const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);
-
 function avatarClassFor(name: string): string {
   let h = 5381;
   for (let i = 0; i < name.length; i++) h = (h * 33 + name.charCodeAt(i)) >>> 0;
@@ -81,27 +66,14 @@ function relativeTime(iso: string): string {
 }
 
 export default function ActivityPage() {
-  return (
-    <Suspense fallback={<BasicPageSkeleton />}>
-      <ActivityPageInner />
-    </Suspense>
-  );
-}
-
-function ActivityPageInner() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const workspaceId = searchParams.get("workspace");
   const { user, loading, logout } = useAuth();
   const [events, setEvents] = useState<ActivityEvent[]>([]);
-  const [workspaceName, setWorkspaceName] = useState("");
   const [fetching, setFetching] = useState(true);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
-  const [density, setDensity] = useState<KnowledgeDensity | null>(null);
-  const [overview, setOverview] = useState<WorkspaceOverview | null>(null);
-  const [sources, setSources] = useState<WorkspaceSource[]>([]);
+  const [overview, setOverview] = useState<MeOverview | null>(null);
   const [insightsLoaded, setInsightsLoaded] = useState(false);
   // Captured once so the "last 24h" window doesn't drift across re-renders.
   const [nowMs] = useState(() => Date.now());
@@ -109,93 +81,51 @@ function ActivityPageInner() {
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
-    const eventsPromise = workspaceId
-      ? listWorkspaceActivity(workspaceId, 200)
-      : listActivity(200);
-    const workspacePromise = workspaceId ? getWorkspace(workspaceId) : null;
-
-    Promise.all([eventsPromise, workspacePromise])
-      .then(([nextEvents, workspace]) => {
-        if (cancelled) return;
-        setEvents(nextEvents);
-        if (workspace) setWorkspaceName(workspace.name);
+    listActivity(200)
+      .then((nextEvents) => {
+        if (!cancelled) setEvents(nextEvents);
       })
       .catch(() => {})
       .finally(() => {
         if (!cancelled) setFetching(false);
       });
-
     return () => {
       cancelled = true;
     };
-  }, [user, workspaceId]);
+  }, [user]);
 
-  // The brain's vitals + visualizations. All workspace-scoped, so for the
-  // global view we resolve the user's own workspace once and fan out.
+  // The brain's vitals + visualizations. All span the user's own content plus
+  // everything shared with them (the /me/* aggregates, called without a
+  // workspace, include readable shared rows).
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
     setInsightsLoaded(false);
-    (async () => {
-      const wsId = workspaceId || (await listMyWorkspaces()).workspaces[0]?.id;
-      if (!wsId) {
-        if (!cancelled) setInsightsLoaded(true);
-        return;
-      }
-      const [t, p, d, o, s] = await Promise.allSettled([
-        getActivityTimeline(30, "day", wsId),
-        getEmbeddingProjection(500, undefined, wsId),
-        getKnowledgeDensity(12, wsId),
-        getWorkspaceOverview(wsId),
-        listWorkspaceSources(wsId),
-      ]);
-      if (cancelled) return;
-      if (t.status === "fulfilled") setTimeline(t.value);
-      if (p.status === "fulfilled") setProjection(p.value);
-      if (d.status === "fulfilled") setDensity(d.value);
-      if (o.status === "fulfilled") setOverview(o.value);
-      if (s.status === "fulfilled") setSources(s.value);
-      setInsightsLoaded(true);
-    })().catch(() => {
-      if (!cancelled) setInsightsLoaded(true);
-    });
+    Promise.allSettled([
+      getActivityTimeline(30, "day"),
+      getEmbeddingProjection(500),
+      getMeOverview(),
+    ])
+      .then(([t, p, o]) => {
+        if (cancelled) return;
+        if (t.status === "fulfilled") setTimeline(t.value);
+        if (p.status === "fulfilled") setProjection(p.value);
+        if (o.status === "fulfilled") setOverview(o.value);
+        setInsightsLoaded(true);
+      });
     return () => {
       cancelled = true;
     };
-  }, [user, workspaceId]);
+  }, [user]);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  const stats = useMemo(() => {
-    const dayMs = 24 * 60 * 60 * 1000;
-    const since = nowMs - dayMs;
-    const recent = events.filter((e) => new Date(e.ts).getTime() >= since);
-    return {
-      recent24h: recent.length,
-      sessions24h: recent.filter((e) => e.kind === "session.uploaded").length,
-      pages24h: recent.filter((e) => e.kind === "page.updated").length,
-      files24h: recent.filter((e) => e.kind === "file.uploaded").length,
-      total: events.length,
-    };
+  const recent24h = useMemo(() => {
+    const since = nowMs - 24 * 60 * 60 * 1000;
+    return events.filter((e) => new Date(e.ts).getTime() >= since).length;
   }, [events, nowMs]);
-
-  // Connected integrations the brain learns from, plus their freshness.
-  const sourceVitals = useMemo(() => {
-    const connected = sources.filter((s) => !NATIVE_SOURCE_TYPES.has(s.type));
-    const syncing = connected.filter((s) => s.sync_status === "syncing").length;
-    const syncedAt = connected
-      .map((s) => s.last_synced_at)
-      .filter((v): v is string => !!v)
-      .sort()
-      .at(-1);
-    let hint = "—";
-    if (syncing > 0) hint = `${syncing} syncing`;
-    else if (syncedAt) hint = `synced ${relativeTime(syncedAt)}`;
-    else if (connected.length > 0) hint = "not synced yet";
-    return { count: connected.length, hint };
-  }, [sources]);
 
   const knowledgePoints = projection?.stats.total_embeddings ?? 0;
 
@@ -222,17 +152,15 @@ function ActivityPageInner() {
     );
   }
 
-  const title = workspaceId ? workspaceName || "Your brain" : "Your brain";
-
   return (
     <AppShell user={user} onLogout={logout}>
       <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
         {/* Header — what this brain holds and how fresh it is. */}
         <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
-          {title}
+          Your brain
         </h1>
         <p className="mt-1 text-[13.5px] text-muted">
-          {`${knowledgePoints.toLocaleString()} things learned across ${sourceVitals.count} connected source${sourceVitals.count === 1 ? "" : "s"} · ${stats.recent24h} new in the last 24 hours.`}
+          {`${knowledgePoints.toLocaleString()} things learned across your own and shared knowledge · ${recent24h} new in the last 24 hours.`}
         </p>
 
         {/* Brain map — the knowledge the brain holds, laid out in space. The
@@ -251,22 +179,13 @@ function ActivityPageInner() {
         </VizCard>
 
         {/* Vitals — the brain's current size and pulse. */}
-        <div className="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
+        <div className="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-4 lg:grid-cols-5">
           <VitalCard label="Knowledge points" value={knowledgePoints} tint="var(--color-brand-600)" />
-          <VitalCard label="Pages" value={overview?.files.pages.length ?? 0} tint="var(--color-human)" />
-          <VitalCard label="Files" value={overview?.files.files.length ?? 0} tint="#16A34A" />
-          <VitalCard label="Sessions" value={overview?.sessions.length ?? 0} tint="var(--color-agent)" />
-          <VitalCard label="Sources" value={sourceVitals.count} hint={sourceVitals.hint} tint="#7C3AED" />
-          <VitalCard label="Learned today" value={stats.recent24h} tint="var(--text-muted)" />
+          <VitalCard label="Pages" value={overview?.pages ?? 0} tint="var(--color-human)" />
+          <VitalCard label="Files" value={overview?.files ?? 0} tint="#16A34A" />
+          <VitalCard label="Sessions" value={overview?.sessions ?? 0} tint="var(--color-agent)" />
+          <VitalCard label="Learned today" value={recent24h} tint="var(--text-muted)" />
         </div>
-
-        {/* What the brain knows — topic clusters. Hidden when there's nothing
-            to show, since it's an optional lens. */}
-        {density && density.clusters.length > 0 && (
-          <VizCard label="What your brain knows" className="mt-7">
-            <KnowledgeDensityMap data={density} />
-          </VizCard>
-        )}
 
         {/* Human / agent commits over time. (Decorative.) */}
         <VizCard label="Human / agent commits — last 30 days" className="mt-5" scroll>
@@ -317,7 +236,7 @@ function ActivityPageInner() {
               <FeedCard
                 key={`${event.kind}-${event.target_id}-${i}`}
                 event={event}
-                showWorkspace={!workspaceId}
+                showWorkspace
               />
             ))
           )}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -23,7 +23,7 @@ import {
 } from "../lib/api";
 import type { User, Workspace } from "../lib/types";
 import AddSourceModal from "./integrations/AddSourceModal";
-import { labelForProvider, providerForSourceType } from "./integrations/connectors";
+import { connectorIcon, labelForProvider, providerForSourceType } from "./integrations/connectors";
 import {
   ActivityIcon,
   FileIcon,
@@ -249,11 +249,18 @@ export default function AppSidebar({
       const provider = providerForSourceType[s.type] ?? s.type;
       if (seen.has(provider)) continue;
       seen.add(provider);
+      const logo = connectorIcon(provider);
       connected.push({
         key: provider,
         href: `/workspaces/${ws}/integrations/${provider}`,
         label: labelForProvider(provider),
-        icon: <SourceDot color={SOURCE_DOT[s.type] ?? "rgba(0,0,0,0.4)"} />,
+        icon: logo ? (
+          <span className="flex h-4 w-4 items-center justify-center [&_img]:h-4 [&_img]:w-4 [&_svg]:h-4 [&_svg]:w-4">
+            {logo}
+          </span>
+        ) : (
+          <SourceDot color={SOURCE_DOT[s.type] ?? "rgba(0,0,0,0.4)"} />
+        ),
         active: pathname.startsWith(`/workspaces/${ws}/integrations/${provider}`),
       });
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -625,6 +625,18 @@ export async function listAllTables(): Promise<{ tables: TableWithWorkspace[] }>
 
 // --- Dashboard Visualizations ---
 
+export interface MeOverview {
+  pages: number;
+  files: number;
+  sessions: number;
+}
+
+// Counts for the "Your brain" vitals, spanning the user's own content plus
+// everything shared with them.
+export async function getMeOverview(): Promise<MeOverview> {
+  return apiFetch(`/api/v1/me/overview`);
+}
+
 export async function getActivityTimeline(
   days = 30,
   bucket = "day",


### PR DESCRIPTION
## What & why

Three follow-up refinements to the sidebar restructure (#553).

### 1. Cartridges — Yours / Shared / Discover are now tabs
The three groupings became the **primary selector** (an underline tab bar at the top) instead of three stacked sections. The pinned/recent quick-access strip and the visibility/view toolbar sit under **Yours** and **Shared with you** only; **Discover** is its own public-library surface with its own search/sort.

| Yours | Discover | Shared with you |
|---|---|---|
| ![yours](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/cf957164ba29/cart_yours.png) | ![discover](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/45ebfccc790b/cart_discover.png) | ![shared](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/efc1da6726b4/cart_shared.png) |

### 2. Your brain — removed the treemap, data now spans own + shared
- Dropped the "What your brain knows" topic treemap.
- The map, vitals, and feed now span the user's **own content plus everything shared with them**, not a single workspace.

**Backend:** the no-workspace `/me/*` aggregates widen their prefilter from *member-only* to *member ∪ shared* workspaces (new `permission_service.accessible_workspace_ids_sql`). This is **leak-safe by construction** — the widened set is ANDed with the unchanged `readable_content_condition`, so only specifically-shared rows surface, never a whole workspace. A new `/me/overview` counts endpoint feeds the vitals. Session events stay member-scoped (session sharing is a deliberate follow-up). Added a permissions test asserting shared content is counted for the recipient but **not** for unrelated users.

![brain](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/5cf60ba998af/brain2.png)

### 3. Sidebar — brand logos instead of colored dots
Connected sources show their brand logo (`connectorIcon`, already used in the connect dialog) with the colored dot as fallback. Logos as they render (the connect dialog uses the same component):

![logos](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/16376bab2e37/connectors.png)

## Verification
- Backend: `ruff` clean; `pytest` permissions + analytics + activity suites pass, incl. the new leak-safety test.
- Frontend: `lint` clean, `vitest` 127 passing, `tsc` clean on changed files.
- Dogfooded headless (fresh account): brain shows 5 vitals + no treemap + no console errors; cartridge tabs switch correctly (Discover hides the owned-only toolbar; Shared keeps the add-by-link form); `/me/overview` + widened aggregates return without SQL errors.

Note: the sidebar-logo screenshot is from the connect dialog (same `connectorIcon`) since the dogfood account has no connected integrations; the sidebar wiring is a direct swap of dot → logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
