### PR TITLE
test: swap Drive scope drive.readonly → auth/docs (CASA experiment)

### DIFF
--- a/backend/integrations/google/provider.py
+++ b/backend/integrations/google/provider.py
@@ -30,11 +30,12 @@ class GoogleIntegration(Integration):
     # files our app creates (for Slides export). Avoids the scary
     # "read all your Drive files" consent screen.
     scopes = [
-        # Read access to the user's whole Drive — needed so federated search
-        # (`fullText contains`) and the folder crawl can see all files, not just
-        # ones picked with the app (the narrower drive.file scope). This is a
-        # Google "restricted" scope; the OAuth consent screen must list it.
-        "https://www.googleapis.com/auth/drive.readonly",
+        # Read access to the user's Drive for the folder crawl + federated
+        # `fullText` search. `auth/docs` is a *sensitive* scope (already
+        # approved on our consent screen), unlike the *restricted*
+        # `drive.readonly`, which requires a CASA assessment to clear the
+        # "unverified app" screen.
+        "https://www.googleapis.com/auth/docs",
         "openid",
         "email",
         "profile",


### PR DESCRIPTION
## What

Swaps the Google Drive OAuth scope from `drive.readonly` (restricted, needs CASA to clear the "unverified app" screen) to `auth/docs` (sensitive, already approved on our consent screen).

## Why

Testing end-to-end, in prod, whether a `auth/docs`-scoped token can still run our Drive folder crawl + federated `fullText` search — or whether Drive's `files.list` rejects it with a 403. If it works, we can let users connect Drive without redoing CASA.

## How to verify

After deploy: disconnect + reconnect Drive (existing tokens hold `drive.readonly`; reconnect issues a fresh `auth/docs` token), then trigger an index and watch the crawl:
- **Crawl returns files** → `auth/docs` is sufficient, CASA avoidable. 🎉
- **403 / insufficient scopes** → `auth/docs` can't crawl Drive, CASA unavoidable. Revert this.

⚠️ Intentionally temporary experiment — revert (or keep) once we have the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)