### PR TITLE
vfs: expose connected sources (Gmail/GitHub/Slack/Jira/…) in the filesystem

### DIFF
--- a/cli/mount.py
+++ b/cli/mount.py
@@ -61,9 +61,14 @@ class StashVfsModel:
         self.client = client
         self.workspace_id = workspace_id
         self.nodes: dict[str, VfsNode] = {}
+        # Source-root path -> thunk that fetches that source's entries. A source's
+        # contents are materialized only when something first descends into it, so
+        # listing source names stays cheap no matter how large the source is.
+        self._expanders: dict[str, Callable[[], None]] = {}
 
     def refresh(self) -> None:
         self.nodes = {}
+        self._expanders = {}
         self._add_dir("/")
         self._add_static_file(
             "/README.md",
@@ -96,7 +101,9 @@ class StashVfsModel:
             self._add_workspace(workspace)
 
     def exists(self, path: str) -> bool:
-        return self._clean_path(path) in self.nodes
+        path = self._clean_path(path)
+        self._ensure_expanded(path)
+        return path in self.nodes
 
     def list_dir(self, path: str) -> list[str]:
         node = self._get_node(path)
@@ -322,11 +329,16 @@ class StashVfsModel:
             source_root = self._add_dir_child(
                 sources_path, _source_slug(source.get("display_name") or handle)
             )
-            try:
-                entries = self.client.list_source_entries(workspace_id, handle, "")
-            except StashError:
-                continue
-            self._add_source_entries(source_root, workspace_id, handle, entries)
+            self._expanders[source_root] = (
+                lambda root=source_root, ws=workspace_id, h=handle: self._expand_source(root, ws, h)
+            )
+
+    def _expand_source(self, source_root: str, workspace_id: str, handle: str) -> None:
+        try:
+            entries = self.client.list_source_entries(workspace_id, handle, "")
+        except StashError:
+            return
+        self._add_source_entries(source_root, workspace_id, handle, entries)
 
     def _add_source_entries(
         self, source_root: str, workspace_id: str, handle: str, entries: list[dict]
@@ -435,10 +447,19 @@ class StashVfsModel:
 
     def _get_node(self, path: str) -> VfsNode:
         path = self._clean_path(path)
+        self._ensure_expanded(path)
         node = self.nodes.get(path)
         if node is None:
             raise FileNotFoundError(path)
         return node
+
+    def _ensure_expanded(self, path: str) -> None:
+        """Materialize any connected source whose subtree contains `path`. No-op
+        once a source has been expanded, and never triggered by listing the
+        `sources/` directory itself — only by descending into a source."""
+        for root in list(self._expanders):
+            if path == root or path.startswith(f"{root}/"):
+                self._expanders.pop(root)()
 
     def _unique_child_name(self, parent: str, name: str) -> str:
         existing = self.nodes[parent].children

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .client import StashClient
+from .client import StashClient, StashError
 
 BytesLoader = Callable[[], bytes]
 BytesWriter = Callable[[bytes], None]
@@ -76,6 +76,8 @@ class StashVfsModel:
                     "- `workspaces/*/files` exposes folders, pages, and uploaded files.",
                     "- Markdown and HTML pages are writable; saves sync back to Stash.",
                     "- Uploaded files, sessions, skills, and tables are read-only projections.",
+                    "- `workspaces/*/sources` exposes connected integrations (Gmail, "
+                    "GitHub, Slack, Jira, …) as read-only documents.",
                     "",
                 ]
             ),
@@ -165,6 +167,7 @@ class StashVfsModel:
         self._add_skills(workspace_path, overview.get("skills", []))
         self._add_sessions(workspace_path, workspace_id, overview.get("sessions", []))
         self._add_tables(workspace_path, workspace_id)
+        self._add_sources(workspace_path, workspace_id)
 
     def _add_files_tree(self, workspace_path: str, workspace_id: str, tree: dict) -> None:
         root_path = f"{workspace_path}/files"
