### PR TITLE
Drag-and-drop like a real file system: quick-access, shared folders, sessions

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -139,7 +139,21 @@ async def upload_ws_file(
     folder_id: UUID | None = Form(None),
     current_user: dict = Depends(get_current_user),
 ):
-    await _check_write(workspace_id, current_user["id"])
+    # Workspace writers can upload anywhere; non-members can upload into a
+    # specific folder shared with them with write permission.
+    if not await workspace_service.can_write(workspace_id, current_user["id"]):
+        can_write_folder = folder_id is not None and await permission_service.check_access(
+            "folder",
+            folder_id,
+            current_user["id"],
+            workspace_id=workspace_id,
+            require="write",
+        )
+        if not can_write_folder:
+            raise HTTPException(
+                status_code=403,
+                detail="Viewers can read but not modify files",
+            )
 
     content = await file.read()
     if len(content) > MAX_FILE_SIZE:
@@ -166,6 +180,15 @@ async def upload_ws_file(
                     status_code=400,
                     detail="folder_id does not belong to workspace",
                 )
+            can_write_folder = await permission_service.check_access(
+                "folder",
+                folder_id,
+                current_user["id"],
+                workspace_id=workspace_id,
+                require="write",
+            )
+            if not can_write_folder:
+                raise HTTPException(status_code=404, detail="Folder not found")
 
         text = content.decode("utf-8", errors="replace")
         exts = _MD_EXTS if page_kind == "markdown" else _HTML_EXTS
@@ -232,7 +255,7 @@ async def upload_ws_file(
             folder_id,
             current_user["id"],
             workspace_id=workspace_id,
-            require_write=True,
+            require="write",
         )
         if not can_write_folder:
             raise HTTPException(status_code=404, detail="Folder not found")
@@ -439,7 +462,7 @@ async def update_ws_file(
             req.folder_id,
             current_user["id"],
             workspace_id=workspace_id,
-            require_write=True,
+            require="write",
         )
         if not can_write_folder:
             raise HTTPException(status_code=404, detail="Folder not found")

--- a/backend/tests/test_shared_folder_writes.py
+++ b/backend/tests/test_shared_folder_writes.py
@@ -3,6 +3,8 @@
 import pytest
 from httpx import AsyncClient
 
+from backend.services import storage_service
+
 from .conftest import unique_name
 
 
