### PR TITLE
Grant Pro to internal team email domains

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -294,6 +294,11 @@ class Settings:
     # The recurring Pro prices (price_...): $20/month and $200/year.
     STRIPE_MONTHLY_PRICE_ID: str | None = os.getenv("STRIPE_MONTHLY_PRICE_ID")
     STRIPE_ANNUAL_PRICE_ID: str | None = os.getenv("STRIPE_ANNUAL_PRICE_ID")
+    # Internal team domains get Pro for free. Set to "false" to make internal
+    # accounts hit the real pay gate — useful for testing the paywall.
+    INTERNAL_DOMAINS_FREE_PRO: bool = (
+        os.getenv("INTERNAL_DOMAINS_FREE_PRO", "true").lower() == "true"
+    )
 
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")

--- a/backend/migrations/versions/0117_html_full_width_layout.py
+++ b/backend/migrations/versions/0117_html_full_width_layout.py
@@ -5,14 +5,14 @@ Adds a third layout mode to the pages.html_layout CHECK constraint. Like
 1200px reading-column cap so the page uses the full window width (keeping the
 comment rail). Right for web-page-style HTML that wants real responsive room.
 
-Revision ID: 0116
-Revises: 0115
+Revision ID: 0117
+Revises: 0116
 """
 
 from alembic import op
 
-revision = "0116"
-down_revision = "0115"
+revision = "0117"
+down_revision = "0116"
 branch_labels = None
 depends_on = None
 

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -26,7 +26,7 @@ async def my_billing(current_user: dict = Depends(get_current_user)):
     status = subscription["status"] if subscription else None
     return {
         "billing_enabled": True,
-        "plan": "pro" if status in billing_service.ACTIVE_STATUSES else "free",
+        "plan": "pro" if await billing_service.is_pro(current_user["id"]) else "free",
         "status": status,
         "connection_count": await billing_service.connection_count(current_user["id"]),
         "connection_limit": billing_service.FREE_CONNECTION_LIMIT,

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -25,6 +25,13 @@ from ..database import get_pool
 ACTIVE_STATUSES = {"active", "trialing"}
 FREE_CONNECTION_LIMIT = 1
 
+# Internal team accounts get Pro without a subscription — no card, no Stripe row.
+INTERNAL_EMAIL_DOMAINS = {"ferganalabs.com", "joinstash.ai"}
+
+
+def is_internal_email(email: str | None) -> bool:
+    return bool(email) and email.rsplit("@", 1)[-1].lower() in INTERNAL_EMAIL_DOMAINS
+
 
 def billing_enabled() -> bool:
     return settings.STRIPE_SECRET_KEY is not None
@@ -41,10 +48,17 @@ async def get_subscription(user_id: UUID) -> dict | None:
 
 
 async def is_pro(user_id: UUID) -> bool:
-    status = await get_pool().fetchval(
-        "SELECT status FROM user_subscriptions WHERE user_id = $1", user_id
+    row = await get_pool().fetchrow(
+        "SELECT u.email, s.status FROM users u "
+        "LEFT JOIN user_subscriptions s ON s.user_id = u.id "
+        "WHERE u.id = $1",
+        user_id,
     )
-    return status in ACTIVE_STATUSES
+    if row is None:
+        return False
+    if is_internal_email(row["email"]):
+        return True
+    return row["status"] in ACTIVE_STATUSES
 
 
 async def connection_count(user_id: UUID) -> int:

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -30,6 +30,8 @@ INTERNAL_EMAIL_DOMAINS = {"ferganalabs.com", "joinstash.ai"}
 
 
 def is_internal_email(email: str | None) -> bool:
+    if not settings.INTERNAL_DOMAINS_FREE_PRO:
+        return False
     return bool(email) and email.rsplit("@", 1)[-1].lower() in INTERNAL_EMAIL_DOMAINS
 
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -108,6 +108,23 @@ async def test_each_account_counts(client, pool, billing_on):
 
 
 @pytest.mark.asyncio
+async def test_internal_email_gets_pro_without_subscription(client, pool, billing_on):
+    """Team accounts on an internal domain bypass the pay gate with no Stripe row."""
+    api_key, user_id = await _register(client)
+    await pool.execute(
+        "UPDATE users SET email = 'dev@joinstash.ai' WHERE id = $1", user_id
+    )
+    await _connect_account(pool, user_id, "github")
+
+    # A free user would be gated here; the internal account is not.
+    await billing_service.ensure_can_connect(user_id)
+
+    me = (await client.get("/api/v1/billing/me", headers=_auth(api_key))).json()
+    assert me["plan"] == "pro"
+    assert me["status"] is None
+
+
+@pytest.mark.asyncio
 async def test_gate_off_when_billing_disabled(client, pool, monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None)
     _, user_id = await _register(client)

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -125,6 +125,20 @@ async def test_internal_email_gets_pro_without_subscription(client, pool, billin
 
 
 @pytest.mark.asyncio
+async def test_internal_bypass_can_be_disabled(client, pool, billing_on, monkeypatch):
+    """Flipping INTERNAL_DOMAINS_FREE_PRO off makes internal accounts hit the
+    real pay gate — for testing the paywall."""
+    monkeypatch.setattr(settings, "INTERNAL_DOMAINS_FREE_PRO", False)
+    _, user_id = await _register(client)
+    await pool.execute("UPDATE users SET email = 'dev@joinstash.ai' WHERE id = $1", user_id)
+    await _connect_account(pool, user_id, "github")
+
+    with pytest.raises(HTTPException) as exc:
+        await billing_service.ensure_can_connect(user_id)
+    assert exc.value.status_code == 402
+
+
+@pytest.mark.asyncio
 async def test_gate_off_when_billing_disabled(client, pool, monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None)
     _, user_id = await _register(client)


### PR DESCRIPTION
## What

Internal team accounts on `@ferganalabs.com` and `@joinstash.ai` now get **Pro for free** — no card, no Stripe subscription. This lets the team connect unlimited integrations (e.g. Google Drive) without hitting the "Upgrade to Pro" pay gate.

## How

The free-plan limit (1 connected account) is enforced at connect time, and both the gate and the `/billing/me` plan display route through `billing_service.is_pro()`. So the change is a single touch point:

- `is_pro()` now joins `users` for the email and returns `True` when the domain is internal — otherwise falls back to the existing Stripe-status check.
- `/billing/me` derives `plan` from `is_pro()` so internal accounts also *display* as Pro (status stays `null` since there's no subscription row).

```python
INTERNAL_EMAIL_DOMAINS = {"ferganalabs.com", "joinstash.ai"}
```

## Drive-by fix (flagging separately)

`alembic upgrade head` was failing because revision `0116` was duplicated across two independently-merged PRs (`0116_linear_source` and `0116_html_full_width_layout`), both with `down_revision = "0115"` and nothing chaining after. This broke the entire backend test suite. Linearized by renumbering the HTML-layout migration to `0117`, chained after `0116_linear_source`. Worth a quick sanity check that this ordering is fine.

## Tests

Added `test_internal_email_gets_pro_without_subscription`: an internal-domain user with one existing connection is **not** gated and reports `plan: pro` with `status: null`.

```
backend/tests/test_billing.py .......... 10 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)