### PR TITLE
fix(integrations): add "Open" link to connected source in connect modal

### DIFF
--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ApiError } from "@/lib/api";
@@ -151,6 +152,8 @@ export default function SourceConnectorList({
                   enabled={enabled}
                   authKind={status?.auth_kind ?? "oauth"}
                   disabledReason={status?.disabled_reason ?? null}
+                  workspaceId={workspaceId}
+                  provider={connector.provider}
                   busy={busy === connector.provider}
                   expanded={expanded === connector.provider}
                   onConnect={() => void connect(connector)}
@@ -204,6 +207,8 @@ function ConnectorAction({
   enabled,
   authKind,
   disabledReason,
+  workspaceId,
+  provider,
   busy,
   expanded,
   onConnect,
@@ -214,6 +219,8 @@ function ConnectorAction({
   enabled: boolean;
   authKind: IntegrationStatus["auth_kind"];
   disabledReason: string | null;
+  workspaceId: string | null;
+  provider: string;
   busy: boolean;
   expanded: boolean;
   onConnect: () => void;
@@ -243,13 +250,24 @@ function ConnectorAction({
       </button>
     );
   }
-  // Once connected, the single action toggles to Disconnect. The dedicated
-  // integration page (for adding specific repos/pages) is still reachable from
-  // the sidebar's External Sources list.
+  // Once connected, offer "Open" alongside Disconnect. The dedicated integration
+  // page is the only place to add folders/repos/pages, but the sidebar only
+  // lists providers that already have a source — so without this link a freshly
+  // connected provider with no sources yet has no in-product path to its page.
   return (
-    <button type="button" onClick={onDisconnect} disabled={busy} className={secondaryButton()}>
-      {busy ? "Disconnecting..." : "Disconnect"}
-    </button>
+    <>
+      {workspaceId && (
+        <Link
+          href={`/workspaces/${workspaceId}/integrations/${provider}`}
+          className={secondaryButton()}
+        >
+          Open
+        </Link>
+      )}
+      <button type="button" onClick={onDisconnect} disabled={busy} className={secondaryButton()}>
+        {busy ? "Disconnecting..." : "Disconnect"}
+      </button>
+    </>
   );
 }
 


### PR DESCRIPTION
## The gap

After connecting a provider (e.g. Google Drive), there was **no in-product way to reach its integration page** — the only page where you add your first folder/repo/page. You had to hand-type the URL.

Root cause, two things compounding:
1. **#638** ("Allow disconnecting a source from the connect modal") replaced the old **"Open"** link in the connect modal with **"Disconnect"**. Its code comment assumed the page was *"still reachable from the sidebar's External Sources list."*
2. But the sidebar's External Sources list (`AppSidebar.tsx`) only renders providers **that already have a source** (it iterates `sourceMap[ws]`). A freshly connected account with zero folders never appears there.

Net: connected + no sources yet = **dead zone**. No sidebar entry, no modal link, only a URL.

## The fix

Restore an **"Open"** link next to **"Disconnect"** in the connect modal for connected sources, so the dedicated page is always reachable. Keeps #638's disconnect action intact.

## Verification
- `npx eslint` + `npx tsc --noEmit` clean on the changed file.
- Screenshots below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)