### PR TITLE
Align search popup with the search bar

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -266,6 +266,7 @@ export default function AppShell({
     () => readCachedWorkspaces(user.id)?.all ?? [],
   );
   const [cmdkOpen, setCmdkOpen] = useState(false);
+  const searchBarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSidebarCollapsed(readBool(SIDEBAR_KEY));
@@ -405,9 +406,9 @@ export default function AppShell({
         </div>
 
         <div className="flex min-w-0 flex-1 justify-center">
-          {/* Match the command-palette modal width (max-w-4xl) so the bar and
-              the popup it opens read as the same element. */}
-          <div className="w-full max-w-4xl">
+          {/* The popup measures this element on open so it lines up exactly
+              with the bar, regardless of sidebar/breadcrumb width. */}
+          <div ref={searchBarRef} className="w-full max-w-4xl">
             <TopSearchButton
               scope={searchScope}
               workspace={activeWorkspace}
@@ -457,6 +458,7 @@ export default function AppShell({
       <CommandPalette
         open={cmdkOpen}
         onClose={() => setCmdkOpen(false)}
+        anchorRef={searchBarRef}
         workspaceId={activeWorkspaceId}
         workspaceName={activeWorkspace?.name}
         searchScope={searchScope}

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -74,6 +74,7 @@ function renderPalette() {
     <CommandPalette
       open
       onClose={vi.fn()}
+      anchorRef={{ current: null }}
       workspaceId="ws-1"
       workspaceName="Demo Workspace"
       searchScope={{

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { listAllTables, semanticSearchPages, type WorkspaceSidebar } from "../lib/api";
 import {
   getCachedWorkspaceSidebar,
@@ -15,6 +15,7 @@ import { useEscapeKey } from "../hooks/useEscapeKey";
 interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
+  anchorRef: RefObject<HTMLDivElement | null>;
   workspaceId: string | null;
   workspaceName?: string | null;
   searchScope: SearchScope | null;
@@ -30,6 +31,7 @@ interface Result {
 export default function CommandPalette({
   open,
   onClose,
+  anchorRef,
   workspaceId,
   workspaceName,
   searchScope,
@@ -42,9 +44,14 @@ export default function CommandPalette({
   const [tables, setTables] = useState<TableWithWorkspace[]>([]);
   const [results, setResults] = useState<Result[]>([]);
   const [selected, setSelected] = useState(0);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEscapeKey(open, onClose);
+
+  useEffect(() => {
+    if (open) setAnchorRect(anchorRef.current?.getBoundingClientRect() ?? null);
+  }, [open, anchorRef]);
 
   useEffect(() => {
     if (!open) return;
@@ -200,9 +207,14 @@ export default function CommandPalette({
   };
 
   return (
-    <div className="fixed inset-0 z-[60] cursor-pointer bg-transparent px-2 pt-2 sm:px-4" onClick={onClose}>
+    <div className="fixed inset-0 z-[60] cursor-pointer bg-transparent" onClick={onClose}>
       <div
-        className="mx-auto flex max-h-[calc(100vh-1rem)] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border bg-base shadow-2xl"
+        className="absolute flex max-h-[calc(100vh-1rem)] flex-col overflow-hidden rounded-lg border border-border bg-base shadow-2xl"
+        style={{
+          left: anchorRect?.left,
+          top: anchorRect?.top,
+          width: anchorRect?.width,
+        }}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-label="Search"


### PR DESCRIPTION
## Problem

When you click the navbar search bar, the command palette popup did not line up horizontally with the bar. The bar is centered within the header's `flex-1` column (between the asymmetric breadcrumb/share sections), while the popup centered itself in the full viewport via `mx-auto` — two different reference frames, so they never aligned.

## Fix

On open, the popup measures the search bar's `getBoundingClientRect()` and positions itself absolutely to match the bar's `left` / `top` / `width` exactly. This makes them line up regardless of sidebar collapse state or breadcrumb width.

## Verification

Measured both elements in the running app — bar and popup dialog are now identical: `left=211, top=8, width=896`. Unit tests pass (`CommandPalette.test.tsx`).

Aligned popup (left edge + width match the bar, sitting flush with the content column):