### PR TITLE
feat(www): PLG home (/) + teams page (/teams)

### DIFF
--- a/www/app/_components/HomePage.tsx
+++ b/www/app/_components/HomePage.tsx
@@ -18,7 +18,9 @@ export default function HomePage() {
       <Hero />
       <Logos />
       <Problem />
+      <CompoundingLoop />
       <HowItWorks />
+      <Messaging />
       <KarpathyQuote />
       <Comparisons />
       <VisualizationsShowcase />
@@ -136,15 +138,16 @@ function Hero() {
         <div className="grid grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:gap-16">
           <div>
             <h1 className="text-balance font-display text-[clamp(44px,6.2vw,80px)] font-black leading-[0.95] tracking-[-0.045em] text-ink">
-              Knowledge bases for
+              Build long-running
               <br />
-              the <span className="text-brand">agent era.</span>
+              <span className="text-brand">agents.</span>
             </h1>
 
             <p className="mt-7 max-w-[540px] text-[18px] leading-[1.55] text-foreground">
-              The one place your agents connect to all your data — GitHub, Drive,
-              Gmail, Notion, Slack and more. Plus an agent-native Drive to store
-              your agent-generated docs and data in.
+              Bring your own agent and give your team a workspace where every
+              session compounds. Stash connects your agents to all your data,
+              remembers what they did, and turns it into a moat that makes the
+              whole team faster the longer you run.
             </p>
 
             <div className="mt-9 flex flex-wrap items-center gap-3">
@@ -284,6 +287,93 @@ function Problem() {
             an agent-native Drive in Markdown and HTML where sessions, files, and
             pages all land. Bundle any slice into a link you can publish or fork.
           </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const LOOP_STEPS: { n: string; title: string; body: string }[] = [
+  { n: "01", title: "Run your agent", body: "Bring your own — Claude Code, Cursor, Codex, OpenCode. Every session streams into Stash automatically." },
+  { n: "02", title: "Capture the work", body: "Transcripts, plans, docs, dashboards, tables — the output lands as real files instead of evaporating." },
+  { n: "03", title: "Build the memory", body: "It compounds into a shared, retrievable world model your whole team and their agents read from." },
+  { n: "04", title: "Get better next run", body: "The next agent starts where the last one left off. The moat deepens every time you run." },
+];
+
+// The compounding cycle is the core teams pitch: agents don't just run, they
+// leave the workspace smarter than they found it.
+function CompoundingLoop() {
+  return (
+    <section className="border-b border-border-subtle py-24 md:py-32">
+      <div className="mx-auto max-w-[1200px] px-7">
+        <EyebrowDot>The compounding cycle</EyebrowDot>
+        <h2 className="mt-4 max-w-[880px] text-balance font-display text-[clamp(32px,4.2vw,52px)] font-bold leading-[1.05] tracking-[-0.03em] text-ink">
+          Agents that leave the workspace
+          <br />
+          <span className="font-medium text-dim">smarter than they found it.</span>
+        </h2>
+        <div className="mt-14 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {LOOP_STEPS.map((s, i) => (
+            <div
+              key={s.n}
+              className="relative flex flex-col rounded-[14px] border border-border bg-background p-6"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-[11px] tracking-[0.14em] text-muted">{s.n}</span>
+                {i < LOOP_STEPS.length - 1 ? (
+                  <span className="font-mono text-[16px] text-brand">→</span>
+                ) : (
+                  <span className="font-mono text-[16px] text-brand">↺</span>
+                )}
+              </div>
+              <h3 className="mt-5 font-display text-[18px] font-bold tracking-[-0.015em] text-ink">
+                {s.title}
+              </h3>
+              <p className="mt-2.5 text-[14px] leading-[1.6] text-dim">{s.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const MESSAGING: { label: string; body: string }[] = [
+  { label: "Bring your own agent", body: "Use the best engine for the job — Claude Code, Cursor, Codex, OpenCode. Stash is the agent-agnostic layer underneath, not another model to adopt." },
+  { label: "Continual learning", body: "Every session feeds the next. Your agents improve continuously instead of starting cold on each run." },
+  { label: "A compounding data moat", body: "The work your team does becomes proprietary context no competitor has — and it grows on its own, every run." },
+  { label: "Memory that takes action", body: "Not just facts to look up. Stash holds the processes and artifacts your agents act on, so memory does work instead of sitting still." },
+  { label: "Collaborate in a workspace", body: "Humans and agents read and write the same files in real time. Memory you can see, edit, and trust — not a per-agent black box." },
+  { label: "Memory-max, not token-max", body: "Optimizing for tokens is Goodhart's law in action. We optimize for what your agents actually remember and reuse." },
+  { label: "Permanent, not disposable", body: "Agents and their artifacts are throwaway today. Stash makes them durable — kept, searchable, and reusable across the team." },
+  { label: "Your agent's native language", body: "The whole workspace mounts as a VFS your agent can ls, find, and grep. No new API to learn — it speaks the shell it already knows." },
+  { label: "We do the maintenance", body: "We keep your integrations current and roll out the latest memory techniques, so you stay on the frontier without chasing it." },
+  { label: "Systematize tribal knowledge", body: "The institutional memory stuck in people's heads becomes shared context every agent and teammate can draw on." },
+  { label: "A world model, not an index", body: "Memory is a reasoning problem — staleness, consistency, stability. We prevent slop and model collapse, not just retrieve text." },
+  { label: "We coach your team", body: "The tooling moves fast. We help your team keep up with how to actually use agents well as the space changes." },
+];
+
+function Messaging() {
+  return (
+    <section className="border-b border-border-subtle py-24 md:py-32">
+      <div className="mx-auto max-w-[1200px] px-7">
+        <div className="flex max-w-[880px] flex-col gap-4">
+          <EyebrowDot>Why Stash</EyebrowDot>
+          <h2 className="font-display text-[clamp(32px,4.2vw,52px)] font-bold leading-[1.05] tracking-[-0.03em] text-ink text-balance">
+            Memory is the moat.
+            <br />
+            <span className="font-medium text-dim">We treat it like one.</span>
+          </h2>
+        </div>
+        <div className="mt-14 grid grid-cols-1 gap-px overflow-hidden rounded-[14px] border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+          {MESSAGING.map((m) => (
+            <div key={m.label} className="flex flex-col gap-2.5 bg-background p-6">
+              <h3 className="font-display text-[16px] font-bold tracking-[-0.01em] text-ink">
+                {m.label}
+              </h3>
+              <p className="text-[13.5px] leading-[1.6] text-dim">{m.body}</p>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/www/app/_components/PlgHomePage.tsx
+++ b/www/app/_components/PlgHomePage.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link";
+
+import AppRedirectForSignedInUsers from "./AppRedirectForSignedInUsers";
+import { ClosingCTA, Footer, Logos } from "./HomePage";
+import LiveDemo from "./LiveDemo";
+import SiteHeader from "./SiteHeader";
+
+const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+
+export default function PlgHomePage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <AppRedirectForSignedInUsers appUrl={APP_URL} />
+      <SiteHeader />
+      <Hero />
+      <Logos />
+      <UseCases />
+      <ClosingCTA />
+      <Footer />
+    </main>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative overflow-hidden">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[680px]"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 55% at 50% 0%, rgba(249,115,22,0.10), transparent 60%)",
+        }}
+      />
+      <div className="relative z-10 mx-auto flex max-w-[820px] flex-col items-center px-7 pb-16 pt-20 text-center lg:pt-28">
+        <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+          <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+          A workspace for your agents
+        </p>
+        <h1 className="mt-5 text-balance font-display text-[clamp(40px,6vw,72px)] font-black leading-[0.98] tracking-[-0.045em] text-ink">
+          What should your agent
+          <br />
+          <span className="text-brand">make today?</span>
+        </h1>
+        <p className="mt-6 max-w-[600px] text-[18px] leading-[1.55] text-foreground">
+          Bring your own agent and give it somewhere to work. Stash turns it
+          into decks, dashboards, docs, and spreadsheets you can share — backed
+          by a memory that compounds every time you use it.
+        </p>
+
+        <div className="mt-9 flex w-full justify-center text-left">
+          <LiveDemo />
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href={APP_URL}
+            className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+          >
+            Start free →
+          </Link>
+          <Link
+            href="/teams"
+            className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+          >
+            For teams →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type UseCase = { tag: string; title: string; body: string };
+
+// The grid doubles as a menu of Skills: each card is a repeatable process an
+// agent can run, fork, and rerun. Grouped by the kind of work, Manus-style.
+const USE_CASES: UseCase[] = [
+  { tag: "Make", title: "Slides & decks", body: "Turn rough notes or a dataset into a polished, shareable deck." },
+  { tag: "Make", title: "Analytics dashboards", body: "Build a live dashboard from raw data and publish it as a link." },
+  { tag: "Make", title: "Spreadsheets", body: "Generate spreadsheets and watch how the data flows in, step by step." },
+  { tag: "Make", title: "Docs you can publish", body: "Write docs and dashboards, then share any slice as a public URL." },
+  { tag: "Make", title: "Write like you", body: "AI writing tuned to your voice, from your past work." },
+  { tag: "Make", title: "Content library", body: "A marketing content library your agents draw from and add to." },
+  { tag: "Make", title: "Creative generation", body: "Generate on-brand AI images and video for a campaign." },
+  { tag: "Research", title: "Deep research", body: "Multi-source, fact-checked research on any topic, with citations." },
+  { tag: "Research", title: "Research → spreadsheet", body: "Research anything and deliver it as a structured spreadsheet." },
+  { tag: "Research", title: "Monitor a topic", body: "Track a topic, feed, or competitor over the last 30 days." },
+  { tag: "Research", title: "Bookmark store", body: "Save podcasts, tweets, YouTube, and papers into one searchable store." },
+  { tag: "Outreach", title: "Find people", body: "Research the right people and draft outreach that lands." },
+  { tag: "Operate", title: "Lightweight CRM", body: "A CRM your agent keeps current from your email and calls." },
+  { tag: "Operate", title: "Email & scheduling", body: "Triage your inbox and manage your calendar on your behalf." },
+  { tag: "Operate", title: "Chase it down", body: "Follow up with people until the thing actually gets done." },
+  { tag: "Operate", title: "Audit your agents", body: "Review what your agents did, then coach them to do it better." },
+];
+
+function UseCases() {
+  return (
+    <section className="border-b border-border-subtle py-24 md:py-32">
+      <div className="mx-auto max-w-[1200px] px-7">
+        <div className="flex max-w-[760px] flex-col gap-4">
+          <p className="flex items-center font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+            <span className="mr-[10px] inline-block h-[6px] w-[6px] rounded-full bg-brand" />
+            Use cases
+          </p>
+          <h2 className="font-display text-[clamp(32px,4.2vw,52px)] font-bold leading-[1.05] tracking-[-0.03em] text-ink text-balance">
+            A starting point for anything
+            <br />
+            <span className="font-medium text-dim">your agent can do.</span>
+          </h2>
+        </div>
+
+        <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {USE_CASES.map((u) => (
+            <div
+              key={u.title}
+              className="flex flex-col rounded-[12px] border border-border bg-background p-5 transition-colors hover:border-brand"
+            >
+              <span
+                className="mb-3 inline-flex w-fit rounded px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-brand"
+                style={{ background: "var(--brand-soft)" }}
+              >
+                {u.tag}
+              </span>
+              <h3 className="font-display text-[16.5px] font-bold tracking-[-0.01em] text-ink">
+                {u.title}
+              </h3>
+              <p className="mt-2 text-[13.5px] leading-[1.55] text-dim">{u.body}</p>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-10 max-w-[680px] text-[15px] leading-[1.6] text-dim">
+          Each one can become a{" "}
+          <Link href="/skills" className="font-medium text-brand hover:underline">
+            Skill
+          </Link>
+          {" "}— a folder your agents rerun, share with a link, and fork. The more
+          you use it, the more your workspace knows.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -43,6 +43,12 @@ export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) 
             </div>
           </div>
           <Link
+            href="/teams"
+            className="hidden rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink sm:block"
+          >
+            For teams
+          </Link>
+          <Link
             href="/docs"
             className="rounded-md px-3 py-2 transition hover:bg-raised hover:text-ink"
           >

--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -14,9 +14,9 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Stash · One place your agents connect to all your data",
+  title: "Stash · A workspace for your agents",
   description:
-    "The one place your agents connect to all your data — GitHub, Drive, Gmail, Notion, Slack and more — plus an agent-native Drive in Markdown and HTML to write the work back into.",
+    "Bring your own agent and give it somewhere to work. Stash turns it into decks, dashboards, docs, and spreadsheets you can share — backed by a memory that compounds every time you use it.",
 };
 
 export default function RootLayout({

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -1,5 +1,5 @@
-import HomePage from "./_components/HomePage";
+import PlgHomePage from "./_components/PlgHomePage";
 
 export default function Page() {
-  return <HomePage />;
+  return <PlgHomePage />;
 }

--- a/www/app/teams/page.tsx
+++ b/www/app/teams/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import HomePage from "../_components/HomePage";
+
+export const metadata: Metadata = {
+  title: "Stash for teams · Long-running agents that compound",
+  description:
+    "Bring your own agent and give your team a workspace where every session compounds — continual learning, a shared data moat, and agents that take action, not just remember.",
+};
+
+export default function TeamsPage() {
+  return <HomePage />;
+}


### PR DESCRIPTION
Experiment: split the landing into two pages.

## What changed
- **`/` is now a PLG page** (Manus/Genspark style): centered hero + a copy-prompt demo box visitors can paste into their own agent, then a grid of 16 use cases that double as Skills (Make / Research / Outreach / Operate).
- **`/teams` is the enterprise page** — the previous homepage narrative, retitled around **building long-running agents**. Adds two new sections:
  - **The compounding cycle** — a 4-step loop (run agent → capture work → build memory → get better next run).
  - **"Memory is the moat"** — a 12-point messaging grid (BYO agent, continual learning, compounding data moat, action over recall, memory-max not token-max, permanent not disposable, VFS as the agent's native language, managed maintenance, systematize tribal knowledge, world-model not index, we coach your team).
- Header gains a **For teams** link; PLG hero has a **For teams →** secondary CTA.
- Root `<title>`/description updated for the PLG default; reused `Logos`, `ClosingCTA`, `Footer` so the two pages stay consistent. Variant `/m/*` pages and shared exports are untouched (verified 200).

## Notes / open questions
- Demo box reuses the existing `LiveDemo` copy-prompt card (no backend) — chosen over a live interactive chat demo to keep this a fast experiment.
- Use-case grid copy is a first pass; happy to retune tags/wording.

Screenshots attached below.