### PR TITLE
www: install X conversion-tracking pixel (rcxyy) site-wide

### DIFF
--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Instrument_Sans, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 const instrumentSans = Instrument_Sans({
@@ -37,7 +38,16 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        {/* X (Twitter) conversion tracking base code — pixel id rcxyy */}
+        <Script id="x-pixel" strategy="afterInteractive">
+          {`!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+twq('config','rcxyy');`}
+        </Script>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
Adds the X (Twitter) universal website tag (pixel id `rcxyy`) to the root layout via `next/script` (afterInteractive), so every page — homepage, `/m/*` message-test pages, and `/m/*/signup` — reports visits to X Ads ahead of the messaging-test campaign launch.

Verified locally: `window.twq` is defined and the browser requests `static.ads-twitter.com/uwt.js` on page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)