### PR TITLE
feat(linear): make Linear a navigable + searchable source

### DIFF
--- a/backend/integrations/linear/indexer.py
+++ b/backend/integrations/linear/indexer.py
@@ -1,0 +1,94 @@
+"""Linear issues → linear_index indexer (index only; search federated).
+
+A Linear source covers every issue the connected user can read. We don't copy
+issue bodies — Linear's own search is used live (see `search_linear`) and the
+description is fetched lazily on read (`fetch_linear_content`). The sync only
+builds the navigable index: one row per issue keyed by its identifier (FER-199).
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from ...services import linear_api_service, source_service
+from ..storage import get_valid_token
+
+logger = logging.getLogger(__name__)
+
+MAX_ISSUES = 5000
+SEARCH_LIMIT = 25
+
+
+def _render_issue(issue: linear_api_service.LinearIssue) -> str:
+    parts = [
+        f"# {issue.identifier} {issue.title}",
+        f"Status: {issue.status or '—'}",
+        f"Assignee: {issue.assignee_name or 'Unassigned'}",
+    ]
+    if issue.team_key or issue.team_name:
+        parts.append(f"Team: {issue.team_name or issue.team_key}")
+    if issue.project_name:
+        parts.append(f"Project: {issue.project_name}")
+    parts.append(f"URL: {issue.url}")
+    if (issue.description or "").strip():
+        parts.append(f"\n{issue.description.strip()}")
+    return "\n".join(parts)
+
+
+async def index_linear(source: dict) -> str | None:
+    """Build the navigable index only — one row per issue (identifier + title)."""
+    source_id = UUID(source["id"])
+    workspace_id = UUID(source["workspace_id"])
+    owner_user_id = UUID(source["owner_user_id"])
+
+    token = await get_valid_token(owner_user_id, "linear")
+
+    present: list[str] = []
+    cursor: str | None = None
+    while len(present) < MAX_ISSUES:
+        issues, cursor = await linear_api_service.list_issues(token, cursor)
+        for issue in issues:
+            identifier = issue["identifier"]
+            await source_service.upsert_index_row(
+                table="linear_index",
+                source_id=source_id,
+                workspace_id=workspace_id,
+                path=identifier,
+                name=f"{identifier} {issue['title']}",
+                kind="issue",
+                external_ref=identifier,
+                external_updated_at=issue["updated_at"],
+            )
+            present.append(identifier)
+        if not cursor:
+            break
+
+    await source_service.remove_missing_documents("linear_index", source_id, present)
+    logger.info("linear source %s: indexed %d issue(s)", source_id, len(present))
+    return None
+
+
+async def search_linear(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
+    """Federated search via Linear's native issue search. Returns hits keyed by
+    issue identifier (the index path)."""
+    owner_user_id = UUID(source["owner_user_id"])
+    token = await get_valid_token(owner_user_id, "linear")
+    issues = await linear_api_service.search_issues(token, query, min(limit, 50))
+    return [
+        {
+            "ref": issue["identifier"],
+            "name": f"{issue['identifier']} {issue['title']}",
+            "snippet": issue["title"],
+        }
+        for issue in issues
+    ]
+
+
+async def fetch_linear_content(owner_user_id: UUID, identifier: str) -> str:
+    """Lazy read: render a single issue. `external_ref` is the issue identifier."""
+    token = await get_valid_token(owner_user_id, "linear")
+    issue = await linear_api_service.fetch_issue(identifier, token)
+    if issue is None:
+        return ""
+    return _render_issue(issue)

--- a/backend/migrations/versions/0116_linear_source.py
+++ b/backend/migrations/versions/0116_linear_source.py
@@ -1,0 +1,42 @@
+"""Add Linear source table.
+
+Linear becomes a navigable, index-only source: `linear_index` holds one row per
+issue (identifier + title), search is federated live to Linear's API, and the
+issue body (description) is fetched lazily when a result is opened. This is in
+addition to the existing session-label enrichment, which is unchanged.
+
+Revision ID: 0116
+Revises: 0115
+"""
+
+from alembic import op
+
+revision = "0116"
+down_revision = "0115"
+branch_labels = None
+depends_on = None
+
+_BASE_COLUMNS = """
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id        uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    source_id           uuid NOT NULL REFERENCES workspace_sources(id) ON DELETE CASCADE,
+    path                text NOT NULL,
+    name                text NOT NULL,
+    kind                text NOT NULL DEFAULT 'issue',
+    external_ref        text,
+    external_updated_at timestamptz,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    deleted_at          timestamptz,
+    UNIQUE (source_id, path)
+"""
+
+
+def upgrade() -> None:
+    # No extra (source_id, path) index: the UNIQUE constraint already provides
+    # the btree the upsert's ON CONFLICT and lookups use.
+    op.execute(f"CREATE TABLE linear_index ({_BASE_COLUMNS})")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS linear_index")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -133,6 +133,14 @@ async def _resolve_twitter_source(user_id) -> tuple[str, str]:
     return me["id"], f"Twitter / X (@{username})"
 
 
+async def _resolve_linear_source(user_id) -> tuple[str, str]:
+    """A Linear source covers every issue the connected user can read, so there
+    is one canonical ref ('me'). Confirm the token exists (raises 401 if not
+    connected) before creating the source."""
+    await integration_storage.get_valid_token(user_id, "linear")
+    return "me", "Linear"
+
+
 @router.get("")
 async def list_sources(workspace_id: UUID, current_user: dict = Depends(get_current_user)):
     """Sources this user can see here: native files + sessions, plus their own
