### PR TITLE
feat(search): make search filter dropdowns type-to-filter

### DIFF
--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -422,6 +422,8 @@ function SearchPageInner() {
                     setSelectedSessionId("");
                   }}
                   ariaLabel="Workspace"
+                  searchable
+                  searchPlaceholder="Search workspaces…"
                   className="w-full rounded-md border border-border bg-base px-2 py-2 text-[13px] text-foreground focus:border-brand focus:outline-none"
                   menuClassName="text-[13px]"
                 />
@@ -443,6 +445,8 @@ function SearchPageInner() {
                     setSelectedProductSkillSlug("");
                   }}
                   ariaLabel="Skill"
+                  searchable
+                  searchPlaceholder="Search Skills…"
                   className="w-full rounded-md border border-border bg-base px-2 py-2 text-[13px] text-foreground focus:border-brand focus:outline-none"
                   menuClassName="text-[13px]"
                 />
@@ -477,6 +481,8 @@ function SearchPageInner() {
                   }}
                   disabled={!selectedWorkspaceId || Boolean(selectedProductSkillId || selectedPageId)}
                   ariaLabel="Folder"
+                  searchable
+                  searchPlaceholder="Search folders…"
                   className="w-full rounded-md border border-border bg-base px-2 py-2 text-[13px] text-foreground focus:border-brand focus:outline-none"
                   menuClassName="text-[13px]"
                 />
@@ -506,6 +512,8 @@ function SearchPageInner() {
                   }}
                   disabled={!selectedWorkspaceId || Boolean(selectedProductSkillId || selectedFolderId)}
                   ariaLabel="Page"
+                  searchable
+                  searchPlaceholder="Search pages…"
                   className="w-full rounded-md border border-border bg-base px-2 py-2 text-[13px] text-foreground focus:border-brand focus:outline-none"
                   menuClassName="text-[13px]"
                 />

--- a/frontend/src/components/CustomSelect.test.tsx
+++ b/frontend/src/components/CustomSelect.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import CustomSelect, { CustomSelectOption } from "./CustomSelect";
+
+const OPTIONS: CustomSelectOption[] = [
+  { value: "", label: "All workspaces" },
+  { value: "ws-1", label: "Engineering" },
+  { value: "ws-2", label: "Design" },
+  { value: "ws-3", label: "Marketing" },
+];
+
+// Mirrors the search filters: the parent owns the selected value, so picking an
+// option must drive that state and the trigger label.
+function Harness({ searchable }: { searchable?: boolean }) {
+  const [value, setValue] = useState("");
+  return (
+    <div>
+      <CustomSelect
+        value={value}
+        options={OPTIONS}
+        onChange={setValue}
+        ariaLabel="Workspace"
+        searchable={searchable}
+      />
+      <output>{value || "none"}</output>
+    </div>
+  );
+}
+
+afterEach(cleanup);
+
+describe("CustomSelect searchable", () => {
+  it("filters options by the typed query", () => {
+    render(<Harness searchable />);
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+
+    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+      target: { value: "des" },
+    });
+
+    expect(screen.getByRole("option", { name: /Design/ })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /Engineering/ })).toBeNull();
+  });
+
+  it("selects a filtered match and reports its value", () => {
+    render(<Harness searchable />);
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+
+    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+      target: { value: "mark" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /Marketing/ }));
+
+    expect(screen.getByText("ws-3")).toBeTruthy();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("selects the first match on Enter from the search input", () => {
+    render(<Harness searchable />);
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+
+    const input = screen.getByLabelText("Search Workspace");
+    fireEvent.change(input, { target: { value: "eng" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Only "Engineering" matches "eng", so Enter commits it.
+    expect(screen.getByText("ws-1")).toBeTruthy();
+  });
+
+  it("shows an empty state when nothing matches", () => {
+    render(<Harness searchable />);
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+
+    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+      target: { value: "zzz" },
+    });
+
+    expect(screen.getByText("No matches")).toBeTruthy();
+    expect(screen.queryByRole("option")).toBeNull();
+  });
+
+  it("renders no search input when not searchable", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+
+    expect(screen.queryByLabelText("Search Workspace")).toBeNull();
+    expect(screen.getAllByRole("option")).toHaveLength(OPTIONS.length);
+  });
+});

--- a/frontend/src/components/CustomSelect.tsx
+++ b/frontend/src/components/CustomSelect.tsx
@@ -21,10 +21,16 @@ interface CustomSelectProps {
   optionClassName?: string;
   align?: "left" | "right";
   autoFocus?: boolean;
+  searchable?: boolean;
+  searchPlaceholder?: string;
 }
 
 const DEFAULT_TRIGGER_CLASS =
   "rounded-md border border-border bg-surface px-2 py-1.5 text-[12px] text-foreground";
