### PR TITLE
Move the free-plan paywall from adding sources to connecting accounts

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
 from ..config import settings
-from ..services import security_audit_service, source_service
+from ..services import billing_service, security_audit_service, source_service
 from . import storage
 from .base import AccountInfo
 from .crypto import integration_fernet, integration_keyring_error
@@ -268,6 +268,7 @@ async def integration_connect(
     """
     p = get_provider(provider)
     _ensure_provider_enabled(provider)
+    await billing_service.ensure_can_connect(current_user["id"])
     # MCP OAuth providers (Granola) register a client + carry PKCE through their
     # own state, so they own the connect step end-to-end.
     if getattr(p, "auth_kind", "oauth") == "mcp_oauth":
@@ -417,6 +418,7 @@ async def integration_connect_with_credentials(
     _ensure_provider_enabled(provider)
     if getattr(p, "auth_kind", "oauth") != "api_key":
         raise HTTPException(status_code=400, detail=f"{provider} does not use credential auth")
+    await billing_service.ensure_can_connect(current_user["id"])
     # Both handlers redact the exception message — provider errors can embed
     # the pasted secrets, so only the exception type is logged.
     try:

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -28,8 +28,8 @@ async def my_billing(current_user: dict = Depends(get_current_user)):
         "billing_enabled": True,
         "plan": "pro" if status in billing_service.ACTIVE_STATUSES else "free",
         "status": status,
-        "source_count": await billing_service.source_count(current_user["id"]),
-        "source_limit": billing_service.FREE_SOURCE_LIMIT,
+        "connection_count": await billing_service.connection_count(current_user["id"]),
+        "connection_limit": billing_service.FREE_CONNECTION_LIMIT,
     }
 
 

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -19,7 +19,6 @@ from ..celery_app import celery
 from ..integrations import storage as integration_storage
 from ..integrations.registry import get_provider
 from ..services import (
-    billing_service,
     permission_service,
     security_audit_service,
     source_service,
@@ -315,9 +314,6 @@ async def add_source(
 
     if not external_ref:
         raise HTTPException(status_code=400, detail="external_ref is required")
-    await billing_service.ensure_can_add_source(
-        current_user["id"], workspace_id, body.source_type, external_ref
-    )
     try:
         created = await source_service.create_source(
             workspace_id=workspace_id,

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -1,9 +1,9 @@
-"""Per-user Stripe billing: Free (1 connected source) vs Pro ($20/mo, unlimited).
+"""Per-user Stripe billing: Free (1 connected account) vs Pro ($20/mo, unlimited).
 
 Billing is switched on by STRIPE_SECRET_KEY being set (managed deployment).
 Self-hosted instances leave it unset: billing endpoints 404 and the pay gate
-is a no-op. Enforcement is connect-time only — existing sources keep syncing
-even after a subscription lapses.
+is a no-op. Enforcement is connect-time only — existing connections keep
+syncing even after a subscription lapses.
 
 The user ↔ Stripe customer mapping row is created when checkout starts, so
 every later webhook resolves by stripe_customer_id regardless of event order.
@@ -23,7 +23,7 @@ from ..database import get_pool
 # Stripe statuses that grant Pro. Everything else (past_due, canceled,
 # unpaid, incomplete) means free-tier enforcement.
 ACTIVE_STATUSES = {"active", "trialing"}
-FREE_SOURCE_LIMIT = 1
+FREE_CONNECTION_LIMIT = 1
 
 
 def billing_enabled() -> bool:
@@ -47,37 +47,26 @@ async def is_pro(user_id: UUID) -> bool:
     return status in ACTIVE_STATUSES
 
 
-async def source_count(user_id: UUID) -> int:
+async def connection_count(user_id: UUID) -> int:
+    """How many integration accounts the user has connected. Each account row
+    counts on its own, so two Gmail mailboxes are two connections."""
     return await get_pool().fetchval(
-        "SELECT count(*) FROM workspace_sources WHERE owner_user_id = $1", user_id
+        "SELECT count(*) FROM user_integrations WHERE user_id = $1", user_id
     )
 
 
-async def ensure_can_add_source(
-    user_id: UUID, workspace_id: UUID, source_type: str, external_ref: str
-) -> None:
-    """Connect-time pay gate. Counts the user's sources across all workspaces,
-    excluding the natural key being added — create_source is an upsert, and a
-    free user re-adding their one existing source must keep working."""
+async def ensure_can_connect(user_id: UUID) -> None:
+    """Connect-time pay gate. The free plan includes one connected account; a
+    second account — another provider or another mailbox on the same one —
+    requires Pro. Sources added under a connection are unlimited."""
     if not billing_enabled():
         return
     if await is_pro(user_id):
         return
-    others = await get_pool().fetchval(
-        """
-        SELECT count(*) FROM workspace_sources
-        WHERE owner_user_id = $1
-          AND NOT (workspace_id = $2 AND source_type = $3 AND external_ref = $4)
-        """,
-        user_id,
-        workspace_id,
-        source_type,
-        external_ref,
-    )
-    if others >= FREE_SOURCE_LIMIT:
+    if await connection_count(user_id) >= FREE_CONNECTION_LIMIT:
         raise HTTPException(
             status_code=402,
-            detail="The free plan includes 1 connected source. Upgrade to Pro to connect more.",
+            detail="The free plan includes 1 connected account. Upgrade to Pro to connect more.",
         )
 
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -1,9 +1,10 @@
 """Billing: the connect-time pay gate and Stripe webhook state sync.
 
-Why these tests matter: the free plan is enforced ONLY when adding a source —
-a free user keeps one connected source, idempotent re-adds of that source must
-not be blocked (create_source is an upsert), and an active subscription lifts
-the cap. Billing is off entirely when STRIPE_SECRET_KEY is unset (self-host).
+Why these tests matter: the free plan is enforced when CONNECTING an account —
+a free user keeps one connected account (each account row counts, so a second
+mailbox on the same provider also gates), and an active subscription lifts the
+cap. Sources added under a connection are unlimited. Billing is off entirely
+when STRIPE_SECRET_KEY is unset (self-host).
 """
 
 import hashlib
@@ -13,9 +14,12 @@ import time
 from uuid import UUID
 
 import pytest
+from cryptography.fernet import Fernet
+from fastapi import HTTPException
 from httpx import AsyncClient
 
 from backend.config import settings
+from backend.services import billing_service
 
 from .conftest import unique_name
 
@@ -34,21 +38,15 @@ def _auth(api_key: str) -> dict:
     return {"Authorization": f"Bearer {api_key}"}
 
 
-async def _create_workspace(client: AsyncClient, api_key: str) -> UUID:
-    resp = await client.post(
-        "/api/v1/workspaces",
-        json={"name": unique_name("bill_ws")},
-        headers=_auth(api_key),
-    )
-    assert resp.status_code == 201
-    return UUID(resp.json()["id"])
-
-
-async def _add_repo(client: AsyncClient, api_key: str, ws: UUID, repo: str):
-    return await client.post(
-        f"/api/v1/workspaces/{ws}/sources",
-        json={"source_type": "github_repo", "external_ref": repo},
-        headers=_auth(api_key),
+async def _connect_account(pool, user_id: UUID, provider: str, account_key: str = "default"):
+    """Simulate a completed connection by inserting the stored-token row."""
+    await pool.execute(
+        "INSERT INTO user_integrations "
+        "(user_id, provider, access_token_encrypted, account_key) VALUES ($1, $2, $3, $4)",
+        user_id,
+        provider,
+        b"\x00",
+        account_key,
     )
 
 
@@ -66,61 +64,86 @@ def billing_on(monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_ANNUAL_PRICE_ID", "price_test_year")
 
 
+@pytest.fixture
+def github_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "INTEGRATIONS_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setattr(settings, "GITHUB_OAUTH_CLIENT_ID", "gh-client")
+    monkeypatch.setattr(settings, "GITHUB_OAUTH_CLIENT_SECRET", "gh-secret")
+    monkeypatch.setattr(settings, "GITHUB_OAUTH_REDIRECT_URI", "https://app.example.com/callback")
+
+
 @pytest.mark.asyncio
-async def test_free_user_gated_at_second_source(client, pool, billing_on):
-    api_key, user_id = await _register(client)
-    ws = await _create_workspace(client, api_key)
+async def test_free_user_gated_at_second_connection(client, pool, billing_on):
+    _, user_id = await _register(client)
 
-    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
+    # No connections yet — the first one is free.
+    await billing_service.ensure_can_connect(user_id)
 
-    blocked = await _add_repo(client, api_key, ws, "acme/two")
-    assert blocked.status_code == 402
-    assert "Upgrade to Pro" in blocked.json()["detail"]
+    await _connect_account(pool, user_id, "github")
+    with pytest.raises(HTTPException) as exc:
+        await billing_service.ensure_can_connect(user_id)
+    assert exc.value.status_code == 402
+    assert "Upgrade to Pro" in exc.value.detail
 
-    # Re-adding the same source is an upsert, not a new source — must not 402.
-    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
-
+    # An active subscription lifts the cap.
     await pool.execute(
         "INSERT INTO user_subscriptions (user_id, stripe_customer_id, status) "
         "VALUES ($1, 'cus_gate', 'active')",
         user_id,
     )
-    assert (await _add_repo(client, api_key, ws, "acme/two")).status_code == 200
+    await billing_service.ensure_can_connect(user_id)
 
 
 @pytest.mark.asyncio
-async def test_gate_counts_sources_across_workspaces(client, billing_on):
-    api_key, _ = await _register(client)
-    ws_a = await _create_workspace(client, api_key)
-    ws_b = await _create_workspace(client, api_key)
+async def test_each_account_counts(client, pool, billing_on):
+    """A second mailbox on an already-connected provider is a second account,
+    so it gates just like a brand-new provider would."""
+    _, user_id = await _register(client)
+    await _connect_account(pool, user_id, "gmail", account_key="a@x.com")
 
-    assert (await _add_repo(client, api_key, ws_a, "acme/one")).status_code == 200
-    assert (await _add_repo(client, api_key, ws_b, "acme/two")).status_code == 402
+    assert await billing_service.connection_count(user_id) == 1
+    with pytest.raises(HTTPException) as exc:
+        await billing_service.ensure_can_connect(user_id)
+    assert exc.value.status_code == 402
 
 
 @pytest.mark.asyncio
-async def test_gate_off_when_billing_disabled(client, monkeypatch):
+async def test_gate_off_when_billing_disabled(client, pool, monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None)
-    api_key, _ = await _register(client)
-    ws = await _create_workspace(client, api_key)
+    _, user_id = await _register(client)
+    await _connect_account(pool, user_id, "github")
 
-    assert (await _add_repo(client, api_key, ws, "acme/one")).status_code == 200
-    assert (await _add_repo(client, api_key, ws, "acme/two")).status_code == 200
+    # Self-hosted: no cap even with an existing connection.
+    await billing_service.ensure_can_connect(user_id)
+
+
+@pytest.mark.asyncio
+async def test_connect_endpoint_gates_second_connection(client, pool, billing_on, github_enabled):
+    api_key, user_id = await _register(client)
+
+    first = await client.get("/api/v1/integrations/github/connect", headers=_auth(api_key))
+    assert first.status_code == 200
+    assert "github.com/login/oauth/authorize" in first.json()["authorize_url"]
+
+    await _connect_account(pool, user_id, "github")
+
+    blocked = await client.get("/api/v1/integrations/github/connect", headers=_auth(api_key))
+    assert blocked.status_code == 402
+    assert "Upgrade to Pro" in blocked.json()["detail"]
 
 
 @pytest.mark.asyncio
 async def test_billing_me_reflects_plan(client, pool, billing_on):
     api_key, user_id = await _register(client)
-    ws = await _create_workspace(client, api_key)
-    await _add_repo(client, api_key, ws, "acme/one")
+    await _connect_account(pool, user_id, "github")
 
     me = (await client.get("/api/v1/billing/me", headers=_auth(api_key))).json()
     assert me == {
         "billing_enabled": True,
         "plan": "free",
         "status": None,
-        "source_count": 1,
-        "source_limit": 1,
+        "connection_count": 1,
+        "connection_limit": 1,
     }
 
     await pool.execute(

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
@@ -8,6 +8,7 @@ import { useBreadcrumbs } from "../../../../../../components/BreadcrumbContext";
 import { useConfirm } from "../../../../../../components/ConfirmDialog";
 import { useAuth } from "../../../../../../hooks/useAuth";
 import {
+  ApiError,
   deleteWorkspaceSource,
   fetchSourceHistory,
   getSourceEntries,
@@ -35,6 +36,7 @@ import {
   primaryButton,
   secondaryButton,
 } from "../../../../../../components/integrations/pickers";
+import PaywallModal from "../../../../../../components/PaywallModal";
 
 export default function IntegrationPage() {
   const params = useParams();
@@ -55,6 +57,7 @@ export default function IntegrationPage() {
   const [showCreds, setShowCreds] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [paymentRequired, setPaymentRequired] = useState(false);
 
   useBreadcrumbs(
     [{ label: connector?.label ?? "Integration" }],
@@ -111,7 +114,11 @@ export default function IntegrationPage() {
     try {
       await startConnect(connector!.provider, pathname);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not start connection");
+      if (e instanceof ApiError && e.status === 402) {
+        setPaymentRequired(true);
+      } else {
+        setError(e instanceof Error ? e.message : "Could not start connection");
+      }
       setBusy(null);
     }
   }
@@ -125,7 +132,11 @@ export default function IntegrationPage() {
       await refresh();
       return true;
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not connect");
+      if (e instanceof ApiError && e.status === 402) {
+        setPaymentRequired(true);
+      } else {
+        setError(e instanceof Error ? e.message : "Could not connect");
+      }
       return false;
     } finally {
       setBusy(null);
@@ -263,6 +274,8 @@ export default function IntegrationPage() {
             {error}
           </div>
         )}
+
+        {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
 
         {/* Add a <thing> */}
         {connected && (

--- a/frontend/src/components/PaywallModal.tsx
+++ b/frontend/src/components/PaywallModal.tsx
@@ -5,7 +5,7 @@ import { useEscapeKey } from "../hooks/useEscapeKey";
 import { startCheckout } from "../lib/api";
 
 // Shown when the backend returns 402 on a connect attempt: the free plan's
-// one-source limit is hit and adding more requires Pro.
+// one-account limit is hit and connecting more requires Pro.
 export default function PaywallModal({ onClose }: { onClose: () => void }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -40,8 +40,8 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
           Upgrade to Pro
         </div>
         <div className="mt-1.5 text-[12.5px] leading-[1.55] text-muted">
-          The free plan includes 1 connected source. Pro unlocks unlimited
-          connected sources — GitHub, Slack, Gmail, Drive, Notion, and more —
+          The free plan includes 1 connected account. Pro unlocks unlimited
+          integrations — GitHub, Slack, Gmail, Drive, Notion, and more —
           for $20/month.
         </div>
         {error && <div className="mt-2 text-[12px] text-error">{error}</div>}

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { ApiError } from "@/lib/api";
 import {
   listIntegrations,
   startConnect,
@@ -15,6 +16,7 @@ import { ObsidianIcon } from "./BrandIcons";
 import { CONNECTORS, connectorIcon, type Connector } from "./connectors";
 import { CredentialForm, primaryButton, secondaryButton } from "./pickers";
 import ObsidianVaultDropZone from "./ObsidianVaultDropZone";
+import PaywallModal from "../PaywallModal";
 
 type Props = {
   workspaceId: string | null;
@@ -36,6 +38,7 @@ export default function SourceConnectorList({
   const [expanded, setExpanded] = useState<IntegrationProvider | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [paymentRequired, setPaymentRequired] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -66,7 +69,11 @@ export default function SourceConnectorList({
     try {
       await startConnect(connector.provider, returnTo);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not start connection");
+      if (e instanceof ApiError && e.status === 402) {
+        setPaymentRequired(true);
+      } else {
+        setError(e instanceof Error ? e.message : "Could not start connection");
+      }
       setBusy(null);
     }
   }
@@ -80,7 +87,11 @@ export default function SourceConnectorList({
       await refresh();
       return true;
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not connect");
+      if (e instanceof ApiError && e.status === 402) {
+        setPaymentRequired(true);
+      } else {
+        setError(e instanceof Error ? e.message : "Could not connect");
+      }
       return false;
     } finally {
       setBusy(null);
@@ -154,6 +165,8 @@ export default function SourceConnectorList({
           {error}
         </div>
       )}
+
+      {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
     </div>
   );
 }

--- a/frontend/src/components/integrations/pickers.test.tsx
+++ b/frontend/src/components/integrations/pickers.test.tsx
@@ -5,14 +5,12 @@ import type { Connector } from "./connectors";
 import { AddSourceControls } from "./pickers";
 
 const addWorkspaceSource = vi.fn();
-const startCheckout = vi.fn();
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/api")>();
   return {
     ...actual,
     addWorkspaceSource: (...args: unknown[]) => addWorkspaceSource(...args),
-    startCheckout: (...args: unknown[]) => startCheckout(...args),
   };
 });
 
@@ -40,26 +38,10 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-// The free plan allows 1 connected source; the backend rejects further adds
-// with 402. The user must see the paywall (not just an error) so the upgrade
-// path is one click away.
-describe("AddSourceControls pay gate", () => {
-  it("shows the paywall modal when the backend returns 402", async () => {
-    addWorkspaceSource.mockRejectedValue(
-      new ApiError(402, "The free plan includes 1 connected source. Upgrade to Pro to connect more.")
-    );
-    renderControls();
-
-    fireEvent.click(screen.getByText("Add My Drive"));
-
-    expect(await screen.findByRole("dialog", { name: "Upgrade to Pro" })).toBeTruthy();
-    expect(addWorkspaceSource).toHaveBeenCalledOnce();
-
-    fireEvent.click(screen.getByText("Not now"));
-    expect(screen.queryByRole("dialog")).toBeNull();
-  });
-
-  it("does not show the paywall for other errors", async () => {
+// Adding sources under a connection is unlimited — the pay gate lives on the
+// connect step, not here. A failed add just surfaces the backend error inline.
+describe("AddSourceControls", () => {
+  it("surfaces the backend error inline, with no paywall", async () => {
     addWorkspaceSource.mockRejectedValue(new ApiError(400, "external_ref is required"));
     renderControls();
 
@@ -67,16 +49,5 @@ describe("AddSourceControls pay gate", () => {
 
     expect(await screen.findByText("external_ref is required")).toBeTruthy();
     expect(screen.queryByRole("dialog")).toBeNull();
-  });
-
-  it("starts checkout from the paywall modal", async () => {
-    addWorkspaceSource.mockRejectedValue(new ApiError(402, "Upgrade to Pro to connect more."));
-    startCheckout.mockReturnValue(new Promise(() => {})); // redirect never settles in tests
-    renderControls();
-
-    fireEvent.click(screen.getByText("Add My Drive"));
-    fireEvent.click(await screen.findByText("Upgrade — $20/month"));
-
-    expect(startCheckout).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
-import { addWorkspaceSource, ApiError } from "@/lib/api";
+import { addWorkspaceSource } from "@/lib/api";
 import {
   type IntegrationAccount,
   listAsanaProjects,
@@ -19,7 +19,6 @@ import {
   type SlackChannelSummary,
 } from "@/lib/integrations";
 
-import PaywallModal from "../PaywallModal";
 import { AsanaIcon, GitHubIcon, JiraIcon, NotionIcon, SlackIcon } from "./BrandIcons";
 import type { Connector } from "./connectors";
 
@@ -56,13 +55,11 @@ export function AddSourceControls({
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
-  const [paymentRequired, setPaymentRequired] = useState(false);
   const [gongWorkspaceIds, setGongWorkspaceIds] = useState("");
 
   async function add(body?: AddSourceBody) {
     setBusy(true);
     setError("");
-    setPaymentRequired(false);
     try {
       await addWorkspaceSource(workspaceId, {
         source_type: connector.sourceType,
@@ -72,7 +69,6 @@ export function AddSourceControls({
       return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not add source");
-      setPaymentRequired(e instanceof ApiError && e.status === 402);
       return false;
     } finally {
       setBusy(false);
@@ -80,10 +76,7 @@ export function AddSourceControls({
   }
 
   const errorRow = error ? (
-    <>
-      <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
-      {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
-    </>
+    <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
   ) : null;
 
   if (connector.kind === "github") {

--- a/frontend/src/components/settings/SubscriptionSection.tsx
+++ b/frontend/src/components/settings/SubscriptionSection.tsx
@@ -41,7 +41,7 @@ export default function SubscriptionSection() {
       <div>
         <h2 className="text-base font-semibold text-foreground">Subscription</h2>
         <p className="text-xs text-muted mt-0.5">
-          The free plan includes 1 connected source. Pro is $20/month for unlimited sources.
+          The free plan includes 1 connected account. Pro is $20/month for unlimited integrations.
         </p>
       </div>
 
@@ -53,7 +53,7 @@ export default function SubscriptionSection() {
           <div className="text-xs text-muted mt-0.5">
             {isPro
               ? `Subscription ${billing.status}.`
-              : `${billing.source_count} of ${billing.source_limit} connected source used.`}
+              : `${billing.connection_count} of ${billing.connection_limit} connected account used.`}
           </div>
         </div>
         {isPro ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -246,8 +246,8 @@ export interface BillingInfo {
   billing_enabled: boolean;
   plan?: "free" | "pro";
   status?: string | null;
-  source_count?: number;
-  source_limit?: number;
+  connection_count?: number;
+  connection_limit?: number;
 }
 
 export async function getBilling(): Promise<BillingInfo> {


### PR DESCRIPTION
## Why

The free-plan pay gate previously fired only when **adding a source** to a workspace, so **connecting** an integration account never triggered the paywall — connecting felt unmetered even though it's the action users perceive as "adding an integration."

## What changed

Move enforcement to the **connect** step. The free plan now includes **one connected account** (each account row counts, so a second mailbox on an already-connected provider also gates). Sources added under a connection are unlimited.

### Backend
- `billing_service.py` — replace `ensure_can_add_source` / `FREE_SOURCE_LIMIT` with `ensure_can_connect` / `FREE_CONNECTION_LIMIT`, counting `user_integrations` rows.
- `integrations/router.py` — gate both connect entry points: `GET /{provider}/connect` (covers OAuth, PKCE, and Granola's MCP-OAuth) and `POST /{provider}/credentials` (api-key: Gong/Snowflake).
- `routers/sources.py` — drop the source-level gate.
- `billing/me` — report `connection_count` / `connection_limit`.

### Frontend
- Surface `PaywallModal` on a 402 from both connect surfaces — the "Connect a source" modal (`SourceConnectorList`) and the per-provider integration page.
- Remove the now-dead add-source paywall handling from the picker.
- Copy updates in `PaywallModal` and `SubscriptionSection` ("1 connected account").

## Behavior

A free user connects their first integration free; the **second connect attempt** — any provider, or a second account on the same provider (Gmail "Connect another") — shows the upgrade modal. Self-hosted (no `STRIPE_SECRET_KEY`) and Pro bypass as before.

## Tests
- Rewrote `test_billing.py` around the connection gate (service-level rule + a live `/connect` 402 wiring test) — 9 passed.
- `test_sources.py` + `test_integration_sources.py` + `test_granola.py` — 116 passed.
- `ruff` clean; frontend picker test passes; `eslint` clean on changed files.

https://claude.ai/code/session_01MfrywvG1ENTbCx2395R2Su

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfrywvG1ENTbCx2395R2Su)_