### PR TITLE
Landing + Pages: memory framing for how-it-works step 2; brand-color the composer toggles

### DIFF
--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -513,9 +513,9 @@ const DEFAULT_HOW_STEPS: HowItWorksStep[] = [
   },
   {
     n: "02",
-    pill: "Capture",
-    title: "Capture every agent session.",
-    body: "Transcripts stream in automatically — prompts, tool calls, artifacts — so your knowledge base accumulates with every run instead of evaporating when the session closes.",
+    pill: "Remember",
+    title: "Memory that builds itself.",
+    body: "Every agent session — prompts, tool calls, artifacts — streams in automatically and becomes shared, retrievable memory. Your agents remember what they did instead of starting from zero each run.",
     viz: <StreamViz />,
   },
   {

--- a/www/app/pages/_components/PageComposer.tsx
+++ b/www/app/pages/_components/PageComposer.tsx
@@ -158,8 +158,10 @@ export default function PageComposer({ appUrl }: { appUrl: string }) {
                   type="button"
                   onClick={() => openHtmlTab(tab)}
                   className={
-                    "rounded px-2.5 py-1 text-[12.5px] transition " +
-                    (htmlTab === tab ? "bg-ink text-white" : "text-dim hover:text-ink")
+                    "rounded px-2.5 py-1 text-[12.5px] font-medium transition " +
+                    (htmlTab === tab
+                      ? "bg-brand text-white shadow-sm"
+                      : "text-dim hover:bg-brand/10 hover:text-brand-ink")
                   }
                 >
                   {tab === "code" ? "Code" : "Edit visually"}
@@ -288,8 +290,10 @@ function Segmented({
           type="button"
           onClick={() => onChange(opt.value)}
           className={
-            "rounded px-2.5 py-1 text-[12.5px] transition " +
-            (value === opt.value ? "bg-ink text-white" : "text-dim hover:text-ink")
+            "rounded px-2.5 py-1 text-[12.5px] font-medium transition " +
+            (value === opt.value
+              ? "bg-brand text-white shadow-sm"
+              : "text-dim hover:bg-brand/10 hover:text-brand-ink")
           }
         >
           {opt.label}


### PR DESCRIPTION
Two small polish items.

**1. How it works → step 02 is now about agent memory.** Reframed "Capture every agent session" as **"Memory that builds itself"** — leads with the high-level value (agent memory) instead of the mechanism. Body: every session streams in automatically and becomes shared, retrievable memory, so agents don't start from zero each run.

**2. /pages composer toggles use the team brand color.** The MD/HTML, Public/Unlisted/Private, and HTML Code/Edit-visually toggles had a near-black active state; they're now **brand orange** when active with a soft-orange hover — friendlier and on-brand.

Verified in-browser: composer shows orange active segments; home step 2 reads as memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)