+
+function firstEnabledIndex(options: CustomSelectOption[]) {
+  return Math.max(0, options.findIndex((option) => !option.disabled));
+}
 
 export default function CustomSelect({
   id,
@@ -38,63 +44,96 @@ export default function CustomSelect({
   optionClassName = "",
   align = "left",
   autoFocus = false,
+  searchable = false,
+  searchPlaceholder = "Search…",
 }: CustomSelectProps) {
   const generatedId = useId();
   const listboxId = `${generatedId}-listbox`;
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [query, setQuery] = useState("");
 
-  const selectedIndex = useMemo(
-    () => Math.max(0, options.findIndex((option) => option.value === value)),
+  const selected = useMemo(
+    () => options.find((option) => option.value === value),
     [options, value]
   );
-  const selected = options[selectedIndex];
 
-  useEscapeKey(open, () => setOpen(false));
+  // The menu lists only options matching the search query; activeIndex and
+  // keyboard navigation operate over this filtered view.
+  const visibleOptions = useMemo(() => {
+    if (!searchable) return options;
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return options;
+    return options.filter((option) => option.label.toLowerCase().includes(trimmed));
+  }, [searchable, options, query]);
+
+  function openMenu() {
+    setQuery("");
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : firstEnabledIndex(options));
+    setOpen(true);
+  }
+
+  function closeMenu() {
+    setOpen(false);
+    setQuery("");
+  }
+
+  // Narrowing the query re-highlights the first remaining match.
+  function changeQuery(next: string) {
+    setQuery(next);
+    const trimmed = next.trim().toLowerCase();
+    const matches = trimmed
+      ? options.filter((option) => option.label.toLowerCase().includes(trimmed))
+      : options;
+    setActiveIndex(firstEnabledIndex(matches));
+  }
+
+  useEscapeKey(open, closeMenu);
 
   useEffect(() => {
     if (autoFocus) triggerRef.current?.focus();
   }, [autoFocus]);
 
   useEffect(() => {
+    if (open && searchable) searchRef.current?.focus();
+  }, [open, searchable]);
+
+  useEffect(() => {
     if (!open) return;
 
     const onMouseDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      if (!rootRef.current?.contains(event.target as Node)) closeMenu();
     };
     document.addEventListener("mousedown", onMouseDown);
     return () => document.removeEventListener("mousedown", onMouseDown);
   }, [open]);
 
-  function openMenu() {
-    setActiveIndex(selectedIndex);
-    setOpen(true);
-  }
-
   function selectOption(index: number) {
-    const option = options[index];
+    const option = visibleOptions[index];
     if (!option || option.disabled) return;
 
     onChange(option.value);
-    setOpen(false);
+    closeMenu();
   }
 
   function moveActive(direction: 1 | -1) {
-    if (options.length === 0) return;
+    if (visibleOptions.length === 0) return;
 
     let nextIndex = activeIndex;
-    for (let count = 0; count < options.length; count += 1) {
-      nextIndex = (nextIndex + direction + options.length) % options.length;
-      if (!options[nextIndex]?.disabled) {
+    for (let count = 0; count < visibleOptions.length; count += 1) {
+      nextIndex = (nextIndex + direction + visibleOptions.length) % visibleOptions.length;
+      if (!visibleOptions[nextIndex]?.disabled) {
         setActiveIndex(nextIndex);
         return;
       }
     }
   }
 
-  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+  function onMenuKeyDown(event: KeyboardEvent<HTMLElement>) {
     if (disabled) return;
 
     if (event.key === "ArrowDown") {
@@ -117,7 +156,10 @@ export default function CustomSelect({
       return;
     }
 
-    if (event.key === "Enter" || event.key === " ") {
+    // Space inserts a character while searching, so only the trigger treats it
+    // as an open/select shortcut.
+    const isSelectKey = event.key === "Enter" || (event.key === " " && !searchable);
+    if (isSelectKey) {
       event.preventDefault();
       if (!open) {
         openMenu();
@@ -140,12 +182,12 @@ export default function CustomSelect({
         aria-controls={open ? listboxId : undefined}
         onClick={() => {
           if (open) {
-            setOpen(false);
+            closeMenu();
             return;
           }
           openMenu();
         }}
-        onKeyDown={onKeyDown}
+        onKeyDown={onMenuKeyDown}
         className={[
           "flex min-w-0 items-center justify-between gap-2 text-left outline-none",
           className,
@@ -171,41 +213,60 @@ export default function CustomSelect({
 
       {open ? (
         <div
-          id={listboxId}
-          role="listbox"
           className={[
-            "absolute top-full z-[70] mt-1 max-h-64 min-w-full overflow-y-auto rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg",
+            "absolute top-full z-[70] mt-1 min-w-full rounded-md border border-border bg-surface text-[12.5px] shadow-lg",
             align === "right" ? "right-0" : "left-0",
             menuClassName,
           ]
             .filter(Boolean)
             .join(" ")}
         >
-          {options.map((option, index) => {
-            const selectedOption = option.value === value;
-            const activeOption = index === activeIndex;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                role="option"
-                aria-selected={selectedOption}
-                disabled={option.disabled}
-                onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => selectOption(index)}
-                className={[
-                  "flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-foreground disabled:cursor-not-allowed disabled:opacity-50",
-                  activeOption ? "bg-raised" : "hover:bg-raised",
-                  optionClassName,
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-              >
-                <span className="w-3 shrink-0 text-center">{selectedOption ? "✓" : ""}</span>
-                <span className="min-w-0 truncate">{option.label}</span>
-              </button>
-            );
-          })}
+          {searchable ? (
+            <div className="border-b border-border p-1.5">
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                onChange={(event) => changeQuery(event.target.value)}
+                onKeyDown={onMenuKeyDown}
+                placeholder={searchPlaceholder}
+                aria-label={ariaLabel ? `Search ${ariaLabel}` : "Search options"}
+                className="w-full rounded border border-border bg-base px-2 py-1 text-[12.5px] text-foreground outline-none focus:border-brand"
+              />
+            </div>
+          ) : null}
+
+          <div id={listboxId} role="listbox" className="max-h-64 overflow-y-auto py-1">
+            {visibleOptions.length === 0 ? (
+              <div className="px-3 py-1.5 text-muted">No matches</div>
+            ) : (
+              visibleOptions.map((option, index) => {
+                const selectedOption = option.value === value;
+                const activeOption = index === activeIndex;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={selectedOption}
+                    disabled={option.disabled}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => selectOption(index)}
+                    className={[
+                      "flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                      activeOption ? "bg-raised" : "hover:bg-raised",
+                      optionClassName,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                  >
+                    <span className="w-3 shrink-0 text-center">{selectedOption ? "✓" : ""}</span>
+                    <span className="min-w-0 truncate">{option.label}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## What

The search page's filter dropdowns (Workspace, Skill, Folder, Page) were plain `CustomSelect` lists with no way to filter — you had to scroll to find an entry once a workspace had many skills/folders/pages.

This adds an optional **`searchable`** mode to `CustomSelect`: when enabled, the open menu renders a type-to-filter input at the top that narrows the options as you type, with a "No matches" empty state. Keyboard nav (↑/↓/Enter) operates over the filtered list. The four search filters opt in; behavior is unchanged for every other `CustomSelect` call site.

## Changes

- `frontend/src/components/CustomSelect.tsx` — new `searchable` / `searchPlaceholder` props; filter input, filtered keyboard nav, and empty state.
- `frontend/src/app/search/page.tsx` — enable `searchable` on the Workspace, Skill, Folder, and Page filters.
- `frontend/src/components/CustomSelect.test.tsx` — new tests covering filtering, selection of a filtered match, Enter-to-select, the empty state, and that the non-searchable path is unchanged.

## Verification

- `vitest` — 5/5 new tests pass.
- `eslint` + `tsc` clean on the changed files.
- Manually exercised in the running app (login → /search): opened the Workspace filter, confirmed the search input appears, filtered the list, and confirmed the "No matches" state.

## Screenshots

**Dropdown open — type-to-filter input at the top of the menu**

![dropdown open](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/e7d89e4f-58a9-4b72-80e1-cef500e8b433/a5dd24cad252/searchable-dropdown-open.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=8b421c7bea15be6913e87eb284a4d838%2F20260622%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260622T181611Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=cc40c31f783ca5c0e525271a96fc425265dd0a86297c3f288c708e2f21eeb7ca)

**Filtered — typing "stash" narrows the list**

![filtered](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/e7d89e4f-58a9-4b72-80e1-cef500e8b433/4f0071fe3a8d/searchable-dropdown-filtered.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=8b421c7bea15be6913e87eb284a4d838%2F20260622%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260622T181742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=65ebf0c23aba35dc2b889d5091e36f78ae0033a6bb02453968cde92102f4a923)

**Empty state — no option matches the query**

![no matches](https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/e7d89e4f-58a9-4b72-80e1-cef500e8b433/75b46260b7cf/searchable-dropdown-no-matches.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=8b421c7bea15be6913e87eb284a4d838%2F20260622%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260622T181743Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=7f159487a46b610bd349dde0869d673dab3d301264e5b37d3a53692ab440401c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
