### PR TITLE
Share-by-email: stop revealing whether an email has an account

### DIFF
--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -71,6 +71,10 @@ async def share_with_user_by_email(
         "SELECT id FROM users WHERE lower(email) = $1",
         normalized_email,
     )
+    # Both branches below return an identical body. A different response for a
+    # known vs unknown email would let any workspace owner probe which
+    # addresses have Stash accounts (a user-enumeration oracle). Owners see
+    # invite-vs-share state via the shares listing instead.
     if not user:
         # No user with that email yet — stash a pending invite that converts on
         # their signup. We can't validate the address, so this never fails the
@@ -102,17 +106,16 @@ async def share_with_user_by_email(
                 "recipient_email_hash": security_audit_service.hash_value(normalized_email),
             },
         )
-        return {"pending": True, "email": normalized_email}
+        return {"ok": True, "email": normalized_email}
     if user["id"] == owner_id:
         raise HTTPException(status_code=400, detail="You already own this")
-    row = await pool.fetchrow(
+    await pool.execute(
         """
         INSERT INTO shares (workspace_id, object_type, object_id, principal_type,
                             principal_id, permission, created_by, expires_at)
         VALUES ($1, $2, $3, 'user', $4, $5, $6, $7)
         ON CONFLICT (object_type, object_id, principal_type, principal_id)
         DO UPDATE SET permission = EXCLUDED.permission, expires_at = EXCLUDED.expires_at
-        RETURNING id
         """,
         workspace_id,
         object_type,
@@ -134,7 +137,7 @@ async def share_with_user_by_email(
             "recipient_user_hash": security_audit_service.hash_value(str(user["id"])),
         },
     )
-    return {"id": str(row["id"]), "principal_type": "user", "principal_id": str(user["id"])}
+    return {"ok": True, "email": normalized_email}
 
 
 async def convert_pending_invites(user_id: UUID, email: str | None) -> int:

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -1269,7 +1269,7 @@ async def test_share_by_email_pending_invite_converts_on_signup(client: AsyncCli
         headers=_auth(owner_key),
     )
     assert share.status_code == 200
-    assert share.json()["pending"] is True
+    assert share.json()["ok"] is True
 
     # The owner sees it listed as a pending invite.
     listing = await client.get(
@@ -1290,6 +1290,40 @@ async def test_share_by_email_pending_invite_converts_on_signup(client: AsyncCli
     rows = after.json()["shares"]
     assert all(not s["pending"] for s in rows)
     assert any(s["email"] == "newcomer@example.com" for s in rows)
+
+
+@pytest.mark.asyncio
+async def test_share_response_does_not_reveal_account_existence(client: AsyncClient):
+    """The share response must be identical for known and unknown emails —
+    a per-branch difference would let any workspace owner probe which
+    addresses have Stash accounts (a user-enumeration oracle)."""
+    owner_key, _ = await _register(client)
+    ws = (await client.get("/api/v1/workspaces/mine", headers=_auth(owner_key))).json()[
+        "workspaces"
+    ][0]["id"]
+    page_id = (
+        await client.post(
+            f"/api/v1/workspaces/{ws}/pages/new",
+            json={"name": "Spec", "content": "secret spec"},
+            headers=_auth(owner_key),
+        )
+    ).json()["id"]
+    await _register_with_email(client, "has-account@example.com")
+
+    async def _share(email: str):
+        return await client.post(
+            "/api/v1/share",
+            json={"object_type": "page", "object_id": page_id, "email": email},
+            headers=_auth(owner_key),
+        )
+
+    known = await _share("has-account@example.com")
+    unknown = await _share("no-account@example.com")
+
+    assert known.status_code == 200
+    assert unknown.status_code == 200
+    assert known.json() == {"ok": True, "email": "has-account@example.com"}
+    assert unknown.json() == {"ok": True, "email": "no-account@example.com"}
 
 
 @pytest.mark.asyncio
@@ -1336,7 +1370,7 @@ async def test_revoked_pending_share_invite_does_not_convert_on_signup(client: A
     )
 
     assert share.status_code == 200
-    assert share.json()["pending"] is True
+    assert share.json()["ok"] is True
     assert revoked.status_code == 200
     assert listing.status_code == 200
     assert listing.json()["shares"] == []
@@ -1377,7 +1411,7 @@ async def test_expired_pending_share_invite_does_not_convert_on_signup(client: A
         headers=_auth(owner_key),
     )
     assert share.status_code == 200
-    assert share.json()["pending"] is True
+    assert share.json()["ok"] is True
 
     newcomer_key, _ = await _register_with_email(client, "late-newcomer@example.com")
 
@@ -1423,7 +1457,7 @@ async def test_converted_share_keeps_invite_expiry(client: AsyncClient, pool):
         headers=_auth(owner_key),
     )
     assert share.status_code == 200
-    assert share.json()["pending"] is True
+    assert share.json()["ok"] is True
 
     newcomer_key, newcomer = await _register_with_email(client, "timed-newcomer@example.com")
 

--- a/backend/tests/test_security_audit.py
+++ b/backend/tests/test_security_audit.py
@@ -280,7 +280,7 @@ async def test_pending_share_invite_conversion_is_audited_without_email_or_conte
     )
 
     assert invited.status_code == 200
-    assert invited.json() == {"pending": True, "email": recipient_email}
+    assert invited.json() == {"ok": True, "email": recipient_email}
     assert recipient_resp.status_code == 201
     assert events_resp.status_code == 200
 
@@ -363,7 +363,7 @@ async def test_pending_share_invite_revocation_is_audited_without_email_or_conte
     )
 
     assert invited.status_code == 200
