### PR TITLE
CLI: consolidate redundant commands into unified verbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,7 @@ A Skill is a *special folder* — one containing a SKILL.md — holding related 
 
 A Skill is **not** a wrapper to slap on every single file you happen to share. One-item Skills clutter Discover and defeat the model. Pick the right tool:
 
-- Internal share of a single file → `stash files upload <path> --json`, hand over `app_url`.
-- Upload a folder/project → `stash upload <path> --json` (returns `app_url`, no Skill).
+- Share a single file or a folder/project → `stash upload <path> --json`, hand over `app_url` (no Skill).
 - Publishing a curated bundle → `stash upload <path> --skill "<title>" --json`.
 - Creating a fresh skill → `stash skills create "<name>" --public --json`.
 - Share a coding session → `stash share <session_id>`.

--- a/README.md
+++ b/README.md
@@ -173,16 +173,12 @@ Then install the CLI:
 ```bash
 pip install stashai   # or: uv tool install stashai
 cd /path/to/the/repo/you/want/to/connect
-stash config base_url http://localhost:3456
-stash login
+stash login   # choose "Self-host" and enter http://localhost:3456
 ```
 
-Use your public URL instead of `http://localhost:3456` when connecting to a
-domain-backed install:
-
-```bash
-stash config base_url https://app.example.com
-```
+When connecting to a domain-backed install, enter your public URL (e.g.
+`https://app.example.com`) at the same prompt. To change the endpoint later,
+run `stash settings`.
 
 Finally see it in action:
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -159,25 +159,6 @@ def register(
         )
 
 
