### PR TITLE
feat: dedicated full-screen CLI install step in onboarding

### DIFF
--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -9,9 +9,11 @@ import { track } from "../../lib/analytics";
 import {
   createPage,
   getAgentApiKey,
+  listMyKeys,
   listMyWorkspaces,
   updateMe,
   updatePage,
+  type ApiKeyInfo,
 } from "../../lib/api";
 import { generateCollabIntroMarkdown } from "../../lib/onboarding/collabIntro";
 import { seedWelcomePage } from "../../lib/onboarding/seedWelcome";
@@ -19,9 +21,9 @@ import SourceConnectorList from "../../components/integrations/SourceConnectorLi
 
 import MemoryAskStep from "./paths/memory/MemoryAskStep";
 
-// The linear flow: a few questions about the user, explain Stash, try one of
-// the three entry points, then ask the agent a real question, then launch.
-const STEP_NAMES = ["about", "intro", "try", "ask"] as const;
+// The linear flow: a few questions about the user, explain Stash, install the
+// CLI, try an entry point, then ask the agent a real question, then launch.
+const STEP_NAMES = ["about", "intro", "cli", "try", "ask"] as const;
 
 const CLI_INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
@@ -160,11 +162,12 @@ function OnboardingInner() {
     );
   }
 
-  // 0 = about, 1 = intro, 2 = try it out, 3 = ask.
+  // 0 = about, 1 = intro, 2 = cli, 3 = try it out, 4 = ask.
   const isAbout = stepIdx <= 0;
   const isIntro = stepIdx === 1;
-  const isTryItOut = stepIdx === 2;
-  const isAsk = stepIdx >= 3;
+  const isCli = stepIdx === 2;
+  const isTryItOut = stepIdx === 3;
+  const isAsk = stepIdx >= 4;
 
   const continueLabel = isIntro
     ? "Get started"
@@ -220,6 +223,7 @@ function OnboardingInner() {
             />
           )}
           {isIntro && <IntroStep />}
