### PR TITLE
Pages: comment replies + delete buttons + names (also restores #618, wiped from main)

### DIFF
--- a/backend/migrations/versions/0113_paste_comment_tokens.py
+++ b/backend/migrations/versions/0113_paste_comment_tokens.py
@@ -1,0 +1,34 @@
+"""Per-comment edit tokens for the pastes pastebin.
+
+Restored: this migration was lost from main (a concurrent push to the
+shared checkout swept the file) while the code that depends on the
+column stayed — leaving the chain broken and prod stamped at a revision
+with no file. Re-adding it repairs the chain. ``IF NOT EXISTS`` keeps it
+safe on databases that already ran the original (prod).
+
+Comments are anonymous like the pages they hang on. To let the author
+edit or delete a comment later — and let agents manage comments they
+post — each comment gets its own write token, minted at create time and
+returned once (same model as a paste's edit_token). Deletion also
+accepts the parent paste's edit_token so the page owner can moderate.
+
+Revision ID: 0113
+Revises: 0112
+"""
+
+from alembic import op
+
+revision = "0113"
+down_revision = "0112"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE paste_comments ADD COLUMN IF NOT EXISTS edit_token TEXT NOT NULL DEFAULT ''"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE paste_comments DROP COLUMN edit_token")

--- a/backend/migrations/versions/0114_paste_comment_replies.py
+++ b/backend/migrations/versions/0114_paste_comment_replies.py
@@ -1,0 +1,28 @@
+"""Threaded replies for paste comments.
+
+A reply is a comment with ``parent_id`` set to the comment it answers.
+Top-level comments carry the page anchor (quoted_text/prefix/suffix);
+replies hang off them and inherit that context. Deleting a comment
+cascades to its replies.
+
+Revision ID: 0114
+Revises: 0113
+"""
+
+from alembic import op
+
+revision = "0114"
+down_revision = "0113"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE paste_comments ADD COLUMN IF NOT EXISTS parent_id UUID "
+        "REFERENCES paste_comments(id) ON DELETE CASCADE"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE paste_comments DROP COLUMN parent_id")

--- a/backend/routers/pastes.py
+++ b/backend/routers/pastes.py
@@ -42,6 +42,8 @@ class CommentCreateRequest(BaseModel):
     quoted_text: str = Field("", max_length=500)
     prefix: str = Field("", max_length=100)
     suffix: str = Field("", max_length=100)
+    # A reply: the id of the comment this answers (must be on the same page).
+    parent_id: str | None = None
 
 
 @router.post("", status_code=201)
@@ -98,8 +100,40 @@ async def list_comments(request: Request, slug: str) -> dict:
 @limiter.limit("10/minute")
 async def add_comment(request: Request, slug: str, body: CommentCreateRequest) -> dict:
     comment = await paste_service.add_comment(
-        slug, body.author_name, body.body, body.quoted_text, body.prefix, body.suffix
+        slug,
+        body.author_name,
+        body.body,
+        body.quoted_text,
+        body.prefix,
+        body.suffix,
+        body.parent_id,
     )
     if not comment:
         raise HTTPException(status_code=404, detail="Paste not found")
     return comment
+
+
+class CommentUpdateRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=5_000)
+
+
+@router.patch("/{slug}/comments/{comment_id}")
+@limiter.limit("30/minute")
+async def update_comment(
+    request: Request, slug: str, comment_id: str, token: str, body: CommentUpdateRequest
+) -> dict:
+    if not token:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    comment = await paste_service.update_comment(slug, comment_id, token, body.body)
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    return comment
+
+
+@router.delete("/{slug}/comments/{comment_id}", status_code=204)
+@limiter.limit("30/minute")
+async def delete_comment(request: Request, slug: str, comment_id: str, token: str) -> None:
+    if not token:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    if not await paste_service.delete_comment(slug, comment_id, token):
+        raise HTTPException(status_code=404, detail="Comment not found")

--- a/backend/services/paste_service.py
+++ b/backend/services/paste_service.py
@@ -146,7 +146,7 @@ async def delete_paste(slug: str, token: str) -> bool:
     return result.endswith(" 1")
 
 
