### PR TITLE
Share dialog: change a person's permission after sharing

### DIFF
--- a/frontend/src/components/share/ResourceShareButton.test.tsx
+++ b/frontend/src/components/share/ResourceShareButton.test.tsx
@@ -123,4 +123,33 @@ describe("ResourceShareButton", () => {
     expect(await screen.findByText("ada@example.com")).toBeInTheDocument();
     expect(screen.getByText("Invited")).toBeInTheDocument();
   });
+
+  it("changes an existing person's permission", async () => {
+    render(
+      <ResourceShareButton
+        objectType="page"
+        objectId="page-1"
+        resourceName="Blog post outline"
+        resourceUrlPath="/p/page-1"
+        currentUser={currentUser}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    await screen.findByText("Ada Lovelace");
+
+    fireEvent.change(screen.getByLabelText("Change permission"), {
+      target: { value: "comment" },
+    });
+
+    await waitFor(() =>
+      expect(shareObjectByEmail).toHaveBeenCalledWith(
+        "page",
+        "page-1",
+        "ada@example.com",
+        "comment",
+      ),
+    );
+    expect(await screen.findByText("Access updated.")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -19,10 +19,11 @@ import {
 } from "../../lib/api";
 import type { User } from "../../lib/types";
 
-type SharePermission = Extract<GeneralPermission, "read" | "write">;
+type SharePermission = Extract<GeneralPermission, "read" | "comment" | "write">;
 
 const PERMISSIONS: { value: SharePermission; label: string }[] = [
   { value: "read", label: "Can view" },
+  { value: "comment", label: "Can comment" },
   { value: "write", label: "Can edit" },
 ];
 
@@ -119,6 +120,24 @@ export default function ResourceShareButton({
       await loadShares();
     } catch (e) {
       setMessage(e instanceof Error ? e.message : "Could not remove access.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function changePermission(share: ObjectShare, next: SharePermission) {
+    if (!share.email || share.permission === next) return;
+
+    setBusy(true);
+    setMessage("");
+    try {
+      // The share endpoint upserts on conflict, so re-sharing the same email
+      // with a new permission updates the existing share or pending invite.
+      await shareObjectByEmail(objectType, objectId, share.email, next);
+      await loadShares();
+      setMessage("Access updated.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "Could not update access.");
     } finally {
       setBusy(false);
     }
@@ -243,8 +262,11 @@ export default function ResourceShareButton({
                         ? "Invited"
                         : share.email ?? share.principal_type
                     }
-                    permissionLabel={
-                      share.permission === "write" ? "Can edit" : "Can view"
+                    permission={share.permission as SharePermission}
+                    onChangePermission={
+                      share.email
+                        ? (next) => void changePermission(share, next)
+                        : undefined
                     }
                     onRemove={
                       share.pending || !share.principal_id
@@ -318,12 +340,16 @@ function AccessRow({
   label,
   sublabel,
   permissionLabel,
+  permission,
+  onChangePermission,
   onRemove,
   busy = false,
 }: {
   label: string;
   sublabel: string;
-  permissionLabel: string;
+  permissionLabel?: string;
+  permission?: SharePermission;
+  onChangePermission?: (permission: SharePermission) => void;
   onRemove?: () => void;
   busy?: boolean;
 }) {
@@ -336,7 +362,25 @@ function AccessRow({
         </span>
         <span className="block truncate text-[12px] text-muted">{sublabel}</span>
       </span>
-      <span className="shrink-0 text-[12px] text-muted">{permissionLabel}</span>
+      {onChangePermission && permission ? (
+        <select
+          value={permission}
+          onChange={(event) =>
+            onChangePermission(event.target.value as SharePermission)
+          }
+          disabled={busy}
+          aria-label="Change permission"
+          className="shrink-0 rounded-md border border-border bg-base px-1.5 py-1 text-[12px] text-foreground disabled:opacity-45"
+        >
+          {PERMISSIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <span className="shrink-0 text-[12px] text-muted">{permissionLabel}</span>
+      )}
       {onRemove && (
         <button
           type="button"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1149,7 +1149,7 @@ export interface SessionSummary {
   session_folder_name: string | null;
 }
 
-export type GeneralPermission = "none" | "read" | "write";
+export type GeneralPermission = "none" | "read" | "comment" | "write";
 // Stored visibility is two-state (the "workspace" tier was dropped after the
 // 1:1 workspace↔user migration). "shared" is a derived display state.
 export type SessionFolderVisibility = "private" | "public";


### PR DESCRIPTION
## What

You can now change someone's permission **after** you've shared with them — no more remove-and-re-invite. Each row under **People with access** has a dropdown to switch between **Can view / Can comment / Can edit**.

Closes the request: "share with someone to view and then change it to comment."

## How

- `ResourceShareButton` renders a permission `<select>` per share row (replacing the static label). Changing it calls the existing share endpoint, which already upserts `ON CONFLICT DO UPDATE SET permission`, so re-sharing the same email with a new permission just updates the existing share or pending invite.
- Added a **Can comment** option — the backend already accepts `read`/`comment`/`write`; the frontend just wasn't offering it. Widened `GeneralPermission` to include `comment`.
- The owner row stays static ("Owner"). Pending invites are editable too (the invite table upserts the same way).

## Tests

- New unit test: changing a person's permission calls `shareObjectByEmail(..., "comment")` and shows "Access updated." All 3 `ResourceShareButton` tests pass.

## Screenshot

Sam switched from "Can view" to "Can comment" in the live component: