### PR TITLE
Tests: drive the in-app confirm dialog instead of window.confirm

### DIFF
--- a/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
@@ -212,7 +212,6 @@ describe("SkillPageClient", () => {
   });
 
   it("unpublishes from the publish popover", async () => {
-    vi.stubGlobal("confirm", vi.fn(() => true));
     vi.mocked(unpublishSkill).mockResolvedValue(undefined);
 
     renderSkill(<SkillPageClient slug="shared-skill" />);
@@ -220,9 +219,12 @@ describe("SkillPageClient", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Published" }));
     const dialog = await screen.findByRole("dialog", { name: "Publish skill" });
     fireEvent.click(within(dialog).getByRole("button", { name: "Unpublish" }));
+    const confirmDialog = await screen.findByRole("alertdialog", {
+      name: "Unpublish this skill?",
+    });
+    fireEvent.click(within(confirmDialog).getByRole("button", { name: "Unpublish" }));
 
     await waitFor(() => expect(unpublishSkill).toHaveBeenCalledWith("skill-1"));
-    vi.unstubAllGlobals();
   });
 
   it("shares the skill folder person-to-person via the generic share button", async () => {

--- a/frontend/src/app/(app)/skills/[slug]/settings/SkillSettingsPageClient.test.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/settings/SkillSettingsPageClient.test.tsx
@@ -4,6 +4,7 @@ import {
   render as renderBase,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -163,15 +164,17 @@ describe("SkillSettingsPageClient", () => {
   });
 
   it("stops sharing via unpublish and returns to the workspace skills page", async () => {
-    vi.stubGlobal("confirm", vi.fn(() => true));
     vi.mocked(unpublishSkill).mockResolvedValue(undefined);
 
     render(<SkillSettingsPageClient slug="shared-skill" />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Stop sharing" }));
+    const confirmDialog = await screen.findByRole("alertdialog", {
+      name: 'Stop sharing "Shared Skill"?',
+    });
+    fireEvent.click(within(confirmDialog).getByRole("button", { name: "Stop sharing" }));
 
     await waitFor(() => expect(unpublishSkill).toHaveBeenCalledWith("skill-1"));
     expect(router.push).toHaveBeenCalledWith("/workspaces/workspace-1/skills");
-    vi.unstubAllGlobals();
   });
 });

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/skills/[folderId]/SkillFolderClient.test.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/skills/[folderId]/SkillFolderClient.test.tsx
@@ -1,8 +1,14 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render as renderBase, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SkillFolderClient from "./SkillFolderClient";
 import { getFolderContents, listSkills } from "../../../../../../lib/api";
 import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
+import { ConfirmDialogProvider } from "../../../../../../components/ConfirmDialog";
+
+function render(ui: ReactNode) {
+  return renderBase(ui, { wrapper: ConfirmDialogProvider });
+}
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/skills/page.test.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/skills/page.test.tsx
@@ -1,7 +1,7 @@
 import {
   cleanup,
   fireEvent,
-  render,
+  render as renderBase,
   screen,
   waitFor,
 } from "@testing-library/react";
@@ -17,6 +17,11 @@ import {
   type Skill,
 } from "../../../../../lib/api";
 import { skillMdTemplate } from "../../../../../lib/localSkill";
+import { ConfirmDialogProvider } from "../../../../../components/ConfirmDialog";
+
+function render(ui: ReactNode) {
+  return renderBase(ui, { wrapper: ConfirmDialogProvider });
+}
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),


### PR DESCRIPTION
These four test files should have landed with #586 but were left uncommitted: wrap renders in `ConfirmDialogProvider` and click through the `alertdialog` instead of stubbing `window.confirm`.

Fixes the 8 vitest failures currently breaking CI on main. All 156 frontend tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)