-_COMMENT_COLS = "id, author_name, body, quoted_text, prefix, suffix, created_at"
+_COMMENT_COLS = "id, parent_id, author_name, body, quoted_text, prefix, suffix, created_at"
 
 
 async def add_comment(
@@ -156,14 +156,24 @@ async def add_comment(
     quoted_text: str,
     prefix: str,
     suffix: str,
+    parent_id: str | None = None,
 ) -> dict | None:
-    """None means the paste doesn't exist."""
+    """None means the paste doesn't exist (or parent_id isn't a comment on
+    it). The returned dict includes the comment's own edit_token — the only
+    time it's exposed."""
     pool = get_pool()
     row = await pool.fetchrow(
         f"""
-        INSERT INTO paste_comments (paste_id, author_name, body, quoted_text, prefix, suffix)
-        SELECT id, $2, $3, $4, $5, $6 FROM pastes WHERE slug = $1
-        RETURNING {_COMMENT_COLS}
+        INSERT INTO paste_comments
+            (paste_id, parent_id, author_name, body, quoted_text, prefix, suffix, edit_token)
+        SELECT p.id, $8::uuid, $2, $3, $4, $5, $6, $7
+        FROM pastes p
+        WHERE p.slug = $1
+          AND ($8::uuid IS NULL OR EXISTS (
+            SELECT 1 FROM paste_comments parent
+            WHERE parent.id = $8::uuid AND parent.paste_id = p.id
+          ))
+        RETURNING edit_token, {_COMMENT_COLS}
         """,
         slug,
         author_name.strip(),
@@ -171,8 +181,51 @@ async def add_comment(
         quoted_text,
         prefix,
         suffix,
+        secrets.token_urlsafe(16),
+        parent_id,
     )
     return dict(row) if row else None
+
+
+async def update_comment(slug: str, comment_id: str, token: str, body: str) -> dict | None:
+    """Edit a comment's body — only its author (the comment's edit_token).
+    None means not-found-or-bad-token."""
+    pool = get_pool()
+    # Qualify the RETURNING columns: id/created_at exist on both tables, so
+    # they're ambiguous in an UPDATE...FROM without the alias.
+    returning = ", ".join(f"c.{col.strip()}" for col in _COMMENT_COLS.split(","))
+    row = await pool.fetchrow(
+        f"""
+        UPDATE paste_comments c
+        SET body = $4
+        FROM pastes p
+        WHERE c.id = $2 AND c.paste_id = p.id AND p.slug = $1 AND c.edit_token = $3
+        RETURNING {returning}
+        """,
+        slug,
+        comment_id,
+        token,
+        body,
+    )
+    return dict(row) if row else None
+
+
+async def delete_comment(slug: str, comment_id: str, token: str) -> bool:
+    """True when deleted. Authorized by the comment's own edit_token (author)
+    or the parent paste's edit_token (page owner moderation)."""
+    pool = get_pool()
+    result = await pool.execute(
+        """
+        DELETE FROM paste_comments c
+        USING pastes p
+        WHERE c.id = $2 AND c.paste_id = p.id AND p.slug = $1
+          AND ($3 = c.edit_token OR $3 = p.edit_token)
+        """,
+        slug,
+        comment_id,
+        token,
+    )
+    return result.endswith(" 1")
 
 
 async def list_comments(slug: str) -> list[dict]:

--- a/backend/tests/test_pastes.py
+++ b/backend/tests/test_pastes.py
@@ -180,6 +180,120 @@ async def test_comment_requires_body(client: AsyncClient):
     assert resp.status_code == 422
 
 
+async def _add_comment(client: AsyncClient, slug: str, **overrides) -> dict:
+    body = {"body": "a comment", **overrides}
+    resp = await client.post(f"/api/v1/pastes/{slug}/comments", json=body)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def test_add_comment_returns_edit_token_once(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    assert comment["edit_token"]
+    # The token never comes back out of the list endpoint.
+    listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")
+    assert "edit_token" not in listed.json()["comments"][0]
+
+
+async def test_edit_comment_with_author_token(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"], body="original")
+    resp = await client.patch(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={comment['edit_token']}",
+        json={"body": "edited"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["body"] == "edited"
+
+
+async def test_edit_comment_wrong_token_404(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.patch(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=wrong",
+        json={"body": "edited"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_delete_comment_by_author(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={comment['edit_token']}"
+    )
+    assert resp.status_code == 204
+    listed = await client.get(f"/api/v1/pastes/{paste['slug']}/comments")
+    assert listed.json()["comments"] == []
+
+
+async def test_delete_comment_by_page_owner(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    # The page's edit_token moderates any comment on the page.
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token={paste['edit_token']}"
+    )
+    assert resp.status_code == 204
+
+
+async def test_delete_comment_wrong_token_404(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    resp = await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=nope"
+    )
+    assert resp.status_code == 404
+    assert (
+        len((await client.get(f"/api/v1/pastes/{paste['slug']}/comments")).json()["comments"]) == 1
+    )
+
+
+async def test_reply_to_comment(client: AsyncClient):
+    paste = await _create(client)
+    top = await _add_comment(client, paste["slug"], body="top-level")
+    assert top["parent_id"] is None
+    reply = await _add_comment(client, paste["slug"], body="a reply", parent_id=top["id"])
+    assert reply["parent_id"] == top["id"]
+
+    listed = (await client.get(f"/api/v1/pastes/{paste['slug']}/comments")).json()["comments"]
+    assert len(listed) == 2
+    by_id = {c["id"]: c for c in listed}
+    assert by_id[reply["id"]]["parent_id"] == top["id"]
+
+
+async def test_deleting_comment_cascades_replies(client: AsyncClient):
+    paste = await _create(client)
+    top = await _add_comment(client, paste["slug"], body="top")
+    await _add_comment(client, paste["slug"], body="reply", parent_id=top["id"])
+    await client.delete(
+        f"/api/v1/pastes/{paste['slug']}/comments/{top['id']}?token={top['edit_token']}"
+    )
+    listed = (await client.get(f"/api/v1/pastes/{paste['slug']}/comments")).json()["comments"]
+    assert listed == []
+
+
+async def test_reply_parent_on_other_page_rejected(client: AsyncClient):
+    page_a = await _create(client)
+    page_b = await _create(client)
+    other = await _add_comment(client, page_b["slug"], body="on page B")
+    # Replying on page A with page B's comment as parent must not insert.
+    resp = await client.post(
+        f"/api/v1/pastes/{page_a['slug']}/comments",
+        json={"body": "cross-page reply", "parent_id": other["id"]},
+    )
+    assert resp.status_code == 404
+
+
+async def test_comment_token_empty_rejected(client: AsyncClient):
+    paste = await _create(client)
+    comment = await _add_comment(client, paste["slug"])
+    # An empty token must not match the column's '' default on legacy rows.
+    resp = await client.delete(f"/api/v1/pastes/{paste['slug']}/comments/{comment['id']}?token=")
+    assert resp.status_code == 404
+
+
 async def test_delete_paste_with_token(client: AsyncClient):
     paste = await _create(client)
     resp = await client.delete(f"/api/v1/pastes/{paste['slug']}?token={paste['edit_token']}")

--- a/www/app/api/pages/[slug]/comments/[commentId]/route.ts
+++ b/www/app/api/pages/[slug]/comments/[commentId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Agent-facing comment edit/delete on the canonical domain:
+//   PATCH  joinstash.ai/pages/{slug}/comments/{id}?token=…  (comment author token)
+//   DELETE joinstash.ai/pages/{slug}/comments/{id}?token=…  (comment author OR page edit token)
+function commentUrl(slug: string, id: string, token: string) {
+  return (
+    `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments/${encodeURIComponent(id)}` +
+    `?token=${encodeURIComponent(token)}`
+  );
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; commentId: string }> },
+) {
+  const { slug, commentId } = await params;
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const contentType = request.headers.get("content-type") ?? "";
+  const rawBody = await request.text();
+  const payload = contentType.includes("application/json")
+    ? JSON.parse(rawBody)
+    : { body: rawBody };
+
+  const res = await fetch(commentUrl(slug, commentId, token), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; commentId: string }> },
+) {
+  const { slug, commentId } = await params;
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const res = await fetch(commentUrl(slug, commentId, token), { method: "DELETE" });
+  return new NextResponse(null, { status: res.status });
+}

--- a/www/app/api/pages/[slug]/comments/route.ts
+++ b/www/app/api/pages/[slug]/comments/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Agent-facing comment list/add on the canonical domain:
+//   GET  joinstash.ai/pages/{slug}/comments
+//   POST joinstash.ai/pages/{slug}/comments   (raw text body = the comment)
+function commentsUrl(slug: string) {
+  return `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments`;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const res = await fetch(commentsUrl(slug), { cache: "no-store" });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const contentType = request.headers.get("content-type") ?? "";
+  const rawBody = await request.text();
+  const payload = contentType.includes("application/json")
+    ? JSON.parse(rawBody)
+    : { body: rawBody };
+
+  const res = await fetch(commentsUrl(slug), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/www/app/pages/_components/CommentsRail.tsx
+++ b/www/app/pages/_components/CommentsRail.tsx
@@ -1,28 +1,59 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { addComment } from "../actions";
+import { addComment, deleteComment } from "../actions";
 import { timeAgo } from "../_lib/time";
 import type { PasteComment } from "../_lib/paste";
 
-// Google-Docs-style right rail: the comment thread list plus an
-// unanchored composer. Anchored comments arrive from the page's
-// selection flow (the pill popover); this rail just displays them.
+const NAME_KEY = "stash-pages-comment-name";
+
+// Google-Docs-style right rail: threads (top-level comments + their
+// replies) plus composers. Comments created this session carry their
+// edit_token, so their author can delete them; on the edit page the page
+// owner's token (pageToken) can delete anything (moderation).
 export default function CommentsRail({
   slug,
   comments,
   onCommentAdded,
+  onCommentDeleted,
+  pageToken,
   headerExtra,
 }: {
   slug: string;
   comments: PasteComment[];
   onCommentAdded: (comment: PasteComment) => void;
+  onCommentDeleted: (id: string) => void;
+  pageToken?: string;
   headerExtra?: React.ReactNode;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
 
-  async function submit(input: { author_name: string; body: string }) {
+  // Top-level comments in order, each with its replies grouped underneath.
+  const threads = useMemo(() => {
+    const tops = comments.filter((c) => !c.parent_id);
+    const repliesByParent = new Map<string, PasteComment[]>();
+    for (const c of comments) {
+      if (!c.parent_id) continue;
+      const list = repliesByParent.get(c.parent_id) ?? [];
+      list.push(c);
+      repliesByParent.set(c.parent_id, list);
+    }
+    return tops.map((top) => ({ top, replies: repliesByParent.get(top.id) ?? [] }));
+  }, [comments]);
+
+  function deleteTokenFor(comment: PasteComment): string | null {
+    return pageToken ?? comment.edit_token ?? null;
+  }
+
+  async function remove(comment: PasteComment) {
+    const token = deleteTokenFor(comment);
+    if (!token) return;
+    const result = await deleteComment(slug, comment.id, token);
+    if (result.status === "ok") onCommentDeleted(comment.id);
+  }
+
+  async function submitTopLevel(input: { author_name: string; body: string }) {
     const result = await addComment(slug, {
       author_name: input.author_name,
       body: input.body,
@@ -59,38 +90,124 @@ export default function CommentsRail({
         </p>
       )}
       <ul className="mt-3 space-y-2.5">
-        {comments.map((comment) => (
-          <li key={comment.id} className="rounded-lg border border-border bg-white p-3">
-            <p className="flex items-baseline gap-2 text-[12px] text-muted">
-              <span className="font-medium text-ink">{comment.author_name || "Anonymous"}</span>
-              {timeAgo(comment.created_at)}
-            </p>
-            {comment.quoted_text && (
-              <p className="mt-1 truncate border-l-2 border-brand/60 pl-2 text-[12px] italic text-dim">
-                {comment.quoted_text}
-              </p>
+        {threads.map(({ top, replies }) => (
+          <li key={top.id} className="rounded-lg border border-border bg-white p-3">
+            <CommentBody comment={top} canDelete={!!deleteTokenFor(top)} onDelete={() => remove(top)} />
+            {replies.length > 0 && (
+              <ul className="mt-2 space-y-2 border-l-2 border-border-subtle pl-3">
+                {replies.map((reply) => (
+                  <li key={reply.id}>
+                    <CommentBody
+                      comment={reply}
+                      canDelete={!!deleteTokenFor(reply)}
+                      onDelete={() => remove(reply)}
+                    />
+                  </li>
+                ))}
+              </ul>
             )}
-            <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">
-              {comment.body}
-            </p>
+            <ReplyControl slug={slug} parentId={top.id} onReplyAdded={onCommentAdded} />
           </li>
         ))}
       </ul>
       {composerOpen && (
         <div className="mt-3">
-          <CommentComposer quoted="" onCancel={() => setComposerOpen(false)} onSubmit={submit} />
+          <CommentComposer quoted="" onCancel={() => setComposerOpen(false)} onSubmit={submitTopLevel} />
         </div>
       )}
     </div>
   );
 }
 
+function CommentBody({
+  comment,
+  canDelete,
+  onDelete,
+}: {
+  comment: PasteComment;
+  canDelete: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="group/comment">
+      <p className="flex items-baseline gap-2 text-[12px] text-muted">
+        <span className="font-medium text-ink">{comment.author_name || "Anonymous"}</span>
+        {timeAgo(comment.created_at)}
+        {canDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label="Delete comment"
+            className="ml-auto text-[12px] text-muted opacity-0 transition hover:text-red-600 group-hover/comment:opacity-100"
+          >
+            Delete
+          </button>
+        )}
+      </p>
+      {comment.quoted_text && (
+        <p className="mt-1 truncate border-l-2 border-brand/60 pl-2 text-[12px] italic text-dim">
+          {comment.quoted_text}
+        </p>
+      )}
+      <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">
+        {comment.body}
+      </p>
+    </div>
+  );
+}
+
+function ReplyControl({
+  slug,
+  parentId,
+  onReplyAdded,
+}: {
+  slug: string;
+  parentId: string;
+  onReplyAdded: (comment: PasteComment) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  async function submit(input: { author_name: string; body: string }) {
+    const result = await addComment(slug, {
+      author_name: input.author_name,
+      body: input.body,
+      quoted_text: "",
+      prefix: "",
+      suffix: "",
+      parent_id: parentId,
+    });
+    if (result.status === "error") return result.message;
+    onReplyAdded(result.comment as PasteComment);
+    setOpen(false);
+    return "";
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-2 text-[12px] font-medium text-dim hover:text-ink"
+      >
+        Reply
+      </button>
+    );
+  }
+  return (
+    <div className="mt-2">
+      <CommentComposer quoted="" placeholder="Reply…" onCancel={() => setOpen(false)} onSubmit={submit} />
+    </div>
+  );
+}
+
 export function CommentComposer({
   quoted,
+  placeholder = "Add a comment…",
   onCancel,
   onSubmit,
 }: {
   quoted: string;
+  placeholder?: string;
   onCancel: () => void;
   onSubmit: (input: { author_name: string; body: string }) => Promise<string>;
 }) {
@@ -99,9 +216,15 @@ export function CommentComposer({
   const [sending, setSending] = useState(false);
   const [error, setError] = useState("");
 
+  // Remember the name across comments in this browser.
+  useEffect(() => {
+    setName(localStorage.getItem(NAME_KEY) ?? "");
+  }, []);
+
   async function send() {
     if (!body.trim() || sending) return;
     setSending(true);
+    if (name.trim()) localStorage.setItem(NAME_KEY, name.trim());
     const message = await onSubmit({ author_name: name, body });
     setSending(false);
     setError(message);
@@ -125,7 +248,7 @@ export function CommentComposer({
       <textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}
-        placeholder="Add a comment…"
+        placeholder={placeholder}
         autoFocus
         className="mt-2 min-h-[64px] w-full resize-y rounded-md border border-border bg-white p-2.5 text-[13px] text-ink placeholder:text-muted focus:border-brand focus:outline-none"
       />

--- a/www/app/pages/_components/EditPageClient.tsx
+++ b/www/app/pages/_components/EditPageClient.tsx
@@ -29,6 +29,10 @@ export default function EditPageClient({
     setComments((cur) => [...cur, comment]);
   }, []);
 
+  const removeLocal = useCallback((id: string) => {
+    setComments((cur) => cur.filter((c) => c.id !== id && c.parent_id !== id));
+  }, []);
+
   const anchors = useMemo(
     () =>
       comments
@@ -88,7 +92,13 @@ export default function EditPageClient({
           <div className="min-w-0">{editor}</div>
           <aside className="mt-8 lg:mt-0">
             <div className="lg:sticky lg:top-6 lg:max-h-[calc(100vh-48px)] lg:overflow-y-auto">
-              <CommentsRail slug={paste.slug} comments={comments} onCommentAdded={addLocal} />
+              <CommentsRail
+                slug={paste.slug}
+                comments={comments}
+                onCommentAdded={addLocal}
+                onCommentDeleted={removeLocal}
+                pageToken={token}
+              />
             </div>
           </aside>
         </div>

--- a/www/app/pages/_components/PasteViewer.tsx
+++ b/www/app/pages/_components/PasteViewer.tsx
@@ -51,6 +51,12 @@ export default function PasteViewer({
     setComments((cur) => [...cur, comment]);
   }, []);
 
+  const removeLocal = useCallback((id: string) => {
+    // Drop the comment and any replies hanging off it (matches the
+    // server's ON DELETE CASCADE).
+    setComments((cur) => cur.filter((c) => c.id !== id && c.parent_id !== id));
+  }, []);
+
   const content = (
     <div ref={wrapRef} className="relative min-w-0">
       {isHtml ? (
@@ -84,7 +90,12 @@ export default function PasteViewer({
       {content}
       <aside className="mt-8 lg:mt-0">
         <div className="lg:sticky lg:top-6 lg:max-h-[calc(100vh-48px)] lg:overflow-y-auto">
-          <CommentsRail slug={paste.slug} comments={comments} onCommentAdded={addLocal} />
+          <CommentsRail
+            slug={paste.slug}
+            comments={comments}
+            onCommentAdded={addLocal}
+            onCommentDeleted={removeLocal}
+          />
         </div>
       </aside>
     </div>

--- a/www/app/pages/_lib/agent-docs.ts
+++ b/www/app/pages/_lib/agent-docs.ts
@@ -31,9 +31,20 @@ Always hand the human **both** links: the view_url to share, and the edit_url to
 
 \`DELETE <view_url>?token=<edit_token>\` — the token is the one in the edit_url. Deletes the page and its comments permanently.
 
+## Comments
+
+Pages can carry comments (anchored to selected text, or general). All comment endpoints live under the page's view URL:
+
+- **Read**: \`GET <view_url>/comments\` → \`{"comments": [...]}\`
+- **Add**: \`POST <view_url>/comments\` with a raw body (the comment text) or JSON \`{"body": "...", "author_name": "...", "quoted_text": "...", "parent_id": "..."}\`. Set \`quoted_text\` to a verbatim snippet from the page to anchor the comment to it. Set \`parent_id\` to another comment's id to post a **reply** to it. The response includes the comment's \`id\` and a one-time \`edit_token\`.
+- **Edit**: \`PATCH <view_url>/comments/{id}?token=<comment_edit_token>\` with the new body. Author only.
+- **Delete**: \`DELETE <view_url>/comments/{id}?token=<token>\` — the token can be the comment's own edit_token (author) or the page's edit_token (page owner moderating).
+
 ## Example
 
 \`\`\`
 curl -X POST https://joinstash.ai/pages -d '# Hello world'
+curl https://joinstash.ai/pages/<slug>/comments
+curl -X POST https://joinstash.ai/pages/<slug>/comments -d 'nice page'
 \`\`\`
 `;

--- a/www/app/pages/_lib/paste.ts
+++ b/www/app/pages/_lib/paste.ts
@@ -14,12 +14,17 @@ export type Paste = {
 
 export type PasteComment = {
   id: string;
+  parent_id: string | null;
   author_name: string;
   body: string;
   quoted_text: string;
   prefix: string;
   suffix: string;
   created_at: string;
+  // Only present on comments created in the current session (the create
+  // response returns it once); lets the author delete their own comment
+  // before a reload. Never comes back from the list endpoint.
+  edit_token?: string;
 };
 
 export async function fetchPaste(slug: string): Promise<Paste | null> {

--- a/www/app/pages/actions.ts
+++ b/www/app/pages/actions.ts
@@ -55,6 +55,7 @@ export async function addComment(
     quoted_text: string;
     prefix: string;
     suffix: string;
+    parent_id?: string | null;
   },
 ): Promise<AddCommentResult> {
   const res = await fetch(`${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments`, {
@@ -70,6 +71,22 @@ export async function addComment(
     return { status: "error", message };
   }
   return { status: "ok", comment: await res.json() };
+}
+
+export async function deleteComment(
+  slug: string,
+  commentId: string,
+  token: string,
+): Promise<UpdatePasteResult> {
+  const res = await fetch(
+    `${API_URL}/api/v1/pastes/${encodeURIComponent(slug)}/comments/` +
+      `${encodeURIComponent(commentId)}?token=${encodeURIComponent(token)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    return { status: "error", message: "Could not delete the comment." };
+  }
+  return { status: "ok" };
 }
 
 export type UpdatePasteResult = { status: "ok" } | { status: "error"; message: string };

--- a/www/proxy.ts
+++ b/www/proxy.ts
@@ -19,6 +19,14 @@ export async function proxy(request: NextRequest) {
   if (pathname === "/pages" && request.method === "POST" && !request.headers.get("next-action")) {
     return NextResponse.rewrite(new URL("/api/pages", request.url));
   }
+  // Comments on the canonical domain (no Next pages live at these paths):
+  //   GET/POST   joinstash.ai/pages/{slug}/comments
+  //   PATCH/DEL  joinstash.ai/pages/{slug}/comments/{id}?token=…
+  if (/^\/pages\/[^/]+\/comments(\/[^/]+)?$/.test(pathname)) {
+    return NextResponse.rewrite(
+      new URL(`/api${pathname}${request.nextUrl.search}`, request.url),
+    );
+  }
   const pasteSlug = pathname.match(/^\/pages\/([^/]+)$/)?.[1];
   if (pasteSlug && (request.method === "PATCH" || request.method === "DELETE")) {
     return NextResponse.rewrite(new URL(`/api/pages/${pasteSlug}${request.nextUrl.search}`, request.url));


### PR DESCRIPTION
## ⚠️ This also repairs main
**#618 (the full comment edit/delete CRUD) merged but was then clobbered off `main` by a concurrent push to the shared checkout** — the classic shared-checkout race. The result: `main` has the comment *create* code but none of #618's edit/delete endpoints, www comment routes, proxy rewrites, agent docs, **or the `0113` migration** — yet prod's DB is stamped at `0113`. So **the next prod deploy from main would fail** (`KeyError: '0113'`, which I hit locally). This PR restores all of #618 and makes its migration idempotent (`IF NOT EXISTS`) so it's safe on prod, which already ran the original.

Verified the repaired chain on a fresh DB: `0112 → 0113 → 0114` ends with `paste_comments` having both `edit_token` and `parent_id`.

## New in this PR (the actual ask)
**Delete buttons:**
- **Edit page**: a Delete on every comment, using the page's edit token → owner moderation (works after reload).
- **View page**: a Delete only on comments you posted *this session* (the one-time comment token), so you can remove your own — but not others'.

**Threaded replies (like the main app):**
- `parent_id` on comments (migration 0114). A reply hangs off a top-level comment; deleting a comment cascades to its replies.
- Rail nests replies under their parent with a **Reply** composer. Agents can reply too: `POST …/comments` with `parent_id`.

**Commenter names:**
- The composer's name field is remembered in `localStorage`, so it prefills across comments.

## Authorization recap (who can delete a comment)
Comment author (one-time comment token) **or** page owner (page edit token, for moderation). Empty/wrong token → 404.

Verified end to end in-browser: nested reply renders, reply composer posts with parent_id, owner-delete on edit page, author-only delete on view page, name persists. 34 backend tests; www build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)