### PR TITLE
Add cursor-pointer to clickable elements across the app

### DIFF
--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -601,7 +601,7 @@ export default function SkillPageView() {
               <button
                 type="button"
                 onClick={handleNewPage}
-                className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+                className="cursor-pointer rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
               >
                 + New page
               </button>
@@ -616,7 +616,7 @@ export default function SkillPageView() {
                 <button
                   type="button"
                   onClick={() => setHtmlEditMode((v) => !v)}
-                  className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+                  className="cursor-pointer rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
                 >
                   {htmlEditMode ? "Done" : "Edit"}
                 </button>
@@ -707,14 +707,14 @@ export default function SkillPageView() {
                 <button
                   type="button"
                   onClick={() => window.location.reload()}
-                  className="font-medium text-[var(--color-brand-600)] hover:underline"
+                  className="cursor-pointer font-medium text-[var(--color-brand-600)] hover:underline"
                 >
                   Reload
                 </button>
                 <button
                   type="button"
                   onClick={() => setExternalEdit(null)}
-                  className="text-[var(--text-muted)] hover:text-foreground"
+                  className="cursor-pointer text-[var(--text-muted)] hover:text-foreground"
                 >
                   Dismiss
                 </button>
@@ -758,7 +758,7 @@ export default function SkillPageView() {
                           selection: htmlSelection,
                         });
                       }}
