### PR TITLE
Editor: make markdown horizontal rules visible

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -348,16 +348,12 @@ details > summary::-webkit-details-marker {
   font-style: italic;
 }
 
-/* Horizontal rule: fade out the line so it looks intentional. */
+/* Horizontal rule: --border-color is too faint against the page
+   background, so use the muted text token instead. */
 .prose :where(hr):not(:where([class~="not-prose"] *)) {
   border: none;
   height: 1px;
-  background: linear-gradient(
-    to right,
-    transparent,
-    var(--border-color, rgba(0, 0, 0, 0.12)),
-    transparent
-  );
+  background: var(--text-muted);
 }
 
 /* Tables — match the rounded-outer, light-inner-border look. */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13,6 +13,7 @@
   --text-primary: #37352F;
   --text-dim: #5C5A53;
   --text-muted: #9B9A97;
+  --divider-color: #DBDAD6;
 }
 
 [data-theme="dark"] {
@@ -24,6 +25,7 @@
   --text-primary: #F1F5F9;
   --text-dim: #94A3B8;
   --text-muted: #64748B;
+  --divider-color: #4C5C73;
 }
 
 @theme inline {
@@ -348,12 +350,13 @@ details > summary::-webkit-details-marker {
   font-style: italic;
 }
 
-/* Horizontal rule: --border-color is too faint against the page
-   background, so use the muted text token instead. */
+/* Horizontal rule: Obsidian-style 2px line. --border-color is too
+   faint against the page background and --text-muted too heavy, so
+   dividers get their own token. */
 .prose :where(hr):not(:where([class~="not-prose"] *)) {
   border: none;
-  height: 1px;
-  background: var(--text-muted);
+  height: 2px;
+  background: var(--divider-color);
 }
 
 /* Tables — match the rounded-outer, light-inner-border look. */


### PR DESCRIPTION
## Problem

Horizontal rules (`---`) in prose/markdown content were nearly invisible: the rule was rendered as a 1px gradient fading to transparent at both ends, with `--border-color` (`#ECECEA`, nearly white) at the center.

## Fix

Obsidian-style divider: a solid 2px line in a soft gray. Neither existing token fit — `--border-color` is too faint and `--text-muted` too dark — so dividers get their own `--divider-color` token (`#DBDAD6` light / `#4C5C73` dark). One rule in `globals.css` covers every `.prose` surface (page editor, rendered markdown).

## Screenshot

[Screenshot of the divider in the page editor](https://app.joinstash.ai/f/12558c2b-21a3-4efd-ae28-4b2785f47504) (Stash login required)

Note: this PR originally inline-embedded the screenshot via an unsigned R2 storage URL, the same pattern as past PRs (e.g. #577, #580) — those URLs all return 400, so none of them render. Linking the Stash upload instead.

Verified live against this branch's full local stack (backend + frontend dev server): typed `---` in the page editor and confirmed the computed style is a solid 2px `rgb(219, 218, 214)` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)