### PR TITLE
fix: make plugin transcript upload work on Windows

### DIFF
--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -28,13 +28,40 @@ if command -v stash >/dev/null 2>&1; then
   # pyenv shim, pyenv prepends its version's bin dir to PATH, so a stale
   # pip-installed `stash` in that dir shadows the real pipx/uv install.
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/plugins/codex-plugin/scripts/_run.sh
+++ b/plugins/codex-plugin/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/plugins/cursor-plugin/scripts/_run.sh
+++ b/plugins/cursor-plugin/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/plugins/openclaw-plugin/scripts/_run.sh
+++ b/plugins/openclaw-plugin/scripts/_run.sh
@@ -21,13 +21,40 @@ if [ -z "$PY" ] && command -v stash >/dev/null 2>&1; then
   # pyenv shim, pyenv prepends its version's bin dir to PATH, so a stale
   # pip-installed `stash` in that dir shadows the real pipx/uv install.
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 if [ -z "$PY" ]; then

--- a/plugins/opencode-plugin/scripts/_run.sh
+++ b/plugins/opencode-plugin/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "rich>=13.0.0",
     "questionary>=2.0.0",
     "mcp>=1.23.0",
+    "filelock>=3.12",
 ]
 
 [project.urls]

--- a/stashai/plugin/assets/codex/scripts/_run.sh
+++ b/stashai/plugin/assets/codex/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/stashai/plugin/assets/cursor/scripts/_run.sh
+++ b/stashai/plugin/assets/cursor/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/stashai/plugin/assets/opencode/scripts/_run.sh
+++ b/stashai/plugin/assets/opencode/scripts/_run.sh
@@ -35,13 +35,40 @@ fi
 PY=""
 if command -v stash >/dev/null 2>&1; then
   STASH_BIN="$(command -v stash)"
-  STASH_REAL="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$STASH_BIN" 2>/dev/null || true)"
-  if [ -n "$STASH_REAL" ]; then
-    CANDIDATE="$(dirname "$STASH_REAL")/python"
-    if [ -x "$CANDIDATE" ]; then
-      PY="$CANDIDATE"
-    fi
-  fi
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except Exception:
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception:
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
 fi
 
 # pip --user (stashai on system site-packages) or any case the venv-python

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -10,12 +10,12 @@ flush daemon.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import time
 from pathlib import Path
 
 import httpx
