### PR TITLE
fix(install): call `stash signin`, not the removed `stash login`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # joinstash.ai/install — install the stashai CLI and run the interactive
-# `stash login` setup wizard (managed-vs-self-host, browser auth,
+# `stash signin` setup wizard (managed-vs-self-host, browser auth,
 # upload-vs-read, agent hooks, repo connection).
 #
 # Recommended invocation (keeps stdin attached to your terminal so the
@@ -70,13 +70,13 @@ Re-run with this form (it keeps stdin attached to your shell):
 
 Or just run it now:
 
-  stash login
+  stash signin
 
 MSG
   exit 0
 fi
 
-# Stdin is a real terminal; launch the questionnaire. `stash login`
+# Stdin is a real terminal; launch the questionnaire. `stash signin`
 # asks scope, managed-vs-self-host, browser sign-in, workspace, and the
 # Claude Code plugin install (when detected).
-exec "$STASH_BIN" login
+exec "$STASH_BIN" signin


### PR DESCRIPTION
## Problem

The CLI auth verb was renamed `login` → `signin` (see the recent `refactor(cli): fold auth command into signin --api-key` line of work), but `install.sh` was never updated. The installer's final setup step still ran `stash login`:

```bash
exec "$STASH_BIN" login
```

`stash login` no longer exists. A fresh **interactive** install via the recommended invocation —

```bash
bash -c "$(curl -fsSL https://joinstash.ai/install)"
```

— installs the CLI fine, then crashes with `No such command 'login'` on the last step, so the first-run setup wizard never launches.

This is live for users: `/install` redirects to `install.sh` on `main`, and `main` still has the broken `login` reference.

## Fix

Point all four references (final `exec`, the non-interactive fallback message, and two comments) at `stash signin`. No other behavior changes.

## Verification

- `grep login install.sh` → no matches
- `bash -n install.sh` → passes
- The `exec "$STASH_BIN" "$@"` arg-passthrough path (used by `… -- signin --non-interactive` in backend tests and `shared_skill_service.py`) was already correct and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)