### PR TITLE
www: fix UTM attribution on message-test signups

### DIFF
--- a/www/app/m/_components/CaptureLanding.tsx
+++ b/www/app/m/_components/CaptureLanding.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+export const LANDING_URL_KEY = "stash-landing-url";
+
+// Records the full landing URL (including the ad's utm params) so the signup
+// form can attach it to the lead email. document.referrer can't do this:
+// Next's client-side navigation to /signup doesn't update it.
+export default function CaptureLanding() {
+  useEffect(() => {
+    sessionStorage.setItem(LANDING_URL_KEY, window.location.href);
+  }, []);
+  return null;
+}

--- a/www/app/m/_components/SignupForm.tsx
+++ b/www/app/m/_components/SignupForm.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from "react-dom";
 
 import CustomSelect from "../../_components/CustomSelect";
 import { submitVariantSignup, type VariantSignupState } from "../actions";
+import { LANDING_URL_KEY } from "./CaptureLanding";
 
 const INITIAL_STATE: VariantSignupState = { status: "idle" };
 
@@ -42,10 +43,14 @@ export default function SignupForm({
   const [agentUsage, setAgentUsage] = useState("");
   const [referralSource, setReferralSource] = useState("");
 
-  // The referrer is the variant page URL, which still carries the ad's
-  // utm params — that's the click-source trail for the lead email.
+  // The landing page recorded its full URL (with the ad's utm params) in
+  // sessionStorage — document.referrer is blank after Next's client-side
+  // navigation. Falls back to the referrer for direct hits on this page.
   function submitWithRef(formData: FormData) {
-    formData.set("ref", document.referrer);
+    formData.set(
+      "ref",
+      sessionStorage.getItem(LANDING_URL_KEY) || document.referrer,
+    );
     formAction(formData);
   }
 

--- a/www/app/m/_components/VariantLanding.tsx
+++ b/www/app/m/_components/VariantLanding.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../_components/HomePage";
 import SiteHeader from "../../_components/SiteHeader";
 import type { VariantCopy } from "../variants";
+import CaptureLanding from "./CaptureLanding";
 
 // A complete landing page per message under test: real header and sections,
 // hero + "How it works" rewritten for the message. Every signup CTA leads to
@@ -25,6 +26,7 @@ export default function VariantLanding({
   const signupHref = `/m/${variant}/signup`;
   return (
     <main className="min-h-screen bg-background text-foreground">
+      <CaptureLanding />
       <SiteHeader ctaHref={signupHref} />
       <VariantHero copy={copy} signupHref={signupHref} />
       <Logos />


### PR DESCRIPTION
document.referrer is empty after Next's client-side navigation from the variant landing page to /signup (verified in-browser), so the lead email's "Came from" line never carried the ad's UTM string. The landing page now records its full URL (with UTMs) in sessionStorage via a tiny client component, and the signup form attaches that to the submission, falling back to the referrer for direct signup-page hits.

Verified: land on /m/drive?utm_source=x&utm_campaign=msgtest&utm_content=drive → click CTA → signup page has the full UTM URL in sessionStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)