-@app.command()
-def login(
-    name: str = typer.Argument(...),
-    password: str = typer.Option(..., prompt=True, hide_input=True),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Login with password."""
-    with _client() as c:
-        try:
-            data = c.login(name, password)
-        except StashError as e:
-            _err(e)
-    save_config(api_key=data["api_key"], username=data["name"])
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(f"[green]Logged in as {data['name']}[/green]")
-
-
 def _default_signin_page(api: str) -> str:
     """Map a backend URL to its matching /connect-token page."""
     api = api.rstrip("/")
@@ -1299,11 +1280,12 @@ def upload(
     ),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Upload local files into a workspace folder.
+    """Upload a local file or directory into a workspace.
 
-    Default: upload only — files land in a workspace folder, and the
-    returned ``app_url`` is the workspace link your teammates can already
-    follow. **No Skill is created.**
+    A single file lands directly in the workspace (Markdown/HTML become
+    editable pages, everything else a binary file) and the returned
+    ``app_url`` is the share link. A directory becomes a workspace folder.
+    **No Skill is created.**
 
     Pass ``--skill <title>`` to *also* bundle the upload into a shareable
     Skill. Use a Skill when you're publishing a folder of related
@@ -1316,6 +1298,23 @@ def upload(
     if not target.exists():
         console.print(f"[red]Not found: {path}[/red]")
         raise typer.Exit(1)
+
+    # A single file with no Skill goes straight into the workspace — no
+    # wrapping folder. The server routes Markdown/HTML to pages.
+    if target.is_file() and not skill:
+        ws = workspace_id or _resolve_workspace()
+        with _client() as c:
+            try:
+                data = _upload_path(c, ws, str(target))
+            except StashError as e:
+                _err(e)
+        if _use_json(as_json):
+            output_json(data)
+            return
+        label = "Uploaded as page" if data.get("kind") == "page" else "Uploaded"
+        console.print(f"[green]{label}[/green] {data['name']}  [dim]{data['id']}[/dim]")
+        console.print(data["app_url"])
+        return
 
     files = _upload_file_list(target)
     if not files:
@@ -2186,32 +2185,21 @@ def files_create_folder(
 @files_app.command("edit-folder")
 def files_edit_folder(
     folder_id: str = typer.Argument(...),
-    name: str = typer.Option(None, "--name", help="Rename the folder."),
-    parent: str = typer.Option(None, "--parent", help="Move under this parent folder id."),
-    to_root: bool = typer.Option(False, "--to-root", help="Move to workspace root."),
+    name: str = typer.Option(..., "--name", help="New folder name."),
     workspace_id: str = typer.Option(None, "--ws"),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Rename and/or reparent a folder."""
-    if parent and to_root:
-        console.print("[red]--parent and --to-root are mutually exclusive[/red]")
-        raise typer.Exit(1)
+    """Rename a folder. Use `stash mv` to relocate it."""
     ws = workspace_id or _resolve_workspace()
     with _client() as c:
         try:
-            data = c.update_folder(
-                ws,
-                folder_id,
-                name=name,
-                parent_folder_id=parent,
-                move_to_root=to_root,
-            )
+            data = c.update_folder(ws, folder_id, name=name)
         except StashError as e:
             _err(e)
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]Folder updated.[/green] {data['name']}  [dim]{data['id']}[/dim]")
+        console.print(f"[green]Folder renamed.[/green] {data['name']}  [dim]{data['id']}[/dim]")
 
 
 @files_app.command("pages")
@@ -2547,24 +2535,6 @@ def hist_new_folder(
     console.print(f"[green]Created folder[/green] {name}  [dim]({data.get('id')})[/dim]")
 
 
-@hist_app.command("assign")
-def hist_assign(
-    session_row_id: str = typer.Argument(..., help="The session row id to move."),
-    folder: str = typer.Option(
-        None, "--folder", help="Target folder id; omit to move back to ungrouped root."
-    ),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Move a session into a session folder (or back to the ungrouped root)."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.assign_session_folder(ws, session_row_id, folder_id=folder)
-        except StashError as e:
-            _err(e)
-    console.print("[green]Session assigned.[/green]")
-
-
 @hist_app.command("push")
 def hist_push(
     content: str = typer.Argument(...),
@@ -2770,57 +2740,6 @@ def _transcript_to_markdown(raw_jsonl: str) -> str:
     return "\n---\n\n".join(lines) if lines else "(empty transcript)"
 
 
-@hist_app.command("share")
-def hist_share(
-    session_id: str = typer.Argument(...),
-    title: str = typer.Option(
-        "", "--title", help="Title for the shared page. Auto-generated if omitted."
-    ),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Share a session transcript as a public Skill link.
-
-    Fetches the transcript, formats it as a readable page, publishes it
-    in a new Skill, and prints the shareable URL.
-    """
-    import gzip
-
-    import httpx
-
-    ws = workspace_id or _resolve_workspace()
-    cfg = load_config()
-    base = cfg["base_url"].rstrip("/")
-    headers = {"Authorization": f"Bearer {cfg.get('api_key', '')}"}
-
-    # 1. Fetch transcript
-    url = f"{base}/api/v1/workspaces/{ws}/transcripts/{session_id}"
-    meta = httpx.get(url, headers=headers, timeout=30).json()
-    if "download_url" not in meta:
-        console.print(f"[red]{meta.get('detail', 'Transcript not found')}[/red]")
-        raise typer.Exit(1)
-    raw = httpx.get(meta["download_url"], timeout=60).content
-    if raw[:2] == b"\x1f\x8b":
-        raw = gzip.decompress(raw)
-    body = raw.decode("utf-8", errors="replace")
-
-    # 2. Format into markdown
-    md = _transcript_to_markdown(body)
-
-    # 3. Create folder + page + public Skill
-    page_title = title or f"Session {session_id[:8]}"
-    with _client() as c:
-        folder = c.create_folder(ws, page_title)
-        c.create_page(ws, page_title, content=md, folder_id=folder["id"])
-        skill = c.publish_skill_folder(
-            ws,
-            folder["id"],
-            title=page_title,
-            description="Shared session transcript",
-        )
-
-    console.print(f"[green]Shared![/green]  {_web_app_url()}/skills/{skill['slug']}")
-
-
 @hist_app.command("import")
 def hist_import(
     workspace_id: str = typer.Option(None, "--ws"),
@@ -2901,58 +2820,6 @@ def hist_import(
             )
 
 
-@hist_app.command("delete")
-def hist_delete(
-    session_row_id: str = typer.Argument(..., help="Session row id (UUID), not session_id."),
-    workspace_id: str = typer.Option(None, "--ws"),
-    permanent: bool = typer.Option(False, "--permanent"),
-):
-    """Move a session to trash. Pass --permanent to wipe it without going through trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.delete_session(ws, session_row_id)
-            if permanent:
-                c.purge_session(ws, session_row_id)
-        except StashError as e:
-            _err(e)
-    console.print(
-        "[green]Session permanently deleted.[/green]"
-        if permanent
-        else "[green]Session moved to trash.[/green]"
-    )
-
-
-@hist_app.command("restore")
-def hist_restore(
-    session_row_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Restore a session from trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.restore_session(ws, session_row_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]Session restored.[/green]")
-
-
-@hist_app.command("purge")
-def hist_purge(
-    session_row_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Permanently delete a session already in trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.purge_session(ws, session_row_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]Session permanently deleted.[/green]")
-
-
 # ===========================================================================
 # Sources — unified VFS over native files/sessions + connected sources
 # ===========================================================================
@@ -2964,7 +2831,7 @@ app.add_typer(sources_app, name="sources")
 
 
 def _print_search(query: str, source: str, workspace_id: str, limit: int, as_json: bool) -> None:
-    """Shared body for `stash search` and `stash sources search`."""
+    """Shared body for `stash search`."""
     telemetry.record("sources.search")
     ws = workspace_id or _resolve_workspace()
     with _client() as c:
@@ -3128,18 +2995,6 @@ def sources_read(
     console.print(data.get("content") or data.get("transcript") or "")
 
 
-@sources_app.command("search")
-def sources_search(
-    query: str = typer.Argument(...),
-    source: str = typer.Option("", "--source", help="Scope to one source handle."),
-    workspace_id: str = typer.Option(None, "--ws"),
-    limit: int = typer.Option(20, "-n", "--limit"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Search across sources (alias of `stash search`)."""
-    _print_search(query, source, workspace_id, limit, as_json)
-
-
 def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
     """Stable filesystem-style directory name per source. Natives keep their
     handle ('files', 'sessions'); connected sources slug their display name,
@@ -3261,6 +3116,145 @@ def _print_ls_path(c: StashClient, ws: str, sources: list[dict], path: str, as_j
 
 
 # ===========================================================================
+# Object operations — rm / restore / mv / cp across every object type
+# ===========================================================================
+
+_OBJECT_TYPES = "page | file | folder | session | table"
+
+
+def _parse_refs(refs: list[str]) -> list[tuple[str, str]]:
+    """Parse `type:id` tokens (e.g. page:abc session:def) into (type, id) pairs."""
+    parsed = []
+    for ref in refs:
+        if ":" not in ref:
+            console.print(f"[red]Invalid item '{ref}' — use type:id, e.g. page:<id>[/red]")
+            raise typer.Exit(1)
+        object_type, object_id = ref.split(":", 1)
+        parsed.append((object_type, object_id))
+    return parsed
+
+
+@app.command("rm")
+def rm_cmd(
+    refs: list[str] = typer.Argument(..., help="Items as type:id. Types: page | file | session"),
+    workspace_id: str = typer.Option(None, "--ws"),
+    permanent: bool = typer.Option(
+        False, "--permanent", help="Skip the trash window — delete immediately."
+    ),
+):
+    """Move pages, files, or sessions to trash. Pass --permanent to wipe immediately.
+
+    Example: stash rm page:<id> file:<id> session:<id>
+    """
+    ws = workspace_id or _resolve_workspace()
+    trash = {
+        "page": (lambda c, i: c.delete_page(ws, i), lambda c, i: c.purge_page(ws, i)),
+        "file": (lambda c, i: c.delete_ws_file(ws, i), lambda c, i: c.purge_ws_file(ws, i)),
+        "session": (lambda c, i: c.delete_session(ws, i), lambda c, i: c.purge_session(ws, i)),
+    }
+    items = _parse_refs(refs)
+    with _client() as c:
+        for object_type, object_id in items:
+            if object_type not in trash:
+                console.print(f"[red]Cannot rm '{object_type}'. Supported: page | file | session[/red]")
+                raise typer.Exit(1)
+            delete, purge = trash[object_type]
+            try:
+                delete(c, object_id)
+                if permanent:
+                    purge(c, object_id)
+            except StashError as e:
+                _err(e)
+    verb = "permanently deleted" if permanent else "moved to trash"
+    console.print(f"[green]{len(items)} item(s) {verb}.[/green]")
+
+
+@app.command("restore")
+def restore_cmd(
+    refs: list[str] = typer.Argument(..., help="Items as type:id. Types: page | file | session"),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Restore pages, files, or sessions from trash.
+
+    Example: stash restore page:<id> session:<id>
+    """
+    ws = workspace_id or _resolve_workspace()
+    restore = {
+        "page": lambda c, i: c.restore_page(ws, i),
+        "file": lambda c, i: c.restore_ws_file(ws, i),
+        "session": lambda c, i: c.restore_session(ws, i),
+    }
+    items = _parse_refs(refs)
+    with _client() as c:
+        for object_type, object_id in items:
+            if object_type not in restore:
+                console.print(f"[red]Cannot restore '{object_type}'. Supported: page | file | session[/red]")
+                raise typer.Exit(1)
+            try:
+                restore[object_type](c, object_id)
+            except StashError as e:
+                _err(e)
+    console.print(f"[green]{len(items)} item(s) restored.[/green]")
+
+
+@app.command("mv")
+def mv_cmd(
+    refs: list[str] = typer.Argument(..., help=f"Items as type:id. Types: {_OBJECT_TYPES}"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id."),
+    to_root: bool = typer.Option(False, "--to-root", help="Move to the workspace root."),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Move objects into a folder (or to the workspace root with --to-root).
+
+    Example: stash mv page:<id> file:<id> --to-folder <id>
+    """
+    if not to_folder and not to_root:
+        console.print("[red]Pass --to-folder <id> or --to-root.[/red]")
+        raise typer.Exit(1)
+    ws = workspace_id or _resolve_workspace()
+    items = _parse_refs(refs)
+    sessions = [i for t, i in items if t == "session"]
+    others = [{"object_type": t, "object_id": i} for t, i in items if t != "session"]
+    with _client() as c:
+        try:
+            if others:
+                c.batch_move(ws, others, target_folder_id=to_folder, move_to_root=to_root)
+            for session_id in sessions:
+                c.assign_session_folder(ws, session_id, folder_id=None if to_root else to_folder)
+        except StashError as e:
+            _err(e)
+    console.print(f"[green]{len(items)} item(s) moved.[/green]")
+
+
+@app.command("cp")
+def cp_cmd(
+    refs: list[str] = typer.Argument(..., help="Items as type:id. Types: page | file | folder"),
+    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id."),
+    workspace_id: str = typer.Option(None, "--ws"),
+):
+    """Duplicate pages, files, or folders as 'Copy of <name>'.
+
+    Example: stash cp page:<id> folder:<id> --to-folder <id>
+    """
+    ws = workspace_id or _resolve_workspace()
+    copy = {
+        "page": lambda c, i: c.copy_page(ws, i, target_folder_id=to_folder or None),
+        "file": lambda c, i: c.copy_ws_file(ws, i, target_folder_id=to_folder or None),
+        "folder": lambda c, i: c.copy_folder(ws, i, target_folder_id=to_folder or None),
+    }
+    for object_type, object_id in _parse_refs(refs):
+        if object_type not in copy:
+            console.print(f"[red]Cannot cp '{object_type}'. Supported: page | file | folder[/red]")
+            raise typer.Exit(1)
+        with _client() as c:
+            try:
+                made = copy[object_type](c, object_id)
+            except StashError as e:
+                _err(e)
+        console.print(f"[green]Copied to[/green] {made['name']} ({made['id']})")
+
+
+# ===========================================================================
 # Shares — grant a person access to a folder/page/file/session by email
 # ===========================================================================
 
@@ -3335,77 +3329,6 @@ def shares_rm(
         except StashError as e:
             _err(e)
     console.print("[green]Access revoked.[/green]")
-
-
-# ===========================================================================
-# Batch ops
-# ===========================================================================
-
-batch_app = typer.Typer(help="Batch — move/delete/restore many items at once.")
-app.add_typer(batch_app, name="batch")
-
-
-def _parse_batch_items(refs: list[str]) -> list[dict]:
-    """Parse `type:id` tokens (e.g. page:abc file:def) into batch items."""
-    items = []
-    for ref in refs:
-        if ":" not in ref:
-            _err(f"Invalid item '{ref}' — use type:id, e.g. page:<id>")
-        object_type, object_id = ref.split(":", 1)
-        items.append({"object_type": object_type, "object_id": object_id})
-    return items
-
-
-@batch_app.command("move")
-def batch_move(
-    refs: list[str] = typer.Argument(..., help="Items as type:id, e.g. page:<id> file:<id>"),
-    workspace_id: str = typer.Option(None, "--ws"),
-    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
-    to_root: bool = typer.Option(False, "--to-root", help="Move to the workspace root"),
-):
-    """Move many items (pages, files, folders, tables) at once."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            result = c.batch_move(
-                ws,
-                _parse_batch_items(refs),
-                target_folder_id=to_folder or None,
-                move_to_root=to_root,
-            )
-        except StashError as e:
-            _err(e)
-    output_json(result)
-
-
-@batch_app.command("delete")
-def batch_delete(
-    refs: list[str] = typer.Argument(..., help="Items as type:id (pages/files)"),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Move many pages/files to the trash at once."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            result = c.batch_delete(ws, _parse_batch_items(refs))
-        except StashError as e:
-            _err(e)
-    output_json(result)
-
-
-@batch_app.command("restore")
-def batch_restore(
-    refs: list[str] = typer.Argument(..., help="Items as type:id (pages/files)"),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Restore many pages/files from the trash at once."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            result = c.batch_restore(ws, _parse_batch_items(refs))
-        except StashError as e:
-            _err(e)
-    output_json(result)
 
 
 # ===========================================================================
@@ -3983,33 +3906,6 @@ def _get_file_meta(c: StashClient, workspace_id: str, file_id: str) -> dict:
     return c.get_ws_file(workspace_id, file_id)
 
 
-@files_app.command("upload")
-def files_upload(
-    path: str = typer.Argument(..., help="Local file path to upload."),
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Upload a file to a workspace.
-
-    Markdown (.md/.markdown/.mdx) and HTML (.html/.htm) become editable
-    pages; everything else becomes a binary file. The server does the
-    routing, so the returned object's `kind` tells you what landed where.
-    """
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = _upload_path(c, ws, path)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        kind = data.get("kind", "file")
-        label = "Uploaded as page" if kind == "page" else "Uploaded"
-        console.print(f"[green]{label}[/green] {data['name']}  [dim]{data['id']}[/dim]")
-        console.print(data["app_url"])
-
-
 @files_app.command("list")
 def files_list(
     workspace_id: str = typer.Option(None, "--ws"),
@@ -4039,188 +3935,21 @@ def files_list(
 @files_app.command("edit-file")
 def files_edit_file(
     file_id: str = typer.Argument(...),
-    name: str = typer.Option(None, "--name", help="Rename the file."),
-    folder: str = typer.Option(None, "--folder", help="Move into this folder id."),
-    to_root: bool = typer.Option(False, "--to-root", help="Move to workspace root."),
+    name: str = typer.Option(..., "--name", help="New file name."),
     workspace_id: str = typer.Option(None, "--ws"),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Rename and/or move a file. Pass any subset of --name / --folder / --to-root."""
-    if folder and to_root:
-        console.print("[red]--folder and --to-root are mutually exclusive[/red]")
-        raise typer.Exit(1)
+    """Rename a file. Use `stash mv` to relocate it."""
     ws = workspace_id or _resolve_workspace()
     with _client() as c:
         try:
-            data = c.update_ws_file(
-                ws,
-                file_id,
-                name=name,
-                folder_id=folder,
-                move_to_root=to_root,
-            )
+            data = c.update_ws_file(ws, file_id, name=name)
         except StashError as e:
             _err(e)
     if _use_json(as_json):
         output_json(data)
     else:
-        console.print(f"[green]File updated.[/green] {data['name']}  [dim]{data['id']}[/dim]")
-
-
-@files_app.command("rm")
-def files_rm(
-    file_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    permanent: bool = typer.Option(
-        False,
-        "--permanent",
-        help="Trash and then immediately purge — skips the recoverable trash window.",
-    ),
-):
-    """Move a file to trash. Pass --permanent to wipe it without going through trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.delete_ws_file(ws, file_id)
-            if permanent:
-                c.purge_ws_file(ws, file_id)
-        except StashError as e:
-            _err(e)
-    console.print(
-        "[green]File permanently deleted.[/green]"
-        if permanent
-        else "[green]File moved to trash.[/green]"
-    )
-
-
-@files_app.command("restore")
-def files_restore(
-    file_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Restore a file from trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.restore_ws_file(ws, file_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]File restored.[/green]")
-
-
-@files_app.command("purge")
-def files_purge(
-    file_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Permanently delete a file already in trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.purge_ws_file(ws, file_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]File permanently deleted.[/green]")
-
-
-@files_app.command("rm-page")
-def files_rm_page(
-    page_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    permanent: bool = typer.Option(False, "--permanent"),
-):
-    """Move a page to trash. Pass --permanent to wipe it without going through trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.delete_page(ws, page_id)
-            if permanent:
-                c.purge_page(ws, page_id)
-        except StashError as e:
-            _err(e)
-    console.print(
-        "[green]Page permanently deleted.[/green]"
-        if permanent
-        else "[green]Page moved to trash.[/green]"
-    )
-
-
-@files_app.command("restore-page")
-def files_restore_page(
-    page_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Restore a page from trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.restore_page(ws, page_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]Page restored.[/green]")
-
-
-@files_app.command("purge-page")
-def files_purge_page(
-    page_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-):
-    """Permanently delete a page already in trash."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            c.purge_page(ws, page_id)
-        except StashError as e:
-            _err(e)
-    console.print("[green]Page permanently deleted.[/green]")
-
-
-@files_app.command("copy-page")
-def files_copy_page(
-    page_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
-):
-    """Duplicate a page as 'Copy of <name>'."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            page = c.copy_page(ws, page_id, target_folder_id=to_folder or None)
-        except StashError as e:
-            _err(e)
-    console.print(f"[green]Copied to[/green] {page['name']} ({page['id']})")
-
-
-@files_app.command("copy-folder")
-def files_copy_folder(
-    folder_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    to_folder: str = typer.Option(None, "--to-folder", help="Target parent folder id"),
-):
-    """Deep-duplicate a folder as 'Copy of <name>'."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            folder = c.copy_folder(ws, folder_id, target_folder_id=to_folder or None)
-        except StashError as e:
-            _err(e)
-    console.print(f"[green]Copied to[/green] {folder['name']} ({folder['id']})")
-
-
-@files_app.command("copy-file")
-def files_copy_file(
-    file_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    to_folder: str = typer.Option(None, "--to-folder", help="Target folder id"),
-):
-    """Duplicate an uploaded file as 'Copy of <name>'."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            f = c.copy_ws_file(ws, file_id, target_folder_id=to_folder or None)
-        except StashError as e:
-            _err(e)
-    console.print(f"[green]Copied to[/green] {f['name']} ({f['id']})")
+        console.print(f"[green]File renamed.[/green] {data['name']}  [dim]{data['id']}[/dim]")
 
 
 @files_app.command("text")
@@ -4416,8 +4145,7 @@ transcript frozen as a page plus the files it produced.
 A Skill is **not** a wrapper to slap on every single file you happen to share. One-item Skills
 clutter Discover and defeat the model. Pick the right tool:
 
-- Internal share of a single file → `stash files upload <path> --json`, hand over `app_url`.
-- Upload a folder/project → `stash upload <path> --json` (returns `app_url`, no Skill).
+- Share a single file or a folder/project → `stash upload <path> --json`, hand over `app_url` (no Skill).
 - Publishing a curated bundle → `stash upload <path> --skill "<title>" --json`.
 - Creating a fresh skill → `stash skills create "<name>" --public --json`.
 - Share a coding session → `stash share <session_id>`.
@@ -5372,76 +5100,6 @@ def vfs_command(
 
 
 # ===========================================================================
-# Config
-# ===========================================================================
-
-
-@app.command("config")
-def config_cmd(
-    key: str | None = typer.Argument(None),
-    value: str | None = typer.Argument(None),
-):
-    """Show or set config. Keys: base_url.
-
-    Writes to ~/.stash/config.json.
-    """
-    from .config import USER_CONFIG_FILE
-
-    if key and value:
-        allowed = {"base_url", "api_key", "username"}
-        if key not in allowed:
-            console.print(f"[red]Unknown config key: {key}[/red]")
-            raise typer.Exit(1)
-        save_config(**{key: value})
-        console.print(f"[green]{key} = {value}[/green]")
-        return
-
-    cfg = load_config()
-    display = dict(cfg)
-    if display.get("api_key"):
-        display["api_key"] = display["api_key"][:10] + "..."
-
-    console.print(f"[dim]config:  {USER_CONFIG_FILE}[/dim]\n")
-    console.print(json.dumps(display, indent=2, default=str))
-
-
-@app.command("publish")
-def publish_cmd(
-    file_path: str = typer.Argument(..., help="Path to .html or .md file to publish"),
-    title: str = typer.Option(None, "--title", "-t", help="Page title (defaults to filename)"),
-    workspace_id: str = typer.Option(None, "--workspace", "-w"),
-    folder_id: str = typer.Option(
-        None, "--folder", "-f", help="Defaults to auto-created 'AI Drafts' folder"
-    ),
-    audience: str = typer.Option("public", "--audience", help="workspace | private | public"),
-):
-    """Publish a local file as a Stash page and print the share URL.
-
-    Single call: creates the page, wraps it in a Stash, and prints the Stash URL.
-    Mirrors what an agent does via the MCP `stash_publish_html` tool."""
-    p = Path(file_path)
-    if not p.exists():
-        console.print(f"[red]File not found: {file_path}[/red]")
-        raise typer.Exit(1)
-    content_type = "html" if p.suffix.lower() in (".html", ".htm") else "markdown"
-    cfg = load_config()
-    c = StashClient(cfg["base_url"], cfg.get("api_key", ""))
-    ws = workspace_id or (load_manifest() or {}).get("workspace_id")
-    if not ws:
-        console.print("[red]No workspace. Pass --workspace or run `stash connect`.[/red]")
-        raise typer.Exit(1)
-    result = c.publish(
-        workspace_id=ws,
-        title=title or p.stem,
-        content=p.read_text(),
-        content_type=content_type,
-        audience=audience,
-        folder_id=folder_id,
-    )
-    console.print(result["url"])
-
-
-# ===========================================================================
 # Prompts — reusable agent-facing prompts the CLI can hand back as text
 # ===========================================================================
 
@@ -5476,16 +5134,15 @@ Do NOT create a Skill when:
 - The user just wants to share one file or page internally. Workspace
   members can already see it — give them the workspace `app_url`.
 - You're emitting incidental artifacts (logs, intermediate outputs).
-  Upload them with `stash files upload` and pass the `app_url` back.
+  Upload them with `stash upload` and pass the `app_url` back.
 
 Commands to reach for
 ---------------------
 
-- `stash files upload <path> --json` — raw file into workspace storage,
-  returns `app_url`. No Skill created. This is the default for "share this
+- `stash upload <path> --json` — a single file (Markdown/HTML become pages,
+  everything else a binary file) or a folder, into workspace storage.
+  Returns `app_url`. No Skill created. This is the default for "share this
   one file with my team."
-- `stash upload <path> --json` — upload files/pages into a workspace
-  folder, returns the folder's `app_url`. No Skill created.
 - `stash upload <path> --skill "<title>" --json` — same as above AND
   publish the uploaded folder as a Skill with the given title. Use only
   when you're producing a shareable collection.

--- a/cli/tests/test_sharing_cli.py
+++ b/cli/tests/test_sharing_cli.py
@@ -94,7 +94,7 @@ def test_session_folders(monkeypatch) -> None:
     calls = _wire(monkeypatch)
     main.hist_folders(workspace_id=None, as_json=True)
     main.hist_new_folder("Launch", workspace_id=None, as_json=True)
-    main.hist_assign("sess-1", folder="f1", workspace_id=None)
+    main.mv_cmd(["session:sess-1"], to_folder="f1", to_root=False, workspace_id=None)
     assert ("folders", "ws-1") in calls
     assert ("new_folder", "ws-1", "Launch") in calls
     assert ("assign", "ws-1", "sess-1", "f1") in calls

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -12,7 +12,7 @@ A Skill is **not** a wrapper around every single file you happen to share. One-i
 
 | What you want to do | Command | What you give the user |
 |---|---|---|
-| Share one file with your teammate (internal) | `stash files upload <path> --json` | the returned `app_url` |
+| Share one file with your teammate (internal) | `stash upload <path> --json` | the returned `app_url` |
 | Upload a folder / project into the workspace | `stash upload <path> --json` | the returned `app_url` |
 | Publish a curated bundle as one shareable thing | `stash upload <path> --skill "<title>" --json` | the returned `url` |
 | Create a fresh skill folder | `stash skills create "<name>" --public --json` | the returned folder |

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -36,7 +36,7 @@ CONTEXT = (
     "supporting files, a research thread with its sources. It is NOT a "
     "wrapper to slap on every single file you share.\n\n"
     "When sharing artifacts, pick the right tool:\n"
-    " - Single file your teammate should look at → `stash files upload "
+    " - Single file your teammate should look at → `stash upload "
     "<path> --json` and hand them the returned `app_url`. NO Skill needed.\n"
     " - Upload a folder/project into the workspace → `stash upload <path> "
     "--json` returns the folder `app_url`. NO Skill created by default.\n"

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -12,7 +12,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 
 ## How to share things
 
-- **One file your teammate should look at** → `stash files upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **One file your teammate should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
 - **A folder / project into the workspace** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -42,8 +42,7 @@ You should see a `user_message` event with the prompt you just sent.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash login` +
-`stash config …`). No Cursor-specific config surface.
+Reads from `~/.stash/config.json` (populated by `stash login`; change it later with `stash settings`). No Cursor-specific config surface.
 
 Override with env vars (set in Cursor's environment):
 - `STASH_CURSOR_DATA=<path>` — custom state dir (default `~/.stash/plugins/cursor`)

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -17,7 +17,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
-When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
 - `stash sessions search "<query>"` — full-text search across transcripts

--- a/plugins/gemini-plugin/GEMINI.md
+++ b/plugins/gemini-plugin/GEMINI.md
@@ -4,7 +4,7 @@ You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use i
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
-When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
 - `stash sessions search "<query>"` — full-text search across transcripts

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -91,5 +91,5 @@ stash workspaces list --json
 ```
 
 For user-requested uploads, run `stash upload <path> --json` and return the
-response `url`. If you use `stash files upload <path> --json` for a raw file,
+response `url`. If you use `stash upload <path> --json` for a raw file,
 return the response `app_url`.

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -12,7 +12,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 
 ## How to share things
 
-- **One file your teammate should look at** → `stash files upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **One file your teammate should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
 - **A folder / project into the workspace** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -12,7 +12,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 
 ## How to share things
 
-- **One file your teammate should look at** → `stash files upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **One file your teammate should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
 - **A folder / project into the workspace** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -42,8 +42,7 @@ You should see a `user_message` event with the prompt you just sent.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash login` +
-`stash config …`). No Cursor-specific config surface.
+Reads from `~/.stash/config.json` (populated by `stash login`; change it later with `stash settings`). No Cursor-specific config surface.
 
 Override with env vars (set in Cursor's environment):
 - `STASH_CURSOR_DATA=<path>` — custom state dir (default `~/.stash/plugins/cursor`)

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -17,7 +17,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 Your activity in this repo is streamed to that workspace, so teammates' agents and humans can see what you're working on.
 
-When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash files upload <path> --json` for a raw file upload, give the user the returned `app_url`.
+When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
 - `stash sessions search "<query>"` — full-text search across transcripts

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -12,7 +12,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 
 ## How to share things
 
-- **One file your teammate should look at** → `stash files upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **One file your teammate should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
 - **A folder / project into the workspace** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -105,20 +105,18 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       />
 
       <CommandRef
-        command="stash config"
-        args="[key] [value]"
-        description="View or update a configuration value. Keys: base_url, default_workspace, output_format. Run without arguments to show all config."
+        command="stash settings"
+        args="[--json]"
+        description="Interactive settings page — change the endpoint, toggle which agents stream, and view config. Pass --json for a read-only snapshot."
         params={[
-          { name: "key", type: "string", desc: "Config key to read or write." },
-          { name: "value", type: "string", desc: "New value. Omit to read the current value." },
+          { name: "--json", type: "flag", desc: "Print a read-only snapshot instead of the interactive page." },
         ]}
       />
 
       <Callout>
-        After <Code>stash connect</Code>, your defaults are stored. You can still override
-        any value: e.g. <Code>stash config base_url https://joinstash.ai</Code> or set{" "}
-        <Code>STASH_API_KEY</Code> / <Code>STASH_URL</Code> as environment variables for
-        CI and scripts.
+        After <Code>stash connect</Code>, your defaults are stored. Change the endpoint
+        any time from <Code>stash settings</Code>, or set <Code>STASH_API_KEY</Code> /{" "}
+        <Code>STASH_URL</Code> as environment variables for CI and scripts.
       </Callout>
 
       <H2>Workspaces</H2>
@@ -293,17 +291,6 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
         description="Create a session folder."
         params={[
           { name: "<name>", type: "string", desc: "Folder name.", required: true },
-          { name: "--ws", type: "string", desc: "Workspace ID override." },
-        ]}
-      />
-
-      <CommandRef
-        command="stash sessions assign"
-        args="<session_row_id> [--folder ID]"
-        description="Move a session into a session folder, or omit --folder to move it back to the ungrouped root."
-        params={[
-          { name: "<session_row_id>", type: "string", desc: "The session row id to move.", required: true },
-          { name: "--folder", type: "string", desc: "Target folder id. Omit to ungroup." },
           { name: "--ws", type: "string", desc: "Workspace ID override." },
         ]}
       />
@@ -572,12 +559,13 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       <H2>Uploaded Files</H2>
 
       <CommandRef
-        command="stash files upload"
-        args="<path> [--ws ID]"
-        description="Upload a file to a workspace or to your personal files."
+        command="stash upload"
+        args="<path> [--skill TITLE] [--ws ID]"
+        description="Upload a single file (Markdown/HTML become pages, everything else a binary file) or a folder into a workspace. Pass --skill to also bundle it into a shareable Skill."
         params={[
-          { name: "<path>", type: "path", desc: "Path to the file.", required: true },
-          { name: "--ws", type: "string", desc: "Workspace ID. Omit to upload as a personal file." },
+          { name: "<path>", type: "path", desc: "File or directory to upload.", required: true },
+          { name: "--skill", type: "string", desc: "Also publish the upload as a Skill with this title." },
+          { name: "--ws", type: "string", desc: "Workspace ID override." },
         ]}
       />
 
@@ -591,20 +579,62 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       />
 
       <CommandRef
-        command="stash files rm"
-        args="<file_id>"
-        description="Delete a file."
-        params={[
-          { name: "<file_id>", type: "string", desc: "ID of the file to delete.", required: true },
-        ]}
-      />
-
-      <CommandRef
         command="stash files text"
         args="<file_id>"
         description="Print extracted text for a file (PDF, image OCR, or plain text)."
         params={[
           { name: "<file_id>", type: "string", desc: "ID of the file.", required: true },
+        ]}
+      />
+
+      <H2>Object operations</H2>
+      <P>
+        One set of verbs across every object type. Pass items as{" "}
+        <Code>type:id</Code> tokens (e.g. <Code>page:abc</Code>, <Code>file:def</Code>,{" "}
+        <Code>session:ghi</Code>); each verb accepts several at once.
+      </P>
+
+      <CommandRef
+        command="stash rm"
+        args="<type:id>... [--permanent] [--ws ID]"
+        description="Move pages, files, or sessions to trash. Pass --permanent to skip the trash window and delete immediately."
+        params={[
+          { name: "<type:id>", type: "string", desc: "Items to delete, e.g. page:<id> session:<id>.", required: true },
+          { name: "--permanent", type: "flag", desc: "Delete immediately instead of trashing." },
+          { name: "--ws", type: "string", desc: "Workspace ID override." },
+        ]}
+      />
+
+      <CommandRef
+        command="stash restore"
+        args="<type:id>... [--ws ID]"
+        description="Restore pages, files, or sessions from trash."
+        params={[
+          { name: "<type:id>", type: "string", desc: "Items to restore, e.g. page:<id> file:<id>.", required: true },
+          { name: "--ws", type: "string", desc: "Workspace ID override." },
+        ]}
+      />
+
+      <CommandRef
+        command="stash mv"
+        args="<type:id>... (--to-folder ID | --to-root) [--ws ID]"
+        description="Move pages, files, folders, tables, or sessions into a folder, or to the workspace root."
+        params={[
+          { name: "<type:id>", type: "string", desc: "Items to move.", required: true },
+          { name: "--to-folder", type: "string", desc: "Target folder id." },
+          { name: "--to-root", type: "flag", desc: "Move to the workspace root." },
+          { name: "--ws", type: "string", desc: "Workspace ID override." },
+        ]}
+      />
+
+      <CommandRef
+        command="stash cp"
+        args="<type:id>... [--to-folder ID] [--ws ID]"
+        description="Duplicate pages, files, or folders as 'Copy of <name>'."
+        params={[
+          { name: "<type:id>", type: "string", desc: "Items to copy.", required: true },
+          { name: "--to-folder", type: "string", desc: "Target folder id for the copies." },
+          { name: "--ws", type: "string", desc: "Workspace ID override." },
         ]}
       />
 

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -36,12 +36,11 @@ curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       </P>
       <CodeBlock>{`pip install stashai   # or: uv tool install stashai
 cd /path/to/your/repo
-stash config base_url http://localhost:3456
-stash login`}</CodeBlock>
+stash login   # choose "Self-host" and enter http://localhost:3456`}</CodeBlock>
       <P>
-        Use your public URL instead of <Code>http://localhost:3456</Code> for a
-        Caddy-backed install.{" "}
-        <Code>stash login</Code> opens it to register and authorize the CLI.
+        Enter your public URL instead of <Code>http://localhost:3456</Code> for a
+        Caddy-backed install. <Code>stash login</Code> opens it to register and
+        authorize the CLI; change the endpoint later from <Code>stash settings</Code>.
       </P>
 
       <H3>Upgrading</H3>


### PR DESCRIPTION
this is the opus 4.8 first pass at cleaning up our CLI. Another PR on this to come.


## Why

A *Philosophy of Software Design*–style review of the `stash` CLI found ~120 commands where many were **shallow duplicates** — multiple doors into one capability — plus inconsistent verbs for the same operation (`rm` vs `delete`, `edit-file`/`assign`/`batch move` all "move"). This consolidates to a smaller, predictable surface. No backwards-compat aliases (per CLAUDE.md).

## What changed

**New unified verbs** (take `type:id` tokens, accept many at once):
- `stash rm <type:id>… [--permanent]` — trash pages/files/sessions
- `stash restore <type:id>…` — restore from trash
- `stash mv <type:id>… (--to-folder ID | --to-root)` — move (batch endpoint + session API)
- `stash cp <type:id>… [--to-folder ID]` — duplicate pages/files/folders

**Removed (folded into the above or into a surviving command):**
- Pure dupes: `sources search` (alias of `search`), a **dead/shadowed** password-`login`, `config` (covered by `settings`)
- Per-type lifecycle: `files rm/restore/purge`, `files rm-page/restore-page/purge-page`, `files copy-page/copy-folder/copy-file`, `sessions delete/restore/purge/assign`, the whole `batch` group
- `files upload` → absorbed by top-level `upload` (single-file path; md/html still route to pages)
- `publish` → covered by `upload … --skill`
- `sessions share` → top-level `share` is the single session-share path
- Move flags stripped from `files edit-file`/`edit-folder` (rename-only now; use `mv`)

`cli/main.py`: **5,542 → 5,199 lines**.

## Verification
- `ruff check cli/` clean; `pytest cli/tests/` → **73 passed** (updated one test that drove the removed `hist_assign`)
- `tsc --noEmit` clean on the changed www docs pages
- **Live end-to-end** against my workspace: created a page, then exercised `cp`, `rm`, `restore`, `rm --permanent`, `mv --to-folder`, and merged single-file `upload` (md → page with direct `app_url`) — all succeeded.

### New top-level surface
\`\`\`
share  upload  read  search  ls  rm  restore  mv  cp  login  connect …
\`\`\`

## Docs
Updated CLAUDE.md (agent guidance), README, all plugin/asset agent docs, and the www CLI + self-hosting docs pages. The only "GUI" change is text in the docs command-reference pages (CommandRef list edits) — happy to attach rendered screenshots of the new **Object operations** section if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)