### PR TITLE
Render markdown in session messages

### DIFF
--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { useBreadcrumbs } from "../../../../components/BreadcrumbContext";
 import { useConfirm } from "../../../../components/ConfirmDialog";
 import {
@@ -601,16 +603,15 @@ function MessageRow({ turn, index }: { turn: MessageTurn; index: number }) {
               </span>
             )}
           </div>
-          <div
-            className={
-              "mt-1 whitespace-pre-wrap leading-relaxed text-foreground " +
-              (turn.toolName
-                ? "rounded-md border border-border-subtle bg-surface px-2.5 py-2 font-mono text-[12px]"
-                : "text-[13.5px]")
-            }
-          >
-            {turn.content}
-          </div>
+          {turn.toolName ? (
+            <div className="mt-1 whitespace-pre-wrap rounded-md border border-border-subtle bg-surface px-2.5 py-2 font-mono text-[12px] leading-relaxed text-foreground">
+              {turn.content}
+            </div>
+          ) : (
+            <div className="markdown-content mt-1 text-[13.5px] leading-relaxed text-foreground">
+              <Markdown remarkPlugins={[remarkGfm]}>{turn.content}</Markdown>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Session message bodies were rendered as raw `whitespace-pre-wrap` text, so markdown (headings, lists, inline code, links, etc.) showed up literally — see the `# Sleep Time Compute` / `## Steps` / numbered-list example in the screenshot.

This renders **non-tool** message content through `react-markdown` + `remark-gfm`, reusing the existing `.markdown-content` styles already used by the skill and page renderers. Tool-call bodies are left as monospace plain text since they're command output, not prose.

## Notes

- No new dependencies — `react-markdown` and `remark-gfm` are already in `frontend/package.json` and used elsewhere.
- Single-file change in `SessionClient.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)