### PR TITLE
feat(www): add "Audit agent sessions" use-case page

### DIFF
--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -998,6 +998,7 @@ export function Footer() {
       links: [
         ["Connect your data", "/connect-your-data"],
         ["Agent-native Drive", "/agent-native-drive"],
+        ["Audit agent sessions", "/audit-agent-sessions"],
         ["Discover", "/discover"],
         ["Pricing", "/#pricing"],
         ["Docs", "/docs"],

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -37,6 +37,7 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
                 <UseCaseItem href="/connect-your-data" title="Connect your data" desc="Plug in GitHub, Drive, Gmail, Notion, Slack." />
                 <UseCaseItem href="/agent-native-drive" title="Agent-native Drive" desc="A workspace agents read and write like a repo." />
                 <UseCaseItem href="/memory" title="Memory" desc="Best-in-class retrieval: wiki + vectors + grep." />
+                <UseCaseItem href="/audit-agent-sessions" title="Audit agent sessions" desc="Onboard, coach, and monitor like Granola or Gong." />
               </div>
             </div>
           </div>

--- a/www/app/audit-agent-sessions/page.tsx
+++ b/www/app/audit-agent-sessions/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import SiteHeader from "../_components/SiteHeader";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export const metadata: Metadata = {
+  title: "Audit agent sessions · Stash",
+  description:
+    "Audit your team's agent sessions like Granola or Gong — onboard faster, coach your team, monitor what's happening, and build automations for continual improvement.",
+};
+
+const FEATURES = [
+  [
+    "Onboarding",
+    "New teammates learn from real sessions, not stale docs. Search how others solved the same problem and ramp on your codebase and tools in days, not weeks.",
+  ],
+  [
+    "Coaching for your team",
+    "See how each person prompts, where they get stuck, and what good looks like. Turn your best sessions into shared playbooks the whole team can learn from.",
+  ],
+  [
+    "Monitoring",
+    "Every session streams in automatically and is indexed full-text. Spot failures, dead ends, and risky patterns across the team without asking anyone for a recap.",
+  ],
+  [
+    "Automations & workflows",
+    "Mine recurring patterns into reusable Skills, prompts, and automations — so the lessons from one session compound into continual improvement for everyone.",
+  ],
+];
+
+export default function AuditAgentSessionsPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+
+      <section className="border-b border-border-subtle py-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Audit agent sessions
+          </p>
+          <h1 className="mt-5 max-w-[900px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-black leading-[1.02] tracking-[-0.04em] text-ink">
+            Audit your team&apos;s{" "}
+            <span className="text-brand">agent sessions.</span>
+          </h1>
+          <p className="mt-7 max-w-[620px] text-[18px] leading-[1.55] text-foreground">
+            Like Granola or Gong for your coding agents. Every session your team
+            runs streams into Stash automatically and is indexed full-text — so
+            you can onboard faster, coach your team, monitor what&apos;s
+            happening, and build automations for continual improvement.
+          </p>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/docs/quickstart"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Quickstart →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Turn every session into team knowledge.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {FEATURES.map(([name, blurb]) => (
+              <div
+                key={name}
+                className="rounded-[12px] border border-border bg-background p-5 transition-colors hover:border-brand"
+              >
+                <div className="font-display text-[17px] font-bold tracking-[-0.01em] text-ink">
+                  {name}
+                </div>
+                <p className="mt-1.5 text-[14px] leading-[1.55] text-dim">{blurb}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            How it works
+          </p>
+          <h2 className="mt-5 max-w-[760px] text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            No manual capture. Nothing to copy-paste.
+          </h2>
+          <p className="mt-5 max-w-[620px] text-[16px] leading-[1.6] text-foreground">
+            Point Claude Code, Cursor, Codex, or OpenCode at Stash and every
+            session lands automatically — transcripts, files, and the decisions
+            along the way — searchable across your whole team.
+          </p>
+          <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-3 md:gap-12">
+            <Point title="Sessions stream in">
+              Each coding-agent session is uploaded as it happens and indexed
+              alongside your docs — no manual recap, no lost context.
+            </Point>
+            <Point title="Search across the team">
+              Full-text and semantic search over every session. Find how a
+              problem was solved, who hit the same wall, and what worked.
+            </Point>
+            <Point title="Compound the lessons">
+              Promote the best patterns into shared Skills and automations, so
+              what one person learns improves how everyone works.
+            </Point>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-surface py-28 text-center">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-black leading-[1.0] tracking-[-0.04em] text-ink">
+            See how your team really works with agents.
+          </h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link
+              href={APP_URL}
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/connect-your-data"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Connect your data →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Point({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="font-display text-[19px] font-bold tracking-[-0.01em] text-ink">{title}</h3>
+      <p className="mt-2.5 text-[15px] leading-[1.6] text-dim">{children}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a new landing-page use case at `/audit-agent-sessions`, positioning Stash as **Granola/Gong for your team's coding-agent sessions**.

The page leads with the four pillars from the brief:

- **Onboarding** — new teammates learn from real sessions
- **Coaching for your team** — see how people prompt, turn best sessions into playbooks
- **Monitoring** — sessions stream in and are indexed full-text
- **Automations & workflows** — mine recurring patterns into reusable Skills for continual improvement

It reuses the existing use-case page template (`SiteHeader`, hero + feature grid + "how it works" + CTA), so it matches `/agent-native-drive`, `/connect-your-data`, and `/memory`.

## Wiring

- Added to the **Use cases** nav dropdown in `SiteHeader`
- Added to the **Product** column in the footer (`HomePage`)

## Verification

- `npm run lint` — 0 errors on touched files (pre-existing warnings unrelated)
- Page serves 200, no console errors
- Rendered desktop + mobile (375px); layout matches sibling use-case pages

> Note: product screenshots were captured during QA but couldn't be auto-attached (Stash upload returned 401 managed-auth, and `gh` has no image-upload path). Happy to add them if you confirm an upload route, or you can drag them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)