### PR TITLE
Collab: shared non-members can live-edit pages

### DIFF
--- a/backend/routers/collab.py
+++ b/backend/routers/collab.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
-from ..services import files_tree_service, paste_service, permission_service, workspace_service
+from ..services import files_tree_service, paste_service, permission_service
 
 router = APIRouter(prefix="/api/v1/collab", tags=["collaboration"])
 
@@ -42,8 +42,16 @@ async def authorize_collab_document(
     current_user: dict = Depends(get_current_user),
 ):
     workspace_id, page_id = _parse_page_document_name(req.document_name)
-    if not await workspace_service.is_member(workspace_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Not a workspace member")
+    # Shares grant access without workspace membership, so gate on read access
+    # (which honors shares) rather than membership; can_write decides editability.
+    if not await permission_service.check_access(
+        "page",
+        page_id,
+        current_user["id"],
+        workspace_id=workspace_id,
+        require="read",
+    ):
+        raise HTTPException(status_code=403, detail="Not authorized")
 
     page = await files_tree_service.get_page(page_id, workspace_id, current_user["id"])
     if not page:

--- a/backend/tests/test_collab.py
+++ b/backend/tests/test_collab.py
@@ -88,6 +88,82 @@ async def test_collab_authorizes_workspace_viewer_as_read_only(
 
 
 @pytest.mark.asyncio
+async def test_collab_authorizes_non_member_with_page_share(
+    client: AsyncClient,
+    pool,
+):
+    """A page shared directly with a non-member grants live-edit access:
+    membership is not required, the share decides read/write."""
+    owner_key, _owner = await _register(client)
+    editor_key, editor = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    await pool.execute(
+        """
+        INSERT INTO shares (workspace_id, object_type, object_id, principal_type,
+                            principal_id, permission, created_by)
+        VALUES ($1, 'page', $2, 'user', $3, 'write', $4)
+        """,
+        uuid.UUID(workspace["id"]),
+        uuid.UUID(page["id"]),
+        uuid.UUID(editor["id"]),
+        uuid.UUID(_owner["id"]),
+    )
+
+    response = await client.post(
+        "/api/v1/collab/authorize",
+        json={"document_name": f"workspace:{workspace['id']}:page:{page['id']}"},
+        headers=_auth(editor_key),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["can_write"] is True
+
+
+@pytest.mark.asyncio
+async def test_collab_rejects_user_without_access(
+    client: AsyncClient,
+):
+    """A user who is neither a member nor a sharee is rejected outright."""
+    owner_key, _owner = await _register(client)
+    outsider_key, _outsider = await _register(client)
+    workspace = (
+        await client.post(
+            "/api/v1/workspaces",
+            json={"name": "Collab"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+    page = (
+        await client.post(
+            f"/api/v1/workspaces/{workspace['id']}/pages/new",
+            json={"name": "Plan", "content": "# Draft"},
+            headers=_auth(owner_key),
+        )
+    ).json()
+
+    response = await client.post(
+        "/api/v1/collab/authorize",
+        json={"document_name": f"workspace:{workspace['id']}:page:{page['id']}"},
+        headers=_auth(outsider_key),
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_collab_rejects_html_pages(client: AsyncClient):
     api_key, _user = await _register(client)
     workspace = (


### PR DESCRIPTION
## Problem

A page shared **directly** with someone who isn't a member of the owning workspace loaded fine (title, comments, read access) but showed a red **`permission-denied`** banner in the editor and couldn't be edited — even when shared as "Can edit".

The cause: the collab (Yjs) `/authorize` endpoint hard-gated on workspace membership *before* it ever consulted shares:

```python
if not await workspace_service.is_member(workspace_id, current_user["id"]):
    raise HTTPException(status_code=403, detail="Not a workspace member")
```

The 403 propagates through the Hocuspocus collab server, which emits the literal `permission-denied` string that `MarkdownEditor` renders as the red banner. The very next lines already computed share-aware `can_write` via `permission_service.check_access`, but the membership gate short-circuited before it ran.

## Fix

Gate on share-aware **read** access (which honors shares, including inherited folder shares) and let the existing `can_write` check decide editable vs read-only. Now:

- Shared editors get write access.
- Shared viewers get the proper grey "Read-only live view" banner instead of `permission-denied`.
- Users with no access are still rejected (403).

Also dropped the now-unused `workspace_service` import.

## Tests

Added two regression tests to `backend/tests/test_collab.py`:
- `test_collab_authorizes_non_member_with_page_share` — non-member with a `write` share gets `can_write: true`.
- `test_collab_rejects_user_without_access` — neither member nor sharee → 403.

All 7 collab tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)