### PR TITLE
Drop <title> content when sanitizing HTML pages

### DIFF
--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -103,7 +103,10 @@ def _sanitize_html(html: str) -> str:
         attributes=_SANITIZE_ATTRS,
         url_schemes=_SANITIZE_URL_SCHEMES,
         link_rel=None,
-        clean_content_tags={"script"},
+        # <title> isn't an allowed tag, so nh3 drops the tag but keeps its text —
+        # which then leaks into the body as unstyled text. Authors routinely put
+        # a <title> in their HTML, so remove its content outright.
+        clean_content_tags={"script", "title"},
         attribute_filter=_drop_unsafe_data_uri,
     )
 

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -69,6 +69,33 @@ async def test_create_page_strips_scripts_keeps_structure(workspace, _db_pool):
 
 
 @pytest.mark.asyncio
+async def test_title_text_does_not_leak_into_body(workspace, _db_pool):
+    """A full HTML document carries a <title>. nh3 drops the (disallowed) tag,
+    but without clean_content_tags it would keep the title's text and render it
+    as unstyled body text. The author's <style> must still survive."""
+    ws_id, user_id = workspace
+    doc = (
+        "<!doctype html><html><head>"
+        "<title>Gong Analysis · Acme Corp</title>"
+        "<style>h1{font-family:Fraunces}</style>"
+        "</head><body><h1>Report</h1></body></html>"
+    )
+    page = await files_tree_service.create_page(
+        workspace_id=ws_id,
+        name="Doc",
+        created_by=user_id,
+        content_type="html",
+        content_html=doc,
+    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
+    # The title text must be gone entirely — not left as a bare body text node.
+    assert "Gong Analysis" not in stored
+    # Author styling and real content are untouched.
+    assert "font-family:Fraunces" in stored
+    assert "<h1>Report</h1>" in stored
+
+
+@pytest.mark.asyncio
 async def test_content_hash_matches_sanitized_bytes(workspace, _db_pool):
     """The stored content_hash must be computed from the sanitized body, so the
     optimistic-concurrency guard on the next edit doesn't spuriously conflict."""


### PR DESCRIPTION
## Problem

HTML pages render their `<title>` as an ugly, unstyled (browser-default Arial) line at the very top of the body, above the author's styled content.

Repro: upload any complete HTML document (with `<head><title>…</title>`). The title text appears as a bare text node in the rendered page.

## Root cause

`_sanitize_html` runs `nh3.clean`. nh3 strips tags that aren't in the allowed set **but keeps their text content**. `<title>` isn't an allowed tag, so the tag is removed while `Data Retention in Sales Calls — Gong Analysis · Acme Corp` survives as a bare text node in the body — and since a `<title>` carries no CSS, it falls back to the browser default font. `<style>` *is* allowed, which is why everything else on the page stays correctly styled.

## Fix

Add `title` to `clean_content_tags` so its content is removed entirely (same treatment `<script>` already gets). Authors routinely include a `<title>` in full HTML documents, so this is the common case, not an edge case.

Verified directly against nh3:

```
BEFORE: Gong Analysis · Acme Corp<style>h1{font-family:Fraunces}</style><h1>Report</h1>
AFTER:  <style>h1{font-family:Fraunces}</style><h1>Report</h1>
```

Author `<style>` and content are untouched.

## Tests

Added `test_title_text_does_not_leak_into_body` to `test_html_sanitize.py`, pinning that the title text is gone while author styling and content survive.

> Note: the DB-backed test wasn't executed locally (this checkout has the CLI venv, not the backend test deps + Postgres test DB). The underlying nh3 sanitization behavior was verified directly, as shown above; the new test mirrors the three existing passing tests in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)