@@ -225,13 +228,17 @@ class StashVfsModel:
         self._add_dir(skills_path)
         self._add_jsonl_file(f"{skills_path}/_index.jsonl", skills)
         for skill in skills:
-            skill_id = str(skill["id"])
-            basename = _object_basename(skill.get("title") or "skill", skill_id)
+            folder_id = str(skill.get("folder_id") or "")
+            if not folder_id:
+                continue
+            basename = _object_basename(skill.get("name") or "skill", folder_id)
             self._add_json_file(f"{skills_path}/{basename}.json", skill)
-            self._add_file(
-                f"{skills_path}/{basename}.md",
-                loader=lambda slug=skill["slug"]: _text_bytes(self.client.get_skill_text(slug)),
-            )
+            slug = (skill.get("published") or {}).get("slug")
+            if slug:
+                self._add_file(
+                    f"{skills_path}/{basename}.md",
+                    loader=lambda s=slug: _text_bytes(self.client.get_skill_text(s)),
+                )
 
     def _add_sessions(self, workspace_path: str, workspace_id: str, sessions: list[dict]) -> None:
         sessions_path = f"{workspace_path}/sessions"
@@ -291,6 +298,55 @@ class StashVfsModel:
                 f"{table_path}/rows.jsonl",
                 loader=lambda ws=workspace_id, tid=table_id: _jsonl_bytes(
                     self._load_all_table_rows(ws, tid).get("rows", [])
+                ),
+            )
+
+    def _add_sources(self, workspace_path: str, workspace_id: str) -> None:
+        """Expose connected integrations (Gmail, GitHub, Slack, Jira, …) as
+        read-only document trees. Native files/sessions are already mounted
+        above, so skip them. Each source's full entry list is materialized;
+        document bodies load lazily on read."""
+        try:
+            sources = self.client.list_sources(workspace_id)
+        except StashError:
+            return
+        connected = [s for s in sources if not str(s.get("type", "")).startswith("native_")]
+        if not connected:
+            return
+
+        sources_path = self._add_dir(f"{workspace_path}/sources")
+        for source in connected:
+            handle = str(source.get("source") or "")
+            if not handle:
+                continue
+            source_root = self._add_dir_child(
+                sources_path, _source_slug(source.get("display_name") or handle)
+            )
+            try:
+                entries = self.client.list_source_entries(workspace_id, handle, "")
+            except StashError:
+                continue
+            self._add_source_entries(source_root, workspace_id, handle, entries)
+
+    def _add_source_entries(
+        self, source_root: str, workspace_id: str, handle: str, entries: list[dict]
+    ) -> None:
+        for entry in entries:
+            ref = str(entry.get("path") or "")
+            segments = [_safe_name(seg) for seg in ref.split("/") if seg]
+            if not segments:
+                continue
+            parent = source_root
+            for segment in segments[:-1]:
+                parent = self._add_dir(f"{parent}/{segment}")
+            display = _safe_name(entry.get("name") or segments[-1])
+            if entry.get("kind") == "folder":
+                self._add_dir(f"{parent}/{display}")
+                continue
+            self._add_file(
+                f"{parent}/{display}",
+                loader=lambda ws=workspace_id, h=handle, r=ref: _text_bytes(
+                    _source_doc_text(self.client.read_source_doc(ws, h, r))
                 ),
             )
 
@@ -753,6 +809,15 @@ def _safe_name(value: str) -> str:
     value = re.sub(r"\s+", " ", value)
     value = value.strip(". ")
     return (value or "untitled")[:96]
