### PR TITLE
feat: full-width layout for HTML pages

### DIFF
--- a/backend/migrations/versions/0116_html_full_width_layout.py
+++ b/backend/migrations/versions/0116_html_full_width_layout.py
@@ -1,0 +1,33 @@
+"""Allow 'full-width' as an html_layout.
+
+Adds a third layout mode to the pages.html_layout CHECK constraint. Like
+'responsive' the iframe auto-sizes its height, but the parent drops the
+1200px reading-column cap so the page uses the full window width (keeping the
+comment rail). Right for web-page-style HTML that wants real responsive room.
+
+Revision ID: 0116
+Revises: 0115
+"""
+
+from alembic import op
+
+revision = "0116"
+down_revision = "0115"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_html_layout_check")
+    op.execute(
+        "ALTER TABLE pages ADD CONSTRAINT pages_html_layout_check "
+        "CHECK (html_layout IN ('responsive', 'fixed-aspect', 'full-width'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_html_layout_check")
+    op.execute(
+        "ALTER TABLE pages ADD CONSTRAINT pages_html_layout_check "
+        "CHECK (html_layout IN ('responsive', 'fixed-aspect'))"
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -274,7 +274,7 @@ class PageCreateRequest(BaseModel):
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
     content_html: str = ""
-    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect)$")
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width)$")
 
 
 class PageUpdateRequest(BaseModel):
@@ -284,7 +284,7 @@ class PageUpdateRequest(BaseModel):
     collab_projection: bool = False
     content_type: str | None = Field(None, pattern=r"^(markdown|html)$")
     content_html: str | None = None
-    html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect)$")
+    html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect|full-width)$")
     move_to_root: bool = False
 
 
