### PR TITLE
Landing: reframe memory section as best-in-class three-way hybrid retrieval

### DIFF
--- a/www/app/_components/VisualizationsShowcase.tsx
+++ b/www/app/_components/VisualizationsShowcase.tsx
@@ -9,7 +9,7 @@ type GraphNode = {
   degree: number;
 };
 
-// Files file tree for "memory_reading_store". Positions are hand-chosen to
+// Curated wiki graph for "reading-store". Positions are hand-chosen to
 // resemble a force-directed layout; degree drives node size + color.
 const GRAPH_NODES: GraphNode[] = [
   { id: "pgvector-howto", x: 295, y: 170, degree: 7 },
@@ -68,13 +68,13 @@ function PageGraphMock() {
       <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-4 py-3">
         <div className="flex items-center gap-2.5">
           <span className="h-2 w-2 rounded-full bg-brand" />
-          <span className="text-[13px] font-semibold text-ink">file tree</span>
+          <span className="text-[13px] font-semibold text-ink">wiki</span>
           <span className="font-mono text-[11px] text-muted">
-            files · reading-store
+            wiki · reading-store
           </span>
         </div>
         <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
-          12 pages · 19 Skills
+          12 pages · 19 links
         </span>
       </div>
       <div className="relative aspect-[600/360] w-full">
@@ -82,7 +82,7 @@ function PageGraphMock() {
           viewBox={`0 0 ${width} ${height}`}
           className="absolute inset-0 h-full w-full"
           role="img"
-          aria-label="Files file tree"
+          aria-label="Curated wiki graph"
         >
           <defs>
             <pattern
@@ -113,6 +113,8 @@ function PageGraphMock() {
           {GRAPH_NODES.map((n) => {
             const r = 6 + n.degree * 1.2;
             const fill = nodeColor(n.degree);
+            // Right-edge labels flip to the left side so they don't clip.
+            const labelLeft = n.x > 450;
             return (
               <g key={n.id}>
                 <circle
@@ -124,10 +126,11 @@ function PageGraphMock() {
                   strokeWidth="1.5"
                 />
                 <text
-                  x={n.x + r + 4}
+                  x={labelLeft ? n.x - r - 4 : n.x + r + 4}
                   y={n.y + 3}
+                  textAnchor={labelLeft ? "end" : "start"}
                   fontFamily="ui-monospace, Menlo, monospace"
-                  fontSize="9.5"
+                  fontSize="12"
                   fill="rgba(15,23,42,0.62)"
                 >
                   {n.id}
@@ -159,6 +162,77 @@ function PageGraphMock() {
   );
 }
 
+const GREP_MATCHES = [
+  { file: "pgvector-howto.md", line: 42, before: "set hnsw.", after: " = 80;" },
+  { file: "reading-store-arch.md", line: 118, before: "tune ", after: " per query" },
+  { file: "eval-harness.md", line: 9, before: "sweep ", after: " {40, 80, 160}" },
+];
+
+function GrepSearchMock() {
+  return (
+    <div
+      className="relative overflow-hidden rounded-[14px] border border-border bg-background"
+      style={{ boxShadow: "var(--shadow-card)" }}
+    >
+      <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-4 py-3">
+        <div className="flex items-center gap-2.5">
+          <span className="h-2 w-2 rounded-full bg-brand" />
+          <span className="text-[13px] font-semibold text-ink">grep</span>
+          <span className="font-mono text-[11px] text-muted">
+            files · reading-store
+          </span>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
+          3 matches · 38 ms
+        </span>
+      </div>
+      <div className="relative aspect-[600/360] w-full">
+        <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
+          <defs>
+            <pattern
+              id="grep-grid"
+              width="40"
+              height="40"
+              patternUnits="userSpaceOnUse"
+            >
+              <path
+                d="M 40 0 L 0 0 0 40"
+                fill="none"
+                stroke="rgba(15,23,42,0.04)"
+                strokeWidth="1"
+              />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#grep-grid)" />
+        </svg>
+        <div className="absolute inset-0 flex flex-col gap-2 overflow-hidden p-5 font-mono text-[12px] leading-[1.5]">
+          <div className="whitespace-nowrap text-dim">
+            <span className="text-muted">$ </span>
+            <span className="text-ink">grep -rn &quot;ef_search&quot; .</span>
+          </div>
+          {GREP_MATCHES.map((m) => (
+            <div key={m.file} className="truncate text-dim">
+              <span className="text-muted">
+                {m.file}:{m.line}:
+              </span>
+              {m.before}
+              <span className="font-semibold text-brand">ef_search</span>
+              {m.after}
+            </div>
+          ))}
+          <div className="whitespace-nowrap text-muted">
+            3 matches in 12 files (0.04s)
+          </div>
+          <div className="whitespace-nowrap text-dim">
+            <span className="text-muted">$ </span>
+            <span className="animate-pulse text-ink">▌</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EyebrowDot({ children }: { children: React.ReactNode }) {
   return (
     <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
@@ -176,36 +250,45 @@ export default function VisualizationsShowcase() {
     >
       <div className="mx-auto max-w-[1200px] px-7">
         <div className="flex max-w-[880px] flex-col gap-4">
-          <EyebrowDot>See the memory form</EyebrowDot>
+          <EyebrowDot>Best-in-class memory</EyebrowDot>
           <h2 className="font-display text-[clamp(32px,4.2vw,52px)] font-bold leading-[1.05] tracking-[-0.03em] text-ink text-balance">
             Your team&apos;s brain,
             <br />
             <span className="font-medium text-dim">actually visible.</span>
           </h2>
           <p className="max-w-[620px] text-[17px] leading-[1.55] text-dim">
-            Retrieval in Stash is hybrid: semantic search over embeddings, plus
-            a knowledge graph — the file tree your agents traverse. Both halves
-            are visual, so you can see how your team&apos;s knowledge clusters
-            by meaning, and which pages have become the hubs everything leans
-            on.
+            Stash memory is hybrid retrieval, three ways. While you sleep, an
+            agent curates your team&apos;s history into a linked wiki — a
+            knowledge graph your agents traverse. Semantic search over
+            embeddings finds knowledge by meaning, not filename. And plain
+            grep over the file system, with search skills, catches the exact
+            matches embeddings miss.
           </p>
         </div>
-        <div className="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-2">
-          <div>
-            <EmbeddingProjection3D />
-            <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
-              <span className="text-ink">3D embedding projection — the semantic
-              half.</span> Sessions, pages, and tables embedded and projected
-              with PCA. Clusters form around topics — not folders.
-            </p>
-          </div>
+        <div className="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-3">
           <div>
             <PageGraphMock />
             <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
-              <span className="text-ink">Knowledge graph — the structural
-              half.</span> The file tree your agents traverse: nodes are pages,
-              edges are <span className="font-mono text-brand">Skills</span>.
-              Orange nodes are the hubs your agents keep citing.
+              <span className="text-ink">Sleep-time curation — the linked
+              graph.</span> While you sleep, an agent curates workspace history
+              into a wiki. Nodes are pages, edges are links — orange nodes are
+              the hubs everything cites.
+            </p>
+          </div>
+          <div>
+            <EmbeddingProjection3D />
+            <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
+              <span className="text-ink">3D embedding projection — the
+              semantic layer.</span> Sessions, pages, and tables embedded and
+              projected with PCA. Clusters form around topics — not folders.
+            </p>
+          </div>
+          <div>
+            <GrepSearchMock />
+            <p className="mt-4 text-[13.5px] leading-[1.6] text-dim">
+              <span className="text-ink">Grep — the exact layer.</span> Agents
+              search the workspace like a repo: file tree, grep, and search
+              skills, for the lookups embeddings miss.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## What

Reframes the landing page's "See the memory form" section as **"Best-in-class memory"**, pitching retrieval as three-way hybrid instead of two-way:

1. **Sleep-time curation** — an agent curates workspace history into a linked wiki (the existing knowledge-graph visual, recaptioned; card header is now `wiki`, edges are links)
2. **Semantic search** — the existing 3D embedding projection, unchanged
3. **Grep / file system** — new `GrepSearchMock` card: a terminal mock showing `grep -rn` over workspace files with highlighted matches, plus search skills called out in the caption

The grid goes from 2-up to 3-up on desktop; graph node labels were bumped from 9.5 → 12 viewBox units (with right-edge labels flipped left) so they stay legible at 1/3 width.

Only file touched: `www/app/_components/VisualizationsShowcase.tsx`.

## Screenshots

- [Desktop, 1440px](https://app.joinstash.ai/f/bb5b8ecb-4b8c-4339-979d-1eb58e9d4a17)
- [Mobile, 390px](https://app.joinstash.ai/f/61054d5e-c6b5-4dff-a28d-06243cde2aeb)

## Test plan

- [ ] `cd www && npm run lint && npm run build` (both pass locally)
- [ ] Visit `/#visualizations` at desktop and mobile widths; check the 3-up grid, wiki/embedding/grep card chrome consistency, and graph label legibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)