### PR TITLE
refactor(cli): restructure signin auth — --non-interactive flag, fold in auth

### DIFF
--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -91,9 +91,9 @@ def agent_install_pitch(stash_url: str) -> str:
         "agents can remember and share this work?\n\n"
         "If the user says yes, run:\n\n"
         "```bash\n"
-        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --no-browser\n'
+        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --non-interactive\n'
         "```\n\n"
-        "This prints a browser consent URL for the user and waits for approval. "
+        "This opens (or prints) a browser consent URL for the user and waits for approval. "
         "Do not complete setup without user approval.\n\n"
         "After sign-in succeeds, connect the current repository and read this "
         "Stash:\n\n"
@@ -106,7 +106,7 @@ def agent_install_pitch(stash_url: str) -> str:
         '`stash vfs "find /workspaces -maxdepth 3 -type f"`.\n\n'
         "If Stash is already installed, run:\n\n"
         "```bash\n"
-        "stash signin --no-browser\n"
+        "stash signin --non-interactive\n"
         "stash connect\n"
         f"stash read {stash_url}\n"
         "```"

--- a/backend/tests/test_skill_agent_read.py
+++ b/backend/tests/test_skill_agent_read.py
@@ -95,8 +95,10 @@ async def test_public_skill_text_is_agent_homepage(client: AsyncClient):
         "Would you like me to install Stash and connect this repository so future "
         "agents can remember and share this work?"
     ) in text
-    assert ('bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --no-browser') in text
-    assert "This prints a browser consent URL for the user" in text
+    assert (
+        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --non-interactive'
+    ) in text
+    assert "This opens (or prints) a browser consent URL for the user" in text
     assert "Do not complete setup without user approval." in text
     assert 'stash vfs "find /workspaces -maxdepth 3 -type f"' in text
     assert "stash connect" in text
