### PR TITLE
[codex] Add table column resizing

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -519,6 +519,7 @@ class ColumnDefinition(BaseModel):
     required: bool = False
     default: str | int | float | bool | list | None = None
     options: list[str] | None = None
+    width: int = Field(180, ge=80, le=800)
 
 
 class TableCreateRequest(BaseModel):
@@ -562,6 +563,7 @@ class ColumnAddRequest(BaseModel):
     required: bool = False
     default: str | int | float | bool | list | None = None
     options: list[str] | None = None
+    width: int = Field(180, ge=80, le=800)
 
 
 class ColumnUpdateRequest(BaseModel):
@@ -573,6 +575,7 @@ class ColumnUpdateRequest(BaseModel):
     required: bool | None = None
     default: str | int | float | bool | list | None = None
     options: list[str] | None = None
+    width: int | None = Field(None, ge=80, le=800)
 
 
 class ColumnReorderRequest(BaseModel):

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -60,6 +60,7 @@ async def create_table(
         if not col.get("id"):
             col["id"] = f"col_{secrets.token_hex(6)}"
         col["order"] = i
+        col.setdefault("width", 180)
     row = await pool.fetchrow(
         "INSERT INTO tables (workspace_id, folder_id, name, description, columns, created_by, updated_by) "
         "VALUES ($1, $2, $3, $4, $5, $6, $6) "
@@ -216,6 +217,7 @@ async def add_column(table_id: UUID, column: dict, updated_by: UUID) -> dict:
         "required": column.get("required", False),
         "default": column.get("default"),
         "options": column.get("options"),
+        "width": column.get("width", 180),
     }
     cols.append(new_col)
     row = await pool.fetchrow(
@@ -243,7 +245,7 @@ async def update_column(
     found = False
     for col in cols:
         if col["id"] == column_id:
-            for key in ("name", "type", "required", "default", "options"):
+            for key in ("name", "type", "required", "default", "options", "width"):
                 if key in updates and updates[key] is not None:
                     col[key] = updates[key]
             found = True

--- a/backend/tests/test_table_canonical_lookup.py
+++ b/backend/tests/test_table_canonical_lookup.py
@@ -57,6 +57,22 @@ async def test_member_resolves_table_by_id_alone(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_column_width_updates_table_metadata(client: AsyncClient):
+    api_key = await _register(client)
+    workspace_id, table_id = await _table_in_new_workspace(client, api_key)
+
+    resp = await client.patch(
+        f"/api/v1/workspaces/{workspace_id}/tables/{table_id}/columns/col_name",
+        json={"width": 260},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["columns"][0]["width"] == 260
+
+
+@pytest.mark.asyncio
 async def test_non_member_gets_404_not_403(client: AsyncClient):
     owner_key = await _register(client)
     _, table_id = await _table_in_new_workspace(client, owner_key)

--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -9,9 +9,11 @@ import {
   useRef,
   useState,
   type AnchorHTMLAttributes,
+  type CSSProperties,
   type FormEvent,
   type HTMLAttributes,
   type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from "react";
 import Markdown from "react-markdown";
@@ -50,6 +52,13 @@ const FILTER_OPS = ["eq", "neq", "gt", "gte", "lt", "lte", "contains", "is_empty
 const COLUMN_TYPE_OPTIONS = COLUMN_TYPES.map((type) => ({ value: type, label: type }));
 const FILTER_OP_OPTIONS = FILTER_OPS.map((op) => ({ value: op, label: op }));
 const MARKDOWN_LINK_RE = /\[[^\]\n]+\]\([^)]+\)/;
+const DEFAULT_COLUMN_WIDTH = 180;
+const MIN_COLUMN_WIDTH = 80;
+const MAX_COLUMN_WIDTH = 800;
+const SELECT_COLUMN_WIDTH = 32;
+const ROW_NUMBER_COLUMN_WIDTH = 40;
+const ADD_COLUMN_WIDTH = 40;
+const ROW_ACTIONS_MIN_WIDTH = 64;
 const TABLE_CELL_MARKDOWN_COMPONENTS = {
   p: ({ children }: HTMLAttributes<HTMLParagraphElement>) => <>{children}</>,
   a: ({ href, children }: AnchorHTMLAttributes<HTMLAnchorElement>) => (
@@ -77,6 +86,12 @@ type CellLinkEditorState = {
   top: number;
   left: number;
 };
+type ColumnResizeState = {
+  colId: string;
+  startX: number;
+  startWidth: number;
+  width: number;
+};
 
 const LINK_EDITOR_DEFAULT_HREF = "https://";
 const LINK_EDITOR_WIDTH = 320;
@@ -92,6 +107,15 @@ function isTextEntryTarget(target: EventTarget | null) {
 
 function canLinkCellText(col: TableColumn) {
   return col.type === "text";
+}
+
+function clampColumnWidth(width: number) {
+  return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, Math.round(width)));
+}
+
+function storedColumnWidth(col: TableColumn) {
+  if (!Number.isFinite(col.width)) return DEFAULT_COLUMN_WIDTH;
+  return clampColumnWidth(col.width);
 }
 
 function cellInputType(col: TableColumn) {
@@ -284,6 +308,7 @@ function TableEditorPageInner() {
   const [colMenu, setColMenu] = useState<{ colId: string; x: number; y: number } | null>(null);
   const [colMenuTypeOpen, setColMenuTypeOpen] = useState(false);
   const [dragCol, setDragCol] = useState<string | null>(null);
+  const [columnResize, setColumnResize] = useState<ColumnResizeState | null>(null);
   const [hiddenCols, setHiddenCols] = useState<Set<string>>(new Set());
   const [showColVisibility, setShowColVisibility] = useState(false);
 
@@ -318,6 +343,21 @@ function TableEditorPageInner() {
   const sortedColumns = table?.columns ? [...table.columns].sort((a, b) => a.order - b.order) : [];
   const visibleColumns = sortedColumns.filter((c) => !hiddenCols.has(c.id));
   const hasMore = rows.length < totalCount;
+  const columnPixelWidth = useCallback((col: TableColumn) => {
+    if (columnResize?.colId === col.id) return columnResize.width;
+    return storedColumnWidth(col);
+  }, [columnResize]);
+  const columnWidthStyle = useCallback((col: TableColumn): CSSProperties => {
+    const width = columnPixelWidth(col);
+    return { width, minWidth: width, maxWidth: width };
+  }, [columnPixelWidth]);
+  const minimumTableWidth = useMemo(() => (
+    SELECT_COLUMN_WIDTH +
+    ROW_NUMBER_COLUMN_WIDTH +
+    ADD_COLUMN_WIDTH +
+    ROW_ACTIONS_MIN_WIDTH +
+    visibleColumns.reduce((total, col) => total + columnPixelWidth(col), 0)
+  ), [columnPixelWidth, visibleColumns]);
 
   const shareAction = useMemo(() => {
     if (!table || readOnly || !user) return null;
@@ -592,6 +632,65 @@ function TableEditorPageInner() {
     // pick won't break the table — it'll just stop accepting new values.
     try { setTable(await updateTableColumn(wsId, tableId, colId, { type })); setColMenu(null); } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
   };
+  const commitColumnWidth = useCallback(async (colId: string, width: number) => {
+    const nextWidth = clampColumnWidth(width);
+    setTable((prev) => prev ? {
+      ...prev,
+      columns: prev.columns.map((col) => col.id === colId ? { ...col, width: nextWidth } : col),
+    } : prev);
+    try {
+      setTable(await updateTableColumn(wsId, tableId, colId, { width: nextWidth }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resize column");
+      void loadTable();
+    }
+  }, [loadTable, tableId, wsId]);
+  const startColumnResize = (
+    event: ReactPointerEvent<HTMLButtonElement>,
+    col: TableColumn,
+  ) => {
+    if (readOnly) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setColMenu(null);
+    const startWidth = columnPixelWidth(col);
+    setColumnResize({
+      colId: col.id,
+      startX: event.clientX,
+      startWidth,
+      width: startWidth,
+    });
+  };
+  const resizingColId = columnResize?.colId ?? null;
+  const resizingStartX = columnResize?.startX ?? null;
+  const resizingStartWidth = columnResize?.startWidth ?? null;
+  useEffect(() => {
+    if (!resizingColId || resizingStartX == null || resizingStartWidth == null) return;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const nextWidth = (clientX: number) => clampColumnWidth(resizingStartWidth + clientX - resizingStartX);
+    const handlePointerMove = (event: PointerEvent) => {
+      const width = nextWidth(event.clientX);
+      setColumnResize((current) => current?.colId === resizingColId ? { ...current, width } : current);
+    };
+    const handlePointerUp = (event: PointerEvent) => {
+      const width = nextWidth(event.clientX);
+      setColumnResize(null);
+      void commitColumnWidth(resizingColId, width);
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", handlePointerUp, { once: true });
+    return () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [commitColumnWidth, resizingColId, resizingStartWidth, resizingStartX]);
   const handleColumnDrop = async (targetColId: string) => {
     if (!dragCol || dragCol === targetColId) { setDragCol(null); return; }
     const ids = sortedColumns.map((c) => c.id);
@@ -977,7 +1076,7 @@ function TableEditorPageInner() {
     const isEditing = editingCell?.rowId === rowId && editingCell?.colId === col.id;
     const startCellEditing = () => { if (!isEditing) startEditing(rowId, col.id, value); };
     return (
-      <td key={col.id} className={`px-1 py-0 border-r border-border/50 min-w-[140px] ${cellBg}`} onClick={startCellEditing}>
+      <td key={col.id} style={columnWidthStyle(col)} className={`px-1 py-0 border-r border-border/50 ${cellBg}`} onClick={startCellEditing}>
         {isEditing ? (
           <div data-table-cell-editor>
             {col.type === "boolean" ? (
@@ -1272,7 +1371,16 @@ function TableEditorPageInner() {
         {/* Grid */}
         {table && (
           <div className="flex-1 overflow-auto overscroll-x-contain">
-            <table className="w-full border-collapse min-w-max">
+            <table className="w-full border-collapse table-fixed" style={{ minWidth: minimumTableWidth }}>
+              <colgroup>
+                <col style={{ width: SELECT_COLUMN_WIDTH }} />
+                <col style={{ width: ROW_NUMBER_COLUMN_WIDTH }} />
+                {visibleColumns.map((col) => (
+                  <col key={col.id} style={{ width: columnPixelWidth(col) }} />
+                ))}
+                <col style={{ width: ADD_COLUMN_WIDTH }} />
+                <col />
+              </colgroup>
               <thead className="sticky top-0 z-10">
                 <tr className="bg-surface border-b border-border">
                   <th className="w-8 px-1 py-2 text-center border-r border-border sticky left-0 z-20 bg-surface"><input type="checkbox" checked={selectedRows.size === rows.length && rows.length > 0} onChange={toggleSelectAll} className="accent-brand" /></th>
@@ -1280,19 +1388,30 @@ function TableEditorPageInner() {
                   {visibleColumns.map((col) => (
                     <th
                       key={col.id}
-                      className={`px-3 py-2 text-left text-xs font-medium text-muted border-r border-border min-w-[140px] select-none cursor-pointer hover:bg-raised transition-colors ${dragCol === col.id ? "opacity-50" : ""}`}
-                      draggable={!readOnly}
+                      style={columnWidthStyle(col)}
+                      className={`relative px-3 py-2 text-left text-xs font-medium text-muted border-r border-border select-none hover:bg-raised transition-colors ${dragCol === col.id ? "opacity-50" : ""}`}
+                      draggable={!readOnly && !columnResize}
                       onDragStart={() => { if (!readOnly) setDragCol(col.id); }}
                       onDragOver={(e) => { if (!readOnly) e.preventDefault(); }}
                       onDrop={() => { if (!readOnly) handleColumnDrop(col.id); }}
                       onDragEnd={() => setDragCol(null)}
                       onContextMenu={(e) => { if (readOnly) return; e.preventDefault(); setColMenu({ colId: col.id, x: e.clientX, y: e.clientY }); }}
                     >
-                      <span className="flex items-center gap-1.5" onClick={() => handleSort(col.id)}>
-                        <span className="text-[10px] text-muted/60 font-mono">{TYPE_ICONS[col.type] || "?"}</span>
-                        {col.name}
-                        {sortBy === col.id && <span className="text-brand text-[10px]">{sortOrder === "asc" ? "\u25B2" : "\u25BC"}</span>}
+                      <span className="flex min-w-0 cursor-pointer items-center gap-1.5 pr-2" onClick={() => handleSort(col.id)}>
+                        <span className="flex-shrink-0 text-[10px] text-muted/60 font-mono">{TYPE_ICONS[col.type] || "?"}</span>
+                        <span className="min-w-0 truncate">{col.name}</span>
+                        {sortBy === col.id && <span className="flex-shrink-0 text-brand text-[10px]">{sortOrder === "asc" ? "\u25B2" : "\u25BC"}</span>}
                       </span>
+                      {!readOnly && (
+                        <button
+                          type="button"
+                          aria-label={`Resize ${col.name} column`}
+                          title="Resize column"
+                          onPointerDown={(event) => startColumnResize(event, col)}
+                          onClick={(event) => event.stopPropagation()}
+                          className={`absolute right-0 top-0 h-full w-2 cursor-col-resize touch-none border-r-2 transition-colors ${columnResize?.colId === col.id ? "border-brand bg-brand/10" : "border-transparent hover:border-brand/60 hover:bg-brand/5"}`}
+                        />
+                      )}
                     </th>
                   ))}
                   <th className="w-10 px-2 py-2 border-r border-border">
@@ -1330,7 +1449,7 @@ function TableEditorPageInner() {
                     {visibleColumns.map((col) => {
                       const s = summary.columns[col.id];
                       return (
-                        <td key={col.id} className="px-2 py-1.5 border-r border-border text-[10px] font-mono text-muted">
+                        <td key={col.id} style={columnWidthStyle(col)} className="px-2 py-1.5 border-r border-border text-[10px] font-mono text-muted">
                           {s ? (
                             s.sum != null ? (
                               <div className="space-y-0.5">

--- a/frontend/src/app/tables/[tableId]/page.test.tsx
+++ b/frontend/src/app/tables/[tableId]/page.test.tsx
@@ -184,6 +184,29 @@ describe("TableEditorPage row creation", () => {
     );
   });
 
+  it("persists resized column widths", async () => {
+    api.updateTableColumn.mockResolvedValue({
+      ...table,
+      columns: [{ ...table.columns[0], width: 260 }],
+    });
+
+    render(<TableEditorPage />);
+
+    const handle = await screen.findByLabelText("Resize Name column");
+    await act(async () => {
+      fireEvent.pointerDown(handle, { clientX: 100 });
+      await Promise.resolve();
+    });
+    fireEvent.pointerMove(document, { clientX: 180 });
+    fireEvent.pointerUp(document, { clientX: 180 });
+
+    await waitFor(() =>
+      expect(api.updateTableColumn).toHaveBeenCalledWith("ws-1", "table-1", "name", {
+        width: 260,
+      }),
+    );
+  });
+
   it("keeps pagination in sync when appending a newly-created row", async () => {
     render(<TableEditorPage />);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -675,7 +675,7 @@ export async function createTable(
   workspaceId: string | null,
   name: string,
   description?: string,
-  columns?: { name: string; type: string; options?: string[] }[]
+  columns?: { name: string; type: string; options?: string[]; width?: number }[]
 ): Promise<Table> {
   return apiFetch(`${scope(workspaceId)}/tables`, {
     method: "POST",
@@ -715,7 +715,7 @@ export async function deleteTable(
 export async function addTableColumn(
   workspaceId: string | null,
   tableId: string,
-  column: { name: string; type: string; required?: boolean; default?: unknown; options?: string[] }
+  column: { name: string; type: string; required?: boolean; default?: unknown; options?: string[]; width?: number }
 ): Promise<Table> {
   return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns`, {
     method: "POST", body: JSON.stringify(column),
@@ -726,7 +726,7 @@ export async function updateTableColumn(
   workspaceId: string | null,
   tableId: string,
   columnId: string,
-  updates: { name?: string; type?: string; required?: boolean; default?: unknown; options?: string[] }
+  updates: { name?: string; type?: string; required?: boolean; default?: unknown; options?: string[]; width?: number }
 ): Promise<Table> {
   return apiFetch(`${scope(workspaceId)}/tables/${tableId}/columns/${columnId}`, {
     method: "PATCH", body: JSON.stringify(updates),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -108,6 +108,7 @@ export interface TableColumn {
   required: boolean;
   default: string | number | boolean | string[] | null;
   options: string[] | null;
+  width: number;
 }
 
 export interface TableView {


### PR DESCRIPTION
## What changed
- Added persisted `width` metadata to table columns, with server-side bounds and API typing.
- Added drag handles to table headers so users can resize columns in the tables UI.
- Applied column widths consistently across headers, body cells, draft rows, and summary cells.

## Why
Wide or narrow table values were stuck with the default sizing behavior, which made spreadsheet-style review awkward. Column widths now stay with the table schema and reload with the table.

## Screenshot
- https://app.joinstash.ai/f/5da6aa19-7317-49ab-89c0-569f7ff72b53

## Validation
- `npm test -- 'src/app/tables/[tableId]/page.test.tsx'`
- `TEST_DATABASE_URL=postgresql://stash:stash@localhost:5432/stash_test_resize_columns_0611 pytest backend/tests/test_table_canonical_lookup.py --no-cov`
- `npm run lint` (passes with one existing warning in `frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx`)
- `ruff check backend/models.py backend/services/table_service.py backend/routers/tables.py backend/tests/test_table_canonical_lookup.py`
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
