### PR TITLE
Landing: how-it-works title 'Connect. Remember. Create.'

### DIFF
--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -530,7 +530,7 @@ const DEFAULT_HOW_STEPS: HowItWorksStep[] = [
 // The message-test variant pages pass their own title/steps so the section
 // tells the story of the message under test.
 export function HowItWorks({
-  title = "Connect. Capture. Create.",
+  title = "Connect. Remember. Create.",
   subtitle = "One workspace, two kinds of writer.",
   steps = DEFAULT_HOW_STEPS,
 }: {


### PR DESCRIPTION
Step 02 is now 'Memory that builds itself' (#623), so the section header's 'Capture' no longer matched. Updated the title verb Capture → Remember so the triad lines up with the steps (Connect / Remember / Create). Subtitle 'One workspace, two kinds of writer' kept — still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)