### PR TITLE
Add NEXT_PUBLIC_FORCE_ONBOARDING dev flag to rerun onboarding on every login

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -11,6 +11,10 @@ import { consumeManualAuth0Logout } from "../../lib/authLogout";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
+// Dev-only: set in frontend/.env.local to land on /onboarding after every
+// login (not just first registration), so the wizard can be iterated on.
+const FORCE_ONBOARDING = process.env.NEXT_PUBLIC_FORCE_ONBOARDING === "true";
+
 // FastAPI returns `detail` as either a string or an array of validation errors
 // like [{ loc, msg, type }]. Flatten to a human-readable string.
 function formatApiError(detail: unknown, fallback: string): string {
@@ -50,7 +54,7 @@ function LoginPageInner() {
   useEffect(() => {
     if (loading || !user || cliSession) return;
 
-    if (justRegistered) {
+    if (justRegistered || FORCE_ONBOARDING) {
       router.push("/onboarding");
       return;
     }


### PR DESCRIPTION
## What

Adds a dev-only `NEXT_PUBLIC_FORCE_ONBOARDING` env flag. When set to `true` (in `frontend/.env.local`, which is gitignored), every login redirects to `/onboarding` instead of the workspace — so the onboarding wizard can be iterated on without registering a fresh user each time.

Unset (the default everywhere), login behavior is unchanged: only freshly registered users see onboarding.

## Why

The wizard only triggers on first registration, which makes developing on it painful.

## Verified

Ran the dev frontend against the local backend with the flag set: registered a test user (lands on onboarding, as before), signed out, signed back in — second login also lands on `/onboarding`. Lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)