### PR TITLE
fix: tab title shows workspace name, not "Skill"

### DIFF
--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -176,11 +176,6 @@ export default function SessionViewerPage() {
   }, [user, load]);
 
   useEffect(() => {
-    if (!sessionDetail) return;
-    document.title = `${sessionHeading(sessionDetail, sessionId)} - Stash`;
-  }, [sessionDetail, sessionId]);
-
-  useEffect(() => {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -21,7 +21,7 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  title: "Skill",
+  title: "Stash",
   description:
     "One place for your agents to connect to all your data, plus an agent-native Drive in Markdown and HTML.",
   icons: {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -317,6 +317,16 @@ export default function AppShell({
 
   const activeWorkspace = workspaces.find((s) => s.id === activeWorkspaceId);
   const searchScope = inferSearchScope(pathname, activeWorkspace, breadcrumbs);
+
+  // Browser tab title: the most specific thing we know — the current item or
+  // section from breadcrumbs, falling back to the workspace name on its home —
+  // suffixed with the brand. Item viewers (pages, sessions, files) set the last
+  // crumb to their own name, so this covers them too.
+  const documentTitle =
+    lastCrumbLabel(breadcrumbs) ?? activeWorkspace?.name ?? null;
+  useEffect(() => {
+    document.title = documentTitle ? `${documentTitle} - Stash` : "Stash";
+  }, [documentTitle]);
   const initial = user.display_name[0].toUpperCase();
   const accountLabel = user.email ?? user.name;
   const usernameLabel = `@${user.name}`;


### PR DESCRIPTION
## Why

Browser tabs for every in-app page showed **"Skill"** as the title.

Root cause: `frontend/src/app/layout.tsx` set the default `metadata.title` to `"Skill"`, and the workspace routes are all client components that never override it — so they inherited the root default. (The `- Skill` suffix on *public skill share* pages is intentional brand and is left unchanged.)

## What

- **AppShell** now derives `document.title` centrally from the active workspace name + breadcrumbs, suffixed with the brand. Item viewers (pages, sessions, files) already set the last breadcrumb to their own name, so this covers them too:
  - Workspace home → `Henry's Workspace - Stash`
  - Section → `Files - Stash`, `Sessions - Stash`
  - Item → `<page title> - Stash`, `<session> - Stash`
- Removed `SessionClient`'s now-redundant inline `document.title` (AppShell derives the identical string from its breadcrumb).
- Root default title `"Skill"` → `"Stash"` (fallback for any page without a more specific title).

## Verification

- `npm run lint` — 0 errors (2 pre-existing warnings, unrelated).
- `npx vitest run src/components/AppShell.test.tsx` — 12/12 pass.
- `tsc` clean for the touched files (pre-existing test-runner-global errors elsewhere are unrelated).

The dynamic title is deterministic client logic; standing up the full authed stack to screenshot a tab title adds little, so it wasn't run. Happy to do a full E2E pass if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)