### PR TITLE
test: deflake CommandPalette table-navigation test

### DIFF
--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { MouseEvent, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CommandPalette from "./CommandPalette";
@@ -150,6 +150,11 @@ describe("CommandPalette search", () => {
     });
 
     expect(await screen.findByText("Hiring Outreach CRM")).toBeInTheDocument();
+
+    // The window keydown listener re-subscribes in a passive effect after the
+    // table result lands; on a loaded runner findByText can resolve before that
+    // effect flushes, leaving ArrowDown bound to the stale one-result list.
+    await act(async () => {});
 
     fireEvent.keyDown(window, { key: "ArrowDown" });
     fireEvent.keyDown(window, { key: "Enter" });


### PR DESCRIPTION
## What

Fixes the flaky `CommandPalette search > finds matching tables in the active workspace` test that failed Vitest on `codex/twitter-integration` (run 27309878776) despite a backend-only diff.

**Root cause:** the palette's window keydown listener re-subscribes in a passive effect whenever `results` changes. On a loaded CI runner, `findByText` can resolve from the DOM mutation before that effect flushes, so ArrowDown runs against the stale listener whose closure still holds the one-result list (`Math.min(s + 1, 0)` keeps selection at 0) and Enter navigates to the search fallback (`/search?workspace=ws-1&q=hiring+outreach`) instead of `/tables/table-1`.

**Fix:** flush effects (`await act(async () => {})`) after the table row appears, before pressing keys. Test-only change.

## Testing

- `npx vitest run src/components/CommandPalette.test.tsx` — 3 passed.
- The failure was CI-load-dependent (passed 5/5 locally before the fix), so the proof is the mechanism above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)