@@ -621,7 +621,7 @@ class PublishRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
-    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect)$")
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width)$")
     folder_id: UUID | None = None
 
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1983,7 +1983,8 @@ def files_add_page(
     layout: str = typer.Option(
         None,
         "--layout",
-        help="HTML layout: 'responsive' (default) or 'fixed-aspect' for 16:9 slide decks.",
+        help="HTML layout: 'responsive' (default), 'full-width' for full-window web pages, "
+        "or 'fixed-aspect' for 16:9 slide decks.",
         case_sensitive=False,
     ),
     attach: list[str] = typer.Option(
@@ -1998,9 +1999,10 @@ def files_add_page(
         raise typer.Exit(1)
     if layout is not None:
         layout = layout.lower()
-        if layout not in ("responsive", "fixed-aspect"):
+        if layout not in ("responsive", "fixed-aspect", "full-width"):
             console.print(
-                f"[red]--layout must be 'responsive' or 'fixed-aspect', got: {layout}[/red]"
+                f"[red]--layout must be 'responsive', 'fixed-aspect', or 'full-width', "
+                f"got: {layout}[/red]"
             )
             raise typer.Exit(1)
         if page_type != "html":
@@ -2065,7 +2067,8 @@ def files_edit_page(
     layout: str = typer.Option(
         None,
         "--layout",
-        help="Switch HTML layout: 'responsive' or 'fixed-aspect' (16:9 slide decks).",
+        help="Switch HTML layout: 'responsive', 'full-width' (full-window web pages), "
+        "or 'fixed-aspect' (16:9 slide decks).",
         case_sensitive=False,
     ),
     attach: list[str] = typer.Option(
@@ -2089,9 +2092,10 @@ def files_edit_page(
             raise typer.Exit(1)
     if layout is not None:
         layout = layout.lower()
-        if layout not in ("responsive", "fixed-aspect"):
+        if layout not in ("responsive", "fixed-aspect", "full-width"):
             console.print(
-                f"[red]--layout must be 'responsive' or 'fixed-aspect', got: {layout}[/red]"
+                f"[red]--layout must be 'responsive', 'fixed-aspect', or 'full-width', "
+                f"got: {layout}[/red]"
             )
             raise typer.Exit(1)
     if html_body is not None and page_type is None:

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
@@ -131,6 +131,60 @@ const emptyContents = {
   tables: [],
 };
 
+function htmlPage(html_layout: "responsive" | "fixed-aspect" | "full-width") {
+  return {
+    id: "page-1",
+    workspace_id: "ws-1",
+    folder_id: null,
+    name: "Web page",
+    content_markdown: "",
+    content_type: "html",
+    content_html: "<!doctype html><html><body><h1>hi</h1></body></html>",
+    html_layout,
+    updated_at: "2026-06-08T00:00:00Z",
+  };
+}
+
+// The page-chrome wrapper is the grid that holds <main> and the comment rail.
+function layoutWrapper(container: HTMLElement): HTMLElement {
+  const main = container.querySelector("main.min-w-0");
+  if (!main?.parentElement) throw new Error("layout wrapper not found");
+  return main.parentElement;
+}
+
+describe("SkillPageView HTML page width", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    route.search = "";
+    api.listCommentThreads.mockResolvedValue({ threads: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the 1200px reading-column cap for responsive HTML pages", async () => {
+    api.getPage.mockResolvedValue(htmlPage("responsive"));
+
+    const { container } = render(<SkillPageView />);
+    await screen.findByText("HTML page view");
+
+    expect(layoutWrapper(container).className).toContain("max-w-[1200px]");
+  });
+
+  it("drops the width cap for full-width HTML pages so they fill the window", async () => {
+    api.getPage.mockResolvedValue(htmlPage("full-width"));
+
+    const { container } = render(<SkillPageView />);
+    await screen.findByText("HTML page view");
+
+    const wrapper = layoutWrapper(container);
+    expect(wrapper.className).not.toContain("max-w-[1200px]");
+    // The comment rail stays — only the cap goes.
+    expect(wrapper.className).toContain("lg:grid-cols-[minmax(0,1fr)_240px]");
+  });
+});
+
 describe("SkillPageView access fallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -530,6 +530,9 @@ export default function SkillPageView() {
   if (!page && !error) return <DocumentPageSkeleton />;
 
   const isHtml = page?.content_type === "html";
+  // Full-width HTML drops the 1200px reading-column cap so the page gets the
+  // whole window (minus the comment rail) — room for real responsive layouts.
+  const isFullWidth = isHtml && page?.html_layout === "full-width";
   // Keep the live-update handler reading current view state without resubscribing.
   liveViewRef.current = { isHtml, htmlEditMode };
   loadRef.current = load;
@@ -693,7 +696,9 @@ export default function SkillPageView() {
       />
       <div
         ref={pageLayoutRef}
-        className="mx-auto mt-6 grid max-w-[1200px] gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px]"
+        className={`mt-6 grid gap-7 px-12 pb-20 lg:grid-cols-[minmax(0,1fr)_240px] ${
+          isFullWidth ? "" : "mx-auto max-w-[1200px]"
+        }`}
       >
         <main className="min-w-0">
           {externalEdit && (

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
-export type HtmlLayout = "responsive" | "fixed-aspect";
+// "full-width" renders exactly like "responsive" here (auto-height iframe at
+// width:100%); the difference is purely the parent's column width, set in
+// PageClient. So every check below treats anything that isn't "fixed-aspect"
+// as the responsive path.
+export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width";
 
 export type HtmlSelectionInfo = {
   quoted_text: string;
@@ -101,7 +105,7 @@ export default function HtmlPageView({
   const [activeSlide, setActiveSlide] = useState(0);
 
   const srcDoc = useMemo(() => {
-    if (layout === "responsive")
+    if (layout !== "fixed-aspect")
       return injectResizeBootstrap(initialHtml, channel, Boolean(onNavigateLink));
     if (isDeck) return injectSlideDeckBootstrap(initialHtml, channel);
     return initialHtml;
@@ -112,7 +116,7 @@ export default function HtmlPageView({
       const data = e.data;
       if (!data || typeof data !== "object" || data.channel !== channel) return;
       if (data.type === "skill:resize" && typeof data.height === "number") {
-        if (layout === "responsive") setHeight(Math.max(0, Math.ceil(data.height)));
+        if (layout !== "fixed-aspect") setHeight(Math.max(0, Math.ceil(data.height)));
         return;
       }
       if (data.type === "skill:selection") {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -551,7 +551,7 @@ export async function createPage(
   options?: {
     content_type?: "markdown" | "html";
     content_html?: string;
-    html_layout?: "responsive" | "fixed-aspect";
+    html_layout?: "responsive" | "fixed-aspect" | "full-width";
   }
 ): Promise<Page> {
   const page = await apiFetch<Page>(`/api/v1/workspaces/${workspaceId}/pages/new`, {
@@ -583,7 +583,7 @@ export async function updatePage(
     collab_projection?: boolean;
     content_type?: "markdown" | "html";
     content_html?: string;
-    html_layout?: "responsive" | "fixed-aspect";
+    html_layout?: "responsive" | "fixed-aspect" | "full-width";
     move_to_root?: boolean;
   }
 ): Promise<Page> {
@@ -1499,7 +1499,7 @@ export interface PublicSkillPage {
   content_type: "markdown" | "html";
   content_markdown: string;
   content_html: string;
-  html_layout: "responsive" | "fixed-aspect";
+  html_layout: "responsive" | "fixed-aspect" | "full-width";
   updated_at: string;
   folder_path: string[];
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,7 +46,7 @@ export interface Folder {
   updated_at: string;
 }
 
-export type HtmlLayout = "responsive" | "fixed-aspect";
+export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width";
 
 export interface Page {
   id: string;


### PR DESCRIPTION
## What

Adds a third `html_layout` value — **`full-width`** — alongside `responsive` and `fixed-aspect`.

Agents write a lot of web-page-style full HTML documents, but until now every page was trapped in the ~836px reading column (1200px page-chrome cap, minus 48px padding and the 240px comment rail). Responsive layouts (media queries, auto-fill grids, flex) never got room to breathe.

`full-width` renders identically to `responsive` inside the iframe (auto-height, `width:100%`) but **drops the 1200px reading-column cap so the page fills the window**. The 240px comment rail stays — comments keep working.

## How agents use it

```
stash page create --type html --layout full-width app.html
stash page update <id> --layout full-width
```

Default stays `responsive`, so nothing changes for existing pages.

## Changes

- **backend/models.py** — widen the `html_layout` pattern on the create / update / publish request models to allow `full-width`.
- **migration 0116** — extend the `pages.html_layout` CHECK constraint to include `full-width`.
- **cli/main.py** — accept and document `--layout full-width` on `page create` and `page update`.
- **frontend HtmlPageView** — treat anything that isn't `fixed-aspect` as the responsive path (full-width === responsive rendering inside the iframe).
- **frontend PageClient** — drop `mx-auto max-w-[1200px]` from the page-chrome grid when the page is `full-width`; keep the comment rail.
- **tests** — assert responsive keeps the 1200px cap and full-width drops it while keeping the comment rail.

## Verification

- New DOM tests in `PageClient.test.tsx` lock in the exact width branch (responsive ⟶ capped, full-width ⟶ uncapped + rail kept). Full `vitest` suite green except one pre-existing, unrelated flaky table-undo test (touches no code in this PR).
- `eslint` clean on all changed files; backend `ruff` clean; migration chain verified (0115 → 0116, single head).

> **Note on the screenshot:** the running local stack belongs to a different Docker compose project (baked images on shared ports 3456/3457), so rebuilding it from this worktree would collide with that stack. The image below is a faithful layout render using the **exact compiled Tailwind values** of the page-chrome grid (`grid-template-columns: minmax(0,1fr) 240px`, `max-width:1200px`, `padding:0 3rem`, `gap:1.75rem`) with a real responsive auto-fill card grid inside, to show the width behavior truthfully.

### Before (`responsive`) vs After (`full-width`)
Same responsive page: capped at 1200px fits ~4 cards/row; full-width fills the window and fits ~6, with the comment rail intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)