### PR TITLE
stash ls: view the whole workspace — integrations included — as one filesystem

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -160,6 +160,22 @@ async def search_sources(
     return {"results": results}
 
 
+@router.get("/tree")
+async def sources_tree(
+    workspace_id: UUID,
+    depth: int = 3,
+    current_user: dict = Depends(get_current_user),
+):
+    """The whole workspace as one filesystem: every source the user can see,
+    each with a nested entry tree trimmed to `depth` levels."""
+    await _require_member(workspace_id, current_user["id"])
+    return {
+        "sources": await source_service.sources_tree(
+            workspace_id, current_user["id"], depth=depth
+        )
+    }
+
+
 @router.get("/{source}/entries")
 async def list_source_entries(
     workspace_id: UUID,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1241,6 +1241,130 @@ async def source_entries(
     return entries
 
 
+# --- sources tree: the whole workspace as one filesystem ---------------------
+
+# Per-source row budget when building the tree. ORDER BY path means a source
+# bigger than this shows a path-ordered slice; the per-directory caps below
+# keep the rendered tree honest about what's hidden.
+TREE_DOC_LIMIT = 5000
+
+
+def build_entry_tree(entries: list[dict], depth: int, per_dir: int) -> list[dict]:
+    """Nest flat path-keyed entries ({path, name, kind}) into a tree trimmed to
+    `depth` levels, with at most `per_dir` children per directory. Directories
+    are synthesized from path segments; a capped directory gets a final
+    {"kind": "truncated", "hidden": n} child so renderers can say '+n more'."""
+    root: dict[str, dict] = {}
+    for entry in entries:
+        parts = [part for part in entry["path"].split("/") if part]
+        if not parts:
+            continue
+        children = root
+        for index, part in enumerate(parts[:depth]):
+            is_entry = index == len(parts) - 1
+            node = children.get(part)
+            if node is None:
+                node = {"name": part, "kind": "folder", "children": {}}
+                children[part] = node
+            if is_entry:
+                node["kind"] = entry["kind"]
+                node["path"] = entry["path"]
+            children = node["children"]
+    return _finalize_tree(root, per_dir)
+
+
+def _finalize_tree(children: dict[str, dict], per_dir: int) -> list[dict]:
+    nodes = []
+    names = sorted(children)
+    for name in names[:per_dir]:
+        node = children[name]
+        out = {"name": node["name"], "kind": node["kind"]}
+        if "path" in node:
+            out["path"] = node["path"]
+        kids = _finalize_tree(node["children"], per_dir)
+        if kids:
+            out["children"] = kids
+        nodes.append(out)
+    hidden = len(names) - per_dir
+    if hidden > 0:
+        nodes.append({"name": "", "kind": "truncated", "hidden": hidden})
+    return nodes
+
+
+def _capped_flat_tree(entries: list[dict], per_dir: int) -> list[dict]:
+    nodes = entries[:per_dir]
+    hidden = len(entries) - per_dir
+    if hidden > 0:
+        nodes.append({"name": "", "kind": "truncated", "hidden": hidden})
+    return nodes
+
+
+async def sources_tree(
+    workspace_id: UUID, user_id: UUID, depth: int = 3, per_dir: int = 50
+) -> list[dict]:
+    """Every source the user can see, each with a nested entry tree — one call
+    renders the whole workspace as a filesystem (`stash ls`)."""
+    from .files_tree_service import list_workspace_pages
+    from .memory_service import list_workspace_sessions
+
+    depth = max(1, min(depth, 10))
+    pages = await list_workspace_pages(workspace_id, user_id)
+    sessions = await list_workspace_sessions(workspace_id, user_id)
+    out = [
+        {
+            "source": NATIVE_FILES,
+            "type": "native_files",
+            "display_name": "Files",
+            "tree": _capped_flat_tree(
+                [{"name": p["name"], "kind": "page", "ref": str(p["id"])} for p in pages],
+                per_dir,
+            ),
+        },
+        {
+            "source": NATIVE_SESSIONS,
+            "type": "native_sessions",
+            "display_name": "Session transcripts",
+            "tree": _capped_flat_tree(
+                [
+                    {
+                        "name": s.get("agent_name") or "session",
+                        "kind": "session",
+                        "ref": s["session_id"],
+                    }
+                    for s in sessions
+                ],
+                per_dir,
+            ),
+        },
+    ]
+
+    for source in await list_connected_sources(workspace_id, user_id):
+        item = {
+            "source": source["id"],
+            "type": source["source_type"],
+            "display_name": source["display_name"],
+            "sync_status": source["sync_status"],
+            "last_synced_at": source["last_synced_at"],
+        }
+        if source["capability"] == "queryable":
+            # Live-query source (Snowflake): no document table to walk.
+            item["tree"] = []
+        else:
+            entries = await list_documents(source, limit=TREE_DOC_LIMIT)
+            item["tree"] = build_entry_tree(entries, depth, per_dir)
+        out.append(item)
+
+    await _audit_source_read(
+        action="source.tree_listed",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source=None,
+        connected=None,
+        metadata={"source_count": len(out)},
+    )
+    return out
+
+
 def source_document_url(
     source_type: str,
     external_ref: str | None,

--- a/backend/tests/test_sources_tree.py
+++ b/backend/tests/test_sources_tree.py
@@ -1,0 +1,110 @@
+"""The sources tree is the agent's answer to "what do you have access to"
+(`stash ls`). Two properties matter beyond plain rendering:
+
+1. EVERY visible source appears — even empty, still-syncing, or queryable ones.
+   A missing source reads as "Stash can't see it", which is the exact
+   impression the feature exists to kill.
+2. Truncation is marked, never silent. A capped directory must say how much it
+   hid, or the tree lies about the company's footprint.
+"""
+
+from uuid import uuid4
+
+from backend.services import source_service
+from backend.services.source_service import build_entry_tree
+
+
+def test_build_entry_tree_nests_paths_into_folders():
+    entries = [
+        {"path": "docs/api.md", "name": "api.md", "kind": "file"},
+        {"path": "docs/guide.md", "name": "guide.md", "kind": "file"},
+        {"path": "README.md", "name": "README.md", "kind": "file"},
+    ]
+    tree = build_entry_tree(entries, depth=3, per_dir=50)
+    assert [n["name"] for n in tree] == ["README.md", "docs"]
+    docs = tree[1]
+    assert docs["kind"] == "folder"
+    assert [n["name"] for n in docs["children"]] == ["api.md", "guide.md"]
+
+
+def test_build_entry_tree_keeps_entry_kind_and_path_on_leaves():
+    entries = [{"path": "#eng/2026-06-01/1717.ts", "name": "1717.ts", "kind": "message"}]
+    tree = build_entry_tree(entries, depth=3, per_dir=50)
+    leaf = tree[0]["children"][0]["children"][0]
+    assert leaf["kind"] == "message"
+    assert leaf["path"] == "#eng/2026-06-01/1717.ts"
+
+
+def test_build_entry_tree_trims_to_depth():
+    entries = [{"path": "a/b/c/d.md", "name": "d.md", "kind": "file"}]
+    tree = build_entry_tree(entries, depth=2, per_dir=50)
+    b = tree[0]["children"][0]
+    assert b["name"] == "b"
+    assert "children" not in b
+
+
+def test_build_entry_tree_marks_truncation_instead_of_silently_dropping():
+    entries = [{"path": f"f{i}.md", "name": f"f{i}.md", "kind": "file"} for i in range(5)]
+    tree = build_entry_tree(entries, depth=1, per_dir=3)
+    assert len(tree) == 4
+    assert tree[-1] == {"name": "", "kind": "truncated", "hidden": 2}
+
+
+async def test_sources_tree_includes_every_visible_source(monkeypatch):
+    from backend.services import files_tree_service, memory_service
+
+    github = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "source_type": "github_repo",
+        "display_name": "stash",
+        "capability": "navigable",
+        "sync_status": "idle",
+        "last_synced_at": None,
+    }
+    snowflake = {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "source_type": "snowflake",
+        "display_name": "warehouse",
+        "capability": "queryable",
+        "sync_status": "idle",
+        "last_synced_at": None,
+    }
+
+    async def fake_pages(workspace_id, user_id):
+        return [{"id": "p1", "name": "Welcome"}]
+
+    async def fake_sessions(workspace_id, user_id):
+        return [{"session_id": "s1", "agent_name": "claude"}]
+
+    async def fake_connected(workspace_id, user_id):
+        return [github, snowflake]
+
+    async def fake_documents(source, prefix="", limit=200):
+        # The registry row itself must pass through — list_documents applies
+        # the per-source security filters (Slack channel / Gong workspace
+        # allowlists) from it.
+        assert source is github
+        return [{"path": "docs/api.md", "name": "api.md", "kind": "file"}]
+
+    audits = []
+
+    async def fake_audit(**kwargs):
+        audits.append(kwargs)
+
+    monkeypatch.setattr(files_tree_service, "list_workspace_pages", fake_pages)
+    monkeypatch.setattr(memory_service, "list_workspace_sessions", fake_sessions)
+    monkeypatch.setattr(source_service, "list_connected_sources", fake_connected)
+    monkeypatch.setattr(source_service, "list_documents", fake_documents)
+    monkeypatch.setattr(source_service, "_audit_source_read", fake_audit)
+
+    sources = await source_service.sources_tree(uuid4(), uuid4(), depth=3)
+
+    assert [s["display_name"] for s in sources] == [
+        "Files",
+        "Session transcripts",
+        "stash",
+        "warehouse",
+    ]
+    assert sources[2]["tree"][0]["name"] == "docs"
+    assert sources[3]["tree"] == []
+    assert audits[0]["action"] == "source.tree_listed"

--- a/cli/client.py
+++ b/cli/client.py
@@ -604,6 +604,9 @@ class StashClient:
     def delete_source(self, workspace_id: str, source_id: str) -> None:
         self._delete(f"/api/v1/workspaces/{workspace_id}/sources/{source_id}")
 
+    def sources_tree(self, workspace_id: str, depth: int = 3) -> list:
+        return self._list(f"/api/v1/workspaces/{workspace_id}/sources/tree", "sources", depth=depth)
+
     def list_source_entries(self, workspace_id: str, source: str, path: str = "") -> list:
         return self._list(
             f"/api/v1/workspaces/{workspace_id}/sources/{source}/entries", "entries", path=path

--- a/cli/main.py
+++ b/cli/main.py
@@ -4153,12 +4153,12 @@ def login_cmd():
         save_enabled_agents([])
 
     # --- Step 5: Which repo? ---
-    repo_root = _git_toplevel()
-    repo_name = repo_root.name if repo_root else None
+    # Outside a git repo, treat the current directory as the repo root: the
+    # .stash manifest lands there and the workspace is named after it.
+    repo_root = _git_toplevel() or Path.cwd()
 
-    this_repo_label = f"This repo ({repo_name})" if repo_name else "This repo"
     repo_choices = [
-        questionary.Choice(this_repo_label, value="this"),
+        questionary.Choice(f"This repo ({repo_root.name})", value="this"),
         questionary.Choice("Another repo", value="other"),
         questionary.Choice("Done", value="done"),
     ]
@@ -4166,22 +4166,17 @@ def login_cmd():
     answer = questionary.select(
         "Which repo do you want to upload transcripts in?",
         choices=repo_choices,
-        default=repo_choices[0] if repo_root else repo_choices[2],
+        default=repo_choices[0],
         use_shortcuts=True,
     ).ask()
     if answer is None:
         raise typer.Exit(1)
 
     if answer == "this":
-        if not repo_root:
-            console.print(
-                "[yellow]Not inside a git repo. Run `stash connect` from a repo.[/yellow]"
-            )
-        else:
-            try:
-                _auto_connect_repo(repo_root, cfg)
-            except StashError as e:
-                console.print(f"[red]Could not connect repo: {e.detail}[/red]")
+        try:
+            _auto_connect_repo(repo_root, cfg)
+        except StashError as e:
+            console.print(f"[red]Could not connect repo: {e.detail}[/red]")
     elif answer == "other":
         _reserve_bottom_padding(4)
         repo_path = typer.prompt("Path to repo").strip()

--- a/cli/main.py
+++ b/cli/main.py
@@ -2830,6 +2830,126 @@ def sources_search(
     _print_search(query, source, workspace_id, limit, as_json)
 
 
+def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
+    """Stable filesystem-style directory name per source. Natives keep their
+    handle ('files', 'sessions'); connected sources slug their display name,
+    with -2/-3 suffixes on collisions."""
+    import re as _re
+
+    names: dict[str, dict] = {}
+    for s in sources:
+        if s["type"].startswith("native_"):
+            name = s["source"]
+        else:
+            name = _re.sub(r"[^a-z0-9._-]+", "-", s["display_name"].lower()).strip("-") or "source"
+        candidate = name
+        suffix = 2
+        while candidate in names:
+            candidate = f"{name}-{suffix}"
+            suffix += 1
+        names[candidate] = s
+    return names
+
+
+def _source_annotation(s: dict) -> str:
+    note = f"  [dim]({s['type']})[/dim]"
+    if s.get("sync_status") == "failed":
+        note += "  [red]sync failed[/red]"
+    elif s.get("sync_status") == "syncing":
+        note += "  [yellow]syncing…[/yellow]"
+    return note
+
+
+def _add_ls_branch(branch, nodes: list[dict]) -> None:
+    for node in nodes:
+        if node["kind"] == "truncated":
+            branch.add(f"[dim]… +{node['hidden']} more[/dim]")
+        elif node.get("children") or node["kind"] == "folder":
+            child = branch.add(f"[bold]{node['name']}/[/bold]")
+            _add_ls_branch(child, node.get("children") or [])
+        else:
+            branch.add(node["name"])
+
+
+@app.command("ls")
+def ls_cmd(
+    path: str = typer.Argument(
+        "", help="Source or path to list, e.g. 'gong' or 'my-repo/docs'. Omit for everything."
+    ),
+    workspace_id: str = typer.Option(None, "--ws"),
+    depth: int = typer.Option(2, "-L", "--depth", help="How many levels deep to render."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Everything Stash can reach, as one filesystem — files, session
+    transcripts, and every connected integration (GitHub, Slack, Gong, …)."""
+    telemetry.record("ls")
+    _require_auth()
+    ws = workspace_id or _resolve_workspace()
+
+    with _client() as c:
+        try:
+            sources = c.sources_tree(ws, depth=depth)
+            if not path:
+                _print_ls_overview(sources, as_json)
+                return
+            _print_ls_path(c, ws, sources, path, as_json)
+        except StashError as e:
+            _err(e)
+
+
+def _print_ls_overview(sources: list[dict], as_json: bool) -> None:
+    if _use_json(as_json):
+        output_json({"sources": sources})
+        return
+    from rich.tree import Tree as RichTree
+
+    root = RichTree("[bold]stash:/[/bold]")
+    for name, s in _source_dir_names(sources).items():
+        branch = root.add(f"[bold]{name}/[/bold]{_source_annotation(s)}")
+        _add_ls_branch(branch, s.get("tree") or [])
+    console.print(root)
+
+
+def _print_ls_path(c: StashClient, ws: str, sources: list[dict], path: str, as_json: bool) -> None:
+    dir_name, _, rest = path.strip("/").partition("/")
+    source = _source_dir_names(sources).get(dir_name)
+    if source is None:
+        console.print(f"[red]No source named '{dir_name}'. Run `stash ls` to see them.[/red]")
+        raise typer.Exit(1)
+
+    entries = c.list_source_entries(ws, source["source"], path=rest)
+    if _use_json(as_json):
+        output_json({"entries": entries})
+        return
+
+    if source["type"].startswith("native_"):
+        for entry in entries:
+            console.print(f"  {entry['name']}  [dim]({entry.get('id', '')})[/dim]")
+        return
+
+    # Entries are a recursive prefix listing; collapse to this directory's
+    # immediate children.
+    base = f"{rest}/" if rest else ""
+    children: dict[str, str] = {}
+    for entry in entries:
+        entry_path = entry.get("path") or ""
+        if entry_path == rest:
+            children[entry_path.rsplit("/", 1)[-1]] = entry.get("kind", "file")
+            continue
+        if not entry_path.startswith(base):
+            continue
+        name, _, remainder = entry_path[len(base) :].partition("/")
+        if remainder or entry.get("kind") == "folder":
+            children[name] = "folder"
+        else:
+            children.setdefault(name, entry.get("kind", "file"))
+    if not children:
+        console.print("[dim]Empty.[/dim]")
+        return
+    for name in sorted(children):
+        console.print(f"  [bold]{name}/[/bold]" if children[name] == "folder" else f"  {name}")
+
+
 # ===========================================================================
 # Shares — grant a person access to a folder/page/file/session by email
 # ===========================================================================
@@ -5069,6 +5189,12 @@ Commands to reach for
 
 Browsing Stash
 --------------
+
+`stash ls` shows everything Stash can reach as one filesystem — workspace
+files, session transcripts, and every connected integration (GitHub, Slack,
+Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it
+and show the tree. Drill in with `stash ls <source>/<path>` and read
+documents with `stash sources read`.
 
 Use `stash vfs` when you want to browse Stash like a filesystem without
 mounting anything into the OS. It accepts bash-shaped commands over the

--- a/cli/main.py
+++ b/cli/main.py
@@ -4109,20 +4109,16 @@ def login_cmd():
         console.print("\n  Run [cyan]stash settings[/cyan] to change agents or endpoint.")
         return
 
-    # --- Step 3: Upload or just read? ---
-    _reserve_bottom_padding(6)
-    usage_mode = questionary.select(
-        "Do you want to upload transcripts, or just read?",
-        choices=[
-            questionary.Choice("Upload transcripts", value="upload"),
-            questionary.Choice("Just read", value="read"),
-        ],
-        use_shortcuts=True,
+    # --- Step 3: Share transcripts? ---
+    _reserve_bottom_padding(4)
+    share_transcripts = questionary.confirm(
+        "Do you want to share your coding agent transcripts to Stash?",
+        default=True,
     ).ask()
-    if usage_mode is None:
+    if share_transcripts is None:
         raise typer.Exit(1)
 
-    if usage_mode == "read":
+    if not share_transcripts:
         _show_setup_complete_splash()
         return
 

--- a/cli/tests/test_ls_cmd.py
+++ b/cli/tests/test_ls_cmd.py
@@ -1,0 +1,104 @@
+"""`stash ls` is the demo-facing answer to "what do you have access to": the
+overview must show every source as a directory (integrations included), and
+drilling into a path must collapse the backend's recursive prefix listing into
+one directory level — otherwise the output reads as a dump, not a filesystem."""
+
+from cli import main
+
+SOURCES = [
+    {"source": "files", "type": "native_files", "display_name": "Files", "tree": []},
+    {
+        "source": "sessions",
+        "type": "native_sessions",
+        "display_name": "Session transcripts",
+        "tree": [{"name": "claude", "kind": "session", "ref": "s1"}],
+    },
+    {
+        "source": "11111111-1111-1111-1111-111111111111",
+        "type": "github_repo",
+        "display_name": "stash",
+        "sync_status": "idle",
+        "tree": [
+            {
+                "name": "docs",
+                "kind": "folder",
+                "children": [
+                    {"name": "api.md", "kind": "file", "path": "docs/api.md"},
+                    {"name": "", "kind": "truncated", "hidden": 7},
+                ],
+            }
+        ],
+    },
+    {
+        "source": "22222222-2222-2222-2222-222222222222",
+        "type": "gong_calls",
+        "display_name": "Gong",
+        "sync_status": "failed",
+        "tree": [],
+    },
+]
+
+
+class FakeClient:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def sources_tree(self, workspace_id, depth=3):
+        return SOURCES
+
+    def list_source_entries(self, workspace_id, source, path=""):
+        assert source == "11111111-1111-1111-1111-111111111111"
+        return [
+            {"path": "docs/api.md", "name": "api.md", "kind": "file"},
+            {"path": "docs/guides/intro.md", "name": "intro.md", "kind": "file"},
+            {"path": "docs2/other.md", "name": "other.md", "kind": "file"},
+        ]
+
+
+def _setup(monkeypatch):
+    monkeypatch.setattr(main, "_require_auth", lambda: {"api_key": "k"})
+    monkeypatch.setattr(main, "_resolve_workspace", lambda: "ws-1")
+    monkeypatch.setattr(main, "_client", lambda: FakeClient())
+    monkeypatch.setattr(main.telemetry, "record", lambda *a, **k: None)
+
+
+def test_ls_overview_shows_every_source_as_a_directory(monkeypatch, capsys):
+    _setup(monkeypatch)
+
+    main.ls_cmd(path="", workspace_id=None, depth=2, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "files/" in out
+    assert "sessions/" in out
+    assert "stash/" in out
+    assert "gong/" in out
+    assert "api.md" in out
+    assert "+7 more" in out
+    assert "sync failed" in out
+
+
+def test_ls_path_collapses_prefix_listing_to_one_level(monkeypatch, capsys):
+    _setup(monkeypatch)
+
+    main.ls_cmd(path="stash/docs", workspace_id=None, depth=2, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "api.md" in out
+    assert "guides/" in out
+    # Recursive descendants and sibling prefix matches must not leak in.
+    assert "intro.md" not in out
+    assert "other.md" not in out
+
+
+def test_ls_unknown_source_fails_loudly(monkeypatch, capsys):
+    _setup(monkeypatch)
+
+    try:
+        main.ls_cmd(path="nope", workspace_id=None, depth=2, as_json=False)
+    except Exception as e:
+        assert type(e).__name__ == "Exit"
+    out = capsys.readouterr().out
+    assert "No source named 'nope'" in out

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -26,6 +26,15 @@ Run `stash prompts agent-guidance` to reprint this rule mid-session.
 
 Most things are plain `stash` CLI subcommands. Always use `--json` for machine-readable output when parsing results.
 
+### Everything as a filesystem
+`stash ls` renders everything Stash can reach as one tree — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree.
+```bash
+stash ls                           # The whole company as a filesystem
+stash ls gong                      # One integration's contents
+stash ls my-repo/docs              # Drill into a directory
+stash ls -L 3 --json               # Deeper tree, machine-readable
+```
+
 ### Virtual filesystem
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 ```bash

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -48,6 +48,10 @@ CONTEXT = (
     "for each file in that session.\n\n"
     "Run `stash prompts agent-guidance` any time you want this guidance "
     "reprinted in full.\n\n"
+    "`stash ls` shows everything Stash can reach as one filesystem — files, "
+    "session transcripts, and every connected integration (GitHub, Slack, "
+    "Gong, Gmail, Drive, Notion, …). When asked what you have access to, run "
+    "it and show the tree; drill in with `stash ls <source>/<path>`.\n\n"
     "Browse Stash through the virtual filesystem first when you need workspace "
     'context: `stash vfs ls /`, `stash vfs "find /workspaces -maxdepth 3 '
     '-type f"`, `stash vfs "rg \\"query\\" /workspaces"`, or '

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -21,6 +21,8 @@ Run `stash prompts agent-guidance` any time you want this guidance reprinted in 
 
 ## Browsing
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, pages, and history from your team's shared Stash workspace.
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -21,6 +21,8 @@ Run `stash prompts agent-guidance` any time you want this guidance reprinted in 
 
 ## Browsing
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`


### PR DESCRIPTION
will make for a great, sexy demo

## What

**One command, one tree.** `stash ls` renders everything Stash can reach as a single filesystem: workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, Jira, Asana, Twitter, Snowflake).

```
stash:/
├── files/  (native_files)
├── sessions/  (native_sessions)
│   └── claude
├── stash/  (github_repo)
│   └── docs/
│       ├── api.md
│       └── … +7 more
└── gong/  (gong_calls)  sync failed

$ stash ls stash/docs
  api.md
  guides/
```

### Backend
- New `GET /api/v1/workspaces/{ws}/sources/tree?depth=` — one round trip for the whole tree. Builds on the existing unified source layer: native files/sessions plus every `workspace_sources` row, with entries pulled through `list_documents` so the per-source security filters (Slack channel / Gong workspace allowlists) keep applying.
- `build_entry_tree` nests the flat path-keyed rows, trims to `depth`, and caps each directory at 50 children with an explicit `{kind: truncated, hidden: n}` marker — the tree never silently hides anything.
- Queryable sources (Snowflake) are listed with an empty tree instead of a live metadata call.
- One `source.tree_listed` audit event per call (instead of one per source).

### CLI
- `stash ls` — the overview tree (rich rendering, `-L` for depth, `--json` for agents). Sync failures show inline on the source line.
- `stash ls <source>/<path>` — lists one directory, collapsing the backend's recursive prefix listing into immediate children.
- `StashClient.sources_tree()`.

### Agent guidance
`stash prompts agent-guidance`, the Claude plugin session-start hook + CLAUDE.md, and the Codex/OpenCode/Cursor plugin docs now tell agents: when asked what you have access to, run `stash ls` and show the tree. That's the demo: "what do you have access to?" → a beautiful filesystem instead of a hodgepodge.

## Why

Exposing integrations as a filesystem is the differentiator: one connection, and the whole company becomes legible to your agent. The backend already modeled integrations as path-keyed document tables; this PR gives that model its front door.

## Testing
- 8 new tests: tree-builder semantics (nesting, depth trim, loud truncation), `sources_tree` shows every visible source, CLI overview + path-collapse + unknown-source failure.
- Full suite: 602 passed, 3 skipped. `ruff` clean.
- Verified route registration order (`/tree` resolves, not captured by `/{source}/entries`) and the rendered output above is real command output.

## Notes
- Per-source row budget is 5000 docs ordered by path; huge sources show a path-ordered slice with truncation markers. Good for the demo; pagination can come later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)