### PR TITLE
Add New page buttons to workspace home and page viewer

### DIFF
--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -35,6 +35,7 @@ import { useAuth } from "../../../../hooks/useAuth";
 import {
   ApiError,
   createCommentThread,
+  createPage,
   deleteCommentMessage,
   deleteCommentThread,
   getFolderContents,
@@ -52,6 +53,7 @@ import {
 import { findInSkillContents } from "../../../../lib/localSkill";
 import type { CommentThread, Page } from "../../../../lib/types";
 import { subscribePageEvents } from "../../../../lib/pageEvents";
+import { refreshWorkspaceSidebar } from "../../../../lib/skillNavigationCache";
 
 function wrapHtml(title: string, body: string): string {
   // HTML pages can be stored as a full document (when imported from .html
@@ -528,6 +530,17 @@ export default function SkillPageView() {
   const baseName = page ? page.name.replace(/\.(md|html)$/i, "") : "";
   const pdfSubtitle = updatedAt ? `Last edited ${updatedAt}` : undefined;
 
+  async function handleNewPage() {
+    if (!page) return;
+    try {
+      const created = await createPage(workspaceId, "Untitled", page.folder_id);
+      refreshWorkspaceSidebar(workspaceId).catch(() => {});
+      router.push(`/p/${created.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create page");
+    }
+  }
+
   // Provenance: when an agent made the last content edit, link the page back to
   // the chat session that produced it.
   const metaItems: ReactNode[] = [];
@@ -568,22 +581,31 @@ export default function SkillPageView() {
         meta={metaItems.length ? metaItems : undefined}
         saveStatus={page && !isHtml ? saveStatus : null}
         rightExtras={
-          isHtml ? (
+          page ? (
             <div className="flex items-center gap-2">
-              {page && (
+              <button
+                type="button"
+                onClick={handleNewPage}
+                className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+              >
+                + New page
+              </button>
+              {isHtml && (
                 <ExportDeckButton
                   pageId={page.id}
                   layout={page.html_layout}
                   contentType={page.content_type}
                 />
               )}
-              <button
-                type="button"
-                onClick={() => setHtmlEditMode((v) => !v)}
-                className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
-              >
-                {htmlEditMode ? "Done" : "Edit"}
-              </button>
+              {isHtml && (
+                <button
+                  type="button"
+                  onClick={() => setHtmlEditMode((v) => !v)}
+                  className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+                >
+                  {htmlEditMode ? "Done" : "Edit"}
+                </button>
+              )}
             </div>
           ) : undefined
         }

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/page.tsx
@@ -11,11 +11,13 @@ import { WorkspaceHomeSkeleton } from "../../../../components/SkeletonStates";
 import { WorkspaceIcon } from "../../../../components/SkillIcons";
 import { useAuth } from "../../../../hooks/useAuth";
 import {
+  createPage,
   getWorkspace,
   joinWorkspace,
   updateWorkspace,
 } from "../../../../lib/api";
 import type { Workspace } from "../../../../lib/types";
+import { refreshWorkspaceSidebar } from "../../../../lib/skillNavigationCache";
 
 function relativeTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -74,6 +76,16 @@ export default function WorkspaceHomePage() {
       .then(setWorkspace)
       .catch(() => {});
   }, [user, workspace, workspaceId]);
+
+  async function handleNewPage() {
+    try {
+      const page = await createPage(workspaceId, "Untitled");
+      refreshWorkspaceSidebar(workspaceId).catch(() => {});
+      router.push(`/p/${page.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create page");
+    }
+  }
 
   async function handleJoin() {
     if (!workspace) return;
@@ -134,6 +146,15 @@ export default function WorkspaceHomePage() {
             </div>
           </div>
           <div className="flex flex-shrink-0 items-center gap-1.5 pt-1">
+            {isMember && (
+              <button
+                type="button"
+                onClick={handleNewPage}
+                className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+              >
+                + New page
+              </button>
+            )}
             {isMember && (
               <Link
                 href={`/workspaces/${workspaceId}/settings`}


### PR DESCRIPTION
## Why

There was no way to create a page from an existing page — page creation only existed in the Files browser's **+ New** menu. From the workspace home or any open page you had to navigate back to Files first.

## What

- **Workspace home**: a `+ New page` button next to the settings gear (members only). Creates an untitled page at the workspace root and navigates to it.
- **Page viewer** (`/p/[pageId]`): a `+ New page` button in the header, left of the export/edit/more-actions controls. Creates the new page in the same folder as the current page.

Both reuse the existing `createPage` API and mirror the file browser's `handleNewPage` flow, including the `refreshWorkspaceSidebar` cache refresh.

Note: creating a second page without renaming the first fails with the backend's duplicate-name error ("Page 'Untitled' already exists…"). That's pre-existing behavior — the Files browser's + New → Page does the same — so this PR keeps it consistent rather than inventing unique-name generation.

## Verification

- `npm run lint` (passes; one pre-existing warning in `sessions/page.tsx`)
- `npm run build`
- Browser QA against this checkout's frontend + backend on a throwaway DB: registered a user, created a page from home, renamed it, created a sibling page from the page viewer — both navigate to the new page.

## Screenshots

- Workspace home with the new button: https://app.joinstash.ai/f/22306490-23b8-421e-8806-428088517939
- Page viewer with the new button: https://app.joinstash.ai/f/95c87b4f-0e9b-420b-966f-2455b5798dd3

🤖 Generated with [Claude Code](https://claude.com/claude-code)