### PR TITLE
docs: update expired Discord invite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://joinstash.ai"><img src="https://img.shields.io/badge/Website-joinstash.ai-F97316" alt="Website" /></a>
   <a href="#self-hosted"><img src="https://img.shields.io/badge/Self--hostable-✓-22C55E" alt="Self-hostable" /></a>
   <a href="#privacy"><img src="https://img.shields.io/badge/Transcripts-opt--in-3B82F6" alt="Opt-in transcripts" /></a>
-  <a href="https://discord.gg/CRepGtEx"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/PVFdcQx2u3"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 <p align="center">
   When we tested this internally, we found that it sped up long-running instances of Claude Code by <a href="https://henrydowling.com/agent-velocity.html"><b>49%</b></a>.<br/>


### PR DESCRIPTION
The Discord invite badge in the README pointed to an expired/revoked invite (`discord.gg/CRepGtEx`), which rendered an **Invite Invalid** page. Swapped in a fresh invite link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)