### PR TITLE
CLI: remove the workspaces command group

### DIFF
--- a/backend/services/invite_token_service.py
+++ b/backend/services/invite_token_service.py
@@ -2,7 +2,7 @@
 
 Tokens are stored as sha256 hashes (raw token returned only at mint time),
 TTL-bounded, and usage-counted. This is the magic-link path — distinct from
-the forever-secret workspaces.invite_code used by `stash workspaces join`.
+the forever-secret workspaces.invite_code redeemed via the join API.
 """
 
 import hashlib

--- a/cli/formatting.py
+++ b/cli/formatting.py
@@ -6,7 +6,6 @@ import json
 
 from rich.console import Console
 from rich.panel import Panel
-from rich.table import Table
 
 console = Console()
 
@@ -37,24 +36,6 @@ def print_messages(messages: list[dict]) -> None:
         console.print(format_message(msg))
 
 
-def print_workspaces(workspaces: list[dict], title: str = "Workspaces") -> None:
-    """Print a table of workspaces."""
-    if not workspaces:
-        console.print("[dim]No workspaces found.[/dim]")
-        return
-    table = Table(title=title)
-    table.add_column("Name", style="bold")
-    table.add_column("ID", style="dim")
-    table.add_column("Members")
-    for workspace in workspaces:
-        table.add_row(
-            workspace.get("name", ""),
-            str(workspace.get("id", ""))[:8],
-            str(workspace.get("member_count", "?")),
-        )
-    console.print(table)
-
-
 def print_user(user: dict, title: str = "Profile") -> None:
     """Print user profile as a panel."""
     lines = [
@@ -69,19 +50,3 @@ def print_user(user: dict, title: str = "Profile") -> None:
     console.print(Panel("\n".join(lines), title=title))
 
 
-def print_members(members: list[dict]) -> None:
-    """Print workspace members table."""
-    if not members:
-        console.print("[dim]No members.[/dim]")
-        return
-    table = Table(title="Members")
-    table.add_column("Name", style="bold")
-    table.add_column("Role")
-    table.add_column("Joined")
-    for m in members:
-        table.add_row(
-            m.get("name", ""),
-            m.get("role", "member"),
-            str(m.get("joined_at", ""))[:19],
-        )
-    console.print(table)

--- a/cli/main.py
+++ b/cli/main.py
@@ -37,7 +37,7 @@ from .config import (
     set_streaming,
     stored_base_url,
 )
-from .formatting import console, output_json, print_members, print_user, print_workspaces
+from .formatting import console, output_json, print_user
 
 app = typer.Typer(
     name="stash",
@@ -726,93 +726,6 @@ def whoami(as_json: bool = typer.Option(False, "--json")):
         output_json(data)
     else:
         print_user(data)
-
-
-# ===========================================================================
-# Workspaces
-# ===========================================================================
-
-ws_app = typer.Typer(help="Stash Workspace management.")
-app.add_typer(ws_app, name="workspaces")
-
-
-@ws_app.command("list")
-def ws_list(as_json: bool = typer.Option(False, "--json")):
-    """List workspaces."""
-    with _client() as c:
-        try:
-            data = c.list_workspaces()
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        print_workspaces(data, title="Workspaces")
-
-
-@ws_app.command("create")
-def ws_create(
-    name: str = typer.Argument(...),
-    description: str = typer.Option(""),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Create workspace."""
-    with _client() as c:
-        try:
-            data = c.create_workspace(name, description=description)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(
-            f"[green]Created '{data['name']}'[/green]  ID: {data['id']}  Invite: {data['invite_code']}"
-        )
-
-
-@ws_app.command("join")
-def ws_join(invite_code: str = typer.Argument(...), as_json: bool = typer.Option(False, "--json")):
-    """Join workspace by invite code."""
-    with _client() as c:
-        try:
-            data = c.join_workspace(invite_code)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(f"[green]Joined '{data.get('name')}'[/green]")
-
-
-@ws_app.command("info")
-def ws_info(workspace_id: str = typer.Argument(...), as_json: bool = typer.Option(False, "--json")):
-    """Show workspace details."""
-    with _client() as c:
-        try:
-            data = c.get_workspace(workspace_id)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(f"[bold]{data['name']}[/bold]  Members: {data.get('member_count', '?')}")
-        console.print(f"ID: {data['id']}  Invite: {data['invite_code']}")
-
-
-@ws_app.command("members")
-def ws_members(
-    workspace_id: str = typer.Argument(...), as_json: bool = typer.Option(False, "--json")
-):
-    """List workspace members."""
-    with _client() as c:
-        try:
-            data = c.workspace_members(workspace_id)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        print_members(data)
 
 
 # ===========================================================================

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -81,12 +81,6 @@ stash tables list --ws <workspace_id>                            # List tables
 stash tables search <table_id> "query" --ws <workspace_id>      # Search rows
 ```
 
-### Workspaces
-```bash
-stash workspaces list                # List your workspaces
-stash workspaces members <workspace_id>     # List workspace members
-```
-
 ### Tips
 - Workspace is determined from the `.stash` manifest in the repo
 - Use `--json` flag on any command for JSON output

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -110,7 +110,6 @@ stash sessions search "database migration" --ws <workspace_id>   # Full-text sea
 stash sessions query --ws <workspace_id> --limit 20              # Recent events
 stash sessions query --all --limit 20                             # Cross-workspace events
 stash files pages --all                                           # List all pages
-stash workspaces list                                     # List your workspaces
 ```
 
 Workspace is determined from the `.stash` manifest in the repo.

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -82,5 +82,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -85,5 +85,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/plugins/gemini-plugin/README.md
+++ b/plugins/gemini-plugin/README.md
@@ -62,5 +62,4 @@ shell out to the `stash` CLI — all commands support `--json`:
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -87,7 +87,6 @@ support `--json`:
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```
 
 For user-requested uploads, run `stash upload <path> --json` and return the

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -69,5 +69,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -82,5 +82,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -85,5 +85,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -69,5 +69,4 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
 stash sessions query --ws <id> --limit 20 --json
 stash sessions search "<query>" --ws <id> --json
 stash whoami --json
-stash workspaces list --json
 ```

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -119,62 +119,6 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
         <Code>STASH_URL</Code> as environment variables for CI and scripts.
       </Callout>
 
