### PR TITLE
First-party view/signup tracking for the messaging test + fix double-encoded analytics properties

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from .routers import (
     exports,
     files,
     files_tree,
+    marketing,
     memory,
     pins,
     publish,
@@ -117,6 +118,7 @@ app.include_router(aggregate.router)
 app.include_router(skill.router)
 app.include_router(admin.router)
 app.include_router(analytics.router)
+app.include_router(marketing.router)
 app.include_router(sessions.router)
 app.include_router(trash.router)
 app.include_router(pins.router)

--- a/backend/migrations/versions/0100_fix_double_encoded_analytics_properties.py
+++ b/backend/migrations/versions/0100_fix_double_encoded_analytics_properties.py
@@ -1,0 +1,32 @@
+"""Repair double-encoded analytics_events.properties.
+
+analytics_events_service json.dumps'd properties while the asyncpg pool's
+jsonb codec serialized them again, so every row's properties was stored as
+a JSON *string* containing JSON ('"{\\"k\\": 1}"' instead of '{"k": 1}'),
+which makes properties->>'k' return NULL. Unwrap the string rows in place.
+
+Revision ID: 0100
+Revises: 0099
+Create Date: 2026-06-10
+"""
+
+from alembic import op
+
+revision = "0100"
+down_revision = "0099"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE analytics_events
+        SET properties = (properties #>> '{}')::jsonb
+        WHERE jsonb_typeof(properties) = 'string'
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/routers/marketing.py
+++ b/backend/routers/marketing.py
@@ -1,0 +1,75 @@
+"""Public marketing-events router.
+
+Anonymous, IP rate-limited beacons from the www landing pages: one event
+per painted-door page view and one per signup, so the messaging test can
+be scored from our own data (views and signups per variant) instead of
+relying on X's dashboards. Rows land in analytics_events.
+"""
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from ..database import get_pool
+from ..middleware import limiter
+from ..services import analytics_events_service
+
+router = APIRouter(prefix="/api/v1/marketing", tags=["marketing"])
+
+_POST_LIMIT = "60/minute"
+_GET_LIMIT = "30/minute"
+
+_KINDS = {"view", "signup"}
+_VARIANTS = {"drive", "wiki", "connect", "assistant"}
+
+
+class MarketingEvent(BaseModel):
+    kind: str = Field(..., pattern=r"^(view|signup)$")
+    variant: str = Field(..., min_length=1, max_length=32)
+    url: str = Field("", max_length=2048)
+    referrer: str = Field("", max_length=2048)
+
+
+@router.post("/events", status_code=204)
+@limiter.limit(_POST_LIMIT)
+async def record_marketing_event(request: Request, event: MarketingEvent) -> None:
+    # Unknown variants are dropped silently — this is a public endpoint and
+    # garbage input shouldn't pollute the test counts or surface errors.
+    if event.variant not in _VARIANTS:
+        return
+    await analytics_events_service.record_event(
+        user_id=None,
+        surface="marketing",
+        event_name=f"marketing.{event.kind}",
+        properties={
+            "variant": event.variant,
+            "url": event.url,
+            "referrer": event.referrer,
+        },
+    )
+
+
+@router.get("/summary")
+@limiter.limit(_GET_LIMIT)
+async def marketing_summary(request: Request) -> dict:
+    """Views and signups per variant — aggregate counts only."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT properties->>'variant' AS variant,
+               event_name,
+               count(*) AS n
+        FROM analytics_events
+        WHERE surface = 'marketing'
+        GROUP BY 1, 2
+        """
+    )
+    summary: dict[str, dict[str, int]] = {
+        v: {"views": 0, "signups": 0} for v in sorted(_VARIANTS)
+    }
+    for r in rows:
+        variant = r["variant"]
+        if variant not in summary:
+            continue
+        key = "views" if r["event_name"] == "marketing.view" else "signups"
+        summary[variant][key] = r["n"]
+    return summary

--- a/backend/services/analytics_events_service.py
+++ b/backend/services/analytics_events_service.py
@@ -4,7 +4,6 @@ This is the lightweight, structured-properties log. Separate from history_events
 which is the agent-transcript log (content-heavy, embedded).
 """
 
-import json
 import logging
 from collections.abc import Iterable
 from uuid import UUID
@@ -14,8 +13,9 @@ from ..database import get_pool
 logger = logging.getLogger(__name__)
 
 # Surfaces an event can come from. 'system' is reserved for backend-emitted
-# rows (e.g. a future signup hook); for now only 'web' and 'cli' are accepted.
-ALLOWED_SURFACES = {"web", "cli", "system"}
+# rows (e.g. a future signup hook); 'marketing' is the anonymous www
+# landing-page beacon (routers/marketing.py). Clients may send 'web'/'cli'.
+ALLOWED_SURFACES = {"web", "cli", "system", "marketing"}
 
 # Closed set of event names we accept from clients. Adding a new event means
 # adding a row here AND wiring the call site — keeps the dashboard honest.
@@ -39,6 +39,9 @@ ALLOWED_EVENT_NAMES = {
     "auth.signed_up",
     # CLI commands (one event per invocation; properties.command is the sub-axis)
     "cli.command_invoked",
+    # Messaging-test landing pages (anonymous; properties.variant is the axis)
+    "marketing.view",
+    "marketing.signup",
 }
 
 
@@ -50,6 +53,8 @@ async def record_event(
     properties: dict | None = None,
     session_anon: str | None = None,
 ) -> None:
+    # The pool's jsonb codec (database.py) serializes dicts itself — passing a
+    # pre-dumped string here double-encodes and breaks properties->> queries.
     pool = get_pool()
     await pool.execute(
         """
@@ -59,7 +64,7 @@ async def record_event(
         user_id,
         surface,
         event_name,
-        json.dumps(properties or {}),
+        properties or {},
         session_anon,
     )
 
@@ -71,7 +76,7 @@ async def record_events_batch(rows: Iterable[dict]) -> int:
             r.get("user_id"),
             r["surface"],
             r["event_name"],
-            json.dumps(r.get("properties") or {}),
+            r.get("properties") or {},
             r.get("session_anon"),
         )
         for r in rows

