### PR TITLE
Prevent swipe-back navigation when scrolling the table grid horizontally

### DIFF
--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -1227,7 +1227,7 @@ function TableEditorPageInner() {
 
         {/* Saved layout tabs */}
         {table?.views && table.views.length > 0 && (
-          <div className="px-4 py-1.5 border-b border-border bg-surface flex items-center gap-1 flex-shrink-0 overflow-x-auto">
+          <div className="px-4 py-1.5 border-b border-border bg-surface flex items-center gap-1 flex-shrink-0 overflow-x-auto overscroll-x-contain">
             <button onClick={() => { setActiveViewId(null); setFilters([]); setSortBy(""); setSortOrder("asc"); setShowFilterBar(false); setHiddenCols(new Set()); }} className={`px-3 py-1 text-xs rounded ${!activeViewId ? "bg-brand/15 text-brand font-medium" : "text-muted hover:text-foreground hover:bg-raised"}`}>All rows</button>
             {table.views.map((layout: TableView) => (
               <div key={layout.id} className="flex items-center group">
@@ -1271,7 +1271,7 @@ function TableEditorPageInner() {
 
         {/* Grid */}
         {table && (
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto overscroll-x-contain">
             <table className="w-full border-collapse min-w-max">
               <thead className="sticky top-0 z-10">
                 <tr className="bg-surface border-b border-border">


### PR DESCRIPTION
## Problem

When scrolling around in the table UI, a horizontal scroll that hits the left edge of the grid triggers the browser's two-finger swipe-back gesture and navigates away from the page — losing your place (and any in-flight edits).

## Fix

Add `overscroll-x-contain` (`overscroll-behavior-x: contain`) to the two horizontal scroll containers in the table view:

- the main grid scroll area
- the saved-layout tabs bar

This is the same mechanism Google Sheets uses: the scroll container absorbs the overscroll at its edge instead of letting it chain up to the browser's navigation gesture. Swipe-back still works everywhere else in the app.

## Verification

- `npm run lint` — passes (one pre-existing unrelated warning)
- `npm run build` — passes

No screenshots: the change is purely gesture behavior with zero visual delta, and a native trackpad swipe can't be captured by browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)