### PR TITLE
Index Shared with me + Shared Drives in Google Drive crawl

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -8,6 +8,13 @@ with the owner's token. The agent still navigates it like a file system.
 
 Listing a folder + federated `fullText` search use the `drive.readonly` scope,
 so the crawl and search see the user's whole Drive (not just app-picked files).
+
+A whole-Drive source ("root") also crawls everything else the user can see but
+does not own: the "Shared with me" corpus (files/folders others shared directly)
+and every Shared Drive they belong to. Drive parents these outside My Drive, so
+without a dedicated pass they would be invisible even though the user sees them
+in the Drive UI. Every list/read call sets the all-drives flags; otherwise the
+API silently drops Shared Drive items.
 """
 
 from __future__ import annotations
@@ -26,6 +33,10 @@ logger = logging.getLogger(__name__)
 DRIVE_LIST_URL = "https://www.googleapis.com/drive/v3/files"
 DRIVE_FILE_URL = "https://www.googleapis.com/drive/v3/files/{file_id}"
 DRIVE_EXPORT_URL = "https://www.googleapis.com/drive/v3/files/{file_id}/export"
+DRIVE_DRIVES_URL = "https://www.googleapis.com/drive/v3/drives"
+# Required on every files call so items living in Shared Drives are returned;
+# without them the API pretends Shared Drive content does not exist.
+ALL_DRIVES = {"supportsAllDrives": "true", "includeItemsFromAllDrives": "true"}
 MIME_FOLDER = "application/vnd.google-apps.folder"
 MIME_GOOGLE_DOC = "application/vnd.google-apps.document"
 MIME_GOOGLE_SHEET = "application/vnd.google-apps.spreadsheet"
@@ -44,13 +55,14 @@ def _parse_time(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-async def _list_folder(client: httpx.AsyncClient, folder_id: str) -> list[dict]:
-    """All non-trashed children of a Drive folder."""
+async def _list(client: httpx.AsyncClient, q: str) -> list[dict]:
+    """All non-trashed files matching a Drive query `q` (paged)."""
     out: list[dict] = []
     page_token: str | None = None
     while True:
         params = {
-            "q": f"'{folder_id}' in parents and trashed = false",
+            **ALL_DRIVES,
+            "q": q,
             "fields": "nextPageToken, files(id, name, mimeType, modifiedTime)",
             "pageSize": 200,
         }
@@ -65,6 +77,23 @@ async def _list_folder(client: httpx.AsyncClient, folder_id: str) -> list[dict]:
             return out
 
 
+async def _shared_drives(client: httpx.AsyncClient) -> list[dict]:
+    """Every Shared Drive the user belongs to."""
+    out: list[dict] = []
+    page_token: str | None = None
+    while True:
+        params = {"pageSize": 100, "fields": "nextPageToken, drives(id, name)"}
+        if page_token:
+            params["pageToken"] = page_token
+        resp = await client.get(DRIVE_DRIVES_URL, params=params)
+        resp.raise_for_status()
+        body = resp.json()
+        out.extend(body.get("drives", []))
+        page_token = body.get("nextPageToken")
+        if not page_token:
+            return out
+
+
 async def index_google_drive(source: dict) -> str | None:
     source_id = UUID(source["id"])
     workspace_id = UUID(source["workspace_id"])
@@ -74,31 +103,55 @@ async def index_google_drive(source: dict) -> str | None:
     token = await get_valid_token(owner_user_id, "google")
     headers = {"Authorization": f"Bearer {token}"}
     present: list[str] = []
+    # A file shared at top level and also nested in a shared folder shows up
+    # twice; dedup by id so it is indexed once and folder cycles can't loop.
+    seen: set[str] = set()
 
     async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+
+        async def _index(entry: dict, prefix: str) -> None:
+            name = entry["name"]
+            path = f"{prefix}{name}"
+            await source_service.upsert_index_row(
+                table="drive_index",
+                source_id=source_id,
+                workspace_id=workspace_id,
+                path=path,
+                name=name,
+                kind="file",
+                external_ref=entry["id"],
+                external_updated_at=_parse_time(entry.get("modifiedTime")),
+            )
+            present.append(path)
 
         async def _walk(folder_id: str, prefix: str, depth: int) -> None:
             if depth > MAX_FOLDER_DEPTH:
                 return
-            for entry in await _list_folder(client, folder_id):
-                name = entry["name"]
-                path = f"{prefix}{name}"
-                if entry["mimeType"] == MIME_FOLDER:
-                    await _walk(entry["id"], f"{path}/", depth + 1)
+            for entry in await _list(client, f"'{folder_id}' in parents and trashed = false"):
+                if entry["id"] in seen:
                     continue
-                await source_service.upsert_index_row(
-                    table="drive_index",
-                    source_id=source_id,
-                    workspace_id=workspace_id,
-                    path=path,
-                    name=name,
-                    kind="file",
-                    external_ref=entry["id"],
-                    external_updated_at=_parse_time(entry.get("modifiedTime")),
-                )
-                present.append(path)
+                seen.add(entry["id"])
+                name = entry["name"]
+                if entry["mimeType"] == MIME_FOLDER:
+                    await _walk(entry["id"], f"{prefix}{name}/", depth + 1)
+                    continue
+                await _index(entry, prefix)
 
         await _walk(root, "", 0)
+
+        # A whole-Drive source also covers what the user can see but doesn't own.
+        if root == "root":
+            for entry in await _list(client, "sharedWithMe = true and trashed = false"):
+                if entry["id"] in seen:
+                    continue
+                seen.add(entry["id"])
+                if entry["mimeType"] == MIME_FOLDER:
+                    await _walk(entry["id"], f"Shared with me/{entry['name']}/", 1)
+                    continue
+                await _index(entry, "Shared with me/")
+
+            for drive in await _shared_drives(client):
+                await _walk(drive["id"], f"Shared drives/{drive['name']}/", 1)
 
     await source_service.remove_missing_documents("drive_index", source_id, present)
     logger.info("google drive source %s: indexed %d file(s)", source_id, len(present))
@@ -122,6 +175,7 @@ async def search_drive(source: dict, query: str, limit: int = 25) -> list[dict]:
         resp = await client.get(
             DRIVE_LIST_URL,
             params={
+                **ALL_DRIVES,
                 "q": f"fullText contains '{_drive_q_escape(query)}' and trashed = false",
                 "fields": "files(id, name)",
                 "pageSize": min(limit, 50),
@@ -160,7 +214,7 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
     async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
         meta = await client.get(
             DRIVE_FILE_URL.format(file_id=file_id),
-            params={"fields": "mimeType,name,size"},
+            params={**ALL_DRIVES, "fields": "mimeType,name,size"},
         )
         if meta.status_code != 200:
             return ""
@@ -190,7 +244,7 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
 
         media = await client.get(
             DRIVE_FILE_URL.format(file_id=file_id),
-            params={"alt": "media"},
+            params={**ALL_DRIVES, "alt": "media"},
         )
         if media.status_code != 200:
             return ""
@@ -207,10 +261,12 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
 
 
 async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:
-    resp = await client.get(DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime})
+    url = DRIVE_EXPORT_URL.format(file_id=file_id)
+    resp = await client.get(url, params={**ALL_DRIVES, "mimeType": mime})
     return resp.text if resp.status_code == 200 else ""
 
 
 async def _export_bytes(client: httpx.AsyncClient, file_id: str, mime: str) -> bytes:
-    resp = await client.get(DRIVE_EXPORT_URL.format(file_id=file_id), params={"mimeType": mime})
+    url = DRIVE_EXPORT_URL.format(file_id=file_id)
+    resp = await client.get(url, params={**ALL_DRIVES, "mimeType": mime})
     return resp.content if resp.status_code == 200 else b""

--- a/backend/tests/test_integration_indexer_log_security.py
+++ b/backend/tests/test_integration_indexer_log_security.py
@@ -134,7 +134,7 @@ async def test_google_drive_index_success_logs_internal_source_id_only(monkeypat
         async def __aexit__(self, exc_type, exc, tb):
             return None
 
-    async def list_folder(client, folder_id):
+    async def list_files(client, q):
         return [
             {
                 "id": "drive-file-secret",
@@ -145,7 +145,7 @@ async def test_google_drive_index_success_logs_internal_source_id_only(monkeypat
 
     monkeypatch.setattr(google_indexer, "get_valid_token", _token)
     monkeypatch.setattr(google_indexer.httpx, "AsyncClient", lambda *args, **kwargs: DriveClient())
-    monkeypatch.setattr(google_indexer, "_list_folder", list_folder)
+    monkeypatch.setattr(google_indexer, "_list", list_files)
     monkeypatch.setattr(google_indexer.source_service, "upsert_index_row", _noop)
     monkeypatch.setattr(google_indexer.source_service, "remove_missing_documents", _noop)
 


### PR DESCRIPTION
## Problem

Connecting Google Drive set the expectation that Stash sees **everything the user can see** in Drive. It didn't. A whole-Drive source only walked the user's **My Drive** folder tree (`'<folder>' in parents`), so:

- **"Shared with me" files were invisible.** Items others own and share with you are not parented under your My Drive root, so the recursion never reached them. (Real case that surfaced this: a co-founder's incorporation folder shared with the user — present in the Drive UI, absent from Stash.)
- **Shared Drive content was invisible.** The list calls omitted `supportsAllDrives` / `includeItemsFromAllDrives`, so the Drive API drops Shared Drive items even when traversed.

Federated search (`fullText contains`) *could* surface shared files, but `search_drive` intersects hits against the crawled index and discards anything not previously walked — so they were filtered out there too.

## Fix

- Add `supportsAllDrives` + `includeItemsFromAllDrives` to **every** files call (list, search, metadata, media, export) so shared content resolves end-to-end.
- For a whole-Drive source (`external_ref == "root"`), after walking My Drive, also crawl:
  - the **Shared with me** corpus (`sharedWithMe = true`), recursing into shared folders, under a `Shared with me/` prefix;
  - every **Shared Drive** the user belongs to (`drives.list`), under `Shared drives/<name>/`.
- Dedup by file id (`seen` set) so a file shared both directly and nested inside a shared folder is indexed once, and folder cycles can't loop.

Folder-scoped sources (a specific picked folder) are unchanged — the shared crawl is guarded by `root == "root"`.

## Testing

- `ruff check` clean.
- Existing log-security test updated for the renamed `_list` helper.
- Verified end-to-end with a standalone harness (mocked Drive client): My Drive files, shared folders + loose shared files, Shared Drive files all index under the expected path prefixes, and a file shared both top-level and nested is indexed exactly once.

> Note: the repo's integration test fixtures require a live Postgres (session-scoped fixture) that isn't available in this environment, so those 8 tests error at setup independent of this change; the indexer logic was verified via the standalone harness above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)