### PR TITLE
fix(sessions): fetch folder sessions from backend, not a global recent window

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -90,12 +90,16 @@ async def _session_artifacts(session_row_id: UUID) -> list[dict]:
 @router.get("/me/sessions")
 async def list_my_sessions(
     owner_user_id: UUID | None = Query(None),
+    session_folder_id: UUID | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     current_user: dict = Depends(get_current_user),
 ):
     """Recent sessions across the user's accessible scopes, grouped by
     session_id. Each row carries the agent name, event count, first & last
-    timestamps, and a preview of the first prompt."""
+    timestamps, and a preview of the first prompt.
+
+    Pass `session_folder_id` to scope to one folder — without it the list is a
+    global recent window, so a folder's older sessions would never appear."""
     pool = get_pool()
     args: list = [current_user["id"]]
     accessible_ws = permission_service.accessible_scope_ids_sql(1)
@@ -116,6 +120,9 @@ async def list_my_sessions(
         args.append(owner_user_id)
         where.append(f"he.owner_user_id = ${len(args)}")
         title_where.append(f"he_title.owner_user_id = ${len(args)}")
+    if session_folder_id is not None:
+        args.append(session_folder_id)
+        where.append(f"s.session_folder_id = ${len(args)}")
 
     rows = await pool.fetch(
         f"""

--- a/frontend/src/app/(app)/sessions/page.tsx
+++ b/frontend/src/app/(app)/sessions/page.tsx
@@ -99,6 +99,9 @@ export default function SkillSessionsPage() {
   const [folders, setFolders] = useState<SessionFolder[]>([]);
   const [sharedFolders, setSharedFolders] = useState<SharedWithMeItem[]>([]);
   const [openFolder, setOpenFolder] = useState<OpenFolder | null>(null);
+  // Bumped after a move/assign so a drilled-in folder refetches its own
+  // sessions — its list is fetched independently of the global recent window.
+  const [drillRefresh, setDrillRefresh] = useState(0);
   const [shareFolder, setShareFolder] = useState<SessionFolder | null>(null);
   const [error, setError] = useState("");
   const [view, setView] = useState<ViewKey>("list");
@@ -233,6 +236,7 @@ export default function SkillSessionsPage() {
       );
       clearSelection();
       await load();
+      setDrillRefresh((n) => n + 1);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not move sessions");
     }
@@ -245,6 +249,7 @@ export default function SkillSessionsPage() {
       await assignSessionFolder(rowIds, folderId);
       clearSelection();
       await load();
+      setDrillRefresh((n) => n + 1);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not move sessions");
     }
@@ -313,7 +318,7 @@ export default function SkillSessionsPage() {
         {openFolder ? (
           <FolderDrill
             folder={openFolder}
-            sessions={sorted ?? []}
+            refreshKey={drillRefresh}
             folders={folders}
             view={view}
             sort={sort}
@@ -1077,7 +1082,7 @@ function SharedFolderCard({
 
 function FolderDrill({
   folder,
-  sessions,
+  refreshKey,
   folders,
   view,
   sort,
@@ -1095,7 +1100,7 @@ function FolderDrill({
   onDropSessions,
 }: {
   folder: OpenFolder;
-  sessions: SessionSummary[];
+  refreshKey: number;
   folders: SessionFolder[];
   view: ViewKey;
   sort: SortKey;
@@ -1112,23 +1117,26 @@ function FolderDrill({
   dragActive: boolean;
   onDropSessions: (rowIds: string[], folderId: string) => void;
 }) {
-  const [shared, setShared] = useState<SessionSummary[] | null>(null);
+  const [folderSessions, setFolderSessions] = useState<SessionSummary[] | null>(null);
   const [error, setError] = useState("");
 
+  // Always fetch the folder's own sessions from the backend. The global recent
+  // window the landing page loads can miss a folder's older sessions entirely,
+  // so a folder-scoped query is the only thing that reliably fills the drill.
   useEffect(() => {
-    if (!folder.shared) return;
-    setShared(null);
-    listSharedSessionFolderSessions(folder.id)
-      .then(setShared)
+    setFolderSessions(null);
+    const request = folder.shared
+      ? listSharedSessionFolderSessions(folder.id)
+      : listMySessions(200, folder.id);
+    request
+      .then(setFolderSessions)
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load sessions"));
-  }, [folder]);
+  }, [folder, refreshKey]);
 
   const ownFolder = folder.folder;
   // Shared folders are read-only: render the same chronological browser, but
   // without selection (no move/delete on sessions you don't own).
-  const drillSessions = folder.shared
-    ? sortSessions(shared ?? [], sort)
-    : sessions.filter((s) => s.session_folder_id === folder.id);
+  const drillSessions = sortSessions(folderSessions ?? [], sort);
 
   return (
     <div>
@@ -1199,7 +1207,7 @@ function FolderDrill({
           onChange={(v) => onChangeSort(v as SortKey)}
         />
       </div>
-      {folder.shared && shared === null ? (
+      {folderSessions === null ? (
         <p className="text-[12.5px] text-muted">Loading…</p>
       ) : (
         <SessionsView

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1123,9 +1123,13 @@ export interface LinearTicketLabel {
   enriched_at: string | null;
 }
 
-export async function listMySessions(limit = 50): Promise<SessionSummary[]> {
+export async function listMySessions(
+  limit = 50,
+  sessionFolderId?: string
+): Promise<SessionSummary[]> {
   const qs = new URLSearchParams();
   qs.set("limit", String(limit));
+  if (sessionFolderId) qs.set("session_folder_id", sessionFolderId);
   const data = await apiFetch<{ sessions: SessionSummary[] }>(
     `${ME}/sessions?${qs.toString()}`
   );


### PR DESCRIPTION
## Problem

Opening a session folder showed **"No sessions yet"** even when the folder held thousands of sessions.

**Root cause:** the sessions page loaded only the **200 most-recent** sessions globally (`listMySessions(200)`), then folder views filtered that array *client-side* (`sessions.filter(s => s.session_folder_id === folder.id)`). Any folder whose sessions all fell outside the recent-200 window rendered empty.

The recent workspace→user-scope collapse (#667) exposed this: it merged every old workspace into one scope, so for a heavy user the single recent window no longer reaches older folders. Example from prod — one user's folder held **4,867 sessions**, but **0** of them were in the most-recent 200 (all in "Default" / unfoldered), so the folder showed empty.

> Note: the *fully* empty page some users saw mid-deploy was a separate, transient `422 /users/me` (the loader is gated on `if (user)`); that resolved itself once the deploy settled. This PR fixes the persistent empty-folder bug.

## Fix

- **Backend** (`routers/sessions.py`): add a `session_folder_id` query param to `GET /me/sessions`. When set, it filters on `s.session_folder_id`. Access control is unchanged — this only narrows the existing accessible-scope/readable conditions.
- **Frontend** (`lib/api.ts`): `listMySessions(limit, sessionFolderId?)` passes the folder through.
- **Frontend** (`sessions/page.tsx`): `FolderDrill` now fetches the folder's own sessions from the backend (mirroring the existing shared-folder path) instead of filtering the global recent list. A `refreshKey` bumps after a move/assign so a drilled-in folder refetches and stays in sync. Removed the now-dead `sessions` prop.

## Verification

- Ran the new folder-filter SQL against the **prod DB** for the affected folder — returns its sessions (dated weeks before the recent window that was hiding them).
- `tsc`, `eslint`, `ruff` clean on changed files.
- Frontend api tests (10) and backend session tests (52) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)