### PR TITLE
Pages: delete a page (edit-UI button + agent DELETE endpoint)

### DIFF
--- a/backend/routers/pastes.py
+++ b/backend/routers/pastes.py
@@ -81,6 +81,13 @@ async def update_paste(request: Request, slug: str, token: str, body: PasteUpdat
     return paste
 
 
+@router.delete("/{slug}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_paste(request: Request, slug: str, token: str) -> None:
+    if not await paste_service.delete_paste(slug, token):
+        raise HTTPException(status_code=404, detail="Paste not found")
+
+
 @router.get("/{slug}/comments")
 @limiter.limit("120/minute")
 async def list_comments(request: Request, slug: str) -> dict:

--- a/backend/services/paste_service.py
+++ b/backend/services/paste_service.py
@@ -134,6 +134,18 @@ async def update_paste(
     return paste
 
 
+async def delete_paste(slug: str, token: str) -> bool:
+    """True when a paste matched slug+token and was deleted. Comments and
+    collab state cascade via their FK ON DELETE CASCADE."""
+    pool = get_pool()
+    result = await pool.execute(
+        "DELETE FROM pastes WHERE slug = $1 AND edit_token = $2",
+        slug,
+        token,
+    )
+    return result.endswith(" 1")
+
+
 _COMMENT_COLS = "id, author_name, body, quoted_text, prefix, suffix, created_at"
 
 

--- a/backend/tests/test_pastes.py
+++ b/backend/tests/test_pastes.py
@@ -180,6 +180,34 @@ async def test_comment_requires_body(client: AsyncClient):
     assert resp.status_code == 422
 
 
+async def test_delete_paste_with_token(client: AsyncClient):
+    paste = await _create(client)
+    resp = await client.delete(f"/api/v1/pastes/{paste['slug']}?token={paste['edit_token']}")
+    assert resp.status_code == 204
+    gone = await client.get(f"/api/v1/pastes/{paste['slug']}")
+    assert gone.status_code == 404
+
+
+async def test_delete_paste_wrong_token_404(client: AsyncClient):
+    paste = await _create(client)
+    resp = await client.delete(f"/api/v1/pastes/{paste['slug']}?token=wrong")
+    assert resp.status_code == 404
+    # Still readable — the bad-token delete didn't go through.
+    still = await client.get(f"/api/v1/pastes/{paste['slug']}")
+    assert still.status_code == 200
+
+
+async def test_delete_cascades_comments(client: AsyncClient):
+    paste = await _create(client)
+    await client.post(
+        f"/api/v1/pastes/{paste['slug']}/comments", json={"body": "doomed comment"}
+    )
+    await client.delete(f"/api/v1/pastes/{paste['slug']}?token={paste['edit_token']}")
+    # Comments endpoint on a deleted paste returns an empty list, not the orphan.
+    listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")
+    assert listed.json()["comments"] == []
+
+
 async def test_collab_authorize_paste(client: AsyncClient):
     paste = await _create(client)
     resp = await client.post(

--- a/backend/tests/test_pastes.py
+++ b/backend/tests/test_pastes.py
@@ -199,9 +199,7 @@ async def test_delete_paste_wrong_token_404(client: AsyncClient):
 
 async def test_delete_cascades_comments(client: AsyncClient):
     paste = await _create(client)
-    await client.post(
-        f"/api/v1/pastes/{paste['slug']}/comments", json={"body": "doomed comment"}
-    )
+    await client.post(f"/api/v1/pastes/{paste['slug']}/comments", json={"body": "doomed comment"})
     await client.delete(f"/api/v1/pastes/{paste['slug']}?token={paste['edit_token']}")
     # Comments endpoint on a deleted paste returns an empty list, not the orphan.
     listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")

--- a/www/app/api/pages/[slug]/route.ts
+++ b/www/app/api/pages/[slug]/route.ts
@@ -35,3 +35,18 @@ export async function PATCH(
     headers: { "Content-Type": "application/json" },
   });
 }
+
+// Agent-facing delete, reached as
+// `curl -X DELETE "joinstash.ai/pages/{slug}?token=…"` via the proxy rewrite.
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const res = await fetch(
+    `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}?token=${encodeURIComponent(token)}`,
+    { method: "DELETE" },
+  );
+  return new NextResponse(null, { status: res.status });
+}

--- a/www/app/pages/[slug]/edit/page.tsx
+++ b/www/app/pages/[slug]/edit/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import DeletePasteButton from "../../_components/DeletePasteButton";
 import EditPageClient from "../../_components/EditPageClient";
 import { fetchComments, fetchPaste } from "../../_lib/paste";
 
@@ -41,6 +42,7 @@ export default async function PasteEditPage({
           <span className="min-w-0 flex-1 truncate text-[14.5px] font-medium text-ink">
             Editing: {paste.title}
           </span>
+          <DeletePasteButton slug={paste.slug} token={token} />
           <Link
             href={`/pages/${paste.slug}`}
             className="shrink-0 text-[12.5px] font-medium text-dim hover:text-ink"

--- a/www/app/pages/_components/DeletePasteButton.tsx
+++ b/www/app/pages/_components/DeletePasteButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { deletePaste } from "../actions";
+
+// Delete control for the edit page header. Two-step (click → confirm) so a
+// stray click can't destroy a page, then routes home on success.
+export default function DeletePasteButton({ slug, token }: { slug: string; token: string }) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function remove() {
+    setDeleting(true);
+    setError("");
+    const result = await deletePaste(slug, token);
+    if (result.status === "error") {
+      setDeleting(false);
+      setError(result.message);
+      return;
+    }
+    router.push("/pages");
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="shrink-0 text-[12.5px] font-medium text-red-600 hover:text-red-700"
+      >
+        Delete
+      </button>
+    );
+  }
+
+  return (
+    <span className="flex shrink-0 items-center gap-2 text-[12.5px]">
+      {error ? (
+        <span className="text-red-600">{error}</span>
+      ) : (
+        <span className="text-dim">Delete this page?</span>
+      )}
+      <button
+        type="button"
+        onClick={remove}
+        disabled={deleting}
+        className="font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+      >
+        {deleting ? "Deleting…" : "Yes, delete"}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setConfirming(false);
+          setError("");
+        }}
+        className="text-dim hover:text-ink"
+      >
+        Cancel
+      </button>
+    </span>
+  );
+}

