### PR TITLE
CLI: collapse auth from four commands to two (signin + auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Built for —
 
 ```bash
 pip install stashai / uv tool install stashai
-stash login
+stash signin
 ```
 
-`stash login` walks you through account creation, picks a workspace, connects
+`stash signin` walks you through sign-in, picks a workspace, connects
 your current repo when you want uploads, and wires up coding-agent plugins.
 Use `stash connect` later when you are already authenticated and only need to
 bind another repo to a workspace.
@@ -90,7 +90,7 @@ bash -c "$(curl -fsSL https://joinstash.ai/install)"
 ```
 
 The installer uses `uv` to install or update `stashai`, bootstrapping `uv`
-when needed, and then runs `stash login`.
+when needed, and then runs `stash signin`.
 Use this when you don't already have a Python toolchain on your machine.
 
 </details>
@@ -124,7 +124,7 @@ Stash supports the following coding agents:
 - **Gemini CLI**
 - **Openclaw** 
 
-Stash supports opt in per-coding agent. `stash login` can auto-install hooks for Claude Code, Cursor, Codex, and OpenCode; Gemini CLI and Openclaw are available in `plugins/` and are installed manually. Mix and match — different teammates can use different agents against the same shared brain.
+Stash supports opt in per-coding agent. `stash signin` can auto-install hooks for Claude Code, Cursor, Codex, and OpenCode; Gemini CLI and Openclaw are available in `plugins/` and are installed manually. Mix and match — different teammates can use different agents against the same shared brain.
 
 ## CLI Reference
 
@@ -173,7 +173,7 @@ Then install the CLI:
 ```bash
 pip install stashai   # or: uv tool install stashai
 cd /path/to/the/repo/you/want/to/connect
-stash login   # choose "Self-host" and enter http://localhost:3456
+stash signin   # choose "Self-host" and enter http://localhost:3456
 ```
 
 When connecting to a domain-backed install, enter your public URL (e.g.

--- a/cli/main.py
+++ b/cli/main.py
@@ -4226,12 +4226,14 @@ def signin(
 
 @app.command()
 def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "--api-key")):
-    """Store a pre-minted API key — non-interactive auth for headless machines.
+    """Store a pre-existing API key — non-interactive auth for unattended machines.
 
-    `signin` needs a browser; env vars only reach the CLI, not the streaming
-    hooks (they read ~/.stash/config.json). This writes the key to that file so
-    an unattended box — CI runner, server, baked image — can stream. Mint the
-    key from `stash keys` on a machine you've already signed in on.
+    Niche tool, not part of normal setup — use `signin` for that. It exists only
+    because `signin` needs a browser and env vars reach the CLI but not the
+    streaming hooks (they read ~/.stash/config.json). `auth` writes the key into
+    that file so a browser-less box — typically a self-hosted CI runner or
+    server — can stream. Get the key from your self-hosted instance's API-key
+    page (managed Stash mints keys only through browser sign-in).
     """
     save_config(base_url=base_url, api_key=api_key)
     with StashClient(base_url=base_url, api_key=api_key) as c:

--- a/cli/main.py
+++ b/cli/main.py
@@ -136,29 +136,6 @@ def _err(e: StashError) -> None:
 # ===========================================================================
 
 
-@app.command()
-def register(
-    name: str = typer.Argument(...),
-    password: str = typer.Option(None, "--password", help="Password for the account"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Create account and store API key."""
-    if not password:
-        password = typer.prompt("Password", hide_input=True, confirmation_prompt=True)
-    with _client() as c:
-        try:
-            data = c.register(name, description="", password=password)
-        except StashError as e:
-            _err(e)
-    save_config(api_key=data["api_key"], username=data["name"])
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(
-            f"[green]Registered as {data['name']}[/green]  API key: [bold]{data['api_key']}[/bold]"
-        )
-
-
 def _default_signin_page(api: str) -> str:
     """Map a backend URL to its matching /connect-token page."""
     api = api.rstrip("/")
@@ -230,52 +207,10 @@ def _browser_auth_flow(
             time.sleep(1)
 
     console.print(
-        f"[red]Timed out waiting for sign-in.[/red] "
-        f"Run [cyan]stash auth {api} --api-key <token>[/cyan] by hand if needed."
+        "[red]Timed out waiting for sign-in.[/red] "
+        "Re-run [cyan]stash signin[/cyan], or set STASH_API_KEY / STASH_URL for headless use."
     )
     raise typer.Exit(1)
-
-
-@app.command()
-def signin(
-    page: str = typer.Option(
-        None,
-        "--page",
-        help="Sign-in page URL. Defaults to the /connect-token page matching --api.",
-    ),
-    api: str = typer.Option(
-        "https://api.joinstash.ai",
-        "--api",
-        help="Stash API base URL. Override for self-hosted deployments.",
-    ),
-    no_browser: bool = typer.Option(
-        False,
-        "--no-browser",
-        help="Skip auto-opening the browser; just print the URL. Use when on SSH or without a display.",
-    ),
-    timeout: int = typer.Option(120, "--timeout", help="Seconds to wait for sign-in."),
-):
-    """Sign in through the browser — blocks until the user authorizes.
-
-    Writes credentials to `~/.stash/config.json` on success and auto-selects
-    the default workspace if the user has exactly one.
-    """
-    api_key, username = _browser_auth_flow(api, page, timeout, no_browser)
-    save_config(base_url=api, api_key=api_key, username=username)
-    console.print(f"[green]✓ Signed in as {username}[/green]")
-
-
-@app.command()
-def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "--api-key")):
-    """Store existing credentials."""
-    save_config(base_url=base_url, api_key=api_key)
-    with StashClient(base_url=base_url, api_key=api_key) as c:
-        try:
-            user = c.whoami()
-            save_config(username=user["name"])
-            console.print(f"[green]Authenticated as {user['name']}[/green]")
-        except StashError:
-            console.print("[yellow]Saved but could not verify.[/yellow]")
 
 
 # ===========================================================================
@@ -3960,7 +3895,7 @@ def _require_auth() -> dict:
     """Return loaded config if authenticated, otherwise print error and exit."""
     cfg = load_config()
     if not cfg.get("api_key"):
-        console.print("[red]Not authenticated. Run `stash login` first.[/red]")
+        console.print("[red]Not authenticated. Run `stash signin` first.[/red]")
         raise typer.Exit(1)
     return cfg
 
@@ -4116,17 +4051,43 @@ def _install_all_hooks(agents: list[str] | None = None) -> None:
             console.print(f"  [red]✗[/red] {_AGENT_LABEL[agent]} hook failed  {detail}")
 
 
-@app.command("login")
-def login_cmd():
-    """Authenticate with Stash. On first run, walks through full onboarding."""
-    console.print("\n[bold]Stash login[/bold]\n")
+@app.command()
+def signin(
+    api: str = typer.Option(
+        None, "--api", help="Stash API base URL. Override for self-hosted deployments."
+    ),
+    no_browser: bool = typer.Option(
+        False,
+        "--no-browser",
+        help="Don't open a browser; just print the URL. Use on SSH or headless machines.",
+    ),
+    timeout: int = typer.Option(120, "--timeout", help="Seconds to wait for sign-in."),
+):
+    """Sign in to Stash through the browser.
+
+    Run interactively for guided first-run setup (endpoint, streaming agents,
+    repo). With --no-browser — or whenever stdin isn't a terminal — it just
+    authenticates, which is the path installers and agents use. For a fully
+    unattended machine (no browser), use `stash auth` to inject a pre-minted
+    key instead.
+    """
+    # Scripted / headless: bare browser auth, no wizard prompts.
+    if no_browser or not sys.stdin.isatty():
+        base_url = api or stored_base_url() or PRODUCTION_BASE_URL
+        api_key, username = _browser_auth_flow(base_url, timeout=timeout, no_browser=no_browser)
+        save_config(base_url=base_url, api_key=api_key, username=username)
+        console.print(f"[green]✓ Signed in as {username}[/green]")
+        return
+
+    console.print("\n[bold]Stash sign-in[/bold]\n")
 
     cfg = load_config()
 
     # --- Step 1: API endpoint ---
-    prev_base = stored_base_url()
+    prev_base = api or stored_base_url()
     if prev_base:
         base_url = prev_base
+        save_config(base_url=base_url)
         console.print(f"  [green]✓[/green] Using endpoint: [bold]{base_url}[/bold]")
     else:
         mode_options = [
@@ -4261,6 +4222,25 @@ def login_cmd():
     _onboarding_import_history(detected)
 
     _show_setup_complete_splash()
+
+
+@app.command()
+def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "--api-key")):
+    """Store a pre-minted API key — non-interactive auth for headless machines.
+
+    `signin` needs a browser; env vars only reach the CLI, not the streaming
+    hooks (they read ~/.stash/config.json). This writes the key to that file so
+    an unattended box — CI runner, server, baked image — can stream. Mint the
+    key from `stash keys` on a machine you've already signed in on.
+    """
+    save_config(base_url=base_url, api_key=api_key)
+    with StashClient(base_url=base_url, api_key=api_key) as c:
+        try:
+            user = c.whoami()
+            save_config(username=user["name"])
+            console.print(f"[green]Authenticated as {user['name']}[/green]")
+        except StashError:
+            console.print("[yellow]Saved but could not verify.[/yellow]")
 
 
 @app.command("connect")
@@ -4872,7 +4852,7 @@ def keys_revoke(key_id: str = typer.Argument(..., help="Key id to revoke.")):
 
 @app.command("logout")
 def logout_cmd(as_json: bool = typer.Option(False, "--json")):
-    """Sign out and clear credentials. Hooks go inert until you `stash login` again."""
+    """Sign out and clear credentials. Hooks go inert until you `stash signin` again."""
     from .config import clear_config
 
     json_mode = as_json
@@ -4881,7 +4861,7 @@ def logout_cmd(as_json: bool = typer.Option(False, "--json")):
         output_json({"logged_out": True})
         return
     console.print("[yellow]Logged out.[/yellow] Cleared auth and preferences.")
-    console.print("  Run [bold]stash login[/bold] to sign in again.")
+    console.print("  Run [bold]stash signin[/bold] to sign in again.")
 
 
 @app.command("disconnect")
@@ -4944,7 +4924,7 @@ def mount_command(
 
     cfg = load_config()
     if not cfg.get("api_key"):
-        console.print("[red]Not signed in. Run [bold]stash login[/bold] first.[/red]")
+        console.print("[red]Not signed in. Run [bold]stash signin[/bold] first.[/red]")
         raise typer.Exit(1)
 
     client = StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"])
@@ -4975,7 +4955,7 @@ def vfs_command(
 
     cfg = load_config()
     if not cfg.get("api_key"):
-        console.print("[red]Not signed in. Run [bold]stash login[/bold] first.[/red]")
+        console.print("[red]Not signed in. Run [bold]stash signin[/bold] first.[/red]")
         raise typer.Exit(1)
 
     client = StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"])

--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -89,7 +89,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
           headers: { Authorization: `Bearer ${token}` },
         },
       );
-      if (!approveRes.ok) throw new Error("CLI session expired. Re-run `stash login`.");
+      if (!approveRes.ok) throw new Error("CLI session expired. Re-run `stash signin`.");
       onCliApproved?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not authorize CLI");

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -138,7 +138,7 @@ function LoginPageInner() {
           },
         );
         if (!approveRes.ok) {
-          throw new Error("CLI session expired. Re-run `stash login` and try again.");
+          throw new Error("CLI session expired. Re-run `stash signin` and try again.");
         }
         setCliApproved(true);
       }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -142,7 +142,7 @@ function OnboardingInner() {
     track("onboarding.collab_path_chosen", {});
     // The starter page embeds its own id in a copy-paste agent prompt, so we
     // create it empty and fill it in after. Self-hosted browsers hold a key
-    // to embed; under managed Auth0 the prompt says `stash login` instead.
+    // to embed; under managed Auth0 the prompt says `stash signin` instead.
     const apiKey = getAgentApiKey();
     const page = await createPage(workspaceId, "Welcome to your Drive");
     const content = generateCollabIntroMarkdown({
@@ -504,7 +504,7 @@ function TryItOutStep({
       >
         <div className="space-y-2">
           <CommandBlock command={CLI_INSTALL_COMMAND} />
-          <CommandBlock command="stash login" />
+          <CommandBlock command="stash signin" />
         </div>
       </TryOption>
     </div>

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -183,7 +183,7 @@ function EmptyChatState({ onPrompt }: { onPrompt: (prompt: string) => void }) {
               <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
             </SetupStep>
             <SetupStep n={2} title="Sign in">
-              <Code>stash login</Code>
+              <Code>stash signin</Code>
             </SetupStep>
             <SetupStep n={3} title="Point your agent at Skill">
               <a

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -87,7 +87,7 @@ export async function getAuth0AccessToken(): Promise<string | null> {
 // The onboarding agent prompt needs a persistent API key — agents can't use
 // the browser's short-lived Auth0 access token. Self-hosted browsers already
 // hold their key; under managed Auth0 the browser never mints keys, so this
-// returns null and the agent prompt tells the user to run `stash login`.
+// returns null and the agent prompt tells the user to run `stash signin`.
 export function getAgentApiKey(): string | null {
   return getToken();
 }

--- a/frontend/src/lib/onboarding/collabIntro.test.ts
+++ b/frontend/src/lib/onboarding/collabIntro.test.ts
@@ -20,7 +20,7 @@ describe("generateCollabIntroMarkdown", () => {
       apiKey: null,
     });
 
-    expect(md).toContain("Authenticate: stash login");
+    expect(md).toContain("Authenticate: stash signin");
     expect(md).not.toContain("STASH_API_KEY");
     expect(md).toContain("stash files read-page page-1");
   });

--- a/frontend/src/lib/onboarding/collabIntro.ts
+++ b/frontend/src/lib/onboarding/collabIntro.ts
@@ -6,7 +6,7 @@
 // the agent installs the CLI, authenticates, and edits this exact page while
 // the user watches. Self-hosted browsers hold a persistent API key we can
 // embed; under managed Auth0 the browser never mints keys, so the prompt
-// points at the CLI sign-in flow (`stash login`) instead.
+// points at the CLI sign-in flow (`stash signin`) instead.
 
 export function generateCollabIntroMarkdown({
   displayName,
@@ -18,7 +18,7 @@ export function generateCollabIntroMarkdown({
   apiKey: string | null;
 }): string {
   const name = displayName.trim() || "there";
-  const authenticate = apiKey ? `export STASH_API_KEY=${apiKey}` : "stash login";
+  const authenticate = apiKey ? `export STASH_API_KEY=${apiKey}` : "stash signin";
   return `# Welcome to your agent-native Drive, ${name}
 
 This is a real page in your Skill — start typing to make it yours, or delete it. Edits save automatically, and you and your agent can edit the same page at the same time (two cursors at once).

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -5,7 +5,7 @@ plugin's event coverage.
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stashai && stash login`)
+- `stash` CLI installed and logged in (`pip install stashai && stash signin`)
 - `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)
