### PR TITLE
Tables: paste spreadsheet sections from Google Sheets at the focused cell

### DIFF
--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -904,6 +904,65 @@ function TableEditorPageInner() {
       await importTabular(text, detectDelimiter(text));
     } catch (err) { setError(err instanceof Error ? err.message : "Failed to paste"); }
   };
+  // --- Block paste (spreadsheet sections) ---
+  // Copying a range of cells in Google Sheets / Excel puts TSV on the
+  // clipboard. Pasting such a block into a cell editor fills cells right and
+  // down from that cell — overwriting the rows it covers and appending new
+  // rows past the end — instead of dumping tab-separated text into one cell.
+  // Clipboard columns past the last visible column are dropped.
+  const pasteCellBlock = async (anchorRowId: string, anchorColId: string, block: string[][]) => {
+    const startColIdx = visibleColumns.findIndex((c) => c.id === anchorColId);
+    const startRowIdx = isDraftRowId(anchorRowId) ? rows.length : rows.findIndex((r) => r.id === anchorRowId);
+    if (startColIdx === -1 || startRowIdx === -1) return;
+    if (hasMore && startRowIdx + block.length > rows.length) {
+      setError("Scroll to load all rows before pasting past the end of the table");
+      return;
+    }
+    setEditingCell(null);
+
+    const targetCols = visibleColumns.slice(startColIdx);
+    const rowData = (cells: string[]) => {
+      const data: Record<string, unknown> = {};
+      cells.slice(0, targetCols.length).forEach((raw, i) => {
+        // Server coerces raw strings per column type; empty cells become NULL.
+        data[targetCols[i].id] = raw === "" ? null : raw;
+      });
+      return data;
+    };
+
+    const overlapCount = Math.min(block.length, rows.length - startRowIdx);
+    const overlapRows = rows.slice(startRowIdx, startRowIdx + overlapCount);
+    const overflow = block.slice(overlapCount);
+    try {
+      const updated = await Promise.all(
+        overlapRows.map((row, i) => updateTableRow(wsId, tableId, row.id, rowData(block[i]))),
+      );
+      overlapRows.forEach((row) => rememberUndo({ kind: "row-update", row: cloneTableRow(row) }));
+      const updatedById = new Map(updated.map((r) => [r.id, r]));
+      setRows((prev) => prev.map((r) => updatedById.get(r.id) ?? r));
+
+      if (overflow.length > 0) {
+        const res = await createTableRowsBatch(wsId, tableId, overflow.map((cells) => ({ data: rowData(cells) })));
+        setRows((prev) => [...prev, ...res.rows]);
+        setTotalCount((c) => c + res.rows.length);
+        res.rows.forEach((row) => rememberUndo({ kind: "row-create", row: cloneTableRow(row) }));
+      }
+    } catch (err) { setError(err instanceof Error ? err.message : "Failed to paste"); }
+  };
+
+  const handleCellEditorPaste = (e: React.ClipboardEvent) => {
+    if (readOnly || !editingCell) return;
+    const block = parseCsv(e.clipboardData.getData("text/plain"), "\t");
+    const isMultiCell = block.length > 1 || (block[0]?.length ?? 0) > 1;
+    if (!isMultiCell) return;
+    e.preventDefault();
+    if (groupByCol) {
+      setError("Pasting a block isn't supported while grouped — clear grouping first");
+      return;
+    }
+    void pasteCellBlock(editingCell.rowId, editingCell.colId, block);
+  };
+
   const handleCsvExport = async () => {
     if (!table || !wsId) return;
     const base = `/api/v1/workspaces/${wsId}/tables`;
@@ -979,7 +1038,7 @@ function TableEditorPageInner() {
     return (
       <td key={col.id} className={`px-1 py-0 border-r border-border/50 min-w-[140px] ${cellBg}`} onClick={startCellEditing}>
         {isEditing ? (
-          <div data-table-cell-editor>
+          <div data-table-cell-editor onPaste={handleCellEditorPaste}>
             {col.type === "boolean" ? (
               <label className="flex items-center h-8 px-2 cursor-pointer"><input aria-label={`Edit row ${rowNumber} ${col.name}`} type="checkbox" checked={cellValue === "true" || cellValue === "1"} onChange={(e) => setCellValue(String(e.target.checked))} onBlur={() => void commitEdit()} onKeyDown={(e) => { if (e.key === "Enter") commitEdit(); if (e.key === "Escape") cancelEdit(); }} className="accent-brand" autoFocus /></label>
             ) : col.type === "select" && col.options ? (

--- a/frontend/src/app/tables/[tableId]/page.test.tsx
+++ b/frontend/src/app/tables/[tableId]/page.test.tsx
@@ -47,16 +47,21 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(route.search),
 }));
 
+// The user must be referentially stable across renders, like the real
+// useAuth. A fresh object per render re-fires every effect that lists
+// `user` in its deps (e.g. the loadRows effect), wiping row state edits.
+const authUser = vi.hoisted(() => ({
+  id: "user-1",
+  name: "Henry",
+  display_name: "Henry",
+  description: "",
+  created_at: "2026-05-31T00:00:00Z",
+  last_seen: "2026-05-31T00:00:00Z",
+}));
+
 vi.mock("../../../hooks/useAuth", () => ({
   useAuth: () => ({
-    user: {
-      id: "user-1",
-      name: "Henry",
-      display_name: "Henry",
-      description: "",
-      created_at: "2026-05-31T00:00:00Z",
-      last_seen: "2026-05-31T00:00:00Z",
-    },
+    user: authUser,
     loading: false,
     logout: vi.fn(),
   }),
@@ -414,5 +419,182 @@ describe("TableEditorPage row creation", () => {
     fireEvent.blur(await screen.findByLabelText(/^Edit row \d+ Name$/));
 
     expect(api.createTableRow).not.toHaveBeenCalled();
+  });
+});
+
+describe("TableEditorPage block paste from spreadsheets", () => {
+  const twoColTable = {
+    ...table,
+    columns: [
+      ...table.columns,
+      {
+        id: "role",
+        name: "Role",
+        type: "text",
+        order: 1,
+        required: false,
+        default: null,
+        options: null,
+      },
+    ],
+  };
+
+  const twoColRows = [
+    { ...existingRows[0], data: { name: "Alice", role: "Dev" } },
+    { ...existingRows[1], data: { name: "Bob", role: "PM" } },
+  ];
+
+  const pasteInto = (target: Element, text: string) =>
+    fireEvent.paste(target, { clipboardData: { getData: () => text } });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    route.search = "";
+    api.getTable.mockResolvedValue(twoColTable);
+    api.summarizeTableRows.mockResolvedValue({ total_rows: 2, columns: {} });
+    api.listTableRows.mockResolvedValue({
+      rows: twoColRows,
+      total_count: 2,
+      has_more: false,
+    });
+    api.updateTableRow.mockImplementation(
+      async (_ws: string, _t: string, rowId: string, data: Record<string, unknown>) => {
+        const base = twoColRows.find((r) => r.id === rowId)!;
+        return { ...base, data: { ...base.data, ...data } };
+      },
+    );
+
+    class TestIntersectionObserver {
+      observe() {}
+      disconnect() {}
+    }
+
+    vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("overwrites cells right and down from the focused cell, dropping extra columns", async () => {
+    render(<TableEditorPage />);
+
+    fireEvent.click(await screen.findByText("Alice"));
+    const input = await screen.findByLabelText("Edit row 1 Name");
+    // Sheets puts TSV on the clipboard; the third column has nowhere to go.
+    pasteInto(input, "A1\tB1\tdropped\nA2\tB2\tdropped\n");
+
+    await waitFor(() =>
+      expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-1", {
+        name: "A1",
+        role: "B1",
+      }),
+    );
+    expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-2", {
+      name: "A2",
+      role: "B2",
+    });
+    expect(api.createTableRowsBatch).not.toHaveBeenCalled();
+    expect(await screen.findByText("A1")).toBeInTheDocument();
+    expect(await screen.findByText("B2")).toBeInTheDocument();
+  });
+
+  it("fills a single pasted column downward from a non-first anchor column", async () => {
+    render(<TableEditorPage />);
+
+    fireEvent.click(await screen.findByText("Dev"));
+    const input = await screen.findByLabelText("Edit row 1 Role");
+    pasteInto(input, "Designer\nSales\n");
+
+    await waitFor(() =>
+      expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-1", {
+        role: "Designer",
+      }),
+    );
+    expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-2", {
+      role: "Sales",
+    });
+  });
+
+  it("appends new rows when the pasted block extends past the last row", async () => {
+    const appendedRow = {
+      ...createdRow,
+      data: { name: "Carol", role: "CTO" },
+    };
+    api.createTableRowsBatch.mockResolvedValue({ rows: [appendedRow] });
+
+    render(<TableEditorPage />);
+
+    fireEvent.click(await screen.findByText("Bob"));
+    const input = await screen.findByLabelText("Edit row 2 Name");
+    pasteInto(input, "Bobby\tCOO\nCarol\tCTO\n");
+
+    await waitFor(() =>
+      expect(api.createTableRowsBatch).toHaveBeenCalledWith("ws-1", "table-1", [
+        { data: { name: "Carol", role: "CTO" } },
+      ]),
+    );
+    expect(api.updateTableRow).toHaveBeenCalledWith("ws-1", "table-1", "row-2", {
+      name: "Bobby",
+      role: "COO",
+    });
+    expect(await screen.findByText("Carol")).toBeInTheDocument();
+  });
+
+  it("creates all rows when pasting into an empty tail row", async () => {
+    api.createTableRowsBatch.mockResolvedValue({
+      rows: [
+        { ...createdRow, id: "row-3", data: { name: "Carol", role: "CTO" } },
+        { ...createdRow, id: "row-4", data: { name: "Dan", role: "CFO" } },
+      ],
+    });
+
+    render(<TableEditorPage />);
+
+    const [emptyCell] = await screen.findAllByLabelText(/^Empty row \d+ Name$/);
+    fireEvent.click(emptyCell);
+    const input = await screen.findByLabelText(/^Edit row \d+ Name$/);
+    pasteInto(input, "Carol\tCTO\nDan\tCFO\n");
+
+    await waitFor(() =>
+      expect(api.createTableRowsBatch).toHaveBeenCalledWith("ws-1", "table-1", [
+        { data: { name: "Carol", role: "CTO" } },
+        { data: { name: "Dan", role: "CFO" } },
+      ]),
+    );
+    expect(api.updateTableRow).not.toHaveBeenCalled();
+    expect(await screen.findByText("Dan")).toBeInTheDocument();
+  });
+
+  it("undoes a block paste one row at a time with command-z", async () => {
+    render(<TableEditorPage />);
+
+    fireEvent.click(await screen.findByText("Alice"));
+    const input = await screen.findByLabelText("Edit row 1 Name");
+    pasteInto(input, "A1\tB1\nA2\tB2\n");
+
+    await waitFor(() => expect(screen.getByText("A2")).toBeInTheDocument());
+
+    fireEvent.keyDown(document, { key: "z", metaKey: true });
+
+    await waitFor(() =>
+      expect(api.updateTableRow).toHaveBeenLastCalledWith("ws-1", "table-1", "row-2", {
+        name: "Bob",
+        role: "PM",
+      }),
+    );
+  });
+
+  it("leaves single-value pastes to the native cell input", async () => {
+    render(<TableEditorPage />);
+
+    fireEvent.click(await screen.findByText("Alice"));
+    const input = await screen.findByLabelText("Edit row 1 Name");
+    const notPrevented = pasteInto(input, "just one value");
+
+    expect(notPrevented).toBe(true);
+    expect(api.updateTableRow).not.toHaveBeenCalled();
+    expect(api.createTableRowsBatch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Copying a range of cells in Google Sheets / Excel puts TSV on the clipboard. Previously, pasting that into a table cell editor dumped the raw tab-separated text into the single cell. Now pasting a multi-cell block into a cell editor fills cells **right and down from that cell**, like a spreadsheet:

- Rows the block covers are overwritten (one PATCH per row, in parallel).
- Rows past the end of the table are appended via the existing batch-create endpoint.
- Clipboard columns past the last visible column are dropped.
- Pasting into an empty tail (draft) row creates all rows as new.
- Every touched row lands on the undo stack, so ⌘Z walks the paste back row by row.
- Single-value pastes keep native input behavior; the existing grid-level paste (header row + data → import with column auto-creation) is unchanged.

Guard rails: pasting past the end while more pages exist server-side, or while grouped, fails loudly with an error instead of corrupting positions.

## Test-infra fix

The test file's `useAuth` mock returned a fresh `user` object every render, which re-fired the `loadRows` effect (deps include `user`) on each re-render and silently reset row state mid-test. The mock user is now referentially stable, matching the real hook.

## Verification

- `npm test` — 138/138 pass (6 new tests covering overwrite, anchor column offset, overflow append, tail-row paste, undo, single-value passthrough).
- Verified E2E against a local stack (working-tree frontend + backend + fresh pgvector Postgres): pasted a 3×3 TSV block from row 1 — both existing rows overwritten, third row appended, all values persisted across reload.

Screenshot after pasting a 3×3 Sheets block into the first cell of a 2-row table: https://app.joinstash.ai/f/e643aa6e-5803-4006-a06d-ba4d8230d45c

🤖 Generated with [Claude Code](https://claude.com/claude-code)