### PR TITLE
fix(sessions): point the record link at the web app, not the API host

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
+from ..config import settings
 from ..database import get_pool
 from ..services import (
     files_tree_service,
@@ -42,6 +43,10 @@ class SessionUpsertRequest(BaseModel):
     session_folder_id: UUID | None = None
 
 
+def _session_app_url(session_id: str) -> str:
+    return f"{settings.PUBLIC_URL.rstrip('/')}/sessions/{session_id}"
+
+
 def _session_response(row: dict, title: str | None = None) -> dict:
     files_touched = row.get("files_touched") or []
     if isinstance(files_touched, str):
@@ -50,6 +55,7 @@ def _session_response(row: dict, title: str | None = None) -> dict:
         "id": str(row["id"]),
         "workspace_id": str(row["workspace_id"]),
         "session_id": row["session_id"],
+        "app_url": _session_app_url(row["session_id"]),
         "title": title
         or session_title_service.title_from_text(
             row.get("title_source"),

--- a/backend/tests/test_item_canonical_lookup.py
+++ b/backend/tests/test_item_canonical_lookup.py
@@ -8,6 +8,7 @@ import uuid
 import pytest
 from httpx import AsyncClient
 
+from ..config import settings
 from .conftest import unique_name
 
 
@@ -120,6 +121,9 @@ async def test_member_resolves_session_by_external_id_alone(client: AsyncClient)
     assert resp.status_code == 200
     assert resp.json()["session_id"] == session_id
     assert resp.json()["workspace_id"] == workspace_id
+    # The record link must point at the web app (PUBLIC_URL), not the API host,
+    # so the plugin can hand it back as a clickable session URL.
+    assert resp.json()["app_url"] == f"{settings.PUBLIC_URL.rstrip('/')}/sessions/{session_id}"
 
 
 @pytest.mark.asyncio

--- a/plugins/tests/test_session_upload.py
+++ b/plugins/tests/test_session_upload.py
@@ -15,6 +15,7 @@ class _FakeClient:
         self.created.append(kwargs)
         return {
             "id": "session-row-1",
+            "app_url": f"https://app.joinstash.ai/sessions/{kwargs['session_id']}",
         }
 
 
@@ -40,11 +41,11 @@ def test_create_session_record_saves_url_and_transcript_path(tmp_path):
 
     url = create_session_record(client, _cfg(), state, event, tmp_path)
 
-    assert url == "https://joinstash.ai/sessions/s1"
+    assert url == "https://app.joinstash.ai/sessions/s1"
     assert client.created[0]["session_id"] == "s1"
     assert client.created[0]["cwd"] == "/repo"
     assert state["session_row_id"] == "session-row-1"
-    assert state["session_url"] == "https://joinstash.ai/sessions/s1"
+    assert state["session_url"] == "https://app.joinstash.ai/sessions/s1"
     assert state["uploaded_session_id"] == "s1"
     assert state["uploaded_workspace_id"] == "ws1"
     assert state["transcript_path"] == "/tmp/s1.jsonl"
@@ -65,7 +66,7 @@ def test_create_session_record_resolves_workspace_from_event_cwd(monkeypatch, tm
 
     url = create_session_record(client, cfg, state, event, tmp_path)
 
-    assert url == "https://joinstash.ai/sessions/s1"
+    assert url == "https://app.joinstash.ai/sessions/s1"
     assert client.created[0]["workspace_id"] == "ws-from-cwd"
     assert state["uploaded_workspace_id"] == "ws-from-cwd"
 

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -235,7 +235,10 @@ def create_session_record(
     record_upload_success(data_dir, "session")
 
     state["session_row_id"] = str(session["id"])
-    state["session_url"] = f"{cfg['api_endpoint'].rstrip('/')}/sessions/{sid}"
+    # The record link points at the web app (PUBLIC_URL), not the API host, so
+    # use the canonical app_url the backend returns rather than building one off
+    # api_endpoint.
+    state["session_url"] = session["app_url"]
     state["uploaded_session_id"] = sid
     state["uploaded_workspace_id"] = workspace_id
     state["cwd"] = event.cwd or state.get("cwd", "")


### PR DESCRIPTION
## Problem

The session record link the plugin prints (e.g. `https://api.joinstash.ai/sessions/<id>`) **404s**.

Verified against prod:

| URL | Result |
|---|---|
| `https://api.joinstash.ai/sessions/{id}` (what was emitted) | **404** |
| `https://api.joinstash.ai/api/v1/sessions/{id}` (real API route) | 401 — JSON, auth-gated |
| `https://app.joinstash.ai/sessions/{id}` (real page) | **200** ✅ |

## Root cause

The canonical `/sessions/[sessionId]` route is a **frontend page** served on `PUBLIC_URL` (`app.joinstash.ai`). The API host only exposes `/api/v1/sessions/{id}` (JSON, requires auth). But the plugin built the link off `api_endpoint` (the API host):

```python
# stashai/plugin/hooks.py (before)
state["session_url"] = f"{cfg['api_endpoint'].rstrip('/')}/sessions/{sid}"
```

Regressed in #567, which moved the route to the frontend and dropped the `/workspaces/{ws}` segment but kept building off the API host.

## Fix

The backend already builds file/page `app_url`s from `settings.PUBLIC_URL` (`_file_app_url`, `_page_app_url`). This adds the same for sessions and has the plugin use the server-returned `app_url` instead of constructing one:

- `backend/routers/sessions.py`: new `_session_app_url()`; `app_url` added to `_session_response`.
- `stashai/plugin/hooks.py`: `session_url` now comes from `session["app_url"]`.

This also fixes local dev, where the API (3456) and web app (3457) differ by **port**, so no host string-transform would have worked.

## Tests

- `backend/tests/test_item_canonical_lookup.py`: asserts the canonical endpoint returns the `PUBLIC_URL`-based `app_url`.
- `plugins/tests/test_session_upload.py`: fake client returns `app_url`; asserts the plugin hands back the web-host URL.

All pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)