### PR TITLE
Linear: per-user OAuth, OAuth-backed enrichment, live webhook sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,9 +82,14 @@ BACKEND_URL=http://localhost:3456
 # EMBEDDING_DIMS=384                        # vector dimensions (must match your DB schema)
 
 # ── Linear ──────────────────────────────────
-# Used by session ticket-label enrichment after Stash extracts a Linear issue
-# identifier from a transcript.
-# LINEAR_API_KEY=lin_api_...
+# Per-user OAuth. Each user connects Linear from Settings; that token enriches
+# session ticket labels for the workspaces they belong to. Create the app at
+# Linear → Settings → API → OAuth Applications, enable webhooks pointed at the
+# callback below's /linear/events sibling, and paste the signing secret.
+# LINEAR_OAUTH_CLIENT_ID=
+# LINEAR_OAUTH_CLIENT_SECRET=
+# LINEAR_OAUTH_REDIRECT_URI=http://localhost:3456/api/v1/integrations/linear/callback
+# LINEAR_WEBHOOK_SECRET=
 # LINEAR_API_URL=https://api.linear.app/graphql
 
 # ── File Storage (S3-compatible) ─────────────

--- a/backend/config.py
+++ b/backend/config.py
@@ -201,8 +201,16 @@ class Settings:
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
     # --- Linear ---
-    LINEAR_API_KEY: str | None = os.getenv("LINEAR_API_KEY") or os.getenv("LINEAR_API_TOKEN")
+    # Issue enrichment reads Linear with each connected user's OAuth token (see
+    # backend/integrations/linear/). LINEAR_API_URL is the GraphQL endpoint.
     LINEAR_API_URL: str = os.getenv("LINEAR_API_URL", "https://api.linear.app/graphql")
+    LINEAR_OAUTH_CLIENT_ID: str | None = os.getenv("LINEAR_OAUTH_CLIENT_ID")
+    LINEAR_OAUTH_CLIENT_SECRET: str | None = os.getenv("LINEAR_OAUTH_CLIENT_SECRET")
+    LINEAR_OAUTH_REDIRECT_URI: str | None = parse_oauth_redirect_uri(
+        "LINEAR_OAUTH_REDIRECT_URI", AUTH0_ENABLED
+    )
+    # Verifies inbound Linear webhook signatures (Linear-Signature header).
+    LINEAR_WEBHOOK_SECRET: str | None = os.getenv("LINEAR_WEBHOOK_SECRET")
 
     # --- Integrations (OAuth + per-user token storage) ---
     # Comma-separated Fernet keyring for encrypting access/refresh tokens at

--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -22,6 +22,7 @@ from . import (
     google,  # noqa: F401
     granola,  # noqa: F401
     jira,  # noqa: F401
+    linear,  # noqa: F401
     notion,  # noqa: F401
     slack,  # noqa: F401
     snowflake,  # noqa: F401

--- a/backend/integrations/linear/__init__.py
+++ b/backend/integrations/linear/__init__.py
@@ -1,0 +1,12 @@
+"""Linear integration: OAuth provider.
+
+A connected Linear account lets Stash read the issues referenced in a
+workspace's sessions (backend/services/linear_ticket_service.py) and keeps
+their labels fresh in real time via the inbound webhook in
+backend/routers/webhooks.py.
+"""
+
+from ..registry import register_provider
+from .provider import LinearIntegration
+
+register_provider(LinearIntegration())

--- a/backend/integrations/linear/provider.py
+++ b/backend/integrations/linear/provider.py
@@ -1,0 +1,96 @@
+"""Linear OAuth provider.
+
+Linear issues long-lived access tokens with no refresh token (like GitHub
+user tokens), so supports_refresh is False. The connected token is what reads
+issues for ticket enrichment (backend/services/linear_ticket_service.py); the
+inbound webhook in backend/routers/webhooks.py keeps those labels fresh.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode
+
+import httpx
+
+from ...config import settings
+from ..base import AccountInfo, Integration, TokenSet
+
+AUTHORIZE_URL = "https://linear.app/oauth/authorize"
+TOKEN_URL = "https://api.linear.app/oauth/token"
+REVOKE_URL = "https://api.linear.app/oauth/revoke"
+VIEWER_QUERY = "query { viewer { name email } }"
+
+
+class LinearIntegration(Integration):
+    name = "linear"
+    display_name = "Linear"
+    # `read` covers issue lookups; app-level webhooks are delivered regardless of scope.
+    scopes = ["read"]
+    supports_refresh = False
+
+    def _client_id(self) -> str:
+        if not settings.LINEAR_OAUTH_CLIENT_ID:
+            raise RuntimeError("LINEAR_OAUTH_CLIENT_ID is not set")
+        return settings.LINEAR_OAUTH_CLIENT_ID
+
+    def _client_secret(self) -> str:
+        if not settings.LINEAR_OAUTH_CLIENT_SECRET:
+            raise RuntimeError("LINEAR_OAUTH_CLIENT_SECRET is not set")
+        return settings.LINEAR_OAUTH_CLIENT_SECRET
+
+    def _redirect_uri(self) -> str:
+        if not settings.LINEAR_OAUTH_REDIRECT_URI:
+            raise RuntimeError("LINEAR_OAUTH_REDIRECT_URI is not set")
+        return settings.LINEAR_OAUTH_REDIRECT_URI
+
+    def authorize_url(self, state: str) -> str:
+        params = {
+            "client_id": self._client_id(),
+            "redirect_uri": self._redirect_uri(),
+            "response_type": "code",
+            "scope": ",".join(self.scopes),
+            "state": state,
+            "prompt": "consent",
+        }
+        return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str) -> TokenSet:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "client_id": self._client_id(),
+                    "client_secret": self._client_secret(),
+                    "redirect_uri": self._redirect_uri(),
+                    "code": code,
+                },
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Linear token endpoint returned status_code={resp.status_code}")
+            data = resp.json()
+        expires_in = data.get("expires_in")
+        expires_at = datetime.now(UTC) + timedelta(seconds=expires_in) if expires_in else None
+        scope = data.get("scope") or ""
+        return TokenSet(
+            access_token=data["access_token"],
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=scope.split(",") if scope else list(self.scopes),
+        )
+
+    async def refresh(self, refresh_token: str) -> TokenSet:
+        raise RuntimeError("Linear OAuth tokens are not refreshable")
+
+    async def revoke(self, access_token: str) -> None:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            await client.post(REVOKE_URL, headers={"Authorization": f"Bearer {access_token}"})
+
+    async def fetch_account(self, access_token: str) -> AccountInfo:
+        headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            resp = await client.post(settings.LINEAR_API_URL, json={"query": VIEWER_QUERY})
+            resp.raise_for_status()
+            viewer = (resp.json().get("data") or {}).get("viewer") or {}
+        return AccountInfo(email=viewer.get("email"), display_name=viewer.get("name"))

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -167,6 +167,11 @@ def _provider_disabled_reason(provider: str) -> str | None:
             "JIRA_OAUTH_CLIENT_SECRET",
             "JIRA_OAUTH_REDIRECT_URI",
         ],
+        "linear": [
+            "LINEAR_OAUTH_CLIENT_ID",
+            "LINEAR_OAUTH_CLIENT_SECRET",
+            "LINEAR_OAUTH_REDIRECT_URI",
+        ],
         "asana": [
             "ASANA_OAUTH_CLIENT_ID",
             "ASANA_OAUTH_CLIENT_SECRET",
@@ -184,6 +189,7 @@ def _provider_disabled_reason(provider: str) -> str | None:
             "twitter": "Twitter / X",
             "granola": "Granola",
             "jira": "Jira",
+            "linear": "Linear",
             "asana": "Asana",
         }
         return f"{display_names.get(provider, provider)} OAuth is not configured for this server."

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -21,6 +21,8 @@ router = APIRouter(prefix="/api/v1/integrations", tags=["webhooks"])
 
 # Reject replays / stale deliveries beyond Slack's recommended 5-minute window.
 SLACK_MAX_SKEW_S = 60 * 5
+# Linear stamps each delivery with webhookTimestamp; reject anything older.
+LINEAR_MAX_SKEW_S = 60
 
 
 # --- BEGIN Slack agent (talk-to-Stash bot) — removable feature block ---
@@ -43,6 +45,12 @@ async def _already_handled(event_id: str | None) -> bool:
         return False
     # SET NX returns True only the first time we see this event_id.
     first = await _get_redis().set(f"slack:evt:{event_id}", "1", nx=True, ex=_SLACK_EVENT_TTL_S)
+    return not first
+
+
+async def _seen_before(key: str) -> bool:
+    """True if we've already processed this dedup key within the TTL window."""
+    first = await _get_redis().set(key, "1", nx=True, ex=_SLACK_EVENT_TTL_S)
     return not first
 
 
@@ -111,4 +119,45 @@ async def slack_events(request: Request):
                 "backend.tasks.sources.ingest_slack_event",
                 kwargs={"team_id": team_id, "event": event},
             )
