### PR TITLE
Login wizard: streamline repo + transcript steps

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4153,12 +4153,12 @@ def login_cmd():
         save_enabled_agents([])
 
     # --- Step 5: Which repo? ---
-    repo_root = _git_toplevel()
-    repo_name = repo_root.name if repo_root else None
+    # Outside a git repo, treat the current directory as the repo root: the
+    # .stash manifest lands there and the workspace is named after it.
+    repo_root = _git_toplevel() or Path.cwd()
 
-    this_repo_label = f"This repo ({repo_name})" if repo_name else "This repo"
     repo_choices = [
-        questionary.Choice(this_repo_label, value="this"),
+        questionary.Choice(f"This repo ({repo_root.name})", value="this"),
         questionary.Choice("Another repo", value="other"),
         questionary.Choice("Done", value="done"),
     ]
@@ -4166,22 +4166,17 @@ def login_cmd():
     answer = questionary.select(
         "Which repo do you want to upload transcripts in?",
         choices=repo_choices,
-        default=repo_choices[0] if repo_root else repo_choices[2],
+        default=repo_choices[0],
         use_shortcuts=True,
     ).ask()
     if answer is None:
         raise typer.Exit(1)
 
     if answer == "this":
-        if not repo_root:
-            console.print(
-                "[yellow]Not inside a git repo. Run `stash connect` from a repo.[/yellow]"
-            )
-        else:
-            try:
-                _auto_connect_repo(repo_root, cfg)
-            except StashError as e:
-                console.print(f"[red]Could not connect repo: {e.detail}[/red]")
+        try:
+            _auto_connect_repo(repo_root, cfg)
+        except StashError as e:
+            console.print(f"[red]Could not connect repo: {e.detail}[/red]")
     elif answer == "other":
         _reserve_bottom_padding(4)
         repo_path = typer.prompt("Path to repo").strip()

--- a/cli/main.py
+++ b/cli/main.py
@@ -4109,20 +4109,16 @@ def login_cmd():
         console.print("\n  Run [cyan]stash settings[/cyan] to change agents or endpoint.")
         return
 
-    # --- Step 3: Upload or just read? ---
-    _reserve_bottom_padding(6)
-    usage_mode = questionary.select(
-        "Do you want to upload transcripts, or just read?",
-        choices=[
-            questionary.Choice("Upload transcripts", value="upload"),
-            questionary.Choice("Just read", value="read"),
-        ],
-        use_shortcuts=True,
+    # --- Step 3: Share transcripts? ---
+    _reserve_bottom_padding(4)
+    share_transcripts = questionary.confirm(
+        "Do you want to share your coding agent transcripts to Stash?",
+        default=True,
     ).ask()
-    if usage_mode is None:
+    if share_transcripts is None:
         raise typer.Exit(1)
 
-    if usage_mode == "read":
+    if not share_transcripts:
         _show_setup_complete_splash()
         return
 


### PR DESCRIPTION
## What

Two onboarding-wizard tweaks in `stash login`:

**1. Repo picker defaults to "This repo" and connects non-git directories**
- "This repo" is now always the default selection. Previously it fell back to "Done" when the wizard ran outside a git repo, so the happy path needed extra keystrokes exactly where new users land (a fresh demo directory).
- Outside a git repo, the current directory is treated as the repo root: the `.stash` manifest is written there and the workspace is named after the directory. Previously selecting "This repo" printed *"Not inside a git repo. Run `stash connect` from a repo."* and did nothing.

**2. Transcript step reworded as a yes/no question**
- "Do you want to upload transcripts, or just read?" → "Do you want to share your coding agent transcripts to Stash?" (confirm, default yes).
- Same flow as before (no → setup-complete splash, skipping hooks/repo steps), but the wording stops framing transcript upload as the product's primary mode — connecting to company resources is the main feature.

## Why

CLI onboarding should connect the user's working directory in one keypress, and the copy should match the product's emphasis. Spotted while dry-running the `joinstash.ai/install` funnel.

## Testing

- `ruff check cli/main.py` clean
- All 59 `cli/tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)