### PR TITLE
Brain: single paginated activity feed + collapsible sidebar Sources

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -51,11 +51,12 @@ async def list_all_session_events(
 
 @router.get("/activity")
 async def list_activity(
-    limit: int = Query(100, ge=1, le=200),
+    limit: int = Query(50, ge=1, le=200),
+    before: datetime | None = Query(None),
     workspace_id: UUID | None = Query(None),
     current_user: dict = Depends(get_current_user),
 ):
-    """Recent product activity across accessible workspaces, optionally one workspace."""
+    """Recent product activity across accessible workspaces, cursor-paginated by ts."""
     pool = get_pool()
     events = await pool.fetch(
         """
@@ -77,6 +78,7 @@ async def list_activity(
         + """
           AND ($3::uuid IS NULL OR w.id = $3)
         )
+        SELECT * FROM (
         (
           SELECT 'session.uploaded' AS kind,
                  MAX(he.created_at) AS ts,
@@ -144,12 +146,18 @@ async def list_activity(
           FROM workspace_members wm
           JOIN member_workspaces aw ON aw.id = wm.workspace_id
         )
+        ) ev
+        WHERE ($4::timestamptz IS NULL OR ev.ts < $4)
         ORDER BY ts DESC LIMIT $2
         """,
         current_user["id"],
-        limit,
+        limit + 1,
         workspace_id,
+        before,
     )
+    has_more = len(events) > limit
+    if has_more:
+        events = events[:limit]
     user_ids = list({r["actor_id"] for r in events if r["actor_id"]})
     users = {}
     if user_ids:
@@ -159,18 +167,21 @@ async def list_activity(
         )
         users = {r["id"]: {"name": r["name"], "display_name": r["display_name"]} for r in rows}
 
-    return [
-        {
-            "kind": r["kind"],
-            "ts": r["ts"],
-            "actor": users[r["actor_id"]],
-            "target_id": r["target_id"],
-            "target_label": r["target_label"],
-            "workspace_id": r["workspace_id"],
-            "workspace_name": r["workspace_name"],
-        }
-        for r in events
-    ]
+    return {
+        "events": [
+            {
+                "kind": r["kind"],
+                "ts": r["ts"],
+                "actor": users[r["actor_id"]],
+                "target_id": r["target_id"],
+                "target_label": r["target_label"],
+                "workspace_id": r["workspace_id"],
+                "workspace_name": r["workspace_name"],
+            }
+            for r in events
+        ],
+        "has_more": has_more,
+    }
 
 
 @router.get("/tables")

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -316,7 +316,7 @@ async def test_user_activity_is_scoped_to_accessible_workspaces(client: AsyncCli
     )
     assert resp.status_code == 200
 
-    events = resp.json()
+    events = resp.json()["events"]
     visible = [
         event
         for event in events
@@ -353,6 +353,48 @@ async def test_user_activity_can_filter_to_one_workspace(client: AsyncClient):
     )
     assert resp.status_code == 200
 
-    events = [event for event in resp.json() if event["kind"] == "session.uploaded"]
+    events = [
+        event for event in resp.json()["events"] if event["kind"] == "session.uploaded"
+    ]
     assert {event["target_id"] for event in events} == {"first-session"}
     assert {event["workspace_id"] for event in events} == {first_workspace["id"]}
+
+
+@pytest.mark.asyncio
+async def test_user_activity_paginates_with_before_cursor(client: AsyncClient):
+    api_key = await _register(client, "activity_paged")
+    workspace = await _workspace(client, api_key, "Paged Activity")
+
+    for hour in (1, 2, 3):
+        await _event(
+            client,
+            api_key,
+            workspace["id"],
+            f"paged-session-{hour}",
+            created_at=f"2026-01-02T0{hour}:00:00Z",
+        )
+
+    # Page through one event at a time using the last event's ts as the cursor.
+    # The feed also contains member.joined events, so only the session events
+    # have a known count and order.
+    seen: list[tuple[str, str, str]] = []
+    before: str | None = None
+    has_more = True
+    while has_more:
+        params: dict = {"limit": 1}
+        if before:
+            params["before"] = before
+        resp = await client.get("/api/v1/me/activity", params=params, headers=_auth(api_key))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["events"]) == 1
+        seen.extend(
+            (event["kind"], event["target_id"], event["ts"]) for event in body["events"]
+        )
+        before = body["events"][-1]["ts"]
+        has_more = body["has_more"]
+        assert len(seen) <= 10, "cursor failed to advance"
+
+    assert len(seen) == len(set(seen)), "an event repeated across pages"
+    session_ids = [target for kind, target, _ in seen if kind == "session.uploaded"]
+    assert session_ids == ["paged-session-3", "paged-session-2", "paged-session-1"]

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -353,9 +353,7 @@ async def test_user_activity_can_filter_to_one_workspace(client: AsyncClient):
     )
     assert resp.status_code == 200
 
-    events = [
-        event for event in resp.json()["events"] if event["kind"] == "session.uploaded"
-    ]
+    events = [event for event in resp.json()["events"] if event["kind"] == "session.uploaded"]
     assert {event["target_id"] for event in events} == {"first-session"}
     assert {event["workspace_id"] for event in events} == {first_workspace["id"]}
 
@@ -388,9 +386,7 @@ async def test_user_activity_paginates_with_before_cursor(client: AsyncClient):
         assert resp.status_code == 200
         body = resp.json()
         assert len(body["events"]) == 1
-        seen.extend(
-            (event["kind"], event["target_id"], event["ts"]) for event in body["events"]
-        )
+        seen.extend((event["kind"], event["target_id"], event["ts"]) for event in body["events"])
         before = body["events"][-1]["ts"]
         has_more = body["has_more"]
         assert len(seen) <= 10, "cursor failed to advance"

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import AppShell from "../../components/AppShell";
 import {
   ActivitySkeleton,
@@ -28,14 +35,7 @@ import {
 } from "../../lib/api";
 import type { ActivityTimeline, EmbeddingProjection } from "../../lib/types";
 
-type FilterKey = "all" | "sessions" | "pages" | "cartridges";
-
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: "all", label: "Everything" },
-  { key: "sessions", label: "Sessions" },
-  { key: "pages", label: "Pages" },
-  { key: "cartridges", label: "Cartridges" },
-];
+const PAGE_SIZE = 50;
 
 const AVATAR_CLASSES = [
   "av-rose",
@@ -70,7 +70,9 @@ export default function ActivityPage() {
   const { user, loading, logout } = useAuth();
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [fetching, setFetching] = useState(true);
-  const [filter, setFilter] = useState<FilterKey>("all");
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
   const [overview, setOverview] = useState<MeOverview | null>(null);
@@ -81,9 +83,11 @@ export default function ActivityPage() {
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
-    listActivity(200)
-      .then((nextEvents) => {
-        if (!cancelled) setEvents(nextEvents);
+    listActivity({ limit: PAGE_SIZE })
+      .then((feed) => {
+        if (cancelled) return;
+        setEvents(feed.events);
+        setHasMore(feed.has_more);
       })
       .catch(() => {})
       .finally(() => {
@@ -93,6 +97,33 @@ export default function ActivityPage() {
       cancelled = true;
     };
   }, [user]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore || events.length === 0) return;
+    setLoadingMore(true);
+    try {
+      const feed = await listActivity({
+        limit: PAGE_SIZE,
+        before: events[events.length - 1].ts,
+      });
+      setEvents((prev) => [...prev, ...feed.events]);
+      setHasMore(feed.has_more);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [events, hasMore, loadingMore]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" }
+    );
+    obs.observe(sentinelRef.current);
+    return () => obs.disconnect();
+  }, [loadMore]);
 
   // The brain's vitals + visualizations. All span the user's own content plus
   // everything shared with them (the /me/* aggregates, called without a
@@ -128,19 +159,6 @@ export default function ActivityPage() {
   }, [events, nowMs]);
 
   const knowledgePoints = projection?.stats.total_embeddings ?? 0;
-
-  const filtered = useMemo(() => {
-    if (filter === "all") return events;
-    if (filter === "sessions")
-      return events.filter((e) => e.kind === "session.uploaded");
-    if (filter === "pages")
-      return events.filter(
-        (e) => e.kind === "page.updated" || e.kind === "file.uploaded"
-      );
-    if (filter === "cartridges")
-      return events.filter((e) => e.kind === "stash.published");
-    return events;
-  }, [events, filter]);
 
   if (loading) return <BasicPageSkeleton />;
   if (!user) return null;
@@ -201,38 +219,18 @@ export default function ActivityPage() {
         </VizCard>
 
         {/* Newsfeed — what the brain has been learning lately. */}
-        <div className="mt-8 flex items-center justify-between border-b border-border pb-2">
-          <div className="flex gap-1">
-            {FILTERS.map((f) => {
-              const active = filter === f.key;
-              return (
-                <button
-                  key={f.key}
-                  onClick={() => setFilter(f.key)}
-                  className={
-                    "rounded-md px-2.5 py-1 text-[12.5px] " +
-                    (active
-                      ? "bg-raised font-semibold text-foreground"
-                      : "text-muted hover:text-foreground")
-                  }
-                >
-                  {f.label}
-                </button>
-              );
-            })}
-          </div>
-          <span className="sys-label">Recent learnings · recent</span>
+        <div className="mt-8 border-b border-border pb-2">
+          <span className="sys-label">Recent learnings</span>
         </div>
 
         <div className="mt-3.5 flex flex-col gap-2.5">
-          {filtered.length === 0 ? (
+          {events.length === 0 ? (
             <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted">
-              {events.length === 0
-                ? "Nothing learned yet. Push a transcript, edit a page, or upload a file."
-                : `No ${filter === "all" ? "" : filter + " "}activity matches this filter.`}
+              Nothing learned yet. Push a transcript, edit a page, or upload a
+              file.
             </div>
           ) : (
-            filtered.map((event, i) => (
+            events.map((event, i) => (
               <FeedCard
                 key={`${event.kind}-${event.target_id}-${i}`}
                 event={event}
@@ -240,6 +238,12 @@ export default function ActivityPage() {
               />
             ))
           )}
+          {loadingMore && (
+            <div className="py-2 text-center text-[12.5px] text-muted">
+              Loading more…
+            </div>
+          )}
+          {hasMore && <div ref={sentinelRef} />}
         </div>
       </div>
     </AppShell>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -47,6 +47,7 @@ interface WorkspaceNode extends Workspace {
 }
 
 const LAST_WORKSPACE_KEY = "stash_sidebar_last_workspace";
+const SOURCES_COLLAPSED_KEY = "stash_sources_collapsed";
 
 // A colored dot per source type, so the grouped Sources list reads as a set of
 // equal peers (matching the mockup). Falls back to neutral.
@@ -158,6 +159,16 @@ export default function AppSidebar({
   // Connected sources (GitHub/Drive/Gmail/Notion/Slack/Granola) for the active
   // workspace, keyed by workspace id. User-scoped — only the viewer's own.
   const [sourceMap, setSourceMap] = useState<Record<string, WorkspaceSource[]>>({});
+  const [sourcesCollapsed, setSourcesCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(SOURCES_COLLAPSED_KEY) === "1";
+  });
+
+  function toggleSourcesCollapsed() {
+    const next = !sourcesCollapsed;
+    setSourcesCollapsed(next);
+    localStorage.setItem(SOURCES_COLLAPSED_KEY, next ? "1" : "0");
+  }
 
   // The sidebar always renders a single workspace context. Priority:
   // (1) the workspace in the current URL, (2) the first owned workspace,
@@ -338,18 +349,29 @@ export default function AppSidebar({
 
       {activeWorkspace ? (
         <nav className="mt-4 px-2 text-[13px]">
-          <div className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted">
+          <button
+            type="button"
+            onClick={toggleSourcesCollapsed}
+            className="flex w-full items-center gap-1 px-2 pb-1 text-left text-[11px] font-semibold uppercase tracking-wide text-muted hover:text-foreground"
+          >
+            <span
+              aria-hidden
+              className={`transition-transform ${sourcesCollapsed ? "-rotate-90" : ""}`}
+            >
+              ▾
+            </span>
             Sources
-          </div>
-          {sourceRows.map((row) => (
-            <NavRow
-              key={row.key}
-              href={row.href}
-              icon={row.icon}
-              label={row.label}
-              active={row.active}
-            />
-          ))}
+          </button>
+          {!sourcesCollapsed &&
+            sourceRows.map((row) => (
+              <NavRow
+                key={row.key}
+                href={row.href}
+                icon={row.icon}
+                label={row.label}
+                active={row.active}
+              />
+            ))}
           <button
             type="button"
             onClick={() => setAddSourceOpen(true)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1722,18 +1722,16 @@ export interface ActivityEvent {
   workspace_name?: string;
 }
 
-export async function listActivity(limit = 100): Promise<ActivityEvent[]> {
-  return apiFetch(`/api/v1/me/activity?limit=${limit}`);
+export interface ActivityFeed {
+  events: ActivityEvent[];
+  has_more: boolean;
 }
 
-export async function listWorkspaceActivity(
-  workspaceId: string,
-  limit = 100
-): Promise<ActivityEvent[]> {
-  const qs = new URLSearchParams({
-    limit: String(limit),
-    workspace_id: workspaceId,
-  });
+export async function listActivity(
+  opts: { limit?: number; before?: string } = {}
+): Promise<ActivityFeed> {
+  const qs = new URLSearchParams({ limit: String(opts.limit ?? 50) });
+  if (opts.before) qs.set("before", opts.before);
   return apiFetch(`/api/v1/me/activity?${qs}`);
 }
 


### PR DESCRIPTION
## What

Part 1 of the agent-native-drive rework: the Brain page becomes one infinite-scrolling feed, and the sidebar Sources section collapses.

### Your brain (`/activity`)
- Removed the Everything / Sessions / Pages / Cartridges filter selector — one feed shows everything.
- `GET /api/v1/me/activity` is now cursor-paginated: `before` timestamp param, `{events, has_more}` envelope, default limit 50 (was a bare array capped at 200).
- Frontend infinite-scrolls via an IntersectionObserver sentinel (same pattern as the table rows view).

### Sidebar
- "Sources" header is now a toggle that collapses the source rows (chevron rotates, state persists in localStorage). "Add a new source" stays outside the accordion, always visible.

## Screenshots

Single feed, no filter selector:

![brain](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/81c2e0d333ef/brain-top.png)

Sources collapsed — Add a new source still visible:

![sources-collapsed](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/83cc7965eb19/sidebar-sources-collapsed.png)

## Testing
- `pytest backend/tests/test_activity.py` — 8 passed, incl. new `test_user_activity_paginates_with_before_cursor` (pages one event at a time, asserts no overlap and correct order).
- Browser-verified: scrolling the feed fires `GET /me/activity?limit=50&before=<ts>` and appends without duplicates (50 → 65 cards), stops when `has_more` is false; accordion state survives reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)