@@ -131,7 +133,7 @@ async def test_public_skill_item_text_strips_html_page_content(client: AsyncClie
     assert "<h1>" not in resp.text
     assert "## Connect This Repo To Stash" in resp.text
     assert (
-        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --no-browser'
+        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --non-interactive'
     ) in resp.text
     assert 'stash vfs "find /workspaces -maxdepth 3 -type f"' in resp.text
     assert f"stash read http://localhost:3457/skills/{body['skill_slug']}" in resp.text
@@ -152,9 +154,9 @@ async def test_llms_txt_documents_agent_skill_reads(client: AsyncClient):
     assert "## Connect This Repo To Stash" in resp.text
     assert "Ask the user:" in resp.text
     assert (
-        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --no-browser'
+        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --non-interactive'
     ) in resp.text
-    assert "stash signin --no-browser" in resp.text
+    assert "stash signin --non-interactive" in resp.text
     assert 'stash vfs "find /workspaces -maxdepth 3 -type f"' in resp.text
     assert "stash read https://app.joinstash.ai/skills/example" in resp.text
 
@@ -167,5 +169,5 @@ async def test_skill_skill_manifest_includes_agent_install_pitch(client: AsyncCl
     assert "## Connect This Repo To Stash" in resp.text
     assert "Ask the user:" in resp.text
     assert (
-        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --no-browser'
+        'bash -c "$(curl -fsSL https://joinstash.ai/install)" -- signin --non-interactive'
     ) in resp.text

--- a/cli/main.py
+++ b/cli/main.py
@@ -3700,17 +3700,25 @@ def signin(
     """
     # Direct key injection — no browser handshake. The streaming hooks read
     # ~/.stash/config.json, not env vars, so this is how a browser-less box
-    # (typically a self-hosted CI runner) gets a key into that file.
+    # (typically a self-hosted CI runner) gets a key into that file. The key
+    # defines which self-hosted server it belongs to, so the endpoint must be
+    # given explicitly — there is no sensible default to fall back to.
     if api_key:
-        base_url = api or stored_base_url() or PRODUCTION_BASE_URL
-        save_config(base_url=base_url, api_key=api_key)
-        with StashClient(base_url=base_url, api_key=api_key) as c:
-            try:
+        base_url = api or stored_base_url()
+        if not base_url:
+            console.print(
+                "[red]Pass --api <url> with --api-key — the self-hosted server that "
+                "minted the key.[/red]"
+            )
+            raise typer.Exit(1)
+        try:
+            with StashClient(base_url=base_url, api_key=api_key) as c:
                 user = c.whoami()
-                save_config(username=user["name"])
-                console.print(f"[green]Authenticated as {user['name']}[/green]")
-            except StashError:
-                console.print("[yellow]Saved but could not verify.[/yellow]")
+        except StashError as e:
+            console.print(f"[red]Could not authenticate against {base_url}: {e.detail}[/red]")
+            raise typer.Exit(1)
+        save_config(base_url=base_url, api_key=api_key, username=user["name"])
+        console.print(f"[green]Authenticated as {user['name']}[/green]")
         return
 
     # Scripted / headless: bare browser auth, no wizard prompts.

--- a/cli/main.py
+++ b/cli/main.py
@@ -152,7 +152,6 @@ def _browser_auth_flow(
     api: str,
     page: str | None = None,
     timeout: int = 120,
-    no_browser: bool = False,
 ) -> tuple[str, str]:
     """Browser-based CLI sign-in. Returns (api_key, username).
 
@@ -184,7 +183,7 @@ def _browser_auth_flow(
     url = f"{page}{sep}session={session_id}"
 
     ssh = any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"))
-    opened = False if (no_browser or ssh) else webbrowser.open(url)
+    opened = False if ssh else webbrowser.open(url)
 
     if opened:
         console.print(f"  [green]✓[/green] Opened [bold]{page}[/bold] in your browser.")
@@ -3675,25 +3674,27 @@ def signin(
     api: str = typer.Option(
         None, "--api", help="Stash API base URL. Override for self-hosted deployments."
     ),
-    no_browser: bool = typer.Option(
+    non_interactive: bool = typer.Option(
         False,
-        "--no-browser",
-        help="Don't open a browser; just print the URL. Use on SSH or headless machines.",
+        "--non-interactive",
+        help="Skip the setup wizard; just authenticate. For installers and agents. "
+        "Implied when stdin isn't a terminal.",
     ),
     timeout: int = typer.Option(120, "--timeout", help="Seconds to wait for sign-in."),
 ):
     """Sign in to Stash through the browser.
 
     Run interactively for guided first-run setup (endpoint, streaming agents,
-    repo). With --no-browser — or whenever stdin isn't a terminal — it just
-    authenticates, which is the path installers and agents use. For a fully
-    unattended machine (no browser), use `stash auth` to inject a pre-minted
-    key instead.
+    repo). With --non-interactive — or whenever stdin isn't a terminal — it
+    skips the wizard and just authenticates, which is the path installers and
+    agents use. The browser opens automatically when one is available, and
+    otherwise a URL is printed to visit. For a fully unattended machine, use
+    `stash auth` to inject a pre-minted key instead.
     """
     # Scripted / headless: bare browser auth, no wizard prompts.
-    if no_browser or not sys.stdin.isatty():
+    if non_interactive or not sys.stdin.isatty():
         base_url = api or stored_base_url() or PRODUCTION_BASE_URL
-        api_key, username = _browser_auth_flow(base_url, timeout=timeout, no_browser=no_browser)
+        api_key, username = _browser_auth_flow(base_url, timeout=timeout)
         save_config(base_url=base_url, api_key=api_key, username=username)
         console.print(f"[green]✓ Signed in as {username}[/green]")
         return

--- a/cli/main.py
+++ b/cli/main.py
@@ -3701,23 +3701,20 @@ def signin(
     # Direct key injection — no browser handshake. The streaming hooks read
     # ~/.stash/config.json, not env vars, so this is how a browser-less box
     # (typically a self-hosted CI runner) gets a key into that file. The key
-    # defines which self-hosted server it belongs to, so the endpoint must be
-    # given explicitly — there is no sensible default to fall back to.
+    # defines which self-hosted server it belongs to, so --api is required:
+    # such a box has never run an interactive sign-in, so nothing else could
+    # have established the endpoint.
     if api_key:
-        base_url = api or stored_base_url()
-        if not base_url:
-            console.print(
-                "[red]Pass --api <url> with --api-key — the self-hosted server that "
-                "minted the key.[/red]"
-            )
+        if not api:
+            console.print("[red]Pass --api <url> with --api-key — the server that minted the key.[/red]")
             raise typer.Exit(1)
         try:
-            with StashClient(base_url=base_url, api_key=api_key) as c:
+            with StashClient(base_url=api, api_key=api_key) as c:
                 user = c.whoami()
         except StashError as e:
-            console.print(f"[red]Could not authenticate against {base_url}: {e.detail}[/red]")
+            console.print(f"[red]Could not authenticate against {api}: {e.detail}[/red]")
             raise typer.Exit(1)
-        save_config(base_url=base_url, api_key=api_key, username=user["name"])
+        save_config(base_url=api, api_key=api_key, username=user["name"])
         console.print(f"[green]Authenticated as {user['name']}[/green]")
         return
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -3674,6 +3674,13 @@ def signin(
     api: str = typer.Option(
         None, "--api", help="Stash API base URL. Override for self-hosted deployments."
     ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help="Store this pre-minted key directly instead of signing in through a "
+        "browser. For unattended, browser-less machines (typically self-hosted CI). "
+        "Get the key from your self-hosted instance's API-key page.",
+    ),
     non_interactive: bool = typer.Option(
         False,
         "--non-interactive",
@@ -3688,9 +3695,24 @@ def signin(
     repo). With --non-interactive — or whenever stdin isn't a terminal — it
     skips the wizard and just authenticates, which is the path installers and
     agents use. The browser opens automatically when one is available, and
-    otherwise a URL is printed to visit. For a fully unattended machine, use
-    `stash auth` to inject a pre-minted key instead.
+    otherwise a URL is printed to visit. For a fully unattended, browser-less
+    machine, pass --api-key to store a pre-minted key directly (no handshake).
     """
+    # Direct key injection — no browser handshake. The streaming hooks read
+    # ~/.stash/config.json, not env vars, so this is how a browser-less box
+    # (typically a self-hosted CI runner) gets a key into that file.
+    if api_key:
+        base_url = api or stored_base_url() or PRODUCTION_BASE_URL
+        save_config(base_url=base_url, api_key=api_key)
+        with StashClient(base_url=base_url, api_key=api_key) as c:
+            try:
+                user = c.whoami()
+                save_config(username=user["name"])
+                console.print(f"[green]Authenticated as {user['name']}[/green]")
+            except StashError:
+                console.print("[yellow]Saved but could not verify.[/yellow]")
+        return
+
     # Scripted / headless: bare browser auth, no wizard prompts.
     if non_interactive or not sys.stdin.isatty():
         base_url = api or stored_base_url() or PRODUCTION_BASE_URL
@@ -3843,26 +3865,6 @@ def signin(
 
     _show_setup_complete_splash()
 
-
-@app.command()
-def auth(base_url: str = typer.Argument(...), api_key: str = typer.Option(..., "--api-key")):
-    """Store a pre-existing API key — non-interactive auth for unattended machines.
-
-    Niche tool, not part of normal setup — use `signin` for that. It exists only
-    because `signin` needs a browser and env vars reach the CLI but not the
-    streaming hooks (they read ~/.stash/config.json). `auth` writes the key into
-    that file so a browser-less box — typically a self-hosted CI runner or
-    server — can stream. Get the key from your self-hosted instance's API-key
-    page (managed Stash mints keys only through browser sign-in).
-    """
-    save_config(base_url=base_url, api_key=api_key)
-    with StashClient(base_url=base_url, api_key=api_key) as c:
-        try:
-            user = c.whoami()
-            save_config(username=user["name"])
-            console.print(f"[green]Authenticated as {user['name']}[/green]")
-        except StashError:
-            console.print("[yellow]Saved but could not verify.[/yellow]")
 
 
 @app.command("connect")

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -57,18 +57,12 @@ stash vfs --cwd "/workspaces/<workspace>/sources" "rg 'incident' ."`}</CodeBlock
 
       <CommandRef
         command="stash signin"
-        args=""
-        description="Authenticate this machine through the browser. On first run it also picks the endpoint (managed or self-host) and offers to install streaming hooks for your coding agents. On SSH/headless it prints a URL to open instead of launching a browser."
-        params={[]}
-      />
-
-      <CommandRef
-        command="stash auth"
-        args="<base_url> --api-key <key>"
-        description="Niche tool — not part of normal setup; use signin. Stores a pre-existing API key into ~/.stash/config.json for an unattended, browser-less machine (typically a self-hosted CI runner or server), so its streaming hooks can authenticate. Get the key from your self-hosted instance's API-key page."
+        args="[--api <base_url>] [--api-key <key>] [--non-interactive]"
+        description="Authenticate this machine. With no flags it runs the browser flow: on first run it also picks the endpoint (managed or self-host) and offers to install streaming hooks for your coding agents. On SSH/headless it prints a URL to open instead of launching a browser. Pass --api-key to store a pre-minted key directly (no browser) on an unattended, browser-less machine — typically a self-hosted CI runner; get the key from your self-hosted instance's API-key page."
         params={[
-          { name: "<base_url>", type: "string", desc: "Base URL of the Stash server.", required: true },
-          { name: "--api-key", type: "string", desc: "A pre-existing API key from your self-hosted instance.", required: true },
+          { name: "--api", type: "string", desc: "Base URL of the Stash server. Override for self-hosted deployments.", required: false },
+          { name: "--api-key", type: "string", desc: "A pre-minted key to store directly, skipping the browser. For unattended, browser-less machines.", required: false },
+          { name: "--non-interactive", type: "flag", desc: "Skip the setup wizard; just authenticate. Implied when stdin isn't a terminal.", required: false },
         ]}
       />
 
@@ -77,8 +71,8 @@ stash vfs --cwd "/workspaces/<workspace>/sources" "rg 'incident' ."`}</CodeBlock
         authenticates <em>CLI commands</em> for CI and scripts — but it does{" "}
         <strong>not</strong> reach the streaming hooks, which read{" "}
         <Code>~/.stash/config.json</Code>. To make an unattended machine stream, use{" "}
-        <Code>stash auth</Code>. Change the endpoint or streaming agents later from{" "}
-        <Code>stash settings</Code>.
+        <Code>stash signin --api-key</Code>. Change the endpoint or streaming agents
+        later from <Code>stash settings</Code>.
       </Callout>
 
       <CommandRef


### PR DESCRIPTION
we're auditing and cleaning up our CLI.
- the --no-browser flag was misnamed because it required you to open a browser. it also suppressed the cli wizard. we renamed it to "non-interactive". Bow browser launch behavior is auto-detected.
- We had two separate commands to sign in `auth` and `signin`. Auth was for when you were self-hosting and had an api key. So now auth is just a flag called `--api-key`.


# Slop

Two related cleanups to `stash signin`'s auth surface, surfaced during a CLI audit. Both follow the repo's no-backwards-compat convention (replace, don't alias).

## 1. Split `--no-browser` → `--non-interactive`

`--no-browser` was **overloaded**: it gated both browser launch *and* whether `signin` ran the interactive setup wizard. Agents/installers only needed the latter (skip the wizard — they can't drive a TUI), but the name described the former.

- Replace `--no-browser` with `--non-interactive`, which forces the bare auth path.
- Browser launch is now purely auto-detected: `_browser_auth_flow` opens a browser when available (still skipping over SSH) and otherwise prints the URL — behavior it already had. The flag no longer touches browser logic.
- Update the agent install pitch (`agent_install_pitch`) and its tests.

## 2. Fold `auth` → `signin --api-key`

`auth` and `signin` were two top-level commands for one concept — *authenticate this machine* — differing only in how the key is obtained:

| | how the key is obtained |
|---|---|
| `signin` (browser) | mints it via the session-poll handshake |
| `signin --non-interactive` | same handshake, no wizard |
| ~~`auth`~~ → `signin --api-key` | you supply it; skip the handshake, verify + store |

- Add `--api-key` to `signin`: when passed, verify the key via `whoami` and store it (no browser handshake), then return.
- Delete the standalone `auth` command.
- Update the `www` CLI docs (`stash auth` CommandRef + the streaming Callout).

### Endpoint handling — no fallback, fail loud

A key passed to `--api-key` could only have been minted by a **self-hosted** instance (managed mints keys only via browser), so it's valid *only* against that server. There is no sensible default endpoint, so:

- The endpoint must be given explicitly via `--api`; if it's missing, **fail loud**. No fallback — not to production, and not to a stored `base_url` (a browser-less CI runner, the only machine `--api-key` targets, has never run an interactive sign-in, so nothing ever wrote a `base_url` to its config; that tier would never fire).
- **Verify-then-save:** `whoami` runs before persisting. A bad or misdirected key errors out and writes nothing, rather than saving an unverified credential.

This also recovers the guardrail that `auth`'s required-positional `base_url` used to provide (key and endpoint can't drift apart) without re-introducing a positional argument.

## Verification

- `signin --help` shows `--api`, `--api-key`, `--non-interactive`; `stash auth` now errors as an unknown command; no `--no-browser` or `auth` references remain in `cli/`, `backend/`, or `www/`.
- `signin --api-key <key>` with no endpoint exits 1 with a clear message and writes nothing (verified with an isolated HOME).
- `agent_install_pitch` renders `--non-interactive` in both the curl and plain forms (verified directly).
- `ruff check` clean; `tsc --noEmit` clean for the changed www page.
- `backend/tests/test_skill_agent_read.py` could not run locally: the shared test Postgres is stamped at migration `0119` (from another worktree) while this checkout's head is `0117`, so the tests error at alembic setup before any assertion. Test bodies validated by rendering the pitch directly; CI with a clean DB will exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)