-      <H2>Workspaces</H2>
-
-      <CommandRef
-        command="stash workspaces list"
-        args=""
-        description="List workspaces you belong to."
-        params={[]}
-      />
-
-      <CommandRef
-        command="stash workspaces create"
-        args="<name> [--description TEXT]"
-        description="Create a new workspace."
-        params={[
-          { name: "<name>", type: "string", desc: "Name for the workspace.", required: true },
-          { name: "--description", type: "string", desc: "Workspace description." },
-        ]}
-      />
-
-      <CommandRef
-        command="stash workspaces join"
-        args="<invite_code>"
-        description="Join a workspace by invite code."
-        params={[
-          { name: "<invite_code>", type: "string", desc: "Invite code or magic link token.", required: true },
-        ]}
-      />
-
-      <CommandRef
-        command="stash workspaces use"
-        args="<workspace> [--scope user|project]"
-        description="Set the default workspace for future commands. Accepts a workspace ID or name."
-        params={[
-          { name: "<workspace>", type: "string", desc: "Workspace ID or name to set as default.", required: true },
-          { name: "--scope", type: "string", desc: 'Where to write config: "user" or "project". Defaults to "user".' },
-        ]}
-      />
-
-      <CommandRef
-        command="stash workspaces info"
-        args="<workspace_id>"
-        description="Show workspace details."
-        params={[
-          { name: "<workspace_id>", type: "string", desc: "ID of the workspace.", required: true },
-        ]}
-      />
-
-      <CommandRef
-        command="stash workspaces members"
-        args="<workspace_id>"
-        description="List members of a workspace."
-        params={[
-          { name: "<workspace_id>", type: "string", desc: "ID of the workspace.", required: true },
-        ]}
-      />
-
       <H2>Files</H2>
 
       <CommandRef


### PR DESCRIPTION
removed `workspaces` CLI verb since workspaces aren't a first-class feature rn.


Follow-up to #630.

## Why
The `workspaces` command group (`list` / `create` / `join` / `info` / `members`) was standalone management UI that nothing internal called. Removing it shrinks the surface and reduces agent confusion. The workspace **concept** is untouched — every command still resolves a workspace, and onboarding (`connect`/`login`) still auto-creates/selects one via the client methods (`list_workspaces`, `create_workspace`), which are kept.

## What changed
- Delete the `ws_app` group (5 commands).
- Delete the now-dead `print_workspaces` / `print_members` helpers and the unused `Table` import in `cli/formatting.py`.
- Docs: remove the Workspaces section from the www CLI reference (also drops a stale `workspaces use` entry that never existed) and all plugin/asset agent docs; fix one backend comment.

## Verification
- `ruff check cli/` clean; `pytest cli/tests/` → **73 passed**; `tsc --noEmit` clean on the changed docs page.
- `stash --help` no longer lists `workspaces`.

## Heads-up on two capability changes
Both removed paths existed **only** in this group:
1. **Create a workspace manually** (`workspaces create`) — still covered automatically by `stash connect` onboarding.
2. **Join/redeem by invite code** (`workspaces join <code>`) — this CLI path is now gone. Top-level `stash join` requests membership for the repo's existing workspace (different flow), and magic-link invites are redeemed via URL in the browser. If you want a CLI redeem-by-code path preserved, say so and I'll add a slim top-level command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)