+from filelock import FileLock
 
 from stashai.plugin.upload_status import (
     record_upload_attempt,
@@ -149,6 +149,12 @@ class StashClient:
             return None
         return self._data_dir / QUEUE_FILENAME
 
+    def _queue_lock(self, qp: Path) -> FileLock:
+        # Cross-platform advisory lock on a sidecar file so concurrent hook
+        # processes don't corrupt the queue. fcntl is Unix-only; FileLock works
+        # on Windows too. Time out rather than hang a hook on a stuck lock.
+        return FileLock(str(qp) + ".lock", timeout=10)
+
     def _enqueue(self, path: str, body: dict) -> None:
         qp = self._queue_path()
         if not qp:
@@ -156,12 +162,8 @@ class StashClient:
         try:
             qp.parent.mkdir(parents=True, exist_ok=True)
             entry = json.dumps({"path": path, "body": body, "ts": time.time()})
-            with open(qp, "a") as f:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                try:
-                    f.write(entry + "\n")
-                finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with self._queue_lock(qp), open(qp, "a") as f:
+                f.write(entry + "\n")
             # Cheap upper bound: trim only when grossly oversized.
             self._maybe_trim_queue(qp)
         except Exception:
@@ -169,19 +171,15 @@ class StashClient:
 
     def _maybe_trim_queue(self, qp: Path) -> None:
         try:
-            with open(qp, "r+") as f:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                try:
-                    lines = f.read().splitlines()
-                    if len(lines) <= QUEUE_MAX_ENTRIES:
-                        return
-                    # Keep the most recent QUEUE_MAX_ENTRIES; oldest are sacrificed.
-                    keep = lines[-QUEUE_MAX_ENTRIES:]
-                    f.seek(0)
-                    f.truncate()
-                    f.write("\n".join(keep) + ("\n" if keep else ""))
-                finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with self._queue_lock(qp), open(qp, "r+") as f:
+                lines = f.read().splitlines()
+                if len(lines) <= QUEUE_MAX_ENTRIES:
+                    return
+                # Keep the most recent QUEUE_MAX_ENTRIES; oldest are sacrificed.
+                keep = lines[-QUEUE_MAX_ENTRIES:]
+                f.seek(0)
+                f.truncate()
+                f.write("\n".join(keep) + ("\n" if keep else ""))
         except Exception:
             pass
 
@@ -191,35 +189,31 @@ class StashClient:
             return True
         drained = True
         try:
-            with open(qp, "r+") as f:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                try:
-                    lines = f.read().splitlines()
-                    if not lines:
-                        return True
-                    remaining: list[str] = []
-                    sent = 0
-                    for line in lines:
-                        if sent >= DRAIN_BATCH:
-                            remaining.append(line)
-                            continue
-                        try:
-                            entry = json.loads(line)
-                            self._post(entry["path"], json=entry["body"])
-                            sent += 1
-                        except Exception as e:
-                            # Backend still unhappy. Stop now; keep this and the rest.
-                            remaining.append(line)
-                            record_upload_failure(self._data_dir, "event_queue", e)
-                            drained = False
-                            # Don't try further entries — likely all will fail.
-                            sent = DRAIN_BATCH
-                    f.seek(0)
-                    f.truncate()
-                    if remaining:
-                        f.write("\n".join(remaining) + "\n")
-                finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with self._queue_lock(qp), open(qp, "r+") as f:
+                lines = f.read().splitlines()
+                if not lines:
+                    return True
+                remaining: list[str] = []
+                sent = 0
+                for line in lines:
+                    if sent >= DRAIN_BATCH:
+                        remaining.append(line)
+                        continue
+                    try:
+                        entry = json.loads(line)
+                        self._post(entry["path"], json=entry["body"])
+                        sent += 1
+                    except Exception as e:
+                        # Backend still unhappy. Stop now; keep this and the rest.
+                        remaining.append(line)
+                        record_upload_failure(self._data_dir, "event_queue", e)
+                        drained = False
+                        # Don't try further entries — likely all will fail.
+                        sent = DRAIN_BATCH
+                f.seek(0)
+                f.truncate()
+                if remaining:
+                    f.write("\n".join(remaining) + "\n")
         except Exception:
             return False
         return drained


### PR DESCRIPTION
## Problem

Stash transcript/event uploads silently fail on Windows. The hooks run, but **nothing is ever uploaded** — confirmed in the field (`ModuleNotFoundError: No module named 'stashai'`). There are two **independent** Windows incompatibilities in the plugin runtime; the original "it's the symlinks" hypothesis is half of it.

### 1. `_run.sh` can't find the venv python (the symlink part)

`_run.sh` resolved the stashai venv interpreter by following the `stash` binary's **symlink** (`dirname(realpath(stash))/python`). On Windows, the uv/pipx `stash` shim is a real `.exe`, **not** a symlink — `realpath` returns it unchanged, `~/.local/bin/python` doesn't exist, and it falls back to the WindowsApps `python3`, which has no `stashai`. Every hook no-ops.

### 2. `stash_client.py` hard-imports `fcntl` (independent)

`stash_client.py` did a top-level `import fcntl` (Unix-only) and used `fcntl.flock` in 3 places to lock the upload queue. The module **won't even import on Windows**. This is orthogonal to #1 — fixing the interpreter alone would just surface this next.

## Fix

**`_run.sh` (all 8 shipped copies — claude / cursor / codex / opencode / openclaw + the 3 `stashai/plugin/assets/*` copies):** do the interpreter resolution in Python instead of bash (bash mishandles Windows backslash paths). We probe both the next-to-binary layout (Unix symlink case, unchanged behavior) and the `uv tool dir` venv (Windows), and only accept an interpreter that can actually `import stashai` — so we never silently pick the wrong python. Bash still resolves `stash` itself (preserves the existing pyenv-shadowing guard).

**`stash_client.py`:** replace `fcntl` with cross-platform [`filelock`](https://pypi.org/project/filelock/) (added to `pyproject.toml` deps), collapsing the manual lock/unlock `try/finally` into a single sidecar-file lock with a timeout.

## Verification

- ✅ macOS (symlink path): resolver picks the uv tool venv python, imports `stashai`.
- ✅ Simulated Windows (non-symlink shim): old code would fall back to a stashai-less python; new code **recovers via `uv tool dir`** and confirms the import.
- ✅ `bash -n` on all 8 `_run.sh` copies.
- ✅ `96 passed` (full plugin test suite, incl. the event-queue lock tests), `ruff` clean.
- ⚠️ I could not run on a real Windows machine. The bash→python resolver change is a strict superset of prior Unix behavior; the Windows paths are exercised via simulation only.

## Follow-up (not in this PR)

The marketplace claude plugin only refreshes `_run.sh` on a **plugin version bump**, so a release bump is needed for #1 to actually reach installed Windows users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)