### PR TITLE
Files list: default to documents only, sorted by recency

### DIFF
--- a/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.test.tsx
@@ -68,6 +68,37 @@ describe("ItemsList type filter", () => {
     );
   }
 
+  it("hides non-document types by default so uploads don't clutter the view", () => {
+    renderMixedList();
+
+    // HTML/Markdown/folders are the default doc set; the PNG stays hidden until
+    // it's explicitly chosen from the Type menu.
+    expect(screen.getByText(item.name)).toBeDefined();
+    expect(screen.queryByText(png.name)).toBeNull();
+  });
+
+  it("reveals every type via All types", () => {
+    renderMixedList();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "All types" }));
+
+    expect(screen.getByText(item.name)).toBeDefined();
+    expect(screen.getByText(png.name)).toBeDefined();
+  });
+
+  it("returns to the document set via Documents only", () => {
+    renderMixedList();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "All types" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Type: All$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Documents only" }));
+
+    expect(screen.getByText(item.name)).toBeDefined();
+    expect(screen.queryByText(png.name)).toBeNull();
+  });
+
   it("narrows the list to the chosen type", () => {
     renderMixedList();
 
@@ -88,6 +119,43 @@ describe("ItemsList type filter", () => {
 
     expect(screen.getByText(item.name)).toBeDefined();
     expect(screen.getByText(png.name)).toBeDefined();
+  });
+});
+
+describe("ItemsList default sort", () => {
+  const older: GridItem = {
+    kind: "page",
+    id: "page-old",
+    name: "Older memo",
+    subtitle: "markdown page",
+    updatedAt: "2026-05-01T00:00:00Z",
+  };
+  const newer: GridItem = {
+    kind: "page",
+    id: "page-new",
+    name: "Newer memo",
+    subtitle: "markdown page",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+
+  it("opens with the most recently modified document first", () => {
+    render(
+      <ItemsList
+        items={[older, newer]}
+        onNavigate={vi.fn()}
+        onReparent={vi.fn()}
+        onReparentMany={vi.fn()}
+        onDelete={vi.fn()}
+        isPinned={() => false}
+        onTogglePin={vi.fn()}
+        selectedIds={new Set()}
+        onToggleSelect={vi.fn()}
+        selectedDragPayloads={[]}
+      />
+    );
+
+    const names = screen.getAllByText(/memo$/).map((el) => el.textContent);
+    expect(names).toEqual(["Newer memo", "Older memo"]);
   });
 });
 

--- a/frontend/src/components/workspace/file-browser/ItemsList.tsx
+++ b/frontend/src/components/workspace/file-browser/ItemsList.tsx
@@ -92,6 +92,15 @@ type Sort = { key: SortKey; dir: "asc" | "desc" } | null;
 
 const SORT_STORAGE_KEY = "stash_files_sort";
 
+const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
+
+// The List view opens on documents only — folders plus the page types people
+// author (HTML, Markdown). Other file types (PDFs, images, tables) stay hidden
+// until chosen from the Type menu, so uploads don't clutter the default view.
+// `typeFilter === null` means this doc set; ALL_TYPES means show everything.
+const DEFAULT_TYPES = new Set(["Folder", "HTML", "Markdown"]);
+const ALL_TYPES = "__all__";
+
 function readSort(): Sort {
   if (typeof window === "undefined") return null;
   const raw = window.localStorage.getItem(SORT_STORAGE_KEY);
@@ -133,7 +142,7 @@ export default function ItemsList({
   onToggleSelect,
   selectedDragPayloads,
 }: Props) {
-  const [sort, setSort] = useState<Sort>(() => readSort());
+  const [sort, setSort] = useState<Sort>(() => readSort() ?? DEFAULT_SORT);
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
 
   function applySort(next: NonNullable<Sort>) {
@@ -154,15 +163,22 @@ export default function ItemsList({
     applySort(next);
   }
 
-  // Options come from the unfiltered items so every type stays pickable
-  // while a filter is active.
+  // Only the non-default types are pickable here; folders/HTML/Markdown already
+  // show by default, so the menu is purely for revealing the other types.
   const typeOptions = useMemo(
-    () => Array.from(new Set(items.map(typeFor))).sort(),
+    () =>
+      Array.from(new Set(items.map(typeFor)))
+        .filter((type) => !DEFAULT_TYPES.has(type))
+        .sort(),
     [items],
   );
 
   const sortedItems = useMemo(() => {
-    const visible = typeFilter ? items.filter((item) => typeFor(item) === typeFilter) : items;
+    const visible = items.filter((item) => {
+      if (typeFilter === null) return DEFAULT_TYPES.has(typeFor(item));
+      if (typeFilter === ALL_TYPES) return true;
+      return typeFor(item) === typeFilter;
+    });
     if (!sort) return visible;
     const arr = [...visible].sort((a, b) => compareItems(a, b, sort.key));
     if (sort.dir === "desc") arr.reverse();
@@ -206,7 +222,9 @@ export default function ItemsList({
         ))}
         {sortedItems.length === 0 && (
           <div className="px-4 py-10 text-center text-[12.5px] text-muted">
-            {typeFilter ? `No ${typeFilter} items here.` : "Empty folder."}
+            {typeFilter && typeFilter !== ALL_TYPES
+              ? `No ${typeFilter} items here.`
+              : "Empty folder."}
           </div>
         )}
       </div>
@@ -292,7 +310,11 @@ function TypeHeader({
           (sortActive || filter ? "text-foreground" : "")
         }
       >
-        {filter ? `Type: ${filter}` : "Type"}
+        {filter === null
+          ? "Type"
+          : filter === ALL_TYPES
+            ? "Type: All"
+            : `Type: ${filter}`}
         {sortActive && <span className="text-[9px]">{sort?.dir === "desc" ? "▼" : "▲"}</span>}
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
           <polyline points="6 9 12 15 18 9" />
@@ -303,7 +325,8 @@ function TypeHeader({
           <MenuItem label="Sort A → Z" checked={sortActive && sort?.dir === "asc"} onSelect={() => choose(() => onSort("asc"))} />
           <MenuItem label="Sort Z → A" checked={sortActive && sort?.dir === "desc"} onSelect={() => choose(() => onSort("desc"))} />
           <div className="my-1 border-t border-border" />
-          <MenuItem label="All types" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
+          <MenuItem label="Documents only" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
+          <MenuItem label="All types" checked={filter === ALL_TYPES} onSelect={() => choose(() => onFilter(ALL_TYPES))} />
           {options.map((type) => (
             <MenuItem key={type} label={type} checked={filter === type} onSelect={() => choose(() => onFilter(type))} />
           ))}


### PR DESCRIPTION
## What

The workspace **List view** now opens on the content people author and browse most — folders, HTML, and Markdown — sorted by **most recently modified**. Other file types (PDFs, images, tables, CSVs) are hidden by default and revealed on demand from the **Type** column menu.

## Why

By default the list was ordered by assembly order and showed every uploaded file type, so authored documents got buried under uploads. This surfaces the docs first and keeps the default view uncluttered.

## Changes (`frontend/src/components/workspace/file-browser/ItemsList.tsx`)

- **Default sort** is now Modified (newest first) instead of assembly order.
- **Default filter** shows only the document set: `Folder`, `HTML`, `Markdown`.
- **Type menu** gains two entries:
  - **Documents only** — the new default (folders + HTML + Markdown)
  - **All types** — reveal everything
  - plus the individual non-doc types (PDF, PNG, Table, …) to opt into one at a time
- Persisted per-browser sort and the existing per-type filtering still work.

## Tests

`ItemsList.test.tsx` adds coverage for the new defaults: docs-only on open, recency ordering, revealing all types, and returning to the document set. All file-browser tests pass (`13 passed`), lint clean.

## Screenshot

Not attached: this session runs headless and the app gates on Auth0 login, so I couldn't establish an authenticated session to capture the real files view. The behavior is verified by the unit tests above. Happy to attach a product screenshot if a logged-in session is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)