### PR TITLE
[codex] Use x.com for Twitter OAuth

### DIFF
--- a/backend/integrations/twitter/provider.py
+++ b/backend/integrations/twitter/provider.py
@@ -18,7 +18,7 @@ from ...config import settings
 from ..base import AccountInfo, Integration, TokenSet
 
 API_BASE = "https://api.x.com"
-AUTHORIZE_URL = "https://twitter.com/i/oauth2/authorize"
+AUTHORIZE_URL = "https://x.com/i/oauth2/authorize"
 TOKEN_URL = f"{API_BASE}/2/oauth2/token"
 REVOKE_URL = f"{API_BASE}/2/oauth2/revoke"
 ME_URL = f"{API_BASE}/2/users/me"

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -394,7 +394,11 @@ def test_twitter_authorize_url_uses_pkce(monkeypatch):
     )
 
     url = TwitterIntegration().authorize_url("state-1", "verifier-1")
-    query = parse_qs(urlparse(url).query)
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "x.com"
+    assert parsed.path == "/i/oauth2/authorize"
+    query = parse_qs(parsed.query)
 
     assert query["client_id"] == ["client-1"]
     assert query["state"] == ["state-1"]


### PR DESCRIPTION
## Summary
- Switch the Twitter / X OAuth authorize URL from `twitter.com` to `x.com`, matching X's current OAuth docs and the domain where users are typically already logged in.
- Pin the authorize URL host/path in the existing PKCE test.

## Validation
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_xauth DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_xauth python -m pytest --no-cov backend/tests/test_integration_sources.py -k twitter_authorize_url_uses_pkce`
- `ruff check backend/integrations/twitter/provider.py backend/tests/test_integration_sources.py`
- `black --check backend/integrations/twitter/provider.py backend/tests/test_integration_sources.py`
- `git diff --check`

Note: the shared local `stash_test` DB was stamped with a branch-local Alembic revision, so the targeted pytest command above uses a clean `stash_test_xauth` DB.