+    return {"ok": True}
+
+
+def _verify_linear_signature(body: bytes, signature: str) -> bool:
+    secret = settings.LINEAR_WEBHOOK_SECRET
+    if not secret or not signature:
+        return False
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, signature)
+
+
+@router.post("/linear/events")
+async def linear_events(request: Request):
+    """Linear delivers one app-level webhook for every workspace that installs
+    the OAuth app. On an Issue change we re-enrich the ticket's labels so a
+    status/assignee edit shows up without waiting for the periodic reconcile."""
+    body = await request.body()
+    if not _verify_linear_signature(body, request.headers.get("Linear-Signature", "")):
+        raise HTTPException(status_code=401, detail="bad signature")
+
+    payload = await request.json()
+    ts = payload.get("webhookTimestamp")
+    if isinstance(ts, (int, float)) and abs(time.time() - ts / 1000) > LINEAR_MAX_SKEW_S:
+        raise HTTPException(status_code=401, detail="stale delivery")
+
+    if payload.get("type") != "Issue":
+        return {"ok": True}
+
+    data = payload.get("data") or {}
+    identifier = data.get("identifier")
+    if not identifier:
+        return {"ok": True}
+
+    # Linear retries on a non-200; dedupe on the issue revision so a retry
+    # doesn't re-enqueue the same enrichment.
+    dedup_key = f"linear:evt:{data.get('id')}:{data.get('updatedAt')}"
+    if not await _seen_before(dedup_key):
+        celery.send_task(
+            "backend.tasks.linear_tickets.enrich_ticket",
+            kwargs={"ticket_identifier": identifier},
+        )
     return {"ok": True}

--- a/backend/services/linear_api_service.py
+++ b/backend/services/linear_api_service.py
@@ -42,14 +42,11 @@ class LinearIssue:
 
 
 def is_configured() -> bool:
-    return bool(settings.LINEAR_API_KEY)
+    return bool(settings.LINEAR_OAUTH_CLIENT_ID and settings.LINEAR_OAUTH_CLIENT_SECRET)
 
 
-async def fetch_issue(ticket_identifier: str) -> LinearIssue | None:
-    if not settings.LINEAR_API_KEY:
-        return None
-
-    payload = await _graphql(ISSUE_QUERY, {"id": ticket_identifier})
+async def fetch_issue(ticket_identifier: str, access_token: str) -> LinearIssue | None:
+    payload = await _graphql(ISSUE_QUERY, {"id": ticket_identifier}, access_token)
     errors = payload.get("errors")
     if errors:
         message = "; ".join(str(error.get("message", error)) for error in errors)
@@ -79,9 +76,9 @@ async def fetch_issue(ticket_identifier: str) -> LinearIssue | None:
     )
 
 
-async def _graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+async def _graphql(query: str, variables: dict[str, Any], access_token: str) -> dict[str, Any]:
     headers = {
-        "Authorization": settings.LINEAR_API_KEY or "",
+        "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
     }
     async with httpx.AsyncClient(timeout=15) as client:

--- a/backend/services/linear_ticket_service.py
+++ b/backend/services/linear_ticket_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from ..database import get_pool
+from ..integrations import storage
 from . import linear_api_service
 
 LINEAR_TICKET_ID = r"[A-Z][A-Z0-9]+-\d+"
