### PR TITLE
Pages: paginate the Recent-pages feed (20/page + Load more)

### DIFF
--- a/backend/routers/pastes.py
+++ b/backend/routers/pastes.py
@@ -54,10 +54,17 @@ async def create_paste(request: Request, body: PasteCreateRequest) -> dict:
     )
 
 
+_FEED_PAGE = 20
+
+
 @router.get("")
 @limiter.limit("60/minute")
-async def list_pastes(request: Request) -> dict:
-    return {"pastes": await paste_service.list_recent()}
+async def list_pastes(request: Request, offset: int = 0) -> dict:
+    offset = max(0, offset)
+    # Fetch one extra to learn whether a "load more" page exists without a
+    # second query.
+    rows = await paste_service.list_recent(_FEED_PAGE + 1, offset)
+    return {"pastes": rows[:_FEED_PAGE], "has_more": len(rows) > _FEED_PAGE}
 
 
 @router.get("/{slug}")

--- a/backend/services/paste_service.py
+++ b/backend/services/paste_service.py
@@ -241,8 +241,9 @@ async def list_comments(slug: str) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-async def list_recent(limit: int = 30) -> list[dict]:
-    """Public pages ranked HN-style: views buoy a page, age sinks it."""
+async def list_recent(limit: int = 20, offset: int = 0) -> list[dict]:
+    """Public pages ranked HN-style: views buoy a page, age sinks it.
+    Paginated by offset so the feed never loads everything at once."""
     pool = get_pool()
     rows = await pool.fetch(
         f"""
@@ -250,9 +251,11 @@ async def list_recent(limit: int = 30) -> list[dict]:
         WHERE visibility = 'public'
         ORDER BY (view_count + 1)
                  / POWER(EXTRACT(EPOCH FROM (now() - created_at)) / 3600 + 2, 1.5)
-                 DESC
-        LIMIT $1
+                 DESC,
+                 created_at DESC
+        LIMIT $1 OFFSET $2
         """,
         limit,
+        offset,
     )
     return [dict(r) for r in rows]

--- a/backend/tests/test_pastes.py
+++ b/backend/tests/test_pastes.py
@@ -73,6 +73,27 @@ async def test_feed_lists_recent_without_content(client: AsyncClient):
     assert "edit_token" not in entry
 
 
