### PR TITLE
Survive transient network errors during history import

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import mimetypes
 import os
+import time
 from pathlib import Path
 
 import httpx
@@ -487,19 +488,28 @@ class StashClient:
         name = os.path.basename(transcript_path)
         if not name.endswith(".gz"):
             name += ".gz"
-        resp = self._request(
-            "POST",
-            f"/api/v1/workspaces/{workspace_id}/transcripts",
-            data={
-                "session_id": session_id,
-                "agent_name": agent_name,
-                "cwd": cwd,
-                "replace": str(replace).lower(),
-            },
-            files={"file": (name, body, "application/gzip")},
-            timeout=120,
-        )
-        return resp.json()
+        # History imports send thousands of sequential uploads, so transient
+        # network blips are expected; retry a couple times before giving up.
+        # Resending is safe: the server skips sessions that already exist.
+        for attempt in range(3):
+            try:
+                resp = self._request(
+                    "POST",
+                    f"/api/v1/workspaces/{workspace_id}/transcripts",
+                    data={
+                        "session_id": session_id,
+                        "agent_name": agent_name,
+                        "cwd": cwd,
+                        "replace": str(replace).lower(),
+                    },
+                    files={"file": (name, body, "application/gzip")},
+                    timeout=120,
+                )
+                return resp.json()
+            except httpx.TransportError:
+                if attempt == 2:
+                    raise
+                time.sleep(1 + attempt)
 
     # --- Files ---
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,7 @@ import textwrap
 import time
 from pathlib import Path
 
+import httpx
 import questionary
 import typer
 from rich.align import Align
@@ -2577,7 +2578,7 @@ def hist_import(
                     replace=replace,
                 )
                 imported += 1
-            except StashError:
+            except (StashError, httpx.HTTPError):
                 errors += 1
             progress.advance(task)
 
@@ -4589,7 +4590,7 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
             try:
                 upload_conversation(c, ws, conv)
                 imported += 1
-            except StashError as e:
+            except (StashError, httpx.HTTPError) as e:
                 errors += 1
                 last_error = str(e)
             progress.advance(task)

--- a/cli/tests/test_client_retry.py
+++ b/cli/tests/test_client_retry.py
@@ -1,0 +1,72 @@
+"""upload_transcript must survive transient network errors.
+
+History imports run thousands of sequential uploads; a single dropped
+connection used to crash the whole onboarding flow (see SSLV3 bad-record-mac
+incident). A blip should be retried, and only a persistent failure should
+surface to the caller.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from cli import client as client_module
+from cli.client import StashClient
+
+
+class _FakeResponse:
+    def json(self):
+        return {"imported": 1}
+
+
+def _make_client(monkeypatch, outcomes):
+    """Build a StashClient whose _request pops from `outcomes` per call.
+
+    Each outcome is either an exception to raise or a response to return.
+    """
+    c = StashClient("https://example.test", api_key="k")
+    calls = []
+
+    def fake_request(method, path, **kwargs):
+        calls.append(path)
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(c, "_request", fake_request)
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    return c, calls
+
+
+def test_upload_transcript_retries_transient_transport_error(monkeypatch, tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("{}\n")
+    c, calls = _make_client(monkeypatch, [httpx.ReadError("blip"), _FakeResponse()])
+
+    result = c.upload_transcript(
+        workspace_id="ws",
+        session_id="s1",
+        transcript_path=transcript,
+        agent_name="claude",
+    )
+
+    assert result == {"imported": 1}
+    assert len(calls) == 2
+
+
+def test_upload_transcript_raises_after_persistent_transport_error(monkeypatch, tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("{}\n")
+    c, calls = _make_client(monkeypatch, [httpx.ReadError("down")] * 3)
+
+    with pytest.raises(httpx.ReadError):
+        c.upload_transcript(
+            workspace_id="ws",
+            session_id="s1",
+            transcript_path=transcript,
+            agent_name="claude",
+        )
+
+    assert len(calls) == 3


### PR DESCRIPTION
## What happened

During onboarding, a single transient TLS error (`SSLV3_ALERT_BAD_RECORD_MAC` → `httpx.ReadError`) crashed the entire flow 2% into a 4,845-conversation history import, dumping a full traceback and skipping the setup-complete splash.

Root cause: both history-import loops only caught `StashError` (raised for non-2xx HTTP responses), and `StashClient` had no handling or retries for httpx transport errors — so any network blip during a ~17-minute sequential upload run propagated raw and aborted onboarding.

## Fix

- `upload_transcript` retries transport errors up to 3 attempts with a short backoff. Resending is safe: the server skips sessions that already have events (`backend/routers/transcripts.py`).
- Both import loops (onboarding and `stash history import`) now catch `httpx.HTTPError` alongside `StashError`, counting the conversation as failed and continuing instead of crashing.

## Tests

New `cli/tests/test_client_retry.py`: a transient transport error is retried and succeeds; a persistent one raises after 3 attempts. Full CLI suite passes (59 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)