### PR TITLE
Fix cmd-z in table cells hijacked by table-level undo

### DIFF
--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -424,9 +424,10 @@ function TableEditorPageInner() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || e.key.toLowerCase() !== "z") return;
-      const isCellEditorTarget = isTableCellEditorTarget(e.target);
-      if (isTextEntryTarget(e.target) && !isCellEditorTarget) return;
-      if (isCellEditorTarget && undoStackRef.current.length === 0) return;
+      // While a text field (including an open cell editor) is focused, cmd-z must
+      // stay as the browser's native text undo. The table-level undo only fires
+      // when focus is outside any text entry.
+      if (isTextEntryTarget(e.target)) return;
       e.preventDefault();
       void undoLastTableAction();
     };


### PR DESCRIPTION
if you hit cmd z while typing in a cell, you would undo something outside of that cell, not the typing *in* that cell

## Problem

In the table view, pressing **cmd-z right after editing/deleting text in a cell** didn't undo your typing — and worse, a *different, previously-saved cell* would silently revert. This is the "jank" reported.

## Root cause

The global cmd-z handler in `TableClient.tsx` had this logic:

```js
const isCellEditorTarget = isTableCellEditorTarget(e.target);
if (isTextEntryTarget(e.target) && !isCellEditorTarget) return;
if (isCellEditorTarget && undoStackRef.current.length === 0) return;
e.preventDefault();
void undoLastTableAction();
```

While a cell editor was focused (`isCellEditorTarget === true`), neither early-return fired as long as the table undo stack was non-empty (i.e. you'd committed any edit earlier in the session). So the handler called `preventDefault()` — killing the browser's native text undo — and ran `undoLastTableAction()`, which reverted the **last committed row**, not the text you were editing.

It only "worked" intermittently because when the undo stack happened to be empty, the second `return` let native undo through.

## Fix

While any text entry (including an open cell editor) is focused, cmd-z now always stays as the browser's native text undo. The table-level undo only fires when focus is outside a text input — standard spreadsheet behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)