### PR TITLE
start.sh: fail fast on an already-running frontend dev server; scope agent kills to the worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Here are some common code patterns that we need you to avoid:
 If you are about to ask the user to do something for you, think about whether you can do it yourself.
 
 - **Never ask the user to check logs.** Check them yourself — via running the server with captured output, MCPs for hosted servers, or ngrok inspector (`localhost:4040`).
-- **Never ask permission to kill/restart local processes.** If you need to restart uvicorn, ngrok, or any dev server to make progress, just do it.
+- **Never ask permission to kill/restart local processes.** If you need to restart uvicorn, ngrok, or any dev server to make progress, just do it. But scope kills to this worktree: several worktrees run the same stack on this machine, so kill by specific PID or port (`kill <pid>`, `pkill -f "next dev -p 3457"`) — never by bare command pattern (`pkill -f "next dev"`, `pkill -f uvicorn`), which takes down other worktrees' servers.
 - **Never speculate about env vars, API keys, or config.** If you need to know whether something is set, check it yourself (e.g. `env | grep`, read `.env`, etc.). Just do it. Do not guess or assume. Do not ask the user. Check it yourself.
 - **Never ask the user to test UI**. Use `agent-browser` as the default tool for manual E2E/QA browser checks: click through the changed workflow, inspect the page state, capture screenshots when useful, and check logs yourself. Use existing Playwright tests for scripted regression coverage when the repo already has them or when adding a durable test is part of the task.
 

--- a/start.sh
+++ b/start.sh
@@ -320,6 +320,67 @@ choose_dev_ports() {
     fi
 }
 
+# Next.js allows one dev server per checkout: `next dev` holds an exclusive
+# flock on frontend/.next/dev/lock, and a second one exits at startup. Without
+# a preflight check that failure happens last — after the database, backend,
+# and collab are already up — and tears the whole stack down on the way out.
+
+frontend_dev_server_info() {
+    # Prints "<pid> <appUrl>" if a live dev server holds the lock, else nothing.
+    # Probes the same flock Next takes, so a crashed server's leftover lock
+    # file (the OS releases its flock) never counts as running.
+    python - "$PROJECT_ROOT/frontend/.next/dev/lock" <<'PY'
+import fcntl
+import json
+import sys
+
+try:
+    f = open(sys.argv[1])
+except OSError:
+    sys.exit(0)
+
+with f:
+    try:
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        sys.exit(0)
+    except OSError:
+        pass
+    try:
+        info = json.load(f)
+    except ValueError:
+        info = {}
+    print(info.get("pid", "unknown"), info.get("appUrl", "unknown"))
+PY
+}
+
+ensure_frontend_dev_server_not_running() {
+    local info pid app_url
+    info="$(frontend_dev_server_info)"
+    if [ -z "$info" ]; then
+        return
+    fi
+
+    pid="${info%% *}"
+    app_url="${info#* }"
+
+    if [ "${START_KILL_DEV_SERVER:-0}" = "1" ] && [ "$pid" != "unknown" ]; then
+        echo "[frontend] Stopping the dev server already running for this worktree (pid ${pid})..."
+        kill "$pid" 2>/dev/null || true
+        for _ in {1..20}; do
+            if [ -z "$(frontend_dev_server_info)" ]; then
+                return
+            fi
+            sleep 0.5
+        done
+        echo "[frontend] The dev server (pid ${pid}) did not exit; stop it manually, then rerun ./start.sh."
+        exit 1
+    fi
+
+    echo "[frontend] A dev server for this worktree is already running at ${app_url} (pid ${pid})."
+    echo "[frontend] Use it, stop it (kill ${pid}), or rerun with START_KILL_DEV_SERVER=1 to replace it."
+    exit 1
+}
+
 wait_for_services() {
     local pid
     local status
@@ -346,6 +407,9 @@ wait_for_services() {
 
 echo "Starting Stash services..."
 echo "================================"
+
+# --- Preflight ---
+ensure_frontend_dev_server_not_running
 
 # --- Dependencies ---
 ensure_python_deps


### PR DESCRIPTION
## Problem

Next.js 16 allows one dev server per checkout: `next dev` holds an exclusive flock on `frontend/.next/dev/lock`, and a second one exits at startup. `start.sh` discovered this conflict **last**: it booted the dev database, ran migrations, and started the backend and collab, then the frontend child lost the lock race and exited — and the supervisor tore the whole stack down on the way out. (This bit us today: a leftover dev server from an earlier agent session made `./start.sh` look broken.)

Separately, agents on this machine were killing each other's dev servers across worktrees with broad `pkill -f "next dev"`-style commands, because CLAUDE.md says to kill processes freely but says nothing about scoping.

## Fix

**start.sh** gets a preflight that runs before anything boots. It probes the same flock Next takes (via `fcntl.flock` non-blocking), so:

- a **live** dev server → fail fast with its URL and PID: *"A dev server for this worktree is already running at http://localhost:3491 (pid 99757). Use it, stop it (kill 99757), or rerun with START_KILL_DEV_SERVER=1 to replace it."*
- `START_KILL_DEV_SERVER=1` → kill that PID, wait for the flock to release, proceed. Killing is opt-in only — the running server may be serving someone.
- a **crashed** server's leftover lock file → ignored (the OS released its flock), startup proceeds normally. No stale-lockfile cleanup needed, matching Next's own semantics.

**CLAUDE.md**: the "never ask permission to kill/restart" rule now requires scoping kills to the current worktree — by PID or specific port, never bare command patterns that match every worktree's servers.

## Verification (all three paths exercised live)

1. Started a dev server in this worktree, ran `./start.sh` → exited immediately with the message above, before deps/db/migrations.
2. `START_KILL_DEV_SERVER=1 ./start.sh` → logged "Stopping the dev server already running for this worktree (pid 99757)", the old server died, and startup proceeded through db/ports/migrations.
3. `kill -9`'d a dev server leaving its lock file on disk → `./start.sh` sailed straight past the preflight to `[db]`.

`bash -n` clean. No GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)