@@ -42,7 +42,7 @@ You should see a `user_message` event with the prompt you just sent.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash login`; change it later with `stash settings`). No Cursor-specific config surface.
+Reads from `~/.stash/config.json` (populated by `stash signin`; change it later with `stash settings`). No Cursor-specific config surface.
 
 Override with env vars (set in Cursor's environment):
 - `STASH_CURSOR_DATA=<path>` — custom state dir (default `~/.stash/plugins/cursor`)

--- a/plugins/cursor-plugin/scripts/config.py
+++ b/plugins/cursor-plugin/scripts/config.py
@@ -1,7 +1,7 @@
 """Cursor plugin config: reads from ~/.stash/config.json (CLI config).
 
 Cursor has no plugin-level userConfig surface, so we piggyback on the CLI
-config the user already set up with `stash login`. Shared logic lives in
+config the user already set up with `stash signin`. Shared logic lives in
 `stashai.plugin.agent_config`; this module only supplies the per-agent
 constants.
 """

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -5,7 +5,7 @@ plugin's event coverage.
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stashai && stash login`)
+- `stash` CLI installed and logged in (`pip install stashai && stash signin`)
 - `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)
@@ -42,7 +42,7 @@ You should see a `user_message` event with the prompt you just sent.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash login`; change it later with `stash settings`). No Cursor-specific config surface.
+Reads from `~/.stash/config.json` (populated by `stash signin`; change it later with `stash settings`). No Cursor-specific config surface.
 
 Override with env vars (set in Cursor's environment):
 - `STASH_CURSOR_DATA=<path>` — custom state dir (default `~/.stash/plugins/cursor`)

--- a/stashai/plugin/assets/cursor/scripts/config.py
+++ b/stashai/plugin/assets/cursor/scripts/config.py
@@ -1,7 +1,7 @@
 """Cursor plugin config: reads from ~/.stash/config.json (CLI config).
 
 Cursor has no plugin-level userConfig surface, so we piggyback on the CLI
-config the user already set up with `stash login`. Shared logic lives in
+config the user already set up with `stash signin`. Shared logic lives in
 `stashai.plugin.agent_config`; this module only supplies the per-agent
 constants.
 """

--- a/www/app/connect-token/page.tsx
+++ b/www/app/connect-token/page.tsx
@@ -43,7 +43,7 @@ export default async function ConnectTokenPage({
         <Heading>Open this page from the CLI</Heading>
         <Body>
           This page completes sign-in for the Stash CLI and has to be opened
-          with a session id. Run <code>stash login</code>{" "}
+          with a session id. Run <code>stash signin</code>{" "}
           in your terminal and it&apos;ll
           open the right URL for you.
         </Body>

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -62,10 +62,10 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       <CommandRef
         command="stash auth"
         args="<base_url> --api-key <key>"
-        description="Non-interactive auth for headless machines. Writes a pre-minted API key (from `stash keys`) into ~/.stash/config.json. Use this when there's no browser to complete sign-in — it's also the only way to authenticate the streaming hooks unattended, since they read the config file, not env vars."
+        description="Niche tool — not part of normal setup; use signin. Stores a pre-existing API key into ~/.stash/config.json for an unattended, browser-less machine (typically a self-hosted CI runner or server), so its streaming hooks can authenticate. Get the key from your self-hosted instance's API-key page."
         params={[
           { name: "<base_url>", type: "string", desc: "Base URL of the Stash server.", required: true },
-          { name: "--api-key", type: "string", desc: "A pre-minted API key.", required: true },
+          { name: "--api-key", type: "string", desc: "A pre-existing API key from your self-hosted instance.", required: true },
         ]}
       />
 

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -20,7 +20,7 @@ export default function CLIPage() {
       <H2>First-time setup</H2>
       <P>
         Run the interactive setup wizard. It configures the API endpoint, authenticates you
-        (login or register), and creates a workspace — all in one shot. No manual config
+        through the browser, and creates a workspace — all in one shot. No manual config
         editing required.
       </P>
       <CodeBlock>{`stash connect`}</CodeBlock>
@@ -53,46 +53,30 @@ stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBloc
       <H2>Authentication</H2>
 
       <CommandRef
-        command="stash login"
-        args="<name> --password <pw>"
-        description="Authenticate with username and password."
-        params={[
-          { name: "<name>", type: "string", desc: "Your username.", required: true },
-          { name: "--password", type: "string", desc: "Your password.", required: true },
-        ]}
-      />
-
-      <CommandRef
         command="stash signin"
-        args="[--api URL] [--no-browser] [--timeout N]"
-        description="Open the browser for OAuth sign-in. Blocks until the user authorizes. Writes credentials on success and auto-selects the default workspace if there is exactly one."
-        params={[
-          { name: "--api", type: "string", desc: "Stash API base URL. Override for self-hosted deployments. Defaults to https://api.stash.ac." },
-          { name: "--page", type: "string", desc: "Sign-in page URL. Defaults to the /connect-token page matching --api." },
-          { name: "--no-browser", type: "flag", desc: "Skip auto-opening the browser; just print the URL. Use on SSH or headless machines." },
-          { name: "--timeout", type: "number", desc: "Seconds to wait for sign-in. Defaults to 120." },
-        ]}
-      />
-
-      <CommandRef
-        command="stash register"
-        args="<name> [--password <pw>]"
-        description="Create a new Stash account and store the API key."
-        params={[
-          { name: "<name>", type: "string", desc: "Username for the new account.", required: true },
-          { name: "--password", type: "string", desc: "Password for the account." },
-        ]}
+        args=""
+        description="Authenticate this machine through the browser. On first run it also picks the endpoint (managed or self-host) and offers to install streaming hooks for your coding agents. On SSH/headless it prints a URL to open instead of launching a browser."
+        params={[]}
       />
 
       <CommandRef
         command="stash auth"
         args="<base_url> --api-key <key>"
-        description="Store existing credentials for a Stash instance."
+        description="Non-interactive auth for headless machines. Writes a pre-minted API key (from `stash keys`) into ~/.stash/config.json. Use this when there's no browser to complete sign-in — it's also the only way to authenticate the streaming hooks unattended, since they read the config file, not env vars."
         params={[
           { name: "<base_url>", type: "string", desc: "Base URL of the Stash server.", required: true },
-          { name: "--api-key", type: "string", desc: "Your API key.", required: true },
+          { name: "--api-key", type: "string", desc: "A pre-minted API key.", required: true },
         ]}
       />
+
+      <Callout>
+        Setting <Code>STASH_API_KEY</Code> / <Code>STASH_URL</Code> in the environment
+        authenticates <em>CLI commands</em> for CI and scripts — but it does{" "}
+        <strong>not</strong> reach the streaming hooks, which read{" "}
+        <Code>~/.stash/config.json</Code>. To make an unattended machine stream, use{" "}
+        <Code>stash auth</Code>. Change the endpoint or streaming agents later from{" "}
+        <Code>stash settings</Code>.
+      </Callout>
 
       <CommandRef
         command="stash whoami"

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -35,7 +35,7 @@ export default function QuickstartPage() {
 
       <H3>2. Install the CLI</H3>
       <CodeBlock>{`pip install stashai
-stash login`}</CodeBlock>
+stash signin`}</CodeBlock>
 
       <H3>3. Try these commands</H3>
       <P>Use the CLI to interact with your workspace:</P>

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -36,10 +36,10 @@ curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       </P>
       <CodeBlock>{`pip install stashai   # or: uv tool install stashai
 cd /path/to/your/repo
-stash login   # choose "Self-host" and enter http://localhost:3456`}</CodeBlock>
+stash signin   # choose "Self-host" and enter http://localhost:3456`}</CodeBlock>
       <P>
         Enter your public URL instead of <Code>http://localhost:3456</Code> for a
-        Caddy-backed install. <Code>stash login</Code> opens it to register and
+        Caddy-backed install. <Code>stash signin</Code> opens it to register and
         authorize the CLI; change the endpoint later from <Code>stash settings</Code>.
       </P>
 


### PR DESCRIPTION
Follow-up to #630 and #633. You asked why we had `login`, `signin`, `auth`, and `register`. Investigating revealed **two were redundant and two were not** — so this collapses 4 → 2, not 4 → 1.

## The four, examined
| Command | Verdict |
|---|---|
| `register` | **Remove.** Password account creation; the backend 403s it whenever `AUTH0_ENABLED` (managed Stash). |
| `login` | **Remove (fold into `signin`).** An interactive wizard whose setup overlaps `stash settings`; would hang headless. |
| `signin` | **Keep.** Browser auth. Now also runs the first-run wizard when interactive, and does bare auth (`--no-browser` / non-TTY) — the installer/agent path. |
| `auth` | **Keep.** See below — it is *not* redundant. |

## Why `auth` survives (the critical finding)
The streaming hooks — the whole point of Stash — read `~/.stash/config.json` **directly** (`stashai/plugin/hooks.py`) and **ignore `STASH_API_KEY` / `STASH_URL`**. So:
- `signin` needs a browser + a human.
- env vars authenticate *CLI commands* but **never reach the uploader hooks**.
- **`auth <url> --api-key <key>`** is the only way to write a pre-minted key into the file the hooks read — i.e. the only way to provision an **unattended** machine (CI runner, server, baked image) to stream.

My earlier "env vars cover headless" was wrong for the streaming case; this corrects it, including the docs guidance.

## Result
Auth surface: **`signin`** (interactive / browser) + **`auth`** (non-interactive / headless). Repointed all `stash login` references to `stash signin`.

## Verification
- `ruff` clean, `pytest cli/tests/` **73 passed**, frontend `collabIntro` test passes, `tsc` clean on changed www pages.
- `stash --help` lists `signin` and `auth` only for auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)