+
+
+def _source_slug(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9._-]+", "-", name.lower()).strip("-")
+    return slug or "source"
+
+
+def _source_doc_text(doc: dict) -> str:
+    return doc.get("content") or doc.get("transcript") or ""
 
 
 def _object_basename(name: str, object_id: str) -> str:

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -40,10 +40,10 @@ class FakeClient:
             },
             "skills": [
                 {
-                    "id": "stash-12345678",
-                    "slug": "demo-stash",
-                    "title": "Demo Stash",
-                    "items": [],
+                    "folder_id": "skillfolder-12345678",
+                    "name": "Demo Skill",
+                    "file_count": 1,
+                    "published": {"slug": "demo-stash"},
                 }
             ],
             "sessions": [
@@ -73,6 +73,26 @@ class FakeClient:
     def get_skill_text(self, slug):
         assert slug == "demo-stash"
         return "# Demo Stash\n"
+
+    def list_sources(self, workspace_id):
+        assert workspace_id == "workspace-12345678"
+        return [
+            {"type": "native_files", "source": "files", "display_name": "Files"},
+            {"type": "gmail", "source": "src-gmail-1", "display_name": "Gmail (demo@x.com)"},
+        ]
+
+    def list_source_entries(self, workspace_id, source, path=""):
+        assert workspace_id == "workspace-12345678"
+        assert source == "src-gmail-1"
+        return [
+            {"path": "msg-1", "name": "Welcome email", "kind": "message"},
+            {"path": "threads/msg-2", "name": "Nested note", "kind": "message"},
+        ]
+
+    def read_source_doc(self, workspace_id, source, ref):
+        assert workspace_id == "workspace-12345678"
+        assert source == "src-gmail-1"
+        return {"content": f"BODY of {ref}"}
 
     def get_transcript_events(self, workspace_id, session_id):
         assert workspace_id == "workspace-12345678"
@@ -131,14 +151,23 @@ def test_vfs_exposes_workspace_sections():
         "sessions",
         "skills",
         "tables",
+        "sources",
     }
-    assert model.read_file(f"{workspace_path}/skills/Demo Stash--stash-12.md") == b"# Demo Stash\n"
+    assert model.read_file(f"{workspace_path}/skills/Demo Skill--skillfol.md") == b"# Demo Stash\n"
     assert b"hello" in model.read_file(
         f"{workspace_path}/sessions/Fix login--session-/transcript.md"
     )
     assert b'"Name": "Mount"' in model.read_file(
         f"{workspace_path}/tables/Ideas--table-12/rows.json"
     )
