### PR TITLE
cli: drop read-only commands now covered by the VFS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,14 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 
 Run `stash prompts agent-guidance` to reprint this guidance mid-session.
 
-Common reads (all support `--json`):
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — latest session events
+Common reads:
+- `stash search "<query>" --json` — full-text search across files, sessions, and connected sources
+- `stash vfs "ls /workspaces"` — browse workspaces as a filesystem: files, sessions, tables, skills, sources
+- `stash vfs "cat '/workspaces/<ws>/files/<page>.md'"` — read any page, file, transcript, or source doc
 - `stash sessions agents` — who's been active
-- `stash files tree` — browse workspace Files
+
+Browsing and reading workspace content (files, pages, sessions, tables, skills, connected sources) is
+done through the VFS — `stash vfs "<bash>"` (ls/cat/find/grep/tree) — not dedicated read subcommands.
 
 ### LLM configuration (server-side)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 <p align="center">
   <img src="docs/assets/visualizations.gif" alt="Stash visualizations — embedding space, file tree, agent activity" width="900" />
 </p>
-<!-- GIF #2 — The product in action: agent runs `stash sessions search`, gets a cited answer -->
+<!-- GIF #2 — The product in action: agent runs `stash search`, gets a cited answer -->
 
 <p align="center">
   <img src="docs/assets/product.gif" alt="Stash in action — agent queries shared memory and gets cited answers" width="900" />