+          {isCli && <CliStep />}
           {isTryItOut && (
             <TryItOutStep
               workspaceId={workspaceId}
@@ -426,6 +430,90 @@ function IntroPoint({ title, children }: { title: string; children: React.ReactN
   );
 }
 
+function CliStep() {
+  const [cliKey, setCliKey] = useState<ApiKeyInfo | null>(null);
+
+  // `stash login` mints an API key named "CLI (<device>)" the moment the user
+  // approves the browser sign-in, so polling for one tells us the install
+  // worked without the user having to confirm anything.
+  useEffect(() => {
+    if (cliKey) return;
+    let firstCheck = true;
+    let cancelled = false;
+    const check = () => {
+      const preexisting = firstCheck;
+      firstCheck = false;
+      listMyKeys()
+        .then((keys) => {
+          if (cancelled) return;
+          const key = keys.find((k) => k.name.startsWith("CLI ("));
+          if (!key) return;
+          setCliKey(key);
+          track("onboarding.cli_connected", { preexisting });
+        })
+        .catch(() => {});
+    };
+    check();
+    const interval = setInterval(check, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [cliKey]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
+          Connect your coding agent
+        </h1>
+        <p className="text-sm text-dim max-w-lg">
+          One command installs the Stash CLI and signs you in. This is how Stash
+          compounds: your agents read this workspace, and everything they do flows
+          back into it.
+        </p>
+      </div>
+      <ul className="space-y-3">
+        <IntroPoint title="Every session is captured">
+          Prompts, tool calls, and artifacts from Claude Code, Codex, Cursor, and
+          OpenCode stream in as they happen — nothing evaporates when a session
+          closes.
+        </IntroPoint>
+        <IntroPoint title="Your agents can read everything">
+          The CLI gives every agent you run access to your whole workspace —
+          connected sources, files, and past sessions.
+        </IntroPoint>
+      </ul>
+      <div className="space-y-2">
+        <CommandBlock command={CLI_INSTALL_COMMAND} />
+        <p className="text-[12px] text-muted">
+          Already have the CLI? Run{" "}
+          <code className="font-mono text-foreground/80">stash login</code> instead.
+        </p>
+      </div>
+      <CliConnectedStatus cliKey={cliKey} />
+    </div>
+  );
+}
+
+function CliConnectedStatus({ cliKey }: { cliKey: ApiKeyInfo | null }) {
+  if (cliKey) {
+    return (
+      <div className="flex items-center gap-2.5 rounded-lg border border-brand/40 bg-brand/5 px-3.5 py-2.5 text-[13px] text-foreground">
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" />
+        Connected — <span className="font-medium">{cliKey.name}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2.5 rounded-lg border border-border bg-surface px-3.5 py-2.5 text-[13px] text-dim">
+      <span className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-muted" />
+      Waiting for the CLI to connect — this updates by itself once you run the
+      command.
+    </div>
+  );
+}
+
 function TryItOutStep({
   workspaceId,
   onCollabDoc,
@@ -448,7 +536,7 @@ function TryItOutStep({
           Try it out
         </h1>
         <p className="text-sm text-dim max-w-md">
-          Three ways to start — pick whichever fits.
+          Two ways to start — pick whichever fits.
         </p>
       </div>
       <TryOption
@@ -478,7 +566,7 @@ function TryItOutStep({
         <div className="space-y-3">
           <SourceConnectorList
             workspaceId={workspaceId}
-            returnTo="/onboarding?step=3"
+            returnTo="/onboarding?step=4"
             onSourceCountChange={onSourceCountChange}
             onObsidianUploaded={onObsidianAdded}
           />
@@ -495,15 +583,6 @@ function TryItOutStep({
               Continue
             </button>
           </div>
-        </div>
-      </TryOption>
-      <TryOption
-        badge="Capture"
-        lead="Run this in your terminal — every Claude Code / Codex session streams into Stash automatically."
-      >
-        <div className="space-y-2">
-          <CommandBlock command={CLI_INSTALL_COMMAND} />
-          <CommandBlock command="stash login" />
         </div>
       </TryOption>
     </div>
@@ -533,10 +612,26 @@ function TryOption({
 }
 
 function CommandBlock({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
   return (
-    <pre className="overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
-      {command}
-    </pre>
+    <div className="flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1.5">
+      <pre className="flex-1 overflow-x-auto font-mono text-[11.5px] text-foreground">
+        {command}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        className="shrink-0 text-[11px] text-muted hover:text-foreground transition-colors"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
   );
 }
 
@@ -563,7 +658,7 @@ function AskStep({
 }
 
 function ProgressBar({ stepIdx }: { stepIdx: number }) {
-  const labels = ["About you", "Welcome", "Try it out", "Ask"];
+  const labels = ["About you", "Welcome", "Install CLI", "Try it out", "Ask"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, i) => {

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -21,9 +21,9 @@ import SourceConnectorList from "../../components/integrations/SourceConnectorLi
 
 import MemoryAskStep from "./paths/memory/MemoryAskStep";
 
-// The linear flow: a few questions about the user, explain Stash, install the
-// CLI, try an entry point, then ask the agent a real question, then launch.
-const STEP_NAMES = ["about", "intro", "cli", "try", "ask"] as const;
+// The linear flow: a few questions about the user, explain Stash, try an
+// entry point, install the CLI, then ask the agent a real question, then launch.
+const STEP_NAMES = ["about", "intro", "try", "cli", "ask"] as const;
 
 const CLI_INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
@@ -162,11 +162,11 @@ function OnboardingInner() {
     );
   }
 
-  // 0 = about, 1 = intro, 2 = cli, 3 = try it out, 4 = ask.
+  // 0 = about, 1 = intro, 2 = try it out, 3 = cli, 4 = ask.
   const isAbout = stepIdx <= 0;
   const isIntro = stepIdx === 1;
-  const isCli = stepIdx === 2;
-  const isTryItOut = stepIdx === 3;
+  const isTryItOut = stepIdx === 2;
+  const isCli = stepIdx === 3;
   const isAsk = stepIdx >= 4;
 
   const continueLabel = isIntro
@@ -223,7 +223,6 @@ function OnboardingInner() {
             />
           )}
           {isIntro && <IntroStep />}
-          {isCli && <CliStep />}
           {isTryItOut && (
             <TryItOutStep
               workspaceId={workspaceId}
@@ -234,6 +233,7 @@ function OnboardingInner() {
               onContinue={() => goToStep(stepIdx + 1)}
             />
           )}
+          {isCli && <CliStep />}
           {isAsk && (
             <AskStep workspaceId={workspaceId} onAnswered={() => setAnswered(true)} />
           )}
@@ -566,7 +566,7 @@ function TryItOutStep({
         <div className="space-y-3">
           <SourceConnectorList
             workspaceId={workspaceId}
-            returnTo="/onboarding?step=4"
+            returnTo="/onboarding?step=3"
             onSourceCountChange={onSourceCountChange}
             onObsidianUploaded={onObsidianAdded}
           />
@@ -658,7 +658,7 @@ function AskStep({
 }
 
 function ProgressBar({ stepIdx }: { stepIdx: number }) {
-  const labels = ["About you", "Welcome", "Install CLI", "Try it out", "Ask"];
+  const labels = ["About you", "Welcome", "Try it out", "Install CLI", "Ask"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, i) => {

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -63,8 +63,6 @@ function OnboardingInner() {
   const searchParams = useSearchParams();
   const { user, loading, logout } = useAuth();
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
-  const [sourceCount, setSourceCount] = useState(0);
-  const [obsidianAdded, setObsidianAdded] = useState(false);
   const [answered, setAnswered] = useState(false);
   const [role, setRole] = useState("");
   const [roleOther, setRoleOther] = useState("");
@@ -180,9 +178,8 @@ function OnboardingInner() {
       ? referralOther.trim() && `Other: ${referralOther.trim()}`
       : referralSource;
   // About: role + referral are required, and "Other" needs to be spelled out
-  // (use-case is optional). Try it out: Continue lives inside the Connect
-  // option and is gated on a connected source. Ask: only let them launch once
-  // the agent has actually replied.
+  // (use-case is optional). Ask: only let them launch once the agent has
+  // actually replied. Everything else can be continued past freely.
   const canContinue = isAbout ? Boolean(roleAnswer && referralAnswer) : !isAsk || answered;
   const onContinue = async () => {
     if (isAbout) {
@@ -224,14 +221,7 @@ function OnboardingInner() {
           )}
           {isIntro && <IntroStep />}
           {isTryItOut && (
-            <TryItOutStep
-              workspaceId={workspaceId}
-              onCollabDoc={finishToCollabDoc}
-              onSourceCountChange={setSourceCount}
-              onObsidianAdded={() => setObsidianAdded(true)}
-              canContinue={sourceCount > 0 || obsidianAdded}
-              onContinue={() => goToStep(stepIdx + 1)}
-            />
+            <TryItOutStep workspaceId={workspaceId} onCollabDoc={finishToCollabDoc} />
           )}
           {isCli && <CliStep />}
           {isAsk && (
@@ -242,7 +232,6 @@ function OnboardingInner() {
             onSkip={skip}
             continueLabel={continueLabel}
             canContinue={canContinue}
-            hideContinue={isTryItOut}
           />
         </div>
       </main>
@@ -517,17 +506,9 @@ function CliConnectedStatus({ cliKey }: { cliKey: ApiKeyInfo | null }) {
 function TryItOutStep({
   workspaceId,
   onCollabDoc,
-  onSourceCountChange,
-  onObsidianAdded,
-  canContinue,
-  onContinue,
 }: {
   workspaceId: string | null;
   onCollabDoc: () => void;
-  onSourceCountChange: (n: number) => void;
-  onObsidianAdded: () => void;
-  canContinue: boolean;
-  onContinue: () => void;
 }) {
   return (
     <div className="space-y-7">
@@ -563,27 +544,7 @@ function TryItOutStep({
         badge="Connect"
         lead="Connect a data source and your agent can navigate it like a file system."
       >
-        <div className="space-y-3">
-          <SourceConnectorList
-            workspaceId={workspaceId}
-            returnTo="/onboarding?step=3"
-            onSourceCountChange={onSourceCountChange}
-            onObsidianUploaded={onObsidianAdded}
-          />
-          <div className="flex items-center justify-end gap-3">
-            {!canContinue && (
-              <span className="text-[12px] text-muted">Connect a source to continue</span>
-            )}
-            <button
-              type="button"
-              onClick={onContinue}
-              disabled={!canContinue}
-              className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Continue
-            </button>
-          </div>
-        </div>
+        <SourceConnectorList workspaceId={workspaceId} returnTo="/onboarding?step=3" />
       </TryOption>
     </div>
   );
@@ -689,13 +650,11 @@ function StepControls({
   onSkip,
   continueLabel,
   canContinue,
-  hideContinue,
 }: {
   onContinue: () => void;
   onSkip: () => void;
   continueLabel: string;
   canContinue: boolean;
-  hideContinue?: boolean;
 }) {
   return (
     <div className="flex items-center justify-between pt-2">
@@ -706,16 +665,14 @@ function StepControls({
       >
         Skip onboarding
       </button>
-      {!hideContinue && (
-        <button
-          type="button"
-          onClick={onContinue}
-          disabled={!canContinue}
-          className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {continueLabel}
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={onContinue}
+        disabled={!canContinue}
+        className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {continueLabel}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## What

The CLI was a footnote — the third "Capture" option on the Try it out step. This promotes it to its own full-screen onboarding step so users understand its significance and are more likely to install it.

New flow: **About you → Welcome → Try it out → Install CLI → Ask** (was 4 steps, now 5). The CLI step comes after integrations are connected.

## The new step

- Headline + two value-prop bullets (sessions captured, agents read the whole workspace)
- The one-command install (`bash -c "$(curl -fsSL https://joinstash.ai/install)")` with a **Copy** button, plus an "already have the CLI? `stash login`" note
- **Live connection status**: `stash login`'s browser auth mints an API key named `CLI (<device>)`, so the step polls `GET /users/me/keys` every 3s and flips to "Connected — CLI (device)" the moment sign-in completes, with no refresh or user action. Fires `onboarding.cli_connected` (with a `preexisting` flag) for conversion tracking.
- Continue is never gated on installing — users can move on freely.

Try it out drops the Capture option and now reads "Two ways to start".

No backend changes — the key-listing and cli-auth endpoints already existed.

## Screenshots

- [Try it out — Continue enabled with zero sources connected](https://app.joinstash.ai/f/477fa33f-115b-40c3-9adc-8307caa135fd)

- [Try it out (step 3) — now two options, Install CLI next in the progress bar](https://app.joinstash.ai/f/3b49e149-7bb6-40a0-974b-00723f5ea894)
- [Install CLI (step 4) — waiting state](https://app.joinstash.ai/f/b328985a-ea50-48fb-890d-e8d9168b0e14)
- [Install CLI (step 4) — flipped to Connected after a real cli-auth approve](https://app.joinstash.ai/f/65df5f81-66d4-4f09-8494-97e1b1932b2b)

## Verification

- `npm run lint` clean (one pre-existing warning elsewhere), `npm test` 169/169 pass
- E2E in the browser against a live backend: signed in as a test user, viewed both steps under the final order, ran a real cli-auth session + approve, and watched the status flip to "Connected — CLI (henrys-macbook)" without a refresh
- Copy button verified in-browser (flips to "Copied")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Also: Try it out is no longer gated on connecting a source — Continue always works, using the standard step controls (the inline gated button is gone).
