### PR TITLE
Files + Cartridges: drive-consistent rows, + New menu, scope tabs

### DIFF
--- a/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/cartridges/page.tsx
@@ -8,7 +8,10 @@ import {
   StashesGridSkeleton,
 } from "../../../../../components/SkeletonStates";
 import { PinIcon, StashIcon } from "../../../../../components/StashIcons";
-import CartridgeCard from "../../../../../components/cartridge/CartridgeCard";
+import CartridgeCard, {
+  VIS_COLOR,
+  VisibilityBadge,
+} from "../../../../../components/cartridge/CartridgeCard";
 import ForkCartridgeCardButton from "../../../../../components/cartridge/ForkCartridgeCardButton";
 import { SelectBox } from "../../../../../components/workspace/file-browser/ItemsList";
 import { useShareModal } from "../../../../../lib/shareModalContext";
@@ -28,30 +31,22 @@ import {
 import { usePins } from "../../../../../lib/pins";
 import { stashSlugFromInput } from "../../../../../lib/cartridgeLinks";
 
-// Visibility is one axis (who can see a Cartridge). "External" is a different
-// axis entirely — where it came from — so it's a section below, not a filter.
-type Visibility = "all" | "private" | "shared" | "public";
 type ViewKey = "grid" | "list";
 // The primary axis: which set of Cartridges you're looking at. Yours and Shared
-// share the visibility filter / view toggle / quick-access; Discover is its own
-// public-library surface.
+// share the view toggle / quick-access; Discover is its own public-library
+// surface. Each row carries its own Private/Shared/Public badge — there's no
+// visibility filter to learn.
 type Tab = "yours" | "shared" | "discover";
 
 const VIEW_STORAGE_KEY = "stash_stashes_view";
 
-const VISIBILITIES: { key: Visibility; label: string }[] = [
-  { key: "all", label: "All" },
-  { key: "private", label: "Private" },
-  { key: "shared", label: "Shared" },
-  { key: "public", label: "Public" },
-];
-
 const COVERS = ["cover-1", "cover-2", "cover-3", "cover-4", "cover-5", "cover-6"];
 
-const VIS_COLOR: Record<string, string> = {
-  public: "#22C55E",
-  shared: "var(--color-brand-500)",
-  private: "#9CA3AF",
+const TAB_COPY: Record<Tab, string> = {
+  yours:
+    "Cartridges you created in this workspace. Share them with people or publish them to the public library.",
+  shared: "Cartridges other people created and shared with you, plus pending invites.",
+  discover: "Public cartridges from the community — fork one into your workspace.",
 };
 
 export default function WorkspaceStashesPage() {
@@ -65,7 +60,6 @@ export default function WorkspaceStashesPage() {
   const [invites, setInvites] = useState<CartridgeInvite[]>([]);
   const [busyInviteId, setBusyInviteId] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("yours");
-  const [visibility, setVisibility] = useState<Visibility>("all");
   const [view, setView] = useState<ViewKey>("grid");
   const [error, setError] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -129,22 +123,11 @@ export default function WorkspaceStashesPage() {
     }
   }
 
-  // Visibility filter applies across both axes; the section split (yours vs
-  // forked) is the origin axis, kept independent of it.
   const visible = useMemo(() => {
     if (!cartridges) return [];
-    const ordered = [...cartridges].sort(
+    return [...cartridges].sort(
       (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
     );
-    if (visibility === "all") return ordered;
-    return ordered.filter((s) => displayVisibility(s.access, s.share_count) === visibility);
-  }, [cartridges, visibility]);
-
-  const counts = useMemo(() => {
-    const list = cartridges ?? [];
-    const by = (v: Visibility) =>
-      list.filter((s) => displayVisibility(s.access, s.share_count) === v).length;
-    return { all: list.length, private: by("private"), shared: by("shared"), public: by("public") };
   }, [cartridges]);
 
   const native = useMemo(() => visible.filter((s) => !s.is_external), [visible]);
@@ -192,14 +175,9 @@ export default function WorkspaceStashesPage() {
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-[1120px] px-12 pb-20 pt-8">
         <div className="flex items-center justify-between gap-4">
-          <div>
-            <h1 className="m-0 font-display text-[21px] font-bold tracking-tight text-foreground">
-              Cartridges
-            </h1>
-            <p className="mt-0.5 text-[12.5px] text-muted">
-              Your knowledge bundles — yours, shared with you, and the public library.
-            </p>
-          </div>
+          <h1 className="m-0 font-display text-[21px] font-bold tracking-tight text-foreground">
+            Cartridges
+          </h1>
           <button
             type="button"
             onClick={() => shareModal.open({ workspaceId })}
@@ -224,9 +202,10 @@ export default function WorkspaceStashesPage() {
             (cartridges ?? []).filter((s) => s.is_external).length + invites.length
           }
         />
+        <p className="mt-2 text-[12.5px] text-muted">{TAB_COPY[tab]}</p>
 
-        {/* Quick-access + the visibility/view toolbar belong to your held
-            Cartridges, so they sit under Yours and Shared, not Discover. */}
+        {/* Quick-access + the view toolbar belong to your held Cartridges, so
+            they sit under Yours and Shared, not Discover. */}
         {tab !== "discover" && (pinnedStashes.length > 0 || recentStashes.length > 0) && (
           <CartridgeQuickAccess
             pinned={pinnedStashes}
@@ -237,12 +216,7 @@ export default function WorkspaceStashesPage() {
         )}
 
         {tab !== "discover" && (
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
-            <VisibilityFilter
-              visibility={visibility}
-              counts={counts}
-              onChange={setVisibility}
-            />
+          <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
             <CartridgeViewToggle view={view} onChange={setViewPersisted} />
           </div>
         )}
@@ -261,9 +235,7 @@ export default function WorkspaceStashesPage() {
                 embedded
               />
             ) : (
-              <EmptyHint>
-                {cartridges.length === 0 ? "No cartridges yet." : "None match this visibility."}
-              </EmptyHint>
+              <EmptyHint>No cartridges yet.</EmptyHint>
             )}
           </div>
         )}
@@ -271,9 +243,9 @@ export default function WorkspaceStashesPage() {
         {tab === "shared" && (
           <div className="mt-4">
             {invites.length > 0 && (
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="overflow-hidden rounded-xl border border-border bg-surface">
                 {invites.map((invite) => (
-                  <SharedInviteCard
+                  <SharedInviteRow
                     key={invite.id}
                     invite={invite}
                     busy={busyInviteId === invite.id}
@@ -295,13 +267,7 @@ export default function WorkspaceStashesPage() {
                 className={invites.length > 0 ? "mt-3" : undefined}
               />
             ) : (
-              invites.length === 0 && (
-                <EmptyHint>
-                  {visibility === "all"
-                    ? "Nothing shared with you yet."
-                    : "None match this visibility."}
-                </EmptyHint>
-              )
+              invites.length === 0 && <EmptyHint>Nothing shared with you yet.</EmptyHint>
             )}
             <ExternalCartridgeLinkForm workspaceId={workspaceId} onAdded={() => void load()} />
           </div>
@@ -408,51 +374,6 @@ function ExternalCartridgeLinkForm({
   );
 }
 
-// The single visibility axis as a segmented control. One pill per level plus
-// "All", each with its live count — replaces the old flat filter row that
-// mixed visibility with the unrelated "External" origin flag.
-function VisibilityFilter({
-  visibility,
-  counts,
-  onChange,
-}: {
-  visibility: Visibility;
-  counts: Record<Visibility, number>;
-  onChange: (next: Visibility) => void;
-}) {
-  return (
-    <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-base p-[3px]">
-      {VISIBILITIES.map((v) => {
-        const active = visibility === v.key;
-        return (
-          <button
-            key={v.key}
-            type="button"
-            onClick={() => onChange(v.key)}
-            className={
-              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-[5px] text-[12.5px] " +
-              (active
-                ? "bg-raised font-semibold text-foreground"
-                : "text-muted hover:text-foreground")
-            }
-          >
-            {v.key !== "all" && (
-              <span
-                className="inline-block h-[7px] w-[7px] rounded-full"
-                style={{ background: VIS_COLOR[v.key] }}
-              />
-            )}
-            {v.label}
-            <span className="sys-label" style={{ fontSize: 10 }}>
-              {counts[v.key]}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 function PlusGlyph() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -514,10 +435,10 @@ function EmptyHint({ children }: { children: React.ReactNode }) {
   );
 }
 
-// A pending invite rendered as a grid peer of the Cartridge cards. View opens
-// the Cartridge; Dismiss removes the invite (the access stays — it can still be
-// reached by link). Mirrors the dismiss logic in CartridgeInviteCenter.
-function SharedInviteCard({
+// A pending invite rendered as a drive-style row above the shared list. View
+// opens the Cartridge; Dismiss removes the invite (the access stays — it can
+// still be reached by link). Mirrors the dismiss logic in CartridgeInviteCenter.
+function SharedInviteRow({
   invite,
   busy,
   onDismiss,
@@ -527,36 +448,36 @@ function SharedInviteCard({
   onDismiss: () => void;
 }) {
   return (
-    <div className="flex flex-col rounded-xl border border-border bg-surface p-4">
-      <div className="flex items-center gap-2">
-        <span className="text-[var(--color-brand-600)]">
-          <StashIcon className="text-[18px]" />
+    <div
+      className="grid items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] last:border-b-0"
+      style={{ gridTemplateColumns: "minmax(0,2fr) minmax(0,1fr) auto" }}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-[var(--color-brand-600)]">
+          <StashIcon />
         </span>
-        <h3 className="min-w-0 flex-1 truncate font-display text-[14px] font-semibold text-foreground">
+        <span className="min-w-0 truncate font-medium text-foreground">
           {invite.cartridge_title}
-        </h3>
+        </span>
         <span className="shrink-0 rounded-full border border-border bg-base px-1.5 py-0.5 font-mono text-[9.5px] text-muted">
           INVITE
         </span>
       </div>
-      <p className="mt-2 line-clamp-2 flex-1 text-[12px] leading-relaxed text-muted">
-        {invite.cartridge_description || "No description."}
-      </p>
-      <p className="mt-2 text-[11px] text-muted">
-        Shared by {invite.invited_by_display_name} · from {invite.source_workspace_name}
-      </p>
-      <div className="mt-3 flex justify-end gap-1.5">
+      <span className="truncate text-[12px] text-muted">
+        from {invite.invited_by_display_name} · {invite.source_workspace_name}
+      </span>
+      <div className="flex items-center justify-end gap-1.5">
         <button
           type="button"
           disabled={busy}
           onClick={onDismiss}
-          className="rounded-md border border-border-subtle px-2.5 py-1.5 text-[12px] text-muted hover:text-foreground disabled:opacity-50"
+          className="rounded-md border border-border-subtle px-2 py-1 text-[12px] text-muted hover:text-foreground disabled:opacity-50"
         >
           Dismiss
         </button>
         <Link
           href={`/cartridges/${invite.cartridge_slug}`}
-          className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+          className="rounded-md bg-[var(--color-brand-600)] px-2 py-1 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
         >
           View
         </Link>
@@ -825,45 +746,43 @@ function CartridgeListRow({
 }) {
   const itemCount = stash.items?.length ?? 0;
   const author = stash.owner_display_name || stash.owner_name || "";
-  const dotColor = VIS_COLOR[displayVisibility(stash.access, stash.share_count)];
 
   return (
     <Link
       href={`/cartridges/${stash.slug}`}
       className={
-        "group grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-3 border-b border-border-subtle px-4 py-3 last:border-b-0 " +
+        "group grid items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] last:border-b-0 " +
         (selected ? "bg-[var(--color-brand-50)]" : "hover:bg-[var(--color-brand-50)]/50")
       }
+      style={{ gridTemplateColumns: "auto minmax(0,2fr) minmax(0,1fr) auto auto" }}
     >
       <SelectBox selected={selected} onToggle={() => onToggleSelect(stash.id)} />
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          {dotColor && (
-            <span
-              className="inline-block h-[8px] w-[8px] shrink-0 rounded-full"
-              style={{ background: dotColor }}
-              title={stash.access}
-            />
-          )}
-          <span className="min-w-0 truncate font-display text-[14px] font-semibold tracking-tight text-foreground group-hover:text-[var(--color-brand-700)]">
-            {stash.title}
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-[var(--color-brand-600)]">
+          <StashIcon />
+        </span>
+        <span className="min-w-0 truncate font-medium text-foreground">{stash.title}</span>
+        {stash.is_external && (
+          <span className="shrink-0 rounded-full border border-border bg-base px-1.5 py-0.5 font-mono text-[9.5px] text-muted">
+            EXTERNAL
           </span>
-          {stash.is_external && (
-            <span className="shrink-0 rounded-full border border-border bg-base px-1.5 py-0.5 font-mono text-[9.5px] text-muted">
-              EXTERNAL
-            </span>
-          )}
-        </div>
-        <p className="mt-0.5 truncate text-[12px] text-muted">
-          {stash.description || "No description."}
-        </p>
+        )}
       </div>
-      <div className="sys-label whitespace-nowrap text-right" style={{ fontSize: 10.5 }}>
+      <span className="truncate text-[12px] text-muted">
         {author && `by ${author} · `}
         {itemCount} item{itemCount === 1 ? "" : "s"}
         {stash.updated_at && ` · ${relativeTime(stash.updated_at)}`}
-      </div>
-      <CartridgePinButton pinned={pinned} onToggle={() => onTogglePin(stash)} />
+      </span>
+      <VisibilityBadge access={stash.access} shareCount={stash.share_count} />
+      <span
+        className={
+          pinned
+            ? ""
+            : "opacity-0 transition focus-within:opacity-100 group-hover:opacity-100"
+        }
+      >
+        <CartridgePinButton pinned={pinned} onToggle={() => onTogglePin(stash)} />
+      </span>
     </Link>
   );
 }

--- a/frontend/src/components/cartridge/CartridgeCard.tsx
+++ b/frontend/src/components/cartridge/CartridgeCard.tsx
@@ -38,11 +38,33 @@ interface CartridgeCardProps {
   selected?: boolean;
 }
 
-const VIS_COLOR: Record<string, string> = {
+export const VIS_COLOR: Record<string, string> = {
   public: "#22C55E",
   shared: "var(--color-brand-500)",
   private: "#9CA3AF",
 };
+
+// The one way visibility is shown on a Cartridge: a dot + label pill. Used on
+// card covers and list rows so there's no filter to learn — every row says
+// Private / Shared / Public itself.
+export function VisibilityBadge({
+  access,
+  shareCount,
+}: {
+  access: "private" | "public";
+  shareCount: number;
+}) {
+  const visibility = displayVisibility(access, shareCount);
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-base px-1.5 py-0.5 text-[10.5px] text-muted">
+      <span
+        className="inline-block h-[7px] w-[7px] rounded-full"
+        style={{ background: VIS_COLOR[visibility] }}
+      />
+      {visibility.charAt(0).toUpperCase() + visibility.slice(1)}
+    </span>
+  );
+}
 
 export default function CartridgeCard({
   stash,
@@ -53,10 +75,6 @@ export default function CartridgeCard({
   selected,
 }: CartridgeCardProps) {
   const itemCount = stash.item_count ?? stash.items?.length ?? 0;
-  const visibility = stash.access
-    ? displayVisibility(stash.access, stash.share_count ?? 0)
-    : null;
-  const dotColor = visibility ? VIS_COLOR[visibility] : null;
   const author = authorName(stash);
 
   return (
@@ -90,14 +108,10 @@ export default function CartridgeCard({
             EXTERNAL
           </span>
         )}
-        {dotColor && (
-          // Visibility lives as a small corner dot on the cover, freeing a
-          // whole row of card body space the inline chip used to occupy.
-          <span
-            className="absolute bottom-2 left-2.5 inline-block h-[8px] w-[8px] rounded-full ring-2 ring-white/80"
-            style={{ background: dotColor }}
-            title={visibility ?? undefined}
-          />
+        {stash.access && (
+          <span className="absolute bottom-2 left-2.5">
+            <VisibilityBadge access={stash.access} shareCount={stash.share_count ?? 0} />
+          </span>
         )}
       </div>
       <div className="flex flex-1 flex-col p-4">

--- a/frontend/src/components/workspace/SharedWithMeFiles.tsx
+++ b/frontend/src/components/workspace/SharedWithMeFiles.tsx
@@ -3,16 +3,17 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { listSharedWithMe, type SharedWithMeItem } from "../../lib/api";
+import { KindIcon, tintFor, type ItemKind } from "./file-browser/kind";
 
 // Shared folders/pages/files/tables surfaced inside the Files source. Session
 // folders are handled in the Agent Sessions view, not here.
 const FILE_KINDS = new Set<SharedWithMeItem["object_type"]>(["folder", "page", "file", "table"]);
 
-const ICON: Record<string, string> = {
-  folder: "📁",
-  page: "📄",
-  file: "📎",
-  table: "▦",
+const ITEM_KIND: Record<string, ItemKind> = {
+  folder: "folder",
+  page: "page",
+  file: "file",
+  table: "datatable",
 };
 const LABEL: Record<string, string> = {
   folder: "Folder",
@@ -20,6 +21,10 @@ const LABEL: Record<string, string> = {
   file: "File",
   table: "Table",
 };
+
+// SharedWithMeItem has no updated_at, so the columns are Name / Shared by /
+// Type rather than the main list's Name / Modified / Type.
+const GRID_COLS = "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr)";
 
 function hrefFor(item: SharedWithMeItem): string {
   const ws = item.workspace_id;
@@ -31,43 +36,70 @@ function hrefFor(item: SharedWithMeItem): string {
 
 export default function SharedWithMeFiles() {
   const [items, setItems] = useState<SharedWithMeItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     listSharedWithMe()
       .then((all) => setItems(all.filter((i) => FILE_KINDS.has(i.object_type))))
-      .catch(() => setItems([]));
+      .catch(() => setItems([]))
+      .finally(() => setLoaded(true));
   }, []);
 
-  if (items.length === 0) return null;
+  if (!loaded) return null;
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-10 text-center text-[12.5px] text-muted">
+        Nothing shared with you yet. Folders, pages, files, and tables others
+        share with you show up here.
+      </p>
+    );
+  }
 
   return (
-    <section className="mt-8">
-      <h2 className="m-0 mb-2 px-1 text-[11px] font-semibold uppercase tracking-wide text-muted">
-        Shared with me
-      </h2>
-      <div className="space-y-1.5">
-        {items.map((item) => (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div
+        className="grid items-center gap-3 border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted"
+        style={{ gridTemplateColumns: GRID_COLS }}
+      >
+        <span>Name</span>
+        <span>Shared by</span>
+        <span>Type</span>
+      </div>
+      {items.map((item) => {
+        const kind = ITEM_KIND[item.object_type];
+        return (
           <Link
             key={`${item.object_type}:${item.object_id}`}
             href={hrefFor(item)}
-            className="flex items-center gap-3 rounded-lg border border-border bg-surface/40 px-4 py-3 hover:bg-raised/40"
+            className="grid items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] last:border-b-0 hover:bg-[var(--color-brand-50)]/50"
+            style={{ gridTemplateColumns: GRID_COLS }}
           >
-            <span aria-hidden>{ICON[item.object_type]}</span>
-            <span className="flex-1 truncate text-[13.5px] font-medium text-foreground">
-              {item.name}
-            </span>
-            {item.shared_by ? (
-              <span className="text-[11.5px] text-muted">from {item.shared_by}</span>
-            ) : null}
-            {item.permission === "write" ? (
-              <span className="rounded bg-raised px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide text-muted">
-                can edit
+            <div className="flex min-w-0 items-center gap-2.5">
+              <span
+                className={
+                  "flex h-4 w-4 flex-shrink-0 items-center justify-center " +
+                  tintFor({ kind, id: item.object_id, name: item.name, subtitle: "" })
+                }
+              >
+                <KindIcon kind={kind} />
               </span>
-            ) : null}
-            <span className="text-[12px] text-muted">{LABEL[item.object_type]}</span>
+              <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
+            </div>
+            <span className="truncate text-[12px] text-muted">
+              {item.shared_by || "—"}
+            </span>
+            <span className="flex items-center gap-2 text-[12px] text-muted">
+              {LABEL[item.object_type]}
+              {item.permission === "write" && (
+                <span className="rounded bg-raised px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide">
+                  can edit
+                </span>
+              )}
+            </span>
           </Link>
-        ))}
-      </div>
-    </section>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -2,30 +2,9 @@
 
 import { useState, type DragEvent } from "react";
 import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
-import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
 import { type FBDragPayload } from "./WorkspaceFileBrowser";
 import { SelectBox, handleFolderDrop, isFbDrag, startItemDrag } from "./ItemsList";
-
-// "table" = a CSV/spreadsheet *file* linked to a table; "datatable" = a
-// standalone structured-data table (the `tables` entity). Both render with the
-// table icon, but they have different backing rows so move/delete/nav differ.
-export type ItemKind = "folder" | "page" | "html" | "table" | "datatable" | "file";
-
-export interface GridItem {
-  kind: ItemKind;
-  id: string;
-  name: string;
-  subtitle: string;
-  sizeBytes?: number;
-  contentType?: string;
-  tableId?: string;
-  tableBackedBy?: "file" | "table";
-  linkedTableId?: string;
-  movable?: boolean;
-  /** ISO timestamp. Renders as "Modified" in the Drive-style List view.
-   *  Not all rows have one — FolderContents.pages currently omits it. */
-  updatedAt?: string;
-}
+import { KindIcon, tintFor, type GridItem } from "./kind";
 
 interface Props {
   items: GridItem[];
@@ -148,9 +127,9 @@ function Tile({
       className={
         "group flex items-start gap-3 rounded-lg border bg-base p-3 transition cursor-pointer select-none " +
         (selected || multiSelected
-          ? "border-[var(--color-brand-400)] bg-[var(--color-brand-50)]/40"
-          : "border-border hover:border-[var(--color-brand-200)] hover:bg-[var(--color-brand-50)]/30") +
-        (over ? " ring-2 ring-[var(--color-brand-300)]" : "")
+          ? "border-[var(--color-brand-400)] bg-[var(--color-brand-50)]"
+          : "border-border hover:border-[var(--color-brand-200)] hover:bg-[var(--color-brand-50)]/50") +
+        (over ? " ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
     >
       {onToggleSelect && (
@@ -187,20 +166,4 @@ function Tile({
       )}
     </div>
   );
-}
-
-function KindIcon({ kind }: { kind: ItemKind }) {
-  if (kind === "folder") return <FolderIcon />;
-  if (kind === "page" || kind === "html") return <PageIcon />;
-  if (kind === "table") return <TableIcon />;
-  return <FileIcon />;
-}
-
-function tintFor(item: GridItem): string {
-  if (item.kind === "folder") return "text-muted";
-  if (item.kind === "html") return "text-[#D97706]";
-  if (item.kind === "table") return "text-emerald-600";
-  if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.includes("image")) return "text-[var(--color-brand-600)]";
-  return "text-muted";
 }

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { getFolderContents, type FolderContents } from "../../../lib/api";
 import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
-import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
-import type { GridItem, ItemKind } from "./FolderItemGrid";
+import { KindIcon, tintFor, type GridItem } from "./kind";
 import { FB_DRAG_MIME, type FBDragPayload } from "./WorkspaceFileBrowser";
 
 interface Props {
@@ -279,7 +278,7 @@ function ColumnRow({
         "group flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 text-[13px] " +
         (active
           ? "bg-[var(--color-brand-600)] text-white"
-          : "text-foreground hover:bg-[var(--color-brand-50)]/40") +
+          : "text-foreground hover:bg-[var(--color-brand-50)]/50") +
         (over ? " ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
     >
@@ -419,23 +418,6 @@ function folderContentsToItems(contents: FolderContents): GridItem[] {
       subtitle: `table · ${t.row_count} row${t.row_count === 1 ? "" : "s"}`,
     })),
   ];
-}
-
-function KindIcon({ kind }: { kind: ItemKind }) {
-  if (kind === "folder") return <FolderIcon />;
-  if (kind === "page" || kind === "html") return <PageIcon />;
-  if (kind === "table" || kind === "datatable") return <TableIcon />;
-  return <FileIcon />;
-}
-
-function tintFor(item: GridItem): string {
-  if (item.kind === "folder") return "text-muted";
-  if (item.kind === "html") return "text-[#D97706]";
-  if (item.kind === "table" || item.kind === "datatable") return "text-emerald-600";
-  if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.startsWith("image/")) return "text-[var(--color-brand-600)]";
-  if (item.kind === "page") return "text-[var(--color-brand-600)]";
-  return "text-muted";
 }
 
 function kindLabel(item: GridItem): string {

--- a/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import ItemsList from "./ItemsList";
-import type { GridItem } from "./FolderItemGrid";
+import type { GridItem } from "./kind";
 
 const item: GridItem = {
   kind: "html",

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -7,8 +7,8 @@ import {
   type FBDragPayload,
 } from "./WorkspaceFileBrowser";
 import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
-import { FileIcon, FolderIcon, PageIcon, PinIcon, TableIcon } from "../../StashIcons";
-import type { GridItem, ItemKind } from "./FolderItemGrid";
+import { PinIcon } from "../../StashIcons";
+import { KindIcon, tintFor, typeFor, type GridItem, type ItemKind } from "./kind";
 
 // Shared drag setup so single rows/tiles and multi-selections behave the same.
 // When dragging an item that's part of a 2+ selection, carry the whole
@@ -380,36 +380,6 @@ export function SelectBox({
       </svg>
     </span>
   );
-}
-
-export function KindIcon({ kind }: { kind: ItemKind }) {
-  if (kind === "folder") return <FolderIcon />;
-  if (kind === "page" || kind === "html") return <PageIcon />;
-  if (kind === "table" || kind === "datatable") return <TableIcon />;
-  return <FileIcon />;
-}
-
-export function tintFor(item: GridItem): string {
-  if (item.kind === "folder") return "text-muted";
-  if (item.kind === "html") return "text-[#D97706]";
-  if (item.kind === "table" || item.kind === "datatable") return "text-emerald-600";
-  if (item.contentType?.includes("pdf")) return "text-rose-500";
-  if (item.contentType?.startsWith("image/")) return "text-[var(--color-brand-600)]";
-  if (item.kind === "page") return "text-[var(--color-brand-600)]";
-  return "text-muted";
-}
-
-export function typeFor(item: GridItem): string {
-  if (item.kind === "folder") return "Folder";
-  if (item.kind === "table" || item.kind === "datatable") return "Table";
-  if (item.kind === "html") return "HTML";
-  if (item.kind === "page") return "Markdown";
-  if (item.contentType?.includes("pdf")) return "PDF";
-  if (item.contentType?.includes("csv")) return "CSV";
-  if (item.contentType?.startsWith("image/")) {
-    return item.contentType.replace("image/", "").toUpperCase();
-  }
-  return item.contentType || "File";
 }
 
 function formatRelative(iso: string | undefined): string {

--- a/frontend/src/components/workspace/file-browser/QuickAccess.tsx
+++ b/frontend/src/components/workspace/file-browser/QuickAccess.tsx
@@ -2,8 +2,7 @@
 
 import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { PinIcon } from "../../StashIcons";
-import type { GridItem } from "./FolderItemGrid";
-import { KindIcon, tintFor, typeFor } from "./ItemsList";
+import { KindIcon, tintFor, typeFor, type GridItem } from "./kind";
 
 interface Props {
   pinned: GridItem[];

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.test.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.test.tsx
@@ -96,12 +96,13 @@ afterEach(() => {
 });
 
 describe("WorkspaceFileBrowser table creation", () => {
-  it("creates a blank table from the root files view", async () => {
+  it("creates a blank table from the + New menu", async () => {
     vi.mocked(createTable).mockResolvedValue(table("table-1", "Untitled table"));
 
     render(<WorkspaceFileBrowser workspaceId="ws-1" folderId={null} />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "+ New table" }));
+    fireEvent.click(await screen.findByRole("button", { name: /\+ New/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Table" }));
 
     await waitFor(() =>
       expect(createTable).toHaveBeenCalledWith("ws-1", "Untitled table")

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEscapeKey } from "../../../hooks/useEscapeKey";
 import {
   ApiError,
   createTable,
@@ -33,11 +34,12 @@ import { openInNewTab, type NavigateOptions } from "../../../lib/linkNavigation"
 import { useWorkspaceRecents } from "../../../lib/pins";
 import { FileBrowserSkeleton } from "../../SkeletonStates";
 import EditableTitle from "../EditableTitle";
-import FolderItemGrid, { type GridItem, type ItemKind } from "./FolderItemGrid";
+import FolderItemGrid from "./FolderItemGrid";
 import ItemsList from "./ItemsList";
 import ItemsColumns from "./ItemsColumns";
 import SharedWithMeFiles from "../SharedWithMeFiles";
 import QuickAccess from "./QuickAccess";
+import { type GridItem, type ItemKind } from "./kind";
 
 interface Props {
   workspaceId: string;
@@ -58,6 +60,9 @@ export interface FBDragPayload {
 }
 
 type View = "list" | "column" | "grid";
+// Which set of files you're looking at: your workspace's drive, or items other
+// people shared with you. Only selectable at root — folders are always "mine".
+type Scope = "mine" | "shared";
 
 const VIEW_STORAGE_KEY = "stash_files_view";
 
@@ -71,6 +76,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
   const [rootTables, setRootTables] = useState<GridItem[]>([]);
   const [allFiles, setAllFiles] = useState<GridItem[]>([]);
   const [view, setView] = useState<View>("grid");
+  const [scope, setScope] = useState<Scope>("mine");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const pins = useFilePins(workspaceId);
   const recents = useWorkspaceRecents(workspaceId);
@@ -424,6 +430,11 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
   async function handleNewTable() {
     try {
       const table = await createTable(workspaceId, "Untitled table");
+      // createTable has no folder param, so move the new table into the
+      // current folder before navigating.
+      if (folderId) {
+        await updateTable(workspaceId, table.id, { folder_id: folderId });
+      }
       refreshWorkspaceSidebar(workspaceId).catch(() => {});
       router.push(`/tables/${table.id}`);
     } catch (e) {
@@ -561,58 +572,45 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
       id: item.id,
     }));
 
+  const showShared = !folderId && scope === "shared";
+
   return (
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-8 py-7">
+        {!folderId && <ScopeTabs scope={scope} onChange={setScope} />}
         {/* Header: the page path lives in AppShell's top-bar breadcrumb, so we
             only show the current folder name (rename target) or the section
             title here, alongside the view toggle + create actions. */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          {folderId && contents?.folder ? (
-            <h1 className="m-0 min-w-0 font-display text-[22px] font-semibold leading-tight tracking-tight text-foreground">
-              <EditableTitle
-                value={contents.folder.name}
-                onSave={(next) => renameItem("folder", folderId, next)}
-              />
-            </h1>
-          ) : (
-            // Root: the breadcrumb + sidebar already say "Files"; no redundant title.
-            <div />
-          )}
-          <div className="flex flex-wrap items-center gap-2">
-            <ViewToggle view={view} onChange={setViewPersisted} />
-            <button
-              type="button"
-              onClick={handleUploadFile}
-              className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
-            >
-              + Upload
-            </button>
-            <button
-              type="button"
-              onClick={handleNewPage}
-              className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
-            >
-              + New page
-            </button>
-            {!folderId && (
+        {!showShared && (
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            {folderId && contents?.folder ? (
+              <h1 className="m-0 min-w-0 font-display text-[22px] font-semibold leading-tight tracking-tight text-foreground">
+                <EditableTitle
+                  value={contents.folder.name}
+                  onSave={(next) => renameItem("folder", folderId, next)}
+                />
+              </h1>
+            ) : (
+              // Root: the breadcrumb + sidebar already say "Files"; no redundant title.
+              <div />
+            )}
+            <div className="flex flex-wrap items-center gap-2">
+              <ViewToggle view={view} onChange={setViewPersisted} />
               <button
                 type="button"
-                onClick={handleNewTable}
+                onClick={handleUploadFile}
                 className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
               >
-                + New table
+                + Upload
               </button>
-            )}
-            <button
-              type="button"
-              onClick={handleNewFolder}
-              className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
-            >
-              + New folder
-            </button>
+              <NewMenu
+                onNewFolder={handleNewFolder}
+                onNewPage={handleNewPage}
+                onNewTable={handleNewTable}
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         {error && (
           <div className="mt-4 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
@@ -620,56 +618,63 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
           </div>
         )}
 
-        {showQuickAccess && (
-          <QuickAccess
-            pinned={pinnedItems}
-            recent={recentItems}
-            onOpen={navigateTo}
-            isPinned={(item) => pins.isPinned(item.id)}
-            onTogglePin={(item) => pins.toggle(item.id)}
-          />
-        )}
+        {showShared ? (
+          <div className="mt-5">
+            <SharedWithMeFiles />
+          </div>
+        ) : (
+          <>
+            {showQuickAccess && (
+              <QuickAccess
+                pinned={pinnedItems}
+                recent={recentItems}
+                onOpen={navigateTo}
+                isPinned={(item) => pins.isPinned(item.id)}
+                onTogglePin={(item) => pins.toggle(item.id)}
+              />
+            )}
 
-        <div className={view === "column" ? "mt-5 h-[68vh]" : "mt-5"}>
-          {view === "list" && (
-            <ItemsList
-              items={items}
-              onNavigate={navigateTo}
-              onReparent={reparent}
-              onReparentMany={reparentMany}
-              onDelete={handleDelete}
-              isPinned={(item) => pins.isPinned(item.id)}
-              onTogglePin={(item) => pins.toggle(item.id)}
-              selectedIds={selectedIds}
-              onToggleSelect={toggleSelect}
-              selectedDragPayloads={selectedDragPayloads}
-            />
-          )}
-          {view === "grid" && (
-            <FolderItemGrid
-              items={items}
-              selectedId={null}
-              onSelect={navigateTo}
-              onNavigate={navigateTo}
-              onReparent={reparent}
-              onReparentMany={reparentMany}
-              onDelete={handleDelete}
-              selectedIds={selectedIds}
-              onToggleSelect={toggleSelect}
-              selectedDragPayloads={selectedDragPayloads}
-            />
-          )}
-          {view === "column" && (
-            <ItemsColumns
-              workspaceId={workspaceId}
-              rootItems={rootItems}
-              onNavigate={navigateTo}
-              onReparent={reparent}
-              onDelete={handleDelete}
-            />
-          )}
-        </div>
-        {!folderId ? <SharedWithMeFiles /> : null}
+            <div className={view === "column" ? "mt-5 h-[68vh]" : "mt-5"}>
+              {view === "list" && (
+                <ItemsList
+                  items={items}
+                  onNavigate={navigateTo}
+                  onReparent={reparent}
+                  onReparentMany={reparentMany}
+                  onDelete={handleDelete}
+                  isPinned={(item) => pins.isPinned(item.id)}
+                  onTogglePin={(item) => pins.toggle(item.id)}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
+                  selectedDragPayloads={selectedDragPayloads}
+                />
+              )}
+              {view === "grid" && (
+                <FolderItemGrid
+                  items={items}
+                  selectedId={null}
+                  onSelect={navigateTo}
+                  onNavigate={navigateTo}
+                  onReparent={reparent}
+                  onReparentMany={reparentMany}
+                  onDelete={handleDelete}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
+                  selectedDragPayloads={selectedDragPayloads}
+                />
+              )}
+              {view === "column" && (
+                <ItemsColumns
+                  workspaceId={workspaceId}
+                  rootItems={rootItems}
+                  onNavigate={navigateTo}
+                  onReparent={reparent}
+                  onDelete={handleDelete}
+                />
+              )}
+            </div>
+          </>
+        )}
       </div>
       {selectedItems.length > 0 && (
         <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center">
@@ -718,6 +723,99 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
               ×
             </button>
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Drive-style root selector: your workspace's files vs items shared with you.
+function ScopeTabs({ scope, onChange }: { scope: Scope; onChange: (next: Scope) => void }) {
+  const tabs: { key: Scope; label: string }[] = [
+    { key: "mine", label: "My files" },
+    { key: "shared", label: "Shared with me" },
+  ];
+  return (
+    <div className="flex gap-1 border-b border-border">
+      {tabs.map((t) => {
+        const active = scope === t.key;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            className={
+              "-mb-px border-b-2 px-3 py-2 text-[13px] transition-colors " +
+              (active
+                ? "border-[var(--color-brand-600)] font-semibold text-foreground"
+                : "border-transparent text-muted hover:text-foreground")
+            }
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// One "+ New" button for everything creatable here (Drive-style), so the
+// toolbar stays two buttons no matter how many creatable kinds we grow.
+function NewMenu({
+  onNewFolder,
+  onNewPage,
+  onNewTable,
+}: {
+  onNewFolder: () => void;
+  onNewPage: () => void;
+  onNewTable: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEscapeKey(open, () => setOpen(false));
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const options: { label: string; onSelect: () => void }[] = [
+    { label: "Folder", onSelect: onNewFolder },
+    { label: "Page", onSelect: onNewPage },
+    { label: "Table", onSelect: onNewTable },
+  ];
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
+      >
+        + New <span aria-hidden className="text-[10px]">▾</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-30 mt-1 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg">
+          {options.map((o) => (
+            <button
+              key={o.label}
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                o.onSelect();
+              }}
+              className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+            >
+              {o.label}
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/workspace/file-browser/kind.tsx
+++ b/frontend/src/components/workspace/file-browser/kind.tsx
@@ -1,0 +1,52 @@
+import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../StashIcons";
+
+// "table" = a CSV/spreadsheet *file* linked to a table; "datatable" = a
+// standalone structured-data table (the `tables` entity). Both render with the
+// table icon, but they have different backing rows so move/delete/nav differ.
+export type ItemKind = "folder" | "page" | "html" | "table" | "datatable" | "file";
+
+export interface GridItem {
+  kind: ItemKind;
+  id: string;
+  name: string;
+  subtitle: string;
+  sizeBytes?: number;
+  contentType?: string;
+  tableId?: string;
+  tableBackedBy?: "file" | "table";
+  linkedTableId?: string;
+  movable?: boolean;
+  /** ISO timestamp. Renders as "Modified" in the Drive-style List view.
+   *  Not all rows have one — FolderContents.pages currently omits it. */
+  updatedAt?: string;
+}
+
+export function KindIcon({ kind }: { kind: ItemKind }) {
+  if (kind === "folder") return <FolderIcon />;
+  if (kind === "page" || kind === "html") return <PageIcon />;
+  if (kind === "table" || kind === "datatable") return <TableIcon />;
+  return <FileIcon />;
+}
+
+export function tintFor(item: GridItem): string {
+  if (item.kind === "folder") return "text-muted";
+  if (item.kind === "html") return "text-[#D97706]";
+  if (item.kind === "table" || item.kind === "datatable") return "text-emerald-600";
+  if (item.contentType?.includes("pdf")) return "text-rose-500";
+  if (item.contentType?.startsWith("image/")) return "text-[var(--color-brand-600)]";
+  if (item.kind === "page") return "text-[var(--color-brand-600)]";
+  return "text-muted";
+}
+
+export function typeFor(item: GridItem): string {
+  if (item.kind === "folder") return "Folder";
+  if (item.kind === "table" || item.kind === "datatable") return "Table";
+  if (item.kind === "html") return "HTML";
+  if (item.kind === "page") return "Markdown";
+  if (item.contentType?.includes("pdf")) return "PDF";
+  if (item.contentType?.includes("csv")) return "CSV";
+  if (item.contentType?.startsWith("image/")) {
+    return item.contentType.replace("image/", "").toUpperCase();
+  }
+  return item.contentType || "File";
+}


### PR DESCRIPTION
## What

Part 2 of the agent-native-drive rework: Files and Cartridges share one consistent drive look.

### Files
- **My files / Shared with me tabs** at root. Shared with me is rebuilt as drive rows (SVG icons, Name / Shared by / Type columns, can-edit chip) instead of the emoji-icon section that used to float under whichever view was active — worst under the fixed-height column view.
- **One "+ New" dropdown** (Folder / Page / Table) next to "+ Upload", replacing three separate buttons. "New table" no longer disappears in subfolders — the table is created and moved into the current folder.
- **Shared `kind.tsx` module**: `KindIcon` / `tintFor` / `typeFor` / `GridItem` were copy-pasted across grid/list/column views; the grid copy was missing the `datatable` case, so standalone tables rendered with a generic file icon in grid view. Fixed by consolidation.
- Hover/selection/drop-ring styles aligned across grid, list, and column views.

### Cartridges
- **Removed the All / Private / Shared / Public filter.** Every card and list row now carries a Private / Shared / Public badge (dot + label) instead.
- **List rows restyled to the Files drive-row pattern** — single line, icon + name + EXTERNAL chip, muted metadata, badge, hover-revealed pin. Pending invites render as rows in the same container (INVITE chip, Dismiss/View) instead of a card grid stacked above the list.
- **Per-tab explainer copy** so the three tabs are self-describing: Yours = cartridges you created to share; Shared with you = ones others created and shared with you; Discover = public ones from the community you can fork.

## Screenshots

Files root (grid) — tabs, two-button toolbar, table icon fixed:

![files-root](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/82ffdb322fe1/files-root-myfiles.png)

"+ New" menu:

![new-menu](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/e53e7f8df755/files-new-menu.png)

Shared with me as drive rows:

![shared-with-me](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/f8fa2d72ad53/files-shared-with-me.png)

Column view — no more floating shared section:

![column](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/f433b756fdce/files-column-view.png)

Cartridges grid with visibility badges + tab copy:

![cart-grid](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/7e59bc39d70c/cartridges-yours-grid.png)

Cartridges list — drive rows with badges:

![cart-list](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/caf50c00cecb/cartridges-yours-list.png)

Shared with you — invite as a row:

![cart-shared](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/91e239b1cf72/cartridges-shared.png)

Discover unchanged (cover cards + fork):

![cart-discover](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/aeaf15304338/cartridges-discover.png)

## Testing
- `npm test` (128 passed) — `WorkspaceFileBrowser.test.tsx` updated for the + New menu; `npm run lint`; `npm run build`.
- Browser-verified: created a table from the menu inside a subfolder and confirmed `folder_id` is set; clicked through both Files tabs, all three views, and all three Cartridges tabs with seeded private/shared/public cartridges and a pending invite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)