-                      className="comment-anchor-pill absolute z-30 inline-flex -translate-x-1/2 -translate-y-full items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-[12px] font-medium text-background shadow-[0_6px_20px_-4px_rgba(0,0,0,0.35)] hover:bg-foreground/90"
+                      className="comment-anchor-pill absolute z-30 inline-flex -translate-x-1/2 -translate-y-full cursor-pointer items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-[12px] font-medium text-background shadow-[0_6px_20px_-4px_rgba(0,0,0,0.35)] hover:bg-foreground/90"
                       style={{
                         top: htmlSelection.rect.top - 8,
                         left: (htmlSelection.rect.left + htmlSelection.rect.right) / 2,

--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -375,7 +375,7 @@ function SaveToSkillButton({
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="rounded-md border border-border bg-base px-2.5 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
+        className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised"
       >
         Save to Skill <span aria-hidden className="text-[10px]">▾</span>
       </button>
@@ -393,7 +393,7 @@ function SaveToSkillButton({
               type="button"
               disabled={busy}
               onClick={() => void save(skill)}
-              className="block w-full truncate px-3 py-1.5 text-left text-foreground hover:bg-raised disabled:opacity-50"
+              className="block w-full cursor-pointer truncate px-3 py-1.5 text-left text-foreground hover:bg-raised disabled:opacity-50"
             >
               {skill.name}
             </button>

--- a/frontend/src/app/(app)/skills/[slug]/AddToWorkspaceButton.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/AddToWorkspaceButton.tsx
@@ -95,7 +95,7 @@ export default function AddToWorkspaceButton({ slug, sourceWorkspaceId }: Props)
         type="button"
         onClick={onClick}
         disabled={busy}
-        className="rounded-lg border border-brand bg-brand px-4 py-2 text-[14px] font-medium text-white transition hover:opacity-90 disabled:opacity-50"
+        className="cursor-pointer rounded-lg border border-brand bg-brand px-4 py-2 text-[14px] font-medium text-white transition hover:opacity-90 disabled:opacity-50"
       >
         {busy ? "Adding..." : "Add to my files"}
       </button>
@@ -112,7 +112,7 @@ export default function AddToWorkspaceButton({ slug, sourceWorkspaceId }: Props)
                 onClick={() =>
                   router.push(`/workspaces/${attached.workspaceId}/skills/${attached.folderId}`)
                 }
-                className="w-full rounded-md border border-border-subtle px-3 py-2 text-[13px] text-foreground hover:border-brand hover:text-brand"
+                className="w-full cursor-pointer rounded-md border border-border-subtle px-3 py-2 text-[13px] text-foreground hover:border-brand hover:text-brand"
               >
                 Open skill
               </button>
@@ -140,7 +140,7 @@ export default function AddToWorkspaceButton({ slug, sourceWorkspaceId }: Props)
                 type="button"
                 disabled={busy || !selectedWorkspaceId}
                 onClick={() => void attachToWorkspace(selectedWorkspaceId)}
-                className="w-full rounded-md bg-brand px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
+                className="w-full cursor-pointer rounded-md bg-brand px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
               >
                 Add Skill
               </button>

--- a/frontend/src/app/(app)/skills/[slug]/settings/SkillSettingsPageClient.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/settings/SkillSettingsPageClient.tsx
@@ -281,7 +281,7 @@ export default function SkillSettingsPageClient({ slug }: { slug: string }) {
                 <button
                   type="submit"
                   disabled={saving === "general" || !title.trim()}
-                  className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                  className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
                 >
                   {saving === "general" ? "Saving..." : "Save changes"}
                 </button>
@@ -335,7 +335,7 @@ export default function SkillSettingsPageClient({ slug }: { slug: string }) {
               type="button"
               onClick={handleStopSharing}
               disabled={saving === "unpublish"}
-              className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-[13px] font-medium text-red-700 hover:bg-red-100 disabled:opacity-50"
+              className="cursor-pointer rounded-md border border-red-300 bg-red-50 px-3 py-2 text-[13px] font-medium text-red-700 hover:bg-red-100 disabled:opacity-50"
             >
               {saving === "unpublish" ? "Stopping..." : "Stop sharing"}
             </button>
@@ -404,7 +404,7 @@ function ImageField({
             <button
               type="button"
               onClick={() => void onClear()}
-              className="text-[11.5px] text-muted hover:text-foreground"
+              className="cursor-pointer text-[11.5px] text-muted hover:text-foreground"
             >
               Clear
             </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/agents/page.tsx
@@ -145,7 +145,7 @@ function AgentsPageInner() {
               <button
                 type="button"
                 onClick={() => setActive(t.id)}
-                className="min-w-0 truncate outline-none"
+                className="min-w-0 cursor-pointer truncate outline-none"
               >
                 {t.title}
               </button>
@@ -154,7 +154,7 @@ function AgentsPageInner() {
                   type="button"
                   aria-label="Close chat"
                   onClick={() => closeChat(t.id)}
-                  className="ml-1 text-muted hover:text-error"
+                  className="ml-1 cursor-pointer text-muted hover:text-error"
                 >
                   ×
                 </button>
@@ -165,7 +165,7 @@ function AgentsPageInner() {
             type="button"
             onClick={newChat}
             aria-label="New chat"
-            className="px-3 py-2 text-[16px] text-muted hover:text-foreground"
+            className="cursor-pointer px-3 py-2 text-[16px] text-muted hover:text-foreground"
           >
             ＋
           </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/folders/[folderId]/FolderClient.tsx
@@ -141,7 +141,7 @@ export default function FolderDetailPage() {
           type="button"
           onClick={() => void convertToSkill()}
           disabled={converting}
-          className="rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground disabled:opacity-50"
+          className="cursor-pointer rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground disabled:opacity-50"
         >
           {converting ? "Converting…" : "Convert to Skill"}
         </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/integrations/[provider]/page.tsx
@@ -227,7 +227,7 @@ export default function IntegrationPage() {
                   type="button"
                   onClick={() => void disconnect()}
                   disabled={busy === "disconnect"}
-                  className="rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-foreground disabled:opacity-60"
+                  className="cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-foreground disabled:opacity-60"
                 >
                   {busy === "disconnect"
                     ? "Disconnecting..."
@@ -455,7 +455,7 @@ function SourceRow({
         (highlighted ? "-mx-2 rounded-lg bg-[var(--color-brand-50)] px-3" : "")
       }
     >
-      <button type="button" onClick={onOpen} className="min-w-0 flex-1 text-left">
+      <button type="button" onClick={onOpen} className="min-w-0 flex-1 cursor-pointer text-left">
         <div className="flex items-center gap-2 truncate text-[13.5px] font-semibold text-foreground">
           {source.display_name}
           {ref && <span className="font-mono text-[12px] font-normal text-muted">{ref}</span>}
@@ -491,10 +491,10 @@ function SourceRow({
 
 // The quiet bordered row action (Browse/Sync) and its borderless ghost (Remove).
 function rowButton(): string {
-  return "rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised disabled:opacity-60";
+  return "cursor-pointer rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised disabled:opacity-60";
 }
 function rowButtonGhost(): string {
-  return "rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-error disabled:opacity-60";
+  return "cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted hover:bg-raised hover:text-error disabled:opacity-60";
 }
 
 function BrowsePanel({
@@ -590,7 +590,7 @@ function DocViewer({
               Open in {providerLabel} ↗
             </a>
           )}
-          <button type="button" onClick={onClose} className="text-[12px] text-muted hover:text-foreground">
+          <button type="button" onClick={onClose} className="cursor-pointer text-[12px] text-muted hover:text-foreground">
             Close
           </button>
         </div>
@@ -654,7 +654,7 @@ function QueryablePanel({ workspaceId, source }: { workspaceId: string; source: 
               key={t.name}
               type="button"
               onClick={() => setSql(`SELECT * FROM ${t.name} LIMIT 100`)}
-              className="rounded-md border border-border bg-base px-2 py-1 text-[11.5px] text-foreground hover:bg-raised"
+              className="cursor-pointer rounded-md border border-border bg-base px-2 py-1 text-[11.5px] text-foreground hover:bg-raised"
             >
               {t.name}
             </button>
@@ -853,7 +853,7 @@ function HitRow({
     <button
       type="button"
       onClick={onOpen}
-      className="block w-full rounded-md px-1.5 py-1.5 text-left hover:bg-raised"
+      className="block w-full cursor-pointer rounded-md px-1.5 py-1.5 text-left hover:bg-raised"
     >
       <div className="flex items-baseline gap-2.5">
         {showKey && <span className="font-mono text-[12px] text-muted">{hitKey}</span>}
@@ -932,7 +932,7 @@ function NavigablePanel({
             <button
               type="button"
               onClick={() => goCrumb(i)}
-              className={i === crumbs.length - 1 ? "text-foreground" : "hover:text-foreground hover:underline"}
+              className={"cursor-pointer " + (i === crumbs.length - 1 ? "text-foreground" : "hover:text-foreground hover:underline")}
             >
               {c.label}
             </button>
@@ -956,7 +956,7 @@ function NavigablePanel({
                 key={key}
                 type="button"
                 onClick={() => openEntry(entry)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised"
+                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised"
               >
                 <span aria-hidden className="text-[13px]">
                   {folder ? "📁" : "📄"}

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/page.tsx
@@ -150,7 +150,7 @@ export default function WorkspaceHomePage() {
               <button
                 type="button"
                 onClick={handleNewPage}
-                className="rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
+                className="cursor-pointer rounded-md border border-border-subtle bg-raised px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised-2"
               >
                 + New page
               </button>
@@ -181,7 +181,7 @@ export default function WorkspaceHomePage() {
             </span>
             <button
               onClick={handleJoin}
-              className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+              className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
             >
               Join workspace
             </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/sessions/page.tsx
@@ -372,14 +372,14 @@ export default function SkillSessionsPage() {
             <button
               type="button"
               onClick={() => void bulkDeleteSessions()}
-              className="rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
+              className="cursor-pointer rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
             >
               Delete
             </button>
             <button
               type="button"
               onClick={clearSelection}
-              className="ml-1 text-[18px] leading-none text-background/70 hover:text-background"
+              className="ml-1 cursor-pointer text-[18px] leading-none text-background/70 hover:text-background"
               aria-label="Clear selection"
             >
               ×
@@ -509,7 +509,7 @@ function DayGroup({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
+        className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
       >
         <Chev open={open} />
         <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
@@ -561,7 +561,7 @@ function FlatGroup({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
+        className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
       >
         <Chev open={open} />
         <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
@@ -610,7 +610,7 @@ function SegmentedControl<T extends string>({
               type="button"
               onClick={() => onChange(opt.key)}
               className={
-                "rounded-full px-2.5 py-1 text-[12px] leading-none transition-colors " +
+                "cursor-pointer rounded-full px-2.5 py-1 text-[12px] leading-none transition-colors " +
                 (active
                   ? "bg-base font-semibold text-foreground shadow-sm"
                   : "text-muted hover:bg-raised/70 hover:text-foreground")
@@ -796,7 +796,7 @@ function SessionTableRow({
           }
         }}
         className={
-          "hidden justify-self-end rounded p-1 transition hover:bg-raised md:block " +
+          "hidden cursor-pointer justify-self-end rounded p-1 transition hover:bg-raised md:block " +
           (pinned
             ? "text-[var(--color-brand-600)] hover:text-[var(--color-brand-700)]"
             : "text-muted/40 hover:text-foreground")
@@ -953,7 +953,7 @@ function FoldersSection({
         <button
           type="button"
           onClick={onNewFolder}
-          className="rounded-md border border-border bg-base px-2.5 py-1 text-[12.5px] font-medium text-foreground hover:bg-raised"
+          className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12.5px] font-medium text-foreground hover:bg-raised"
         >
           + New folder
         </button>
@@ -1052,7 +1052,7 @@ function FolderCard({
           e.stopPropagation();
           onShare();
         }}
-        className="shrink-0 rounded-md px-2 py-0.5 text-[11.5px] font-medium text-muted opacity-0 transition group-hover:opacity-100 hover:bg-base hover:text-foreground"
+        className="shrink-0 cursor-pointer rounded-md px-2 py-0.5 text-[11.5px] font-medium text-muted opacity-0 transition group-hover:opacity-100 hover:bg-base hover:text-foreground"
       >
         Share
       </button>
@@ -1073,7 +1073,7 @@ function SharedFolderCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex items-start gap-2.5 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised/50"
+      className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised/50"
     >
       <span aria-hidden className="mt-0.5 text-[18px]">
         🗂️
@@ -1148,7 +1148,7 @@ function FolderDrill({
       <button
         type="button"
         onClick={onBack}
-        className="mb-3 inline-flex items-center gap-1 text-[12.5px] text-muted hover:text-foreground"
+        className="mb-3 inline-flex cursor-pointer items-center gap-1 text-[12.5px] text-muted hover:text-foreground"
       >
         ← All folders
       </button>
@@ -1163,7 +1163,7 @@ function FolderDrill({
             <button
               type="button"
               onClick={() => onShare(ownFolder)}
-              className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+              className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
             >
               Share
             </button>
@@ -1171,7 +1171,7 @@ function FolderDrill({
               <button
                 type="button"
                 onClick={() => onDelete(ownFolder)}
-                className="rounded-md border border-border px-2.5 py-1 text-[12.5px] text-muted hover:text-rose-500"
+                className="cursor-pointer rounded-md border border-border px-2.5 py-1 text-[12.5px] text-muted hover:text-rose-500"
               >
                 Delete
               </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/skills/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/skills/[folderId]/SkillFolderClient.tsx
@@ -138,7 +138,7 @@ export default function SkillFolderClient() {
         <button
           type="button"
           onClick={() => void convertToFolder()}
-          className="rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground"
+          className="cursor-pointer rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground"
         >
           Convert to folder
         </button>

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/skills/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/skills/page.tsx
@@ -184,7 +184,7 @@ export default function WorkspaceSkillsPage() {
           <button
             type="button"
             onClick={() => void newSkill()}
-            className="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
           >
             <PlusGlyph /> New Skill
           </button>
@@ -266,14 +266,14 @@ export default function WorkspaceSkillsPage() {
             <button
               type="button"
               onClick={() => void bulkDeleteSkills()}
-              className="rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
+              className="cursor-pointer rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
             >
               Delete
             </button>
             <button
               type="button"
               onClick={clearSelection}
-              className="ml-1 text-[18px] leading-none text-background/70 hover:text-background"
+              className="ml-1 cursor-pointer text-[18px] leading-none text-background/70 hover:text-background"
               aria-label="Clear selection"
             >
               ×
@@ -342,7 +342,7 @@ function ExternalSkillLinkForm({
         <button
           type="submit"
           disabled={busy || !input.trim()}
-          className="rounded-md bg-[var(--color-brand-600)] px-3 py-2 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-45 sm:mt-6"
+          className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-3 py-2 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-45 sm:mt-6"
         >
           {busy ? "Adding…" : "Add Skill"}
         </button>
@@ -389,7 +389,7 @@ function SkillTabs({
             type="button"
             onClick={() => onChange(t.key)}
             className={
-              "-mb-px border-b-2 px-3 py-2 text-[13px] transition-colors " +
+              "-mb-px cursor-pointer border-b-2 px-3 py-2 text-[13px] transition-colors " +
               (active
                 ? "border-[var(--color-brand-600)] font-semibold text-foreground"
                 : "border-transparent text-muted hover:text-foreground")
@@ -532,7 +532,7 @@ function DiscoverSection({ workspaceId }: { workspaceId: string }) {
                 type="button"
                 onClick={() => setSort(option)}
                 className={
-                  "rounded-md px-2.5 py-[3px] text-[12px] " +
+                  "cursor-pointer rounded-md px-2.5 py-[3px] text-[12px] " +
                   (sort === option
                     ? "bg-raised font-semibold text-foreground"
                     : "text-muted hover:text-foreground")
@@ -775,7 +775,7 @@ function SkillPinButton({
         onToggle();
       }}
       className={
-        "flex h-6 w-6 items-center justify-center rounded transition " +
+        "flex h-6 w-6 cursor-pointer items-center justify-center rounded transition " +
         (onCover
           ? "bg-white/70 backdrop-blur hover:bg-white "
           : "hover:bg-raised ") +
@@ -909,7 +909,7 @@ function SkillViewToggle({
             type="button"
             onClick={() => onChange(opt.key)}
             className={
-              "rounded px-2 py-[3px] " +
+              "cursor-pointer rounded px-2 py-[3px] " +
               (active
                 ? "bg-raised font-semibold text-foreground"
                 : "text-muted hover:text-foreground")

--- a/frontend/src/app/(app)/workspaces/[workspaceId]/trash/page.tsx
+++ b/frontend/src/app/(app)/workspaces/[workspaceId]/trash/page.tsx
@@ -247,7 +247,7 @@ export default function TrashPage() {
               type="button"
               disabled={bulkBusy || selected.size === 0}
               onClick={handleBulkRestore}
-              className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+              className="cursor-pointer rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
             >
               Restore {selected.size > 0 ? `(${selected.size})` : ""}
             </button>
@@ -255,7 +255,7 @@ export default function TrashPage() {
               type="button"
               disabled={bulkBusy || selected.size === 0}
               onClick={handleBulkPurge}
-              className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+              className="cursor-pointer rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
             >
               Delete forever {selected.size > 0 ? `(${selected.size})` : ""}
             </button>
@@ -360,7 +360,7 @@ function TrashSection({
                 type="button"
                 disabled={busyId === entry.id || bulkBusy}
                 onClick={() => onRestore(kind, entry.id)}
-                className="rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
+                className="cursor-pointer rounded-md border border-border bg-base px-3 py-1 text-[12px] text-foreground hover:bg-raised disabled:opacity-50"
               >
                 Restore
               </button>
@@ -368,7 +368,7 @@ function TrashSection({
                 type="button"
                 disabled={busyId === entry.id || bulkBusy}
                 onClick={() => onPurge(kind, entry.id, entry.name)}
-                className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+                className="cursor-pointer rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10 disabled:opacity-50"
               >
                 Delete forever
               </button>

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -68,7 +68,7 @@ export default function DiscoverPage() {
               type="button"
               onClick={() => setSort(option)}
               className={
-                "rounded-md px-2.5 py-[3px] text-[12px] " +
+                "cursor-pointer rounded-md px-2.5 py-[3px] text-[12px] " +
                 (sort === option
                   ? "bg-raised font-semibold text-foreground"
                   : "text-muted hover:text-foreground")

--- a/frontend/src/app/join/[code]/page.tsx
+++ b/frontend/src/app/join/[code]/page.tsx
@@ -59,7 +59,7 @@ export default function JoinPage() {
               <p className="text-red-400 mb-4">{error}</p>
               <button
                 onClick={() => router.push("/")}
-                className="bg-raised hover:bg-raised text-foreground px-4 py-2 rounded text-sm"
+                className="bg-raised hover:bg-raised text-foreground px-4 py-2 rounded text-sm cursor-pointer"
               >
                 Go Home
               </button>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -185,14 +185,14 @@ function LoginPageInner() {
         {mode === "login" ? (
           <>
             New here?{" "}
-            <button type="button" onClick={() => { setMode("register"); setError(""); }} className="text-brand hover:underline">
+            <button type="button" onClick={() => { setMode("register"); setError(""); }} className="cursor-pointer text-brand hover:underline">
               Create an account
             </button>
           </>
         ) : (
           <>
             Already have an account?{" "}
-            <button type="button" onClick={() => { setMode("login"); setError(""); }} className="text-brand hover:underline">
+            <button type="button" onClick={() => { setMode("login"); setError(""); }} className="cursor-pointer text-brand hover:underline">
               Sign in
             </button>
           </>
@@ -291,14 +291,14 @@ function AuthorizeCliPanel({
           type="button"
           onClick={handleAuthorize}
           disabled={submitting}
-          className="w-full bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-60"
+          className="w-full cursor-pointer bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-60"
         >
           {submitting ? "Authorizing..." : "Authorize CLI"}
         </button>
         <button
           type="button"
           onClick={onUseDifferentAccount}
-          className="text-[11px] text-muted hover:text-foreground"
+          className="cursor-pointer text-[11px] text-muted hover:text-foreground"
         >
           Use a different account
         </button>
@@ -560,7 +560,7 @@ function BrandButton({ submitting, label }: { submitting: boolean; label: string
     <button
       type="submit"
       disabled={submitting}
-      className="group relative w-full bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-60 shadow-[0_8px_24px_-8px_oklch(0.7_0.14_55_/_0.5)] hover:shadow-[0_10px_28px_-6px_oklch(0.7_0.14_55_/_0.6)]"
+      className="group relative w-full cursor-pointer bg-brand hover:bg-brand-hover text-white py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-60 shadow-[0_8px_24px_-8px_oklch(0.7_0.14_55_/_0.5)] hover:shadow-[0_10px_28px_-6px_oklch(0.7_0.14_55_/_0.6)]"
     >
       <span className="inline-flex items-center justify-center gap-2">
         {label}

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -348,7 +348,7 @@ function PillGroup({
             type="button"
             aria-pressed={selected}
             onClick={() => onChange(selected ? "" : option)}
-            className={`rounded-full border px-3 py-1.5 text-[12.5px] transition-colors ${
+            className={`cursor-pointer rounded-full border px-3 py-1.5 text-[12.5px] transition-colors ${
               selected
                 ? "border-brand bg-brand text-white"
                 : "border-border bg-surface text-dim hover:border-foreground/40 hover:text-foreground"
@@ -459,7 +459,7 @@ function TryItOutStep({
         <button
           type="button"
           onClick={onCollabDoc}
-          className="group flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
+          className="group flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
         >
           <div>
             <div className="text-[13.5px] font-medium text-foreground">
@@ -491,7 +491,7 @@ function TryItOutStep({
               type="button"
               onClick={onContinue}
               disabled={!canContinue}
-              className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Continue
             </button>
@@ -608,7 +608,7 @@ function StepControls({
       <button
         type="button"
         onClick={onSkip}
-        className="text-[12px] text-muted hover:text-foreground transition-colors"
+        className="cursor-pointer text-[12px] text-muted hover:text-foreground transition-colors"
       >
         Skip onboarding
       </button>
@@ -617,7 +617,7 @@ function StepControls({
           type="button"
           onClick={onContinue}
           disabled={!canContinue}
-          className="rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {continueLabel}
         </button>

--- a/frontend/src/app/onboarding/paths/memory/MemoryAskStep.tsx
+++ b/frontend/src/app/onboarding/paths/memory/MemoryAskStep.tsx
@@ -179,7 +179,7 @@ export default function MemoryAskStep({
                     setQuestion(s);
                     void ask(s);
                   }}
-                  className="rounded-full border border-border bg-surface px-3 py-1.5 text-[12px] text-foreground hover:bg-raised hover:border-brand"
+                  className="cursor-pointer rounded-full border border-border bg-surface px-3 py-1.5 text-[12px] text-foreground hover:bg-raised hover:border-brand"
                 >
                   {s}
                 </button>
@@ -204,7 +204,7 @@ export default function MemoryAskStep({
             <button
               type="submit"
               disabled={!question.trim()}
-              className="rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
+              className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
             >
               Ask
             </button>

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -496,7 +496,7 @@ function SearchPageInner() {
                       type="button"
                       onClick={() => setContentScope(scope.id)}
                       className={
-                        "rounded px-2 py-1 text-[12px] " +
+                        "cursor-pointer rounded px-2 py-1 text-[12px] " +
                         (contentScope === scope.id
                           ? "bg-[var(--color-brand-600)] text-white"
                           : "text-muted hover:bg-raised hover:text-foreground")
@@ -529,7 +529,7 @@ function SearchPageInner() {
               <button
                 type="submit"
                 disabled={searching || !query.trim() || fetching}
-                className="rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-3 py-1.5 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
               >
                 {searching ? "Searching..." : "Search"}
               </button>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -42,7 +42,7 @@ export default function SettingsPage() {
           <button
             type="button"
             onClick={() => router.push("/")}
-            className="text-sm text-muted hover:text-foreground inline-flex items-center gap-1.5"
+            className="cursor-pointer text-sm text-muted hover:text-foreground inline-flex items-center gap-1.5"
           >
             <span aria-hidden>←</span> Home
           </button>
@@ -121,7 +121,7 @@ function Profile({ user, onUpdated }: { user: User; onUpdated: () => void }) {
         <button
           type="submit"
           disabled={saving}
-          className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+          className="cursor-pointer bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
         >
           {saving ? "Saving…" : "Save profile"}
         </button>
@@ -220,7 +220,7 @@ function ActiveSessions() {
         </div>
         <button
           onClick={load}
-          className="text-xs text-muted hover:text-foreground"
+          className="cursor-pointer text-xs text-muted hover:text-foreground"
           type="button"
         >
           Refresh
@@ -242,7 +242,7 @@ function ActiveSessions() {
           <button
             type="submit"
             disabled={creating}
-            className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors whitespace-nowrap"
+            className="cursor-pointer bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors whitespace-nowrap"
           >
             {creating ? "Creating…" : "Create key"}
           </button>
@@ -268,7 +268,7 @@ function ActiveSessions() {
               <button
                 onClick={() => handleRevoke(k.id)}
                 disabled={revoking === k.id}
-                className="text-xs px-3 py-1.5 rounded-md border border-border hover:border-error hover:text-error disabled:opacity-60 transition-colors"
+                className="cursor-pointer text-xs px-3 py-1.5 rounded-md border border-border hover:border-error hover:text-error disabled:opacity-60 transition-colors"
                 type="button"
               >
                 {revoking === k.id ? "Revoking…" : "Revoke"}
@@ -311,14 +311,14 @@ function MintedKey({
         <button
           onClick={copy}
           type="button"
-          className="text-xs px-3 py-1.5 rounded-md border border-border hover:border-brand hover:text-brand transition-colors"
+          className="cursor-pointer text-xs px-3 py-1.5 rounded-md border border-border hover:border-brand hover:text-brand transition-colors"
         >
           {copied ? "Copied" : "Copy"}
         </button>
         <button
           onClick={onDismiss}
           type="button"
-          className="text-xs text-muted hover:text-foreground px-2"
+          className="cursor-pointer text-xs text-muted hover:text-foreground px-2"
         >
           Dismiss
         </button>
@@ -383,7 +383,7 @@ function ChangePassword() {
         <button
           type="submit"
           disabled={submitting || !current || !next || !confirm}
-          className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+          className="cursor-pointer bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
         >
           {submitting ? "Saving…" : "Change password"}
         </button>

--- a/frontend/src/app/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/tables/[tableId]/TableClient.tsx
@@ -213,14 +213,14 @@ function CellLinkEditorPopover({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-md px-2 py-1.5 text-[12.5px] font-medium text-muted hover:bg-raised hover:text-foreground"
+          className="cursor-pointer rounded-md px-2 py-1.5 text-[12.5px] font-medium text-muted hover:bg-raised hover:text-foreground"
         >
           Cancel
         </button>
         <button
           type="submit"
           disabled={!href.trim()}
-          className="rounded-md bg-brand px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+          className="cursor-pointer rounded-md bg-brand px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-50"
         >
           Save
         </button>
@@ -1249,8 +1249,8 @@ function TableEditorPageInner() {
       <td className="px-1 py-0 whitespace-nowrap">
         {!readOnly && (
           <>
-            <button onClick={() => handleDuplicateRow(row.id)} className="text-xs text-muted/50 hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Duplicate">\u2398</button>
-            <button onClick={() => handleDeleteRow(row.id)} className="text-xs text-red-400/50 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Delete">&times;</button>
+            <button onClick={() => handleDuplicateRow(row.id)} className="cursor-pointer text-xs text-muted/50 hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Duplicate">\u2398</button>
+            <button onClick={() => handleDeleteRow(row.id)} className="cursor-pointer text-xs text-red-400/50 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity px-1" title="Delete">&times;</button>
           </>
         )}
       </td>
@@ -1335,8 +1335,8 @@ function TableEditorPageInner() {
           </div>
           <div className="flex-1" />
           {table && <>
-            {!readOnly && <button onClick={addFilter} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Filter</button>}
-            {!readOnly && (filters.length > 0 || sortBy) && <button onClick={handleSaveLayout} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Save layout</button>}
+            {!readOnly && <button onClick={addFilter} className="cursor-pointer text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Filter</button>}
+            {!readOnly && (filters.length > 0 || sortBy) && <button onClick={handleSaveLayout} className="cursor-pointer text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Save layout</button>}
             {/* Group by */}
             <CustomSelect
               value={groupByCol}
@@ -1350,14 +1350,14 @@ function TableEditorPageInner() {
               className="min-w-[132px] rounded border border-border bg-raised px-2 py-1 text-xs text-foreground"
               menuClassName="text-xs"
             />
-            {!readOnly && <button onClick={() => setShowSummary((p) => !p)} className={`text-xs px-2 py-1 rounded ${showSummary ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Summary</button>}
-            {!readOnly && wsId && <button onClick={() => setShowEmbeddings((p) => !p)} className={`text-xs px-2 py-1 rounded ${showEmbeddings ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Embeddings</button>}
-            <button onClick={() => setShowColVisibility((p) => !p)} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Columns</button>
-            <button onClick={() => setWrapCells((p) => !p)} className={`text-xs px-2 py-1 rounded ${wrapCells ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>{wrapCells ? "Wrap" : "Compact"}</button>
-            {!readOnly && <button onClick={() => fileInputRef.current?.click()} className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>}
+            {!readOnly && <button onClick={() => setShowSummary((p) => !p)} className={`cursor-pointer text-xs px-2 py-1 rounded ${showSummary ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Summary</button>}
+            {!readOnly && wsId && <button onClick={() => setShowEmbeddings((p) => !p)} className={`cursor-pointer text-xs px-2 py-1 rounded ${showEmbeddings ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>Embeddings</button>}
+            <button onClick={() => setShowColVisibility((p) => !p)} className="cursor-pointer text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Columns</button>
+            <button onClick={() => setWrapCells((p) => !p)} className={`cursor-pointer text-xs px-2 py-1 rounded ${wrapCells ? "bg-brand/15 text-brand" : "text-muted hover:text-foreground hover:bg-raised"}`}>{wrapCells ? "Wrap" : "Compact"}</button>
+            {!readOnly && <button onClick={() => fileInputRef.current?.click()} className="cursor-pointer text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised">Import</button>}
             {!readOnly && <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleCsvImport(e.target.files[0]); e.target.value = ""; }} />}
-            {!readOnly && selectedRows.size > 0 && <button onClick={handleBulkDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}
-            {!readOnly && <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>}
+            {!readOnly && selectedRows.size > 0 && <button onClick={handleBulkDelete} className="cursor-pointer text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete {selectedRows.size}</button>}
+            {!readOnly && <button onClick={handleDelete} className="cursor-pointer text-xs text-red-400 hover:text-red-300 px-2 py-1">Delete table</button>}
           </>}
         </div>
 
@@ -1370,7 +1370,7 @@ function TableEditorPageInner() {
                 {c.name}
               </label>
             ))}
-            <button onClick={() => setShowColVisibility(false)} className="text-xs text-muted hover:text-foreground ml-2">Done</button>
+            <button onClick={() => setShowColVisibility(false)} className="cursor-pointer text-xs text-muted hover:text-foreground ml-2">Done</button>
           </div>
         )}
 
@@ -1398,7 +1398,7 @@ function TableEditorPageInner() {
                     setTimeout(() => setBackfillStatus(""), 2000);
                   } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
                 }}
-                className="text-xs bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-2 py-1 rounded"
+                className="cursor-pointer text-xs bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-2 py-1 rounded"
               >
                 Save
               </button>
@@ -1410,7 +1410,7 @@ function TableEditorPageInner() {
                     setTimeout(() => setBackfillStatus(""), 5000);
                   } catch (err) { setError(err instanceof Error ? err.message : "Failed"); }
                 }}
-                className="text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised"
+                className="cursor-pointer text-xs text-muted hover:text-foreground px-2 py-1 rounded hover:bg-raised"
               >
                 Backfill all rows
               </button>
@@ -1436,14 +1436,14 @@ function TableEditorPageInner() {
         {/* Saved layout tabs */}
         {table?.views && table.views.length > 0 && (
           <div className="px-4 py-1.5 border-b border-border bg-surface flex items-center gap-1 flex-shrink-0 overflow-x-auto overscroll-x-contain">
-            <button onClick={() => { setActiveViewId(null); setFilters([]); setSortBy(""); setSortOrder("asc"); setShowFilterBar(false); setHiddenCols(new Set()); }} className={`px-3 py-1 text-xs rounded ${!activeViewId ? "bg-brand/15 text-brand font-medium" : "text-muted hover:text-foreground hover:bg-raised"}`}>All rows</button>
+            <button onClick={() => { setActiveViewId(null); setFilters([]); setSortBy(""); setSortOrder("asc"); setShowFilterBar(false); setHiddenCols(new Set()); }} className={`cursor-pointer px-3 py-1 text-xs rounded ${!activeViewId ? "bg-brand/15 text-brand font-medium" : "text-muted hover:text-foreground hover:bg-raised"}`}>All rows</button>
             {table.views.map((layout: TableView) => (
               <div key={layout.id} className="flex items-center group">
-                <button onClick={() => handleLoadLayout(layout)} className={`px-3 py-1 text-xs rounded ${activeViewId === layout.id ? "bg-brand/15 text-brand font-medium" : "text-muted hover:text-foreground hover:bg-raised"}`}>{layout.name}</button>
-                <button onClick={() => handleDeleteLayout(layout.id)} className="text-[10px] text-muted hover:text-red-400 opacity-0 group-hover:opacity-100 -ml-1">&times;</button>
+                <button onClick={() => handleLoadLayout(layout)} className={`cursor-pointer px-3 py-1 text-xs rounded ${activeViewId === layout.id ? "bg-brand/15 text-brand font-medium" : "text-muted hover:text-foreground hover:bg-raised"}`}>{layout.name}</button>
+                <button onClick={() => handleDeleteLayout(layout.id)} className="cursor-pointer text-[10px] text-muted hover:text-red-400 opacity-0 group-hover:opacity-100 -ml-1">&times;</button>
               </div>
             ))}
-            <button onClick={handleSaveLayout} className="px-2 py-1 text-xs text-muted hover:text-brand">+ Save layout</button>
+            <button onClick={handleSaveLayout} className="cursor-pointer px-2 py-1 text-xs text-muted hover:text-brand">+ Save layout</button>
           </div>
         )}
 
@@ -1467,11 +1467,11 @@ function TableEditorPageInner() {
                   menuClassName="text-xs"
                 />
                 {f.op !== "is_empty" && f.op !== "is_not_empty" && <input value={f.value} onChange={(e) => updateFilter(idx, "value", e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") loadRows(); }} className="w-24 bg-transparent outline-none text-foreground border-b border-border" placeholder="value" />}
-                <button onClick={() => removeFilter(idx)} className="text-muted hover:text-red-400 ml-1">&times;</button>
+                <button onClick={() => removeFilter(idx)} className="cursor-pointer text-muted hover:text-red-400 ml-1">&times;</button>
               </div>
             ))}
-            <button onClick={addFilter} className="text-xs text-brand hover:text-brand-hover">+ Add</button>
-            <button onClick={() => { setFilters([]); setShowFilterBar(false); }} className="text-xs text-muted hover:text-foreground ml-2">Clear all</button>
+            <button onClick={addFilter} className="cursor-pointer text-xs text-brand hover:text-brand-hover">+ Add</button>
+            <button onClick={() => { setFilters([]); setShowFilterBar(false); }} className="cursor-pointer text-xs text-muted hover:text-foreground ml-2">Clear all</button>
           </div>
         )}
 
@@ -1524,7 +1524,7 @@ function TableEditorPageInner() {
                     </th>
                   ))}
                   <th className="w-10 px-2 py-2 border-r border-border">
-                    {!readOnly && <button onClick={() => setShowAddCol(true)} className="w-6 h-6 rounded bg-raised hover:bg-brand/15 text-muted hover:text-brand text-sm font-bold">+</button>}
+                    {!readOnly && <button onClick={() => setShowAddCol(true)} className="cursor-pointer w-6 h-6 rounded bg-raised hover:bg-brand/15 text-muted hover:text-brand text-sm font-bold">+</button>}
                   </th>
                   <th className="w-16" />
                 </tr>
@@ -1580,7 +1580,7 @@ function TableEditorPageInner() {
             </table>
 
             {/* Add row + infinite scroll sentinel */}
-            {!readOnly && <button onClick={handleAddRow} className="w-full py-2 text-sm text-muted hover:text-foreground hover:bg-raised border-b border-border/50 transition-colors text-left px-4">+ New row</button>}
+            {!readOnly && <button onClick={handleAddRow} className="cursor-pointer w-full py-2 text-sm text-muted hover:text-foreground hover:bg-raised border-b border-border/50 transition-colors text-left px-4">+ New row</button>}
             {hasMore && (
               <div ref={sentinelRef} className="py-4 text-center text-xs text-muted">
                 {loadingMore ? (
@@ -1611,25 +1611,25 @@ function TableEditorPageInner() {
           <div data-colmenu className="fixed z-50 bg-surface border border-border rounded-lg shadow-lg py-1 min-w-[180px]" style={{ left: colMenu.x, top: colMenu.y }} onClick={(e) => e.stopPropagation()}>
             {!colMenuTypeOpen ? (
               <>
-                <button onClick={() => { handleSort(colMenu.colId); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Sort {sortBy === colMenu.colId && sortOrder === "asc" ? "descending" : "ascending"}</button>
-                <button onClick={() => handleRenameColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Rename</button>
-                <button onClick={() => setColMenuTypeOpen(true)} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised flex items-center justify-between">
+                <button onClick={() => { handleSort(colMenu.colId); setColMenu(null); }} className="cursor-pointer w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Sort {sortBy === colMenu.colId && sortOrder === "asc" ? "descending" : "ascending"}</button>
+                <button onClick={() => handleRenameColumn(colMenu.colId)} className="cursor-pointer w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Rename</button>
+                <button onClick={() => setColMenuTypeOpen(true)} className="cursor-pointer w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised flex items-center justify-between">
                   <span>Change type</span>
                   <span className="text-[10px] text-muted font-mono">{sortedColumns.find((c) => c.id === colMenu.colId)?.type ?? ""} ›</span>
                 </button>
-                <button onClick={() => { setHiddenCols((prev) => new Set([...prev, colMenu.colId])); setColMenu(null); }} className="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Hide column</button>
-                <button onClick={() => handleDeleteColumn(colMenu.colId)} className="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-raised">Delete column</button>
+                <button onClick={() => { setHiddenCols((prev) => new Set([...prev, colMenu.colId])); setColMenu(null); }} className="cursor-pointer w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-raised">Hide column</button>
+                <button onClick={() => handleDeleteColumn(colMenu.colId)} className="cursor-pointer w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-raised">Delete column</button>
               </>
             ) : (
               <>
-                <button onClick={() => setColMenuTypeOpen(false)} className="w-full text-left px-3 py-1.5 text-xs text-muted hover:text-foreground hover:bg-raised">‹ Back</button>
+                <button onClick={() => setColMenuTypeOpen(false)} className="cursor-pointer w-full text-left px-3 py-1.5 text-xs text-muted hover:text-foreground hover:bg-raised">‹ Back</button>
                 {COLUMN_TYPES.map((t) => {
                   const current = sortedColumns.find((c) => c.id === colMenu.colId)?.type;
                   return (
                     <button
                       key={t}
                       onClick={() => { void handleChangeColumnType(colMenu.colId, t); setColMenuTypeOpen(false); }}
-                      className={`w-full text-left px-3 py-1.5 text-sm hover:bg-raised flex items-center gap-2 ${current === t ? "text-brand" : "text-foreground"}`}
+                      className={`cursor-pointer w-full text-left px-3 py-1.5 text-sm hover:bg-raised flex items-center gap-2 ${current === t ? "text-brand" : "text-foreground"}`}
                     >
                       <span className="text-[10px] text-muted font-mono w-4 text-center">{TYPE_ICONS[t] ?? "?"}</span>
                       <span>{t}</span>
@@ -1644,7 +1644,7 @@ function TableEditorPageInner() {
 
         {/* Add column dialog */}
         {showAddCol && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setShowAddCol(false)}>
+          <div className="fixed inset-0 z-50 flex cursor-pointer items-center justify-center bg-black/40" onClick={() => setShowAddCol(false)}>
             <div className="bg-surface border border-border rounded-xl p-6 w-[360px] shadow-xl" onClick={(e) => e.stopPropagation()}>
               <h2 className="text-base font-bold font-display text-foreground mb-4">Add Column</h2>
               <div className="space-y-3">
@@ -1662,8 +1662,8 @@ function TableEditorPageInner() {
                 {(newColType === "select" || newColType === "multiselect") && <div><label className="text-xs text-muted mb-1 block">Options (comma-separated)</label><input value={newColOptions} onChange={(e) => setNewColOptions(e.target.value)} className="w-full px-3 py-2 text-sm bg-raised border border-border rounded text-foreground outline-none focus:ring-1 focus:ring-brand" placeholder="option1, option2" /></div>}
               </div>
               <div className="flex justify-end gap-2 mt-5">
-                <button onClick={() => setShowAddCol(false)} className="text-sm text-muted hover:text-foreground px-3 py-1.5">Cancel</button>
-                <button onClick={handleAddColumn} className="text-sm bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-4 py-1.5 rounded">Add</button>
+                <button onClick={() => setShowAddCol(false)} className="cursor-pointer text-sm text-muted hover:text-foreground px-3 py-1.5">Cancel</button>
+                <button onClick={handleAddColumn} className="cursor-pointer text-sm bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-4 py-1.5 rounded">Add</button>
               </div>
             </div>
           </div>
@@ -1671,7 +1671,7 @@ function TableEditorPageInner() {
 
         {/* Row detail modal */}
         {detailRow && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setDetailRow(null)}>
+          <div className="fixed inset-0 z-50 flex cursor-pointer items-center justify-center bg-black/40" onClick={() => setDetailRow(null)}>
             <div className="bg-surface border border-border rounded-xl p-6 w-[480px] max-h-[80vh] overflow-y-auto shadow-xl" onClick={(e) => e.stopPropagation()}>
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-base font-bold font-display text-foreground">Row Detail</h2>
@@ -1711,10 +1711,10 @@ function TableEditorPageInner() {
                 </div>
               </div>
               <div className="flex justify-between mt-5">
-                <button onClick={() => { handleDuplicateRow(detailRow.id); setDetailRow(null); }} className="text-sm text-muted hover:text-foreground px-3 py-1.5">Duplicate</button>
+                <button onClick={() => { handleDuplicateRow(detailRow.id); setDetailRow(null); }} className="cursor-pointer text-sm text-muted hover:text-foreground px-3 py-1.5">Duplicate</button>
                 <div className="flex gap-2">
-                  <button onClick={() => setDetailRow(null)} className="text-sm text-muted hover:text-foreground px-3 py-1.5">Cancel</button>
-                  <button onClick={saveDetail} className="text-sm bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-4 py-1.5 rounded">Save</button>
+                  <button onClick={() => setDetailRow(null)} className="cursor-pointer text-sm text-muted hover:text-foreground px-3 py-1.5">Cancel</button>
+                  <button onClick={saveDetail} className="cursor-pointer text-sm bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)] text-white px-4 py-1.5 rounded">Save</button>
                 </div>
               </div>
             </div>

--- a/frontend/src/app/workspaces/new/page.tsx
+++ b/frontend/src/app/workspaces/new/page.tsx
@@ -83,14 +83,14 @@ export default function NewWorkspacePage() {
             <button
               type="button"
               onClick={() => router.back()}
-              className="text-[13px] text-muted hover:text-foreground"
+              className="cursor-pointer text-[13px] text-muted hover:text-foreground"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={busy || !name.trim()}
-              className="rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-hover)] disabled:opacity-40"
+              className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-hover)] disabled:opacity-40"
             >
               {busy ? "Creating…" : "Create workspace"}
             </button>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -227,7 +227,7 @@ function TopSearchButton({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-10 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[14px] text-muted shadow-sm transition-colors hover:border-[var(--color-brand-300)] hover:bg-raised hover:text-foreground"
+      className="flex h-10 w-full cursor-pointer items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[14px] text-muted shadow-sm transition-colors hover:border-[var(--color-brand-300)] hover:bg-raised hover:text-foreground"
       aria-label="Search"
     >
       <svg
@@ -392,7 +392,7 @@ export default function AppShell({
                 return next;
               });
             }}
-            className="rounded p-1 text-muted hover:bg-raised"
+            className="cursor-pointer rounded p-1 text-muted hover:bg-raised"
             aria-label="Toggle sidebar"
             title="Toggle sidebar (⌘\\)"
           >
@@ -501,7 +501,7 @@ function UserMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         title={accountLabel}
-        className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-100 text-[10px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
+        className="ml-1 inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-brand-100 text-[10px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
       >
         {initial}
       </button>
@@ -532,7 +532,7 @@ function UserMenu({
               setOpen(false);
               onLogout();
             }}
-            className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+            className="block w-full cursor-pointer px-3 py-1.5 text-left text-foreground hover:bg-raised"
           >
             Sign out
           </button>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -377,7 +377,7 @@ export default function AppSidebar({
           <button
             type="button"
             onClick={toggleExternalCollapsed}
-            className="flex w-full items-center gap-1 px-2 pb-1 text-left text-[11px] font-semibold uppercase tracking-wide text-muted hover:text-foreground"
+            className="flex w-full cursor-pointer items-center gap-1 px-2 pb-1 text-left text-[11px] font-semibold uppercase tracking-wide text-muted hover:text-foreground"
           >
             <span
               aria-hidden
@@ -400,7 +400,7 @@ export default function AppSidebar({
           <button
             type="button"
             onClick={() => setAddSourceOpen(true)}
-            className="page-row group/nav flex w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-left text-[13px] text-dim transition-colors hover:bg-raised hover:text-foreground"
+            className="page-row group/nav flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-left text-[13px] text-dim transition-colors hover:bg-raised hover:text-foreground"
           >
             <span className="flex h-4 w-4 shrink-0 items-center justify-center text-[14px]" aria-hidden>
               ＋

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -200,7 +200,7 @@ export default function CommandPalette({
   };
 
   return (
-    <div className="fixed inset-0 z-[60] bg-transparent px-2 pt-2 sm:px-4" onClick={onClose}>
+    <div className="fixed inset-0 z-[60] cursor-pointer bg-transparent px-2 pt-2 sm:px-4" onClick={onClose}>
       <div
         className="mx-auto flex max-h-[calc(100vh-1rem)] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border bg-base shadow-2xl"
         onClick={(e) => e.stopPropagation()}
@@ -223,7 +223,7 @@ export default function CommandPalette({
           <button
             type="button"
             onClick={onClose}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted hover:bg-surface hover:text-foreground"
+            className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted hover:bg-surface hover:text-foreground"
             aria-label="Close search"
           >
             <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -50,7 +50,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
       {children}
       {options && (
         <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30 px-4"
+          className="fixed inset-0 z-[60] flex cursor-pointer items-center justify-center bg-black/30 px-4"
           onClick={() => settle(false)}
         >
           <div
@@ -70,7 +70,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
               <button
                 type="button"
                 onClick={() => settle(false)}
-                className="rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
+                className="cursor-pointer rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
               >
                 Cancel
               </button>
@@ -79,7 +79,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
                 autoFocus
                 onClick={() => settle(true)}
                 className={
-                  "rounded-md px-3 py-1.5 text-[12.5px] font-medium text-white " +
+                  "cursor-pointer rounded-md px-3 py-1.5 text-[12.5px] font-medium text-white " +
                   (destructive
                     ? "bg-red-600 hover:bg-red-700"
                     : "bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)]")

--- a/frontend/src/components/CustomSelect.tsx
+++ b/frontend/src/components/CustomSelect.tsx
@@ -149,7 +149,7 @@ export default function CustomSelect({
         className={[
           "flex min-w-0 items-center justify-between gap-2 text-left outline-none",
           className,
-          disabled ? "cursor-not-allowed opacity-50" : "",
+          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
         ]
           .filter(Boolean)
           .join(" ")}
@@ -194,7 +194,7 @@ export default function CustomSelect({
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => selectOption(index)}
                 className={[
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                  "flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-foreground disabled:cursor-not-allowed disabled:opacity-50",
                   activeOption ? "bg-raised" : "hover:bg-raised",
                   optionClassName,
                 ]

--- a/frontend/src/components/DownloadMenu.tsx
+++ b/frontend/src/components/DownloadMenu.tsx
@@ -36,7 +36,7 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-base text-muted hover:bg-raised hover:text-foreground"
+        className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-border bg-base text-muted hover:bg-raised hover:text-foreground"
         aria-label="More actions"
         title="More actions"
       >
@@ -55,7 +55,7 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
                 setOpen(false);
                 o.onSelect();
               }}
-              className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+              className="block w-full cursor-pointer px-3 py-1.5 text-left text-foreground hover:bg-raised"
             >
               {o.label}
             </button>
@@ -70,7 +70,7 @@ export default function DownloadMenu({ options }: { options: DownloadOption[] })
                 setOpen(false);
                 o.onSelect();
               }}
-              className="block w-full px-3 py-1.5 text-left text-red-600 hover:bg-red-500/10"
+              className="block w-full cursor-pointer px-3 py-1.5 text-left text-red-600 hover:bg-red-500/10"
             >
               {o.label}
             </button>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -61,7 +61,7 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
         aria-haspopup="menu"
         aria-expanded={open}
         title={accountLabel}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand-100 text-[11px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
+        className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-full bg-brand-100 text-[11px] font-semibold text-[var(--color-brand-700)] hover:ring-2 hover:ring-[var(--color-brand-200)]"
       >
         {initial}
       </button>
@@ -92,7 +92,7 @@ function HeaderUserMenu({ user, onLogout }: { user: User; onLogout?: () => void 
               setOpen(false);
               onLogout?.();
             }}
-            className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+            className="block w-full cursor-pointer px-3 py-1.5 text-left text-foreground hover:bg-raised"
           >
             Sign out
           </button>

--- a/frontend/src/components/PaywallModal.tsx
+++ b/frontend/src/components/PaywallModal.tsx
@@ -26,7 +26,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30 px-4"
+      className="fixed inset-0 z-[60] flex cursor-pointer items-center justify-center bg-black/30 px-4"
       onClick={onClose}
     >
       <div
@@ -49,7 +49,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
+            className="cursor-pointer rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
           >
             Not now
           </button>
@@ -58,7 +58,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
             autoFocus
             disabled={busy}
             onClick={() => upgrade("month")}
-            className="rounded-md bg-brand px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
+            className="cursor-pointer rounded-md bg-brand px-3 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover disabled:opacity-60"
           >
             {busy ? "Redirecting…" : "Upgrade — $20/month"}
           </button>
@@ -67,7 +67,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
           type="button"
           disabled={busy}
           onClick={() => upgrade("year")}
-          className="mt-2 block w-full text-right text-[11.5px] text-muted underline hover:text-foreground disabled:opacity-60"
+          className="mt-2 block w-full cursor-pointer text-right text-[11.5px] text-muted underline hover:text-foreground disabled:opacity-60"
         >
           or $200/year — 2 months free
         </button>

--- a/frontend/src/components/SessionUpload.tsx
+++ b/frontend/src/components/SessionUpload.tsx
@@ -99,7 +99,7 @@ export default function SessionUpload({ workspaceId, onUploaded }: SessionUpload
           type="button"
           onClick={() => inputRef.current?.click()}
           disabled={status === "uploading"}
-          className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-50"
+          className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-50"
         >
           {status === "uploading" ? "Uploading..." : "+ Add session"}
         </button>

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -163,7 +163,7 @@ function EmptyChatState({ onPrompt }: { onPrompt: (prompt: string) => void }) {
               key={prompt}
               type="button"
               onClick={() => onPrompt(prompt)}
-              className="min-h-12 rounded-md border border-border bg-surface px-3 py-2 text-left text-[12.5px] leading-4 text-foreground hover:border-[var(--color-brand-300)] hover:bg-raised"
+              className="min-h-12 cursor-pointer rounded-md border border-border bg-surface px-3 py-2 text-left text-[12.5px] leading-4 text-foreground hover:border-[var(--color-brand-300)] hover:bg-raised"
             >
               {prompt}
             </button>
@@ -306,7 +306,7 @@ function Composer({
           type="button"
           onClick={onSend}
           disabled={disabled || !value.trim()}
-          className="rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
+          className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
           Send
         </button>

--- a/frontend/src/components/export/ExportDeckButton.tsx
+++ b/frontend/src/components/export/ExportDeckButton.tsx
@@ -159,7 +159,7 @@ export default function ExportDeckButton({ pageId, layout, contentType }: Props)
         type="button"
         onClick={() => setOpen((o) => !o)}
         disabled={!!busyFormat}
-        className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] font-medium text-foreground hover:bg-raised disabled:cursor-wait disabled:opacity-80"
+        className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] font-medium text-foreground hover:bg-raised disabled:cursor-wait disabled:opacity-80"
       >
         {busyFormat && <Spinner />}
         {busyFormat ? busyCopyFor(busyFormat) : "Export deck"}
@@ -174,7 +174,7 @@ export default function ExportDeckButton({ pageId, layout, contentType }: Props)
               key={f.value}
               role="menuitem"
               onClick={() => runExport(f.value)}
-              className="block w-full rounded-md px-2.5 py-2 text-left transition hover:bg-raised"
+              className="block w-full cursor-pointer rounded-md px-2.5 py-2 text-left transition hover:bg-raised"
             >
               <div className="text-[13px] font-medium text-foreground">{f.label}</div>
               <div className="mt-0.5 text-[12px] text-muted">{f.help}</div>
@@ -219,7 +219,7 @@ export default function ExportDeckButton({ pageId, layout, contentType }: Props)
           <button
             type="button"
             onClick={() => setResult(null)}
-            className="ml-3 text-muted hover:text-foreground"
+            className="ml-3 cursor-pointer text-muted hover:text-foreground"
           >
             Dismiss
           </button>
@@ -231,7 +231,7 @@ export default function ExportDeckButton({ pageId, layout, contentType }: Props)
           <button
             type="button"
             onClick={() => setError(null)}
-            className="ml-2 underline"
+            className="ml-2 cursor-pointer underline"
           >
             Dismiss
           </button>

--- a/frontend/src/components/integrations/AddSourceModal.tsx
+++ b/frontend/src/components/integrations/AddSourceModal.tsx
@@ -23,7 +23,7 @@ export default function AddSourceModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-50 flex cursor-pointer items-center justify-center bg-black/40 p-4"
       onClick={onClose}
     >
       <div
@@ -41,7 +41,7 @@ export default function AddSourceModal({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="rounded-md px-2 py-1 text-[18px] leading-none text-muted hover:bg-raised hover:text-foreground"
+            className="cursor-pointer rounded-md px-2 py-1 text-[18px] leading-none text-muted hover:bg-raised hover:text-foreground"
           >
             ×
           </button>

--- a/frontend/src/components/integrations/ObsidianVaultDropZone.tsx
+++ b/frontend/src/components/integrations/ObsidianVaultDropZone.tsx
@@ -168,7 +168,7 @@ export default function ObsidianVaultDropZone({ workspaceId, onUploaded }: Props
           e.dataTransfer.dropEffect = "copy";
         }}
         onDrop={handleDrop}
-        className={`w-full flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-6 py-10 text-center transition-colors ${
+        className={`w-full cursor-pointer flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-6 py-10 text-center transition-colors ${
           dragActive
             ? "border-brand bg-brand/10"
             : "border-border bg-background/40 hover:border-brand hover:bg-raised"

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -29,11 +29,11 @@ type AddSourceBody = {
 };
 
 export function primaryButton(): string {
-  return "shrink-0 rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
+  return "shrink-0 cursor-pointer rounded-md bg-brand px-3 py-1.5 text-[12px] font-medium text-white hover:bg-brand-hover disabled:opacity-60";
 }
 
 export function secondaryButton(): string {
-  return "shrink-0 rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60";
+  return "shrink-0 cursor-pointer rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60";
 }
 
 // Renders the right "add a specific project/page/repo" UI for a connector and
@@ -388,7 +388,7 @@ export function GitHubRepoPicker({
           type="button"
           disabled={busy}
           onClick={() => void onAdd(repo)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+          className="flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
         >
           <GitHubIcon className="mt-0.5 text-muted" size={14} />
           <span className="min-w-0 flex-1">
@@ -451,7 +451,7 @@ export function NotionPagePicker({
           type="button"
           disabled={busy}
           onClick={() => void onAdd(page)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+          className="flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
         >
           <NotionIcon className="mt-0.5 text-muted" size={14} />
           <span className="min-w-0 flex-1">
@@ -514,7 +514,7 @@ export function JiraProjectPicker({
           type="button"
           disabled={busy}
           onClick={() => void onAdd(project)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+          className="flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
         >
           <JiraIcon className="mt-0.5" size={14} />
           <span className="min-w-0 flex-1">
@@ -575,7 +575,7 @@ export function AsanaProjectPicker({
           type="button"
           disabled={busy}
           onClick={() => void onAdd(project)}
-          className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
+          className="flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-raised disabled:opacity-60"
         >
           <AsanaIcon className="mt-0.5" size={14} />
           <span className="min-w-0 flex-1">

--- a/frontend/src/components/settings/SubscriptionSection.tsx
+++ b/frontend/src/components/settings/SubscriptionSection.tsx
@@ -61,7 +61,7 @@ export default function SubscriptionSection() {
             type="button"
             disabled={busy}
             onClick={() => redirectTo(openBillingPortal)}
-            className="text-sm font-semibold px-4 py-2 rounded-lg border border-border text-foreground hover:bg-raised disabled:opacity-60 transition-colors"
+            className="cursor-pointer text-sm font-semibold px-4 py-2 rounded-lg border border-border text-foreground hover:bg-raised disabled:opacity-60 transition-colors"
           >
             {busy ? "Opening…" : "Manage subscription"}
           </button>
@@ -71,7 +71,7 @@ export default function SubscriptionSection() {
               type="button"
               disabled={busy}
               onClick={() => redirectTo(() => startCheckout("month"))}
-              className="bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+              className="cursor-pointer bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
             >
               {busy ? "Redirecting…" : "Upgrade — $20/month"}
             </button>
@@ -79,7 +79,7 @@ export default function SubscriptionSection() {
               type="button"
               disabled={busy}
               onClick={() => redirectTo(() => startCheckout("year"))}
-              className="text-xs text-muted hover:text-foreground underline disabled:opacity-60"
+              className="cursor-pointer text-xs text-muted hover:text-foreground underline disabled:opacity-60"
             >
               or $200/year — 2 months free
             </button>

--- a/frontend/src/components/settings/WorkspaceSection.tsx
+++ b/frontend/src/components/settings/WorkspaceSection.tsx
@@ -107,7 +107,7 @@ export default function WorkspaceSection() {
                 key={g.label}
                 onClick={() => setGradient(g.css)}
                 className={
-                  "h-8 w-16 rounded-md border " +
+                  "h-8 w-16 cursor-pointer rounded-md border " +
                   (workspace.color_gradient === g.css
                     ? "border-foreground ring-2 ring-brand/30"
                     : "border-border")
@@ -119,7 +119,7 @@ export default function WorkspaceSection() {
             {workspace.color_gradient && (
               <button
                 onClick={() => clearField("color_gradient")}
-                className="text-[11.5px] text-muted hover:text-foreground"
+                className="cursor-pointer text-[11.5px] text-muted hover:text-foreground"
               >
                 Clear
               </button>
@@ -138,7 +138,7 @@ export default function WorkspaceSection() {
         </div>
         <button
           onClick={handleDelete}
-          className="rounded-lg border border-error/60 px-3 py-2 text-sm font-medium text-error hover:bg-error/10 transition-colors"
+          className="cursor-pointer rounded-lg border border-error/60 px-3 py-2 text-sm font-medium text-error hover:bg-error/10 transition-colors"
         >
           Delete this workspace
         </button>
@@ -198,7 +198,7 @@ function ImageField({
             }}
           />
           {url && (
-            <button onClick={onClear} className="text-[11.5px] text-muted hover:text-foreground">
+            <button onClick={onClear} className="cursor-pointer text-[11.5px] text-muted hover:text-foreground">
               Clear
             </button>
           )}

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -160,7 +160,7 @@ export default function ResourceShareButton({
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+        className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
       >
         Share
       </button>
@@ -180,7 +180,7 @@ export default function ResourceShareButton({
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded p-1 text-muted hover:bg-raised hover:text-foreground"
+              className="cursor-pointer rounded p-1 text-muted hover:bg-raised hover:text-foreground"
               aria-label="Close share dialog"
             >
               <svg
@@ -228,7 +228,7 @@ export default function ResourceShareButton({
               <button
                 type="submit"
                 disabled={busy || !email.trim()}
-                className="rounded-md bg-foreground px-3 py-2 text-[12.5px] font-medium text-background disabled:opacity-45"
+                className="cursor-pointer rounded-md bg-foreground px-3 py-2 text-[12.5px] font-medium text-background disabled:opacity-45"
               >
                 Invite
               </button>
@@ -312,14 +312,14 @@ export default function ResourceShareButton({
             <button
               type="button"
               onClick={() => void copyLink()}
-              className="rounded-full border border-border bg-base px-4 py-2 text-[13px] font-medium text-foreground hover:bg-raised"
+              className="cursor-pointer rounded-full border border-border bg-base px-4 py-2 text-[13px] font-medium text-foreground hover:bg-raised"
             >
               Copy link
             </button>
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded-full bg-[var(--color-brand-600)] px-5 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+              className="cursor-pointer rounded-full bg-[var(--color-brand-600)] px-5 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)]"
             >
               Done
             </button>
@@ -386,7 +386,7 @@ function AccessRow({
           type="button"
           onClick={onRemove}
           disabled={busy}
-          className="shrink-0 text-[12px] text-red-500 hover:underline disabled:opacity-40"
+          className="shrink-0 cursor-pointer text-[12px] text-red-500 hover:underline disabled:opacity-40"
         >
           Remove
         </button>

--- a/frontend/src/components/share/SessionFolderShareModal.tsx
+++ b/frontend/src/components/share/SessionFolderShareModal.tsx
@@ -118,7 +118,7 @@ export default function SessionFolderShareModal({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-[60] flex cursor-pointer items-center justify-center bg-black/40 p-4"
       onClick={onClose}
     >
       <div
@@ -133,7 +133,7 @@ export default function SessionFolderShareModal({
           <button
             type="button"
             onClick={onClose}
-            className="text-[20px] leading-none text-muted hover:text-foreground"
+            className="cursor-pointer text-[20px] leading-none text-muted hover:text-foreground"
             aria-label="Close"
           >
             ×
@@ -154,7 +154,7 @@ export default function SessionFolderShareModal({
                 disabled={busy}
                 onClick={() => changeVisibility(v.key)}
                 className={
-                  "flex-1 rounded-md px-2 py-[5px] text-[12.5px] " +
+                  "flex-1 cursor-pointer rounded-md px-2 py-[5px] text-[12.5px] " +
                   (visibility === v.key
                     ? "bg-raised font-semibold text-foreground"
                     : "text-muted hover:text-foreground")
@@ -175,7 +175,7 @@ export default function SessionFolderShareModal({
             <button
               type="button"
               onClick={copyLink}
-              className="shrink-0 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+              className="shrink-0 cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12px] font-medium text-white hover:bg-[var(--color-brand-700)]"
             >
               {copied ? "Copied" : "Copy link"}
             </button>
@@ -205,7 +205,7 @@ export default function SessionFolderShareModal({
             <button
               type="submit"
               disabled={busy || !email.trim()}
-              className="rounded-md bg-foreground px-3 py-1.5 text-[12.5px] font-medium text-background disabled:opacity-45"
+              className="cursor-pointer rounded-md bg-foreground px-3 py-1.5 text-[12.5px] font-medium text-background disabled:opacity-45"
             >
               Invite
             </button>
@@ -229,7 +229,7 @@ export default function SessionFolderShareModal({
                     <button
                       type="button"
                       onClick={() => void removePerson(s)}
-                      className="text-[11.5px] text-rose-500 hover:underline"
+                      className="cursor-pointer text-[11.5px] text-rose-500 hover:underline"
                     >
                       Remove
                     </button>

--- a/frontend/src/components/skill/ForkSkillCardButton.tsx
+++ b/frontend/src/components/skill/ForkSkillCardButton.tsx
@@ -125,7 +125,7 @@ export default function ForkSkillCardButton({ slug, sourceWorkspaceId }: Props) 
         onClick={onPrimaryClick}
         disabled={showBusy}
         title={showDone ? "Saved to workspace" : "Save to your workspace"}
-        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium shadow-sm ring-1 backdrop-blur transition ${
+        className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium shadow-sm ring-1 backdrop-blur transition ${
           showDone
             ? "bg-[var(--color-brand-600)] text-white ring-[var(--color-brand-600)]"
             : "bg-white/85 text-foreground ring-border hover:bg-white"
@@ -160,7 +160,7 @@ export default function ForkSkillCardButton({ slug, sourceWorkspaceId }: Props) 
               <button
                 type="button"
                 onClick={() => void save(phase.selectedId)}
-                className="w-full rounded-md bg-brand px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover"
+                className="w-full cursor-pointer rounded-md bg-brand px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-brand-hover"
               >
                 Save
               </button>
@@ -179,7 +179,7 @@ export default function ForkSkillCardButton({ slug, sourceWorkspaceId }: Props) 
                 onClick={() =>
                   router.push(`/workspaces/${phase.workspaceId}`)
                 }
-                className="w-full rounded-md border border-border px-2.5 py-1.5 text-[12.5px] text-foreground hover:border-brand hover:text-brand"
+                className="w-full cursor-pointer rounded-md border border-border px-2.5 py-1.5 text-[12.5px] text-foreground hover:border-brand hover:text-brand"
               >
                 Open workspace →
               </button>

--- a/frontend/src/components/skill/SkillShareButton.tsx
+++ b/frontend/src/components/skill/SkillShareButton.tsx
@@ -177,7 +177,7 @@ export default function SkillShareButton({
         disabled={handoffStatus === "copying"}
         aria-label="Copy agent handoff link"
         title="Copy an agent-readable public link"
-        className="inline-flex min-w-[72px] items-center justify-center rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground disabled:opacity-50"
+        className="inline-flex min-w-[72px] cursor-pointer items-center justify-center rounded-md bg-surface px-2.5 py-1 text-[12.5px] font-medium text-dim ring-1 ring-inset ring-border hover:bg-raised hover:text-foreground disabled:opacity-50"
       >
         {handoffStatus === "copying"
           ? "Copying"
@@ -190,7 +190,7 @@ export default function SkillShareButton({
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+        className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
       >
         {publish ? "Published" : "Publish"}
       </button>
@@ -215,7 +215,7 @@ export default function SkillShareButton({
                 type="button"
                 onClick={() => void publishNow()}
                 disabled={busy}
-                className="mt-3 w-full rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
+                className="mt-3 w-full cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-50"
               >
                 {busy ? "Publishing..." : "Publish"}
               </button>
@@ -232,7 +232,7 @@ export default function SkillShareButton({
                 <button
                   type="button"
                   onClick={() => void copyLink()}
-                  className="rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
+                  className="cursor-pointer rounded-md border border-border bg-base px-2 py-1.5 text-[11.5px] font-medium text-foreground hover:bg-raised"
                 >
                   {copied ? "Copied" : "Copy"}
                 </button>
@@ -256,7 +256,7 @@ export default function SkillShareButton({
                   type="button"
                   onClick={() => void unpublish()}
                   disabled={busy}
-                  className="text-[11.5px] font-medium text-red-500 hover:underline disabled:opacity-40"
+                  className="cursor-pointer text-[11.5px] font-medium text-red-500 hover:underline disabled:opacity-40"
                 >
                   Unpublish
                 </button>

--- a/frontend/src/components/workspace/CommentComposerPopover.tsx
+++ b/frontend/src/components/workspace/CommentComposerPopover.tsx
@@ -72,7 +72,7 @@ export default function CommentComposerPopover({
           type="button"
           onClick={onCancel}
           disabled={submitting}
-          className="rounded-sm px-2 py-1 text-[12px] text-muted hover:bg-background"
+          className="cursor-pointer rounded-sm px-2 py-1 text-[12px] text-muted hover:bg-background"
         >
           Cancel
         </button>
@@ -80,7 +80,7 @@ export default function CommentComposerPopover({
           type="button"
           onClick={submit}
           disabled={submitting || !body.trim()}
-          className="rounded-sm bg-[var(--color-brand-600)] px-2.5 py-1 text-[12px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+          className="cursor-pointer rounded-sm bg-[var(--color-brand-600)] px-2.5 py-1 text-[12px] font-medium text-white hover:opacity-90 disabled:opacity-50"
         >
           {submitting ? "…" : "Comment"}
         </button>

--- a/frontend/src/components/workspace/CommentsSidebar.tsx
+++ b/frontend/src/components/workspace/CommentsSidebar.tsx
@@ -291,7 +291,7 @@ function Group({
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="sys-label flex w-full items-center justify-between"
+        className="sys-label flex w-full cursor-pointer items-center justify-between"
         style={{ fontSize: 11 }}
       >
         <span>
@@ -396,7 +396,7 @@ function ThreadCard({
                       onDeleteMessage(thread.id, m.id);
                     }}
                     title="Delete comment"
-                    className="ml-auto px-1 text-[11px] leading-none text-muted opacity-0 transition-opacity hover:text-red-500 group-hover/msg:opacity-100"
+                    className="ml-auto cursor-pointer px-1 text-[11px] leading-none text-muted opacity-0 transition-opacity hover:text-red-500 group-hover/msg:opacity-100"
                   >
                     ×
                   </button>
@@ -432,7 +432,7 @@ function ThreadCard({
                   e.stopPropagation();
                   onDeleteThread(thread.id);
                 }}
-                className="text-[11px] text-muted underline hover:text-red-500"
+                className="cursor-pointer text-[11px] text-muted underline hover:text-red-500"
               >
                 Delete
               </button>
@@ -443,7 +443,7 @@ function ThreadCard({
                 e.stopPropagation();
                 toggleResolved();
               }}
-              className="rounded-sm border border-border-subtle bg-background px-2 py-0.5 text-[11px] text-muted hover:bg-raised hover:text-foreground"
+              className="cursor-pointer rounded-sm border border-border-subtle bg-background px-2 py-0.5 text-[11px] text-muted hover:bg-raised hover:text-foreground"
             >
               Resolve
             </button>
@@ -458,7 +458,7 @@ function ThreadCard({
               e.stopPropagation();
               toggleResolved();
             }}
-            className="text-[11.5px] text-muted underline hover:text-foreground"
+            className="cursor-pointer text-[11.5px] text-muted underline hover:text-foreground"
           >
             Reopen
           </button>
@@ -469,7 +469,7 @@ function ThreadCard({
                 e.stopPropagation();
                 onDeleteThread(thread.id);
               }}
-              className="text-[11.5px] text-muted underline hover:text-red-500"
+              className="cursor-pointer text-[11.5px] text-muted underline hover:text-red-500"
             >
               Delete
             </button>

--- a/frontend/src/components/workspace/EditorToolbar.tsx
+++ b/frontend/src/components/workspace/EditorToolbar.tsx
@@ -291,7 +291,7 @@ export default function EditorToolbar({
               "inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[12.5px] font-medium transition " +
               (selectionEmpty
                 ? "cursor-not-allowed text-muted/40"
-                : "text-foreground hover:bg-raised")
+                : "cursor-pointer text-foreground hover:bg-raised")
             }
           >
             <CommentIcon />
@@ -346,8 +346,8 @@ function Btn({
         (disabled
           ? "cursor-not-allowed text-muted/40"
           : active
-            ? "bg-foreground/5 text-foreground"
-            : "text-muted hover:bg-raised hover:text-foreground")
+            ? "cursor-pointer bg-foreground/5 text-foreground"
+            : "cursor-pointer text-muted hover:bg-raised hover:text-foreground")
       }
     >
       {children}
@@ -410,7 +410,7 @@ function Item({
       type="button"
       onClick={onClick}
       className={
-        "block w-full px-3 py-1.5 text-left transition " +
+        "block w-full cursor-pointer px-3 py-1.5 text-left transition " +
         (destructive
           ? "text-red-600 hover:bg-red-500/10"
           : "text-foreground hover:bg-raised")

--- a/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
+++ b/frontend/src/components/workspace/file-browser/FolderItemGrid.tsx
@@ -151,7 +151,7 @@ function Tile({
             e.stopPropagation();
             void onDelete(item);
           }}
-          className="rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+          className="cursor-pointer rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
           title="Delete"
           aria-label="Delete"
         >

--- a/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsColumns.tsx
@@ -297,7 +297,7 @@ function ColumnRow({
             void onDelete(item);
           }}
           className={
-            "flex-shrink-0 rounded p-0.5 opacity-0 transition focus-visible:opacity-100 group-hover:opacity-100 " +
+            "flex-shrink-0 cursor-pointer rounded p-0.5 opacity-0 transition focus-visible:opacity-100 group-hover:opacity-100 " +
             (active ? "text-white hover:bg-white/10" : "text-muted hover:bg-raised hover:text-red-600")
           }
           title="Delete"
@@ -364,7 +364,7 @@ function PreviewPanel({
         <button
           type="button"
           onClick={onOpen}
-          className="flex-1 rounded-md border border-border bg-base px-3 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
+          className="flex-1 cursor-pointer rounded-md border border-border bg-base px-3 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
         >
           Open
         </button>
@@ -372,7 +372,7 @@ function PreviewPanel({
           <button
             type="button"
             onClick={onDelete}
-            className="rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10"
+            className="cursor-pointer rounded-md border border-red-300/60 bg-red-500/5 px-3 py-1 text-[12px] text-red-600 hover:bg-red-500/10"
             title="Move to trash"
           >
             Delete

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -231,7 +231,7 @@ function SortHeader({
       type="button"
       onClick={() => onSort(sortKey)}
       className={
-        "flex items-center gap-1 text-left uppercase tracking-wide transition-colors hover:text-foreground " +
+        "flex cursor-pointer items-center gap-1 text-left uppercase tracking-wide transition-colors hover:text-foreground " +
         (active ? "text-foreground" : "")
       }
     >
@@ -288,7 +288,7 @@ function TypeHeader({
         type="button"
         onClick={() => setOpen((o) => !o)}
         className={
-          "flex items-center gap-1 text-left uppercase tracking-wide transition-colors hover:text-foreground " +
+          "flex cursor-pointer items-center gap-1 text-left uppercase tracking-wide transition-colors hover:text-foreground " +
           (sortActive || filter ? "text-foreground" : "")
         }
       >
@@ -326,7 +326,7 @@ function MenuItem({
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"
+      className="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"
     >
       <span className="truncate">{label}</span>
       {checked && (
@@ -422,7 +422,7 @@ function Row({
             onTogglePin(item);
           }}
           className={
-            "rounded p-1 transition hover:bg-raised " +
+            "cursor-pointer rounded p-1 transition hover:bg-raised " +
             (pinned
               ? "text-[var(--color-brand-600)] hover:text-[var(--color-brand-700)]"
               : "text-muted opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100")
@@ -439,7 +439,7 @@ function Row({
             e.stopPropagation();
             void onDelete(item);
           }}
-          className="rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
+          className="cursor-pointer rounded p-1 text-muted opacity-0 transition hover:bg-raised hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100"
           title="Delete"
           aria-label="Delete"
         >

--- a/frontend/src/components/workspace/file-browser/QuickAccess.tsx
+++ b/frontend/src/components/workspace/file-browser/QuickAccess.tsx
@@ -143,7 +143,7 @@ function Card({
           onTogglePin(item);
         }}
         className={
-          "flex h-5 w-5 shrink-0 items-center justify-center rounded text-[14px] transition " +
+          "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[14px] transition " +
           (pinned
             ? "text-[var(--color-brand-600)] hover:text-[var(--color-brand-700)]"
             : "text-muted opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover/qa:opacity-100")

--- a/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
+++ b/frontend/src/components/workspace/file-browser/WorkspaceFileBrowser.tsx
@@ -611,7 +611,7 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId, folderHref
               <button
                 type="button"
                 onClick={handleUploadFile}
-                className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
+                className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
               >
                 + Upload
               </button>
@@ -702,14 +702,14 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId, folderHref
             <button
               type="button"
               onClick={() => void bulkDelete(selectedItems)}
-              className="rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
+              className="cursor-pointer rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
             >
               Delete
             </button>
             <button
               type="button"
               onClick={clearSelection}
-              className="ml-1 text-[18px] leading-none text-background/70 hover:text-background"
+              className="ml-1 cursor-pointer text-[18px] leading-none text-background/70 hover:text-background"
               aria-label="Clear selection"
             >
               ×
@@ -724,14 +724,14 @@ export default function WorkspaceFileBrowser({ workspaceId, folderId, folderHref
             <button
               type="button"
               onClick={handleUndoDelete}
-              className="rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
+              className="cursor-pointer rounded-md border border-background/40 px-2 py-0.5 text-[12px] font-semibold hover:bg-background/10"
             >
               Undo
             </button>
             <button
               type="button"
               onClick={() => setUndo(null)}
-              className="ml-1 text-[18px] leading-none text-background/70 hover:text-background"
+              className="ml-1 cursor-pointer text-[18px] leading-none text-background/70 hover:text-background"
               aria-label="Dismiss"
             >
               ×
@@ -759,7 +759,7 @@ function ScopeTabs({ scope, onChange }: { scope: Scope; onChange: (next: Scope) 
             type="button"
             onClick={() => onChange(t.key)}
             className={
-              "-mb-px border-b-2 px-3 py-2 text-[13px] transition-colors " +
+              "-mb-px cursor-pointer border-b-2 px-3 py-2 text-[13px] transition-colors " +
               (active
                 ? "border-[var(--color-brand-600)] font-semibold text-foreground"
                 : "border-transparent text-muted hover:text-foreground")
@@ -811,7 +811,7 @@ function NewMenu({
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
+        className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] font-medium text-foreground hover:bg-raised"
       >
         + New <span aria-hidden className="text-[10px]">▾</span>
       </button>
@@ -825,7 +825,7 @@ function NewMenu({
                 setOpen(false);
                 o.onSelect();
               }}
-              className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised"
+              className="block w-full cursor-pointer px-3 py-1.5 text-left text-foreground hover:bg-raised"
             >
               {o.label}
             </button>
@@ -852,7 +852,7 @@ function ViewToggle({ view, onChange }: { view: View; onChange: (next: View) => 
             type="button"
             onClick={() => onChange(opt.key)}
             className={
-              "rounded px-2 py-[3px] " +
+              "cursor-pointer rounded px-2 py-[3px] " +
               (active ? "bg-raised font-semibold text-foreground" : "text-muted hover:text-foreground")
             }
           >


### PR DESCRIPTION
## What

Audited the whole frontend for native interactive elements that were missing a pointer cursor and added `cursor-pointer` so hovering them reads as clickable.

The trigger was the Files page (List/Column/Grid toggle, sort headers, action buttons, etc.) showing the default arrow cursor on hover. Native `<button>` and `<div onClick>` elements default to the arrow cursor — only MUI components and `<a href>` anchors got a pointer for free, so a lot of the app's buttons looked non-interactive.

## Scope

~214 className additions across 49 files: files browser, tables, sessions, skills, settings, share dialogs, integrations, onboarding, command palette, editor toolbars, and clickable modal backdrops.

## Rules applied

- Added `cursor-pointer` to native `<button>`, `role="button"` elements, `<a>` without href, and `<div>/<span>` with `onClick` that lacked any `cursor-*` class.
- Skipped MUI components (already pointer), text inputs / `cursor-text` editors, pure `stopPropagation` wrappers, and href anchors.
- Preserved existing `disabled:cursor-not-allowed` / `disabled:cursor-wait` variants (they win over `cursor-pointer` when disabled via higher specificity).
- `CustomSelect` trigger uses a `disabled ? cursor-not-allowed : cursor-pointer` ternary to avoid same-specificity ambiguity.

## Verification

- `npm run lint` — 0 errors (1 pre-existing unused-var warning, unrelated)
- Component tests for touched files — 35 passed
- Every added line in the diff contains `cursor-pointer`; no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)