--- a/www/app/api/track/route.ts
+++ b/www/app/api/track/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Same-origin beacon target for the message-test pages; forwards to the
+// backend server-side so the browser never makes a cross-origin call.
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const res = await fetch(`${API_URL}/api/v1/marketing/events`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  return new NextResponse(null, { status: res.ok ? 204 : res.status });
+}

--- a/www/app/m/_components/CaptureLanding.tsx
+++ b/www/app/m/_components/CaptureLanding.tsx
@@ -5,11 +5,21 @@ import { useEffect } from "react";
 export const LANDING_URL_KEY = "stash-landing-url";
 
 // Records the full landing URL (including the ad's utm params) so the signup
-// form can attach it to the lead email. document.referrer can't do this:
-// Next's client-side navigation to /signup doesn't update it.
-export default function CaptureLanding() {
+// form can attach it to the lead email — document.referrer can't do this:
+// Next's client-side navigation to /signup doesn't update it. Also fires a
+// first-party view beacon so views per variant are counted in our own data.
+export default function CaptureLanding({ variant }: { variant: string }) {
   useEffect(() => {
     sessionStorage.setItem(LANDING_URL_KEY, window.location.href);
-  }, []);
+    navigator.sendBeacon(
+      "/api/track",
+      JSON.stringify({
+        kind: "view",
+        variant,
+        url: window.location.href,
+        referrer: document.referrer,
+      }),
+    );
+  }, [variant]);
   return null;
 }

--- a/www/app/m/_components/VariantLanding.tsx
+++ b/www/app/m/_components/VariantLanding.tsx
@@ -26,7 +26,7 @@ export default function VariantLanding({
   const signupHref = `/m/${variant}/signup`;
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <CaptureLanding />
+      <CaptureLanding variant={variant} />
       <SiteHeader ctaHref={signupHref} />
       <VariantHero copy={copy} signupHref={signupHref} />
       <Logos />

--- a/www/app/m/actions.ts
+++ b/www/app/m/actions.ts
@@ -4,6 +4,20 @@ import { escapeHtml, sendPostmark } from "../_lib/postmark";
 
 const LEADS_EMAIL = "sam@joinstash.ai";
 const FROM_ADDRESS = "Stash <notifications@joinstash.ai>";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Tracking is best-effort: a down backend must never break a signup.
+async function recordSignupEvent(variant: string, ref: string) {
+  try {
+    await fetch(`${API_URL}/api/v1/marketing/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "signup", variant, url: ref, referrer: "" }),
+    });
+  } catch (err) {
+    console.error("marketing signup event failed", err);
+  }
+}
 
 export type VariantSignupState = {
   status: "idle" | "ok" | "error";
@@ -69,5 +83,6 @@ export async function submitVariantSignup(
     };
   }
 
+  await recordSignupEvent(variant, ref);
   return { status: "ok" };
 }


### PR DESCRIPTION
## What

We can now count **views and signups per message variant from our own data**, instead of relying on X's dashboards:

- **Backend**: new public, IP rate-limited router `backend/routers/marketing.py` — `POST /api/v1/marketing/events` (kind: view|signup, variant, url, referrer → `analytics_events` with `surface=marketing`) and `GET /api/v1/marketing/summary` (aggregate counts per variant). Unknown variants are dropped silently.
- **www**: variant landing pages fire a view beacon (`navigator.sendBeacon`) through a same-origin `/api/track` route handler that forwards server-side (no CORS); the signup server action records a signup event carrying the UTM'd landing URL. Tracking is best-effort — a down backend never breaks a signup.

## Pre-existing bug fixed at the root

`analytics_events_service` `json.dumps`'d properties while the asyncpg pool's jsonb codec serialized them **again** — so every `analytics_events` row in the DB stored `properties` as a JSON *string* and any `properties->>` query silently returned NULL (this affects all onboarding/web/cli events, not just the new ones). The service now passes dicts through to the codec, and **migration 0100** unwraps all existing double-encoded rows in place (`properties = (properties #>> '{}')::jsonb where jsonb_typeof = 'string'`).

## Verified locally (full stack)

- Backend up with migration 0100 applied; POST event → 204; summary counts correct
- Browser → `/m/connect?utm…` → view beacon lands (`connect.views=1`)
- CTA → signup flow → submit → `connect.signups=1`, and the event's properties carry the full UTM URL
- `ruff` clean; `pytest -k analytic` 9/9 pass; www build green

## How to read the test

`GET https://api.joinstash.ai/api/v1/marketing/summary` → `{"drive": {"views": N, "signups": M}, ...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)