### PR TITLE
Landing: header nav — Use cases dropdown, Share docs, Memory page

### DIFF
--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -22,23 +22,29 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
           stash
         </Link>
         <nav className="flex items-center gap-2 text-[14px] text-dim">
+          <div className="group relative hidden sm:block">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-md px-3 py-2 transition group-hover:bg-raised group-hover:text-ink"
+            >
+              Use cases
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+            <div className="invisible absolute left-0 top-full w-60 pt-2 opacity-0 transition group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100">
+              <div className="overflow-hidden rounded-xl border border-border bg-background p-1.5 shadow-card">
+                <UseCaseItem href="/connect-your-data" title="Connect your data" desc="Plug in GitHub, Drive, Gmail, Notion, Slack." />
+                <UseCaseItem href="/agent-native-drive" title="Agent-native Drive" desc="A workspace agents read and write like a repo." />
+                <UseCaseItem href="/memory" title="Memory" desc="Best-in-class retrieval: wiki + vectors + grep." />
+              </div>
+            </div>
+          </div>
           <Link
-            href="/connect-your-data"
+            href="/pages"
             className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
           >
-            Connect your data
-          </Link>
-          <Link
-            href="/agent-native-drive"
-            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
-          >
-            Agent-native Drive
-          </Link>
-          <Link
-            href="/#pricing"
-            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:inline-flex"
-          >
-            Pricing
+            Share docs
           </Link>
           <Link
             href="/docs"
@@ -51,22 +57,6 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
             className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
           >
             Blog
-          </Link>
-          <Link
-            href="/contact-sales"
-            className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-          >
-            Contact sales
-          </Link>
-          <Link
-            href="https://github.com/Fergana-Labs/stash"
-            className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
-            aria-label="Stash on GitHub"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-              <path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 0 0 7.86 10.92c.57.11.78-.25.78-.55v-1.94c-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.07 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.6.23 2.78.12 3.07.74.81 1.19 1.84 1.19 3.1 0 4.41-2.69 5.38-5.26 5.67.41.35.77 1.05.77 2.12v3.14c0 .3.21.67.79.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
-            </svg>
-            <span className="hidden sm:inline">GitHub</span>
           </Link>
           <Link
             href="/login"
@@ -86,5 +76,17 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
         </nav>
       </div>
     </header>
+  );
+}
+
+function UseCaseItem({ href, title, desc }: { href: string; title: string; desc: string }) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-lg px-3 py-2 transition hover:bg-raised"
+    >
+      <span className="block text-[14px] font-medium text-ink">{title}</span>
+      <span className="mt-0.5 block text-[12.5px] leading-snug text-dim">{desc}</span>
+    </Link>
   );
 }

--- a/www/app/memory/page.tsx
+++ b/www/app/memory/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import SiteHeader from "../_components/SiteHeader";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export const metadata: Metadata = {
+  title: "Memory · Stash",
+  description:
+    "Best-in-class agent memory: a three-way hybrid index — curated wiki, vector search, and grep — so your agents retrieve the right thing every time. Every retrieval method has blind spots; Stash runs all three.",
+};
+
+const METHODS = [
+  {
+    name: "Curated wiki",
+    tag: "structure",
+    blurb:
+      "While you sleep, an agent curates your history into linked pages — a virtual file system your agents navigate directly, the way a teammate would open the right doc.",
+  },
+  {
+    name: "Vector search",
+    tag: "meaning",
+    blurb:
+      "Every session, page, and table is embedded, so agents find knowledge by meaning — not by remembering the exact filename or wording.",
+  },
+  {
+    name: "Grep",
+    tag: "exactness",
+    blurb:
+      "Agents search the workspace like a repo, for the literal identifiers, error strings, and names that embeddings gloss over.",
+  },
+];
+
+const POINTS = [
+  {
+    title: "Shared, not per-agent",
+    body: "One memory the whole team and every agent reads from — no per-agent black box, no knowledge trapped in one run's context.",
+  },
+  {
+    title: "Kept in sync",
+    body: "As your connected sources change, the index updates — agents reason over the current state of your work, not a stale snapshot.",
+  },
+  {
+    title: "Cited back to the source",
+    body: "Retrieved knowledge links to where it came from — the page, session, or table — so answers are checkable, not vibes.",
+  },
+];
+
+export default function MemoryPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+
+      <section className="border-b border-border-subtle py-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Memory
+          </p>
+          <h1 className="mt-5 max-w-[900px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
+            Your team&apos;s memory,{" "}
+            <span className="text-brand">actually retrievable.</span>
+          </h1>
+          <p className="mt-7 max-w-[640px] text-[18px] leading-[1.55] text-foreground">
+            Every retrieval method has blind spots, so Stash runs three at once — a
+            curated wiki, vector search, and grep. Your agents get the best of all
+            worlds, instead of one index that misses.
+          </p>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/connect-your-data"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Connect your data →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Three indexes, one retrieval.
+          </h2>
+          <p className="mt-4 max-w-[620px] text-[17px] leading-[1.55] text-dim">
+            A question runs against all three and the results merge — keyword
+            precision, semantic recall, and a navigable structure, together.
+          </p>
+          <div className="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-3">
+            {METHODS.map((m) => (
+              <div
+                key={m.name}
+                className="rounded-[12px] border border-border bg-background p-6 transition-colors hover:border-brand"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="font-display text-[19px] font-bold tracking-[-0.01em] text-ink">
+                    {m.name}
+                  </div>
+                  <span className="rounded border border-border bg-raised px-1.5 py-0.5 font-mono text-[10.5px] text-dim">
+                    {m.tag}
+                  </span>
+                </div>
+                <p className="mt-3 text-[14.5px] leading-[1.6] text-dim">{m.blurb}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle py-20 md:py-28">
+        <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-7 md:grid-cols-3 md:gap-12">
+          {POINTS.map((p) => (
+            <div key={p.title}>
+              <h3 className="font-display text-[19px] font-bold tracking-[-0.01em] text-ink">
+                {p.title}
+              </h3>
+              <p className="mt-2.5 text-[15px] leading-[1.6] text-dim">{p.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-surface py-28 text-center">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-black leading-[1.0] tracking-[-0.04em] text-ink">
+            Memory your agents can actually find.
+          </h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/agent-native-drive"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              See the agent-native Drive →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Header reorg on the landing site.

**Removed** from the header: Pricing, Contact sales, and the GitHub link.

**Added**:
- **Share docs** → `/pages` (the new pastebin).
- **Use cases** dropdown grouping the use-case pages: Connect your data, Agent-native Drive, and a new **Memory** page. Pure-CSS dropdown (hover + `focus-within`), no client component.

**New `/memory` page**: sells the three-way hybrid retrieval — curated wiki + vector search + grep — matching the landing's "best-in-class memory / actually retrievable" positioning (and deliberately *not* leading with the decorative visualizations).

Verified in-browser: dropdown opens with all three use cases, Share docs → /pages, removed items gone, memory page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)