-    assert invited.json() == {"pending": True, "email": recipient_email}
+    assert invited.json() == {"ok": True, "email": recipient_email}
     assert revoked.status_code == 200
     assert events_resp.status_code == 200
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2885,10 +2885,10 @@ def shares_add(
     if _use_json(as_json):
         output_json(data)
         return
-    if data.get("pending"):
-        console.print(f"[green]Invite pending[/green] for {email} (converts on signup).")
-    else:
-        console.print(f"[green]Shared[/green] with {email} ({permission}).")
+    console.print(
+        f"[green]Shared[/green] with {email} ({permission}). "
+        "If they don't have an account yet, it converts when they sign up."
+    )
 
 
 @shares_app.command("rm")

--- a/cli/tests/test_sharing_cli.py
+++ b/cli/tests/test_sharing_cli.py
@@ -19,7 +19,7 @@ class _FakeClient:
     # object sharing
     def share_object(self, object_type, object_id, email, permission="read", expires_at=None):
         self._calls.append(("share", object_type, object_id, email, permission))
-        return {"pending": True, "email": email}
+        return {"ok": True, "email": email}
 
     def unshare_object(self, object_type, object_id, principal_type, principal_id):
         self._calls.append(("unshare", object_type, object_id, principal_type, principal_id))


### PR DESCRIPTION
## Problem

`POST /api/v1/share` returned a different body depending on whether the recipient email belonged to an existing user: a share object with `principal_id` for a known email, versus `{"pending": true, ...}` for an unknown one. Any workspace owner could use this as an oracle to probe which email addresses have Stash accounts (flagged while auditing our security-posture letter).

## Fix

- `share_with_user_by_email` now returns the identical body `{"ok": true, "email": ...}` on both branches. No caller used the old fields: the frontend ignores the response body, and the CLI only branched on `pending` for its success message.
- The CLI `stash shares add` success message no longer branches on the response.
- New test `test_share_response_does_not_reveal_account_existence` pins the guarantee.

Owners still see invite-vs-share state where they always have: the shares listing (`GET /api/v1/share`). Note that listing therefore remains a slower, owner-only existence signal — equalizing it would mean hiding pending-vs-accepted state from owners, which is a product decision left out of scope here.

## Testing

Full backend + CLI suite passes locally (536 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)