### PR TITLE
Login: landing-aligned branded sign-in page

### DIFF
--- a/frontend/managed/auth0/LoginButton.tsx
+++ b/frontend/managed/auth0/LoginButton.tsx
@@ -4,14 +4,26 @@ export default function LoginButton({ cliSession }: { cliSession?: string | null
   const returnTo = cliSession ? `/login?cli=${encodeURIComponent(cliSession)}` : "/login";
   const href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
   return (
-    <a
-      href={href}
-      className="group flex items-center justify-center gap-2 w-full bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold text-center transition-all shadow-[0_8px_24px_-8px_oklch(0.7_0.14_55_/_0.5)] hover:shadow-[0_10px_28px_-6px_oklch(0.7_0.14_55_/_0.6)]"
-    >
-      Continue with Auth0
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="transition-transform group-hover:translate-x-0.5">
-        <path d="M5 12h14M13 5l7 7-7 7" />
-      </svg>
-    </a>
+    <div className="space-y-4">
+      <p className="text-sm text-dim text-center">
+        You&apos;ll be redirected to a secure sign-in page.
+      </p>
+      <a
+        href={href}
+        className="group flex items-center justify-center gap-2 w-full bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold text-center transition-all shadow-[0_8px_24px_-8px_oklch(0.7_0.14_55_/_0.5)] hover:shadow-[0_10px_28px_-6px_oklch(0.7_0.14_55_/_0.6)]"
+      >
+        Continue to sign in
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="transition-transform group-hover:translate-x-0.5">
+          <path d="M5 12h14M13 5l7 7-7 7" />
+        </svg>
+      </a>
+      <p className="flex items-center justify-center gap-1.5 text-[10px] font-mono uppercase tracking-[0.14em] text-muted">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <rect x="4" y="11" width="16" height="10" rx="2" />
+          <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+        </svg>
+        Secured by Auth0
+      </p>
+    </div>
   );
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -223,6 +223,9 @@ function LoginPageInner() {
       }
     >
       <FormCard>{formBody}</FormCard>
+      <p className="text-center text-[11px] text-muted">
+        You&apos;re seeing this because you&apos;re running in self-hosted/dev mode.
+      </p>
     </AuthShell>
   );
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -175,9 +175,9 @@ function LoginPageInner() {
 
   const formBody = (
     <>
-      <form onSubmit={handleSubmit} className="space-y-3">
-        <FormField type="text" placeholder="Username" value={name} onChange={setName} autoFocus />
-        <FormField type="password" placeholder="Password" value={password} onChange={setPassword} />
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField label="Username" type="text" placeholder="yourname" value={name} onChange={setName} autoFocus />
+        <FormField label="Password" type="password" placeholder="••••••••" value={password} onChange={setPassword} />
         {error && <ErrorLine message={error} />}
         <BrandButton submitting={submitting} label={ctaLabel} />
       </form>
@@ -214,19 +214,16 @@ function LoginPageInner() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header user={user} onLogout={logout} />
-      <main className="flex-1 flex items-center justify-center px-4 py-12">
-        <div className="w-full max-w-sm space-y-4">
-          <div className="rounded-2xl border border-border bg-surface p-6 space-y-4">
-            <h2 className="text-base font-semibold text-foreground">
-              {mode === "login" ? "Sign in" : "Create an account"}
-            </h2>
-            {formBody}
-          </div>
-        </div>
-      </main>
-    </div>
+    <AuthShell
+      title={mode === "login" ? "Welcome back" : "Create your stash"}
+      subtitle={
+        mode === "login"
+          ? "Sign in to the workspace you share with your agents."
+          : "One account for you and your agents."
+      }
+    >
+      <FormCard>{formBody}</FormCard>
+    </AuthShell>
   );
 }
 
@@ -364,17 +361,12 @@ function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0Panel
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header user={user} onLogout={logout} />
-      <main className="flex-1 flex items-center justify-center px-4 py-12">
-        <div className="w-full max-w-sm space-y-4">
-          <div className="rounded-2xl border border-border bg-surface p-6">
-            <h2 className="text-base font-semibold text-foreground mb-4">Sign in</h2>
-            {body}
-          </div>
-        </div>
-      </main>
-    </div>
+    <AuthShell
+      title="Welcome back"
+      subtitle="Sign in to the workspace you share with your agents."
+    >
+      <FormCard>{body}</FormCard>
+    </AuthShell>
   );
 }
 