@@ -57,8 +59,15 @@ async def _share_folder(
 
 
 @pytest.mark.asyncio
-async def test_member_can_move_file_into_folder(client: AsyncClient, _db_pool):
+async def test_member_can_move_file_into_folder(client: AsyncClient, _db_pool, monkeypatch):
     """Regression: this PATCH 500'd (check_access called with a bad kwarg)."""
+
+    # The response serializer resolves a download URL; S3 isn't configured in CI.
+    async def _fake_url(storage_key: str) -> str:
+        return f"https://files.test/{storage_key}"
+
+    monkeypatch.setattr(storage_service, "get_file_url", _fake_url)
+
     api_key, _, user_id = await _register(client, "fmove_owner")
     ws = await _workspace(client, api_key)
     folder_id = await _folder(client, api_key, ws)

--- a/backend/tests/test_shared_folder_writes.py
+++ b/backend/tests/test_shared_folder_writes.py
@@ -1,0 +1,164 @@
+"""Writes into folders: member moves, and non-member writes via write shares."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient, prefix: str) -> tuple[str, str, str]:
+    """Returns (api_key, name, user_id)."""
+    name = unique_name(prefix)
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1", "email": f"{name}@test.local"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], name, body["id"]
+
+
+async def _workspace(client: AsyncClient, api_key: str) -> str:
+    resp = await client.post(
+        "/api/v1/workspaces", json={"name": "Folder Writes"}, headers=_auth(api_key)
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _folder(client: AsyncClient, api_key: str, workspace_id: str) -> str:
+    resp = await client.post(
+        f"/api/v1/workspaces/{workspace_id}/folders",
+        json={"name": "Drop zone"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _share_folder(
+    client: AsyncClient, owner_key: str, folder_id: str, email: str, permission: str
+) -> None:
+    resp = await client.post(
+        "/api/v1/share",
+        json={
+            "object_type": "folder",
+            "object_id": folder_id,
+            "email": email,
+            "permission": permission,
+        },
+        headers=_auth(owner_key),
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_member_can_move_file_into_folder(client: AsyncClient, _db_pool):
+    """Regression: this PATCH 500'd (check_access called with a bad kwarg)."""
+    api_key, _, user_id = await _register(client, "fmove_owner")
+    ws = await _workspace(client, api_key)
+    folder_id = await _folder(client, api_key, ws)
+
+    file_id = await _db_pool.fetchval(
+        "INSERT INTO files "
+        "(workspace_id, name, content_type, size_bytes, storage_key, uploaded_by) "
+        "VALUES ($1, 'notes.txt', 'text/plain', 5, 'test/key', $2) RETURNING id",
+        ws,
+        user_id,
+    )
+
+    resp = await client.patch(
+        f"/api/v1/workspaces/{ws}/files/{file_id}",
+        json={"folder_id": folder_id},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["folder_id"] == folder_id
+
+
+@pytest.mark.asyncio
+async def test_write_share_allows_upload_and_move_into_shared_folder(client: AsyncClient):
+    owner_key, _, _ = await _register(client, "fshare_owner")
+    guest_key, guest_name, _ = await _register(client, "fshare_guest")
+    ws = await _workspace(client, owner_key)
+    folder_id = await _folder(client, owner_key, ws)
+
+    # Before the share: a non-member can't upload at all.
+    denied = await client.post(
+        f"/api/v1/workspaces/{ws}/files",
+        files={"file": ("notes.md", b"# hi", "text/markdown")},
+        data={"folder_id": folder_id},
+        headers=_auth(guest_key),
+    )
+    assert denied.status_code == 403
+
+    await _share_folder(client, owner_key, folder_id, f"{guest_name}@test.local", "write")
+
+    # Markdown upload into the shared folder becomes a page in that folder.
+    uploaded = await client.post(
+        f"/api/v1/workspaces/{ws}/files",
+        files={"file": ("notes.md", b"# hi", "text/markdown")},
+        data={"folder_id": folder_id},
+        headers=_auth(guest_key),
+    )
+    assert uploaded.status_code == 201
+    assert uploaded.json()["kind"] == "page"
+    assert uploaded.json()["folder_id"] == folder_id
+
+    # Upload without a target folder stays forbidden for non-members.
+    rootless = await client.post(
+        f"/api/v1/workspaces/{ws}/files",
+        files={"file": ("more.md", b"# hi", "text/markdown")},
+        headers=_auth(guest_key),
+    )
+    assert rootless.status_code == 403
+
+    # A page shared writable with the guest can be moved into the folder
+    # (the share on the folder cascades to its contents).
+    page = await client.post(
+        f"/api/v1/workspaces/{ws}/pages/new",
+        json={"name": "Loose doc"},
+        headers=_auth(owner_key),
+    )
+    assert page.status_code == 201
+    page_id = page.json()["id"]
+    share = await client.post(
+        "/api/v1/share",
+        json={
+            "object_type": "page",
+            "object_id": page_id,
+            "email": f"{guest_name}@test.local",
+            "permission": "write",
+        },
+        headers=_auth(owner_key),
+    )
+    assert share.status_code == 200
+
+    moved = await client.patch(
+        f"/api/v1/workspaces/{ws}/pages/{page_id}",
+        json={"folder_id": folder_id},
+        headers=_auth(guest_key),
+    )
+    assert moved.status_code == 200
+    assert moved.json()["folder_id"] == folder_id
+
+
+@pytest.mark.asyncio
+async def test_read_share_does_not_allow_upload(client: AsyncClient):
+    owner_key, _, _ = await _register(client, "fread_owner")
+    guest_key, guest_name, _ = await _register(client, "fread_guest")
+    ws = await _workspace(client, owner_key)
+    folder_id = await _folder(client, owner_key, ws)
+    await _share_folder(client, owner_key, folder_id, f"{guest_name}@test.local", "read")
+
+    resp = await client.post(
+        f"/api/v1/workspaces/{ws}/files",
+        files={"file": ("notes.md", b"# hi", "text/markdown")},
+        data={"folder_id": folder_id},
+        headers=_auth(guest_key),
+    )
+    assert resp.status_code == 403

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
 import { useBreadcrumbs } from "../../../../../components/BreadcrumbContext";
 import SessionUpload from "../../../../../components/SessionUpload";
 import { SessionsListSkeleton } from "../../../../../components/SkeletonStates";
@@ -58,6 +58,36 @@ const SORTS: { key: SortKey; label: string }[] = [
   { key: "name", label: "Name" },
 ];
 
+// Drag payload: the DB row ids (sessions.id) of the dragged sessions. Dragging
+// a selected row carries the whole selection, like the file browser.
+const SESSION_DRAG_MIME = "application/x-stash-sessions";
+
+// Drag wiring threaded down to session rows: whether rows can be dragged at
+// all (off inside shared folders), the row ids the current selection would
+// carry, and a signal so drop targets can reveal themselves mid-drag.
+interface SessionDrag {
+  canDrag: boolean;
+  selectedRowIds: string[];
+  onActiveChange: (active: boolean) => void;
+}
+
+const NO_DRAG: SessionDrag = {
+  canDrag: false,
+  selectedRowIds: [],
+  onActiveChange: () => {},
+};
+
+function readSessionDrop(e: DragEvent<HTMLElement>): string[] {
+  const raw = e.dataTransfer.getData(SESSION_DRAG_MIME);
+  if (!raw) return [];
+  try {
+    const ids = JSON.parse(raw);
+    return Array.isArray(ids) ? ids.filter((id) => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 export default function CartridgeSessionsPage() {
   const params = useParams();
   const router = useRouter();
@@ -74,6 +104,7 @@ export default function CartridgeSessionsPage() {
   const [view, setView] = useState<ViewKey>("list");
   const [sort, setSort] = useState<SortKey>("recent");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [dragActive, setDragActive] = useState(false);
 
   function toggleSelect(sessionId: string) {
     setSelectedIds((current) => {
@@ -138,6 +169,13 @@ export default function CartridgeSessionsPage() {
   const selectedSessions = (sorted ?? []).filter((s) =>
     selectedIds.has(s.session_id),
   );
+  const drag: SessionDrag = {
+    canDrag: true,
+    selectedRowIds: selectedSessions
+      .filter((s) => s.id)
+      .map((s) => s.id!),
+    onActiveChange: setDragActive,
+  };
 
   function clearSelection() {
     setSelectedIds(new Set());
@@ -199,6 +237,18 @@ export default function CartridgeSessionsPage() {
     }
   }
 
+  // Drop handler: move the dragged session row ids into a folder.
+  async function moveRowsToFolder(rowIds: string[], folderId: string) {
+    if (rowIds.length === 0) return;
+    try {
+      await assignSessionFolder(workspaceId, rowIds, folderId);
+      clearSelection();
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not move sessions");
+    }
+  }
+
   async function newFolder() {
     const name = window.prompt("New folder name")?.trim();
     if (!name) return;
@@ -249,6 +299,7 @@ export default function CartridgeSessionsPage() {
               onTogglePin={pins.toggle}
               selectedIds={selectedIds}
               onToggleSelect={toggleSelect}
+              drag={drag}
             />
           </section>
         )}
@@ -273,6 +324,9 @@ export default function CartridgeSessionsPage() {
             onTogglePin={pins.toggle}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
+            drag={drag}
+            dragActive={dragActive}
+            onDropSessions={moveRowsToFolder}
           />
         ) : (
           <FoldersSection
@@ -282,6 +336,7 @@ export default function CartridgeSessionsPage() {
             onOpen={setOpenFolder}
             onNewFolder={newFolder}
             onShare={(f) => setShareFolder(f)}
+            onDropSessions={moveRowsToFolder}
           />
         )}
       </div>
@@ -347,6 +402,7 @@ function SessionsView({
   onTogglePin,
   selectedIds,
   onToggleSelect,
+  drag,
 }: {
   view: ViewKey;
   sessions: SessionSummary[];
@@ -355,6 +411,7 @@ function SessionsView({
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (sessionId: string) => void;
+  drag: SessionDrag;
 }) {
   if (sessions.length === 0) {
     return (
@@ -372,6 +429,7 @@ function SessionsView({
         onTogglePin={onTogglePin}
         selectedIds={selectedIds}
         onToggleSelect={onToggleSelect}
+        drag={drag}
       />
     );
   }
@@ -389,6 +447,7 @@ function SessionsView({
             onTogglePin={onTogglePin}
             selectedIds={selectedIds}
             onToggleSelect={onToggleSelect}
+            drag={drag}
           />
         ))}
       </div>
@@ -414,6 +473,7 @@ function SessionsView({
           onTogglePin={onTogglePin}
           selectedIds={selectedIds}
           onToggleSelect={onToggleSelect}
+          drag={drag}
         />
       ))}
     </div>
@@ -427,6 +487,7 @@ function DayGroup({
   onTogglePin,
   selectedIds,
   onToggleSelect,
+  drag,
 }: {
   group: SessionDayGroup;
   initialOpen: boolean;
@@ -434,6 +495,7 @@ function DayGroup({
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (sessionId: string) => void;
+  drag: SessionDrag;
 }) {
   const [open, setOpen] = useState(initialOpen);
   return (
@@ -460,6 +522,7 @@ function DayGroup({
                 onTogglePin={onTogglePin}
                 selectedIds={selectedIds}
                 onToggleSelect={onToggleSelect}
+                drag={drag}
               />
             </div>
           ))}
@@ -476,6 +539,7 @@ function FlatGroup({
   onTogglePin,
   selectedIds,
   onToggleSelect,
+  drag,
 }: {
   group: SessionFlatGroup;
   initialOpen: boolean;
@@ -483,6 +547,7 @@ function FlatGroup({
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (sessionId: string) => void;
+  drag: SessionDrag;
 }) {
   const [open, setOpen] = useState(initialOpen);
   return (
@@ -506,6 +571,7 @@ function FlatGroup({
             onTogglePin={onTogglePin}
             selectedIds={selectedIds}
             onToggleSelect={onToggleSelect}
+            drag={drag}
           />
         </div>
       )}
@@ -575,12 +641,14 @@ function SessionsTable({
   onTogglePin,
   selectedIds,
   onToggleSelect,
+  drag = NO_DRAG,
 }: {
   sessions: SessionSummary[];
   isPinned: (sessionId: string) => boolean;
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (sessionId: string) => void;
+  drag?: SessionDrag;
 }) {
   if (sessions.length === 0) {
     return (
@@ -610,6 +678,7 @@ function SessionsTable({
           onTogglePin={onTogglePin}
           selected={selectedIds.has(session.session_id)}
           onToggleSelect={onToggleSelect}
+          drag={drag}
         />
       ))}
     </div>
@@ -622,12 +691,14 @@ function SessionTableRow({
   onTogglePin,
   selected,
   onToggleSelect,
+  drag,
 }: {
   session: SessionSummary;
   pinned: boolean;
   onTogglePin: (sessionId: string) => void;
   selected: boolean;
   onToggleSelect: (sessionId: string) => void;
+  drag: SessionDrag;
 }) {
   const user = requireSessionUserName(session.user_name);
   const agent = session.agent_name || "agent";
@@ -637,6 +708,18 @@ function SessionTableRow({
   return (
     <Link
       href={`/sessions/${encodeURIComponent(session.session_id)}`}
+      draggable={drag.canDrag && !!session.id}
+      onDragStart={(e: DragEvent<HTMLAnchorElement>) => {
+        if (!session.id) return;
+        const ids =
+          selected && drag.selectedRowIds.length > 1
+            ? drag.selectedRowIds
+            : [session.id];
+        e.dataTransfer.setData(SESSION_DRAG_MIME, JSON.stringify(ids));
+        e.dataTransfer.effectAllowed = "move";
+        drag.onActiveChange(true);
+      }}
+      onDragEnd={() => drag.onActiveChange(false)}
       className={
         "group/srow grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-2 text-[13px] last:border-b-0 md:grid-cols-[minmax(128px,0.68fr)_minmax(240px,1.7fr)_86px_58px_minmax(104px,0.62fr)_94px_88px_28px] " +
         (selected ? "bg-[var(--color-brand-50)]" : "hover:bg-[var(--color-brand-50)]")
@@ -847,6 +930,7 @@ function FoldersSection({
   onOpen,
   onNewFolder,
   onShare,
+  onDropSessions,
 }: {
   ownFolders: SessionFolder[];
   sharedFolders: SharedWithMeItem[];
@@ -854,6 +938,7 @@ function FoldersSection({
   onOpen: (f: OpenFolder) => void;
   onNewFolder: () => void;
   onShare: (f: SessionFolder) => void;
+  onDropSessions: (rowIds: string[], folderId: string) => void;
 }) {
   return (
     <section>
@@ -874,6 +959,7 @@ function FoldersSection({
             folder={f}
             onClick={() => onOpen({ id: f.id, name: f.name, workspaceId, shared: false, folder: f })}
             onShare={() => onShare(f)}
+            onDropSessions={(rowIds) => onDropSessions(rowIds, f.id)}
           />
         ))}
         {sharedFolders.map((f) => (
@@ -895,18 +981,38 @@ function FolderCard({
   folder,
   onClick,
   onShare,
+  onDropSessions,
 }: {
   folder: SessionFolder;
   onClick: () => void;
   onShare: () => void;
+  onDropSessions: (rowIds: string[]) => void;
 }) {
+  const [over, setOver] = useState(false);
   return (
     <div
       role="button"
       tabIndex={0}
       onClick={onClick}
       onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onClick()}
-      className="group flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised/50"
+      onDragOver={(e) => {
+        if (!e.dataTransfer.types.includes(SESSION_DRAG_MIME)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        setOver(false);
+        const rowIds = readSessionDrop(e);
+        if (rowIds.length === 0) return;
+        e.preventDefault();
+        onDropSessions(rowIds);
+      }}
+      className={
+        "group flex cursor-pointer items-start gap-2.5 rounded-lg border bg-surface/50 px-3 py-3 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised/50 " +
+        (over ? "border-[var(--color-brand-300)] ring-1 ring-inset ring-[var(--color-brand-300)]" : "border-border")
+      }
     >
       <span aria-hidden className="mt-0.5 text-[18px]">
         {folder.is_default ? "🗃️" : "📁"}
@@ -990,6 +1096,9 @@ function FolderDrill({
   onTogglePin,
   selectedIds,
   onToggleSelect,
+  drag,
+  dragActive,
+  onDropSessions,
 }: {
   folder: OpenFolder;
   sessions: SessionSummary[];
@@ -1006,6 +1115,9 @@ function FolderDrill({
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (sessionId: string) => void;
+  drag: SessionDrag;
+  dragActive: boolean;
+  onDropSessions: (rowIds: string[], folderId: string) => void;
 }) {
   const [shared, setShared] = useState<SessionSummary[] | null>(null);
   const [error, setError] = useState("");
@@ -1062,6 +1174,24 @@ function FolderDrill({
         )}
       </div>
       {error ? <p className="text-[13px] text-rose-500">{error}</p> : null}
+      {/* Other folders surface as drop targets only while a session drag is in
+          flight — the drill view otherwise has no folder list to drop onto. */}
+      {dragActive && !folder.shared && (
+        <div className="mb-3 flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-[var(--color-brand-300)] bg-[var(--color-brand-50)]/40 px-3 py-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted">
+            Move to
+          </span>
+          {folders
+            .filter((f) => f.id !== folder.id)
+            .map((f) => (
+              <FolderDropChip
+                key={f.id}
+                folder={f}
+                onDrop={(rowIds) => onDropSessions(rowIds, f.id)}
+              />
+            ))}
+        </div>
+      )}
       <div className="mb-3 flex flex-wrap items-center gap-3 border-b border-border pb-2.5">
         <SegmentedControl
           label="View"
@@ -1087,9 +1217,48 @@ function FolderDrill({
           onTogglePin={onTogglePin}
           selectedIds={folder.shared ? EMPTY_SELECTION : selectedIds}
           onToggleSelect={folder.shared ? noop : onToggleSelect}
+          drag={folder.shared ? NO_DRAG : drag}
         />
       )}
     </div>
+  );
+}
+
+// A folder pill that lights up while a session drag hovers it.
+function FolderDropChip({
+  folder,
+  onDrop,
+}: {
+  folder: SessionFolder;
+  onDrop: (rowIds: string[]) => void;
+}) {
+  const [over, setOver] = useState(false);
+  return (
+    <span
+      onDragOver={(e) => {
+        if (!e.dataTransfer.types.includes(SESSION_DRAG_MIME)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        setOver(false);
+        const rowIds = readSessionDrop(e);
+        if (rowIds.length === 0) return;
+        e.preventDefault();
+        onDrop(rowIds);
+      }}
+      className={
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] " +
+        (over
+          ? "border-[var(--color-brand-400)] bg-[var(--color-brand-50)] font-semibold text-foreground"
+          : "border-border bg-base text-dim")
+      }
+    >
+      <span aria-hidden>{folder.is_default ? "🗃️" : "📁"}</span>
+      {folder.name}
+    </span>
   );
 }
 

--- a/frontend/src/components/workspace/SharedWithMeFiles.tsx
+++ b/frontend/src/components/workspace/SharedWithMeFiles.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
 import {
   getMyRecents,
   listSharedWithMe,
+  updateFile,
+  updateFolder,
+  updatePage,
   type RecentEntry,
   type SharedWithMeItem,
 } from "../../lib/api";
@@ -27,6 +30,23 @@ const LABEL: Record<string, string> = {
   table: "Table",
 };
 
+// Drag payload for shared items. Distinct from the main browser's FB_DRAG_MIME
+// because shared items carry their home workspace — moves run against it, and
+// items can only move within it.
+const SHARED_DRAG_MIME = "application/x-stash-shared-item";
+
+interface SharedDragPayload {
+  object_type: SharedWithMeItem["object_type"];
+  object_id: string;
+  workspace_id: string;
+}
+
+// Table moves require workspace membership on the backend, so shared tables
+// stay non-draggable.
+function isDraggable(item: SharedWithMeItem): boolean {
+  return item.object_type !== "table" && item.permission === "write";
+}
+
 // SharedWithMeItem has no updated_at, so the columns are Name / Shared by /
 // Type rather than the main list's Name / Modified / Type.
 const GRID_COLS = "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr)";
@@ -39,12 +59,27 @@ function hrefFor(item: SharedWithMeItem): string {
   return `/workspaces/${ws}/folders/${item.object_id}`;
 }
 
+function startSharedDrag(e: DragEvent<HTMLElement>, item: SharedWithMeItem) {
+  const payload: SharedDragPayload = {
+    object_type: item.object_type,
+    object_id: item.object_id,
+    workspace_id: item.workspace_id,
+  };
+  e.dataTransfer.setData(SHARED_DRAG_MIME, JSON.stringify(payload));
+  e.dataTransfer.effectAllowed = "move";
+}
+
+function isSharedDrag(e: DragEvent<HTMLElement>): boolean {
+  return e.dataTransfer.types.includes(SHARED_DRAG_MIME);
+}
+
 export default function SharedWithMeFiles() {
   const [items, setItems] = useState<SharedWithMeItem[]>([]);
   const [recents, setRecents] = useState<RecentEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
 
-  useEffect(() => {
+  const load = useCallback(() => {
     listSharedWithMe()
       .then((all) => setItems(all.filter((i) => FILE_KINDS.has(i.object_type))))
       .catch(() => setItems([]))
@@ -53,6 +88,10 @@ export default function SharedWithMeFiles() {
       .then(setRecents)
       .catch(() => setRecents([]));
   }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   // Recently-viewed shared items: /me/recents spans all workspaces, so its
   // intersection with the share list is exactly "shared things I opened".
@@ -63,6 +102,56 @@ export default function SharedWithMeFiles() {
       .filter((item): item is SharedWithMeItem => !!item)
       .slice(0, 8);
   }, [items, recents]);
+
+  // Move a dragged shared item into a shared folder. Both live in their home
+  // workspace — the backend allows this through the write share.
+  async function moveInto(payload: SharedDragPayload, folder: SharedWithMeItem) {
+    if (payload.object_id === folder.object_id) return;
+    if (payload.workspace_id !== folder.workspace_id) {
+      setError("Items can only move within their home workspace.");
+      return;
+    }
+    setError("");
+    const ws = payload.workspace_id;
+    try {
+      if (payload.object_type === "folder") {
+        await updateFolder(ws, payload.object_id, { parent_folder_id: folder.object_id });
+      } else if (payload.object_type === "page") {
+        await updatePage(ws, payload.object_id, { folder_id: folder.object_id });
+      } else {
+        await updateFile(ws, payload.object_id, { folder_id: folder.object_id });
+      }
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Move failed");
+    }
+  }
+
+  function dropHandlers(item: SharedWithMeItem, setOver: (v: boolean) => void) {
+    // Only writable folders accept drops — a read-only share would reject the
+    // move server-side anyway.
+    if (item.object_type !== "folder" || item.permission !== "write") return {};
+    return {
+      onDragOver: (e: DragEvent<HTMLElement>) => {
+        if (!isSharedDrag(e)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setOver(true);
+      },
+      onDragLeave: () => setOver(false),
+      onDrop: (e: DragEvent<HTMLElement>) => {
+        setOver(false);
+        const raw = e.dataTransfer.getData(SHARED_DRAG_MIME);
+        if (!raw) return;
+        e.preventDefault();
+        try {
+          void moveInto(JSON.parse(raw) as SharedDragPayload, item);
+        } catch {
+          /* malformed */
+        }
+      },
+    };
+  }
 
   if (!loaded) return null;
 
@@ -77,6 +166,11 @@ export default function SharedWithMeFiles() {
 
   return (
     <div>
+      {error && (
+        <div className="mb-3 rounded-lg border border-red-300/40 bg-red-500/10 px-4 py-2 text-[13px] text-red-500">
+          {error}
+        </div>
+      )}
       {recentItems.length > 0 && (
         <section className="mb-5">
           <h2 className="m-0 mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
@@ -84,67 +178,95 @@ export default function SharedWithMeFiles() {
           </h2>
           <div className="flex flex-wrap gap-2.5">
             {recentItems.map((item) => (
-              <RecentCard key={`${item.object_type}:${item.object_id}`} item={item} />
+              <RecentCard
+                key={`${item.object_type}:${item.object_id}`}
+                item={item}
+                dropHandlers={dropHandlers}
+              />
             ))}
           </div>
         </section>
       )}
       <div className="overflow-hidden rounded-xl border border-border bg-surface">
-      <div
-        className="grid items-center gap-3 border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted"
-        style={{ gridTemplateColumns: GRID_COLS }}
-      >
-        <span>Name</span>
-        <span>Shared by</span>
-        <span>Type</span>
-      </div>
-      {items.map((item) => {
-        const kind = ITEM_KIND[item.object_type];
-        return (
-          <Link
+        <div
+          className="grid items-center gap-3 border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted"
+          style={{ gridTemplateColumns: GRID_COLS }}
+        >
+          <span>Name</span>
+          <span>Shared by</span>
+          <span>Type</span>
+        </div>
+        {items.map((item) => (
+          <SharedRow
             key={`${item.object_type}:${item.object_id}`}
-            href={hrefFor(item)}
-            className="grid items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] last:border-b-0 hover:bg-[var(--color-brand-50)]/50"
-            style={{ gridTemplateColumns: GRID_COLS }}
-          >
-            <div className="flex min-w-0 items-center gap-2.5">
-              <span
-                className={
-                  "flex h-4 w-4 flex-shrink-0 items-center justify-center " +
-                  tintFor({ kind, id: item.object_id, name: item.name, subtitle: "" })
-                }
-              >
-                <KindIcon kind={kind} />
-              </span>
-              <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
-            </div>
-            <span className="truncate text-[12px] text-muted">
-              {item.shared_by || "—"}
-            </span>
-            <span className="flex items-center gap-2 text-[12px] text-muted">
-              {LABEL[item.object_type]}
-              {item.permission === "write" && (
-                <span className="rounded bg-raised px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide">
-                  can edit
-                </span>
-              )}
-            </span>
-          </Link>
-        );
-      })}
+            item={item}
+            dropHandlers={dropHandlers}
+          />
+        ))}
       </div>
     </div>
   );
 }
 
-// Compact quick-access card, mirroring the My-files Recent strip (minus the
-// pin button — pins are workspace-scoped and shared items live elsewhere).
-function RecentCard({ item }: { item: SharedWithMeItem }) {
+type DropHandlers = (
+  item: SharedWithMeItem,
+  setOver: (v: boolean) => void,
+) => Record<string, unknown>;
+
+function SharedRow({ item, dropHandlers }: { item: SharedWithMeItem; dropHandlers: DropHandlers }) {
+  const [over, setOver] = useState(false);
   const kind = ITEM_KIND[item.object_type];
   return (
     <Link
       href={hrefFor(item)}
-      className="flex w-[180px] items-center gap-2.5 rounded-lg border border-border bg-surface px-3 py-2.5 transition hover:border-[var(--color-brand-300)] hover:bg-raised"
+      draggable={isDraggable(item)}
+      onDragStart={(e: DragEvent<HTMLAnchorElement>) => startSharedDrag(e, item)}
+      {...dropHandlers(item, setOver)}
+      className={
+        "grid items-center gap-3 border-b border-border-subtle px-4 py-2 text-[13px] last:border-b-0 hover:bg-[var(--color-brand-50)]/50" +
+        (over ? " ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
+      }
+      style={{ gridTemplateColumns: GRID_COLS }}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          className={
+            "flex h-4 w-4 flex-shrink-0 items-center justify-center " +
+            tintFor({ kind, id: item.object_id, name: item.name, subtitle: "" })
+          }
+        >
+          <KindIcon kind={kind} />
+        </span>
+        <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
+      </div>
+      <span className="truncate text-[12px] text-muted">{item.shared_by || "—"}</span>
+      <span className="flex items-center gap-2 text-[12px] text-muted">
+        {LABEL[item.object_type]}
+        {item.permission === "write" && (
+          <span className="rounded bg-raised px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide">
+            can edit
+          </span>
+        )}
+      </span>
+    </Link>
+  );
+}
+
+// Compact quick-access card, mirroring the My-files Recent strip (minus the
+// pin button — pins are workspace-scoped and shared items live elsewhere).
+function RecentCard({ item, dropHandlers }: { item: SharedWithMeItem; dropHandlers: DropHandlers }) {
+  const [over, setOver] = useState(false);
+  const kind = ITEM_KIND[item.object_type];
+  return (
+    <Link
+      href={hrefFor(item)}
+      draggable={isDraggable(item)}
+      onDragStart={(e: DragEvent<HTMLAnchorElement>) => startSharedDrag(e, item)}
+      {...dropHandlers(item, setOver)}
+      className={
+        "flex w-[180px] items-center gap-2.5 rounded-lg border bg-surface px-3 py-2.5 transition hover:border-[var(--color-brand-300)] hover:bg-raised " +
+        (over ? "border-[var(--color-brand-300)] ring-1 ring-inset ring-[var(--color-brand-300)]" : "border-border")
+      }
     >
       <span
         className={

--- a/frontend/src/components/workspace/file-browser/QuickAccess.tsx
+++ b/frontend/src/components/workspace/file-browser/QuickAccess.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState, type DragEvent } from "react";
 import { shouldOpenInNewTab, type NavigateOptions } from "../../../lib/linkNavigation";
 import { PinIcon } from "../../StashIcons";
+import type { FBDragPayload } from "./WorkspaceFileBrowser";
+import { handleFolderDrop, isFbDrag, startItemDrag } from "./ItemsList";
 import { KindIcon, tintFor, typeFor, type GridItem } from "./kind";
 
 interface Props {
@@ -10,6 +13,8 @@ interface Props {
   onOpen: (item: GridItem, options?: NavigateOptions) => void;
   isPinned: (item: GridItem) => boolean;
   onTogglePin: (item: GridItem) => void;
+  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
 }
 
 // Quick-access strip above the file list: pinned items the user chose, plus a
@@ -22,6 +27,8 @@ export default function QuickAccess({
   onOpen,
   isPinned,
   onTogglePin,
+  onReparent,
+  onReparentMany,
 }: Props) {
   return (
     <div className="mt-5 space-y-4">
@@ -34,6 +41,8 @@ export default function QuickAccess({
               pinned
               onOpen={onOpen}
               onTogglePin={onTogglePin}
+              onReparent={onReparent}
+              onReparentMany={onReparentMany}
             />
           ))}
         </Section>
@@ -47,6 +56,8 @@ export default function QuickAccess({
               pinned={isPinned(item)}
               onOpen={onOpen}
               onTogglePin={onTogglePin}
+              onReparent={onReparent}
+              onReparentMany={onReparentMany}
             />
           ))}
         </Section>
@@ -71,12 +82,19 @@ function Card({
   pinned,
   onOpen,
   onTogglePin,
+  onReparent,
+  onReparentMany,
 }: {
   item: GridItem;
   pinned: boolean;
   onOpen: (item: GridItem, options?: NavigateOptions) => void;
   onTogglePin: (item: GridItem) => void;
+  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
 }) {
+  const [over, setOver] = useState(false);
+  const isFolder = item.kind === "folder";
+
   return (
     <div
       role="button"
@@ -88,7 +106,26 @@ function Card({
       onKeyDown={(e) => {
         if (e.key === "Enter") onOpen(item);
       }}
-      className="group/qa relative flex w-[180px] cursor-pointer items-center gap-2.5 rounded-lg border border-border bg-surface px-3 py-2.5 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised"
+      draggable={item.movable !== false}
+      onDragStart={(e: DragEvent<HTMLDivElement>) => startItemDrag(e, item, false, [])}
+      onDragOver={(e) => {
+        if (!isFolder) return;
+        if (!isFbDrag(e)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        if (!isFolder) return;
+        setOver(false);
+        e.preventDefault();
+        handleFolderDrop(e, item.id, onReparent, onReparentMany);
+      }}
+      className={
+        "group/qa relative flex w-[180px] cursor-pointer items-center gap-2.5 rounded-lg border bg-surface px-3 py-2.5 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised " +
+        (over ? "border-[var(--color-brand-300)] ring-1 ring-inset ring-[var(--color-brand-300)]" : "border-border")
+      }
     >
       <span className={"flex h-5 w-5 shrink-0 items-center justify-center " + tintFor(item)}>
         <KindIcon kind={item.kind} />

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -631,6 +631,8 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId }: Props) {
                 onOpen={navigateTo}
                 isPinned={(item) => pins.isPinned(item.id)}
                 onTogglePin={(item) => pins.toggle(item.id)}
+                onReparent={reparent}
+                onReparentMany={reparentMany}
               />
             )}
 


### PR DESCRIPTION
## What

Files and Sessions now move things by drag, everywhere you'd expect:

### Files
- **Quick-access (Pinned/Recent) strips**: cards are drag sources, and folder cards are drop targets — drag a file onto a recent folder to move it in.
- **Shared with me**: rows and Recent cards with write permission drag onto writable shared **folder** rows/cards. The move runs against the item's home workspace through the existing write-share-gated PATCH endpoints; cross-workspace drops show a clear error (no cross-workspace move exists). Shared tables stay non-draggable — table moves are member-gated server-side.

### Sessions
- Session rows drag onto folder cards on the folder landing.
- Inside a folder drill (where no other folders are visible), a **"Move to" chip bar** of the other folders appears while a drag is in flight — drop on a chip to move. Dragging a selected row carries the whole multi-selection, like the file browser.

### Backend fixes uncovered along the way
- `permission_service.check_access` was being called with a nonexistent `require_write=` kwarg in two places, so **every binary upload into a folder and every file move into a folder 500'd with a TypeError**. Fixed to `require="write"`.
- Upload (`POST /workspaces/{id}/files`) now allows non-members into folders shared with them with write permission ("like a real file system" — create page / create folder / move already worked for write shares; upload was the odd one out). Markdown/HTML uploads get the same target-folder write check binary uploads had.

## Screenshots

Session drag in flight — "Move to" chip bar:

![sessions-dnd](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/0e1ec0b4c9ed/sessions-drag-chips.png)

Quick-access strip (cards drag, folder cards accept drops):

![quickaccess](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/1e90a9056062/files-quickaccess.png)

Shared with me (writable rows drag onto the writable folder):

![shared](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/3bf47bc3-778c-4fd7-ad71-07c454259de5/6a84883cd0a0/shared-before-drag.png)

## Testing
- New `test_shared_folder_writes.py`: member file-move regression (previously 500), write-share markdown upload + page move into shared folder, read-share denial. Full backend suite: 304 passed.
- `npm test` (128), `npm run lint`, `npm run build`.
- Browser-verified with synthetic DragEvents: quick-access card → folder card move; shared page row → shared folder row move (as a non-member, via write share); session row → "Move to" chip → folder reassignment; non-member markdown upload into a shared folder (201, lands in folder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)