@@ -311,6 +319,9 @@ async def add_source(
     elif body.source_type == "twitter":
         external_ref, resolved_name = await _resolve_twitter_source(current_user["id"])
         display_name = resolved_name
+    elif body.source_type == "linear":
+        external_ref, resolved_name = await _resolve_linear_source(current_user["id"])
+        display_name = display_name or resolved_name
 
     if not external_ref:
         raise HTTPException(status_code=400, detail="external_ref is required")

--- a/backend/services/linear_api_service.py
+++ b/backend/services/linear_api_service.py
@@ -16,12 +16,33 @@ query Issue($id: String!) {
     id
     identifier
     title
+    description
     url
     updatedAt
     state { name }
     assignee { name }
     team { key name }
     project { name }
+  }
+}
+"""
+
+# Lists every issue the connected user can read, newest first, for the navigable
+# index. Only the fields the index needs — the body is fetched lazily on read.
+ISSUES_QUERY = """
+query Issues($after: String) {
+  issues(first: 100, after: $after, orderBy: updatedAt) {
+    nodes { identifier title updatedAt }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+"""
+
+# Linear's native full-text search, used for federated source search.
+SEARCH_QUERY = """
+query SearchIssues($term: String!, $first: Int!) {
+  searchIssues(term: $term, first: $first) {
+    nodes { identifier title }
   }
 }
 """
@@ -39,6 +60,7 @@ class LinearIssue:
     team_name: str | None
     project_name: str | None
     updated_at: datetime | None
+    description: str | None = None
 
 
 def is_configured() -> bool:
@@ -47,10 +69,7 @@ def is_configured() -> bool:
 
 async def fetch_issue(ticket_identifier: str, access_token: str) -> LinearIssue | None:
     payload = await _graphql(ISSUE_QUERY, {"id": ticket_identifier}, access_token)
-    errors = payload.get("errors")
-    if errors:
-        message = "; ".join(str(error.get("message", error)) for error in errors)
-        raise RuntimeError(f"Linear issue lookup failed: {message}")
+    _raise_on_errors(payload, "issue lookup")
 
     issue = payload.get("data", {}).get("issue")
     if not issue:
@@ -73,7 +92,52 @@ async def fetch_issue(ticket_identifier: str, access_token: str) -> LinearIssue 
         team_name=team.get("name"),
         project_name=project.get("name"),
         updated_at=_parse_datetime(updated_at) if updated_at else None,
+        description=issue.get("description"),
     )
+
+
+async def list_issues(
+    access_token: str, after: str | None = None
+) -> tuple[list[dict[str, Any]], str | None]:
+    """One page of issues the connected user can read, newest first. Returns the
+    page's lightweight rows (identifier/title/updated_at) and the next cursor, or
+    None when the listing is exhausted."""
+    payload = await _graphql(ISSUES_QUERY, {"after": after}, access_token)
+    _raise_on_errors(payload, "issue listing")
+
+    connection = payload.get("data", {}).get("issues") or {}
+    page_info = connection.get("pageInfo") or {}
+    issues = [
+        {
+            "identifier": node["identifier"],
+            "title": node.get("title") or node["identifier"],
+            "updated_at": _parse_datetime(node["updatedAt"]) if node.get("updatedAt") else None,
+        }
+        for node in connection.get("nodes") or []
+        if node.get("identifier")
+    ]
+    next_cursor = page_info.get("endCursor") if page_info.get("hasNextPage") else None
+    return issues, next_cursor
+
+
+async def search_issues(access_token: str, term: str, first: int = 25) -> list[dict[str, str]]:
+    """Linear's native full-text issue search. Returns identifier/title rows."""
+    payload = await _graphql(SEARCH_QUERY, {"term": term, "first": first}, access_token)
+    _raise_on_errors(payload, "issue search")
+
+    nodes = (payload.get("data", {}).get("searchIssues") or {}).get("nodes") or []
+    return [
+        {"identifier": node["identifier"], "title": node.get("title") or node["identifier"]}
+        for node in nodes
+        if node.get("identifier")
+    ]
+
+
+def _raise_on_errors(payload: dict[str, Any], action: str) -> None:
+    errors = payload.get("errors")
+    if errors:
+        message = "; ".join(str(error.get("message", error)) for error in errors)
+        raise RuntimeError(f"Linear {action} failed: {message}")
 
 
 async def _graphql(query: str, variables: dict[str, Any], access_token: str) -> dict[str, Any]:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -39,6 +39,9 @@ from . import security_audit_service
 
 logger = logging.getLogger(__name__)
 TWITTER_HANDLE_RE = re.compile(r"@([A-Za-z0-9_]{1,15})")
+# A Linear issue identifier (FER-199). Any such ref is readable live from the
+# API, so reads work even before a sync has indexed the issue.
+LINEAR_IDENTIFIER_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
 
 # Native source handles. Connected sources use their workspace_sources.id (str).
 NATIVE_FILES = "files"
@@ -55,6 +58,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "granola": 21600,
     "jira_project": 1800,
     "asana_project": 1800,
+    "linear": 1800,
     "gong_calls": 21600,
 }
 
@@ -68,6 +72,7 @@ SOURCE_CAPABILITY = {
     "granola": "searchable",
     "jira_project": "searchable",
     "asana_project": "navigable",
+    "linear": "navigable",
     "gong_calls": "searchable",
     "twitter": "searchable",
     # Queryable sources run live read-only SQL; they have no document table or
@@ -84,9 +89,7 @@ PROVIDER_SOURCE_TYPES = {
     "granola": ("granola",),
     "jira": ("jira_project",),
     "asana": ("asana_project",),
-    # Linear is enrichment-only (labels are scanned from transcripts, not a
-    # connected source), so disconnecting removes no source rows.
-    "linear": (),
+    "linear": ("linear",),
     "gong": ("gong_calls",),
     "snowflake": ("snowflake",),
     "twitter": ("twitter",),
@@ -115,6 +118,10 @@ def parse_jira_project_ref(external_ref: str) -> tuple[str, str]:
 def validate_source_external_ref(source_type: str, external_ref: str) -> None:
     if source_type == "jira_project":
         parse_jira_project_ref(external_ref)
+    # A Linear source always covers every issue the connected user can read, so
+    # there is one canonical ref; the router resolves it before we get here.
+    if source_type == "linear" and external_ref != "me":
+        raise ValueError("Linear external_ref must be 'me'")
 
 
 def _clean_string_list(value, field_name: str) -> list[str]:
@@ -489,6 +496,7 @@ SOURCE_TABLE = {
     "granola": "granola_notes",
     "jira_project": "jira_documents",
     "asana_project": "asana_documents",
+    "linear": "linear_index",
     "gong_calls": "gong_documents",
     "twitter": "twitter_posts",
 }
@@ -511,7 +519,14 @@ CONTENT_TABLES = {
 # Index-only source types whose `search` is federated live to the provider's
 # native search instead of our FTS (no copied content). source_type -> the
 # provider search coroutine, resolved lazily to avoid an import cycle.
-FEDERATED_SEARCH_TYPES = {"gmail", "google_drive", "jira_project", "asana_project", "twitter"}
+FEDERATED_SEARCH_TYPES = {
+    "gmail",
+    "google_drive",
+    "jira_project",
+    "asana_project",
+    "linear",
+    "twitter",
+}
 
 # Federated types excluded from UNSCOPED search fan-out: the owner's API quota
 # is metered (X free tier: one recent-search per 15 minutes), too scarce to
@@ -765,6 +780,26 @@ async def _read_twitter_live_ref(source: dict, ref: str) -> dict:
     return {**doc, "content": content, "external_ref": ref}
 
 
+async def _read_linear_live_ref(source: dict, identifier: str) -> dict | None:
+    from ..integrations.linear.indexer import fetch_linear_content
+
+    owner_user_id = UUID(source["owner_user_id"])
+    doc = {"path": identifier, "name": identifier, "kind": "issue"}
+    try:
+        content = await fetch_linear_content(owner_user_id, identifier)
+    except Exception as exc:
+        logger.warning(
+            "source document fetch failed source=%s source_type=%s exception_type=%s",
+            source["id"],
+            source["source_type"],
+            type(exc).__name__,
+        )
+        return {**doc, "content": "", "error": "source document fetch failed"}
+    if not content:
+        return None
+    return {**doc, "content": content, "external_ref": identifier}
+
+
 async def read_document(source: dict, path: str) -> dict | None:
     """Read one document. Content tables return their stored body; index-only
     tables fetch it lazily from the provider with the owner's token."""
@@ -773,6 +808,10 @@ async def read_document(source: dict, path: str) -> dict | None:
 
         if is_twitter_live_ref(path):
             return await _read_twitter_live_ref(source, path)
+
+    # Any Linear identifier is readable live, even one not yet in the index.
+    if source["source_type"] == "linear" and LINEAR_IDENTIFIER_RE.match(path):
+        return await _read_linear_live_ref(source, path)
 
     table = _table_for(source["source_type"])
     if table in CONTENT_TABLES:
@@ -891,6 +930,10 @@ async def _lazy_fetch(source: dict, external_ref: str | None) -> str:
         from ..integrations.asana.indexer import fetch_asana_content
 
         return await fetch_asana_content(owner_user_id, external_ref)
+    if source_type == "linear":
+        from ..integrations.linear.indexer import fetch_linear_content
+
+        return await fetch_linear_content(owner_user_id, external_ref)
     # twitter never reaches here: every cached path is a numeric post id, which
     # read_document already routes through the live-ref path.
     return ""
@@ -955,6 +998,8 @@ async def _federated_search(
             from ..integrations.jira.indexer import search_jira as fn
         elif source_type == "asana_project":
             from ..integrations.asana.indexer import search_asana as fn
+        elif source_type == "linear":
+            from ..integrations.linear.indexer import search_linear as fn
         elif source_type == "twitter":
             from ..integrations.twitter.indexer import search_twitter as fn
         else:

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -24,6 +24,7 @@ from ..integrations.gong.indexer import index_gong
 from ..integrations.google.indexer import index_google_drive
 from ..integrations.granola.indexer import index_granola
 from ..integrations.jira.indexer import index_jira
+from ..integrations.linear.indexer import index_linear
 from ..integrations.notion.indexer import index_notion
 from ..integrations.slack.indexer import index_slack, ingest_slack_message
 from ..services import source_service
@@ -43,6 +44,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "granola": index_granola,
     "jira_project": index_jira,
     "asana_project": index_asana,
+    "linear": index_linear,
     "gong_calls": index_gong,
 }
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -62,6 +62,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "granola": "granola",
         "jira_project": "cloud-1:PROJ_1",
         "asana_project": "asana-project-1",
+        "linear": "me",
         "gong_calls": "gong-source",
         "snowflake": "account/database/schema",
         "twitter": "111",
@@ -2694,3 +2695,136 @@ async def test_vfs_endpoints_reject_unowned_source(client: AsyncClient):
     # The owner still does not see it leak into the other member's listing.
     other_listing = await client.get(f"/api/v1/workspaces/{ws}/sources", headers=_auth(other_key))
     assert src["id"] not in {s["source"] for s in other_listing.json()["sources"]}
+
+
+# --- Linear: navigable + searchable source ----------------------------------
+
+
+async def _create_linear_source(ws: UUID, owner_id: UUID) -> dict:
+    return await source_service.create_source(
+        workspace_id=ws,
+        owner_user_id=owner_id,
+        source_type="linear",
+        external_ref="me",
+        display_name="Linear",
+    )
+
+
+@pytest.mark.asyncio
+async def test_linear_source_resolves_to_all_issues(monkeypatch):
+    """A Linear source has one canonical ref ('me') covering every issue the
+    connected user can read; the resolver only confirms the token exists."""
+
+    async def fake_token(user_id, provider):
+        assert provider == "linear"
+        return "tok"
+
+    monkeypatch.setattr(sources_router.integration_storage, "get_valid_token", fake_token)
+
+    external_ref, display_name = await sources_router._resolve_linear_source(uuid4())
+
+    assert external_ref == "me"
+    assert display_name == "Linear"
+
+
+@pytest.mark.asyncio
+async def test_linear_index_builds_navigable_issue_rows(client: AsyncClient, monkeypatch):
+    """The sync paginates the user's issues into a navigable index — one row per
+    issue keyed by its identifier — without copying the body."""
+    from backend.integrations.linear import indexer as linear_indexer
+    from backend.services import linear_api_service
+
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await _create_linear_source(ws, owner_id)
+
+    async def fake_token(user_id, provider):
+        return "tok"
+
+    pages = [
+        ([{"identifier": "FER-1", "title": "First", "updated_at": None}], "cursor-1"),
+        ([{"identifier": "FER-2", "title": "Second", "updated_at": None}], None),
+    ]
+
+    async def fake_list_issues(token, after=None):
+        return pages.pop(0)
+
+    monkeypatch.setattr(linear_indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(linear_api_service, "list_issues", fake_list_issues)
+
+    await linear_indexer.index_linear(src)
+
+    live = await source_service.list_documents(src)
+    assert {d["path"] for d in live} == {"FER-1", "FER-2"}
+    assert {d["name"] for d in live} == {"FER-1 First", "FER-2 Second"}
+
+
+@pytest.mark.asyncio
+async def test_linear_source_reads_issue_body_lazily(client: AsyncClient, monkeypatch):
+    """Reading an issue renders its body — including the description — fetched
+    live from Linear. The identifier is readable even without a prior sync."""
+    from backend.integrations.linear import indexer as linear_indexer
+    from backend.services import linear_api_service
+
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await _create_linear_source(ws, owner_id)
+
+    async def fake_token(user_id, provider):
+        return "tok"
+
+    async def fake_fetch_issue(identifier, token):
+        assert identifier == "FER-199"
+        return linear_api_service.LinearIssue(
+            issue_id="uuid-1",
+            identifier="FER-199",
+            title="Make Linear a real source",
+            url="https://linear.app/ferganalabs/issue/FER-199",
+            status="In Progress",
+            assignee_name="Henry",
+            team_key="FER",
+            team_name="Fergana",
+            project_name="Sources",
+            updated_at=None,
+            description="Stash should let agents view Linear issues.",
+        )
+
+    monkeypatch.setattr(linear_indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(linear_api_service, "fetch_issue", fake_fetch_issue)
+
+    doc = await source_service.read_document(src, "FER-199")
+
+    assert doc["path"] == "FER-199"
+    assert doc["kind"] == "issue"
+    assert "Make Linear a real source" in doc["content"]
+    assert "Status: In Progress" in doc["content"]
+    assert "Stash should let agents view Linear issues." in doc["content"]
+
+
+@pytest.mark.asyncio
+async def test_linear_federated_search_returns_issue_hits(client: AsyncClient, monkeypatch):
+    """Search is federated live to Linear's native search; hits are keyed by the
+    issue identifier (the index path the agent can then read)."""
+    from backend.integrations.linear import indexer as linear_indexer
+    from backend.services import linear_api_service
+
+    api_key, owner_id = await _register(client)
+    ws = await _create_workspace(client, api_key)
+    src = await _create_linear_source(ws, owner_id)
+
+    async def fake_token(user_id, provider):
+        return "tok"
+
+    async def fake_search_issues(token, term, first=25):
+        assert term == "real source"
+        return [{"identifier": "FER-199", "title": "Make Linear a real source"}]
+
+    monkeypatch.setattr(linear_indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(linear_api_service, "search_issues", fake_search_issues)
+
+    results = await source_service.search_all(ws, owner_id, "real source", source=src["id"])
+
+    assert any(r["ref"] == "FER-199" for r in results)
+    hit = next(r for r in results if r["ref"] == "FER-199")
+    assert hit["source"] == src["id"]
+    assert hit["name"] == "FER-199 Make Linear a real source"

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -75,7 +75,7 @@ export const CONNECTORS: Connector[] = [
     label: "Linear",
     sourceType: "linear",
     kind: "auto",
-    blurb: "Label sessions with their Linear issue status.",
+    blurb: "Search and read your Linear issues.",
   },
   {
     provider: "slack",


### PR DESCRIPTION
## What

Linear was **enrichment-only** — #635 wired up OAuth + a GraphQL client, but only to stamp ticket *labels* onto sessions. An agent could never actually *view* a Linear issue through Stash. This makes Linear a **real connected source**, so issues are browsable and searchable through the unified source layer, exactly like GitHub/Notion/Asana.

Now `stash search "FER-199"` finds the issue, and reading it returns the full body (title, status, assignee, team, project, **description**).

## How

Modeled directly on the **Asana** source — *navigable, index-only, federated search, lazy body fetch* — reusing #635's OAuth, token storage, and `linear_api_service`:

- **`linear_index` table** (migration `0116`) — one row per issue (identifier + title); no copied body.
- **`linear_api_service`** — issue query now also fetches `description`; added `list_issues` (paginated viewer issues) and `search_issues` (Linear's native search).
- **`integrations/linear/indexer.py`** (new) — `index_linear` (build the navigable index), `fetch_linear_content` (lazy body incl. description → markdown), `search_linear` (federated).
- **`source_service`** — registered `linear` across the source-type maps (`PROVIDER_SOURCE_TYPES`, `SOURCE_CAPABILITY=navigable`, `DEFAULT_SYNC_INTERVAL_S`, `SOURCE_TABLE`, `FEDERATED_SEARCH_TYPES`), plus `_lazy_fetch` + `_federated_search` branches. Any issue identifier (`FER-199`) is also readable **live**, so reads work before/independent of a sync (mirrors the Twitter live-ref precedent).
- **`tasks/sources`** — registered the indexer.
- **`routers/sources`** — `_resolve_linear_source`: a connected Linear covers **every issue the user can read** (`external_ref = "me"`), resolved server-side and created via the existing "Add" button (Linear is already `kind: "auto"` in the UI).

### Product decisions
- **Scope:** one source = all issues you can access (no per-team picker).
- **Indexing:** index + lazy fetch (Asana-style), search federated to Linear — not a full local content copy.

Session-label enrichment from #635 is **unchanged** and keeps working alongside this.

## Tests
- `backend/tests/test_sources.py`: Linear source resolution, index build, lazy body read (incl. description), and federated search — plus Linear now flows through the parametrized provider-cleanup/scoping tests.
- Full `test_sources.py` + `test_linear_ticket_service.py` pass (76 tests); enrichment still green.
- `ruff` clean on all touched backend files.

## Frontend
Only the Linear connector blurb changed ("Search and read your Linear issues."); the existing generic `auto` Add button + `providerForSourceType` already handle creation. `node_modules` isn't installed in this worktree, so the frontend lint/build wasn't run for a one-line string change — flagging for CI.

> No GUI screenshots: the only user-facing change is a connector card blurb; the rest is backend source plumbing surfaced via the agent's search/read tools and the VFS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)