--- a/www/app/pages/_lib/agent-docs.ts
+++ b/www/app/pages/_lib/agent-docs.ts
@@ -27,6 +27,10 @@ Always hand the human **both** links: the view_url to share, and the edit_url to
 
 \`PATCH <edit_url>\` with the new content as the body — raw markdown/HTML, or JSON \`{"content": "..."}\`.
 
+## Delete a page
+
+\`DELETE <view_url>?token=<edit_token>\` — the token is the one in the edit_url. Deletes the page and its comments permanently.
+
 ## Example
 
 \`\`\`

--- a/www/app/pages/actions.ts
+++ b/www/app/pages/actions.ts
@@ -74,6 +74,20 @@ export async function addComment(
 
 export type UpdatePasteResult = { status: "ok" } | { status: "error"; message: string };
 
+export async function deletePaste(slug: string, token: string): Promise<UpdatePasteResult> {
+  const res = await fetch(
+    `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}?token=${encodeURIComponent(token)}`,
+    { method: "DELETE" },
+  );
+  if (res.status === 404) {
+    return { status: "error", message: "Invalid edit link — could not delete." };
+  }
+  if (!res.ok) {
+    return { status: "error", message: "Delete failed. Try again." };
+  }
+  return { status: "ok" };
+}
+
 export async function updatePaste(
   slug: string,
   token: string,

--- a/www/proxy.ts
+++ b/www/proxy.ts
@@ -12,14 +12,15 @@ export async function proxy(request: NextRequest) {
   // Agent API for /pages: a page.tsx and route.ts can't share a segment,
   // so writes rewrite to /api/pages route handlers.
   //   curl -X POST joinstash.ai/pages -d '# Hello'
-  //   curl -X PATCH "joinstash.ai/pages/{slug}?token=…" -d '…'
+  //   curl -X PATCH  "joinstash.ai/pages/{slug}?token=…" -d '…'
+  //   curl -X DELETE "joinstash.ai/pages/{slug}?token=…"
   // (Server-action POSTs to /pages carry a Next-Action header — those
   // belong to the composer UI, not the agent API.)
   if (pathname === "/pages" && request.method === "POST" && !request.headers.get("next-action")) {
     return NextResponse.rewrite(new URL("/api/pages", request.url));
   }
   const pasteSlug = pathname.match(/^\/pages\/([^/]+)$/)?.[1];
-  if (pasteSlug && request.method === "PATCH") {
+  if (pasteSlug && (request.method === "PATCH" || request.method === "DELETE")) {
     return NextResponse.rewrite(new URL(`/api/pages/${pasteSlug}${request.nextUrl.search}`, request.url));
   }
   // Content negotiation on the canonical URL: curl/agents (Accept without


### PR DESCRIPTION
Follow-up to #610/#615. Adds the ability to delete a page, for both humans and agents.

## Backend
- `DELETE /api/v1/pastes/{slug}?token=…` — edit-token gated, returns 204; 404 on bad token (same no-oracle behavior as PATCH). Comments and collab Y.Doc state cascade via their existing `ON DELETE CASCADE` FKs.

## Humans
- The edit page header gets a **Delete** control with a two-step confirm (click → "Delete this page? Yes, delete / Cancel") so a stray click can't nuke a page. On success it routes back to `/pages`.

## Agents
- Reachable on the canonical URL via the same proxy rewrite as PATCH: `curl -X DELETE "https://joinstash.ai/pages/{slug}?token=…"`. The agent-docs page (`/pages/agents`) now documents create / read / update / **delete**.

## Verified locally (full agent lifecycle)
create → edit (PATCH) → comment → delete (DELETE), all over the www canonical URLs, bad token 404s, page 404s after delete; plus the UI button's click-confirm-delete-redirect and comment-cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)