### PR TITLE
fix: don't sign out of Google when signing out of Stash

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -64,9 +64,10 @@ export function useAuth() {
     // legacy mc_ keys minted by old Auth0 sign-ins too.
     setUser(null);
     await revokeStoredApiKey();
-    // Hard navigation so module-level caches reset. `?federated` asks Auth0 to
-    // clear upstream identity-provider state too.
-    window.location.href = AUTH0_ENABLED ? "/auth/logout?federated" : "/login";
+    // Hard navigation so module-level caches reset. We intentionally do NOT use
+    // `?federated` — that would tell Auth0 to clear the upstream identity provider
+    // (e.g. Google) session, signing the user out of Google itself, not just Stash.
+    window.location.href = AUTH0_ENABLED ? "/auth/logout" : "/login";
   }, []);
 
   return {


### PR DESCRIPTION
## Problem

Clicking **Sign out** in Stash signed the user out of their **Google account**, not just Stash:

> accounts.google.com/signout → "Signed out - syncing is paused"

## Root cause

The logout flow navigated to Auth0's `/auth/logout?federated`. The `?federated` flag asks Auth0 to clear the **upstream identity-provider** session too — so Auth0 redirected on to Google's logout endpoint and ended the user's Google session.

`frontend/src/hooks/useAuth.ts`:
```ts
window.location.href = AUTH0_ENABLED ? "/auth/logout?federated" : "/login";
```

## Fix

Drop `?federated`. We still clear local state, revoke the stored API key, and end the Stash/Auth0 session via `/auth/logout` — but we no longer touch the user's Google session.

```ts
window.location.href = AUTH0_ENABLED ? "/auth/logout" : "/login";
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)