### PR TITLE
Onboarding: clicking a selected pill unselects it

### DIFF
--- a/frontend/src/app/onboarding/page.test.tsx
+++ b/frontend/src/app/onboarding/page.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OnboardingPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const authUser = vi.hoisted(() => ({
+  id: "user-1",
+  name: "Henry",
+  display_name: "Henry",
+  description: "",
+  created_at: "2026-05-31T00:00:00Z",
+  last_seen: "2026-05-31T00:00:00Z",
+}));
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({ user: authUser, loading: false, logout: vi.fn() }),
+}));
+
+vi.mock("../../components/Header", () => ({ default: () => null }));
+vi.mock("../../components/integrations/SourceConnectorList", () => ({
+  default: () => null,
+}));
+vi.mock("./paths/memory/MemoryAskStep", () => ({ default: () => null }));
+vi.mock("../../lib/analytics", () => ({ track: vi.fn() }));
+vi.mock("../../lib/api", () => ({
+  createPage: vi.fn(),
+  getAgentApiKey: vi.fn(),
+  listMyWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+  updateMe: vi.fn(),
+  updatePage: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+describe("about step pills", () => {
+  it("clicking a selected pill unselects it, so a mis-click is recoverable", () => {
+    render(<OnboardingPage />);
+    const pill = screen.getByRole("button", { name: "Engineer" });
+
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("unselecting a required answer disables Continue again", () => {
+    render(<OnboardingPage />);
+    const role = screen.getByRole("button", { name: "Engineer" });
+    const referral = screen.getByRole("button", { name: "Search" });
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+
+    fireEvent.click(role);
+    fireEvent.click(referral);
+    expect(continueButton).toBeEnabled();
+
+    fireEvent.click(role);
+    expect(continueButton).toBeDisabled();
+  });
+});

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -346,7 +346,8 @@ function PillGroup({
           <button
             key={option}
             type="button"
-            onClick={() => onChange(option)}
+            aria-pressed={selected}
+            onClick={() => onChange(selected ? "" : option)}
             className={`rounded-full border px-3 py-1.5 text-[12.5px] transition-colors ${
               selected
                 ? "border-brand bg-brand text-white"


### PR DESCRIPTION
## What

The role and "How did you hear about us?" pills on the onboarding About step couldn't be unselected — once you clicked one, the only way out was picking a different option. Clicking the selected pill now toggles it off, and Continue goes back to disabled when a required answer is cleared.

Also adds `aria-pressed` to the pills since they're toggle buttons now.

## Screenshots

Verified live in the browser (dev frontend against local backend):

- [Pill selected](https://app.joinstash.ai/f/6a501db9-dccd-4794-9bf0-56fe1d4991cd) — "Engineer" + "Search" selected, Continue enabled
- [After clicking "Engineer" again](https://app.joinstash.ai/f/b275285e-40d4-48e3-bc07-1900b92b247c) — pill unselected, Continue disabled again

## Tests

New `frontend/src/app/onboarding/page.test.tsx` covers both behaviors (toggle off + Continue gating). Full frontend suite passes: 39 files, 171 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)