@@ -400,6 +392,48 @@ function Auth0Exchange(props: { cliSession: string | null; onCliApproved: () => 
   return <Comp cliSession={props.cliSession} onCliApproved={props.onCliApproved} />;
 }
 
+// --- Branded auth shell (plain login + Auth0) ----------------------------------
+
+// The auth shell only ever renders for signed-out visitors, so it skips the app
+// Header (whose only signed-out affordance is a link right back to /login).
+function AuthShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col relative overflow-hidden">
+      <AuthBackdrop />
+      <main className="flex-1 flex items-center justify-center px-4 py-12 relative">
+        <div className="w-full max-w-[400px] space-y-7 animate-in fade-in slide-in-from-bottom-3 duration-500">
+          <div className="space-y-3 text-center">
+            <Wordmark />
+            <h1 className="font-display text-[32px] leading-[1.05] font-bold tracking-tight text-foreground">
+              {title}
+            </h1>
+            <p className="text-sm text-dim">{subtitle}</p>
+          </div>
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Wordmark() {
+  return (
+    <div className="flex items-center justify-center gap-2 font-display text-[19px] font-bold tracking-[-0.03em] text-foreground">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/octopus.svg" alt="" width={24} height={27} />
+      stash
+    </div>
+  );
+}
+
 // --- CLI hero shell ----------------------------------------------------------
 
 function CliShell({
@@ -415,7 +449,7 @@ function CliShell({
 }) {
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden">
-      <CliBackdrop />
+      <AuthBackdrop />
       <Header user={user} onLogout={logout} />
       <main className="flex-1 flex items-center justify-center px-4 py-10 relative">
         <div className="w-full max-w-[420px] space-y-7 animate-in fade-in slide-in-from-bottom-3 duration-500">
@@ -450,7 +484,7 @@ function CliSuccess({
 }) {
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden">
-      <CliBackdrop />
+      <AuthBackdrop />
       <Header user={user} onLogout={logout} />
       <main className="flex-1 flex items-center justify-center px-4 py-12 relative">
         <div className="w-full max-w-md text-center space-y-5 animate-in fade-in slide-in-from-bottom-2 duration-500">
@@ -486,12 +520,14 @@ function FormCard({ children }: { children: React.ReactNode }) {
 }
 
 function FormField({
+  label,
   type,
   placeholder,
   value,
   onChange,
   autoFocus,
 }: {
+  label: string;
   type: string;
   placeholder: string;
   value: string;
@@ -499,15 +535,20 @@ function FormField({
   autoFocus?: boolean;
 }) {
   return (
-    <input
-      type={type}
-      placeholder={placeholder}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      autoFocus={autoFocus}
-      className="w-full px-3.5 py-2.5 rounded-lg border border-border bg-background text-foreground text-sm placeholder:text-muted focus:outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 transition-all"
-      required
-    />
+    <label className="block space-y-1.5">
+      <span className="block text-[10px] font-mono uppercase tracking-[0.14em] text-muted">
+        {label}
+      </span>
+      <input
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoFocus={autoFocus}
+        className="w-full px-3.5 py-2.5 rounded-lg border border-border bg-background text-foreground text-sm placeholder:text-muted focus:outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 transition-all"
+        required
+      />
+    </label>
   );
 }
 
@@ -557,7 +598,7 @@ function SessionCodePanel({ code }: { code: string }) {
   );
 }
 
-function CliBackdrop() {
+function AuthBackdrop() {
   return (
     <div aria-hidden className="absolute inset-0 -z-10 overflow-hidden">
       <div


### PR DESCRIPTION
## What

Replaces the unbranded gray sign-in card with a landing-aligned auth screen. The plain `/login` (and the Auth0 non-CLI variant) now use a shared `AuthShell`: octopus wordmark, display headline ("Welcome back" / "Create your stash"), mono uppercase field labels, and the same subtle brand-radial + grid backdrop the CLI authorize flow already had.

The app `Header` is dropped from this shell — the page only ever renders for signed-out visitors, and the header's only signed-out affordance was an orange "Register / Login" button linking right back to `/login`.

The Auth0 (managed) variant also gets a reworked card body: the vendor-branded "Continue with Auth0" CTA becomes supporting copy + a "Continue to sign in" button, with "Secured by Auth0" demoted to mono fine print.

The password page also gets a fine-print line below the card — "You're seeing this because you're running in self-hosted/dev mode." — since password sign-in only appears when `NEXT_PUBLIC_AUTH0_ENABLED` is off (not in the screenshot below, added in a later commit).

## Screenshots

### Sign in
![sign in](https://app.joinstash.ai/f/688a07fb-1fa3-4016-a73a-f29fccbdc2ca)

### Create account
![create account](https://app.joinstash.ai/f/0bb32ebb-28b4-4497-9eb1-fa968dea1300)

### CLI authorize flow (unchanged shell, now with matching field labels)
![cli authorize](https://app.joinstash.ai/f/ee59f831-1a08-4b9f-9911-05c3596ac354)

### Auth0 (managed) sign-in
![auth0 sign in](https://app.joinstash.ai/f/759e7541-ca22-4adc-b4ab-182b02811547)

## Verification

- `npm test` — 169/169 pass
- `npm run lint` — clean (one pre-existing warning elsewhere)
- Manually clicked through sign-in, register toggle, and the `?cli=` flow in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

