### PR TITLE
fix: show session title in browser tab and breadcrumb

### DIFF
--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -134,7 +134,10 @@ export default function SessionViewerPage() {
   const [error, setError] = useState("");
 
   useBreadcrumbs(
-    [{ label: "Sessions" }, { label: `#${sessionId}` }],
+    [
+      { label: "Sessions" },
+      { label: sessionDetail ? sessionHeading(sessionDetail, sessionId) : `#${sessionId}` },
+    ],
     `${workspaceId}/session/${sessionId}`
   );
 
@@ -169,6 +172,11 @@ export default function SessionViewerPage() {
   useEffect(() => {
     if (user) load();
   }, [user, load]);
+
+  useEffect(() => {
+    if (!sessionDetail) return;
+    document.title = `${sessionHeading(sessionDetail, sessionId)} - Stash`;
+  }, [sessionDetail, sessionId]);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");


### PR DESCRIPTION
## What

The session viewer hard-coded the browser tab title to **"Session - Stash"** and the breadcrumb to the raw session id (`#019eaa3f-…`). Both now reflect the actual session title (e.g. *"Enable Twitter Integration for Coding Agent"*) once the session loads.

## Why

Reported: the tab title and the in-app session breadcrumb should match the session's name, like the `<h1>` already does.

## Changes

- `SessionClient.tsx`: set `document.title` to `"<session title> - Stash"` once the session detail loads.
- `SessionClient.tsx`: breadcrumb now shows the session heading instead of `#<sessionId>` once loaded (falls back to the id while loading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)