+
+    # Connected sources are mounted read-only; native sources are skipped
+    # (files/sessions already appear above). Document bodies load lazily.
+    assert model.list_dir(f"{workspace_path}/sources") == ["gmail-demo-x.com"]
+    gmail = f"{workspace_path}/sources/gmail-demo-x.com"
+    assert "Welcome email" in model.list_dir(gmail)
+    assert model.read_file(f"{gmail}/Welcome email") == b"BODY of msg-1"
+    assert model.read_file(f"{gmail}/threads/Nested note") == b"BODY of threads/msg-2"
 
 
 def test_vfs_reads_files_and_writes_pages():

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -12,6 +12,7 @@ from cli.mount import (
 class FakeClient:
     def __init__(self):
         self.page_updates = []
+        self.source_entry_calls = 0
 
     def list_workspaces(self):
         return [{"id": "workspace-12345678", "name": "Demo Workspace", "description": "Demo"}]
@@ -84,6 +85,7 @@ class FakeClient:
     def list_source_entries(self, workspace_id, source, path=""):
         assert workspace_id == "workspace-12345678"
         assert source == "src-gmail-1"
+        self.source_entry_calls += 1
         return [
             {"path": "msg-1", "name": "Welcome email", "kind": "message"},
             {"path": "threads/msg-2", "name": "Nested note", "kind": "message"},
@@ -168,6 +170,25 @@ def test_vfs_exposes_workspace_sections():
     assert "Welcome email" in model.list_dir(gmail)
     assert model.read_file(f"{gmail}/Welcome email") == b"BODY of msg-1"
     assert model.read_file(f"{gmail}/threads/Nested note") == b"BODY of threads/msg-2"
+
+
+def test_vfs_loads_source_entries_lazily():
+    # Listing source names must not fetch any source's contents — that's the
+    # whole point: enumerating a 10k-doc source costs the same as a 1-doc one.
+    client = FakeClient()
+    model = StashVfsModel(client)
+    model.refresh()
+    workspace_name = model.list_dir("/workspaces")[0]
+    sources_path = f"/workspaces/{workspace_name}/sources"
+
+    assert model.list_dir(sources_path) == ["gmail-demo-x.com"]
+    assert client.source_entry_calls == 0
+
+    # Descending into a source materializes only that source, once.
+    model.list_dir(f"{sources_path}/gmail-demo-x.com")
+    assert client.source_entry_calls == 1
+    model.list_dir(f"{sources_path}/gmail-demo-x.com")
+    assert client.source_entry_calls == 1
 
 
 def test_vfs_reads_files_and_writes_pages():

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -31,14 +31,17 @@ export default function CLIPage() {
 
       <H2>Virtual filesystem</H2>
       <P>
-        Use <Code>stash vfs</Code> when an agent needs to browse workspace files, pages,
-        sessions, stashes, and tables through one filesystem-shaped interface without
-        mounting anything into the OS.
+        Use <Code>stash vfs</Code> when an agent needs to browse Stash through one
+        filesystem-shaped interface without mounting anything into the OS. Each
+        workspace exposes <Code>files</Code>, <Code>sessions</Code>, <Code>skills</Code>,{" "}
+        <Code>tables</Code>, and <Code>sources</Code> — the last surfacing every connected
+        integration (Gmail, GitHub, Slack, Jira, …) as read-only documents you can{" "}
+        <Code>ls</Code>, <Code>cat</Code>, and <Code>grep</Code>.
       </P>
       <CodeBlock>{`stash vfs ls /
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg 'database migration' /workspaces"
-stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`}</CodeBlock>
+stash vfs --cwd "/workspaces/<workspace>/sources" "rg 'incident' ."`}</CodeBlock>
       <CommandRef
         command="stash vfs"
         args={'[--ws ID] [--cwd PATH] "command"'}


### PR DESCRIPTION
## What
`stash vfs` (and the experimental `stash mount`) exposed only workspace-native objects (files/pages, sessions, skills, tables). Now each workspace also gets a **`sources/`** subtree containing every connected integration — Gmail, GitHub, Slack, Jira, Granola, … — as read-only documents.

```
stash vfs --cwd "/workspaces/<ws>/sources" "ls"
# → gmail-you-company.com   github-acme-repo   jira-ENG   slack-...

stash vfs --cwd "/workspaces/<ws>/sources/jira-ENG" "rg 'flaky test'"
# greps the *content* of every Jira issue
```

## How
- New `_add_sources` in `cli/mount.py`: lists connected sources (`list_sources`), skips natives, and creates one directory per source.
- **Lazy expansion:** a source's entries are fetched (`list_source_entries(handle, "")`) and turned into a subtree only when something first *descends into that source*. Listing `sources/` shows names without fetching any contents, so enumerating a 10k-document source costs the same as a 1-document one. Nested paths become folders; leaves are files.
- Document bodies then **load lazily** on read (`read_source_doc`) — only what you `cat`/`grep` is fetched.
- Read-only (no writer). Lives in the shared `StashVfsModel`, so both `stash vfs` and `stash mount` get it.

## Bundled fix (was blocking this)
`_add_skills` still read `id`/`title`/`slug`, but the workspace overview now returns folder-based skills (`folder_id`/`name`/`published.slug`). That `KeyError: 'id'` **crashed `stash vfs` entirely** for any workspace containing skills. Fixed to the current shape.

## Verification (live, against my workspace's two Gmail sources)
- `sources/` appears next to files/sessions/skills/tables ✓
- both Gmail accounts listed; descending mounts their messages (240 total) ✓
- `cat` lazily renders a message body; `rg registration` returns file:line content matches ✓
- **Lazy proven:** `refresh()` → 0 entry fetches; `ls /sources` → 0; descending into one source → exactly 1 ✓
- `ruff` clean · **74 CLI tests pass** (added source-tree + lazy-loading coverage) · www `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)