### PR TITLE
Stripe billing: Pro plan pay gate, subscription settings, landing pricing

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -278,6 +278,14 @@ class Settings:
     GOOGLE_PICKER_API_KEY: str | None = os.getenv("GOOGLE_PICKER_API_KEY")
     GOOGLE_PICKER_APP_ID: str | None = os.getenv("GOOGLE_PICKER_APP_ID")
 
+    # --- Billing (Stripe, managed deployment only) ---
+    # Leave STRIPE_SECRET_KEY unset to disable billing entirely (self-host
+    # default): billing endpoints 404 and the source pay gate is not enforced.
+    STRIPE_SECRET_KEY: str | None = os.getenv("STRIPE_SECRET_KEY")
+    STRIPE_WEBHOOK_SECRET: str | None = os.getenv("STRIPE_WEBHOOK_SECRET")
+    # The recurring $20/mo Pro price (price_...).
+    STRIPE_PRICE_ID: str | None = os.getenv("STRIPE_PRICE_ID")
+
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from .routers import (
     aggregate,
     analytics,
     batch,
+    billing,
     collab,
     demo,
     discover,
@@ -139,6 +140,7 @@ app.include_router(session_folders.ws_router)
 app.include_router(session_folders.public_router)
 app.include_router(shares.router)
 app.include_router(webhooks.router)
+app.include_router(billing.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
 

--- a/backend/migrations/versions/0111_user_subscriptions.py
+++ b/backend/migrations/versions/0111_user_subscriptions.py
@@ -1,0 +1,32 @@
+"""Per-user Stripe subscription state for the Pro plan pay gate.
+
+Revision ID: 0111
+Revises: 0110
+"""
+
+from alembic import op
+
+revision = "0111"
+down_revision = "0110"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # One row per user, created the first time they start checkout. Status
+    # mirrors Stripe's subscription status vocabulary (no CHECK — Stripe owns
+    # it). The UNIQUE on stripe_customer_id is the webhook lookup index.
+    op.execute("""
+        CREATE TABLE user_subscriptions (
+            user_id                uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+            stripe_customer_id     text NOT NULL UNIQUE,
+            stripe_subscription_id text,
+            status                 text NOT NULL DEFAULT 'incomplete',
+            created_at             timestamptz NOT NULL DEFAULT now(),
+            updated_at             timestamptz NOT NULL DEFAULT now()
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS user_subscriptions")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,4 @@ playwright>=1.49
 Pillow>=10.0
 pillow-heif>=0.19
 snowflake-connector-python>=3.12
+stripe>=12.0

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -1,0 +1,61 @@
+"""Billing endpoints: plan status, Stripe Checkout/Portal redirects, and the
+Stripe webhook. The webhook is public (Stripe calls it) and verified by
+signature, mirroring the Slack webhook pattern in webhooks.py."""
+
+from __future__ import annotations
+
+import json
+
+import stripe
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ..auth import get_current_user
+from ..config import settings
+from ..services import billing_service
+
+router = APIRouter(prefix="/api/v1/billing", tags=["billing"])
+
+
+@router.get("/me")
+async def my_billing(current_user: dict = Depends(get_current_user)):
+    if not billing_service.billing_enabled():
+        return {"billing_enabled": False}
+    subscription = await billing_service.get_subscription(current_user["id"])
+    status = subscription["status"] if subscription else None
+    return {
+        "billing_enabled": True,
+        "plan": "pro" if status in billing_service.ACTIVE_STATUSES else "free",
+        "status": status,
+        "source_count": await billing_service.source_count(current_user["id"]),
+        "source_limit": billing_service.FREE_SOURCE_LIMIT,
+    }
+
+
+@router.post("/checkout")
+async def start_checkout(current_user: dict = Depends(get_current_user)):
+    billing_service.require_billing_enabled()
+    return {"url": await billing_service.create_checkout_session(current_user)}
+
+
+@router.post("/portal")
+async def open_portal(current_user: dict = Depends(get_current_user)):
+    billing_service.require_billing_enabled()
+    return {"url": await billing_service.create_portal_session(current_user["id"])}
+
+
+@router.post("/webhook")
+async def stripe_webhook(request: Request):
+    billing_service.require_billing_enabled()
+    payload = await request.body()
+    # construct_event verifies the signature; we then work with the plain
+    # parsed JSON rather than stripe's object wrappers.
+    try:
+        stripe.Webhook.construct_event(
+            payload,
+            request.headers.get("stripe-signature", ""),
+            settings.STRIPE_WEBHOOK_SECRET,
+        )
+    except (ValueError, stripe.SignatureVerificationError):
+        raise HTTPException(status_code=400, detail="bad signature")
+    await billing_service.apply_webhook_event(json.loads(payload))
+    return {"ok": True}

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -19,6 +19,7 @@ from ..celery_app import celery
 from ..integrations import storage as integration_storage
 from ..integrations.registry import get_provider
 from ..services import (
+    billing_service,
     permission_service,
     security_audit_service,
     source_service,
@@ -300,6 +301,9 @@ async def add_source(
 
     if not external_ref:
         raise HTTPException(status_code=400, detail="external_ref is required")
+    await billing_service.ensure_can_add_source(
+        current_user["id"], workspace_id, body.source_type, external_ref
+    )
     try:
         created = await source_service.create_source(
             workspace_id=workspace_id,

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -36,9 +36,7 @@ def require_billing_enabled() -> None:
 
 
 async def get_subscription(user_id: UUID) -> dict | None:
-    row = await get_pool().fetchrow(
-        "SELECT * FROM user_subscriptions WHERE user_id = $1", user_id
-    )
+    row = await get_pool().fetchrow("SELECT * FROM user_subscriptions WHERE user_id = $1", user_id)
     return dict(row) if row else None
 
 

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -1,0 +1,172 @@
+"""Per-user Stripe billing: Free (1 connected source) vs Pro ($20/mo, unlimited).
+
+Billing is switched on by STRIPE_SECRET_KEY being set (managed deployment).
+Self-hosted instances leave it unset: billing endpoints 404 and the pay gate
+is a no-op. Enforcement is connect-time only — existing sources keep syncing
+even after a subscription lapses.
+
+The user ↔ Stripe customer mapping row is created when checkout starts, so
+every later webhook resolves by stripe_customer_id regardless of event order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import stripe
+from fastapi import HTTPException
+
+from ..config import settings
+from ..database import get_pool
+
+# Stripe statuses that grant Pro. Everything else (past_due, canceled,
+# unpaid, incomplete) means free-tier enforcement.
+ACTIVE_STATUSES = {"active", "trialing"}
+FREE_SOURCE_LIMIT = 1
+
+
+def billing_enabled() -> bool:
+    return settings.STRIPE_SECRET_KEY is not None
+
+
+def require_billing_enabled() -> None:
+    if not billing_enabled():
+        raise HTTPException(status_code=404, detail="Billing is not enabled on this instance")
+
+
+async def get_subscription(user_id: UUID) -> dict | None:
+    row = await get_pool().fetchrow(
+        "SELECT * FROM user_subscriptions WHERE user_id = $1", user_id
+    )
+    return dict(row) if row else None
+
+
+async def is_pro(user_id: UUID) -> bool:
+    status = await get_pool().fetchval(
+        "SELECT status FROM user_subscriptions WHERE user_id = $1", user_id
+    )
+    return status in ACTIVE_STATUSES
+
+
+async def source_count(user_id: UUID) -> int:
+    return await get_pool().fetchval(
+        "SELECT count(*) FROM workspace_sources WHERE owner_user_id = $1", user_id
+    )
+
+
+async def ensure_can_add_source(
+    user_id: UUID, workspace_id: UUID, source_type: str, external_ref: str
+) -> None:
+    """Connect-time pay gate. Counts the user's sources across all workspaces,
+    excluding the natural key being added — create_source is an upsert, and a
+    free user re-adding their one existing source must keep working."""
+    if not billing_enabled():
+        return
+    if await is_pro(user_id):
+        return
+    others = await get_pool().fetchval(
+        """
+        SELECT count(*) FROM workspace_sources
+        WHERE owner_user_id = $1
+          AND NOT (workspace_id = $2 AND source_type = $3 AND external_ref = $4)
+        """,
+        user_id,
+        workspace_id,
+        source_type,
+        external_ref,
+    )
+    if others >= FREE_SOURCE_LIMIT:
+        raise HTTPException(
+            status_code=402,
+            detail="The free plan includes 1 connected source. Upgrade to Pro to connect more.",
+        )
+
+
+async def _get_or_create_customer_id(user: dict) -> str:
+    existing = await get_pool().fetchval(
+        "SELECT stripe_customer_id FROM user_subscriptions WHERE user_id = $1", user["id"]
+    )
+    if existing:
+        return existing
+
+    kwargs: dict = {"metadata": {"user_id": str(user["id"])}}
+    if user.get("email"):
+        kwargs["email"] = user["email"]
+    customer = await asyncio.to_thread(
+        stripe.Customer.create, api_key=settings.STRIPE_SECRET_KEY, **kwargs
+    )
+    await get_pool().execute(
+        "INSERT INTO user_subscriptions (user_id, stripe_customer_id) VALUES ($1, $2)",
+        user["id"],
+        customer.id,
+    )
+    return customer.id
+
+
+async def create_checkout_session(user: dict) -> str:
+    customer_id = await _get_or_create_customer_id(user)
+    session = await asyncio.to_thread(
+        stripe.checkout.Session.create,
+        api_key=settings.STRIPE_SECRET_KEY,
+        mode="subscription",
+        customer=customer_id,
+        client_reference_id=str(user["id"]),
+        line_items=[{"price": settings.STRIPE_PRICE_ID, "quantity": 1}],
+        success_url=f"{settings.PUBLIC_URL}/settings?billing=success",
+        cancel_url=f"{settings.PUBLIC_URL}/settings",
+    )
+    return session.url
+
+
+async def create_portal_session(user_id: UUID) -> str:
+    customer_id = await get_pool().fetchval(
+        "SELECT stripe_customer_id FROM user_subscriptions WHERE user_id = $1", user_id
+    )
+    if not customer_id:
+        raise HTTPException(status_code=400, detail="No subscription to manage")
+    session = await asyncio.to_thread(
+        stripe.billing_portal.Session.create,
+        api_key=settings.STRIPE_SECRET_KEY,
+        customer=customer_id,
+        return_url=f"{settings.PUBLIC_URL}/settings",
+    )
+    return session.url
+
+
+async def apply_webhook_event(event: dict) -> None:
+    """Sync subscription state from Stripe. Events for unknown customers
+    (e.g. manual dashboard actions) are ignored, not errors."""
+    kind = event["type"]
+    obj = event["data"]["object"]
+
+    if kind == "checkout.session.completed":
+        await get_pool().execute(
+            """
+            UPDATE user_subscriptions
+            SET stripe_subscription_id = $1, status = 'active', updated_at = now()
+            WHERE stripe_customer_id = $2
+            """,
+            obj.get("subscription"),
+            obj.get("customer"),
+        )
+    elif kind == "customer.subscription.updated":
+        await get_pool().execute(
+            """
+            UPDATE user_subscriptions
+            SET stripe_subscription_id = $1, status = $2, updated_at = now()
+            WHERE stripe_customer_id = $3
+            """,
+            obj.get("id"),
+            obj.get("status"),
+            obj.get("customer"),
+        )
+    elif kind == "customer.subscription.deleted":
+        await get_pool().execute(
+            """
+            UPDATE user_subscriptions
+            SET status = 'canceled', updated_at = now()
+            WHERE stripe_customer_id = $1
+            """,
+            obj.get("customer"),
+        )

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -1,0 +1,210 @@
+"""Billing: the connect-time pay gate and Stripe webhook state sync.
+
+Why these tests matter: the free plan is enforced ONLY when adding a source —
+a free user keeps one connected source, idempotent re-adds of that source must
+not be blocked (create_source is an upsert), and an active subscription lifts
+the cap. Billing is off entirely when STRIPE_SECRET_KEY is unset (self-host).
+"""
+
+import hashlib
+import hmac
+import json
+import time
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.config import settings
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient, prefix: str = "bill") -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(prefix), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _create_workspace(client: AsyncClient, api_key: str) -> UUID:
+    resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": unique_name("bill_ws")},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return UUID(resp.json()["id"])
+
+
+async def _add_repo(client: AsyncClient, api_key: str, ws: UUID, repo: str):
+    return await client.post(
+        f"/api/v1/workspaces/{ws}/sources",
+        json={"source_type": "github_repo", "external_ref": repo},
+        headers=_auth(api_key),
+    )
+
+
+def _stripe_signature(payload: bytes, secret: str) -> str:
+    ts = int(time.time())
+    sig = hmac.new(secret.encode(), f"{ts}.".encode() + payload, hashlib.sha256).hexdigest()
+    return f"t={ts},v1={sig}"
+
+
+@pytest.fixture
+def billing_on(monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x")
+    monkeypatch.setattr(settings, "STRIPE_WEBHOOK_SECRET", "whsec_test_x")
+    monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test_x")
+
+
+@pytest.mark.asyncio
+async def test_free_user_gated_at_second_source(client, pool, billing_on):
+    api_key, user_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+
+    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
+
+    blocked = await _add_repo(client, api_key, ws, "acme/two")
+    assert blocked.status_code == 402
+    assert "Upgrade to Pro" in blocked.json()["detail"]
+
+    # Re-adding the same source is an upsert, not a new source — must not 402.
+    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
+
+    await pool.execute(
+        "INSERT INTO user_subscriptions (user_id, stripe_customer_id, status) "
+        "VALUES ($1, 'cus_gate', 'active')",
+        user_id,
+    )
+    assert (await _add_repo(client, api_key, ws, "acme/two")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_gate_counts_sources_across_workspaces(client, billing_on):
+    api_key, _ = await _register(client)
+    ws_a = await _create_workspace(client, api_key)
+    ws_b = await _create_workspace(client, api_key)
+
+    assert (await _add_repo(client, api_key, ws_a, "acme/one")).status_code == 200
+    assert (await _add_repo(client, api_key, ws_b, "acme/two")).status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_gate_off_when_billing_disabled(client, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None)
+    api_key, _ = await _register(client)
+    ws = await _create_workspace(client, api_key)
+
+    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
+    assert (await _add_repo(client, api_key, ws, "acme/two")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_billing_me_reflects_plan(client, pool, billing_on):
+    api_key, user_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    await _add_repo(client, api_key, ws, "acme/one")
+
+    me = (await client.get("/api/v1/billing/me", headers=_auth(api_key))).json()
+    assert me == {
+        "billing_enabled": True,
+        "plan": "free",
+        "status": None,
+        "source_count": 1,
+        "source_limit": 1,
+    }
+
+    await pool.execute(
+        "INSERT INTO user_subscriptions (user_id, stripe_customer_id, status) "
+        "VALUES ($1, 'cus_me', 'active')",
+        user_id,
+    )
+    me = (await client.get("/api/v1/billing/me", headers=_auth(api_key))).json()
+    assert me["plan"] == "pro"
+    assert me["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_billing_me_when_disabled(client, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None)
+    api_key, _ = await _register(client)
+    resp = await client.get("/api/v1/billing/me", headers=_auth(api_key))
+    assert resp.json() == {"billing_enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_deleted_downgrades(client, pool, billing_on):
+    _, user_id = await _register(client)
+    await pool.execute(
+        "INSERT INTO user_subscriptions (user_id, stripe_customer_id, stripe_subscription_id, status) "
+        "VALUES ($1, 'cus_hook', 'sub_1', 'active')",
+        user_id,
+    )
+
+    payload = json.dumps(
+        {
+            "object": "event",
+            "type": "customer.subscription.deleted",
+            "data": {"object": {"id": "sub_1", "customer": "cus_hook", "status": "canceled"}},
+        }
+    ).encode()
+    resp = await client.post(
+        "/api/v1/billing/webhook",
+        content=payload,
+        headers={"stripe-signature": _stripe_signature(payload, "whsec_test_x")},
+    )
+    assert resp.status_code == 200
+
+    status = await pool.fetchval(
+        "SELECT status FROM user_subscriptions WHERE user_id = $1", user_id
+    )
+    assert status == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_bad_signature(client, billing_on):
+    payload = json.dumps(
+        {"object": "event", "type": "customer.subscription.deleted", "data": {"object": {}}}
+    ).encode()
+    resp = await client.post(
+        "/api/v1/billing/webhook",
+        content=payload,
+        headers={"stripe-signature": _stripe_signature(payload, "whsec_wrong")},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_webhook_checkout_completed_activates(client, pool, billing_on):
+    _, user_id = await _register(client)
+    # The customer mapping row is created when checkout starts, before any webhook.
+    await pool.execute(
+        "INSERT INTO user_subscriptions (user_id, stripe_customer_id) VALUES ($1, 'cus_co')",
+        user_id,
+    )
+
+    payload = json.dumps(
+        {
+            "object": "event",
+            "type": "checkout.session.completed",
+            "data": {"object": {"customer": "cus_co", "subscription": "sub_new"}},
+        }
+    ).encode()
+    resp = await client.post(
+        "/api/v1/billing/webhook",
+        content=payload,
+        headers={"stripe-signature": _stripe_signature(payload, "whsec_test_x")},
+    )
+    assert resp.status_code == 200
+
+    row = await pool.fetchrow("SELECT * FROM user_subscriptions WHERE user_id = $1", user_id)
+    assert row["status"] == "active"
+    assert row["stripe_subscription_id"] == "sub_new"

--- a/collab/package-lock.json
+++ b/collab/package-lock.json
@@ -35,14 +35,14 @@
         "@types/markdown-it": "14.1.2",
         "@types/node": "20.19.1",
         "@types/pg": "8.11.11",
-        "tsx": "4.20.3",
+        "tsx": "4.22.4",
         "typescript": "5.8.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -329,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1130,32 +1130,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {
@@ -1171,19 +1171,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/happy-dom": {
@@ -1671,16 +1658,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -1703,14 +1680,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
-      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"

--- a/collab/package.json
+++ b/collab/package.json
@@ -36,7 +36,7 @@
     "@types/markdown-it": "14.1.2",
     "@types/node": "20.19.1",
     "@types/pg": "8.11.11",
-    "tsx": "4.20.3",
+    "tsx": "4.22.4",
     "typescript": "5.8.3"
   }
 }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useConfirm } from "../../components/ConfirmDialog";
 import Header from "../../components/Header";
 import IntegrationsSettings from "../../components/integrations/IntegrationsSettings";
+import SubscriptionSection from "../../components/settings/SubscriptionSection";
 import WorkspaceSection from "../../components/settings/WorkspaceSection";
 import { AccountSettingsSkeleton, ApiKeysSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
@@ -52,6 +53,7 @@ export default function SettingsPage() {
             </p>
           </div>
           <Profile user={user} onUpdated={refresh} />
+          <SubscriptionSection />
           <WorkspaceSection />
           <IntegrationsSettings embedded />
           <ActiveSessions />

--- a/frontend/src/components/PaywallModal.tsx
+++ b/frontend/src/components/PaywallModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+import { startCheckout } from "../lib/api";
+
+// Shown when the backend returns 402 on a connect attempt: the free plan's
+// one-source limit is hit and adding more requires Pro.
+export default function PaywallModal({ onClose }: { onClose: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEscapeKey(true, onClose);
+
+  async function upgrade() {
+    setBusy(true);
+    setError("");
+    try {
+      const { url } = await startCheckout();
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not start checkout");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30 px-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Upgrade to Pro"
+        className="w-full max-w-sm rounded-xl border border-border bg-base p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-[14px] font-semibold text-foreground">
+          Upgrade to Pro
+        </div>
+        <div className="mt-1.5 text-[12.5px] leading-[1.55] text-muted">
+          The free plan includes 1 connected source. Pro unlocks unlimited
+          connected sources — GitHub, Slack, Gmail, Drive, Notion, and more —
+          for $20/month.
+        </div>
+        {error && <div className="mt-2 text-[12px] text-error">{error}</div>}
+        <div className="mt-4 flex justify-end gap-1.5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
+          >
+            Not now
+          </button>
+          <button
+            type="button"
+            autoFocus
+            disabled={busy}
+            onClick={upgrade}
+            className="rounded-md bg-brand px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
+          >
+            {busy ? "Redirecting…" : "Upgrade — $20/month"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/pickers.test.tsx
+++ b/frontend/src/components/integrations/pickers.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../lib/api";
+import type { Connector } from "./connectors";
+import { AddSourceControls } from "./pickers";
+
+const addWorkspaceSource = vi.fn();
+const startCheckout = vi.fn();
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/api")>();
+  return {
+    ...actual,
+    addWorkspaceSource: (...args: unknown[]) => addWorkspaceSource(...args),
+    startCheckout: (...args: unknown[]) => startCheckout(...args),
+  };
+});
+
+const driveConnector: Connector = {
+  provider: "google",
+  label: "Google Drive",
+  sourceType: "google_drive",
+  kind: "drive",
+  blurb: "",
+};
+
+function renderControls() {
+  return render(
+    <AddSourceControls
+      connector={driveConnector}
+      workspaceId="ws-1"
+      connected
+      onAdded={() => {}}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// The free plan allows 1 connected source; the backend rejects further adds
+// with 402. The user must see the paywall (not just an error) so the upgrade
+// path is one click away.
+describe("AddSourceControls pay gate", () => {
+  it("shows the paywall modal when the backend returns 402", async () => {
+    addWorkspaceSource.mockRejectedValue(
+      new ApiError(402, "The free plan includes 1 connected source. Upgrade to Pro to connect more.")
+    );
+    renderControls();
+
+    fireEvent.click(screen.getByText("Add My Drive"));
+
+    expect(await screen.findByRole("dialog", { name: "Upgrade to Pro" })).toBeTruthy();
+    expect(addWorkspaceSource).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByText("Not now"));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("does not show the paywall for other errors", async () => {
+    addWorkspaceSource.mockRejectedValue(new ApiError(400, "external_ref is required"));
+    renderControls();
+
+    fireEvent.click(screen.getByText("Add My Drive"));
+
+    expect(await screen.findByText("external_ref is required")).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("starts checkout from the paywall modal", async () => {
+    addWorkspaceSource.mockRejectedValue(new ApiError(402, "Upgrade to Pro to connect more."));
+    startCheckout.mockReturnValue(new Promise(() => {})); // redirect never settles in tests
+    renderControls();
+
+    fireEvent.click(screen.getByText("Add My Drive"));
+    fireEvent.click(await screen.findByText("Upgrade — $20/month"));
+
+    expect(startCheckout).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -19,6 +19,7 @@ import {
   type SlackChannelSummary,
 } from "@/lib/integrations";
 
+import PaywallModal from "../PaywallModal";
 import { AsanaIcon, GitHubIcon, JiraIcon, NotionIcon, SlackIcon } from "./BrandIcons";
 import type { Connector } from "./connectors";
 
@@ -79,17 +80,10 @@ export function AddSourceControls({
   }
 
   const errorRow = error ? (
-    <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">
-      {error}
-      {paymentRequired && (
-        <>
-          {" "}
-          <a href="/settings" className="font-semibold underline">
-            Upgrade to Pro
-          </a>
-        </>
-      )}
-    </div>
+    <>
+      <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
+      {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
+    </>
   ) : null;
 
   if (connector.kind === "github") {

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
-import { addWorkspaceSource } from "@/lib/api";
+import { addWorkspaceSource, ApiError } from "@/lib/api";
 import {
   type IntegrationAccount,
   listAsanaProjects,
@@ -55,11 +55,13 @@ export function AddSourceControls({
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [paymentRequired, setPaymentRequired] = useState(false);
   const [gongWorkspaceIds, setGongWorkspaceIds] = useState("");
 
   async function add(body?: AddSourceBody) {
     setBusy(true);
     setError("");
+    setPaymentRequired(false);
     try {
       await addWorkspaceSource(workspaceId, {
         source_type: connector.sourceType,
@@ -69,6 +71,7 @@ export function AddSourceControls({
       return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not add source");
+      setPaymentRequired(e instanceof ApiError && e.status === 402);
       return false;
     } finally {
       setBusy(false);
@@ -76,7 +79,17 @@ export function AddSourceControls({
   }
 
   const errorRow = error ? (
-    <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
+    <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">
+      {error}
+      {paymentRequired && (
+        <>
+          {" "}
+          <a href="/settings" className="font-semibold underline">
+            Upgrade to Pro
+          </a>
+        </>
+      )}
+    </div>
   ) : null;
 
   if (connector.kind === "github") {

--- a/frontend/src/components/settings/SubscriptionSection.tsx
+++ b/frontend/src/components/settings/SubscriptionSection.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  BillingInfo,
+  getBilling,
+  openBillingPortal,
+  startCheckout,
+} from "../../lib/api";
+
+// Renders nothing on self-hosted instances (billing_enabled false).
+export default function SubscriptionSection() {
+  const [billing, setBilling] = useState<BillingInfo | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getBilling()
+      .then(setBilling)
+      .catch((e) => setError(e instanceof Error ? e.message : "Could not load billing"));
+  }, []);
+
+  if (!billing?.billing_enabled) return null;
+
+  const isPro = billing.plan === "pro";
+
+  async function redirectTo(action: () => Promise<{ url: string }>) {
+    setBusy(true);
+    setError("");
+    try {
+      const { url } = await action();
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border bg-surface p-6 space-y-4">
+      <div>
+        <h2 className="text-base font-semibold text-foreground">Subscription</h2>
+        <p className="text-xs text-muted mt-0.5">
+          The free plan includes 1 connected source. Pro is $20/month for unlimited sources.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="text-sm font-medium text-foreground">
+            {isPro ? "Pro — $20/month" : "Free"}
+          </div>
+          <div className="text-xs text-muted mt-0.5">
+            {isPro
+              ? `Subscription ${billing.status}.`
+              : `${billing.source_count} of ${billing.source_limit} connected source used.`}
+          </div>
+        </div>
+        {isPro ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => redirectTo(openBillingPortal)}
+            className="text-sm font-semibold px-4 py-2 rounded-lg border border-border text-foreground hover:bg-raised disabled:opacity-60 transition-colors"
+          >
+            {busy ? "Opening…" : "Manage subscription"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => redirectTo(startCheckout)}
+            className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+          >
+            {busy ? "Redirecting…" : "Upgrade to Pro"}
+          </button>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-error">{error}</p>}
+      <p className="text-[11px] text-muted">
+        Plan changes can take a few seconds to apply after checkout.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -240,6 +240,28 @@ export async function searchUsers(query: string): Promise<UserSearchResult[]> {
   return apiFetch(`/api/v1/users/search?q=${encodeURIComponent(query)}`);
 }
 
+// --- Billing ---
+
+export interface BillingInfo {
+  billing_enabled: boolean;
+  plan?: "free" | "pro";
+  status?: string | null;
+  source_count?: number;
+  source_limit?: number;
+}
+
+export async function getBilling(): Promise<BillingInfo> {
+  return apiFetch("/api/v1/billing/me");
+}
+
+export async function startCheckout(): Promise<{ url: string }> {
+  return apiFetch("/api/v1/billing/checkout", { method: "POST" });
+}
+
+export async function openBillingPortal(): Promise<{ url: string }> {
+  return apiFetch("/api/v1/billing/portal", { method: "POST" });
+}
+
 // --- Workspaces ---
 
 export async function createWorkspace(name: string, description?: string): Promise<Workspace> {

--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -24,6 +24,7 @@ export default function HomePage() {
       <VisualizationsShowcase />
       <Features />
       <CliAndPlugin />
+      <Pricing />
       <ClosingCTA />
       <Footer />
     </main>
@@ -845,6 +846,108 @@ function CliAndPlugin() {
   );
 }
 
+const PRICING_TIERS = [
+  {
+    name: "Free",
+    price: "$0",
+    period: "forever",
+    blurb: "Try the whole product with one connected source.",
+    features: [
+      "1 connected integration / external source",
+      "Unlimited pages, sessions, and tables",
+      "Full agent access — CLI, MCP, plugins",
+      "Self-hostable, MIT licensed",
+    ],
+    cta: { label: "Start free →", href: APP_URL },
+    highlight: false,
+  },
+  {
+    name: "Pro",
+    price: "$20",
+    period: "per user / month",
+    blurb: "For people whose agents read from everywhere.",
+    features: [
+      "Unlimited connected sources",
+      "GitHub, Slack, Gmail, Drive, Notion, and more",
+      "Everything in Free",
+    ],
+    cta: { label: "Upgrade in app →", href: APP_URL },
+    highlight: true,
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    period: "annual pricing",
+    blurb: "For teams with security and deployment requirements.",
+    features: [
+      "Custom deployment options",
+      "SSO and admin controls",
+      "Support SLAs",
+    ],
+    cta: { label: "Contact us →", href: "/contact-sales" },
+    highlight: false,
+  },
+];
+
+export function Pricing() {
+  return (
+    <section id="pricing" className="border-b border-border-subtle bg-surface py-24 md:py-32">
+      <div className="mx-auto max-w-[1200px] px-7">
+        <EyebrowDot>Pricing</EyebrowDot>
+        <h2 className="mt-4 font-display text-[clamp(32px,4.2vw,52px)] font-bold leading-[1.05] tracking-[-0.03em] text-ink text-balance">
+          Free to try.
+          <br />
+          <span className="font-medium text-dim">Pay when your agents need more.</span>
+        </h2>
+        <div className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-3">
+          {PRICING_TIERS.map((tier) => (
+            <div
+              key={tier.name}
+              className={`relative flex flex-col rounded-[14px] border bg-background p-7 ${
+                tier.highlight ? "border-brand" : "border-border"
+              }`}
+            >
+              {tier.highlight && (
+                <span className="absolute -top-3 left-7 inline-flex items-center rounded bg-brand px-2 py-1 font-mono text-[10px] font-medium uppercase leading-none tracking-[0.12em] text-white">
+                  Most popular
+                </span>
+              )}
+              <h3 className="font-mono text-[12px] font-medium uppercase tracking-[0.14em] text-brand">
+                {tier.name}
+              </h3>
+              <div className="mt-4 flex items-baseline gap-2">
+                <span className="font-display text-[40px] font-bold tracking-[-0.03em] text-ink">
+                  {tier.price}
+                </span>
+                <span className="text-[13px] text-muted">{tier.period}</span>
+              </div>
+              <p className="mt-2 text-[14.5px] leading-[1.55] text-dim">{tier.blurb}</p>
+              <ul className="mt-6 flex-1 space-y-2.5">
+                {tier.features.map((feature) => (
+                  <li key={feature} className="flex gap-2.5 text-[14px] leading-[1.5] text-foreground">
+                    <span className="mt-[7px] inline-block h-[5px] w-[5px] shrink-0 rounded-full bg-brand" />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href={tier.cta.href}
+                className={`mt-7 inline-flex h-10 items-center justify-center rounded-lg px-4 text-[13.5px] font-medium transition ${
+                  tier.highlight
+                    ? "bg-brand text-white shadow-sm hover:bg-brand-hover"
+                    : "border border-border bg-background text-ink hover:border-ink"
+                }`}
+              >
+                {tier.cta.label}
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 // Variant pages pass ctaHref="#survey" so the signup button leads to the form.
 export function ClosingCTA({ ctaHref = APP_URL }: { ctaHref?: string }) {
   const ctaClassName =
@@ -895,6 +998,7 @@ export function Footer() {
         ["Connect your data", "/connect-your-data"],
         ["Agent-native Drive", "/agent-native-drive"],
         ["Discover", "/discover"],
+        ["Pricing", "/#pricing"],
         ["Docs", "/docs"],
       ],
     },

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -35,6 +35,12 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
             Agent-native Drive
           </Link>
           <Link
+            href="/#pricing"
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
+          >
+            Pricing
+          </Link>
+          <Link
             href="/docs"
             className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
           >


### PR DESCRIPTION
## What

Adds Stripe billing end to end:

- **Landing page** (`www/`): new Pricing section before the closing CTA — Free ($0, 1 connected source), Pro ($20/user/month, unlimited sources, "Most popular"), Enterprise (custom, contact us). Pricing links added to the site header and footer.
- **Pay gate** (backend): billing is **per-user**. A free user may have 1 connected source, counted across all workspaces (`workspace_sources.owner_user_id`). Connecting a 2nd source returns **402** with an upgrade message. Enforcement is connect-time only — existing sources keep syncing if a subscription lapses. The gate excludes the natural key being added, so idempotent re-adds of an existing source still work (create_source is an upsert).
- **Settings** (`frontend/`): new Subscription section showing the current plan, with **Upgrade to Pro** (Stripe Checkout) and **Manage subscription** (Stripe Customer Portal) redirects. The 402 in the source-connect UI links to settings.

## How

- Migration `0111_user_subscriptions`: one row per user (`stripe_customer_id` UNIQUE for webhook lookup, `status` mirrors Stripe's vocabulary). The row is created when checkout starts, so webhooks always resolve regardless of event ordering.
- `billing_service.py`: gate + checkout/portal session creation (`asyncio.to_thread` around the sync stripe SDK) + webhook state sync (`checkout.session.completed`, `customer.subscription.updated/deleted`).
- `routers/billing.py`: `GET /api/v1/billing/me`, `POST /checkout`, `POST /portal`, and the signature-verified public `POST /webhook` (mirrors the Slack webhook pattern).
- Billing is switched on by `STRIPE_SECRET_KEY` being set (plus `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`). Self-hosted instances leave it unset: billing endpoints 404, the gate is a no-op, and the settings section renders nothing.

## Migration note

A parallel in-flight branch also has an uncommitted `0111` migration (`0111_pastes`). Whichever lands second needs a renumber.

## Testing

- `backend/tests/test_billing.py` (8 tests): gate at 2nd source, idempotent re-add not blocked, cross-workspace counting, gate off when unconfigured, `/me` free/pro, webhook downgrade + activation, bad signature → 400.
- Full backend suite: **543 passed, 3 skipped**. Frontend: lint clean, 171 vitest tests pass. `www` builds.
- Verified live in a local stack: settings section in both free and pro states (screenshots below).

For end-to-end Stripe verification: create a $20/mo price in test mode, set the three env vars, run `stripe listen --forward-to localhost:3456/api/v1/billing/webhook`, upgrade with card `4242 4242 4242 4242`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)