### PR TITLE
Billing: add annual Pro plan ($200/year)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -283,8 +283,9 @@ class Settings:
     # default): billing endpoints 404 and the source pay gate is not enforced.
     STRIPE_SECRET_KEY: str | None = os.getenv("STRIPE_SECRET_KEY")
     STRIPE_WEBHOOK_SECRET: str | None = os.getenv("STRIPE_WEBHOOK_SECRET")
-    # The recurring $20/mo Pro price (price_...).
-    STRIPE_PRICE_ID: str | None = os.getenv("STRIPE_PRICE_ID")
+    # The recurring Pro prices (price_...): $20/month and $200/year.
+    STRIPE_MONTHLY_PRICE_ID: str | None = os.getenv("STRIPE_MONTHLY_PRICE_ID")
+    STRIPE_ANNUAL_PRICE_ID: str | None = os.getenv("STRIPE_ANNUAL_PRICE_ID")
 
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -5,9 +5,11 @@ signature, mirroring the Slack webhook pattern in webhooks.py."""
 from __future__ import annotations
 
 import json
+from typing import Literal
 
 import stripe
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
 
 from ..auth import get_current_user
 from ..config import settings
@@ -31,10 +33,14 @@ async def my_billing(current_user: dict = Depends(get_current_user)):
     }
 
 
+class CheckoutRequest(BaseModel):
+    interval: Literal["month", "year"] = "month"
+
+
 @router.post("/checkout")
-async def start_checkout(current_user: dict = Depends(get_current_user)):
+async def start_checkout(body: CheckoutRequest, current_user: dict = Depends(get_current_user)):
     billing_service.require_billing_enabled()
-    return {"url": await billing_service.create_checkout_session(current_user)}
+    return {"url": await billing_service.create_checkout_session(current_user, body.interval)}
 
 
 @router.post("/portal")

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -102,15 +102,18 @@ async def _get_or_create_customer_id(user: dict) -> str:
     return customer.id
 
 
-async def create_checkout_session(user: dict) -> str:
+async def create_checkout_session(user: dict, interval: str) -> str:
     customer_id = await _get_or_create_customer_id(user)
+    price_id = (
+        settings.STRIPE_MONTHLY_PRICE_ID if interval == "month" else settings.STRIPE_ANNUAL_PRICE_ID
+    )
     session = await asyncio.to_thread(
         stripe.checkout.Session.create,
         api_key=settings.STRIPE_SECRET_KEY,
         mode="subscription",
         customer=customer_id,
         client_reference_id=str(user["id"]),
-        line_items=[{"price": settings.STRIPE_PRICE_ID, "quantity": 1}],
+        line_items=[{"price": price_id, "quantity": 1}],
         success_url=f"{settings.PUBLIC_URL}/settings?billing=success",
         cancel_url=f"{settings.PUBLIC_URL}/settings",
     )

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -62,7 +62,8 @@ def _stripe_signature(payload: bytes, secret: str) -> str:
 def billing_on(monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x")
     monkeypatch.setattr(settings, "STRIPE_WEBHOOK_SECRET", "whsec_test_x")
-    monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test_x")
+    monkeypatch.setattr(settings, "STRIPE_MONTHLY_PRICE_ID", "price_test_month")
+    monkeypatch.setattr(settings, "STRIPE_ANNUAL_PRICE_ID", "price_test_year")
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -116,9 +116,11 @@ describe("AppSidebar workspace nav", () => {
     await waitFor(() => expect(navLink("Index")).toBeTruthy());
 
     expect(navLink("Index").getAttribute("href")).toBe("/activity");
-    expect(screen.getByText("Your Brain")).toBeTruthy();
+    // The section headers render only after the workspace fetch resolves,
+    // later than the Index link — await them or this test flakes under load.
+    expect(await screen.findByText("Your Brain")).toBeTruthy();
     // The External Sources header renders even with no connected sources.
-    expect(screen.getByText("External Sources")).toBeTruthy();
+    expect(await screen.findByText("External Sources")).toBeTruthy();
   });
 
   it("does not render native <details> trees for the sections", async () => {

--- a/frontend/src/components/PaywallModal.tsx
+++ b/frontend/src/components/PaywallModal.tsx
@@ -12,11 +12,11 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
 
   useEscapeKey(true, onClose);
 
-  async function upgrade() {
+  async function upgrade(interval: "month" | "year") {
     setBusy(true);
     setError("");
     try {
-      const { url } = await startCheckout();
+      const { url } = await startCheckout(interval);
       window.location.href = url;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not start checkout");
@@ -45,7 +45,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
           for $20/month.
         </div>
         {error && <div className="mt-2 text-[12px] text-error">{error}</div>}
-        <div className="mt-4 flex justify-end gap-1.5">
+        <div className="mt-4 flex items-center justify-end gap-1.5">
           <button
             type="button"
             onClick={onClose}
@@ -57,12 +57,20 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
             type="button"
             autoFocus
             disabled={busy}
-            onClick={upgrade}
+            onClick={() => upgrade("month")}
             className="rounded-md bg-brand px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
           >
             {busy ? "Redirecting…" : "Upgrade — $20/month"}
           </button>
         </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => upgrade("year")}
+          className="mt-2 block w-full text-right text-[11.5px] text-muted underline hover:text-foreground disabled:opacity-60"
+        >
+          or $200/year — 2 months free
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/settings/SubscriptionSection.tsx
+++ b/frontend/src/components/settings/SubscriptionSection.tsx
@@ -66,14 +66,24 @@ export default function SubscriptionSection() {
             {busy ? "Opening…" : "Manage subscription"}
           </button>
         ) : (
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => redirectTo(startCheckout)}
-            className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
-          >
-            {busy ? "Redirecting…" : "Upgrade to Pro"}
-          </button>
+          <div className="flex flex-col items-end gap-1.5">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => redirectTo(() => startCheckout("month"))}
+              className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+            >
+              {busy ? "Redirecting…" : "Upgrade — $20/month"}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => redirectTo(() => startCheckout("year"))}
+              className="text-xs text-muted hover:text-foreground underline disabled:opacity-60"
+            >
+              or $200/year — 2 months free
+            </button>
+          </div>
         )}
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -254,8 +254,11 @@ export async function getBilling(): Promise<BillingInfo> {
   return apiFetch("/api/v1/billing/me");
 }
 
-export async function startCheckout(): Promise<{ url: string }> {
-  return apiFetch("/api/v1/billing/checkout", { method: "POST" });
+export async function startCheckout(interval: "month" | "year"): Promise<{ url: string }> {
+  return apiFetch("/api/v1/billing/checkout", {
+    method: "POST",
+    body: JSON.stringify({ interval }),
+  });
 }
 
 export async function openBillingPortal(): Promise<{ url: string }> {

--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -870,6 +870,7 @@ const PRICING_TIERS = [
       "Unlimited connected sources",
       "GitHub, Slack, Gmail, Drive, Notion, and more",
       "Everything in Free",
+      "$200/year — 2 months free",
     ],
     cta: { label: "Upgrade in app →", href: APP_URL },
     highlight: true,


### PR DESCRIPTION
Follow-up to #608. Checkout now takes an interval (`month` | `year`, default month); `STRIPE_PRICE_ID` is replaced by `STRIPE_MONTHLY_PRICE_ID` + `STRIPE_ANNUAL_PRICE_ID` (nothing was configured in prod yet, so no compat needed). The settings Subscription section and the paywall modal offer "$20/month" with an "or $200/year — 2 months free" option, and the landing Pro card lists the annual price.

Tests: billing suite updated for the new env names (8 passed); frontend 174 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)