### PR TITLE
docs: advise stash login instead of stash signin in user-facing copy

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4882,7 +4882,7 @@ def mount_command(
 
     cfg = load_config()
     if not cfg.get("api_key"):
-        console.print("[red]Not signed in. Run [bold]stash signin[/bold] first.[/red]")
+        console.print("[red]Not signed in. Run [bold]stash login[/bold] first.[/red]")
         raise typer.Exit(1)
 
     client = StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"])
@@ -4913,7 +4913,7 @@ def vfs_command(
 
     cfg = load_config()
     if not cfg.get("api_key"):
-        console.print("[red]Not signed in. Run [bold]stash signin[/bold] first.[/red]")
+        console.print("[red]Not signed in. Run [bold]stash login[/bold] first.[/red]")
         raise typer.Exit(1)
 
     client = StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"])

--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -89,7 +89,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
           headers: { Authorization: `Bearer ${token}` },
         },
       );
-      if (!approveRes.ok) throw new Error("CLI session expired. Re-run `stash signin`.");
+      if (!approveRes.ok) throw new Error("CLI session expired. Re-run `stash login`.");
       onCliApproved?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not authorize CLI");

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -138,7 +138,7 @@ function LoginPageInner() {
           },
         );
         if (!approveRes.ok) {
-          throw new Error("CLI session expired. Re-run `stash signin` and try again.");
+          throw new Error("CLI session expired. Re-run `stash login` and try again.");
         }
         setCliApproved(true);
       }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -503,7 +503,7 @@ function TryItOutStep({
       >
         <div className="space-y-2">
           <CommandBlock command={CLI_INSTALL_COMMAND} />
-          <CommandBlock command="stash signin" />
+          <CommandBlock command="stash login" />
         </div>
       </TryOption>
     </div>

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -183,7 +183,7 @@ function EmptyChatState({ onPrompt }: { onPrompt: (prompt: string) => void }) {
               <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
             </SetupStep>
             <SetupStep n={2} title="Sign in">
-              <Code>stash signin</Code>
+              <Code>stash login</Code>
             </SetupStep>
             <SetupStep n={3} title="Point your agent at Skill">
               <a

--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -66,7 +66,8 @@ export default function ConnectTokenClient({ apiUrl, sessionId, userName, access
           CLI authorized as {userName}
         </p>
         <p className="mt-4 max-w-[560px] text-[16px] leading-[1.6] text-dim">
-          Head back to your terminal — <code>stash signin</code> has the token and will finish
+          Head back to your terminal — the <code>stash</code>{" "}
+          CLI has the token and will finish
           wiring up your workspace. You can close this tab.
         </p>
       </div>

--- a/www/app/connect-token/page.tsx
+++ b/www/app/connect-token/page.tsx
@@ -40,8 +40,9 @@ export default async function ConnectTokenPage({
       <Shell>
         <Heading>Open this page from the CLI</Heading>
         <Body>
-          This page completes sign-in for <code>stash signin</code> and has to be opened
-          with a session id. Run <code>stash signin</code> in your terminal and it&apos;ll
+          This page completes sign-in for the Stash CLI and has to be opened
+          with a session id. Run <code>stash login</code>{" "}
+          in your terminal and it&apos;ll
           open the right URL for you.
         </Body>
       </Shell>


### PR DESCRIPTION
we were telling users to use the wrong command. TODO we should audit the full CLI surface and remove redundant or undesirable commands.



## What

`stash login` is the canonical onboarding command — it's what `joinstash.ai/install` execs, and it walks the full wizard (endpoint, browser auth, workspace, agent hooks), skipping steps already done. `stash signin` is just its browser-auth sub-step. This PR fixes every place that told *users* to run `stash signin`:

- **frontend onboarding page** (`/onboarding` Capture option): command block now `stash login`
- **frontend agents ChatPanel** setup step 2: `stash login`
- **frontend login page + Auth0 ExchangeAndRedirect**: "CLI session expired" errors now say re-run `stash login`
- **www /connect-token**: no-session copy says "Run `stash login`"; done-state copy refers to "the `stash` CLI" generically (both `login` and `signin` poll this page)
- **cli mount/vfs**: "Not signed in" errors now point at `stash login`

Also fixes a pre-existing rendering bug on the same /connect-token lines: the space after an inline `<code>` element was being swallowed (the page rendered "stash signinin your terminal"). Used the file's existing `{" "}` idiom.

## Intentionally unchanged

- `backend/services/shared_skill_service.py` agent install pitch keeps `stash signin --no-browser` — it targets headless coding agents, and the interactive `stash login` wizard would hang them.
- `www/app/docs/cli` keeps its `stash signin` CommandRef — that's reference documentation of the command, not onboarding advice. (Side note for a follow-up: that page documents the password-based `stash login <name> --password` rather than the wizard, and lists a stale default API of api.stash.ac.)

## Screenshots

/connect-token opened without a session id (www, after fix — note `stash login` and correct spacing): [screenshot](https://app.joinstash.ai/f/a41cf29c-dce1-4859-90af-49c961ca456b)

The remaining changed screens are error states (expired CLI session) and authed onboarding steps; the copy changes there are single-word command swaps.

## Verification

- `ruff check cli/main.py` clean; no tests assert the old strings (the agent-pitch test still passes untouched since that path is unchanged)
- `npm run lint` clean in both `frontend/` and `www/` (only pre-existing warnings, none in touched files)
- Rendered `/connect-token` locally and confirmed the new copy and spacing in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)