### PR TITLE
Files: Recent strip on Shared with me

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -49,6 +49,29 @@ async def list_all_session_events(
     return {"events": events, "has_more": has_more}
 
 
+@router.get("/recents")
+async def list_my_recents(current_user: dict = Depends(get_current_user)):
+    """Recently-viewed objects across all workspaces, most recent first.
+
+    Includes objects in workspaces the user isn't a member of (shared items),
+    which the Shared-with-me Recent strip resolves against the share list.
+    """
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT object_id, kind, workspace_id FROM user_recents "
+        "WHERE user_id = $1 ORDER BY viewed_at DESC LIMIT 30",
+        current_user["id"],
+    )
+    return [
+        {
+            "object_id": r["object_id"],
+            "kind": r["kind"],
+            "workspace_id": r["workspace_id"],
+        }
+        for r in rows
+    ]
+
+
 @router.get("/activity")
 async def list_activity(
     limit: int = Query(50, ge=1, le=200),

--- a/backend/routers/pins.py
+++ b/backend/routers/pins.py
@@ -2,7 +2,8 @@
 
 Pins are an explicit per-kind set the user curates (cartridges / sessions /
 files); recents are stamped automatically as the user opens things. Both are
-private to the user — membership in the workspace is the only access check.
+private to the user. Pins require workspace membership; recents can also be
+stamped by non-members for objects shared with them.
 """
 
 import json
@@ -13,7 +14,7 @@ from pydantic import BaseModel
 
 from ..auth import get_current_user
 from ..database import get_pool
-from ..services import workspace_service
+from ..services import permission_service, workspace_service
 
 router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}", tags=["pins"])
 
@@ -23,6 +24,27 @@ RECENTS_LIMIT = 24
 
 async def _require_member(workspace_id: UUID, user_id: UUID) -> None:
     if not await workspace_service.is_member(workspace_id, user_id):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+
+async def _require_member_or_readable(
+    workspace_id: UUID, user_id: UUID, kind: str, object_id: str
+) -> None:
+    """Members can stamp anything; non-members only objects shared with them.
+
+    Lets opening a shared page/file/folder record a recent in the object's
+    home workspace, which powers the Shared-with-me Recent strip.
+    """
+    if await workspace_service.is_member(workspace_id, user_id):
+        return
+    try:
+        parsed_id = UUID(object_id)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    readable = await permission_service.check_access(
+        kind, parsed_id, user_id, workspace_id=workspace_id
+    )
+    if not readable:
         raise HTTPException(status_code=403, detail="Not a workspace member")
 
 
@@ -106,7 +128,7 @@ async def record_recent(
     req: RecordRecentRequest,
     current_user: dict = Depends(get_current_user),
 ) -> None:
-    await _require_member(workspace_id, current_user["id"])
+    await _require_member_or_readable(workspace_id, current_user["id"], req.kind, req.object_id)
     pool = get_pool()
     await pool.execute(
         """

--- a/backend/tests/test_recents.py
+++ b/backend/tests/test_recents.py
@@ -1,0 +1,75 @@
+"""Recents: shared objects can be stamped by non-members and read back via /me/recents."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient, prefix: str) -> tuple[str, str]:
+    name = unique_name(prefix)
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1", "email": f"{name}@test.local"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"], name
+
+
+async def _workspace(client: AsyncClient, api_key: str, name: str) -> dict:
+    resp = await client.post("/api/v1/workspaces", json={"name": name}, headers=_auth(api_key))
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_shared_page_recent_is_recordable_and_listed(client: AsyncClient):
+    owner_key, _ = await _register(client, "recents_owner")
+    viewer_key, viewer_name = await _register(client, "recents_viewer")
+    workspace = await _workspace(client, owner_key, "Recents Source")
+
+    page_resp = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/pages/new",
+        json={"name": "Shared Doc"},
+        headers=_auth(owner_key),
+    )
+    assert page_resp.status_code == 201
+    page_id = page_resp.json()["id"]
+
+    # Before the share, the viewer (a non-member) can't stamp a recent there.
+    denied = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/recents",
+        json={"object_id": page_id, "kind": "page"},
+        headers=_auth(viewer_key),
+    )
+    assert denied.status_code == 403
+
+    share = await client.post(
+        "/api/v1/share",
+        json={
+            "object_type": "page",
+            "object_id": page_id,
+            "email": f"{viewer_name}@test.local",
+            "permission": "read",
+        },
+        headers=_auth(owner_key),
+    )
+    assert share.status_code == 200
+
+    recorded = await client.post(
+        f"/api/v1/workspaces/{workspace['id']}/recents",
+        json={"object_id": page_id, "kind": "page"},
+        headers=_auth(viewer_key),
+    )
+    assert recorded.status_code == 204
+
+    resp = await client.get("/api/v1/me/recents", headers=_auth(viewer_key))
+    assert resp.status_code == 200
+    recents = resp.json()
+    assert [r["object_id"] for r in recents] == [page_id]
+    assert recents[0]["kind"] == "page"
+    assert recents[0]["workspace_id"] == workspace["id"]

--- a/frontend/src/components/workspace/SharedWithMeFiles.tsx
+++ b/frontend/src/components/workspace/SharedWithMeFiles.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { listSharedWithMe, type SharedWithMeItem } from "../../lib/api";
+import { useEffect, useMemo, useState } from "react";
+import {
+  getMyRecents,
+  listSharedWithMe,
+  type RecentEntry,
+  type SharedWithMeItem,
+} from "../../lib/api";
 import { KindIcon, tintFor, type ItemKind } from "./file-browser/kind";
 
 // Shared folders/pages/files/tables surfaced inside the Files source. Session
@@ -36,6 +41,7 @@ function hrefFor(item: SharedWithMeItem): string {
 
 export default function SharedWithMeFiles() {
   const [items, setItems] = useState<SharedWithMeItem[]>([]);
+  const [recents, setRecents] = useState<RecentEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -43,7 +49,20 @@ export default function SharedWithMeFiles() {
       .then((all) => setItems(all.filter((i) => FILE_KINDS.has(i.object_type))))
       .catch(() => setItems([]))
       .finally(() => setLoaded(true));
+    getMyRecents()
+      .then(setRecents)
+      .catch(() => setRecents([]));
   }, []);
+
+  // Recently-viewed shared items: /me/recents spans all workspaces, so its
+  // intersection with the share list is exactly "shared things I opened".
+  const recentItems = useMemo(() => {
+    const byId = new Map(items.map((item) => [item.object_id, item]));
+    return recents
+      .map((entry) => byId.get(entry.object_id))
+      .filter((item): item is SharedWithMeItem => !!item)
+      .slice(0, 8);
+  }, [items, recents]);
 
   if (!loaded) return null;
 
@@ -57,7 +76,20 @@ export default function SharedWithMeFiles() {
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+    <div>
+      {recentItems.length > 0 && (
+        <section className="mb-5">
+          <h2 className="m-0 mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
+            Recent
+          </h2>
+          <div className="flex flex-wrap gap-2.5">
+            {recentItems.map((item) => (
+              <RecentCard key={`${item.object_type}:${item.object_id}`} item={item} />
+            ))}
+          </div>
+        </section>
+      )}
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
       <div
         className="grid items-center gap-3 border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted"
         style={{ gridTemplateColumns: GRID_COLS }}
@@ -100,6 +132,37 @@ export default function SharedWithMeFiles() {
           </Link>
         );
       })}
+      </div>
     </div>
+  );
+}
+
+// Compact quick-access card, mirroring the My-files Recent strip (minus the
+// pin button — pins are workspace-scoped and shared items live elsewhere).
+function RecentCard({ item }: { item: SharedWithMeItem }) {
+  const kind = ITEM_KIND[item.object_type];
+  return (
+    <Link
+      href={hrefFor(item)}
+      className="flex w-[180px] items-center gap-2.5 rounded-lg border border-border bg-surface px-3 py-2.5 transition hover:border-[var(--color-brand-300)] hover:bg-raised"
+    >
+      <span
+        className={
+          "flex h-5 w-5 shrink-0 items-center justify-center " +
+          tintFor({ kind, id: item.object_id, name: item.name, subtitle: "" })
+        }
+      >
+        <KindIcon kind={kind} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12.5px] font-medium text-foreground">
+          {item.name}
+        </span>
+        <span className="block truncate text-[10.5px] text-muted">
+          {LABEL[item.object_type]}
+          {item.shared_by ? ` · from ${item.shared_by}` : ""}
+        </span>
+      </span>
+    </Link>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1294,6 +1294,12 @@ export async function getWorkspaceRecents(workspaceId: string): Promise<RecentEn
   return apiFetch(`/api/v1/workspaces/${workspaceId}/recents`);
 }
 
+// Recently-viewed objects across all workspaces (incl. shared items in
+// workspaces the user isn't a member of), most recent first.
+export async function getMyRecents(): Promise<RecentEntry[]> {
+  return apiFetch(`/api/v1/me/recents`);
+}
+
 export async function recordWorkspaceRecent(
   workspaceId: string,
   objectId: string,


### PR DESCRIPTION
## What

Follow-up to #577: the Shared with me tab now has a **Recent** strip, mirroring the quick-access Recent row in My files.

- `POST /workspaces/{id}/recents` now accepts non-members when the object is shared with them (`permission_service.check_access`). Opening a shared page/file/folder already fired this call — it just 403'd silently before.
- New `GET /api/v1/me/recents`: the user's recently-viewed objects across all workspaces.
- Shared with me intersects `/me/recents` with the share list and renders the matches as compact quick-access cards (same style as the My files Recent strip, minus the pin button — pins are workspace-scoped).

## Screenshot

![shared-recent](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/8694da8086b9/shared-with-recent.png)

## Testing
- New backend test `test_recents.py`: non-member 403 before share, 204 after, `/me/recents` returns the stamped entry with its home workspace.
- `pytest backend/tests/test_recents.py backend/tests/test_activity.py` (9 passed), `ruff`, `black`; `npm test` (128), `npm run lint`.
- Browser-verified: opened a shared page + shared folder as a non-member, both appeared in the Recent strip on the Shared with me tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)