+async def test_feed_paginates(client: AsyncClient):
+    # More than one page (page size is 20).
+    for i in range(23):
+        await _create(client, title=f"Page {i}")
+
+    first = await client.get("/api/v1/pastes")
+    body = first.json()
+    assert len(body["pastes"]) == 20
+    assert body["has_more"] is True
+
+    second = await client.get("/api/v1/pastes?offset=20")
+    body2 = second.json()
+    assert len(body2["pastes"]) == 3
+    assert body2["has_more"] is False
+
+    # No overlap between the two pages.
+    slugs1 = {p["slug"] for p in body["pastes"]}
+    slugs2 = {p["slug"] for p in body2["pastes"]}
+    assert slugs1.isdisjoint(slugs2)
+
+
 async def test_patch_with_token_updates(client: AsyncClient):
     paste = await _create(client)
     resp = await client.patch(

--- a/www/app/pages/_components/RecentPages.tsx
+++ b/www/app/pages/_components/RecentPages.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { loadMorePages, type FeedPaste } from "../actions";
+import { timeAgo } from "../_lib/time";
+
+// The Recent-pages feed list with offset "Load more" pagination — the
+// initial page is server-rendered (small + fast), subsequent pages are
+// fetched on demand through a server action so the browser never loads
+// the whole feed up front.
+export default function RecentPages({
+  initial,
+  initialHasMore,
+}: {
+  initial: FeedPaste[];
+  initialHasMore: boolean;
+}) {
+  const [pages, setPages] = useState(initial);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [loading, setLoading] = useState(false);
+
+  async function more() {
+    if (loading) return;
+    setLoading(true);
+    const result = await loadMorePages(pages.length);
+    setPages((cur) => [...cur, ...result.pastes]);
+    setHasMore(result.has_more);
+    setLoading(false);
+  }
+
+  if (pages.length === 0) {
+    return <p className="mt-4 text-[14px] text-muted">Nothing published yet — be the first.</p>;
+  }
+
+  return (
+    <>
+      <ul className="mt-4 divide-y divide-border-subtle rounded-xl border border-border bg-surface">
+        {pages.map((paste) => (
+          <li key={paste.slug}>
+            <Link
+              href={`/pages/${paste.slug}`}
+              className="flex items-center gap-3 px-4 py-3 transition hover:bg-raised/60"
+            >
+              <TypeBadge contentType={paste.content_type} />
+              <span className="min-w-0 flex-1 truncate text-[14.5px] font-medium text-ink">
+                {paste.title}
+              </span>
+              <span className="w-16 shrink-0 text-right text-[12.5px] text-muted">
+                {timeAgo(paste.created_at)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            onClick={more}
+            disabled={loading}
+            className="inline-flex h-9 items-center rounded-md border border-border bg-white px-4 text-[13px] font-medium text-ink transition hover:bg-raised disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function TypeBadge({ contentType }: { contentType: "markdown" | "html" }) {
+  return (
+    <span className="inline-flex w-12 shrink-0 justify-center rounded border border-border bg-white px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-dim">
+      {contentType === "markdown" ? "MD" : "HTML"}
+    </span>
+  );
+}

--- a/www/app/pages/actions.ts
+++ b/www/app/pages/actions.ts
@@ -5,6 +5,27 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
 export type PasteContentType = "markdown" | "html";
 export type PasteVisibility = "public" | "unlisted";
 
+export type FeedPaste = {
+  slug: string;
+  title: string;
+  content_type: PasteContentType;
+  view_count: number;
+  created_at: string;
+};
+
+export async function fetchFeed(
+  offset = 0,
+): Promise<{ pastes: FeedPaste[]; has_more: boolean }> {
+  const res = await fetch(`${API_URL}/api/v1/pastes?offset=${offset}`, { cache: "no-store" });
+  if (!res.ok) return { pastes: [], has_more: false };
+  const body = await res.json();
+  return { pastes: body.pastes ?? [], has_more: body.has_more ?? false };
+}
+
+export async function loadMorePages(offset: number) {
+  return fetchFeed(offset);
+}
+
 export type CreatePasteResult =
   | {
       status: "ok";

--- a/www/app/pages/page.tsx
+++ b/www/app/pages/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import SiteHeader from "../_components/SiteHeader";
 import PageComposer from "./_components/PageComposer";
-import { timeAgo } from "./_lib/time";
+import RecentPages from "./_components/RecentPages";
+import { fetchFeed } from "./actions";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
 
 export const metadata: Metadata = {
@@ -13,21 +12,6 @@ export const metadata: Metadata = {
   description:
     "Shareable docs for your agents — publish a markdown doc or a mini HTML site and get a public view link and a private edit link. No signup.",
 };
-
-type FeedPaste = {
-  slug: string;
-  title: string;
-  content_type: "markdown" | "html";
-  view_count: number;
-  created_at: string;
-};
-
-async function fetchFeed(): Promise<FeedPaste[]> {
-  const res = await fetch(`${API_URL}/api/v1/pastes`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const body = await res.json();
-  return body.pastes ?? [];
-}
 
 export default async function PagesHome() {
   const feed = await fetchFeed();
@@ -48,37 +32,8 @@ export default async function PagesHome() {
 
       <section className="mx-auto max-w-[920px] px-7 pb-24">
         <h2 className="font-display text-[20px] font-semibold text-ink">Recent pages</h2>
-        {feed.length === 0 ? (
-          <p className="mt-4 text-[14px] text-muted">Nothing published yet — be the first.</p>
-        ) : (
-          <ul className="mt-4 divide-y divide-border-subtle rounded-xl border border-border bg-surface">
-            {feed.map((paste) => (
-              <li key={paste.slug}>
-                <Link
-                  href={`/pages/${paste.slug}`}
-                  className="flex items-center gap-3 px-4 py-3 transition hover:bg-raised/60"
-                >
-                  <TypeBadge contentType={paste.content_type} />
-                  <span className="min-w-0 flex-1 truncate text-[14.5px] font-medium text-ink">
-                    {paste.title}
-                  </span>
-                  <span className="w-16 shrink-0 text-right text-[12.5px] text-muted">
-                    {timeAgo(paste.created_at)}
-                  </span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
+        <RecentPages initial={feed.pastes} initialHasMore={feed.has_more} />
       </section>
     </main>
-  );
-}
-
-function TypeBadge({ contentType }: { contentType: "markdown" | "html" }) {
-  return (
-    <span className="inline-flex w-12 shrink-0 justify-center rounded border border-border bg-white px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-dim">
-      {contentType === "markdown" ? "MD" : "HTML"}
-    </span>
   );
 }


### PR DESCRIPTION
The Recent-pages feed was bounded (capped at 30, lean columns, no content) but always fetched the whole cap in one go and couldn't browse past it. This adds real pagination so it scales.

- **Smaller initial paint**: 20 rows server-rendered (was 30).
- **Load more**: offset pagination. `GET /api/v1/pastes?offset=` returns `has_more` (the endpoint fetches one extra row to know, no second query). The feed list is now a client component that appends the next page via a server action — the browser never loads the whole feed when there are lots of pages.
- **Stable ordering**: the existing hotness rank with a `created_at` tiebreak so paging doesn't skip/dupe.

Verified: API `page1=20/has_more:true`, `page2=remainder/has_more:false`, no overlap; in-browser Load more grows 20→35 and the button disappears at the end. 35 backend tests; www build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)