### PR TITLE
Fix stash-ls CI + demo polish: readable names in the tree

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -170,9 +170,7 @@ async def sources_tree(
     each with a nested entry tree trimmed to `depth` levels."""
     await _require_member(workspace_id, current_user["id"])
     return {
-        "sources": await source_service.sources_tree(
-            workspace_id, current_user["id"], depth=depth
-        )
+        "sources": await source_service.sources_tree(workspace_id, current_user["id"], depth=depth)
     }
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1269,6 +1269,9 @@ def build_entry_tree(entries: list[dict], depth: int, per_dir: int) -> list[dict
             if is_entry:
                 node["kind"] = entry["kind"]
                 node["path"] = entry["path"]
+                # Display the document's name, not the raw path segment —
+                # Gmail paths are opaque message ids; the name is the subject.
+                node["name"] = entry["name"] or part
             children = node["children"]
     return _finalize_tree(root, per_dir)
 
@@ -1299,6 +1302,14 @@ def _capped_flat_tree(entries: list[dict], per_dir: int) -> list[dict]:
     return nodes
 
 
+def _session_title(session: dict) -> str:
+    """A human-readable session label: the first user message, one line."""
+    title = " ".join((session.get("title_source") or "").split())
+    if len(title) > 80:
+        title = title[:77] + "…"
+    return title or session.get("agent_name") or "session"
+
+
 async def sources_tree(
     workspace_id: UUID, user_id: UUID, depth: int = 3, per_dir: int = 50
 ) -> list[dict]:
@@ -1327,7 +1338,7 @@ async def sources_tree(
             "tree": _capped_flat_tree(
                 [
                     {
-                        "name": s.get("agent_name") or "session",
+                        "name": _session_title(s),
                         "kind": "session",
                         "ref": s["session_id"],
                     }

--- a/backend/tests/test_sources_tree.py
+++ b/backend/tests/test_sources_tree.py
@@ -35,6 +35,14 @@ def test_build_entry_tree_keeps_entry_kind_and_path_on_leaves():
     assert leaf["path"] == "#eng/2026-06-01/1717.ts"
 
 
+def test_build_entry_tree_leaves_display_document_name_not_path_segment():
+    # Gmail-style: the path is an opaque message id; the name is the subject.
+    entries = [{"path": "19eb2b5141a3bbed", "name": "Q3 board deck", "kind": "message"}]
+    tree = build_entry_tree(entries, depth=3, per_dir=50)
+    assert tree[0]["name"] == "Q3 board deck"
+    assert tree[0]["path"] == "19eb2b5141a3bbed"
+
+
 def test_build_entry_tree_trims_to_depth():
     entries = [{"path": "a/b/c/d.md", "name": "d.md", "kind": "file"}]
     tree = build_entry_tree(entries, depth=2, per_dir=50)
@@ -74,7 +82,14 @@ async def test_sources_tree_includes_every_visible_source(monkeypatch):
         return [{"id": "p1", "name": "Welcome"}]
 
     async def fake_sessions(workspace_id, user_id):
-        return [{"session_id": "s1", "agent_name": "claude"}]
+        return [
+            {
+                "session_id": "s1",
+                "agent_name": "claude",
+                "title_source": "  Fix the onboarding\nwizard  ",
+            },
+            {"session_id": "s2", "agent_name": "claude", "title_source": None},
+        ]
 
     async def fake_connected(workspace_id, user_id):
         return [github, snowflake]
@@ -105,6 +120,8 @@ async def test_sources_tree_includes_every_visible_source(monkeypatch):
         "stash",
         "warehouse",
     ]
+    session_names = [n["name"] for n in sources[1]["tree"]]
+    assert session_names == ["Fix the onboarding wizard", "claude"]
     assert sources[2]["tree"][0]["name"] == "docs"
     assert sources[3]["tree"] == []
     assert audits[0]["action"] == "source.tree_listed"

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -21,6 +21,8 @@ Run `stash prompts agent-guidance` any time you want this guidance reprinted in 
 
 ## Browsing
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, pages, and history from your team's shared Stash workspace.
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -21,6 +21,8 @@ Run `stash prompts agent-guidance` any time you want this guidance reprinted in 
 
 ## Browsing
 
+`stash ls` shows everything Stash can reach as one filesystem — workspace files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
 Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find /workspaces -maxdepth 3 -type f"`


### PR DESCRIPTION
## What

**CI fixes for #609:**
- `black` reformat of the new `/sources/tree` route's return in `backend/routers/sources.py`.
- #609 edited the cursor/codex/opencode plugin guidance without re-copying into `stashai/plugin/assets/` (the byte-identical vendor copies `stash connect` ships). Synced all three.

**Demo polish, found by running `stash ls` against a real account:**
- Tree leaves now display the document's **name** instead of the raw path segment — Gmail entries showed opaque message ids (`19eb2b51…`); now they show subjects.
- `sessions/` entries now use the session's first user message as a one-line title (was a wall of `user` / `claude-subagent` agent names).

## Testing
- `ruff check backend/ cli/` and `black --check backend/ cli/` clean (exact CI scope).
- `plugins/tests` 94 passed; sources-tree + `stash ls` tests 9 passed (2 new: leaf-name display, session titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)