### PR TITLE
Pages: New page button never collides on "Untitled"

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -453,19 +453,16 @@ async def create_page(
             current_user["id"],
             require="write",
         )
-    try:
-        page = await files_tree_service.create_page(
-            workspace_id,
-            req.name,
-            current_user["id"],
-            folder_id=req.folder_id,
-            content=req.content,
-            content_type=req.content_type,
-            content_html=req.content_html,
-            html_layout=req.html_layout,
-        )
-    except DuplicatePageName as e:
-        raise HTTPException(status_code=409, detail=str(e))
+    page = await files_tree_service.create_page_unique(
+        workspace_id,
+        req.name,
+        current_user["id"],
+        req.folder_id,
+        content=req.content,
+        content_type=req.content_type,
+        content_html=req.content_html,
+        html_layout=req.html_layout,
+    )
     return PageResponse(**page)
 
 

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -774,9 +774,12 @@ async def list_trashed_pages(workspace_id: UUID) -> list[dict]:
 # names (the new folder is empty, so they can't collide).
 
 
-async def _create_page_unique(
+async def create_page_unique(
     workspace_id: UUID, base_name: str, created_by: UUID, folder_id: UUID | None, **content
 ) -> dict:
+    """Create a page, appending ' (2)', ' (3)', … until the name is free in the
+    target folder. Use for human-initiated creates where a collision should just
+    pick the next free name rather than fail."""
     name = base_name
     n = 2
     while True:
@@ -824,7 +827,7 @@ async def copy_page(
     if src is None:
         return None
     folder_id = target_folder_id if target_folder_id is not None else src["folder_id"]
-    return await _create_page_unique(
+    return await create_page_unique(
         workspace_id, f"Copy of {src['name']}", copied_by, folder_id, **_page_content_kwargs(src)
     )
 

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -791,3 +791,23 @@ async def test_owner_cannot_leave(client: AsyncClient):
 
     resp = await client.post(f"/api/v1/workspaces/{ws['id']}/leave", headers=_auth(key))
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_new_page_button_never_collides(client: AsyncClient):
+    """The 'New page' button always sends 'Untitled'. Clicking it repeatedly must
+    keep working: each new page gets the next free name instead of a 409."""
+    key, _ = await _register(client)
+    ws = (await client.post("/api/v1/workspaces", json={"name": "Pages"}, headers=_auth(key))).json()
+
+    names = []
+    for _ in range(3):
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws['id']}/pages/new",
+            json={"name": "Untitled"},
+            headers=_auth(key),
+        )
+        assert resp.status_code == 201
+        names.append(resp.json()["name"])
+
+    assert names == ["Untitled", "Untitled (2)", "Untitled (3)"]


### PR DESCRIPTION
## Problem

Clicking **+ New page** a second time failed with:

> Page 'Untitled' already exists in the root of the workspace.

The button always sends the name `Untitled`, and there's a DB unique constraint on `(workspace_id, name)` for root pages — so the first page works, every subsequent click 409s. The button is dead after one use.

## Fix

Route the web `POST /pages/new` endpoint through `create_page_unique` — the same `" (2)"`, `" (3)"` auto-naming already used when copying a page. Repeated clicks now create `Untitled`, `Untitled (2)`, `Untitled (3)`, … (Notion-style).

Agent/tool page creation still calls `create_page` directly and keeps the strict 409 on genuine name collisions — only the human-initiated web button auto-dedupes.

Net: `_create_page_unique` promoted to public `create_page_unique`; the now-unreachable duplicate-name handler removed from the endpoint.

## Tests

Added `test_new_page_button_never_collides`: posts `Untitled` three times and asserts all return 201 with names `["Untitled", "Untitled (2)", "Untitled (3)"]`. Full `test_workspaces.py` suite passes (20 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)