### PR TITLE
Pages: full comment CRUD for agents (edit + delete, canonical-domain routes)

### DIFF
--- a/backend/migrations/versions/0113_paste_comment_tokens.py
+++ b/backend/migrations/versions/0113_paste_comment_tokens.py
@@ -1,0 +1,26 @@
+"""Per-comment edit tokens for the pastes pastebin.
+
+Comments are anonymous like the pages they hang on. To let the author
+edit or delete a comment later — and let agents manage comments they
+post — each comment gets its own write token, minted at create time and
+returned once (same model as a paste's edit_token). Deletion also
+accepts the parent paste's edit_token so the page owner can moderate.
+
+Revision ID: 0113
+Revises: 0112
+"""
+
+from alembic import op
+
+revision = "0113"
+down_revision = "0112"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE paste_comments ADD COLUMN edit_token TEXT NOT NULL DEFAULT ''")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE paste_comments DROP COLUMN edit_token")

--- a/backend/routers/pastes.py
+++ b/backend/routers/pastes.py
@@ -103,3 +103,29 @@ async def add_comment(request: Request, slug: str, body: CommentCreateRequest) -
     if not comment:
         raise HTTPException(status_code=404, detail="Paste not found")
     return comment
+
+
+class CommentUpdateRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=5_000)
+
+
+@router.patch("/{slug}/comments/{comment_id}")
+@limiter.limit("30/minute")
+async def update_comment(
+    request: Request, slug: str, comment_id: str, token: str, body: CommentUpdateRequest
+) -> dict:
+    if not token:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    comment = await paste_service.update_comment(slug, comment_id, token, body.body)
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    return comment
+
+
+@router.delete("/{slug}/comments/{comment_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_comment(request: Request, slug: str, comment_id: str, token: str) -> None:
+    if not token:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    if not await paste_service.delete_comment(slug, comment_id, token):
+        raise HTTPException(status_code=404, detail="Comment not found")

--- a/backend/services/paste_service.py
+++ b/backend/services/paste_service.py
@@ -157,13 +157,15 @@ async def add_comment(
     prefix: str,
     suffix: str,
 ) -> dict | None:
-    """None means the paste doesn't exist."""
+    """None means the paste doesn't exist. The returned dict includes the
+    comment's own edit_token — the only time it's exposed."""
     pool = get_pool()
     row = await pool.fetchrow(
         f"""
-        INSERT INTO paste_comments (paste_id, author_name, body, quoted_text, prefix, suffix)
-        SELECT id, $2, $3, $4, $5, $6 FROM pastes WHERE slug = $1
-        RETURNING {_COMMENT_COLS}
+        INSERT INTO paste_comments
+            (paste_id, author_name, body, quoted_text, prefix, suffix, edit_token)
+        SELECT id, $2, $3, $4, $5, $6, $7 FROM pastes WHERE slug = $1
+        RETURNING edit_token, {_COMMENT_COLS}
         """,
         slug,
         author_name.strip(),
@@ -171,8 +173,50 @@ async def add_comment(
         quoted_text,
         prefix,
         suffix,
+        secrets.token_urlsafe(16),
     )
     return dict(row) if row else None
+
+
+async def update_comment(slug: str, comment_id: str, token: str, body: str) -> dict | None:
+    """Edit a comment's body — only its author (the comment's edit_token).
+    None means not-found-or-bad-token."""
+    pool = get_pool()
+    # Qualify the RETURNING columns: id/created_at exist on both tables, so
+    # they're ambiguous in an UPDATE...FROM without the alias.
+    returning = ", ".join(f"c.{col.strip()}" for col in _COMMENT_COLS.split(","))
+    row = await pool.fetchrow(
+        f"""
+        UPDATE paste_comments c
+        SET body = $4
+        FROM pastes p
+        WHERE c.id = $2 AND c.paste_id = p.id AND p.slug = $1 AND c.edit_token = $3
+        RETURNING {returning}
+        """,
+        slug,
+        comment_id,
+        token,
+        body,
+    )
+    return dict(row) if row else None
+
+
+async def delete_comment(slug: str, comment_id: str, token: str) -> bool:
+    """True when deleted. Authorized by the comment's own edit_token (author)
+    or the parent paste's edit_token (page owner moderation)."""
+    pool = get_pool()
+    result = await pool.execute(
+        """
+        DELETE FROM paste_comments c
+        USING pastes p
+        WHERE c.id = $2 AND c.paste_id = p.id AND p.slug = $1
+          AND ($3 = c.edit_token OR $3 = p.edit_token)
+        """,
+        slug,
+        comment_id,
+        token,
+    )
+    return result.endswith(" 1")
 
 
 async def list_comments(slug: str) -> list[dict]:

--- a/backend/tests/test_pastes.py
+++ b/backend/tests/test_pastes.py
@@ -180,6 +180,84 @@ async def test_comment_requires_body(client: AsyncClient):
     assert resp.status_code == 422
 
 
+async def _add_comment(client: AsyncClient, slug: str, **overrides) -> dict:
+    body = {"body": "a comment", **overrides}
+    resp = await client.post(f"/api/v1/pastes/{slug}/comments", json=body)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def test_add_comment_returns_edit_token_once(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    assert comment["edit_token"]
+    # The token never comes back out of the list endpoint.
+    listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")
+    assert "edit_token" not in listed.json()["comments"][0]
+
+
+async def test_edit_comment_with_author_token(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"], body="original")
+    resp = await client.patch(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={comment['edit_token']}",
+        json={"body": "edited"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["body"] == "edited"
+
+
+async def test_edit_comment_wrong_token_404(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.patch(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=wrong",
+        json={"body": "edited"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_delete_comment_by_author(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={comment['edit_token']}"
+    )
+    assert resp.status_code == 204
+    listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")
+    assert listed.json()["comments"] == []
+
+
+async def test_delete_comment_by_page_owner(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    # The page's edit_token moderates any comment on the page.
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={paste['edit_token']}"
+    )
+    assert resp.status_code == 204
+
+
+async def test_delete_comment_wrong_token_404(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=nope"
+    )
+    assert resp.status_code == 404
+    assert (
+        len((await client.get(f"/api/v1/pastes/{paste['slug']}/comments")).json()["comments"]) == 1
+    )
+
+
+async def test_comment_token_empty_rejected(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    # An empty token must not match the column's '' default on legacy rows.
+    resp = await client.delete(f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=")
+    assert resp.status_code == 404
+
+
 async def test_delete_paste_with_token(client: AsyncClient):
     paste = await _create(client)
     resp = await client.delete(f"/api/v1/pastes/{paste['slug']}?token={paste['edit_token']}")

--- a/www/app/api/pages/[slug]/comments/[commentId]/route.ts
+++ b/www/app/api/pages/[slug]/comments/[commentId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Agent-facing comment edit/delete on the canonical domain:
+//   PATCH  joinstash.ai/pages/{slug}/comments/{id}?token=…  (comment author token)
+//   DELETE joinstash.ai/pages/{slug}/comments/{id}?token=…  (comment author OR page edit token)
+function commentUrl(slug: string, id: string, token: string) {
+  return (
+    `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments/${encodeURIComponent(id)}` +
+    `?token=${encodeURIComponent(token)}`
+  );
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; commentId: string }> },
+) {
+  const { slug, commentId } = await params;
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const contentType = request.headers.get("content-type") ?? "";
+  const rawBody = await request.text();
+  const payload = contentType.includes("application/json")
+    ? JSON.parse(rawBody)
+    : { body: rawBody };
+
+  const res = await fetch(commentUrl(slug, commentId, token), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; commentId: string }> },
+) {
+  const { slug, commentId } = await params;
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const res = await fetch(commentUrl(slug, commentId, token), { method: "DELETE" });
+  return new NextResponse(null, { status: res.status });
+}

--- a/www/app/api/pages/[slug]/comments/route.ts
+++ b/www/app/api/pages/[slug]/comments/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Agent-facing comment list/add on the canonical domain:
+//   GET  joinstash.ai/pages/{slug}/comments
+//   POST joinstash.ai/pages/{slug}/comments   (raw text body = the comment)
+function commentsUrl(slug: string) {
+  return `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments`;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const res = await fetch(commentsUrl(slug), { cache: "no-store" });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const contentType = request.headers.get("content-type") ?? "";
+  const rawBody = await request.text();
+  const payload = contentType.includes("application/json")
+    ? JSON.parse(rawBody)
+    : { body: rawBody };
+
+  const res = await fetch(commentsUrl(slug), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/www/app/pages/_lib/agent-docs.ts
+++ b/www/app/pages/_lib/agent-docs.ts
@@ -31,9 +31,20 @@ Always hand the human **both** links: the view_url to share, and the edit_url to
 
 \`DELETE <view_url>?token=<edit_token>\` — the token is the one in the edit_url. Deletes the page and its comments permanently.
 
+## Comments
+
+Pages can carry comments (anchored to selected text, or general). All comment endpoints live under the page's view URL:
+
+- **Read**: \`GET <view_url>/comments\` → \`{"comments": [...]}\`
+- **Add**: \`POST <view_url>/comments\` with a raw body (the comment text) or JSON \`{"body": "...", "author_name": "...", "quoted_text": "..."}\`. Set \`quoted_text\` to a verbatim snippet from the page to anchor the comment to it. The response includes the comment's \`id\` and a one-time \`edit_token\`.
+- **Edit**: \`PATCH <view_url>/comments/{id}?token=<comment_edit_token>\` with the new body. Author only.
+- **Delete**: \`DELETE <view_url>/comments/{id}?token=<token>\` — the token can be the comment's own edit_token (author) or the page's edit_token (page owner moderating).
+
 ## Example
 
 \`\`\`
 curl -X POST https://joinstash.ai/pages -d '# Hello world'
+curl https://joinstash.ai/pages/<slug>/comments
+curl -X POST https://joinstash.ai/pages/<slug>/comments -d 'nice page'
 \`\`\`
 `;

--- a/www/proxy.ts
+++ b/www/proxy.ts
@@ -19,6 +19,14 @@ export async function proxy(request: NextRequest) {
   if (pathname === "/pages" && request.method === "POST" && !request.headers.get("next-action")) {
     return NextResponse.rewrite(new URL("/api/pages", request.url));
   }
+  // Comments on the canonical domain (no Next pages live at these paths):
+  //   GET/POST   joinstash.ai/pages/{slug}/comments
+  //   PATCH/DEL  joinstash.ai/pages/{slug}/comments/{id}?token=…
+  if (/^\/pages\/[^/]+\/comments(\/[^/]+)?$/.test(pathname)) {
+    return NextResponse.rewrite(
+      new URL(`/api${pathname}${request.nextUrl.search}`, request.url),
+    );
+  }
   const pasteSlug = pathname.match(/^\/pages\/([^/]+)$/)?.[1];
   if (pasteSlug && (request.method === "PATCH" || request.method === "DELETE")) {
     return NextResponse.rewrite(new URL(`/api/pages/${pasteSlug}${request.nextUrl.search}`, request.url));


### PR DESCRIPTION
Answering "can agents add/edit/delete/read comments?" — **before this PR: add ✓, read ✓, edit ✗ (404), delete ✗ (404)**. This closes the gap.

## What agents can now do (all on the canonical domain)
- **Read**: `GET joinstash.ai/pages/{slug}/comments`
- **Add**: `POST joinstash.ai/pages/{slug}/comments` (raw body or JSON). Response now includes the comment `id` and a one-time `edit_token`.
- **Edit**: `PATCH joinstash.ai/pages/{slug}/comments/{id}?token=…` — author only (the comment's edit_token).
- **Delete**: `DELETE joinstash.ai/pages/{slug}/comments/{id}?token=…` — the comment's edit_token (author) **or** the page's edit_token (owner moderation).

## Backend
- Migration 0113 adds `edit_token` to `paste_comments`, minted at create, returned once (never in the list endpoint).
- New PATCH/DELETE comment endpoints, token-gated, 404 on bad/empty token (no oracle). `UPDATE…FROM` RETURNING columns are alias-qualified (id/created_at exist on both tables).

## www
- Proxy rewrites + route handlers put all four operations on `joinstash.ai/pages/{slug}/comments[/ {id}]`, same pattern as create/edit/delete page.
- Agent docs (`/pages/agents`) now document the comment API.

Verified end to end over the www URLs: add → read → edit (wrong token → 404) → owner-moderation delete. 31 backend tests green; www build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)