@@ -206,17 +207,44 @@ def enqueue_session_enrichment(workspace_id: UUID, session_row_id: UUID) -> None
     enrich_session_linear_tickets.delay(str(workspace_id), str(session_row_id))
 
 
+async def _workspace_linear_token(workspace_id: UUID) -> str | None:
+    """A Linear OAuth token for any member of this workspace, or None if no
+    member has connected Linear. Linear issues are workspace-shared, so any
+    member's token can read the tickets every session in the workspace cites."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        SELECT ui.user_id
+        FROM user_integrations ui
+        JOIN workspace_members wm ON wm.user_id = ui.user_id
+        WHERE ui.provider = 'linear' AND wm.workspace_id = $1
+        ORDER BY ui.created_at
+        LIMIT 1
+        """,
+        workspace_id,
+    )
+    if row is None:
+        return None
+    return await storage.get_valid_token(row["user_id"], "linear")
+
+
 async def enrich_session_labels(session_row_id: UUID) -> int:
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT ticket_identifier FROM session_linear_tickets "
+        "SELECT ticket_identifier, workspace_id FROM session_linear_tickets "
         "WHERE session_row_id = $1 ORDER BY ticket_identifier",
         session_row_id,
     )
+    if not rows:
+        return 0
+
+    token = await _workspace_linear_token(rows[0]["workspace_id"])
+    if token is None:
+        return 0
 
     updated = 0
     for row in rows:
-        issue = await linear_api_service.fetch_issue(row["ticket_identifier"])
+        issue = await linear_api_service.fetch_issue(row["ticket_identifier"], token)
         if not issue:
             await pool.execute(
                 "UPDATE session_linear_tickets SET enriched_at = now(), updated_at = now() "
@@ -276,6 +304,56 @@ async def enrich_stale_sessions(limit: int) -> int:
     updated = 0
     for row in rows:
         updated += await enrich_session_labels(row["session_row_id"])
+    return updated
+
+
+async def enrich_ticket(ticket_identifier: str) -> int:
+    """Re-enrich every session that cites this ticket, one workspace at a time.
+    Driven by the Linear webhook so a ticket's status/assignee refreshes the
+    moment it changes upstream, instead of waiting for the periodic reconcile."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT DISTINCT workspace_id FROM session_linear_tickets WHERE ticket_identifier = $1",
+        ticket_identifier,
+    )
+
+    updated = 0
+    for row in rows:
+        token = await _workspace_linear_token(row["workspace_id"])
+        if token is None:
+            continue
+        issue = await linear_api_service.fetch_issue(ticket_identifier, token)
+        if not issue:
+            continue
+        await pool.execute(
+            """
+            UPDATE session_linear_tickets SET
+              linear_issue_id = $3,
+              ticket_title = $4,
+              ticket_url = $5,
+              ticket_status = $6,
+              ticket_assignee_name = $7,
+              ticket_team_key = $8,
+              ticket_team_name = $9,
+              ticket_project_name = $10,
+              linear_updated_at = $11,
+              enriched_at = now(),
+              updated_at = now()
+            WHERE workspace_id = $1 AND ticket_identifier = $2
+            """,
+            row["workspace_id"],
+            ticket_identifier,
+            issue.issue_id,
+            issue.title,
+            issue.url,
+            issue.status,
+            issue.assignee_name,
+            issue.team_key,
+            issue.team_name,
+            issue.project_name,
+            issue.updated_at,
+        )
+        updated += 1
     return updated
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -84,6 +84,9 @@ PROVIDER_SOURCE_TYPES = {
     "granola": ("granola",),
     "jira": ("jira_project",),
     "asana": ("asana_project",),
+    # Linear is enrichment-only (labels are scanned from transcripts, not a
+    # connected source), so disconnecting removes no source rows.
+    "linear": (),
     "gong": ("gong_calls",),
     "snowflake": ("snowflake",),
     "twitter": ("twitter",),

--- a/backend/tasks/linear_tickets.py
+++ b/backend/tasks/linear_tickets.py
@@ -19,6 +19,13 @@ def enrich_session_linear_tickets(_workspace_id: str, session_row_id: str) -> in
     return run_async(linear_ticket_service.enrich_session_labels(UUID(session_row_id)))
 
 
+@celery.task(name="backend.tasks.linear_tickets.enrich_ticket")
+def enrich_ticket(ticket_identifier: str) -> int:
+    if not linear_api_service.is_configured():
+        return 0
+    return run_async(linear_ticket_service.enrich_ticket(ticket_identifier))
+
+
 @celery.task(name="backend.tasks.linear_tickets.discover_session_github_prs")
 def discover_session_github_prs(session_row_id: str) -> int:
     return run_async(github_pr_service.discover_session_labels(UUID(session_row_id)))

--- a/backend/tests/test_linear_ticket_service.py
+++ b/backend/tests/test_linear_ticket_service.py
@@ -9,8 +9,9 @@ from backend.services.linear_api_service import LinearIssue
 
 @pytest.mark.asyncio
 async def test_fetch_issue_parses_linear_graphql_response(monkeypatch):
-    async def graphql(query, variables):
+    async def graphql(query, variables, access_token):
         assert variables == {"id": "FER-19"}
+        assert access_token == "test-token"
         return {
             "data": {
                 "issue": {
@@ -27,10 +28,9 @@ async def test_fetch_issue_parses_linear_graphql_response(monkeypatch):
             }
         }
 
-    monkeypatch.setattr(linear_api_service.settings, "LINEAR_API_KEY", "test-key")
     monkeypatch.setattr(linear_api_service, "_graphql", graphql)
 
-    issue = await linear_api_service.fetch_issue("FER-19")
+    issue = await linear_api_service.fetch_issue("FER-19", "test-token")
 
     assert issue == LinearIssue(
         issue_id="issue-id",
@@ -49,6 +49,7 @@ async def test_fetch_issue_parses_linear_graphql_response(monkeypatch):
 @pytest.mark.asyncio
 async def test_enrich_session_labels_updates_canonical_linear_fields(monkeypatch):
     session_row_id = UUID("00000000-0000-0000-0000-000000000019")
+    WORKSPACE_ID = UUID("00000000-0000-0000-0000-0000000000aa")
     updated_at = datetime(2026, 5, 19, 21, 45, 50, tzinfo=UTC)
 
     class Pool:
@@ -56,15 +57,16 @@ async def test_enrich_session_labels_updates_canonical_linear_fields(monkeypatch
             self.executed = []
 
         async def fetch(self, *args):
-            return [{"ticket_identifier": "FER-19"}]
+            return [{"ticket_identifier": "FER-19", "workspace_id": WORKSPACE_ID}]
 
         async def execute(self, *args):
             self.executed.append(args)
 
     pool = Pool()
 
-    async def fetch_issue(identifier):
+    async def fetch_issue(identifier, access_token):
         assert identifier == "FER-19"
+        assert access_token == "test-token"
         return LinearIssue(
             issue_id="issue-id",
             identifier="FER-19",
@@ -78,7 +80,12 @@ async def test_enrich_session_labels_updates_canonical_linear_fields(monkeypatch
             updated_at=updated_at,
         )
 
+    async def workspace_token(workspace_id):
+        assert workspace_id == WORKSPACE_ID
+        return "test-token"
+
     monkeypatch.setattr(linear_ticket_service, "get_pool", lambda: pool)
+    monkeypatch.setattr(linear_ticket_service, "_workspace_linear_token", workspace_token)
     monkeypatch.setattr(linear_ticket_service.linear_api_service, "fetch_issue", fetch_issue)
 
     updated = await linear_ticket_service.enrich_session_labels(session_row_id)

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -160,6 +160,22 @@ export function JiraIcon({ className, size = defaultSize }: Props) {
   );
 }
 
+export function LinearIcon({ className, size = defaultSize }: Props) {
+  // Official Linear mark — interlocking diagonals in Linear's indigo.
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="#5E6AD2"
+      aria-hidden
+    >
+      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.181 6.561 17.44 22.82c-.336.176-.682.335-1.038.477L.703 7.6c.142-.356.3-.703.477-1.039h.001ZM.002 11.882 12.118 24c-.51-.025-1.014-.082-1.508-.17L.17 13.39a12.087 12.087 0 0 1-.17-1.508h.002Zm.452 4.341 7.323 7.324a12.03 12.03 0 0 1-7.323-7.324Z" />
+    </svg>
+  );
+}
+
 export function AsanaIcon({ className, size = defaultSize }: Props) {
   // Official Asana mark — three coral dots forming a triangle.
   return (

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -10,6 +10,7 @@ import {
   GoogleDriveIcon,
   GranolaIcon,
   JiraIcon,
+  LinearIcon,
   NotionIcon,
   SlackIcon,
   SnowflakeIcon,
@@ -70,6 +71,13 @@ export const CONNECTORS: Connector[] = [
     blurb: "Navigate tasks from a project.",
   },
   {
+    provider: "linear",
+    label: "Linear",
+    sourceType: "linear",
+    kind: "auto",
+    blurb: "Label sessions with their Linear issue status.",
+  },
+  {
     provider: "slack",
     label: "Slack",
     sourceType: "slack",
@@ -115,6 +123,7 @@ export const providerForSourceType: Record<string, string> = {
   notion: "notion",
   jira_project: "jira",
   asana_project: "asana",
+  linear: "linear",
   slack: "slack",
   granola: "granola",
   gong_calls: "gong",
@@ -144,6 +153,8 @@ export function connectorIcon(provider: string): ReactNode {
       return <JiraIcon />;
     case "asana":
       return <AsanaIcon />;
+    case "linear":
+      return <LinearIcon />;
     case "slack":
       return <SlackIcon />;
     case "granola":
@@ -168,6 +179,7 @@ export function labelForSourceType(type: string): string {
   if (type === "granola") return "Granola";
   if (type === "jira_project") return "Jira";
   if (type === "asana_project") return "Asana";
+  if (type === "linear") return "Linear";
   if (type === "gong_calls") return "Gong";
   if (type === "snowflake") return "Snowflake";
   if (type === "twitter") return "Twitter / X";

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -16,6 +16,7 @@ export type IntegrationProvider =
   | "slack"
   | "granola"
   | "jira"
+  | "linear"
   | "asana"
   | "gong"
   | "snowflake"


### PR DESCRIPTION
## What

Turns the dormant, shared-key Linear integration (FER-245) into a real **per-user OAuth** integration with **live webhook sync**, while keeping the existing session ticket-label enrichment working — now powered by users' own Linear tokens.

### Before
- A single workspace-wide `LINEAR_API_KEY` read issues to enrich session labels.
- No connect flow, no per-user auth, polling-only refresh (every 6h via reconcile).

### After
1. **Per-user OAuth** (`backend/integrations/linear/`) — mirrors the Jira/GitHub providers. A user clicks *Connect Linear* in Settings; the generic `/connect` → `/callback` flow stores their encrypted token. Linear tokens are long-lived and non-refreshable, so `supports_refresh = False` (like GitHub).
2. **OAuth-backed enrichment** — `linear_api_service.fetch_issue` now takes a Bearer token. A session's tickets are enriched with **any connected workspace member's** token (Linear issues are workspace-shared, so any member can read them). The global `LINEAR_API_KEY` path is removed.
3. **Live webhook sync** — `POST /api/v1/integrations/linear/events` verifies the `Linear-Signature` HMAC, dedupes on issue revision via Redis, and enqueues `enrich_ticket`, so a status/assignee/title change in Linear refreshes the session labels immediately instead of waiting for the periodic reconcile.
4. **Frontend** — Linear connector card + brand icon in Settings → Integrations.

## Design note: whose token enriches a session?
`user_integrations` is keyed per-user, but sessions belong to a (possibly multi-member) workspace. We resolve enrichment to **any** workspace member who has connected Linear — one person connects and every session in that workspace gets labels. Robust whether a workspace has 1 member or 10.
\
## Tests
- `backend/tests/test_linear_ticket_service.py` updated for the token-based signatures — passing.
- `ruff` clean on all touched backend files.

## Screenshots
The connector card is a static mirror of the 11 existing connectors. A live screenshot of the connect flow requires the Linear OAuth app above; I'll add one once credentials are in (or attach the rendered card shortly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)