### PR TITLE
Onboarding: landing-aligned pillars, Try it out step, live agent-edit starter doc

### DIFF
--- a/backend/migrations/versions/0100_fix_double_encoded_analytics_properties.py
+++ b/backend/migrations/versions/0100_fix_double_encoded_analytics_properties.py
@@ -19,13 +19,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE analytics_events
         SET properties = (properties #>> '{}')::jsonb
         WHERE jsonb_typeof(properties) = 'string'
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/routers/marketing.py
+++ b/backend/routers/marketing.py
@@ -53,19 +53,15 @@ async def record_marketing_event(request: Request, event: MarketingEvent) -> Non
 async def marketing_summary(request: Request) -> dict:
     """Views and signups per variant — aggregate counts only."""
     pool = get_pool()
-    rows = await pool.fetch(
-        """
+    rows = await pool.fetch("""
         SELECT properties->>'variant' AS variant,
                event_name,
                count(*) AS n
         FROM analytics_events
         WHERE surface = 'marketing'
         GROUP BY 1, 2
-        """
-    )
-    summary: dict[str, dict[str, int]] = {
-        v: {"views": 0, "signups": 0} for v in sorted(_VARIANTS)
-    }
+        """)
+    summary: dict[str, dict[str, int]] = {v: {"views": 0, "signups": 0} for v in sorted(_VARIANTS)}
     for r in rows:
         variant = r["variant"]
         if variant not in summary:

--- a/backend/services/analytics_events_service.py
+++ b/backend/services/analytics_events_service.py
@@ -20,10 +20,12 @@ ALLOWED_SURFACES = {"web", "cli", "system", "marketing"}
 # Closed set of event names we accept from clients. Adding a new event means
 # adding a row here AND wiring the call site — keeps the dashboard honest.
 ALLOWED_EVENT_NAMES = {
-    # Onboarding funnel (linear Connect → Ask; no path picker)
+    # Onboarding funnel (linear Try it out → Ask; no path picker)
     "onboarding.viewed",
     "onboarding.step_viewed",
+    "onboarding.about_submitted",
     "onboarding.source_selected",
+    "onboarding.collab_path_chosen",
     "onboarding.skipped",
     "onboarding.completed",
     # Web actions

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -67,6 +67,8 @@ function OnboardingInner() {
   const { user, loading, logout } = useAuth();
   const apiKey = useStashToken();
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [sourceCount, setSourceCount] = useState(0);
+  const [obsidianAdded, setObsidianAdded] = useState(false);
   const [answered, setAnswered] = useState(false);
   const [role, setRole] = useState("");
   const [roleOther, setRoleOther] = useState("");
@@ -179,8 +181,9 @@ function OnboardingInner() {
       ? referralOther.trim() && `Other: ${referralOther.trim()}`
       : referralSource;
   // About: role + referral are required, and "Other" needs to be spelled out
-  // (use-case is optional). Ask: only let them launch once the agent has
-  // actually replied.
+  // (use-case is optional). Try it out: Continue lives inside the Connect
+  // option and is gated on a connected source. Ask: only let them launch once
+  // the agent has actually replied.
   const canContinue = isAbout ? Boolean(roleAnswer && referralAnswer) : !isAsk || answered;
   const onContinue = async () => {
     if (isAbout) {
@@ -222,7 +225,14 @@ function OnboardingInner() {
           )}
           {isIntro && <IntroStep />}
           {isTryItOut && (
-            <TryItOutStep workspaceId={workspaceId} onCollabDoc={finishToCollabDoc} />
+            <TryItOutStep
+              workspaceId={workspaceId}
+              onCollabDoc={finishToCollabDoc}
+              onSourceCountChange={setSourceCount}
+              onObsidianAdded={() => setObsidianAdded(true)}
+              canContinue={sourceCount > 0 || obsidianAdded}
+              onContinue={() => goToStep(stepIdx + 1)}
+            />
           )}
           {isAsk && (
             <AskStep workspaceId={workspaceId} onAnswered={() => setAnswered(true)} />
@@ -232,6 +242,7 @@ function OnboardingInner() {
             onSkip={skip}
             continueLabel={continueLabel}
             canContinue={canContinue}
+            hideContinue={isTryItOut}
           />
         </div>
       </main>
@@ -422,9 +433,17 @@ function IntroPoint({ title, children }: { title: string; children: React.ReactN
 function TryItOutStep({
   workspaceId,
   onCollabDoc,
+  onSourceCountChange,
+  onObsidianAdded,
+  canContinue,
+  onContinue,
 }: {
   workspaceId: string | null;
   onCollabDoc: () => void;
+  onSourceCountChange: (n: number) => void;
+  onObsidianAdded: () => void;
+  canContinue: boolean;
+  onContinue: () => void;
 }) {
   return (
     <div className="space-y-7">
@@ -460,7 +479,27 @@ function TryItOutStep({
         badge="Connect"
         lead="Connect a data source and your agent can navigate it like a file system."
       >
-        <SourceConnectorList workspaceId={workspaceId} returnTo="/onboarding?step=3" />
+        <div className="space-y-3">
+          <SourceConnectorList
+            workspaceId={workspaceId}
+            returnTo="/onboarding?step=3"
+            onSourceCountChange={onSourceCountChange}
+            onObsidianUploaded={onObsidianAdded}
+          />
+          <div className="flex items-center justify-end gap-3">
+            {!canContinue && (
+              <span className="text-[12px] text-muted">Connect a source to continue</span>
+            )}
+            <button
+              type="button"
+              onClick={onContinue}
+              disabled={!canContinue}
+              className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
       </TryOption>
       <TryOption
         badge="Capture"
@@ -559,11 +598,13 @@ function StepControls({
   onSkip,
   continueLabel,
   canContinue,
+  hideContinue,
 }: {
   onContinue: () => void;
   onSkip: () => void;
   continueLabel: string;
   canContinue: boolean;
+  hideContinue?: boolean;
 }) {
   return (
     <div className="flex items-center justify-between pt-2">
@@ -574,14 +615,16 @@ function StepControls({
       >
         Skip onboarding
       </button>
-      <button
-        type="button"
-        onClick={onContinue}
-        disabled={!canContinue}
-        className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {continueLabel}
-      </button>
+      {!hideContinue && (
+        <button
+          type="button"
+          onClick={onContinue}
+          disabled={!canContinue}
+          className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {continueLabel}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -6,16 +6,18 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../../components/Header";
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
-import { createPage, getToken, listMyWorkspaces, updateMe } from "../../lib/api";
+import { createPage, getToken, listMyWorkspaces, updateMe, updatePage } from "../../lib/api";
 import { generateCollabIntroMarkdown } from "../../lib/onboarding/collabIntro";
 import { seedWelcomePage } from "../../lib/onboarding/seedWelcome";
 import SourceConnectorList from "../../components/integrations/SourceConnectorList";
 
 import MemoryAskStep from "./paths/memory/MemoryAskStep";
 
-// The linear flow: a few questions about the user, explain Stash, connect a
-// source, then ask the agent a real question over your data, then launch.
-const STEP_NAMES = ["about", "intro", "connect", "ask"] as const;
+// The linear flow: a few questions about the user, explain Stash, try one of
+// the three entry points, then ask the agent a real question, then launch.
+const STEP_NAMES = ["about", "intro", "try", "ask"] as const;
+
+const CLI_INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
 const ROLE_OPTIONS = [
   "Engineer",
@@ -65,11 +67,11 @@ function OnboardingInner() {
   const { user, loading, logout } = useAuth();
   const apiKey = useStashToken();
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
-  const [sourceCount, setSourceCount] = useState(0);
-  const [obsidianAdded, setObsidianAdded] = useState(false);
   const [answered, setAnswered] = useState(false);
   const [role, setRole] = useState("");
+  const [roleOther, setRoleOther] = useState("");
   const [referralSource, setReferralSource] = useState("");
+  const [referralOther, setReferralOther] = useState("");
   const [useCase, setUseCase] = useState("");
 
   const stepIdx = useMemo(() => {
@@ -142,8 +144,15 @@ function OnboardingInner() {
   const finishToCollabDoc = useCallback(async () => {
     if (!workspaceId) return;
     track("onboarding.collab_path_chosen", {});
-    const content = generateCollabIntroMarkdown(user?.display_name || user?.name || "");
-    const page = await createPage(workspaceId, "Welcome to your Drive", undefined, content);
+    // The starter page embeds its own id and the user's API key in a
+    // copy-paste agent prompt, so we create it empty and fill it in after.
+    const page = await createPage(workspaceId, "Welcome to your Drive");
+    const content = generateCollabIntroMarkdown({
+      displayName: user?.display_name || user?.name || "",
+      pageId: page.id,
+      apiKey: getToken() ?? "",
+    });
+    await updatePage(workspaceId, page.id, { content });
     router.push(`/p/${page.id}`);
   }, [workspaceId, user, router]);
 
@@ -153,10 +162,10 @@ function OnboardingInner() {
     );
   }
 
-  // 0 = about, 1 = intro, 2 = connect, 3 = ask.
+  // 0 = about, 1 = intro, 2 = try it out, 3 = ask.
   const isAbout = stepIdx <= 0;
   const isIntro = stepIdx === 1;
-  const isConnect = stepIdx === 2;
+  const isTryItOut = stepIdx === 2;
   const isAsk = stepIdx >= 3;
 
   const continueLabel = isIntro
@@ -164,23 +173,27 @@ function OnboardingInner() {
     : isAsk
       ? "Launch workspace"
       : "Continue";
-  // About: role + referral are required (use-case is optional). Ask: only let
-  // them launch once the agent has actually replied.
-  const canContinue = isAbout
-    ? Boolean(role && referralSource)
-    : isIntro || (isAsk ? answered : sourceCount > 0 || obsidianAdded);
+  const roleAnswer = role === "Other" ? roleOther.trim() && `Other: ${roleOther.trim()}` : role;
+  const referralAnswer =
+    referralSource === "Other"
+      ? referralOther.trim() && `Other: ${referralOther.trim()}`
+      : referralSource;
+  // About: role + referral are required, and "Other" needs to be spelled out
+  // (use-case is optional). Ask: only let them launch once the agent has
+  // actually replied.
+  const canContinue = isAbout ? Boolean(roleAnswer && referralAnswer) : !isAsk || answered;
   const onContinue = async () => {
     if (isAbout) {
       try {
         await updateMe({
-          role,
-          referral_source: referralSource,
+          role: roleAnswer,
+          referral_source: referralAnswer,
           use_case: useCase || undefined,
         });
       } catch {
         // Best-effort — don't block onboarding on a profile write.
       }
-      track("onboarding.about_submitted", { role, referral_source: referralSource });
+      track("onboarding.about_submitted", { role: roleAnswer, referral_source: referralAnswer });
       return goToStep(stepIdx + 1);
     }
     if (isAsk) return void finishAndExit();
@@ -196,21 +209,20 @@ function OnboardingInner() {
           {isAbout && (
             <AboutStep
               role={role}
+              roleOther={roleOther}
               referralSource={referralSource}
+              referralOther={referralOther}
               useCase={useCase}
               onRole={setRole}
+              onRoleOther={setRoleOther}
               onReferral={setReferralSource}
+              onReferralOther={setReferralOther}
               onUseCase={setUseCase}
             />
           )}
           {isIntro && <IntroStep />}
-          {isConnect && (
-            <ConnectStep
-              workspaceId={workspaceId}
-              onSourceCountChange={setSourceCount}
-              onObsidianAdded={() => setObsidianAdded(true)}
-              onCollabDoc={finishToCollabDoc}
-            />
+          {isTryItOut && (
+            <TryItOutStep workspaceId={workspaceId} onCollabDoc={finishToCollabDoc} />
           )}
           {isAsk && (
             <AskStep workspaceId={workspaceId} onAnswered={() => setAnswered(true)} />
@@ -229,17 +241,25 @@ function OnboardingInner() {
 
 function AboutStep({
   role,
+  roleOther,
   referralSource,
+  referralOther,
   useCase,
   onRole,
+  onRoleOther,
   onReferral,
+  onReferralOther,
   onUseCase,
 }: {
   role: string;
+  roleOther: string;
   referralSource: string;
+  referralOther: string;
   useCase: string;
   onRole: (v: string) => void;
+  onRoleOther: (v: string) => void;
   onReferral: (v: string) => void;
+  onReferralOther: (v: string) => void;
   onUseCase: (v: string) => void;
 }) {
   return (
@@ -254,9 +274,19 @@ function AboutStep({
       </div>
       <Field label="What's your role?">
         <PillGroup options={ROLE_OPTIONS} value={role} onChange={onRole} />
+        {role === "Other" && (
+          <OtherInput value={roleOther} onChange={onRoleOther} placeholder="What's your role?" />
+        )}
       </Field>
       <Field label="How did you hear about us?">
         <PillGroup options={REFERRAL_OPTIONS} value={referralSource} onChange={onReferral} />
+        {referralSource === "Other" && (
+          <OtherInput
+            value={referralOther}
+            onChange={onReferralOther}
+            placeholder="Where did you hear about us?"
+          />
+        )}
       </Field>
       <Field label="What do you want to use Stash for?" optional>
         <textarea
@@ -324,6 +354,28 @@ function PillGroup({
   );
 }
 
+function OtherInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      maxLength={200}
+      autoFocus
+      placeholder={placeholder}
+      className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-[13.5px] text-foreground placeholder:text-muted/70 focus:border-brand focus:outline-none"
+    />
+  );
+}
+
 function IntroStep() {
   return (
     <div className="space-y-5">
@@ -338,24 +390,19 @@ function IntroStep() {
       </div>
       <ul className="space-y-3">
         <IntroPoint title="Connect any data source">
-          GitHub, Google Drive, Gmail, Notion, Slack, Granola, an Obsidian vault. Your
-          agent navigates each like a file system and searches across all of them.
+          GitHub, Drive, Gmail, Notion, Slack and more — one connection per source,
+          and every agent you run can read all of them.
         </IntroPoint>
-        <IntroPoint title="A workspace built for agents">
-          Pages in HTML and markdown, files, and your agent session transcripts —
-          stored the way agents read and write, not buried in a UI.
+        <IntroPoint title="Capture every agent session">
+          Transcripts stream in automatically — prompts, tool calls, artifacts — so
+          your knowledge base accumulates with every run instead of evaporating when
+          the session closes.
         </IntroPoint>
-        <IntroPoint title="Share when you need to">
-          Bundle anything into a Cartridge with a shareable link, or give specific
-          people access to a folder — so teammates and their agents work from the
-          same context.
+        <IntroPoint title="An agent-native Drive">
+          HTML docs, Markdown, dashboards, decks — your agents&rsquo; work lands as
+          real files. Edit visually, and share any folder or file as a link.
         </IntroPoint>
       </ul>
-      <div className="rounded-lg border border-border bg-surface px-4 py-3 text-[13px] text-muted">
-        Two quick steps: <span className="text-foreground">connect a source</span>,
-        then <span className="text-foreground">ask your agent a question</span> over
-        it. You can skip and do this later anytime.
-      </div>
     </div>
   );
 }
@@ -372,50 +419,89 @@ function IntroPoint({ title, children }: { title: string; children: React.ReactN
   );
 }
 
-function ConnectStep({
+function TryItOutStep({
   workspaceId,
-  onSourceCountChange,
-  onObsidianAdded,
   onCollabDoc,
 }: {
   workspaceId: string | null;
-  onSourceCountChange: (n: number) => void;
-  onObsidianAdded: () => void;
   onCollabDoc: () => void;
 }) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-7">
       <div className="space-y-2">
         <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
-          Connect a data source
+          Try it out
         </h1>
         <p className="text-sm text-dim max-w-md">
-          Connect a source and your agent can read it — navigate it like a file system
-          and search across everything you connect.
+          Three ways to start — pick whichever fits.
         </p>
       </div>
-      <SourceConnectorList
-        workspaceId={workspaceId}
-        returnTo="/onboarding?step=3"
-        onSourceCountChange={onSourceCountChange}
-        onObsidianUploaded={onObsidianAdded}
-      />
-      <button
-        type="button"
-        onClick={onCollabDoc}
-        className="group flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
+      <TryOption
+        badge="Create"
+        lead="Just want a place to write with your agent?"
       >
-        <div>
-          <div className="text-[13.5px] font-medium text-foreground">
-            Just want a place to write with your agent?
+        <button
+          type="button"
+          onClick={onCollabDoc}
+          className="group flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
+        >
+          <div>
+            <div className="text-[13.5px] font-medium text-foreground">
+              Start a collaborative doc
+            </div>
+            <div className="text-[12px] text-muted">
+              You and your agent edit the same page — two cursors at once.
+            </div>
           </div>
-          <div className="text-[12px] text-muted">
-            Skip connecting sources — start a collaborative doc instead.
-          </div>
+          <span className="text-muted transition-colors group-hover:text-brand">&rarr;</span>
+        </button>
+      </TryOption>
+      <TryOption
+        badge="Connect"
+        lead="Connect a data source and your agent can navigate it like a file system."
+      >
+        <SourceConnectorList workspaceId={workspaceId} returnTo="/onboarding?step=3" />
+      </TryOption>
+      <TryOption
+        badge="Capture"
+        lead="Run this in your terminal — every Claude Code / Codex session streams into Stash automatically."
+      >
+        <div className="space-y-2">
+          <CommandBlock command={CLI_INSTALL_COMMAND} />
+          <CommandBlock command="stash signin" />
         </div>
-        <span className="text-muted transition-colors group-hover:text-brand">&rarr;</span>
-      </button>
+      </TryOption>
     </div>
+  );
+}
+
+function TryOption({
+  badge,
+  lead,
+  children,
+}: {
+  badge: string;
+  lead: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2.5">
+      <div className="flex items-center gap-2.5">
+        <span className="rounded bg-brand/10 px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-brand">
+          {badge}
+        </span>
+        <span className="text-[13px] text-dim">{lead}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CommandBlock({ command }: { command: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
+      {command}
+    </pre>
   );
 }
 
@@ -442,7 +528,7 @@ function AskStep({
 }
 
 function ProgressBar({ stepIdx }: { stepIdx: number }) {
-  const labels = ["About you", "Welcome", "Connect", "Ask"];
+  const labels = ["About you", "Welcome", "Try it out", "Ask"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, i) => {

--- a/frontend/src/lib/onboarding/collabIntro.ts
+++ b/frontend/src/lib/onboarding/collabIntro.ts
@@ -1,29 +1,54 @@
 // The starter page seeded when a user picks the "just write with my agent"
 // onboarding path. It's a real Markdown page in their Drive — editable and
 // deletable — that doubles as an explainer for how the agent-native Drive works.
+//
+// The page embeds its own id and the user's API key so the agent prompt is a
+// one-shot copy-paste: the agent installs the CLI, authenticates, and edits
+// this exact page while the user watches.
 
-export function generateCollabIntroMarkdown(displayName: string): string {
+export function generateCollabIntroMarkdown({
+  displayName,
+  pageId,
+  apiKey,
+}: {
+  displayName: string;
+  pageId: string;
+  apiKey: string;
+}): string {
   const name = displayName.trim() || "there";
   return `# Welcome to your agent-native Drive, ${name}
 
 This is a real page in your Stash — start typing to make it yours, or delete it. Edits save automatically, and you and your agent can edit the same page at the same time (two cursors at once).
 
-## What lives here
+## See your agent edit this page — right now
 
-- **Markdown & HTML pages** — like this one. The formats your agent already reads and writes.
-- **Files** — drop in PDFs, CSVs, images; your agent can open them too.
-- **Agent session transcripts** — every conversation with your coding agent, pushed in automatically.
+Paste this into Claude Code, Codex, or Cursor — keep this tab open and watch the edit land live:
+
+\`\`\`
+Install the Stash CLI: bash -c "$(curl -fsSL https://joinstash.ai/install)"
+Authenticate: export STASH_API_KEY=${apiKey}
+Read this page: stash files read-page ${pageId}
+Then append a short hello note at the bottom and save the full updated markdown with:
+stash files edit-page ${pageId} --content "<full updated markdown>"
+\`\`\`
+
+## What people keep here
+
+- **Analytics dashboards** — live HTML pages your agent regenerates as the numbers change.
+- **Slide decks & presentations** — we ship skills for building these.
+- **Markdown plans your agents work from** — task lists, specs, runbooks.
+- **Research notes, meeting summaries, PRDs** — anything you and your agent write together.
 
 ## How your agent reaches it
 
 Your whole Drive mounts as a virtual filesystem your agent can navigate and edit:
 
-- **CLI** — \`pip install stashai\`, then your coding agent can \`ls\`, \`find\`, and \`rg\` across everything.
+- **CLI** — \`bash -c "$(curl -fsSL https://joinstash.ai/install)"\`, then your coding agent can \`ls\`, \`find\`, and \`rg\` across everything.
 - **MCP** — point Claude Code, Cursor, Codex, or OpenCode at the Stash MCP server and they read and write pages directly.
 - **API** — the same surface over HTTP for anything custom.
 
 ## Share it
 
-Bundle any set of pages into a Cartridge with a link, or share a folder with specific people — so teammates and their agents work from the same docs.
+Share any folder, page, or file with a link, or give specific people access — so teammates and their agents work from the same docs.
 `;
 }

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -37,19 +37,18 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
   parts.push(
     `<ul>
       <li><strong><a href="/settings/integrations">Connect a data source</a></strong> — GitHub, Google Drive, Gmail, Notion, Slack, Granola. Your agent reads across everything you connect.</li>
-      <li><strong><a href="/discover">Discover &amp; install Cartridges</a></strong> — browse skills and knowledge others have published; add them to your Stash.</li>
       <li><strong>Invite a teammate</strong>${
         inviteLink
           ? ` — share <a href="${escapeAttr(inviteLink)}">${escapeHtml(inviteLink)}</a>.`
           : ` from settings.`
       }</li>
-      <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>pip install stashai</code></li>
+      <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>bash -c "$(curl -fsSL https://joinstash.ai/install)"</code></li>
     </ul>`,
   );
 
   parts.push(`<h2>How Stash works</h2>`);
   parts.push(
-    `<p>Stash is built around <strong>sources</strong> your agents read and write, <strong>cartridges</strong> you share on top of them, and the <strong>agents</strong> you talk to over all of it.</p>
+    `<p>Stash is built around <strong>sources</strong> your agents read and write, the <strong>folders and files</strong> you share, and the <strong>agents</strong> you talk to over all of it.</p>
     <ul>
       <li><strong>Sources</strong> — everything your agents produce or consume, all searchable:
         <ul>
@@ -57,7 +56,7 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
           <li><strong>Files</strong> — a file system for documents (markdown, HTML, images, PDF, CSV, tables), plus connected sources like Notion, Google Drive, Slack, and GitHub. Built so agents can use it natively.</li>
         </ul>
       </li>
-      <li><strong>Cartridges</strong> — curated bundles you share on top of your sources: pick any subset and publish it, or share it with specific people. The go-to surface for a team, workstream, or project.</li>
+      <li><strong>Sharing</strong> — share any folder, page, or file with a link, or give specific people access — so teammates and their agents work from the same docs.</li>
       <li><strong>Agents</strong> — talk to an agent grounded on everything above: search it, ask about it, and let your coding agents work against it.</li>
     </ul>`,
   );


### PR DESCRIPTION
## What

Reworks onboarding to match the landing page's Connect / Capture / Drive story and makes every entry point try-able from one step.

- **About step** — picking "Other" for role or referral now opens a required text input; saved as `Other: <text>` so the bucket stays identifiable in analytics.
- **Welcome step** — the three points now mirror the landing page's how-it-works pillars (Connect any data source / Capture every agent session / An agent-native Drive). The "Two quick steps" tip box is removed.
- **Connect step → "Try it out"** — three labeled options, top to bottom: **Create** (the "just want a place to write with your agent" collab-doc card, moved to the top), **Connect** (source list, unchanged), **Capture** (the CLI install command + `stash signin`). The step's Continue lives inside the Connect option, gated on a connected source (or vault upload) — Create navigates away and Capture finishes in the terminal.
- **Seeded collab doc** — now embeds a one-shot copy-paste prompt with the real page id and the user's API key (`STASH_API_KEY` + `stash files read-page` / `edit-page`), so pasting it into any coding agent produces a visible live edit. Also adds a "What people keep here" list (dashboards, decks — we have skills for those — markdown plans, research notes).
- **Cartridges** — all mentions removed from onboarding, the collab doc, and the seeded welcome page; sharing is described through folders/files instead.
- **Backend** — registers `onboarding.about_submitted` and `onboarding.collab_path_chosen` in `ALLOWED_EVENT_NAMES`. Both were already tracked by the frontend but were rejected with 400s and silently dropped.

## Screenshots

| About step ("Other" → required text) | Welcome step (landing pillars) |
|---|---|
| ![about](https://app.joinstash.ai/f/40240a2a-8d72-46a3-878a-a8e609aa3f74) | ![welcome](https://app.joinstash.ai/f/2bc3337f-bb00-4a09-88e5-a4964dbf89b1) |

| Try it out (Create / Connect / Capture) | Seeded collab doc (agent prompt, token redacted) |
|---|---|
| ![tryitout](https://app.joinstash.ai/f/8c555bec-c421-4ae1-bf6c-3c70f17d5eb0) | ![collabdoc](https://app.joinstash.ai/f/d4d3d716-334d-435e-93c4-8b122d85bf6f) |

## Testing

- `frontend`: lint, vitest (128 passed), production build.
- `backend`: ruff, full pytest suite (299 passed, 4 skipped).
- E2E on the local stack with a fresh account: "Other" gating blocks Continue until filled and lands as `Other: Solutions architect` on the user record; Try it out renders all three options with Continue enabled; clicking Create seeds the doc with the real page id + key; ran the embedded prompt's commands verbatim from a terminal and the edit landed on the page (verified via reload — the local stack doesn't run the collab websocket server on :3458, so live push couldn't be observed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
