### PR TITLE
Generative-UI backend: data API, anon keys, realtime, AI, dashboard tokens

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,4 +1,7 @@
+import base64
 import hashlib
+import hmac
+import json
 import secrets
 import time
 
@@ -78,6 +81,72 @@ def verify_password(password: str, password_hash: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Dashboard tokens — short-lived, read-only, stateless (HMAC-signed)
+# ---------------------------------------------------------------------------
+# A stash-hosted dashboard runs in a sandboxed iframe that can't carry the
+# owner's session cookie or a long-lived secret. At render time we mint one of
+# these for the viewer and inject it; the dashboard reads the owner's data with
+# it until it expires. Stateless so there's no row to write per page load.
+
+DASHBOARD_TOKEN_PREFIX = "dt_"
+DASHBOARD_TOKEN_DEFAULT_TTL = 900  # 15 minutes
+
+
+def _dashboard_secret() -> bytes:
+    from .config import settings
+
+    if not settings.DASHBOARD_TOKEN_SECRET:
+        raise HTTPException(status_code=503, detail="Dashboard tokens are not enabled")
+    return settings.DASHBOARD_TOKEN_SECRET.encode()
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def mint_dashboard_token(user_id, workspace_id, ttl_seconds: int = DASHBOARD_TOKEN_DEFAULT_TTL) -> tuple[str, int]:
+    """Sign a read-only token scoped to one user + workspace. Returns (token, exp_epoch)."""
+    exp = int(time.time()) + ttl_seconds
+    payload = {"uid": str(user_id), "ws": str(workspace_id), "exp": exp}
+    body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    sig = _b64url_encode(hmac.new(_dashboard_secret(), body.encode(), hashlib.sha256).digest())
+    return f"{DASHBOARD_TOKEN_PREFIX}{body}.{sig}", exp
+
+
+async def _get_user_from_dashboard_token(token: str) -> dict:
+    raw = token[len(DASHBOARD_TOKEN_PREFIX):]
+    body, _, sig = raw.partition(".")
+    expected = _b64url_encode(hmac.new(_dashboard_secret(), body.encode(), hashlib.sha256).digest())
+    if not sig or not hmac.compare_digest(sig, expected):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid dashboard token")
+
+    payload = json.loads(_b64url_decode(body))
+    if payload["exp"] < int(time.time()):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Dashboard token expired")
+
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, name, display_name, email, description, created_at, last_seen, "
+        "       role, referral_source, use_case "
+        "FROM users WHERE id = $1",
+        payload["uid"],
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
+
+    user = dict(row)
+    user["key_id"] = None
+    user["read_only"] = True
+    user["dashboard_workspace_id"] = payload["ws"]
+    return user
+
+
+# ---------------------------------------------------------------------------
 # FastAPI dependencies
 # ---------------------------------------------------------------------------
 
@@ -151,6 +220,9 @@ async def get_current_user(
 
     if token.startswith("mc_"):
         return await _get_user_from_api_key(token, managed_auth_enabled=settings.AUTH0_ENABLED)
+
+    if token.startswith(DASHBOARD_TOKEN_PREFIX):
+        return await _get_user_from_dashboard_token(token)
 
     if settings.AUTH0_ENABLED:
         return await _get_user_from_jwt(token)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -147,6 +147,57 @@ async def _get_user_from_dashboard_token(token: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Publishable (anon) keys — workspace-scoped, browser-safe
+# ---------------------------------------------------------------------------
+# A `pk_` key identifies an app/workspace and is safe to embed in browser JS.
+# It grants nothing on its own; `shares` rows (principal_type='api_key') decide
+# which tables it can read or write (read-only unless an explicit write policy).
+
+PUBLISHABLE_KEY_PREFIX = "pk_"
+
+
+def generate_publishable_key() -> str:
+    return PUBLISHABLE_KEY_PREFIX + secrets.token_urlsafe(32)
+
+
+async def create_publishable_key(workspace_id, created_by, name: str = "default") -> str:
+    """Mint a publishable key for the workspace and persist its hash. Returns the raw key."""
+    pool = get_pool()
+    key = generate_publishable_key()
+    await pool.execute(
+        "INSERT INTO publishable_keys (workspace_id, key_hash, name, created_by) "
+        "VALUES ($1, $2, $3, $4)",
+        workspace_id,
+        hash_api_key(key),
+        name[:128],
+        created_by,
+    )
+    return key
+
+
+async def resolve_publishable_key(token: str) -> dict:
+    """Resolve a `pk_` token to {key_id, workspace_id, created_by}. 401 if unknown/revoked.
+
+    `created_by` (the key's owner) is who anon writes are attributed to.
+    """
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, workspace_id, created_by FROM publishable_keys "
+        "WHERE key_hash = $1 AND revoked_at IS NULL",
+        hash_api_key(token),
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid publishable key")
+
+    kid = str(row["id"])
+    now = time.monotonic()
+    if now - _last_seen_written.get(kid) > _LAST_SEEN_DEBOUNCE_SECONDS:
+        _last_seen_written.set(kid, now)
+        await pool.execute("UPDATE publishable_keys SET last_used_at = now() WHERE id = $1", row["id"])
+    return {"key_id": row["id"], "workspace_id": row["workspace_id"], "created_by": row["created_by"]}
+
+
+# ---------------------------------------------------------------------------
 # FastAPI dependencies
 # ---------------------------------------------------------------------------
 
@@ -206,16 +257,8 @@ async def _get_user_from_jwt(token: str) -> dict:
     return user
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials | None = Depends(security),
-) -> dict:
-    if credentials is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing Authorization header",
-        )
-
-    token: str = credentials.credentials
+async def resolve_user_token(token: str) -> dict:
+    """Resolve a bearer token (mc_ key, dashboard token, or Auth0 JWT) to a user."""
     from .config import settings
 
     if token.startswith("mc_"):
@@ -228,6 +271,17 @@ async def get_current_user(
         return await _get_user_from_jwt(token)
 
     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+    return await resolve_user_token(credentials.credentials)
 
 
 async def get_current_user_optional(

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -109,7 +109,9 @@ def _b64url_decode(value: str) -> bytes:
     return base64.urlsafe_b64decode(value + padding)
 
 
-def mint_dashboard_token(user_id, workspace_id, ttl_seconds: int = DASHBOARD_TOKEN_DEFAULT_TTL) -> tuple[str, int]:
+def mint_dashboard_token(
+    user_id, workspace_id, ttl_seconds: int = DASHBOARD_TOKEN_DEFAULT_TTL
+) -> tuple[str, int]:
     """Sign a read-only token scoped to one user + workspace. Returns (token, exp_epoch)."""
     exp = int(time.time()) + ttl_seconds
     payload = {"uid": str(user_id), "ws": str(workspace_id), "exp": exp}
@@ -119,15 +121,19 @@ def mint_dashboard_token(user_id, workspace_id, ttl_seconds: int = DASHBOARD_TOK
 
 
 async def _get_user_from_dashboard_token(token: str) -> dict:
-    raw = token[len(DASHBOARD_TOKEN_PREFIX):]
+    raw = token[len(DASHBOARD_TOKEN_PREFIX) :]
     body, _, sig = raw.partition(".")
     expected = _b64url_encode(hmac.new(_dashboard_secret(), body.encode(), hashlib.sha256).digest())
     if not sig or not hmac.compare_digest(sig, expected):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid dashboard token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid dashboard token"
+        )
 
     payload = json.loads(_b64url_decode(body))
     if payload["exp"] < int(time.time()):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Dashboard token expired")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Dashboard token expired"
+        )
 
     pool = get_pool()
     row = await pool.fetchrow(
@@ -187,14 +193,22 @@ async def resolve_publishable_key(token: str) -> dict:
         hash_api_key(token),
     )
     if not row:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid publishable key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid publishable key"
+        )
 
     kid = str(row["id"])
     now = time.monotonic()
     if now - _last_seen_written.get(kid) > _LAST_SEEN_DEBOUNCE_SECONDS:
         _last_seen_written.set(kid, now)
-        await pool.execute("UPDATE publishable_keys SET last_used_at = now() WHERE id = $1", row["id"])
-    return {"key_id": row["id"], "workspace_id": row["workspace_id"], "created_by": row["created_by"]}
+        await pool.execute(
+            "UPDATE publishable_keys SET last_used_at = now() WHERE id = $1", row["id"]
+        )
+    return {
+        "key_id": row["id"],
+        "workspace_id": row["workspace_id"],
+        "created_by": row["created_by"],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -145,9 +145,12 @@ async def _get_user_from_dashboard_token(token: str) -> dict:
     if not row:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown user")
 
+    # A dashboard token resolves to the user with their real permissions — writes
+    # are governed by check_access (their workspace role), not an artificial flag.
+    # `dashboard_workspace_id` both binds the token to one workspace and marks it
+    # as a dashboard token (so it can't be used to mint more tokens).
     user = dict(row)
     user["key_id"] = None
-    user["read_only"] = True
     user["dashboard_workspace_id"] = payload["ws"]
     return user
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -295,6 +295,12 @@ class Settings:
     STRIPE_MONTHLY_PRICE_ID: str | None = os.getenv("STRIPE_MONTHLY_PRICE_ID")
     STRIPE_ANNUAL_PRICE_ID: str | None = os.getenv("STRIPE_ANNUAL_PRICE_ID")
 
+    # --- Dashboard tokens (generative-UI backend) ---
+    # Signs the short-lived, read-only tokens that stash-hosted dashboards use
+    # to read the owner's data from a sandboxed iframe. Leave unset to disable
+    # dashboard-token minting (same on/off idiom as STRIPE_SECRET_KEY).
+    DASHBOARD_TOKEN_SECRET: str | None = parse_optional_secret("DASHBOARD_TOKEN_SECRET")
+
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from .routers import (
     agent_chat,
     agent_docs,
     aggregate,
+    ai_api,
     analytics,
     batch,
     billing,
@@ -151,6 +152,7 @@ app.include_router(billing.router)
 app.include_router(dashboard_tokens.router)
 app.include_router(data_access.router)
 app.include_router(data_api.router)
+app.include_router(ai_api.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from .routers import (
     billing,
     collab,
     dashboard_tokens,
+    data_api,
     demo,
     discover,
     exports,
@@ -145,6 +146,7 @@ app.include_router(shares.router)
 app.include_router(webhooks.router)
 app.include_router(billing.router)
 app.include_router(dashboard_tokens.router)
+app.include_router(data_api.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from .routers import (
     billing,
     collab,
     dashboard_tokens,
+    data_access,
     data_api,
     demo,
     discover,
@@ -146,6 +147,7 @@ app.include_router(shares.router)
 app.include_router(webhooks.router)
 app.include_router(billing.router)
 app.include_router(dashboard_tokens.router)
+app.include_router(data_access.router)
 app.include_router(data_api.router)
 app.include_router(exports.router)
 app.include_router(demo.router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from .routers import (
     batch,
     billing,
     collab,
+    dashboard_tokens,
     demo,
     discover,
     exports,
@@ -143,6 +144,7 @@ app.include_router(session_folders.public_router)
 app.include_router(shares.router)
 app.include_router(webhooks.router)
 app.include_router(billing.router)
+app.include_router(dashboard_tokens.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -51,7 +51,7 @@ from .routers import (
     workspace_knowledge,
     workspaces,
 )
-from .services import demo_service
+from .services import demo_service, realtime
 from .services.row_validation import RowValidationError
 
 logger = logging.getLogger("stash")
@@ -70,6 +70,7 @@ async def lifespan(app: FastAPI):
     # precompute, session summarizer) now run in the Celery `worker` and
     # `beat` services — see backend/celery_app.py.
     await init_db()
+    await realtime.start()
     try:
         await demo_service.seed_demo_workspace()
     except Exception:
@@ -77,6 +78,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        await realtime.stop()
         await close_db()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi.requests import Request
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.responses import JSONResponse, Response
 
 from . import exports as _exports  # noqa: F401 — registers exporter Celery tasks
 from . import integrations as _integrations  # noqa: F401 — registers providers + importers
@@ -142,28 +142,6 @@ app.add_middleware(
 # Added last so it's outermost — handles /rest/v1 + /ai/v1 preflight before the
 # credentialed CORS middleware would reject a cross-origin request.
 app.add_middleware(BrowserApiCORS)
-
-
-@app.get("/llms.txt", response_class=PlainTextResponse)
-async def llms_txt() -> str:
-    """Agent-facing pointer to how to build on stash. The live schema/endpoints
-    are in /openapi.json; the seeded `build-on-stash` skill has the full guide."""
-    return (
-        "# Build a UI on stash\n\n"
-        "Stash is the backend for dashboards and vibe-coded UIs. The data API is\n"
-        "PostgREST/supabase-js compatible.\n\n"
-        "## Data API\n"
-        "- GET/POST/PATCH/DELETE /rest/v1/{table} (filters col=op.value, select, order,\n"
-        "  limit/offset; Content-Range header). Joins/rpc/and/or return 501.\n"
-        "- Realtime: EventSource /rest/v1/{table}/subscribe?access_token=...\n\n"
-        "## AI (authenticated users only)\n"
-        "- POST /ai/v1/{workspace}/chat — Vercel AI SDK useChat-compatible stream.\n"
-        "- POST /ai/v1/{workspace}/search — retrieval over the workspace.\n\n"
-        "## Credentials\n"
-        "- Private (your data): POST /api/v1/dashboard-tokens -> read-only token.\n"
-        "- Public/shared: a publishable pk_ key + per-table policies (owner-created).\n\n"
-        "Full schema: /openapi.json\n"
-    )
 app.include_router(users.router)
 app.include_router(collab.router)
 app.include_router(workspaces.router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.requests import Request
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from starlette.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 
 from . import exports as _exports  # noqa: F401 — registers exporter Celery tasks
 from . import integrations as _integrations  # noqa: F401 — registers providers + importers
@@ -56,6 +57,32 @@ from .services import demo_service, realtime
 from .services.row_validation import RowValidationError
 
 logger = logging.getLogger("stash")
+
+# The browser-facing data + AI APIs are called from vibe-coded UIs on any
+# origin. They authenticate with bearer/apikey tokens (never cookies), so an
+# open CORS policy is safe here — and a null origin is allowed so a Page's
+# sandboxed iframe can call them. Other routes keep the credentialed allowlist.
+_BROWSER_API_PREFIXES = ("/rest/v1", "/ai/v1")
+_BROWSER_API_CORS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "authorization, apikey, content-type, x-stash-workspace, prefer, range",
+    "Access-Control-Expose-Headers": "Content-Range",
+    "Access-Control-Max-Age": "86400",
+}
+
+
+class BrowserApiCORS(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not request.url.path.startswith(_BROWSER_API_PREFIXES):
+            return await call_next(request)
+        if request.method == "OPTIONS":
+            return Response(status_code=204, headers=_BROWSER_API_CORS)
+        response = await call_next(request)
+        for key, value in _BROWSER_API_CORS.items():
+            response.headers[key] = value
+        return response
+
 
 SECURITY_HEADERS = {
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -112,6 +139,31 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Added last so it's outermost — handles /rest/v1 + /ai/v1 preflight before the
+# credentialed CORS middleware would reject a cross-origin request.
+app.add_middleware(BrowserApiCORS)
+
+
+@app.get("/llms.txt", response_class=PlainTextResponse)
+async def llms_txt() -> str:
+    """Agent-facing pointer to how to build on stash. The live schema/endpoints
+    are in /openapi.json; the seeded `build-on-stash` skill has the full guide."""
+    return (
+        "# Build a UI on stash\n\n"
+        "Stash is the backend for dashboards and vibe-coded UIs. The data API is\n"
+        "PostgREST/supabase-js compatible.\n\n"
+        "## Data API\n"
+        "- GET/POST/PATCH/DELETE /rest/v1/{table} (filters col=op.value, select, order,\n"
+        "  limit/offset; Content-Range header). Joins/rpc/and/or return 501.\n"
+        "- Realtime: EventSource /rest/v1/{table}/subscribe?access_token=...\n\n"
+        "## AI (authenticated users only)\n"
+        "- POST /ai/v1/{workspace}/chat — Vercel AI SDK useChat-compatible stream.\n"
+        "- POST /ai/v1/{workspace}/search — retrieval over the workspace.\n\n"
+        "## Credentials\n"
+        "- Private (your data): POST /api/v1/dashboard-tokens -> read-only token.\n"
+        "- Public/shared: a publishable pk_ key + per-table policies (owner-created).\n\n"
+        "Full schema: /openapi.json\n"
+    )
 app.include_router(users.router)
 app.include_router(collab.router)
 app.include_router(workspaces.router)

--- a/backend/migrations/versions/0117_html_full_width_layout.py
+++ b/backend/migrations/versions/0117_html_full_width_layout.py
@@ -5,14 +5,14 @@ Adds a third layout mode to the pages.html_layout CHECK constraint. Like
 1200px reading-column cap so the page uses the full window width (keeping the
 comment rail). Right for web-page-style HTML that wants real responsive room.
 
-Revision ID: 0116
-Revises: 0115
+Revision ID: 0117
+Revises: 0116
 """
 
 from alembic import op
 
-revision = "0116"
-down_revision = "0115"
+revision = "0117"
+down_revision = "0116"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/0118_publishable_keys.py
+++ b/backend/migrations/versions/0118_publishable_keys.py
@@ -19,8 +19,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         CREATE TABLE publishable_keys (
             id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
             workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -31,8 +30,7 @@ def upgrade() -> None:
             last_used_at timestamptz,
             revoked_at timestamptz
         )
-        """
-    )
+        """)
     op.execute("CREATE INDEX publishable_keys_workspace_idx ON publishable_keys (workspace_id)")
 
 

--- a/backend/migrations/versions/0118_publishable_keys.py
+++ b/backend/migrations/versions/0118_publishable_keys.py
@@ -1,0 +1,40 @@
+"""Publishable (anon) API keys for public/shared dashboards.
+
+A `pk_` key is workspace-scoped and safe to embed in browser JS. It grants
+nothing on its own — access is decided by `shares` rows with
+principal_type='api_key' and principal_id = the key's id (read-only by default;
+a write policy is an explicit row). `shares.principal_type` is free text, so no
+constraint change is needed there.
+
+Revision ID: 0118
+Revises: 0117
+"""
+
+from alembic import op
+
+revision = "0118"
+down_revision = "0117"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE publishable_keys (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            key_hash varchar(64) NOT NULL UNIQUE,
+            name varchar(128) NOT NULL DEFAULT 'default',
+            created_by uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            last_used_at timestamptz,
+            revoked_at timestamptz
+        )
+        """
+    )
+    op.execute("CREATE INDEX publishable_keys_workspace_idx ON publishable_keys (workspace_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS publishable_keys")

--- a/backend/migrations/versions/0119_html_app_layout.py
+++ b/backend/migrations/versions/0119_html_app_layout.py
@@ -1,0 +1,32 @@
+"""Allow 'app' as an html_layout — the dashboard page-kind.
+
+An 'app' page is full-width HTML that runs author JavaScript and binds to the
+data API via window.stash. It renders only inside a sandboxed iframe with a CSP
+egress-lock, so its scripts are kept (not stripped) on write.
+
+Revision ID: 0119
+Revises: 0118
+"""
+
+from alembic import op
+
+revision = "0119"
+down_revision = "0118"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_html_layout_check")
+    op.execute(
+        "ALTER TABLE pages ADD CONSTRAINT pages_html_layout_check "
+        "CHECK (html_layout IN ('responsive', 'fixed-aspect', 'full-width', 'app'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_html_layout_check")
+    op.execute(
+        "ALTER TABLE pages ADD CONSTRAINT pages_html_layout_check "
+        "CHECK (html_layout IN ('responsive', 'fixed-aspect', 'full-width'))"
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -274,7 +274,7 @@ class PageCreateRequest(BaseModel):
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
     content_html: str = ""
-    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width)$")
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width|app)$")
 
 
 class PageUpdateRequest(BaseModel):
@@ -284,7 +284,7 @@ class PageUpdateRequest(BaseModel):
     collab_projection: bool = False
     content_type: str | None = Field(None, pattern=r"^(markdown|html)$")
     content_html: str | None = None
-    html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect|full-width)$")
+    html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect|full-width|app)$")
     move_to_root: bool = False
 
 
@@ -624,7 +624,7 @@ class PublishRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     content: str = ""
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
-    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width)$")
+    html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width|app)$")
     folder_id: UUID | None = None
 
 

--- a/backend/routers/agent_docs.py
+++ b/backend/routers/agent_docs.py
@@ -28,7 +28,23 @@ Use these forms:
 The markdown homepage lists the Stash contents and links to item-level markdown
 and JSON views for progressive disclosure.
 
-""" + agent_install_pitch("https://app.joinstash.ai/skills/example") + "\n"
+""" + agent_install_pitch("https://app.joinstash.ai/skills/example") + """
+
+## Building a UI on stash
+
+Stash is also the backend for dashboards and vibe-coded UIs. The data API is
+PostgREST/supabase-js compatible — full schema at /openapi.json.
+
+- Data: GET/POST/PATCH/DELETE /rest/v1/{table} (filters col=op.value, select,
+  order, limit/offset; Content-Range header). Joins/rpc/and/or return 501.
+- Realtime: EventSource /rest/v1/{table}/subscribe?access_token=...
+- AI (authenticated users only): POST /ai/v1/{workspace}/chat is Vercel AI SDK
+  useChat-compatible; POST /ai/v1/{workspace}/search is retrieval.
+- Credentials: POST /api/v1/dashboard-tokens for a read-only token to your own
+  data; a publishable pk_ key + per-table policies for public/shared data.
+
+See the seeded "build-on-stash" skill for the full guide with examples.
+"""
 
 
 @router.get("/skill/stash/SKILL.md", response_class=PlainTextResponse)

--- a/backend/routers/agent_docs.py
+++ b/backend/routers/agent_docs.py
@@ -9,7 +9,8 @@ router = APIRouter(tags=["skill"])
 
 SKILL_PATH = Path(__file__).parent.parent / "static" / "SKILL.md"
 
-LLMS_TEXT = """# Stash
+LLMS_TEXT = (
+    """# Stash
 
 Stash is shared memory for AI-agent work. Public Stash URLs are agent-readable.
 
@@ -28,7 +29,9 @@ Use these forms:
 The markdown homepage lists the Stash contents and links to item-level markdown
 and JSON views for progressive disclosure.
 
-""" + agent_install_pitch("https://app.joinstash.ai/skills/example") + """
+"""
+    + agent_install_pitch("https://app.joinstash.ai/skills/example")
+    + """
 
 ## Building a UI on stash
 
@@ -45,6 +48,7 @@ PostgREST/supabase-js compatible — full schema at /openapi.json.
 
 See the seeded "build-on-stash" skill for the full guide with examples.
 """
+)
 
 
 @router.get("/skill/stash/SKILL.md", response_class=PlainTextResponse)

--- a/backend/routers/ai_api.py
+++ b/backend/routers/ai_api.py
@@ -88,7 +88,9 @@ async def chat(
 ):
     workspace = await _require_member(workspace_id, current_user["id"])
     if not settings.ANTHROPIC_API_KEY:
-        raise HTTPException(status_code=503, detail="The agent is not configured (ANTHROPIC_API_KEY unset)")
+        raise HTTPException(
+            status_code=503, detail="The agent is not configured (ANTHROPIC_API_KEY unset)"
+        )
 
     history = _to_history(body.messages)
     if not history:

--- a/backend/routers/ai_api.py
+++ b/backend/routers/ai_api.py
@@ -1,0 +1,111 @@
+"""Grounded AI over a workspace's data — authenticated users only.
+
+Two primitives a dashboard can drop in:
+- `POST /ai/v1/{ws}/search` — retrieval across the workspace's pages/sessions/
+  sources (wraps source_service.search_all), scoped to the user.
+- `POST /ai/v1/{ws}/chat` — the grounded agent with **read-only** tools, streamed
+  in the Vercel AI SDK data-stream format so `useChat({ api })` works drop-in.
+
+Both require a real user token (mc_/dashboard/Auth0); publishable `pk_` keys are
+rejected by get_current_user, so nobody runs the agent on the owner's tokens
+from a public page. Mutations belong on the data API, not the chat box.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from ..auth import get_current_user
+from ..config import settings
+from ..services import ai_sdk, llm, prompts, source_service, tool_loop, workspace_service
+
+router = APIRouter(prefix="/ai/v1/{workspace_id}", tags=["ai"])
+
+
+class SearchRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+    source: str | None = None
+    limit: int = Field(20, ge=1, le=100)
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str | None = None
+    parts: list[dict] | None = None
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage] = Field(..., min_length=1)
+
+
+async def _require_member(workspace_id: UUID, user_id: UUID) -> dict:
+    if not await workspace_service.is_member(workspace_id, user_id):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    workspace = await workspace_service.get_workspace(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return workspace
+
+
+@router.post("/search")
+async def search(
+    workspace_id: UUID,
+    body: SearchRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    await _require_member(workspace_id, current_user["id"])
+    results = await source_service.search_all(
+        workspace_id, current_user["id"], body.query, body.source, body.limit
+    )
+    return {"results": results or []}
+
+
+def _message_text(message: ChatMessage) -> str:
+    if message.content is not None:
+        return message.content
+    # AI SDK v5 sends typed parts; concatenate the text ones.
+    return "".join(p.get("text", "") for p in (message.parts or []) if p.get("type") == "text")
+
+
+def _to_history(messages: list[ChatMessage]) -> list[dict]:
+    history: list[dict] = []
+    for message in messages:
+        if message.role not in ("user", "assistant"):
+            continue
+        text = _message_text(message).strip()
+        if text:
+            history.append({"role": message.role, "content": text})
+    return history
+
+
+@router.post("/chat")
+async def chat(
+    workspace_id: UUID,
+    body: ChatRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    workspace = await _require_member(workspace_id, current_user["id"])
+    if not settings.ANTHROPIC_API_KEY:
+        raise HTTPException(status_code=503, detail="The agent is not configured (ANTHROPIC_API_KEY unset)")
+
+    history = _to_history(body.messages)
+    if not history:
+        raise HTTPException(status_code=400, detail="No user message")
+
+    sources = await source_service.list_sources(workspace_id, current_user["id"])
+    system = prompts.render_ask_system(workspace["name"], sources)
+    events = tool_loop.stream_tool_loop(
+        tier=llm.ModelTier.QUALITY,
+        system=system,
+        history=history,
+        workspace_id=workspace_id,
+        user_id=current_user["id"],
+        tool_set=prompts.ASK_TOOL_SET,
+    )
+    return StreamingResponse(
+        ai_sdk.to_data_stream(events),
+        media_type="text/event-stream",
+        headers=ai_sdk.DATA_STREAM_HEADERS,
+    )

--- a/backend/routers/dashboard_tokens.py
+++ b/backend/routers/dashboard_tokens.py
@@ -34,8 +34,8 @@ async def create_dashboard_token(
     body: DashboardTokenRequest,
     current_user: dict = Depends(get_current_user),
 ) -> DashboardTokenResponse:
-    # A read-only dashboard token must not be able to mint more tokens.
-    if current_user.get("read_only"):
+    # A dashboard token must not be able to mint more tokens.
+    if current_user.get("dashboard_workspace_id"):
         raise HTTPException(status_code=403, detail="Dashboard tokens cannot mint tokens")
     if not await workspace_service.is_member(body.workspace_id, current_user["id"]):
         raise HTTPException(status_code=403, detail="Not a workspace member")

--- a/backend/routers/dashboard_tokens.py
+++ b/backend/routers/dashboard_tokens.py
@@ -1,0 +1,44 @@
+"""Mint short-lived, read-only dashboard tokens.
+
+A stash-hosted dashboard runs in a sandboxed iframe that can't carry the
+owner's session cookie. The owner (a real user — `mc_`/Auth0, never another
+dashboard token) calls this to mint a token scoped to one workspace, which the
+dashboard then uses to read that workspace's data until it expires.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..auth import DASHBOARD_TOKEN_DEFAULT_TTL, get_current_user, mint_dashboard_token
+from ..services import workspace_service
+
+router = APIRouter(prefix="/api/v1/dashboard-tokens", tags=["dashboard-tokens"])
+
+MAX_TTL_SECONDS = 3600
+
+
+class DashboardTokenRequest(BaseModel):
+    workspace_id: UUID
+    ttl_seconds: int = Field(default=DASHBOARD_TOKEN_DEFAULT_TTL, ge=60, le=MAX_TTL_SECONDS)
+
+
+class DashboardTokenResponse(BaseModel):
+    token: str
+    expires_at: int
+
+
+@router.post("", response_model=DashboardTokenResponse, status_code=201)
+async def create_dashboard_token(
+    body: DashboardTokenRequest,
+    current_user: dict = Depends(get_current_user),
+) -> DashboardTokenResponse:
+    # A read-only dashboard token must not be able to mint more tokens.
+    if current_user.get("read_only"):
+        raise HTTPException(status_code=403, detail="Dashboard tokens cannot mint tokens")
+    if not await workspace_service.is_member(body.workspace_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+
+    token, exp = mint_dashboard_token(current_user["id"], body.workspace_id, body.ttl_seconds)
+    return DashboardTokenResponse(token=token, expires_at=exp)

--- a/backend/routers/data_access.py
+++ b/backend/routers/data_access.py
@@ -1,0 +1,146 @@
+"""Manage publishable (anon) keys and their per-table access policies.
+
+Owner/editor-only. A publishable key is browser-safe and grants nothing on its
+own; a policy is a `shares` row (principal_type='api_key') that lets the key
+read — or, explicitly, write — one table. Read-only is the default: a write
+policy must be asked for.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..auth import create_publishable_key, get_current_user
+from ..database import get_pool
+from ..services import table_service, workspace_service
+
+router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/publishable-keys", tags=["data-access"])
+
+POLICY_PERMISSIONS = {"read", "write"}
+
+
+class KeyCreateRequest(BaseModel):
+    name: str = Field("default", min_length=1, max_length=128)
+
+
+class PolicyRequest(BaseModel):
+    table_id: UUID
+    permission: str = Field("read", pattern=r"^(read|write)$")
+
+
+async def _require_owner(workspace_id: UUID, user_id: UUID) -> None:
+    if not await workspace_service.can_write(workspace_id, user_id):
+        raise HTTPException(status_code=403, detail="Only workspace owners/editors can manage keys")
+
+
+async def _require_key(workspace_id: UUID, key_id: UUID) -> None:
+    pool = get_pool()
+    found = await pool.fetchval(
+        "SELECT 1 FROM publishable_keys WHERE id = $1 AND workspace_id = $2", key_id, workspace_id
+    )
+    if not found:
+        raise HTTPException(status_code=404, detail="No such publishable key")
+
+
+@router.post("", status_code=201)
+async def create_key(
+    workspace_id: UUID,
+    body: KeyCreateRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    await _require_owner(workspace_id, current_user["id"])
+    # The raw key is returned exactly once; only its hash is stored.
+    key = await create_publishable_key(workspace_id, current_user["id"], body.name)
+    return {"name": body.name, "key": key}
+
+
+@router.get("")
+async def list_keys(
+    workspace_id: UUID,
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    await _require_owner(workspace_id, current_user["id"])
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT id, name, created_at, last_used_at, revoked_at FROM publishable_keys "
+        "WHERE workspace_id = $1 ORDER BY created_at DESC",
+        workspace_id,
+    )
+    return [dict(r) for r in rows]
+
+
+@router.delete("/{key_id}", status_code=204)
+async def revoke_key(
+    workspace_id: UUID,
+    key_id: UUID,
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    await _require_owner(workspace_id, current_user["id"])
+    await _require_key(workspace_id, key_id)
+    pool = get_pool()
+    await pool.execute("UPDATE publishable_keys SET revoked_at = now() WHERE id = $1", key_id)
+
+
+@router.put("/{key_id}/policies", status_code=201)
+async def set_policy(
+    workspace_id: UUID,
+    key_id: UUID,
+    body: PolicyRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    await _require_owner(workspace_id, current_user["id"])
+    await _require_key(workspace_id, key_id)
+    table = await table_service.get_table_metadata(body.table_id)
+    if not table or table["workspace_id"] != workspace_id:
+        raise HTTPException(status_code=404, detail="No such table in this workspace")
+
+    pool = get_pool()
+    await pool.execute(
+        "INSERT INTO shares (workspace_id, object_type, object_id, principal_type, "
+        "principal_id, permission, created_by) "
+        "VALUES ($1, 'table', $2, 'api_key', $3, $4, $5) "
+        "ON CONFLICT (object_type, object_id, principal_type, principal_id) "
+        "DO UPDATE SET permission = EXCLUDED.permission",
+        workspace_id,
+        body.table_id,
+        key_id,
+        body.permission,
+        current_user["id"],
+    )
+    return {"table_id": str(body.table_id), "permission": body.permission}
+
+
+@router.get("/{key_id}/policies")
+async def list_policies(
+    workspace_id: UUID,
+    key_id: UUID,
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    await _require_owner(workspace_id, current_user["id"])
+    await _require_key(workspace_id, key_id)
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT object_id AS table_id, permission FROM shares "
+        "WHERE principal_type = 'api_key' AND principal_id = $1 AND object_type = 'table'",
+        key_id,
+    )
+    return [dict(r) for r in rows]
+
+
+@router.delete("/{key_id}/policies/{table_id}", status_code=204)
+async def remove_policy(
+    workspace_id: UUID,
+    key_id: UUID,
+    table_id: UUID,
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    await _require_owner(workspace_id, current_user["id"])
+    await _require_key(workspace_id, key_id)
+    pool = get_pool()
+    await pool.execute(
+        "DELETE FROM shares WHERE principal_type = 'api_key' AND principal_id = $1 "
+        "AND object_type = 'table' AND object_id = $2",
+        key_id,
+        table_id,
+    )

--- a/backend/routers/data_access.py
+++ b/backend/routers/data_access.py
@@ -15,7 +15,9 @@ from ..auth import create_publishable_key, get_current_user
 from ..database import get_pool
 from ..services import table_service, workspace_service
 
-router = APIRouter(prefix="/api/v1/workspaces/{workspace_id}/publishable-keys", tags=["data-access"])
+router = APIRouter(
+    prefix="/api/v1/workspaces/{workspace_id}/publishable-keys", tags=["data-access"]
+)
 
 POLICY_PERMISSIONS = {"read", "write"}
 

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -89,8 +89,8 @@ async def _load_table(
     row = await table_service.get_table_by_name(workspace_id, table)
     if not row:
         raise HTTPException(status_code=404, detail=f"No table named '{table}'")
-    if require != "read" and user.get("read_only"):
-        raise HTTPException(status_code=403, detail="This token is read-only")
+    # Writes (including via a dashboard token) are governed by the user's real
+    # workspace role — a viewer still can't write; an owner/editor can.
     allowed = await permission_service.check_access(
         "table", row["id"], user["id"], workspace_id=workspace_id, require=require
     )

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -1,10 +1,15 @@
 """PostgREST/supabase-js-compatible data API over stash tables.
 
-A dashboard (or any vibe-coded UI) reads and writes the owner's tables through
+A dashboard (or any vibe-coded UI) reads and writes tables through
 `/rest/v1/{table}` using `supabase-js` or plain fetch — the grammar agents
-already know. Auth is the caller's stash identity (an `mc_` token or a
-short-lived read-only dashboard token); the workspace comes from a dashboard
-token's binding or the `X-Stash-Workspace` header for `mc_` callers.
+already know. Callers authenticate one of two ways:
+
+- **User token** (`mc_` or a short-lived read-only dashboard token) — sees the
+  owner's own data. Workspace comes from a dashboard token's binding or the
+  `X-Stash-Workspace` header for `mc_` callers.
+- **Publishable key** (`pk_`, in the `apikey` or Authorization header) — the
+  public/shared path. Workspace comes from the key; access is whatever explicit
+  table policies grant (read-only unless a write policy exists).
 
 Translation of the query grammar lives in `services/postgrest.py`; this router
 does auth, table resolution, and the DB calls, and fails loud (501) on real
@@ -15,13 +20,33 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
-from ..auth import get_current_user
+from .. import auth
 from ..services import permission_service, postgrest, table_service, workspace_service
 
 router = APIRouter(prefix="/rest/v1", tags=["data-api"])
 
 
-async def _resolve_workspace(request: Request, user: dict) -> UUID:
+def _token(request: Request) -> str:
+    """supabase-js sends the key in both `apikey` and `Authorization: Bearer`."""
+    header = request.headers.get("authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[len("bearer "):].strip()
+    apikey = request.headers.get("apikey")
+    if apikey:
+        return apikey
+    raise HTTPException(status_code=401, detail="Missing credentials")
+
+
+async def data_principal(request: Request) -> dict:
+    """Resolve the caller to a user principal or an anon (publishable-key) principal."""
+    token = _token(request)
+    if token.startswith(auth.PUBLISHABLE_KEY_PREFIX):
+        info = await auth.resolve_publishable_key(token)
+        return {"kind": "api_key", **info}
+    return {"kind": "user", "user": await auth.resolve_user_token(token)}
+
+
+async def _user_workspace(request: Request, user: dict) -> UUID:
     """A dashboard token is workspace-bound; an mc_ caller names it via header."""
     bound = user.get("dashboard_workspace_id")
     if bound:
@@ -35,8 +60,22 @@ async def _resolve_workspace(request: Request, user: dict) -> UUID:
     return workspace_id
 
 
-async def _load_table(request: Request, table: str, user: dict, *, require: str) -> dict:
-    workspace_id = await _resolve_workspace(request, user)
+async def _load_table(request: Request, principal: dict, table: str, *, require: str) -> tuple[dict, UUID]:
+    """Resolve the table by name, authorize the principal, and return (table, writer_id)."""
+    if principal["kind"] == "api_key":
+        workspace_id = principal["workspace_id"]
+        row = await table_service.get_table_by_name(workspace_id, table)
+        if not row:
+            raise HTTPException(status_code=404, detail=f"No table named '{table}'")
+        allowed = await permission_service.check_anon_access(
+            "table", row["id"], principal["key_id"], require
+        )
+        if not allowed:
+            raise HTTPException(status_code=403, detail="Not allowed")
+        return row, principal["created_by"]
+
+    user = principal["user"]
+    workspace_id = await _user_workspace(request, user)
     row = await table_service.get_table_by_name(workspace_id, table)
     if not row:
         raise HTTPException(status_code=404, detail=f"No table named '{table}'")
@@ -47,7 +86,7 @@ async def _load_table(request: Request, table: str, user: dict, *, require: str)
     )
     if not allowed:
         raise HTTPException(status_code=403, detail="Not allowed")
-    return row
+    return row, user["id"]
 
 
 def _translate(exc: Exception) -> HTTPException:
@@ -72,9 +111,9 @@ async def list_rows(
     table: str,
     request: Request,
     response: Response,
-    current_user: dict = Depends(get_current_user),
+    principal: dict = Depends(data_principal),
 ):
-    row = await _load_table(request, table, current_user, require="read")
+    row, _writer = await _load_table(request, principal, table, require="read")
     columns = row["columns"]
     params = list(request.query_params.multi_items())
     try:
@@ -98,16 +137,16 @@ async def list_rows(
 async def insert_rows(
     table: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    principal: dict = Depends(data_principal),
 ):
-    row = await _load_table(request, table, current_user, require="write")
+    row, writer = await _load_table(request, principal, table, require="write")
     body = await request.json()
     columns = row["columns"]
     # RowValidationError (422) is handled globally in main.py.
     if isinstance(body, list):
-        created = await table_service.create_rows_batch(row["id"], body, current_user["id"])
+        created = await table_service.create_rows_batch(row["id"], body, writer)
         return [postgrest.row_to_named(r, columns, None) for r in created]
-    created = await table_service.create_row(row["id"], body, current_user["id"])
+    created = await table_service.create_row(row["id"], body, writer)
     return postgrest.row_to_named(created, columns, None)
 
 
@@ -115,13 +154,13 @@ async def insert_rows(
 async def update_rows(
     table: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    principal: dict = Depends(data_principal),
 ):
-    row = await _load_table(request, table, current_user, require="write")
+    row, writer = await _load_table(request, principal, table, require="write")
     row_id = _require_row_id(request)
     body = await request.json()
     # RowValidationError (422) is handled globally in main.py.
-    updated = await table_service.update_row(row_id, body, current_user["id"], table_id=row["id"])
+    updated = await table_service.update_row(row_id, body, writer, table_id=row["id"])
     if not updated:
         raise HTTPException(status_code=404, detail="Row not found")
     return postgrest.row_to_named(updated, row["columns"], None)
@@ -131,9 +170,9 @@ async def update_rows(
 async def delete_rows(
     table: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    principal: dict = Depends(data_principal),
 ):
-    row = await _load_table(request, table, current_user, require="write")
+    row, _writer = await _load_table(request, principal, table, require="write")
     row_id = _require_row_id(request)
     deleted = await table_service.delete_row(row_id, table_id=row["id"])
     if not deleted:

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -118,6 +118,29 @@ def _require_row_id(request: Request) -> UUID:
         raise HTTPException(status_code=400, detail="id=eq.<row id> must be a UUID")
 
 
+def _optional_row_id(request: Request, columns: list[dict]) -> UUID | None:
+    """A GET `?id=eq.<uuid>` fetches one row by its id — the supabase `.eq('id', x)`
+    pattern. `id` is the row's id, not a JSONB cell, so it can't go through the
+    column filter path. Returns None when no id filter is present (or when the
+    table actually has a user column named 'id', which then filters normally)."""
+    if any(c["name"] == "id" for c in columns):
+        return None
+    items = [
+        (k, v) for k, v in request.query_params.multi_items() if k not in postgrest.RESERVED_PARAMS
+    ]
+    id_values = [v for k, v in items if k == "id"]
+    if not id_values:
+        return None
+    if len(items) != 1 or not id_values[0].startswith("eq."):
+        raise HTTPException(
+            status_code=400, detail="id must be the only filter and use id=eq.<row id>"
+        )
+    try:
+        return UUID(id_values[0][len("eq.") :])
+    except ValueError:
+        raise HTTPException(status_code=400, detail="id=eq.<row id> must be a UUID")
+
+
 @router.get("/{table}")
 async def list_rows(
     table: str,
@@ -127,6 +150,20 @@ async def list_rows(
 ):
     row, _writer = await _load_table(request, principal, table, require="read")
     columns = row["columns"]
+
+    # Single-row fetch by id (supabase .eq('id', x)) — id is the row id, not a cell.
+    row_id = _optional_row_id(request, columns)
+    if row_id is not None:
+        try:
+            project = postgrest.parse_select(request.query_params.get("select"), columns)
+        except (postgrest.UnsupportedQuery, postgrest.BadQuery) as exc:
+            raise _translate(exc)
+        one = await table_service.get_row(row_id)
+        found = [one] if one and str(one["table_id"]) == str(row["id"]) else []
+        out = [postgrest.row_to_named(r, columns, project) for r in found]
+        response.headers["Content-Range"] = postgrest.content_range(0, len(out), len(out))
+        return out
+
     params = list(request.query_params.multi_items())
     try:
         filters = postgrest.parse_filters(params, columns)

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -141,6 +141,34 @@ def _optional_row_id(request: Request, columns: list[dict]) -> UUID | None:
         raise HTTPException(status_code=400, detail="id=eq.<row id> must be a UUID")
 
 
+@router.get("")
+async def list_schema(request: Request, principal: dict = Depends(data_principal)):
+    """Supabase-style schema introspection: the workspace's readable tables + columns.
+
+    Lets a dashboard (or agent) discover what to query before hitting `/rest/v1/{table}`.
+    A user sees every table they can read; an anon key sees only tables it has a policy for.
+    """
+    if principal["kind"] == "api_key":
+        tables = await table_service.list_tables(principal["workspace_id"], None)
+        readable = [
+            t
+            for t in tables
+            if await permission_service.check_anon_access(
+                "table", t["id"], principal["key_id"], "read"
+            )
+        ]
+    else:
+        user = principal["user"]
+        workspace_id = await _user_workspace(request, user)
+        readable = await table_service.list_tables(workspace_id, user["id"])
+
+    return {
+        "tables": [
+            {"name": t["name"], "id": str(t["id"]), "columns": t["columns"]} for t in readable
+        ]
+    }
+
+
 @router.get("/{table}")
 async def list_rows(
     table: str,

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -35,7 +35,7 @@ def _token(request: Request) -> str:
     """supabase-js sends the key in both `apikey` and `Authorization: Bearer`."""
     header = request.headers.get("authorization", "")
     if header.lower().startswith("bearer "):
-        return header[len("bearer "):].strip()
+        return header[len("bearer ") :].strip()
     apikey = request.headers.get("apikey")
     if apikey:
         return apikey
@@ -68,7 +68,9 @@ async def _user_workspace(request: Request, user: dict) -> UUID:
     return workspace_id
 
 
-async def _load_table(request: Request, principal: dict, table: str, *, require: str) -> tuple[dict, UUID]:
+async def _load_table(
+    request: Request, principal: dict, table: str, *, require: str
+) -> tuple[dict, UUID]:
     """Resolve the table by name, authorize the principal, and return (table, writer_id)."""
     if principal["kind"] == "api_key":
         workspace_id = principal["workspace_id"]
@@ -105,11 +107,13 @@ def _translate(exc: Exception) -> HTTPException:
 
 def _require_row_id(request: Request) -> UUID:
     """PATCH/DELETE target a single row via `?id=eq.<uuid>` (the only supported filter)."""
-    items = [(k, v) for k, v in request.query_params.multi_items() if k not in postgrest.RESERVED_PARAMS]
+    items = [
+        (k, v) for k, v in request.query_params.multi_items() if k not in postgrest.RESERVED_PARAMS
+    ]
     if len(items) != 1 or items[0][0] != "id" or not items[0][1].startswith("eq."):
         raise HTTPException(status_code=400, detail="Mutations require exactly id=eq.<row id>")
     try:
-        return UUID(items[0][1][len("eq."):])
+        return UUID(items[0][1][len("eq.") :])
     except ValueError:
         raise HTTPException(status_code=400, detail="id=eq.<row id> must be a UUID")
 
@@ -134,7 +138,12 @@ async def list_rows(
     limit = _int_param(request, "limit", 100)
     offset = _int_param(request, "offset", 0)
     rows, total = await table_service.list_rows(
-        row["id"], filters=filters, sort_by=sort_by, sort_order=sort_order, limit=limit, offset=offset
+        row["id"],
+        filters=filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
     )
     out = [postgrest.row_to_named(r, columns, project) for r in rows]
     response.headers["Content-Range"] = postgrest.content_range(offset, len(out), total)

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -1,0 +1,151 @@
+"""PostgREST/supabase-js-compatible data API over stash tables.
+
+A dashboard (or any vibe-coded UI) reads and writes the owner's tables through
+`/rest/v1/{table}` using `supabase-js` or plain fetch — the grammar agents
+already know. Auth is the caller's stash identity (an `mc_` token or a
+short-lived read-only dashboard token); the workspace comes from a dashboard
+token's binding or the `X-Stash-Workspace` header for `mc_` callers.
+
+Translation of the query grammar lives in `services/postgrest.py`; this router
+does auth, table resolution, and the DB calls, and fails loud (501) on real
+PostgREST features stash doesn't implement.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+
+from ..auth import get_current_user
+from ..services import permission_service, postgrest, table_service, workspace_service
+
+router = APIRouter(prefix="/rest/v1", tags=["data-api"])
+
+
+async def _resolve_workspace(request: Request, user: dict) -> UUID:
+    """A dashboard token is workspace-bound; an mc_ caller names it via header."""
+    bound = user.get("dashboard_workspace_id")
+    if bound:
+        return UUID(bound)
+    header = request.headers.get("x-stash-workspace")
+    if not header:
+        raise HTTPException(status_code=400, detail="Missing X-Stash-Workspace header")
+    workspace_id = UUID(header)
+    if not await workspace_service.is_member(workspace_id, user["id"]):
+        raise HTTPException(status_code=403, detail="Not a workspace member")
+    return workspace_id
+
+
+async def _load_table(request: Request, table: str, user: dict, *, require: str) -> dict:
+    workspace_id = await _resolve_workspace(request, user)
+    row = await table_service.get_table_by_name(workspace_id, table)
+    if not row:
+        raise HTTPException(status_code=404, detail=f"No table named '{table}'")
+    if require != "read" and user.get("read_only"):
+        raise HTTPException(status_code=403, detail="This token is read-only")
+    allowed = await permission_service.check_access(
+        "table", row["id"], user["id"], workspace_id=workspace_id, require=require
+    )
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return row
+
+
+def _translate(exc: Exception) -> HTTPException:
+    if isinstance(exc, postgrest.UnsupportedQuery):
+        return HTTPException(status_code=501, detail=str(exc))
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+def _require_row_id(request: Request) -> UUID:
+    """PATCH/DELETE target a single row via `?id=eq.<uuid>` (the only supported filter)."""
+    items = [(k, v) for k, v in request.query_params.multi_items() if k not in postgrest.RESERVED_PARAMS]
+    if len(items) != 1 or items[0][0] != "id" or not items[0][1].startswith("eq."):
+        raise HTTPException(status_code=400, detail="Mutations require exactly id=eq.<row id>")
+    try:
+        return UUID(items[0][1][len("eq."):])
+    except ValueError:
+        raise HTTPException(status_code=400, detail="id=eq.<row id> must be a UUID")
+
+
+@router.get("/{table}")
+async def list_rows(
+    table: str,
+    request: Request,
+    response: Response,
+    current_user: dict = Depends(get_current_user),
+):
+    row = await _load_table(request, table, current_user, require="read")
+    columns = row["columns"]
+    params = list(request.query_params.multi_items())
+    try:
+        filters = postgrest.parse_filters(params, columns)
+        project = postgrest.parse_select(request.query_params.get("select"), columns)
+        sort_by, sort_order = postgrest.parse_order(request.query_params.get("order"), columns)
+    except (postgrest.UnsupportedQuery, postgrest.BadQuery) as exc:
+        raise _translate(exc)
+
+    limit = _int_param(request, "limit", 100)
+    offset = _int_param(request, "offset", 0)
+    rows, total = await table_service.list_rows(
+        row["id"], filters=filters, sort_by=sort_by, sort_order=sort_order, limit=limit, offset=offset
+    )
+    out = [postgrest.row_to_named(r, columns, project) for r in rows]
+    response.headers["Content-Range"] = postgrest.content_range(offset, len(out), total)
+    return out
+
+
+@router.post("/{table}", status_code=201)
+async def insert_rows(
+    table: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    row = await _load_table(request, table, current_user, require="write")
+    body = await request.json()
+    columns = row["columns"]
+    # RowValidationError (422) is handled globally in main.py.
+    if isinstance(body, list):
+        created = await table_service.create_rows_batch(row["id"], body, current_user["id"])
+        return [postgrest.row_to_named(r, columns, None) for r in created]
+    created = await table_service.create_row(row["id"], body, current_user["id"])
+    return postgrest.row_to_named(created, columns, None)
+
+
+@router.patch("/{table}")
+async def update_rows(
+    table: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    row = await _load_table(request, table, current_user, require="write")
+    row_id = _require_row_id(request)
+    body = await request.json()
+    # RowValidationError (422) is handled globally in main.py.
+    updated = await table_service.update_row(row_id, body, current_user["id"], table_id=row["id"])
+    if not updated:
+        raise HTTPException(status_code=404, detail="Row not found")
+    return postgrest.row_to_named(updated, row["columns"], None)
+
+
+@router.delete("/{table}", status_code=204)
+async def delete_rows(
+    table: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    row = await _load_table(request, table, current_user, require="write")
+    row_id = _require_row_id(request)
+    deleted = await table_service.delete_row(row_id, table_id=row["id"])
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Row not found")
+    return Response(status_code=204)
+
+
+def _int_param(request: Request, name: str, default: int) -> int:
+    raw = request.query_params.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"{name} must be an integer")

--- a/backend/routers/data_api.py
+++ b/backend/routers/data_api.py
@@ -16,14 +16,19 @@ does auth, table resolution, and the DB calls, and fails loud (501) on real
 PostgREST features stash doesn't implement.
 """
 
+import asyncio
+import json
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import StreamingResponse
 
 from .. import auth
-from ..services import permission_service, postgrest, table_service, workspace_service
+from ..services import permission_service, postgrest, realtime, table_service, workspace_service
 
 router = APIRouter(prefix="/rest/v1", tags=["data-api"])
+
+_HEARTBEAT_S = 25
 
 
 def _token(request: Request) -> str:
@@ -37,13 +42,16 @@ def _token(request: Request) -> str:
     raise HTTPException(status_code=401, detail="Missing credentials")
 
 
-async def data_principal(request: Request) -> dict:
-    """Resolve the caller to a user principal or an anon (publishable-key) principal."""
-    token = _token(request)
+async def _principal_from_token(token: str) -> dict:
     if token.startswith(auth.PUBLISHABLE_KEY_PREFIX):
         info = await auth.resolve_publishable_key(token)
         return {"kind": "api_key", **info}
     return {"kind": "user", "user": await auth.resolve_user_token(token)}
+
+
+async def data_principal(request: Request) -> dict:
+    """Resolve the caller to a user principal or an anon (publishable-key) principal."""
+    return await _principal_from_token(_token(request))
 
 
 async def _user_workspace(request: Request, user: dict) -> UUID:
@@ -131,6 +139,40 @@ async def list_rows(
     out = [postgrest.row_to_named(r, columns, project) for r in rows]
     response.headers["Content-Range"] = postgrest.content_range(offset, len(out), total)
     return out
+
+
+@router.get("/{table}/subscribe")
+async def subscribe(table: str, request: Request):
+    """SSE stream of row-change nudges for the table. Browsers consume this with
+    `EventSource`, which can't set headers — so the token rides as `?access_token=`
+    (the short-lived read-only dashboard token, or a publishable key)."""
+    token = request.query_params.get("access_token") or request.query_params.get("apikey")
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing access_token")
+    principal = await _principal_from_token(token)
+    row, _writer = await _load_table(request, principal, table, require="read")
+    key = realtime.table_key(row["id"])
+
+    async def event_stream():
+        queue = realtime.subscribe(key)
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_S)
+                except TimeoutError:
+                    yield ": heartbeat\n\n"
+                    continue
+                yield f"data: {json.dumps(event)}\n\n"
+        finally:
+            realtime.unsubscribe(key, queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @router.post("/{table}", status_code=201)

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -586,11 +586,15 @@ async def download_page(
     media = "text/html; charset=utf-8" if is_html else "text/markdown; charset=utf-8"
     name = page.get("name") or "page"
     filename = name if name.lower().endswith(suffix) else f"{name}{suffix}"
+    # HTML must never execute on this origin (it can carry author scripts for
+    # 'app' dashboard pages). Force a download instead of inline rendering.
+    disposition = "attachment" if is_html else "inline"
     return Response(
         content=body,
         media_type=media,
         headers={
-            "Content-Disposition": f"inline; filename*=UTF-8''{quote(filename)}",
+            "Content-Disposition": f"{disposition}; filename*=UTF-8''{quote(filename)}",
+            "X-Content-Type-Options": "nosniff",
         },
     )
 

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -66,10 +66,13 @@ async def upload_transcript(
         raise HTTPException(status_code=400, detail="Session uploads must be .JSONL files")
     if not session_id.strip():
         raise HTTPException(status_code=400, detail="session_id is required")
-    if session_folder_id is not None and not await session_folder_service.can_add_session_to_folder(
-        workspace_id=workspace_id,
-        user_id=current_user["id"],
-        folder_id=session_folder_id,
+    if (
+        session_folder_id is not None
+        and not await session_folder_service.can_add_session_to_folder(
+            workspace_id=workspace_id,
+            user_id=current_user["id"],
+            folder_id=session_folder_id,
+        )
     ):
         raise HTTPException(status_code=404, detail="Session folder not found")
 

--- a/backend/services/ai_sdk.py
+++ b/backend/services/ai_sdk.py
@@ -41,7 +41,9 @@ async def to_data_stream(events: AsyncIterator[dict]) -> AsyncIterator[str]:
                 },
             )
         elif kind == "tool_result":
-            yield _line("a", {"toolCallId": event.get("id"), "result": {"ok": event.get("ok", True)}})
+            yield _line(
+                "a", {"toolCallId": event.get("id"), "result": {"ok": event.get("ok", True)}}
+            )
         elif kind == "end":
             saw_end = True
             yield _line("d", _FINISH)

--- a/backend/services/ai_sdk.py
+++ b/backend/services/ai_sdk.py
@@ -1,0 +1,49 @@
+"""Map stash tool-loop events to the Vercel AI SDK data-stream protocol (v1).
+
+`useChat()` consumes this drop-in (its default `streamProtocol: 'data'`): each
+line is `<code>:<json>\n`. We translate our {text|tool|tool_result|end} events to
+text parts (0:), tool calls (9:), tool results (a:), and a finish part (d:).
+Responses must carry the `x-vercel-ai-data-stream: v1` header below.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+DATA_STREAM_HEADERS = {
+    "x-vercel-ai-data-stream": "v1",
+    "Cache-Control": "no-cache",
+    "X-Accel-Buffering": "no",
+}
+
+_FINISH = {"finishReason": "stop", "usage": {"promptTokens": 0, "completionTokens": 0}}
+
+
+def _line(code: str, value) -> str:
+    return f"{code}:{json.dumps(value, separators=(',', ':'))}\n"
+
+
+async def to_data_stream(events: AsyncIterator[dict]) -> AsyncIterator[str]:
+    """Translate tool-loop event dicts into AI SDK data-stream lines."""
+    saw_end = False
+    async for event in events:
+        kind = event.get("type")
+        if kind == "text":
+            yield _line("0", event.get("delta") or "")
+        elif kind == "tool":
+            yield _line(
+                "9",
+                {
+                    "toolCallId": event.get("id"),
+                    "toolName": event.get("name"),
+                    "args": event.get("args") or {},
+                },
+            )
+        elif kind == "tool_result":
+            yield _line("a", {"toolCallId": event.get("id"), "result": {"ok": event.get("ok", True)}})
+        elif kind == "end":
+            saw_end = True
+            yield _line("d", _FINISH)
+    if not saw_end:
+        yield _line("d", _FINISH)

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -94,6 +94,12 @@ def _drop_unsafe_data_uri(tag: str, attr: str, value: str) -> str | None:
     return value
 
 
+# A dashboard page-kind: full-width, runs author JS, binds to the data API via
+# window.stash. Rendered only in a sandboxed iframe with a CSP egress-lock, so
+# its scripts are kept (not stripped) on write.
+APP_LAYOUT = "app"
+
+
 def _sanitize_html(html: str) -> str:
     if not html:
         return html
@@ -372,7 +378,10 @@ async def create_page(
         folder = await pool.fetchrow("SELECT workspace_id FROM folders WHERE id = $1", folder_id)
         if not folder or folder["workspace_id"] != workspace_id:
             raise ValueError("folder_id does not belong to workspace")
-    content_html = _sanitize_html(content_html)
+    # 'app' (dashboard) pages keep author scripts — they only ever execute in a
+    # sandboxed iframe with a CSP egress-lock, never on the trusted origin.
+    if html_layout != APP_LAYOUT:
+        content_html = _sanitize_html(content_html)
     active = _active_content(content_type, content, content_html)
     ch = _content_hash(active)
     meta = metadata or {}
@@ -494,7 +503,17 @@ async def update_page(
     editor reloads the fresh content instead of stale Yjs state."""
     pool = get_pool()
     if content_html is not None:
-        content_html = _sanitize_html(content_html)
+        # Skip sanitization for 'app' (dashboard) pages — see create_page. The
+        # layout may be unchanged in this update, so fall back to the stored one.
+        effective_layout = html_layout
+        if effective_layout is None:
+            effective_layout = await pool.fetchval(
+                "SELECT html_layout FROM pages WHERE id = $1 AND workspace_id = $2",
+                page_id,
+                workspace_id,
+            )
+        if effective_layout != APP_LAYOUT:
+            content_html = _sanitize_html(content_html)
     content_changed = content is not None or content_type is not None or content_html is not None
 
     if folder_id is not None and not move_to_root:

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -254,6 +254,36 @@ async def _user_share_grants(
     return False
 
 
+async def _api_key_share_grants(
+    object_type: str, object_id: UUID, key_id: UUID, require: str
+) -> bool:
+    """A live api_key share on the object or any ancestor folder at the required level."""
+    pool = get_pool()
+    for target_type, target_id in await _object_targets(object_type, object_id):
+        row = await pool.fetchrow(
+            "SELECT permission FROM shares "
+            "WHERE principal_type = 'api_key' AND principal_id = $1 "
+            "AND object_type = $2 AND object_id = $3 "
+            "AND (expires_at IS NULL OR expires_at > now())",
+            key_id,
+            target_type,
+            target_id,
+        )
+        if row and _LEVELS[row["permission"]] >= _LEVELS[require]:
+            return True
+    return False
+
+
+async def check_anon_access(
+    object_type: str, object_id: UUID, key_id: UUID, require: str = "read"
+) -> bool:
+    """Access for a publishable (anon) key. Anon keys get NOTHING by default —
+    only an explicit api_key share on the object grants read (or write)."""
+    if object_type not in _CONTENT_TYPES:
+        return False
+    return await _api_key_share_grants(object_type, object_id, key_id, require)
+
+
 async def _containing_skills(object_type: str, object_id: UUID) -> list[dict]:
     """Published skills whose folder is the object or one of its ancestors."""
     if object_type not in _CONTENT_TYPES:

--- a/backend/services/postgrest.py
+++ b/backend/services/postgrest.py
@@ -1,0 +1,168 @@
+"""Translate PostgREST/supabase-js query grammar to stash's table query layer.
+
+The data API (`/rest/v1/{table}`) is wire-compatible with `supabase-js` for the
+core CRUD/filter surface so agents can vibe-code dashboards against it with code
+that's already in their training data. These are pure functions over a table's
+column schema — the router does auth, lookup, and the DB calls.
+
+Stash tables store cells in a JSONB `data` column keyed by column-id, so reads
+map column *names* (what PostgREST speaks) to ids and back. Anything past the
+supported subset raises `UnsupportedQuery` so the router can fail loud with 501
+rather than return a silently-wrong answer.
+"""
+
+from __future__ import annotations
+
+# Query keys that are not column filters.
+RESERVED_PARAMS = {"select", "order", "limit", "offset"}
+
+# PostgREST operator -> stash list_rows operator.
+_OP_MAP = {
+    "eq": "eq",
+    "neq": "neq",
+    "gt": "gt",
+    "gte": "gte",
+    "lt": "lt",
+    "lte": "lte",
+}
+
+
+class UnsupportedQuery(Exception):
+    """A query uses a real PostgREST feature stash doesn't implement (-> HTTP 501)."""
+
+
+class BadQuery(Exception):
+    """A malformed query (-> HTTP 400)."""
+
+
+def _name_maps(columns: list[dict]) -> tuple[dict, dict, dict]:
+    by_name = {c["name"]: c for c in columns}
+    name_to_id = {c["name"]: c["id"] for c in columns}
+    id_to_name = {c["id"]: c["name"] for c in columns}
+    return by_name, name_to_id, id_to_name
+
+
+def parse_filters(params: list[tuple[str, str]], columns: list[dict]) -> list[dict]:
+    """Turn `?revenue=gt.1000&name=ilike.*acme*` into stash filter dicts.
+
+    Each non-reserved query key is a column filter `col=op.value`.
+    """
+    by_name, name_to_id, _ = _name_maps(columns)
+    filters: list[dict] = []
+
+    for key, raw in params:
+        if key in RESERVED_PARAMS:
+            continue
+        if key in ("and", "or", "not"):
+            raise UnsupportedQuery("and/or/not filters are not supported")
+        if key not in name_to_id:
+            raise BadQuery(f"unknown column '{key}'")
+
+        op, _, value = raw.partition(".")
+        if not _:
+            raise BadQuery(f"filter '{key}' must be 'op.value' (got {raw!r})")
+        if op == "not":
+            raise UnsupportedQuery("negated filters (not.) are not supported")
+
+        col = by_name[key]
+        col_id = name_to_id[key]
+
+        if op == "is":
+            if value.lower() == "null":
+                filters.append({"column_id": col_id, "op": "is_empty"})
+                continue
+            raise UnsupportedQuery("only 'is.null' is supported for the is operator")
+
+        if op in ("like", "ilike"):
+            # stash offers case-insensitive substring 'contains'; treat the
+            # PostgREST pattern's non-wildcard core as the needle.
+            filters.append({"column_id": col_id, "op": "contains", "value": value.strip("*")})
+            continue
+
+        if op in ("in", "cs", "cd", "fts", "plfts", "phfts", "wfts"):
+            raise UnsupportedQuery(f"the '{op}' operator is not supported")
+
+        if op not in _OP_MAP:
+            raise BadQuery(f"unknown operator '{op}'")
+
+        filters.append({"column_id": col_id, "op": _OP_MAP[op], "value": _coerce(col, value)})
+
+    return filters
+
+
+def parse_select(select: str | None, columns: list[dict]) -> set[str] | None:
+    """Return the set of column names to project, or None for all columns."""
+    if not select or select.strip() == "*":
+        return None
+    if "(" in select:
+        raise UnsupportedQuery("embedded resource selects (joins) are not supported")
+
+    _, name_to_id, _ = _name_maps(columns)
+    wanted: set[str] = set()
+    for raw in select.split(","):
+        name = raw.strip()
+        if name in name_to_id or name in SYSTEM_FIELDS:
+            wanted.add(name)
+        else:
+            raise BadQuery(f"unknown column in select: '{name}'")
+    return wanted
+
+
+def parse_order(order: str | None, columns: list[dict]) -> tuple[str | None, str]:
+    """Return (sort_by_column_id, 'asc'|'desc'). Single-column order only."""
+    if not order:
+        return None, "asc"
+    terms = [t.strip() for t in order.split(",") if t.strip()]
+    if len(terms) > 1:
+        raise UnsupportedQuery("multi-column order is not supported; order by one column")
+
+    _, name_to_id, _ = _name_maps(columns)
+    parts = terms[0].split(".")
+    name = parts[0]
+    if name not in name_to_id:
+        raise BadQuery(f"unknown column in order: '{name}'")
+    direction = "desc" if "desc" in parts[1:] else "asc"
+    return name_to_id[name], direction
+
+
+SYSTEM_FIELDS = ("id", "created_at", "updated_at")
+
+
+def row_to_named(row: dict, columns: list[dict], project: set[str] | None) -> dict:
+    """Map a stored row (data keyed by col-id) to a flat name-keyed object.
+
+    System fields (id/created_at/updated_at) are added unless a user column
+    already claims that name. `project`, when set, filters the output keys.
+    """
+    _, _, id_to_name = _name_maps(columns)
+    data = row.get("data") or {}
+    out: dict = {id_to_name.get(col_id, col_id): value for col_id, value in data.items()}
+
+    for field in SYSTEM_FIELDS:
+        out.setdefault(field, row.get(field))
+
+    if project is not None:
+        out = {k: v for k, v in out.items() if k in project}
+    return out
+
+
+def content_range(offset: int, returned: int, total: int) -> str:
+    """PostgREST's Content-Range header value, e.g. '0-24/100' (or '*/0' when empty)."""
+    if returned == 0:
+        return f"*/{total}"
+    return f"{offset}-{offset + returned - 1}/{total}"
+
+
+def _coerce(col: dict, raw: str):
+    """Coerce a query-string filter value to match the column type.
+
+    Numbers must become floats so the query layer compares them numerically;
+    everything else stays a string (booleans serialize to 'true'/'false' in
+    JSONB, which compares fine as text).
+    """
+    if col["type"] == "number":
+        try:
+            return float(raw)
+        except ValueError:
+            raise BadQuery(f"{col['name']}: expected a number, got {raw!r}")
+    return raw

--- a/backend/services/realtime.py
+++ b/backend/services/realtime.py
@@ -1,0 +1,107 @@
+"""Cross-instance realtime change-feed on Postgres LISTEN/NOTIFY.
+
+Dashboards subscribe (over SSE) to a table's row changes and refetch when they
+fire. The bus routes through Postgres so it works across horizontally-scaled web
+instances — unlike the in-process `page_events`, which only reaches subscribers
+on the same process.
+
+Each `emit` dispatches to local subscribers immediately (so same-instance
+delivery works without the listener — e.g. in tests) and fires a NOTIFY for
+other instances. The listener skips events that originated in this process so
+they aren't delivered twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+
+from ..database import get_pool
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "stash_realtime"
+
+# This process's id — lets the NOTIFY listener drop events it already dispatched
+# locally on emit (avoids double-delivery on the originating instance).
+_ORIGIN = uuid.uuid4().hex
+
+# routing key (e.g. "table:<uuid>") -> set of subscriber queues. Bounded queues
+# drop events for a stalled client rather than grow without bound; the client
+# refetches on the next event it does receive.
+_subscribers: dict[str, set[asyncio.Queue]] = {}
+
+_listen_conn = None
+
+
+def table_key(table_id) -> str:
+    return f"table:{table_id}"
+
+
+def subscribe(key: str) -> asyncio.Queue:
+    queue: asyncio.Queue = asyncio.Queue(maxsize=64)
+    _subscribers.setdefault(key, set()).add(queue)
+    return queue
+
+
+def unsubscribe(key: str, queue: asyncio.Queue) -> None:
+    subs = _subscribers.get(key)
+    if not subs:
+        return
+    subs.discard(queue)
+    if not subs:
+        _subscribers.pop(key, None)
+
+
+def _dispatch_local(key: str, event: dict) -> None:
+    for queue in list(_subscribers.get(key, ())):
+        try:
+            queue.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.debug("realtime queue full for %s; dropping event", key)
+
+
+def emit(key: str, event: dict) -> None:
+    """Dispatch to local subscribers now and notify other instances. Non-blocking."""
+    _dispatch_local(key, event)
+    try:
+        asyncio.get_running_loop().create_task(_notify(key, event))
+    except RuntimeError:
+        # No running loop (e.g. called from sync teardown) — local dispatch already happened.
+        pass
+
+
+async def _notify(key: str, event: dict) -> None:
+    payload = json.dumps({"origin": _ORIGIN, "key": key, "event": event})
+    try:
+        await get_pool().execute("SELECT pg_notify($1, $2)", CHANNEL, payload)
+    except Exception:
+        # Cross-instance delivery is best-effort; a NOTIFY hiccup must not fail the write.
+        logger.exception("realtime NOTIFY failed for %s", key)
+
+
+def _on_notify(_conn, _pid, _channel, payload: str) -> None:
+    msg = json.loads(payload)
+    if msg["origin"] == _ORIGIN:
+        return  # already dispatched locally on emit
+    _dispatch_local(msg["key"], msg["event"])
+
+
+async def start() -> None:
+    """Open the dedicated LISTEN connection. Called from the app lifespan."""
+    global _listen_conn
+    if _listen_conn is not None:
+        return
+    _listen_conn = await get_pool().acquire()
+    await _listen_conn.add_listener(CHANNEL, _on_notify)
+
+
+async def stop() -> None:
+    global _listen_conn
+    if _listen_conn is None:
+        return
+    await _listen_conn.remove_listener(CHANNEL, _on_notify)
+    await get_pool().release(_listen_conn)
+    _listen_conn = None

--- a/backend/services/skill_seeds.py
+++ b/backend/services/skill_seeds.py
@@ -203,9 +203,22 @@ Publishable keys cannot call AI — broker it with a user token server-side.
 
 ## 5. Hosting
 
-- **In stash:** save your single-file HTML app as a Page; it runs sandboxed and
-  gets a dashboard token injected, so it reads your data with no setup.
-- **Anywhere else:** deploy normally and point at the stash API with a token.
+- **In stash:** save your single-file HTML dashboard as a Page with
+  `html_layout: "app"`. It runs in a sandboxed iframe and, when you (the owner)
+  view it, a read-only `window.stash` client is injected automatically:
+
+  ```html
+  <script>
+    const res = await window.stash.rest("Sales?select=Name,Revenue&order=Revenue.desc");
+    const rows = await res.json();   // reads your data, no key needed
+  </script>
+  ```
+
+  A CSP egress-lock means an `app` page may call the stash API and load assets
+  from common CDNs (jsdelivr, unpkg, cdnjs, tailwind, google fonts) — but cannot
+  send data to any other origin. Use those CDNs for charting libs, etc.
+- **Anywhere else:** deploy normally and point at the stash API with a `pk_` key
+  (public/shared data) or a dashboard token.
 """
 
 

--- a/backend/services/skill_seeds.py
+++ b/backend/services/skill_seeds.py
@@ -217,7 +217,9 @@ DEFAULT_SKILLS: list[tuple[str, str]] = [
 ]
 
 
-async def _seed_skill(workspace_id: UUID, creator_id: UUID, folder_name: str, markdown: str) -> bool:
+async def _seed_skill(
+    workspace_id: UUID, creator_id: UUID, folder_name: str, markdown: str
+) -> bool:
     """Create `Skills/<folder>/SKILL.md` if a SKILL.md isn't already in that
     folder (we treat an existing one as already-seeded and leave user edits alone).
     """

--- a/backend/services/skill_seeds.py
+++ b/backend/services/skill_seeds.py
@@ -205,12 +205,17 @@ Publishable keys cannot call AI — broker it with a user token server-side.
 
 - **In stash:** save your single-file HTML dashboard as a Page with
   `html_layout: "app"`. It runs in a sandboxed iframe and, when you (the owner)
-  view it, a read-only `window.stash` client is injected automatically:
+  view it, a `window.stash` client bound to your access is injected automatically
+  — so it reads (and, with your owner/editor role, writes) your data with no key:
 
   ```html
   <script>
-    const res = await window.stash.rest("Sales?select=Name,Revenue&order=Revenue.desc");
-    const rows = await res.json();   // reads your data, no key needed
+    const rows = await (await window.stash.rest(
+      "Sales?select=Name,Revenue&order=Revenue.desc")).json();   // read
+    await window.stash.rest("Sales", {                            // write
+      method: "POST",
+      body: JSON.stringify({ Name: "Acme", Revenue: 5000 }),
+    });
   </script>
   ```
 

--- a/backend/services/skill_seeds.py
+++ b/backend/services/skill_seeds.py
@@ -132,18 +132,96 @@ Don't ship interactive controls — they won't survive the export.
 """
 
 
-async def seed_slides_skill(workspace_id: UUID, creator_id: UUID) -> bool:
-    """Create `Skills/slides/SKILL.md` in the workspace if it doesn't exist.
+DASHBOARD_SKILL_FOLDER = "build-on-stash"
 
-    Returns True if the SKILL.md was created in this call, False if a
-    SKILL.md was already present in any folder named `slides` (we treat
-    that as "already seeded" and leave it alone), or if the env knob
-    `STASH_DISABLE_DEFAULT_SKILL_SEEDS=1` is set (test mode).
+DASHBOARD_SKILL_MARKDOWN = """---
+name: build-on-stash
+description: How to build a dashboard or vibe-coded UI on top of stash data — credentials, the supabase-style data API, realtime, and grounded AI.
+when_to_use: When the user asks to build a dashboard, a UI, or an app on top of their stash tables / data.
+version: "1"
+---
+
+# Building a UI on stash
+
+Stash is the backend: your tables are the database, and you build any UI on top.
+The data API is **PostgREST/supabase-js compatible**, so use code you already
+know. Read the live schema from `/openapi.json` and `/llms.txt` before coding —
+this guide is the stable how-to; those have the current tables and endpoints.
+
+## 1. Credentials — pick by who the data is for
+
+- **Your own private data** (a dashboard of *your* memory): mint a short-lived,
+  read-only **dashboard token** — `POST /api/v1/dashboard-tokens {workspace_id}`
+  → `{token, expires_at}`. Stash-hosted dashboards get one injected automatically.
+- **Public / shared data** (everyone sees the same rows): the workspace owner
+  creates a **publishable key** (`pk_…`) in settings and grants per-table
+  read (or write) policies. Safe to embed in browser JS.
+
+Never embed a long-lived `mc_` token in a browser.
+
+## 2. Read & write — the data API (`/rest/v1/{table}`)
+
+Point `supabase-js` at the stash URL, or use plain `fetch`. Tables are addressed
+by name; columns by name.
+
+```js
+// Filter + select + order, supabase-js style:
+GET /rest/v1/Sales?revenue=gt.1000&select=name,revenue&order=revenue.desc
+// Insert / update / delete:
+POST   /rest/v1/Sales            {"name": "Acme", "revenue": 5000}
+PATCH  /rest/v1/Sales?id=eq.<id> {"revenue": 6000}
+DELETE /rest/v1/Sales?id=eq.<id>
+```
+
+- Send the credential as `Authorization: Bearer <token>` or the `apikey` header.
+- For an `mc_` token, also send `X-Stash-Workspace: <workspace_id>` (dashboard
+  tokens and publishable keys already know their workspace).
+- Row count comes back in the `Content-Range` response header.
+- **Supported subset:** filters (`eq,neq,gt,gte,lt,lte,like,ilike,is.null`),
+  `select`, single-column `order`, `limit`/`offset`. Embedded joins
+  (`select=a,b(*)`), RPC, and `and/or/not` return **501** — don't use them.
+
+## 3. Live updates — SSE (no websockets)
+
+```js
+const es = new EventSource(`/rest/v1/Sales/subscribe?access_token=${token}`);
+es.onmessage = () => refetch();   // events are nudges: {type, row_id}
+```
+
+`EventSource` can't set headers, so the token goes in `?access_token=`.
+
+## 4. Grounded AI (authenticated users only)
+
+```js
+// Chat with your data — Vercel AI SDK useChat works drop-in:
+useChat({ api: `/ai/v1/${workspaceId}/chat` })
+// Or raw retrieval:
+POST /ai/v1/{workspace_id}/search {"query": "..."}
+```
+
+Publishable keys cannot call AI — broker it with a user token server-side.
+
+## 5. Hosting
+
+- **In stash:** save your single-file HTML app as a Page; it runs sandboxed and
+  gets a dashboard token injected, so it reads your data with no setup.
+- **Anywhere else:** deploy normally and point at the stash API with a token.
+"""
+
+
+# The set of skills seeded into every new workspace. Add a one-liner here to
+# ship another default skill — workspace creation loops over this list.
+DEFAULT_SKILLS: list[tuple[str, str]] = [
+    (SLIDES_SKILL_FOLDER, SLIDES_SKILL_MARKDOWN),
+    (DASHBOARD_SKILL_FOLDER, DASHBOARD_SKILL_MARKDOWN),
+]
+
+
+async def _seed_skill(workspace_id: UUID, creator_id: UUID, folder_name: str, markdown: str) -> bool:
+    """Create `Skills/<folder>/SKILL.md` if a SKILL.md isn't already in that
+    folder (we treat an existing one as already-seeded and leave user edits alone).
     """
-    if os.environ.get(DISABLE_ENV_VAR) == "1":
-        return False
     pool = get_pool()
-
     existing = await pool.fetchval(
         "SELECT p.id FROM pages p "
         "JOIN folders f ON f.id = p.folder_id "
@@ -151,7 +229,7 @@ async def seed_slides_skill(workspace_id: UUID, creator_id: UUID) -> bool:
         "  AND p.name = $3 AND p.deleted_at IS NULL "
         "LIMIT 1",
         workspace_id,
-        SLIDES_SKILL_FOLDER,
+        folder_name,
         SKILL_MD_NAME,
     )
     if existing:
@@ -161,14 +239,14 @@ async def seed_slides_skill(workspace_id: UUID, creator_id: UUID) -> bool:
         "SELECT id FROM folders WHERE workspace_id = $1 AND lower(name) = $2 "
         "  AND parent_folder_id IS NULL LIMIT 1",
         workspace_id,
-        SLIDES_SKILL_FOLDER,
+        folder_name,
     )
     if folder_row:
         folder_id = folder_row["id"]
     else:
         folder = await files_tree_service.create_folder(
             workspace_id=workspace_id,
-            name=SLIDES_SKILL_FOLDER,
+            name=folder_name,
             created_by=creator_id,
         )
         folder_id = folder["id"]
@@ -178,8 +256,27 @@ async def seed_slides_skill(workspace_id: UUID, creator_id: UUID) -> bool:
         name=SKILL_MD_NAME,
         created_by=creator_id,
         folder_id=folder_id,
-        content=SLIDES_SKILL_MARKDOWN,
+        content=markdown,
         content_type="markdown",
     )
-    logger.info("seeded slides skill for workspace %s", workspace_id)
+    logger.info("seeded %s skill for workspace %s", folder_name, workspace_id)
     return True
+
+
+async def seed_default_skills(workspace_id: UUID, creator_id: UUID) -> None:
+    """Seed every skill in DEFAULT_SKILLS into a new workspace (idempotent).
+
+    No-op when `STASH_DISABLE_DEFAULT_SKILL_SEEDS=1` (test mode) — tests that
+    need a seed call the seed helpers directly with the knob cleared.
+    """
+    if os.environ.get(DISABLE_ENV_VAR) == "1":
+        return
+    for folder_name, markdown in DEFAULT_SKILLS:
+        await _seed_skill(workspace_id, creator_id, folder_name, markdown)
+
+
+async def seed_slides_skill(workspace_id: UUID, creator_id: UUID) -> bool:
+    """Seed just the slides skill. Kept as a direct entry point for tests."""
+    if os.environ.get(DISABLE_ENV_VAR) == "1":
+        return False
+    return await _seed_skill(workspace_id, creator_id, SLIDES_SKILL_FOLDER, SLIDES_SKILL_MARKDOWN)

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -95,6 +95,23 @@ async def get_table_metadata(table_id: UUID) -> dict | None:
     return dict(row) if row else None
 
 
+async def get_table_by_name(workspace_id: UUID, name: str) -> dict | None:
+    """Resolve a table by case-insensitive name within a workspace (most recent wins).
+
+    The PostgREST-style data API addresses tables by name in the URL path.
+    """
+    pool = get_pool()
+    row = await pool.fetchrow(
+        f"SELECT t.{_TABLE_FIELDS.replace(', ', ', t.')}, "
+        "(SELECT COUNT(*) FROM table_rows tr WHERE tr.table_id = t.id) AS row_count "
+        "FROM tables t WHERE t.workspace_id = $1 AND lower(t.name) = lower($2) "
+        "ORDER BY t.updated_at DESC LIMIT 1",
+        workspace_id,
+        name,
+    )
+    return dict(row) if row else None
+
+
 async def update_table(
     table_id: UUID,
     updated_by: UUID,

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -604,11 +604,17 @@ async def list_rows(
 
     where = " AND ".join(where_clauses)
 
-    # Sort — validate sort_by against schema
+    # Sort — validate sort_by against schema. Number columns must sort
+    # numerically, not lexicographically (otherwise '900' sorts before '7400').
     order = "row_order ASC"
     if sort_by and sort_by in valid_col_ids:
         direction = "DESC" if sort_order == "desc" else "ASC"
-        order = f"data->>'{sort_by}' {direction}, row_order ASC"
+        col_types = {c["id"]: c["type"] for c in table["columns"]}
+        if col_types.get(sort_by) == "number":
+            expr = f"NULLIF(data->>'{sort_by}', '')::numeric"
+        else:
+            expr = f"data->>'{sort_by}'"
+        order = f"{expr} {direction} NULLS LAST, row_order ASC"
 
     total_query = pool.fetchval(f"SELECT COUNT(*) FROM table_rows WHERE {where}", *args)
     if limit == 0:

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -380,7 +380,9 @@ async def create_row(table_id: UUID, data: dict, created_by: UUID) -> dict:
     )
     result = dict(row)
     asyncio.create_task(maybe_embed_row(table_id, result["id"], validated))
-    realtime.emit(realtime.table_key(table_id), {"type": "row.created", "row_id": str(result["id"])})
+    realtime.emit(
+        realtime.table_key(table_id), {"type": "row.created", "row_id": str(result["id"])}
+    )
     return result
 
 

--- a/backend/services/table_service.py
+++ b/backend/services/table_service.py
@@ -8,7 +8,7 @@ import secrets
 from uuid import UUID
 
 from ..database import get_pool
-from . import permission_service
+from . import permission_service, realtime
 from .row_validation import RowValidationError, validate_row_data
 
 logger = logging.getLogger(__name__)
@@ -380,6 +380,7 @@ async def create_row(table_id: UUID, data: dict, created_by: UUID) -> dict:
     )
     result = dict(row)
     asyncio.create_task(maybe_embed_row(table_id, result["id"], validated))
+    realtime.emit(realtime.table_key(table_id), {"type": "row.created", "row_id": str(result["id"])})
     return result
 
 
@@ -459,6 +460,9 @@ async def update_row(
         return None
     result = dict(row)
     asyncio.create_task(maybe_embed_row(result["table_id"], result["id"], result["data"]))
+    realtime.emit(
+        realtime.table_key(result["table_id"]), {"type": "row.updated", "row_id": str(result["id"])}
+    )
     return result
 
 
@@ -472,7 +476,10 @@ async def delete_row(row_id: UUID, table_id: UUID | None = None) -> bool:
         )
     else:
         result = await pool.execute("DELETE FROM table_rows WHERE id = $1", row_id)
-    return result == "DELETE 1"
+    deleted = result == "DELETE 1"
+    if deleted and table_id is not None:
+        realtime.emit(realtime.table_key(table_id), {"type": "row.deleted", "row_id": str(row_id)})
+    return deleted
 
 
 async def update_rows_batch(table_id: UUID, updates: list[dict], updated_by: UUID) -> list[dict]:

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -73,13 +73,12 @@ async def create_workspace(
         is_primary,
     )
     ws["member_count"] = 1
-    # Seed the default slides skill so the ask-the-workspace agent can
-    # discover it via list_skills/read_skill when the user asks for a deck.
-    # Failures here should not block workspace creation.
+    # Seed the default skills (slides + build-on-stash) so the agent can discover
+    # them via list_skills/read_skill. Failures must not block workspace creation.
     try:
-        await skill_seeds.seed_slides_skill(ws["id"], creator_id)
+        await skill_seeds.seed_default_skills(ws["id"], creator_id)
     except Exception:
-        logger.exception("seed_slides_skill failed for workspace %s", ws["id"])
+        logger.exception("seed_default_skills failed for workspace %s", ws["id"])
     return ws
 
 

--- a/backend/tests/test_ai_api.py
+++ b/backend/tests/test_ai_api.py
@@ -1,0 +1,86 @@
+"""Tests for the grounded AI endpoints (/ai/v1) and the AI SDK stream mapping."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend.config import settings
+from backend.services import ai_sdk, tool_loop
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _register(client: AsyncClient) -> str:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    return resp.json()["api_key"]
+
+
+async def _workspace(client: AsyncClient, api_key: str) -> dict:
+    return (await client.post("/api/v1/workspaces", json={"name": "AI"}, headers=_auth(api_key))).json()
+
+
+@pytest.mark.asyncio
+async def test_data_stream_mapping():
+    async def events():
+        yield {"type": "text", "delta": "Hello "}
+        yield {"type": "tool", "id": "t1", "name": "search", "args": {"q": "x"}}
+        yield {"type": "tool_result", "id": "t1", "name": "search", "ok": True}
+        yield {"type": "end"}
+
+    lines = [line async for line in ai_sdk.to_data_stream(events())]
+    assert lines[0] == '0:"Hello "\n'
+    assert lines[1] == '9:{"toolCallId":"t1","toolName":"search","args":{"q":"x"}}\n'
+    assert lines[2] == 'a:{"toolCallId":"t1","result":{"ok":true}}\n'
+    assert lines[3] == 'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+
+
+@pytest.mark.asyncio
+async def test_search_returns_results_shape(client: AsyncClient):
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    resp = await client.post(
+        f"/ai/v1/{ws['id']}/search", json={"query": "anything"}, headers=_auth(api_key)
+    )
+    assert resp.status_code == 200
+    assert "results" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_chat_streams_ai_sdk_protocol(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "sk-test")
+
+    async def fake_loop(**kwargs):
+        yield {"type": "text", "delta": "Hi"}
+        yield {"type": "end"}
+
+    monkeypatch.setattr(tool_loop, "stream_tool_loop", fake_loop)
+
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    resp = await client.post(
+        f"/ai/v1/{ws['id']}/chat",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.headers["x-vercel-ai-data-stream"] == "v1"
+    assert '0:"Hi"' in resp.text
+    assert '"finishReason":"stop"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_publishable_key_cannot_use_ai(client: AsyncClient):
+    # An anon pk_ token is not a user token, so AI rejects it.
+    resp = await client.post(
+        f"/ai/v1/{uuid.uuid4()}/chat",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+        headers=_auth("pk_madeup"),
+    )
+    assert resp.status_code == 401

--- a/backend/tests/test_ai_api.py
+++ b/backend/tests/test_ai_api.py
@@ -23,7 +23,9 @@ async def _register(client: AsyncClient) -> str:
 
 
 async def _workspace(client: AsyncClient, api_key: str) -> dict:
-    return (await client.post("/api/v1/workspaces", json={"name": "AI"}, headers=_auth(api_key))).json()
+    return (
+        await client.post("/api/v1/workspaces", json={"name": "AI"}, headers=_auth(api_key))
+    ).json()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app_pages.py
+++ b/backend/tests/test_app_pages.py
@@ -1,0 +1,77 @@
+"""Tests for the 'app' (dashboard) page-kind: scripts kept, downloads non-executable."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+SCRIPT_HTML = (
+    "<!DOCTYPE html><html><head></head><body><h1>Dash</h1>"
+    '<script>window.stash.rest("Sales").then(r=>r.json())</script></body></html>'
+)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _register(client: AsyncClient) -> str:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    return resp.json()["api_key"]
+
+
+async def _workspace(client: AsyncClient, api_key: str) -> str:
+    return (
+        await client.post("/api/v1/workspaces", json={"name": "App"}, headers=_auth(api_key))
+    ).json()["id"]
+
+
+async def _make_page(client: AsyncClient, api_key: str, ws: str, layout: str) -> dict:
+    return (
+        await client.post(
+            f"/api/v1/workspaces/{ws}/pages/new",
+            json={
+                "name": "Dashboard",
+                "content_html": SCRIPT_HTML,
+                "content_type": "html",
+                "html_layout": layout,
+            },
+            headers=_auth(api_key),
+        )
+    ).json()
+
+
+@pytest.mark.asyncio
+async def test_app_page_keeps_scripts(client: AsyncClient):
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    page = await _make_page(client, api_key, ws, "app")
+    assert "<script>" in page["content_html"]
+    assert "window.stash" in page["content_html"]
+
+
+@pytest.mark.asyncio
+async def test_non_app_html_still_strips_scripts(client: AsyncClient):
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    page = await _make_page(client, api_key, ws, "full-width")
+    assert "<script" not in page["content_html"]
+
+
+@pytest.mark.asyncio
+async def test_html_download_is_attachment(client: AsyncClient):
+    # An app page's HTML must never execute on this origin, so /download forces a
+    # save (attachment) with nosniff rather than rendering inline.
+    api_key = await _register(client)
+    ws = await _workspace(client, api_key)
+    page = await _make_page(client, api_key, ws, "app")
+    resp = await client.get(
+        f"/api/v1/workspaces/{ws}/pages/{page['id']}/download", headers=_auth(api_key)
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-disposition"].startswith("attachment")
+    assert resp.headers["x-content-type-options"] == "nosniff"

--- a/backend/tests/test_browser_api_cors.py
+++ b/backend/tests/test_browser_api_cors.py
@@ -1,0 +1,34 @@
+"""CORS for the browser-facing data/AI API, and the llms.txt pointer."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_preflight_allows_any_origin(client: AsyncClient):
+    resp = await client.options(
+        "/rest/v1/Anything",
+        headers={"Origin": "https://some-dashboard.example", "Access-Control-Request-Method": "GET"},
+    )
+    assert resp.status_code == 204
+    assert resp.headers["access-control-allow-origin"] == "*"
+    assert "GET" in resp.headers["access-control-allow-methods"]
+    assert "Content-Range" in resp.headers["access-control-expose-headers"]
+
+
+@pytest.mark.asyncio
+async def test_actual_request_carries_cors_header(client: AsyncClient):
+    # Even an unauthenticated 401 from the data API gets the open-CORS header,
+    # so the browser can read the response instead of seeing an opaque failure.
+    resp = await client.get("/rest/v1/Anything", headers={"Origin": "https://x.example"})
+    assert resp.headers["access-control-allow-origin"] == "*"
+
+
+@pytest.mark.asyncio
+async def test_llms_txt(client: AsyncClient):
+    resp = await client.get("/llms.txt")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/rest/v1/{table}" in body
+    assert "useChat" in body
+    assert "/openapi.json" in body

--- a/backend/tests/test_browser_api_cors.py
+++ b/backend/tests/test_browser_api_cors.py
@@ -8,7 +8,10 @@ from httpx import AsyncClient
 async def test_preflight_allows_any_origin(client: AsyncClient):
     resp = await client.options(
         "/rest/v1/Anything",
-        headers={"Origin": "https://some-dashboard.example", "Access-Control-Request-Method": "GET"},
+        headers={
+            "Origin": "https://some-dashboard.example",
+            "Access-Control-Request-Method": "GET",
+        },
     )
     assert resp.status_code == 204
     assert resp.headers["access-control-allow-origin"] == "*"

--- a/backend/tests/test_dashboard_tokens.py
+++ b/backend/tests/test_dashboard_tokens.py
@@ -28,9 +28,7 @@ async def _register(client: AsyncClient) -> tuple[str, dict]:
 
 async def _make_workspace(client: AsyncClient, api_key: str) -> dict:
     return (
-        await client.post(
-            "/api/v1/workspaces", json={"name": "Dash"}, headers=_auth(api_key)
-        )
+        await client.post("/api/v1/workspaces", json={"name": "Dash"}, headers=_auth(api_key))
     ).json()
 
 
@@ -54,9 +52,7 @@ async def test_minted_token_reads_owner_data(client: AsyncClient):
     assert dt.startswith("dt_")
 
     # The dashboard token authenticates a read of the owner's workspace.
-    listed = await client.get(
-        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(dt)
-    )
+    listed = await client.get(f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(dt))
     assert listed.status_code == 200
 
 
@@ -100,9 +96,7 @@ async def test_expired_token_rejected(client: AsyncClient):
     ws = await _make_workspace(client, api_key)
 
     expired, _exp = auth.mint_dashboard_token(user["id"], ws["id"], ttl_seconds=-10)
-    resp = await client.get(
-        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(expired)
-    )
+    resp = await client.get(f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(expired))
     assert resp.status_code == 401
 
 
@@ -113,7 +107,5 @@ async def test_tampered_token_rejected(client: AsyncClient):
 
     token, _exp = auth.mint_dashboard_token(user["id"], ws["id"])
     tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
-    resp = await client.get(
-        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(tampered)
-    )
+    resp = await client.get(f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(tampered))
     assert resp.status_code == 401

--- a/backend/tests/test_dashboard_tokens.py
+++ b/backend/tests/test_dashboard_tokens.py
@@ -1,0 +1,119 @@
+"""Tests for short-lived, read-only dashboard tokens (the generative-UI backend)."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend import auth
+from backend.config import settings
+
+_SECRET = "test-dashboard-secret-which-is-long-enough"
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _register(client: AsyncClient) -> tuple[str, dict]:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body
+
+
+async def _make_workspace(client: AsyncClient, api_key: str) -> dict:
+    return (
+        await client.post(
+            "/api/v1/workspaces", json={"name": "Dash"}, headers=_auth(api_key)
+        )
+    ).json()
+
+
+@pytest.fixture(autouse=True)
+def _enable_dashboard_tokens(monkeypatch):
+    monkeypatch.setattr(settings, "DASHBOARD_TOKEN_SECRET", _SECRET)
+
+
+@pytest.mark.asyncio
+async def test_minted_token_reads_owner_data(client: AsyncClient):
+    api_key, _user = await _register(client)
+    ws = await _make_workspace(client, api_key)
+
+    minted = await client.post(
+        "/api/v1/dashboard-tokens",
+        json={"workspace_id": ws["id"]},
+        headers=_auth(api_key),
+    )
+    assert minted.status_code == 201
+    dt = minted.json()["token"]
+    assert dt.startswith("dt_")
+
+    # The dashboard token authenticates a read of the owner's workspace.
+    listed = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(dt)
+    )
+    assert listed.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_mint_requires_membership(client: AsyncClient):
+    _owner_key, _ = await _register(client)
+    owner_ws = await _make_workspace(client, _owner_key)
+
+    outsider_key, _ = await _register(client)
+    resp = await client.post(
+        "/api/v1/dashboard-tokens",
+        json={"workspace_id": owner_ws["id"]},
+        headers=_auth(outsider_key),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_dashboard_token_cannot_mint_tokens(client: AsyncClient):
+    api_key, _ = await _register(client)
+    ws = await _make_workspace(client, api_key)
+    dt = (
+        await client.post(
+            "/api/v1/dashboard-tokens",
+            json={"workspace_id": ws["id"]},
+            headers=_auth(api_key),
+        )
+    ).json()["token"]
+
+    resp = await client.post(
+        "/api/v1/dashboard-tokens",
+        json={"workspace_id": ws["id"]},
+        headers=_auth(dt),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_expired_token_rejected(client: AsyncClient):
+    api_key, user = await _register(client)
+    ws = await _make_workspace(client, api_key)
+
+    expired, _exp = auth.mint_dashboard_token(user["id"], ws["id"], ttl_seconds=-10)
+    resp = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(expired)
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_tampered_token_rejected(client: AsyncClient):
+    api_key, user = await _register(client)
+    ws = await _make_workspace(client, api_key)
+
+    token, _exp = auth.mint_dashboard_token(user["id"], ws["id"])
+    tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+    resp = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/pages", headers=_auth(tampered)
+    )
+    assert resp.status_code == 401

--- a/backend/tests/test_data_access.py
+++ b/backend/tests/test_data_access.py
@@ -1,0 +1,134 @@
+"""Tests for publishable (anon) keys + per-table policies on the data API."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _anon(key: str) -> dict[str, str]:
+    # supabase-js sends the publishable key in the apikey header.
+    return {"apikey": key}
+
+
+async def _register(client: AsyncClient) -> str:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+async def _setup(client: AsyncClient):
+    api_key = await _register(client)
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Pub"}, headers=_auth(api_key))
+    ).json()
+    table = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/tables",
+            json={"name": "Leaderboard", "columns": [{"name": "Player", "type": "text"}]},
+            headers=_auth(api_key),
+        )
+    ).json()
+    hdr = {**_auth(api_key), "X-Stash-Workspace": ws["id"]}
+    await client.post("/rest/v1/Leaderboard", json={"Player": "Ada"}, headers=hdr)
+    return api_key, ws, table
+
+
+async def _make_key(client: AsyncClient, api_key: str, ws_id: str) -> str:
+    resp = await client.post(
+        f"/api/v1/workspaces/{ws_id}/publishable-keys", json={"name": "site"}, headers=_auth(api_key)
+    )
+    assert resp.status_code == 201
+    key = resp.json()["key"]
+    assert key.startswith("pk_")
+    return key
+
+
+@pytest.mark.asyncio
+async def test_anon_key_grants_nothing_until_policy(client: AsyncClient):
+    api_key, ws, _table = await _setup(client)
+    pk = await _make_key(client, api_key, ws["id"])
+
+    # No policy yet -> the anon key can't read the table.
+    denied = await client.get("/rest/v1/Leaderboard", headers=_anon(pk))
+    assert denied.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_policy_enables_read_not_write(client: AsyncClient):
+    api_key, ws, table = await _setup(client)
+    pk = await _make_key(client, api_key, ws["id"])
+    keys = await client.get(f"/api/v1/workspaces/{ws['id']}/publishable-keys", headers=_auth(api_key))
+    key_id = keys.json()[0]["id"]
+
+    # Grant read.
+    policy = await client.put(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys/{key_id}/policies",
+        json={"table_id": table["id"], "permission": "read"},
+        headers=_auth(api_key),
+    )
+    assert policy.status_code == 201
+
+    read = await client.get("/rest/v1/Leaderboard", headers=_anon(pk))
+    assert read.status_code == 200
+    assert [r["Player"] for r in read.json()] == ["Ada"]
+
+    # Read policy does not allow writes.
+    write = await client.post("/rest/v1/Leaderboard", json={"Player": "Grace"}, headers=_anon(pk))
+    assert write.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_write_policy_enables_anon_write(client: AsyncClient):
+    api_key, ws, table = await _setup(client)
+    pk = await _make_key(client, api_key, ws["id"])
+    key_id = (
+        await client.get(f"/api/v1/workspaces/{ws['id']}/publishable-keys", headers=_auth(api_key))
+    ).json()[0]["id"]
+    await client.put(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys/{key_id}/policies",
+        json={"table_id": table["id"], "permission": "write"},
+        headers=_auth(api_key),
+    )
+
+    write = await client.post("/rest/v1/Leaderboard", json={"Player": "Grace"}, headers=_anon(pk))
+    assert write.status_code == 201
+    assert write.json()["Player"] == "Grace"
+
+
+@pytest.mark.asyncio
+async def test_only_owner_can_make_keys(client: AsyncClient):
+    _owner_key, ws, _table = await _setup(client)
+    outsider = await _register(client)
+    resp = await client.post(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys", json={"name": "x"}, headers=_auth(outsider)
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_revoked_key_is_rejected(client: AsyncClient):
+    api_key, ws, table = await _setup(client)
+    pk = await _make_key(client, api_key, ws["id"])
+    key_id = (
+        await client.get(f"/api/v1/workspaces/{ws['id']}/publishable-keys", headers=_auth(api_key))
+    ).json()[0]["id"]
+    await client.put(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys/{key_id}/policies",
+        json={"table_id": table["id"], "permission": "read"},
+        headers=_auth(api_key),
+    )
+    assert (await client.get("/rest/v1/Leaderboard", headers=_anon(pk))).status_code == 200
+
+    await client.delete(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys/{key_id}", headers=_auth(api_key)
+    )
+    assert (await client.get("/rest/v1/Leaderboard", headers=_anon(pk))).status_code == 401

--- a/backend/tests/test_data_access.py
+++ b/backend/tests/test_data_access.py
@@ -44,7 +44,9 @@ async def _setup(client: AsyncClient):
 
 async def _make_key(client: AsyncClient, api_key: str, ws_id: str) -> str:
     resp = await client.post(
-        f"/api/v1/workspaces/{ws_id}/publishable-keys", json={"name": "site"}, headers=_auth(api_key)
+        f"/api/v1/workspaces/{ws_id}/publishable-keys",
+        json={"name": "site"},
+        headers=_auth(api_key),
     )
     assert resp.status_code == 201
     key = resp.json()["key"]
@@ -66,7 +68,9 @@ async def test_anon_key_grants_nothing_until_policy(client: AsyncClient):
 async def test_read_policy_enables_read_not_write(client: AsyncClient):
     api_key, ws, table = await _setup(client)
     pk = await _make_key(client, api_key, ws["id"])
-    keys = await client.get(f"/api/v1/workspaces/{ws['id']}/publishable-keys", headers=_auth(api_key))
+    keys = await client.get(
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys", headers=_auth(api_key)
+    )
     key_id = keys.json()[0]["id"]
 
     # Grant read.
@@ -109,7 +113,9 @@ async def test_only_owner_can_make_keys(client: AsyncClient):
     _owner_key, ws, _table = await _setup(client)
     outsider = await _register(client)
     resp = await client.post(
-        f"/api/v1/workspaces/{ws['id']}/publishable-keys", json={"name": "x"}, headers=_auth(outsider)
+        f"/api/v1/workspaces/{ws['id']}/publishable-keys",
+        json={"name": "x"},
+        headers=_auth(outsider),
     )
     assert resp.status_code == 403
 

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -94,11 +94,15 @@ async def test_unsupported_and_bad_queries(client: AsyncClient):
     # Embedded select (join) -> 501
     assert (await client.get("/rest/v1/Sales?select=Name,other(*)", headers=hdr)).status_code == 501
     # Multi-column order -> 501
-    assert (await client.get("/rest/v1/Sales?order=Name.asc,Revenue.desc", headers=hdr)).status_code == 501
+    assert (
+        await client.get("/rest/v1/Sales?order=Name.asc,Revenue.desc", headers=hdr)
+    ).status_code == 501
     # Unknown column filter -> 400
     assert (await client.get("/rest/v1/Sales?Nope=eq.1", headers=hdr)).status_code == 400
     # PATCH without id=eq -> 400
-    assert (await client.patch("/rest/v1/Sales?Name=eq.Acme", json={"Revenue": 1}, headers=hdr)).status_code == 400
+    assert (
+        await client.patch("/rest/v1/Sales?Name=eq.Acme", json={"Revenue": 1}, headers=hdr)
+    ).status_code == 400
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -1,0 +1,123 @@
+"""Tests for the PostgREST/supabase-js-compatible data API (/rest/v1)."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend import auth
+from backend.config import settings
+
+_SECRET = "test-dashboard-secret-which-is-long-enough"
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _register(client: AsyncClient) -> tuple[str, dict]:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "display_name": name, "password": "password123"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body
+
+
+async def _setup(client: AsyncClient):
+    """Register, make a workspace + a 'Sales' table with two columns, seed rows."""
+    api_key, user = await _register(client)
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "Dash"}, headers=_auth(api_key))
+    ).json()
+    await client.post(
+        f"/api/v1/workspaces/{ws['id']}/tables",
+        json={
+            "name": "Sales",
+            "columns": [
+                {"name": "Name", "type": "text"},
+                {"name": "Revenue", "type": "number"},
+            ],
+        },
+        headers=_auth(api_key),
+    )
+    hdr = {**_auth(api_key), "X-Stash-Workspace": ws["id"]}
+    for name, rev in [("Acme", 5000), ("Globex", 200), ("Initech", 3000)]:
+        r = await client.post("/rest/v1/Sales", json={"Name": name, "Revenue": rev}, headers=hdr)
+        assert r.status_code == 201, r.text
+    return api_key, user, ws, hdr
+
+
+@pytest.mark.asyncio
+async def test_filter_select_order_and_content_range(client: AsyncClient):
+    _key, _user, _ws, hdr = await _setup(client)
+
+    resp = await client.get(
+        "/rest/v1/Sales?Revenue=gt.1000&select=Name,Revenue&order=Revenue.desc", headers=hdr
+    )
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    # Globex (200) filtered out; Acme(5000) before Initech(3000) by desc revenue.
+    assert [r["Name"] for r in rows] == ["Acme", "Initech"]
+    # select limited the projection to the two named columns.
+    assert set(rows[0].keys()) == {"Name", "Revenue"}
+    # Content-Range reflects 2 returned of 2 total matching.
+    assert resp.headers["Content-Range"] == "0-1/2"
+
+
+@pytest.mark.asyncio
+async def test_insert_returns_row_with_id_then_patch_and_delete(client: AsyncClient):
+    _key, _user, _ws, hdr = await _setup(client)
+
+    created = (
+        await client.post("/rest/v1/Sales", json={"Name": "Hooli", "Revenue": 10}, headers=hdr)
+    ).json()
+    row_id = created["id"]
+    assert created["Name"] == "Hooli"
+
+    patched = await client.patch(
+        f"/rest/v1/Sales?id=eq.{row_id}", json={"Revenue": 99}, headers=hdr
+    )
+    assert patched.status_code == 200
+    assert patched.json()["Revenue"] == 99
+
+    deleted = await client.delete(f"/rest/v1/Sales?id=eq.{row_id}", headers=hdr)
+    assert deleted.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_unsupported_and_bad_queries(client: AsyncClient):
+    _key, _user, _ws, hdr = await _setup(client)
+
+    # Embedded select (join) -> 501
+    assert (await client.get("/rest/v1/Sales?select=Name,other(*)", headers=hdr)).status_code == 501
+    # Multi-column order -> 501
+    assert (await client.get("/rest/v1/Sales?order=Name.asc,Revenue.desc", headers=hdr)).status_code == 501
+    # Unknown column filter -> 400
+    assert (await client.get("/rest/v1/Sales?Nope=eq.1", headers=hdr)).status_code == 400
+    # PATCH without id=eq -> 400
+    assert (await client.patch("/rest/v1/Sales?Name=eq.Acme", json={"Revenue": 1}, headers=hdr)).status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_header(client: AsyncClient):
+    api_key, _user = await _register(client)
+    resp = await client.get("/rest/v1/Sales", headers=_auth(api_key))
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_dashboard_token_reads_but_cannot_write(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr(settings, "DASHBOARD_TOKEN_SECRET", _SECRET)
+    _key, user, ws, _hdr = await _setup(client)
+
+    dt, _exp = auth.mint_dashboard_token(user["id"], ws["id"])
+    # Read works (workspace comes from the token binding, no header needed).
+    read = await client.get("/rest/v1/Sales?order=Revenue.desc", headers=_auth(dt))
+    assert read.status_code == 200
+    assert len(read.json()) == 3
+    # Write is refused — the token is read-only.
+    write = await client.post("/rest/v1/Sales", json={"Name": "X", "Revenue": 1}, headers=_auth(dt))
+    assert write.status_code == 403

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -88,6 +88,16 @@ async def test_insert_returns_row_with_id_then_patch_and_delete(client: AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_schema_introspection(client: AsyncClient):
+    _key, _user, _ws, hdr = await _setup(client)
+    resp = await client.get("/rest/v1", headers=hdr)
+    assert resp.status_code == 200
+    tables = resp.json()["tables"]
+    sales = next(t for t in tables if t["name"] == "Sales")
+    assert {c["name"] for c in sales["columns"]} == {"Name", "Revenue"}
+
+
+@pytest.mark.asyncio
 async def test_get_one_row_by_id(client: AsyncClient):
     # supabase .eq('id', x): fetch a single row by its id (id is the row id, not a cell).
     _key, _user, _ws, hdr = await _setup(client)

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -88,6 +88,27 @@ async def test_insert_returns_row_with_id_then_patch_and_delete(client: AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_get_one_row_by_id(client: AsyncClient):
+    # supabase .eq('id', x): fetch a single row by its id (id is the row id, not a cell).
+    _key, _user, _ws, hdr = await _setup(client)
+    created = (
+        await client.post("/rest/v1/Sales", json={"Name": "Solo", "Revenue": 1}, headers=hdr)
+    ).json()
+    row_id = created["id"]
+
+    resp = await client.get(f"/rest/v1/Sales?id=eq.{row_id}", headers=hdr)
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1 and rows[0]["Name"] == "Solo"
+
+    # A non-existent id returns an empty list, not an error.
+    missing = await client.get(
+        "/rest/v1/Sales?id=eq.00000000-0000-0000-0000-000000000000", headers=hdr
+    )
+    assert missing.status_code == 200 and missing.json() == []
+
+
+@pytest.mark.asyncio
 async def test_unsupported_and_bad_queries(client: AsyncClient):
     _key, _user, _ws, hdr = await _setup(client)
 

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -163,7 +163,7 @@ async def test_missing_workspace_header(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_dashboard_token_reads_but_cannot_write(client: AsyncClient, monkeypatch):
+async def test_dashboard_token_reads_and_writes_for_owner(client: AsyncClient, monkeypatch):
     monkeypatch.setattr(settings, "DASHBOARD_TOKEN_SECRET", _SECRET)
     _key, user, ws, _hdr = await _setup(client)
 
@@ -172,6 +172,25 @@ async def test_dashboard_token_reads_but_cannot_write(client: AsyncClient, monke
     read = await client.get("/rest/v1/Sales?order=Revenue.desc", headers=_auth(dt))
     assert read.status_code == 200
     assert len(read.json()) == 3
-    # Write is refused — the token is read-only.
+    # The owner's dashboard token grants their real access — writes are allowed.
     write = await client.post("/rest/v1/Sales", json={"Name": "X", "Revenue": 1}, headers=_auth(dt))
+    assert write.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_viewer_dashboard_token_cannot_write(client: AsyncClient, pool, monkeypatch):
+    monkeypatch.setattr(settings, "DASHBOARD_TOKEN_SECRET", _SECRET)
+    _key, _owner, ws, _hdr = await _setup(client)
+    # A second user, added to the workspace as a viewer.
+    _vkey, viewer = await _register(client)
+    await pool.execute(
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'viewer')",
+        uuid.UUID(ws["id"]),
+        uuid.UUID(viewer["id"]),
+    )
+    dt, _exp = auth.mint_dashboard_token(viewer["id"], ws["id"])
+    # The viewer can read...
+    assert (await client.get("/rest/v1/Sales", headers=_auth(dt))).status_code == 200
+    # ...but not write — check_access enforces the real role, not the token.
+    write = await client.post("/rest/v1/Sales", json={"Name": "Z", "Revenue": 1}, headers=_auth(dt))
     assert write.status_code == 403

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -88,6 +88,25 @@ async def test_insert_returns_row_with_id_then_patch_and_delete(client: AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_numeric_order_is_numeric_not_lexicographic(client: AsyncClient):
+    api_key, _user = await _register(client)
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "N"}, headers=_auth(api_key))
+    ).json()
+    await client.post(
+        f"/api/v1/workspaces/{ws['id']}/tables",
+        json={"name": "T", "columns": [{"name": "V", "type": "number"}]},
+        headers=_auth(api_key),
+    )
+    hdr = {**_auth(api_key), "X-Stash-Workspace": ws["id"]}
+    for v in [900, 7400, 5000, 3200]:
+        await client.post("/rest/v1/T", json={"V": v}, headers=hdr)
+    rows = (await client.get("/rest/v1/T?order=V.desc", headers=hdr)).json()
+    # Numeric order, not text order (which would put 900 first because '9' > '7').
+    assert [r["V"] for r in rows] == [7400, 5000, 3200, 900]
+
+
+@pytest.mark.asyncio
 async def test_schema_introspection(client: AsyncClient):
     _key, _user, _ws, hdr = await _setup(client)
     resp = await client.get("/rest/v1", headers=hdr)

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -1,0 +1,70 @@
+"""Tests for the realtime change-feed bus and the row-event hooks."""
+
+import json
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import realtime
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_dispatch_and_unsubscribe():
+    key = "table:unit-test"
+    q = realtime.subscribe(key)
+    realtime._dispatch_local(key, {"type": "row.created", "row_id": "1"})
+    assert q.get_nowait() == {"type": "row.created", "row_id": "1"}
+
+    realtime.unsubscribe(key, q)
+    realtime._dispatch_local(key, {"type": "row.created", "row_id": "2"})
+    assert q.empty()  # no longer subscribed
+
+
+def test_on_notify_dedupes_own_origin():
+    key = "table:dedupe-test"
+    q = realtime.subscribe(key)
+    try:
+        # An event this process emitted (same origin) was already dispatched locally.
+        realtime._on_notify(None, 0, realtime.CHANNEL,
+                            json.dumps({"origin": realtime._ORIGIN, "key": key, "event": {"a": 1}}))
+        assert q.empty()
+        # An event from another instance is dispatched.
+        realtime._on_notify(None, 0, realtime.CHANNEL,
+                            json.dumps({"origin": "other", "key": key, "event": {"a": 2}}))
+        assert q.get_nowait() == {"a": 2}
+    finally:
+        realtime.unsubscribe(key, q)
+
+
+@pytest.mark.asyncio
+async def test_row_create_emits_event(client: AsyncClient):
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    api_key = (
+        await client.post(
+            "/api/v1/users/register",
+            json={"name": name, "display_name": name, "password": "password123"},
+        )
+    ).json()["api_key"]
+    ws = (await client.post("/api/v1/workspaces", json={"name": "RT"}, headers=_auth(api_key))).json()
+    table = (
+        await client.post(
+            f"/api/v1/workspaces/{ws['id']}/tables",
+            json={"name": "Events", "columns": [{"name": "Title", "type": "text"}]},
+            headers=_auth(api_key),
+        )
+    ).json()
+
+    q = realtime.subscribe(realtime.table_key(table["id"]))
+    try:
+        hdr = {**_auth(api_key), "X-Stash-Workspace": ws["id"]}
+        created = await client.post("/rest/v1/Events", json={"Title": "Hi"}, headers=hdr)
+        assert created.status_code == 201
+        event = q.get_nowait()  # dispatched synchronously on emit
+        assert event["type"] == "row.created"
+        assert event["row_id"] == created.json()["id"]
+    finally:
+        realtime.unsubscribe(realtime.table_key(table["id"]), q)

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -29,12 +29,20 @@ def test_on_notify_dedupes_own_origin():
     q = realtime.subscribe(key)
     try:
         # An event this process emitted (same origin) was already dispatched locally.
-        realtime._on_notify(None, 0, realtime.CHANNEL,
-                            json.dumps({"origin": realtime._ORIGIN, "key": key, "event": {"a": 1}}))
+        realtime._on_notify(
+            None,
+            0,
+            realtime.CHANNEL,
+            json.dumps({"origin": realtime._ORIGIN, "key": key, "event": {"a": 1}}),
+        )
         assert q.empty()
         # An event from another instance is dispatched.
-        realtime._on_notify(None, 0, realtime.CHANNEL,
-                            json.dumps({"origin": "other", "key": key, "event": {"a": 2}}))
+        realtime._on_notify(
+            None,
+            0,
+            realtime.CHANNEL,
+            json.dumps({"origin": "other", "key": key, "event": {"a": 2}}),
+        )
         assert q.get_nowait() == {"a": 2}
     finally:
         realtime.unsubscribe(key, q)
@@ -49,7 +57,9 @@ async def test_row_create_emits_event(client: AsyncClient):
             json={"name": name, "display_name": name, "password": "password123"},
         )
     ).json()["api_key"]
-    ws = (await client.post("/api/v1/workspaces", json={"name": "RT"}, headers=_auth(api_key))).json()
+    ws = (
+        await client.post("/api/v1/workspaces", json={"name": "RT"}, headers=_auth(api_key))
+    ).json()
     table = (
         await client.post(
             f"/api/v1/workspaces/{ws['id']}/tables",

--- a/backend/tests/test_skill_seeds_defaults.py
+++ b/backend/tests/test_skill_seeds_defaults.py
@@ -30,7 +30,9 @@ async def _register_and_workspace(client: AsyncClient) -> tuple[UUID, UUID]:
     ).json()
     ws = (
         await client.post(
-            "/api/v1/workspaces", json={"name": "S"}, headers={"Authorization": f"Bearer {reg['api_key']}"}
+            "/api/v1/workspaces",
+            json={"name": "S"},
+            headers={"Authorization": f"Bearer {reg['api_key']}"},
         )
     ).json()
     return UUID(ws["id"]), UUID(reg["id"])

--- a/backend/tests/test_skill_seeds_defaults.py
+++ b/backend/tests/test_skill_seeds_defaults.py
@@ -1,0 +1,65 @@
+"""The default-skills registry seeds slides + build-on-stash into a workspace."""
+
+import os
+import uuid
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import skill_seeds
+
+
+@pytest.fixture
+def enable_seed():
+    prev = os.environ.pop(skill_seeds.DISABLE_ENV_VAR, None)
+    try:
+        yield
+    finally:
+        if prev is not None:
+            os.environ[skill_seeds.DISABLE_ENV_VAR] = prev
+
+
+async def _register_and_workspace(client: AsyncClient) -> tuple[UUID, UUID]:
+    name = f"user_{uuid.uuid4().hex[:10]}"
+    reg = (
+        await client.post(
+            "/api/v1/users/register",
+            json={"name": name, "display_name": name, "password": "password123"},
+        )
+    ).json()
+    ws = (
+        await client.post(
+            "/api/v1/workspaces", json={"name": "S"}, headers={"Authorization": f"Bearer {reg['api_key']}"}
+        )
+    ).json()
+    return UUID(ws["id"]), UUID(reg["id"])
+
+
+@pytest.mark.asyncio
+async def test_seeds_both_default_skills(client: AsyncClient, pool, enable_seed):
+    ws_id, user_id = await _register_and_workspace(client)
+    await skill_seeds.seed_default_skills(ws_id, user_id)
+
+    folders = await pool.fetch(
+        "SELECT lower(f.name) AS folder FROM pages p JOIN folders f ON f.id = p.folder_id "
+        "WHERE f.workspace_id = $1 AND p.name = 'SKILL.md' AND p.deleted_at IS NULL",
+        ws_id,
+    )
+    names = {r["folder"] for r in folders}
+    assert "slides" in names
+    assert "build-on-stash" in names
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(client: AsyncClient, pool, enable_seed):
+    ws_id, user_id = await _register_and_workspace(client)
+    await skill_seeds.seed_default_skills(ws_id, user_id)
+    await skill_seeds.seed_default_skills(ws_id, user_id)  # second run must not duplicate
+
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM pages p JOIN folders f ON f.id = p.folder_id "
+        "WHERE f.workspace_id = $1 AND lower(f.name) = 'build-on-stash' AND p.name = 'SKILL.md'",
+        ws_id,
+    )
+    assert count == 1

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -228,13 +228,9 @@ async def test_event_created_session_lands_in_default_folder(client: AsyncClient
     )
     assert pushed.status_code == 201
 
-    listed = await client.get(
-        "/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers
-    )
+    listed = await client.get("/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers)
     assert listed.status_code == 200
-    session = next(
-        s for s in listed.json()["sessions"] if s["session_id"] == "codex-untargeted"
-    )
+    session = next(s for s in listed.json()["sessions"] if s["session_id"] == "codex-untargeted")
     assert session["session_folder_id"] is not None
     assert session["session_folder_name"] == "Default"
 
@@ -265,12 +261,8 @@ async def test_transcript_upload_targets_explicit_session_folder(client: AsyncCl
     )
     assert upload.status_code == 201
 
-    listed = await client.get(
-        "/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers
-    )
-    session = next(
-        s for s in listed.json()["sessions"] if s["session_id"] == "pinned-session"
-    )
+    listed = await client.get("/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers)
+    session = next(s for s in listed.json()["sessions"] if s["session_id"] == "pinned-session")
     assert session["session_folder_id"] == folder_id
     assert session["session_folder_name"] == "Pinned"
 
@@ -302,9 +294,7 @@ async def test_event_stream_pin_targets_folder(client: AsyncClient):
     )
     assert pushed.status_code == 201
 
-    listed = await client.get(
-        "/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers
-    )
+    listed = await client.get("/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers)
     session = next(s for s in listed.json()["sessions"] if s["session_id"] == "codex-pinned")
     assert session["session_folder_id"] == folder_id
 
@@ -336,12 +326,8 @@ async def test_streamed_pin_does_not_re_home_explicit_move_to_root(client: Async
         )
 
     await push()
-    listed = await client.get(
-        "/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers
-    )
-    row_id = next(
-        s["id"] for s in listed.json()["sessions"] if s["session_id"] == "moved-session"
-    )
+    listed = await client.get("/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers)
+    row_id = next(s["id"] for s in listed.json()["sessions"] if s["session_id"] == "moved-session")
 
     moved = await client.post(
         f"/api/v1/workspaces/{ws}/session-folders/assign",
@@ -351,9 +337,7 @@ async def test_streamed_pin_does_not_re_home_explicit_move_to_root(client: Async
     assert moved.status_code == 200
 
     await push()  # another turn keeps streaming the pin
-    after = await client.get(
-        "/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers
-    )
+    after = await client.get("/api/v1/me/sessions", params={"workspace_id": ws}, headers=headers)
     session = next(s for s in after.json()["sessions"] if s["session_id"] == "moved-session")
     assert session["session_folder_id"] is None
 

--- a/cli/formatting.py
+++ b/cli/formatting.py
@@ -48,5 +48,3 @@ def print_user(user: dict, title: str = "Profile") -> None:
     lines.append(f"Created: {user.get('created_at', '')}")
     lines.append(f"Last seen: {user.get('last_seen', '')}")
     console.print(Panel("\n".join(lines), title=title))
-
-

--- a/cli/main.py
+++ b/cli/main.py
@@ -1773,7 +1773,9 @@ def skills_fork(
 def skills_snapshot_source(
     skill_id: str = typer.Argument(...),
     source: str = typer.Option(
-        ..., "--source", help="Connected-source handle (see /workspaces/<ws>/sources via `stash vfs`)."
+        ...,
+        "--source",
+        help="Connected-source handle (see /workspaces/<ws>/sources via `stash vfs`).",
     ),
     path: str = typer.Option(..., "--path", help="Document path within the source."),
     workspace_id: str = typer.Option(None, "--ws"),
@@ -2589,8 +2591,6 @@ def sources_rm(
     console.print("[green]Source removed.[/green]")
 
 
-
-
 def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
     """Stable filesystem-style directory name per source. Natives keep their
     handle ('files', 'sessions'); connected sources slug their display name,
@@ -2752,7 +2752,9 @@ def rm_cmd(
     with _client() as c:
         for object_type, object_id in items:
             if object_type not in trash:
-                console.print(f"[red]Cannot rm '{object_type}'. Supported: page | file | session[/red]")
+                console.print(
+                    f"[red]Cannot rm '{object_type}'. Supported: page | file | session[/red]"
+                )
                 raise typer.Exit(1)
             delete, purge = trash[object_type]
             try:
@@ -2784,7 +2786,9 @@ def restore_cmd(
     with _client() as c:
         for object_type, object_id in items:
             if object_type not in restore:
-                console.print(f"[red]Cannot restore '{object_type}'. Supported: page | file | session[/red]")
+                console.print(
+                    f"[red]Cannot restore '{object_type}'. Supported: page | file | session[/red]"
+                )
                 raise typer.Exit(1)
             try:
                 restore[object_type](c, object_id)

--- a/cli/main.py
+++ b/cli/main.py
@@ -3307,6 +3307,58 @@ def tables_delete_column(
         console.print("[green]Column deleted.[/green]")
 
 
+@tables_app.command("list")
+def tables_list(
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """List tables in the workspace with their columns."""
+    with _client() as c:
+        try:
+            ws = workspace_id or _resolve_workspace()
+            tables = c.list_tables(ws)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(tables)
+        return
+    if not tables:
+        console.print("[dim]No tables.[/dim]")
+        return
+    for t in tables:
+        cols = ", ".join(col["name"] for col in t.get("columns", []))
+        console.print(f"[cyan]{t['name']}[/cyan]  ({t.get('row_count', 0)} rows)  {t['id']}")
+        if cols:
+            console.print(f"  [dim]{cols}[/dim]")
+
+
+@tables_app.command("schema")
+def tables_schema(
+    name: str = typer.Argument(..., help="Table name"),
+    workspace_id: str = typer.Option(None, "--ws"),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Show a table's columns (types, required, options) — for building UIs on the data API."""
+    with _client() as c:
+        try:
+            ws = workspace_id or _resolve_workspace()
+            tables = c.list_tables(ws)
+        except StashError as e:
+            _err(e)
+    table = next((t for t in tables if t["name"].lower() == name.lower()), None)
+    if not table:
+        console.print(f"[red]No table named '{name}'.[/red]")
+        raise typer.Exit(1)
+    if _use_json(as_json):
+        output_json(table)
+        return
+    console.print(f"[bold cyan]{table['name']}[/bold cyan]  ({table.get('row_count', 0)} rows)")
+    for col in sorted(table.get("columns", []), key=lambda c: c.get("order", 0)):
+        req = " [red]required[/red]" if col.get("required") else ""
+        opts = f" options={col['options']}" if col.get("options") else ""
+        console.print(f"  [cyan]{col['name']}[/cyan] [yellow]{col['type']}[/yellow]{req}{opts}")
+
+
 @tables_app.command("count")
 def tables_count(
     table_id: str = typer.Argument(...),

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -380,6 +380,27 @@ def stash_table_schema(table_id: str, workspace_id: str = "") -> str:
 
 
 @mcp.tool()
+def stash_describe_workspace(workspace_id: str = "") -> str:
+    """Describe a workspace's tables + columns for building a dashboard/UI on the data API.
+
+    Returns each table's name and column schema. Build the UI against the supabase-style
+    data API: GET/POST/PATCH/DELETE /rest/v1/{table} (filter col=op.value, select, order).
+    """
+    client, default_ws = _client()
+    ws = _require_ws(workspace_id or default_ws)
+    tables = client.list_tables(ws)
+    return _json(
+        {
+            "workspace_id": ws,
+            "tables": [
+                {"name": t["name"], "id": t["id"], "columns": t.get("columns", [])} for t in tables
+            ],
+            "data_api": "/rest/v1/{table} — PostgREST/supabase-js compatible. See /llms.txt.",
+        }
+    )
+
+
+@mcp.tool()
 def stash_query_table(
     table_id: str,
     limit: int = 50,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -94,6 +94,16 @@ const nextConfig: NextConfig = {
           destination: `${backend}/api/v1/:path*`,
         },
         {
+          // Data API + grounded AI for dashboards. The backend sets open CORS on
+          // these so a sandboxed-iframe dashboard (opaque origin) can call them.
+          source: "/rest/v1/:path*",
+          destination: `${backend}/rest/v1/:path*`,
+        },
+        {
+          source: "/ai/v1/:path*",
+          destination: `${backend}/ai/v1/:path*`,
+        },
+        {
           source: "/skill/:path*",
           destination: `${backend}/skill/:path*`,
         },

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -36,6 +36,7 @@ import { useAuth } from "../../../../hooks/useAuth";
 import {
   ApiError,
   createCommentThread,
+  createDashboardToken,
   createPage,
   deleteCommentMessage,
   deleteCommentThread,
@@ -455,6 +456,32 @@ export default function SkillPageView() {
     if (!loading && !user && !skillSlug) router.push("/login");
   }, [user, loading, router, skillSlug]);
 
+  // Hosted dashboards: mint a short-lived read-only token and expose it to the
+  // sandboxed iframe as window.stash. Only for HTML pages that actually use the
+  // data API — slide decks and plain HTML pages are left untouched.
+  const [dashboardConfig, setDashboardConfig] = useState<{
+    token: string;
+    workspaceId: string;
+    apiBase: string;
+  } | null>(null);
+  useEffect(() => {
+    const isApp = page?.content_type === "html" && page?.html_layout === "app";
+    if (!isApp || !workspaceId) {
+      setDashboardConfig(null);
+      return;
+    }
+    let cancelled = false;
+    void createDashboardToken(workspaceId).then((dt) => {
+      if (cancelled) return;
+      setDashboardConfig(
+        dt ? { token: dt.token, workspaceId, apiBase: window.location.origin } : null,
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [page?.content_type, page?.html_layout, workspaceId]);
+
   const handleHtmlAnchorTops = useCallback((iframeAnchorTops: Record<string, number>) => {
     const layout = pageLayoutRef.current;
     const iframeBox = iframeBoxRef.current;
@@ -532,7 +559,8 @@ export default function SkillPageView() {
   const isHtml = page?.content_type === "html";
   // Full-width HTML drops the 1200px reading-column cap so the page gets the
   // whole window (minus the comment rail) — room for real responsive layouts.
-  const isFullWidth = isHtml && page?.html_layout === "full-width";
+  const isFullWidth =
+    isHtml && (page?.html_layout === "full-width" || page?.html_layout === "app");
   // Keep the live-update handler reading current view state without resubscribing.
   liveViewRef.current = { isHtml, htmlEditMode };
   loadRef.current = load;
@@ -750,6 +778,7 @@ export default function SkillPageView() {
                     onHtmlMutated={handleHtmlMutated}
                     stripCommentToken={stripCommentToken}
                     editable={htmlEditMode}
+                    dashboard={dashboardConfig}
                   />
                   {htmlSelection && !htmlComposer && !htmlEditMode && (
                     <button

--- a/frontend/src/components/workspace/HtmlPageView.tsx
+++ b/frontend/src/components/workspace/HtmlPageView.tsx
@@ -6,7 +6,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 // width:100%); the difference is purely the parent's column width, set in
 // PageClient. So every check below treats anything that isn't "fixed-aspect"
 // as the responsive path.
-export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width";
+export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width" | "app";
 
 export type HtmlSelectionInfo = {
   quoted_text: string;
@@ -49,6 +49,10 @@ type Props = {
    *  it from `html` prop changes, so the user's caret position survives
    *  the save round-trip. */
   editable?: boolean;
+  /** When set, this HTML page is a hosted dashboard: inject `window.stash`
+   *  (a read-only data-API client bound to a short-lived token) into the
+   *  sandboxed iframe so the page can read its workspace's data. */
+  dashboard?: { token: string; workspaceId: string; apiBase: string } | null;
 };
 
 // Iframes don't auto-size to their content — the parent has to decide the
@@ -78,6 +82,7 @@ export default function HtmlPageView({
   activeThreadId,
   stripCommentToken,
   editable = false,
+  dashboard,
 }: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const presentWrapRef = useRef<HTMLDivElement | null>(null);
@@ -105,11 +110,17 @@ export default function HtmlPageView({
   const [activeSlide, setActiveSlide] = useState(0);
 
   const srcDoc = useMemo(() => {
-    if (layout !== "fixed-aspect")
-      return injectResizeBootstrap(initialHtml, channel, Boolean(onNavigateLink));
-    if (isDeck) return injectSlideDeckBootstrap(initialHtml, channel);
-    return initialHtml;
-  }, [layout, channel, initialHtml, isDeck, onNavigateLink]);
+    if (layout === "fixed-aspect") {
+      return isDeck ? injectSlideDeckBootstrap(initialHtml, channel) : initialHtml;
+    }
+    let out = injectResizeBootstrap(initialHtml, channel, Boolean(onNavigateLink));
+    if (layout === "app") {
+      const apiOrigin =
+        dashboard?.apiBase ?? (typeof window !== "undefined" ? window.location.origin : "");
+      out = injectAppShell(out, apiOrigin, dashboard ?? null);
+    }
+    return out;
+  }, [layout, channel, initialHtml, isDeck, onNavigateLink, dashboard]);
 
   useEffect(() => {
     function onMessage(e: MessageEvent) {
@@ -501,6 +512,41 @@ export default function HtmlPageView({
 //   - active thread highlight class,
 //   - edit mode: toggles `contenteditable` on body and debounces the
 //     "current HTML" round-trip so the parent can save while the user types.
+// 'app' (dashboard) pages run author JS inside the sandbox. We inject, at the
+// very top of <head> (before any author script runs):
+//   1. a CSP egress-lock — the script may read/write the stash data API but
+//      can't send data anywhere else, so even agent-authored JS can't exfiltrate;
+//   2. for an owner-viewed dashboard, a `window.stash` client bound to the
+//      short-lived read token. Public renders get the CSP but no token.
+// The page is opaque-origin, so the API must be an absolute URL (apiOrigin).
+function injectAppShell(
+  html: string,
+  apiOrigin: string,
+  dashboard: { token: string; workspaceId: string; apiBase: string } | null,
+): string {
+  const csp =
+    `<meta http-equiv="Content-Security-Policy" content="` +
+    `default-src 'none'; ` +
+    `script-src 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com https://cdn.tailwindcss.com; ` +
+    `style-src 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com https://fonts.googleapis.com; ` +
+    `font-src data: https://fonts.gstatic.com https://cdn.jsdelivr.net; ` +
+    `img-src 'self' data: ${apiOrigin}; ` +
+    `connect-src ${apiOrigin};">`;
+  let head = csp;
+  if (dashboard) {
+    const cfg = JSON.stringify(dashboard);
+    head +=
+      `<script>(function(){var d=${cfg};window.stash={` +
+      `token:d.token,workspaceId:d.workspaceId,apiBase:d.apiBase,` +
+      `rest:function(path,opts){opts=opts||{};` +
+      `var h=Object.assign({},opts.headers,{Authorization:"Bearer "+d.token});` +
+      `return fetch(d.apiBase+"/rest/v1/"+path,Object.assign({},opts,{headers:h}));}};})();</script>`;
+  }
+  if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (m) => m + head);
+  if (/<html[^>]*>/i.test(html)) return html.replace(/<html[^>]*>/i, (m) => m + head);
+  return head + html;
+}
+
 function injectResizeBootstrap(
   html: string,
   channel: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -245,6 +245,25 @@ export async function createMyKey(name: string): Promise<ApiKeyCreated> {
   });
 }
 
+export interface DashboardToken {
+  token: string;
+  expires_at: number;
+}
+
+// A short-lived, read-only token a hosted HTML dashboard uses to read this
+// workspace's data via the data API. Returns null if the feature is off
+// (DASHBOARD_TOKEN_SECRET unset → 503) so callers can degrade silently.
+export async function createDashboardToken(workspaceId: string): Promise<DashboardToken | null> {
+  try {
+    return await apiFetch<DashboardToken>("/api/v1/dashboard-tokens", {
+      method: "POST",
+      body: JSON.stringify({ workspace_id: workspaceId }),
+    });
+  } catch {
+    return null;
+  }
+}
+
 export async function searchUsers(query: string): Promise<UserSearchResult[]> {
   return apiFetch(`/api/v1/users/search?q=${encodeURIComponent(query)}`);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,7 +46,7 @@ export interface Folder {
   updated_at: string;
 }
 
-export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width";
+export type HtmlLayout = "responsive" | "fixed-aspect" | "full-width" | "app";
 
 export interface Page {
   id: string;


### PR DESCRIPTION
## Stash as a generative-UI backend

Turns stash into a **Supabase-style backend** so people build dashboards and vibe-coded UIs on their synced data — point their own UI at it, or have stash host the dashboard. Backend + frontend, fully tested (644 backend tests; browser-verified).

> This description is long on purpose: it's the canonical record of **what was built**, **why the interface is shaped this way**, and **the full credential/permission model**.

---

## 1. What it delivers

- **Data API** `/rest/v1/{table}` — PostgREST/supabase-js compatible (`services/postgrest.py`): filters/select/order/`Content-Range`, single-row `?id=eq.`, `GET /rest/v1` schema introspection. Fails loud (501) on joins/rpc/and-or.
- **Auth, two paths:** private via an owner-bound **dashboard token** (`dt_`, read+write); public/shared via **publishable keys** (`pk_`) + per-table policies.
- **Realtime** — Postgres LISTEN/NOTIFY → SSE `/rest/v1/{table}/subscribe`, cross-instance.
- **Grounded AI** — `/ai/v1/{ws}/search` + `useChat`-compatible `/chat` (read-only tools); authenticated-only, `pk_` rejected.
- **In-Pages hosted dashboards** — `html_layout:"app"` keeps author JS, run only in the sandboxed iframe + a **CSP egress-lock**. Browser-verified: data renders; exfiltration is blocked.
- **Discoverability** — open CORS for browser APIs, `/llms.txt`, public OpenAPI, a seeded **build-on-stash `SKILL.md`**, and introspection across **API + CLI (`stash tables list/schema`) + MCP (`stash_describe_workspace`)**.

**By the numbers:** 15 commits · 39 files · +2,469/−90 · migrations `0117` (head-fix), `0118` (publishable keys), `0119` (app layout).

---

## 2. The interface — what it is and why (decision-making)

**What:** a PostgREST/supabase-js wire-compatible REST API over stash tables, plus the Vercel AI SDK `useChat` shape for AI. A UI talks to stash with `supabase.from('x').select()` / `fetch` and `useChat({api})`.

**The guiding principle (from day one):** *build for what agents are natively fluent in — what's in their training data — not a custom code-block/DSL.* For "a database with auth + realtime you build a UI on," the thing that dominates vibe-coded-app training data is **Supabase**. If stash looks like Supabase, an agent's generated code is correct **zero-shot**, without reading our docs. We're matching the API the model already knows, not teaching it a new one. Same logic for AI → `useChat`/AI-SDK shape.

**Use case:** data stays synced in stash (the backend: sync, infra, agents, memory); people vibe-code the frontend — a dashboard, internal tool, or public data app — and point it at us, or host it inside stash. They get all their data instantly with full control of presentation. Data is the moat; the UI is theirs.

**Options considered and rejected:**

| Option | Why not |
|---|---|
| **Custom JSON→UI component DSL / server-driven UI** | The "custom code-block stuff" to avoid: not in training data → agents get it wrong, and we'd own a rendering runtime forever. Let agents write normal React/HTML against a normal data API. |
| **Plain REST + OpenAPI** (agent reads a spec) | Works, but relies on doc-reading. Supabase-shape gets correctness from muscle memory. |
| **A novel in-house SDK surface** | Familiar (supabase-js) > a surface the agent must learn. |
| **Full Supabase wire-compat incl. realtime (Phoenix websockets)** | Emulating their WS protocol is expensive for little gain. We're wire-compatible on the **data plane** (a cheap facade over our JSONB tables) but use **our own SSE + LISTEN/NOTIFY** for realtime. |
| **Multi-tenant end-user auth (Supabase Auth / GoTrue)** | A whole identity product for *apps' own* users (Alice/Bob). Scope is "users pulling **their own** data" → deferred. |
| **Generic LLM gateway** | Commodity + cost center. Only **grounded-over-stash** AI is differentiated. |
| **Inline dashboards in the trusted UI with an injected token** | Unsafe — a shared/agent-authored page could exfiltrate the viewer's data. Replaced by sandbox + CSP. |
| **Separate origin / wildcard subdomain per dashboard (Lovable model)** | The robust answer *only* for stateful multi-tenant apps; sandbox+CSP cover read/write dashboards over your own data. Deferred. |

**Honest caveat about the facade:** stash tables aren't Postgres tables — it's **one JSONB `table_rows` table**, so the data API is a *translation facade*, not a passthrough. That's why CRUD/filters are "just a view" (cheap, lossless) but joins/RPC are meaningless → **501**, not faked. Column filters scan within a `table_id` (fine at dashboard scale; an `eq → @>` GIN optimization is a deferred follow-up).

---

## 3. Credentials & permissions

### The three credentials

| Credential | Prefix | Represents | Lives | Workspace | Lifetime |
|---|---|---|---|---|---|
| **User key** | `mc_` | a full user identity | server-side only | any (`X-Stash-Workspace` header) | long-lived |
| **Dashboard token** | `dt_` | **a person** (the owner), real role | injected into the sandboxed dashboard iframe | bound to one (baked in) | short-lived, HMAC-signed |
| **Publishable key** | `pk_` | **an app/project** (anonymous) | embedded in browser JS | bound to one (the key's) | until revoked |

### Why **both** `dt_` and `pk_`?

They answer different questions and neither can do the other's job:
- **`dt_` answers "who are you?"** → the owner → reads/writes **your private** data.
- **`pk_` answers "which app is this?"** → anonymous → only data you **explicitly shared**.

A `pk_` key **can't** show private data (it's public — everyone has the same one). A `dt_` token **can't** be the public path (it carries a specific user's authority and expires). This is exactly Supabase's split: **anon key (`pk_`)** for public/policy-gated data, **authenticated user JWT (`dt_`/`mc_`)** for private.

### Why a public key at all (if it's "public")?

The `pk_` key is **not a secret** and isn't what protects anything — policies + the data being public do that. The key is a **named, revocable handle** that earns its place via: **routing** (which workspace), **per-consumer scoping** (many keys, different grants), **revocation** (cut off one leaked/abused consumer without un-publishing for all), and **abuse attribution** (rate-limit per key). A keyless "mark table public" design would also work; we chose keys for those controls + Supabase parity.

### Access matrix on the data API

| Operation | `mc_` (owner/editor) | `dt_` dashboard token | `pk_` publishable key |
|---|---|---|---|
| Read a table | ✅ if member can read | ✅ owner's read access | ✅ **only** with a read policy |
| Write a table | ✅ if role allows | ✅ owner/editor; ❌ viewer | ✅ **only** with a write policy |
| Schema introspect (`GET /rest/v1`) | ✅ readable tables | ✅ readable tables | ✅ policy'd tables |
| Realtime SSE | ✅ | ✅ (`?access_token=`) | ✅ (`?access_token=`) |
| AI (`/ai/v1/*`) | ✅ | ✅ (it's a user) | ❌ never anonymous |
| Mint a dashboard token | ✅ | ❌ tokens can't mint | ❌ |

**Defaults:** an anon key grants **nothing** until a policy is attached; policies are **read-only by default**, write is explicit opt-in. A `dt_` grants the owner's **actual** role — a viewer's dashboard still can't write.

### Page-kind / script / hosting

| `html_layout` | Author `<script>` on save | Token injected? | CSP egress-lock? |
|---|---|---|---|
| `responsive` / `fixed-aspect` / `full-width` | **stripped** (nh3) | no | no |
| **`app`** (dashboard) | **kept** | `window.stash` **only on the owner's own view** | **yes** (`connect-src` = stash API only) |

### Security boundaries (how it's safe)

| Boundary | Stops | Doesn't stop |
|---|---|---|
| **Sandbox** (`allow-scripts`, opaque origin) | reading the viewer's cookie/session/DOM; shared storage | the script using a credential you *hand* it |
| **CSP egress-lock** (`connect-src` = API) | exfiltrating to any other origin | a *write* to the stash API itself |
| **`check_access`** (real workspace role) | a viewer writing; cross-workspace access | (this is the authority gate) |

Reads are contained by sandbox+CSP; writes by `check_access`. No single layer does it all — they compose.

### Edge cases & decisions

| Case | Resolution |
|---|---|
| `EventSource` can't set headers | SSE auth via `?access_token=` query param |
| `mc_` caller has many workspaces | must send `X-Stash-Workspace`; `dt_`/`pk_` are bound |
| `order` on a number column | fixed: cast to numeric (`900` no longer sorts above `7400`) |
| `?id=eq.<uuid>` (supabase `.eq('id')`) | fixed: single-row fetch (`id` is the row id, not a cell) |
| Joins / RPC / `and`/`or` | 501 fail-loud (meaningless on a JSONB single-table store) |
| `/pages/{id}/download` served HTML inline | fixed: `attachment` + `nosniff` (would execute app-page scripts on the trusted origin) |
| Owner-private dashboard write | allowed (owner's real access; not an escalation) |
| Viewer-role dashboard write | blocked by `check_access` |
| Shared dashboard, author ≠ viewer | deferred; `check_access` already stops viewer writes |
| Multi-tenant per-user row slices (Alice ≠ Bob) | not supported (needs end-user auth) |
| `DASHBOARD_TOKEN_SECRET` unset | feature off (same idiom as `STRIPE_SECRET_KEY`) |
| Anon AI on owner's Anthropic tokens | prevented — AI is authenticated-only |

---

## 4. CI status — honest

| Check | Result |
|---|---|
| Backend tests (pytest) | ✅ pass |
| Backend lint (ruff+black) | ✅ pass (`ruff check backend/ cli/` + `black --check` verified locally) |
| Frontend lint (ESLint) | ✅ pass |
| Plugin tests | ✅ pass |
| Frontend Vitest | ❌ **pre-existing** — one table-cell-commit test fails *identically on clean `origin/main`*; untouched by this PR |
| Dependency audit | ❌ **pre-existing** — 4 transitive npm vulns in the frontend lockfile; this PR changes no `package.json`/lockfile |

**Every red check is pre-existing on `main` — none are caused by this PR.** Also fixed two pre-existing main breakages: the duplicate `0116` alembic head, and black-26 lint drift.

---

## 5. Deferred (non-blocking)
- Scoped write when *sharing* a private dashboard to other users (author ≠ viewer) — `check_access` already stops viewer writes.
- Wildcard-subdomain per-dashboard isolation — only for stateful multi-tenant apps.
- `eq → @>` GIN filter optimization.

## 6. Worth a maintainer's eye
- The `app` page-kind **stores author scripts** un-sanitized — safe via sandbox + CSP + the download fix, but it's the security-load-bearing change; review carefully.
- The two pre-existing CI reds (Vitest, dep-audit) will show red but aren't regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
