### PR TITLE
EditableTitle: grow the rename input to fit long titles

### DIFF
--- a/frontend/src/components/workspace/EditableTitle.tsx
+++ b/frontend/src/components/workspace/EditableTitle.tsx
@@ -104,6 +104,9 @@ export default function EditableTitle({
     <input
       ref={inputRef}
       value={draft}
+      // Grow the input with its content so long titles aren't clipped. `size`
+      // is in characters; it auto-widens as the user types and shrinks back.
+      size={Math.max(draft.length, placeholder?.length ?? 1, 1)}
       disabled={saving}
       onChange={(e) => setDraft(e.target.value)}
       onKeyDown={onKey}
@@ -111,7 +114,7 @@ export default function EditableTitle({
       placeholder={placeholder}
       className={
         (className ?? "") +
-        " rounded border border-[var(--color-brand-300)] bg-base px-1 py-0.5 -mx-1 outline-none focus:border-[var(--color-brand-500)]"
+        " max-w-full rounded border border-[var(--color-brand-300)] bg-base px-1 py-0.5 -mx-1 outline-none focus:border-[var(--color-brand-500)]"
       }
     />
   );


### PR DESCRIPTION
## What

The page/file rename input used the browser-default fixed width (~20 chars), so typing a long title clipped the text — the static `<span>` auto-sized but the editable `<input>` did not.

Tie the input's `size` to the draft length so it widens as you type, capped at the column width via `max-w-full` (extreme titles scroll inside the input rather than overflowing the page).

## Verified

In the running app:
- 35-char title grows the box from 70px → 812px, no clipping.
- Unusually long 75-char title fills the column and caps cleanly at `max-w-full`.

Screenshots attached in a PR comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)