--- a/cli/main.py
+++ b/cli/main.py
@@ -1289,51 +1289,6 @@ skills_app = typer.Typer(
 app.add_typer(skills_app, name="skills")
 
 
-@skills_app.command("list")
-def skills_list(
-    workspace_id: str = typer.Argument(None, help="Workspace ID; falls back to .stash."),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """List skills in a workspace — folders with a SKILL.md, plus publish info."""
-    ws_id = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c.list_skills(ws_id)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-    if not data:
-        console.print("[dim]No skills in this workspace.[/dim]")
-        return
-    for v in data:
-        published = v.get("published")
-        if published:
-            flag = f"[cyan]{published['access']}[/cyan]  /skills/{published['slug']}"
-        else:
-            flag = "[dim]private[/dim]"
-        console.print(
-            f"[bold]{v['name']}[/bold]  {flag}  "
-            f"[dim]({v['file_count']} files)  {v.get('description', '')}[/dim]"
-        )
-
-
-@skills_app.command("show")
-def skills_show(
-    name: str = typer.Argument(..., help="Local skill name (frontmatter or folder name)."),
-    workspace_id: str = typer.Option("", "--ws", help="Workspace ID; falls back to .stash."),
-):
-    """Read a local skill: SKILL.md frontmatter + body + sibling files concatenated."""
-    ws_id = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c._get(f"/api/v1/workspaces/{ws_id}/skills/{name}")
-        except StashError as e:
-            _err(e)
-    console.print(data["combined"])
-
-
 @skills_app.command("add")
 def skills_add(
     folder: str = typer.Argument(..., help="Local folder containing a SKILL.md file."),
@@ -1817,7 +1772,7 @@ def skills_fork(
 def skills_snapshot_source(
     skill_id: str = typer.Argument(...),
     source: str = typer.Option(
-        ..., "--source", help="Connected-source id (from `stash sources ls`)."
+        ..., "--source", help="Connected-source handle (see /workspaces/<ws>/sources via `stash vfs`)."
     ),
     path: str = typer.Option(..., "--path", help="Document path within the source."),
     workspace_id: str = typer.Option(None, "--ws"),
@@ -1953,63 +1908,6 @@ files_app = typer.Typer(help="Files — folders, pages, and uploaded files.")
 app.add_typer(files_app, name="files")
 
 
-@files_app.command("tree")
-def files_tree(
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Show the nested folder + page tree for the workspace."""
-    with _client() as c:
-        try:
-            ws = workspace_id or _resolve_workspace()
-            data = c.get_workspace_tree(ws)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-
-    def _print_folder(folder: dict, depth: int) -> None:
-        pad = "  " * depth
-        console.print(f"{pad}[bold]{folder['name']}/[/bold]  (id: {str(folder['id'])[:8]})")
-        for sub in folder.get("folders", []):
-            _print_folder(sub, depth + 1)
-        for p in folder.get("pages", []):
-            console.print(f"{pad}  {p['name']}  (id: {str(p['id'])[:8]})")
-
-    for folder in data.get("folders", []):
-        _print_folder(folder, 0)
-    for p in data.get("pages", []):
-        console.print(f"  {p['name']}  (id: {str(p['id'])[:8]})")
-
-
-@files_app.command("folders")
-def files_folders(
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Flat list of every folder in the workspace."""
-    with _client() as c:
-        try:
-            ws = workspace_id or _resolve_workspace()
-            data = c.list_folders(ws)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        if not data:
-            console.print("[dim]No folders.[/dim]")
-        else:
-            for f in data:
-                parent = (
-                    f"  parent: {str(f['parent_folder_id'])[:8]}"
-                    if f.get("parent_folder_id")
-                    else ""
-                )
-                console.print(f"  {f['name']}  (id: {str(f['id'])[:8]}){parent}")
-
-
 @files_app.command("create-folder")
 def files_create_folder(
     name: str = typer.Argument(...),
@@ -2048,31 +1946,6 @@ def files_edit_folder(
         output_json(data)
     else:
         console.print(f"[green]Folder renamed.[/green] {data['name']}  [dim]{data['id']}[/dim]")
-
-
-@files_app.command("pages")
-def files_pages(
-    workspace_id: str = typer.Option(None, "--ws"),
-    all_: bool = typer.Option(False, "--all", help="list pages across every workspace"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """List pages. --all for cross-workspace, default for the active workspace."""
-    with _client() as c:
-        try:
-            data = c.all_pages() if all_ else c.list_pages(workspace_id or _resolve_workspace())
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        if not data:
-            console.print("[dim]No pages.[/dim]")
-            return
-        for p in data:
-            path = "/".join(p.get("folder_path") or [])
-            label = f"{path}/{p['name']}" if path else p["name"]
-            ws = f" [{p.get('workspace_name', '')}]" if p.get("workspace_name") else ""
-            console.print(f"  {label}{ws}  (id: {str(p['id'])[:8]})")
 
 
 def _markdown_snippet(file_resp: dict) -> str:
@@ -2175,29 +2048,6 @@ def files_add_page(
             f"[green]Page '{data['name']}' created.[/green]  ID: {data['id']}  "
             f"Type: {data.get('content_type', 'markdown')}"
         )
-
-
-@files_app.command("read-page")
-def files_read_page(
-    page_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Read a page's content."""
-    with _client() as c:
-        try:
-            ws = workspace_id or _resolve_workspace()
-            data = c.get_page(ws, page_id)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(f"[bold]{data['name']}[/bold]\n")
-        if data.get("content_type") == "html":
-            console.print(data.get("content_html", ""))
-        else:
-            console.print(data.get("content_markdown", ""))
 
 
 @files_app.command("edit-page")
@@ -2436,91 +2286,6 @@ def hist_push(
         console.print(f"[green]Event recorded.[/green]  ID: {data['id']}")
 
 
-@hist_app.command("query")
-def hist_query(
-    workspace_id: str = typer.Option(None, "--ws"),
-    agent_name: str = typer.Option(None, "--agent"),
-    event_type: str = typer.Option(None, "--type"),
-    limit: int = typer.Option(50, "-n", "--limit"),
-    before: str = typer.Option(None, "--before", help="Cursor: ISO timestamp for previous page"),
-    after: str = typer.Option(None, "--after", help="Cursor: ISO timestamp for next page"),
-    order: str = typer.Option(
-        "desc", "--order", help="Sort order: desc (newest first) or asc (oldest first)"
-    ),
-    all_: bool = typer.Option(False, "--all"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Query events (newest first by default). --all for cross-workspace."""
-    telemetry.record("history.query")
-    with _client() as c:
-        try:
-            if all_:
-                data = c.all_events(
-                    agent_name=agent_name,
-                    event_type=event_type,
-                    limit=limit,
-                    before=before,
-                    after=after,
-                    order=order,
-                )
-            else:
-                ws = workspace_id or _resolve_workspace()
-                data = c.query_events(
-                    ws,
-                    agent_name=agent_name,
-                    event_type=event_type,
-                    limit=limit,
-                    before=before,
-                    after=after,
-                    order=order,
-                )
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        for ev in data:
-            tool = f" ({ev['tool_name']})" if ev.get("tool_name") else ""
-            console.print(
-                f"  [{ev['created_at'][:19]}] {ev['agent_name']}/{ev['event_type']}{tool}: {ev['content'][:200]}"
-            )
-
-
-@hist_app.command("transcript")
-def hist_transcript(
-    session_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    save: str = typer.Option(None, "--save"),
-):
-    """Fetch a full session transcript (.jsonl) and print or save it.
-
-    Transcripts are stored gzipped on the server; we decompress here so
-    `--save` writes plain .jsonl and stdout is readable.
-    """
-    import gzip
-
-    import httpx
-
-    ws = workspace_id or _resolve_workspace()
-    cfg = load_config()
-    url = f"{cfg['base_url'].rstrip('/')}/api/v1/workspaces/{ws}/transcripts/{session_id}"
-    headers = {"Authorization": f"Bearer {cfg.get('api_key', '')}"}
-    meta = httpx.get(url, headers=headers, timeout=30).json()
-    if "download_url" not in meta:
-        console.print(f"[red]{meta.get('detail', 'not found')}[/red]")
-        raise typer.Exit(1)
-    raw = httpx.get(meta["download_url"], timeout=60).content
-    # Detect gzip via magic bytes so legacy uncompressed uploads still work.
-    if raw[:2] == b"\x1f\x8b":
-        raw = gzip.decompress(raw)
-    body = raw.decode("utf-8", errors="replace")
-    if save:
-        Path(save).write_text(body)
-        console.print(f"[green]Saved {len(body):,} chars to {save}[/green]")
-        return
-    sys.stdout.write(body)
-
-
 def _transcript_to_markdown(raw_jsonl: str) -> str:
     """Convert a Claude Code .jsonl transcript into readable markdown."""
     lines = []
@@ -2673,7 +2438,8 @@ def hist_import(
 # ===========================================================================
 
 sources_app = typer.Typer(
-    help="Sources — browse, read, and search files, sessions, and connected sources."
+    help="Sources — connect, sync, and disconnect external sources. "
+    "Browse and read their contents with `stash vfs` under /workspaces/<ws>/sources."
 )
 app.add_typer(sources_app, name="sources")
 
@@ -2714,27 +2480,6 @@ def search(
 ):
     """Search everything you can see — files, sessions, and connected sources."""
     _print_search(query, source, workspace_id, limit, as_json)
-
-
-@sources_app.command("ls")
-def sources_ls(
-    workspace_id: str = typer.Option(None, "--ws"), as_json: bool = typer.Option(False, "--json")
-):
-    """List every source you can read here."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c.list_sources(ws)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-    for s in data:
-        console.print(
-            f"  [bold]{s['display_name']}[/bold]  [dim]({s['type']}, {s['capability']}) "
-            f"→ {s['source']}[/dim]"
-        )
 
 
 @sources_app.command("add")
@@ -2798,49 +2543,6 @@ def sources_rm(
     console.print("[green]Source removed.[/green]")
 
 
-@sources_app.command("browse")
-def sources_browse(
-    source: str = typer.Argument(..., help="A source handle from `stash sources ls`."),
-    path: str = typer.Argument("", help="Path prefix (connected sources only)."),
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """List a source's entries like a file system."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c.list_source_entries(ws, source, path=path)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-    if not data:
-        console.print("[dim]Empty.[/dim]")
-        return
-    for entry in data:
-        ref = entry.get("path") or entry.get("id")
-        console.print(f"  [{entry.get('kind', 'file')}] {entry['name']}  [dim]({ref})[/dim]")
-
-
-@sources_app.command("read")
-def sources_read(
-    source: str = typer.Argument(..., help="A source handle from `stash sources ls`."),
-    ref: str = typer.Argument(..., help="Page id (files), session id (sessions), or doc path."),
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Read one document from a source."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c.read_source_doc(ws, source, ref)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-    console.print(data.get("content") or data.get("transcript") or "")
 
 
 def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
@@ -3269,36 +2971,6 @@ def _resolve_sort_name(table: dict, sort_by: str) -> str:
     return name_to_id.get(sort_by, sort_by)
 
 
-@tables_app.command("list")
-def tables_list(
-    workspace_id: str = typer.Option(None, "--ws"),
-    all_: bool = typer.Option(False, "--all"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """List tables. --all for cross-workspace."""
-    with _client() as c:
-        try:
-            if all_:
-                data = c.all_tables()
-            else:
-                data = c.list_tables(workspace_id or _resolve_workspace())
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        if not data:
-            console.print("[dim]No tables.[/dim]")
-        else:
-            for t in data:
-                ws = f" [{t.get('workspace_name', '')}]" if t.get("workspace_name") else ""
-                cols = len(t.get("columns", []))
-                rows = t.get("row_count", 0)
-                console.print(
-                    f"  {t['name']}{ws}  ({cols} cols, {rows} rows, id: {str(t['id'])[:8]})"
-                )
-
-
 @tables_app.command("create")
 def tables_create(
     name: str = typer.Argument(...),
@@ -3348,79 +3020,6 @@ def tables_update(
         output_json(data)
     else:
         console.print("[green]Table updated.[/green]")
-
-
-@tables_app.command("schema")
-def tables_schema(
-    table_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Show a table's column schema."""
-    with _client() as c:
-        try:
-            ws = workspace_id or _resolve_workspace()
-            data = c.get_table(ws, table_id)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print(f"[bold]{data['name']}[/bold]  ({data.get('row_count', 0)} rows)")
-        cols = data.get("columns", [])
-        if not cols:
-            console.print("[dim]No columns defined.[/dim]")
-        else:
-            for col in sorted(cols, key=lambda c: c.get("order", 0)):
-                extra = ""
-                if col.get("options"):
-                    extra = f"  options: {', '.join(col['options'])}"
-                if col.get("required"):
-                    extra += "  REQUIRED"
-                console.print(f"  {col['name']}  [dim]({col['type']}, {col['id']})[/dim]{extra}")
-
-
-@tables_app.command("rows")
-def tables_rows(
-    table_id: str = typer.Argument(...),
-    workspace_id: str = typer.Option(None, "--ws"),
-    limit: int = typer.Option(50, "-n", "--limit"),
-    offset: int = typer.Option(0, "--offset"),
-    sort_by: str = typer.Option("", "--sort", help="Column name or ID to sort by"),
-    sort_order: str = typer.Option("asc", "--order"),
-    filters: str = typer.Option(
-        "", "--filter", help='JSON: [{"column_id":"Name","op":"eq","value":"Alice"}]'
-    ),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Read rows. --sort and --filter accept column names (auto-resolved)."""
-    with _client() as c:
-        try:
-            ws = workspace_id or _resolve_workspace()
-            table = c.get_table(ws, table_id)
-            id_to_name = {col["id"]: col["name"] for col in table.get("columns", [])}
-            resolved_sort = _resolve_sort_name(table, sort_by)
-            resolved_filters = _resolve_filter_names(table, filters) if filters else ""
-            result = c.list_table_rows(
-                ws,
-                table_id,
-                limit=limit,
-                offset=offset,
-                sort_by=resolved_sort,
-                sort_order=sort_order,
-                filters=resolved_filters,
-            )
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(result)
-    else:
-        rows = result.get("rows", []) if isinstance(result, dict) else result
-        total = result.get("total_count", len(rows)) if isinstance(result, dict) else len(rows)
-        console.print(f"[dim]Showing {len(rows)} of {total} rows[/dim]")
-        for row in rows:
-            named = {id_to_name.get(k, k): v for k, v in row.get("data", {}).items()}
-            console.print(f"  [{str(row['id'])[:8]}] {named}")
 
 
 def _parse_uploads(upload: list[str] | None) -> dict[str, str]:
@@ -3754,32 +3353,6 @@ def _get_file_meta(c: StashClient, workspace_id: str, file_id: str) -> dict:
     return c.get_ws_file(workspace_id, file_id)
 
 
-@files_app.command("list")
-def files_list(
-    workspace_id: str = typer.Option(None, "--ws"),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """List files in a workspace."""
-    ws = workspace_id or _resolve_workspace()
-    with _client() as c:
-        try:
-            data = c.list_ws_files(ws)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-        return
-    if not data:
-        console.print("[dim]No files.[/dim]")
-        return
-    for f in data:
-        size_kb = (f.get("size_bytes") or 0) / 1024
-        console.print(
-            f"  {f['id']}  [bold]{f['name']}[/bold]  "
-            f"[dim]{f.get('content_type', '')}  {size_kb:.1f} KB[/dim]"
-        )
-
-
 @files_app.command("edit-file")
 def files_edit_file(
     file_id: str = typer.Argument(...),
@@ -4008,11 +3581,11 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs "rg 'query' /workspaces"`
 - `stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"`
 
-Common reads (all support `--json`):
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — latest events
+Common reads:
+- `stash search "<query>" --json` — full-text search across files, sessions, and connected sources
+- `stash vfs "ls /workspaces"` — browse workspaces: files, sessions, tables, skills, and connected sources
+- `stash vfs "cat '/workspaces/<workspace>/sessions/_index.jsonl'"` — recent sessions
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages across workspaces
 
 Common writes:
 - `stash share --title "..."` — share this session as a public Skill
@@ -4564,8 +4137,8 @@ def _setup_complete_intro(ws_url: str) -> str:
         f"{workspace_link_section}"
         "[bold]Commands your agent can now use[/bold]\n"
         '  [#1e3a8a]stash vfs "find /workspaces -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
-        '  [#1e3a8a]stash sessions search "<query>"[/#1e3a8a]   full-text search across transcripts\n'
-        "  [#1e3a8a]stash sessions query --agent <name>[/#1e3a8a]   pull a specific agent's events\n"
+        '  [#1e3a8a]stash search "<query>"[/#1e3a8a]   full-text search across files, sessions, and sources\n'
+        "  [#1e3a8a]stash sessions agents[/#1e3a8a]   see which agents have been active\n"
         "\n"
         "Run [bold]stash --help[/bold] to see everything.\n"
         "\n"
@@ -5063,8 +4636,8 @@ Browsing Stash
 `stash ls` shows everything Stash can reach as one filesystem — workspace
 files, session transcripts, and every connected integration (GitHub, Slack,
 Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it
-and show the tree. Drill in with `stash ls <source>/<path>` and read
-documents with `stash sources read`.
+and show the tree. Drill in with `stash ls <source>/<path>`, and read a
+document with `stash vfs "cat '/workspaces/<ws>/sources/<source>/<path>'"`.
 
 Use `stash vfs` when you want to browse Stash like a filesystem without
 mounting anything into the OS. It accepts bash-shaped commands over the

--- a/cli/tests/test_history_pagination.py
+++ b/cli/tests/test_history_pagination.py
@@ -1,6 +1,5 @@
 """Tests for history pagination plumbing in the CLI."""
 
-from cli import main as cli_main
 from cli.client import StashClient
 
 
@@ -39,42 +38,3 @@ def test_all_events_client_sends_cursor_params() -> None:
             },
         )
     ]
-
-
-def test_hist_query_all_forwards_cursor_params(monkeypatch) -> None:
-    captured = {}
-
-    class FakeClient:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def all_events(self, **kwargs):
-            captured.update(kwargs)
-            return []
-
-    monkeypatch.setattr(cli_main, "_client", lambda: FakeClient())
-    monkeypatch.setattr(cli_main, "output_json", lambda data: None)
-
-    cli_main.hist_query(
-        workspace_id=None,
-        agent_name="agent",
-        event_type="note",
-        limit=7,
-        before="2026-01-02T00:00:00Z",
-        after="2026-01-01T00:00:00Z",
-        order="asc",
-        all_=True,
-        as_json=True,
-    )
-
-    assert captured == {
-        "agent_name": "agent",
-        "event_type": "note",
-        "limit": 7,
-        "before": "2026-01-02T00:00:00Z",
-        "after": "2026-01-01T00:00:00Z",
-        "order": "asc",
-    }

--- a/cli/tests/test_sources_cli.py
+++ b/cli/tests/test_sources_cli.py
@@ -61,14 +61,6 @@ def test_search_scoped_passes_the_source(monkeypatch) -> None:
     assert calls == [("search", "ws-1", "rotate", "src-9", 5)]
 
 
-def test_sources_browse_and_read(monkeypatch) -> None:
-    calls = _wire(monkeypatch)
-    main.sources_browse("src-9", "specs/", workspace_id=None, as_json=True)
-    main.sources_read("src-9", "specs/auth.md", workspace_id=None, as_json=True)
-    assert ("entries", "ws-1", "src-9", "specs/") in calls
-    assert ("read", "ws-1", "src-9", "specs/auth.md") in calls
-
-
 def test_list_source_entries_sends_path_as_query_param(monkeypatch) -> None:
     """The entries endpoint takes a query param literally named "path". The real
     client method must not collide with the helpers' URL argument (it did once:

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -57,12 +57,12 @@ stash disconnect                   # Pause event streaming across every plugin
 
 ### Files
 ```bash
-stash files tree --ws <workspace_id>                               # Show folders and pages
-stash files pages --ws <workspace_id>                              # List workspace pages
-stash files pages --all                                            # List shared pages across workspaces
+stash vfs "tree /workspaces/<workspace_id>/files"                  # Show folders and pages
+stash vfs "ls /workspaces/<workspace_id>/files"                    # List workspace pages
+stash vfs "find /workspaces -name '*.md'"                          # List shared pages across workspaces
 stash files create-folder "name" --ws <workspace_id>               # Create a folder
 stash files add-page "title" --ws <ws_id> --content "markdown content"
-stash files read-page <page_id> --ws <ws_id>                       # Read a page
+stash vfs "cat '/workspaces/<ws_id>/files/<page>.md'"             # Read a page
 stash files edit-page <page_id> --ws <ws_id> --content "new content"
 ```
 
@@ -70,14 +70,14 @@ stash files edit-page <page_id> --ws <ws_id> --content "new content"
 ```bash
 stash sessions agents --ws <workspace_id>                              # List distinct agent names
 stash sessions push "text" --ws <ws_id> --agent <name> --type <event_type>
-stash sessions query --ws <ws_id> --limit 20                           # Query events
-stash sessions search "query" --ws <ws_id>                             # Full-text search
-stash sessions query --all --limit 20                                  # Cross-workspace events
+stash vfs "cat '/workspaces/<ws_id>/sessions/_index.jsonl'"            # Query events
+stash search "query"                                                   # Full-text search
+stash vfs "find /workspaces -path '*/sessions/_index.jsonl'"           # Cross-workspace events
 ```
 
 ### Tables
 ```bash
-stash tables list --ws <workspace_id>                            # List tables
+stash vfs "cat '/workspaces/<workspace_id>/tables/_index.jsonl'" # List tables
 stash tables search <table_id> "query" --ws <workspace_id>      # Search rows
 ```
 

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -60,7 +60,7 @@ To collaborate with teammates in a shared workspace:
 
 Now everyone's activity streams to the same workspace. You can:
 - Collaborate on shared pages
-- Query each other's activity (`stash sessions query --ws <workspace_id>`)
+- Query each other's activity (`stash vfs "cat '/workspaces/<workspace_id>/sessions/_index.jsonl'"`)
 
 ---
 
@@ -106,10 +106,10 @@ The plugin also gives Claude access to the rest of the `stash` CLI. Key commands
 stash vfs "find /workspaces -maxdepth 3 -type f"                 # Browse Stash like a filesystem without an OS mount
 stash vfs "rg \"database migration\" /workspaces"                # Search the virtual Stash tree
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions search "database migration" --ws <workspace_id>   # Full-text search events
-stash sessions query --ws <workspace_id> --limit 20              # Recent events
-stash sessions query --all --limit 20                             # Cross-workspace events
-stash files pages --all                                           # List all pages
+stash search "database migration"                                # Full-text search events
+stash vfs "cat '/workspaces/<workspace_id>/sessions/_index.jsonl'"  # Recent events
+stash vfs "find /workspaces -path '*/sessions/_index.jsonl'"     # Cross-workspace events
+stash vfs "find /workspaces -name '*.md'"                        # List all pages
 ```
 
 Workspace is determined from the `.stash` manifest in the repo.

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -60,11 +60,11 @@ CONTEXT = (
     '-type f"`, `stash vfs "rg \\"query\\" /workspaces"`, or '
     "`stash vfs \"cat '/workspaces/<workspace>/README.md' | sed -n "
     "'1,80p'\"`.\n\n"
-    "Common direct reads (all support `--json`): "
-    '`stash sessions search "<query>"`, '
-    "`stash sessions query --limit 20`, "
+    "Common direct reads: "
+    '`stash search "<query>"`, '
+    "`stash vfs \"cat '/workspaces/<id>/sessions/_index.jsonl'\"`, "
     "`stash sessions agents`, "
-    "`stash files pages --all`."
+    "`stash vfs \"find /workspaces -name '*.md'\"`."
 )
 
 SESSION_CONTEXT = (

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -31,7 +31,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 ## Common reads (all support `--json`)
 
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -79,7 +79,7 @@ the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mou
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -35,7 +35,7 @@ with `${PLUGIN_ROOT}` replaced by the absolute path.
 ```
 # In Cursor, open a new chat and send any message.
 # Then from a shell:
-stash sessions query --limit 5
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
 ```
 
 You should see a `user_message` event with the prompt you just sent.
@@ -82,7 +82,7 @@ shell out to the `stash` CLI. Use `stash vfs` for filesystem-style browsing with
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -20,7 +20,7 @@ Your activity in this repo is streamed to that workspace, so teammates' agents a
 When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/plugins/gemini-plugin/GEMINI.md
+++ b/plugins/gemini-plugin/GEMINI.md
@@ -7,7 +7,7 @@ Your activity in this repo is streamed to that workspace, so teammates' agents a
 When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/plugins/gemini-plugin/README.md
+++ b/plugins/gemini-plugin/README.md
@@ -59,7 +59,7 @@ Gemini CLI has shell access. For reads mid-conversation, let the agent
 shell out to the `stash` CLI — all commands support `--json`:
 
 ```
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -84,8 +84,8 @@ so point it at the `stash` CLI for reads mid-conversation — all commands
 support `--json`:
 
 ```
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```
 

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -31,7 +31,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 ## Common reads (all support `--json`)
 
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -66,7 +66,7 @@ opencode agents have shell access. Point the agent at the `stash` CLI for reads 
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -31,7 +31,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 ## Common reads (all support `--json`)
 
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -79,7 +79,7 @@ the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mou
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -35,7 +35,7 @@ with `${PLUGIN_ROOT}` replaced by the absolute path.
 ```
 # In Cursor, open a new chat and send any message.
 # Then from a shell:
-stash sessions query --limit 5
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
 ```
 
 You should see a `user_message` event with the prompt you just sent.
@@ -82,7 +82,7 @@ shell out to the `stash` CLI. Use `stash vfs` for filesystem-style browsing with
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -20,7 +20,7 @@ Your activity in this repo is streamed to that workspace, so teammates' agents a
 When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
 Common reads (all support `--json`):
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -31,7 +31,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 
 ## Common reads (all support `--json`)
 
-- `stash sessions search "<query>"` — full-text search across transcripts
-- `stash sessions query --limit 20` — recent events
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"` — recent events
 - `stash sessions agents` — who's been active
-- `stash files pages --all` — shared pages
+- `stash vfs "find /workspaces -name '*.md'"` — shared pages

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -66,7 +66,7 @@ opencode agents have shell access. Point the agent at the `stash` CLI for reads 
 stash vfs "find /workspaces -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /workspaces"
 stash vfs "cat '/workspaces/<workspace>/README.md' | sed -n '1,80p'"
-stash sessions query --ws <id> --limit 20 --json
-stash sessions search "<query>" --ws <id> --json
+stash vfs "cat '/workspaces/<id>/sessions/_index.jsonl'"
+stash search "<query>"
 stash whoami --json
 ```


### PR DESCRIPTION
## What

Phase 1 of collapsing the CLI surface into the VFS. The VFS (`stash vfs`, `stash mount`) already exposes workspace **files, pages, sessions, tables, skills, and connected sources** as a browsable filesystem (sources landed in #639). These read-only subcommands just reprinted that same data, so they're removed and agents are pointed at the VFS instead.

### Removed (all pure reads the VFS already serves)
| Group | Removed | VFS equivalent |
|-------|---------|----------------|
| sources | `ls`, `browse`, `read` | `stash vfs "ls\|cat /workspaces/<ws>/sources/…"` |
| skills | `list`, `show` | `stash vfs "cat /workspaces/<ws>/skills/…"` |
| files | `tree`, `folders`, `pages`, `read-page`, `list` | `stash vfs "tree\|ls\|cat /workspaces/<ws>/files/…"` |
| sessions | `query`, `transcript` | `stash vfs "cat /workspaces/<ws>/sessions/…"` |
| tables | `list`, `schema`, `rows` | `stash vfs "cat /workspaces/<ws>/tables/…"` |

### Deliberately kept (VFS does **not** replicate these)
- **`stash search`** — backend full-text search; VFS `grep`/`rg` only matches already-loaded content.
- **`stash ls`** — the friendly one-shot overview / VFS front door.
- **`files text`** — extracted text (PDFs). The VFS serves *raw* file bytes (`download_ws_file`), so `cat`-ing a PDF gives binary, not text.
- **`tables count` / `export`** — aggregation / CSV transform (VFS only has `rows.json`/`rows.jsonl`).
- **`sessions agents` / `folders`**, the no-arg `stash sessions` events glance, and all writes/mutations.

## Docs
Updated CLI help, the signin/`prompts agent-guidance` text, repo `CLAUDE.md`, and every plugin doc (claude / codex / cursor / gemini / opencode / openclaw, plus the byte-identical `stashai/plugin/assets/*` twins) to use the VFS equivalents. Also fixed stray `stash sessions search` references — that command never existed (→ `stash search`).

## Testing
- `ruff check cli/` — clean
- `pytest cli/tests/ plugins/tests/` — **168 passed** (removed the 2 tests for deleted commands)
- Verified `--help` for every affected group: targeted reads gone, kept commands present.

No GUI changes (CLI/docs only), so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)