### PR TITLE
feat(sessions): paginate folder sessions with infinite scroll

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -92,6 +92,7 @@ async def list_my_sessions(
     owner_user_id: UUID | None = Query(None),
     session_folder_id: UUID | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     current_user: dict = Depends(get_current_user),
 ):
     """Recent sessions across the user's accessible scopes, grouped by
@@ -99,7 +100,8 @@ async def list_my_sessions(
     timestamps, and a preview of the first prompt.
 
     Pass `session_folder_id` to scope to one folder — without it the list is a
-    global recent window, so a folder's older sessions would never appear."""
+    global recent window, so a folder's older sessions would never appear.
+    `offset` pages through the (last_event_at DESC) order for infinite scroll."""
     pool = get_pool()
     args: list = [current_user["id"]]
     accessible_ws = permission_service.accessible_scope_ids_sql(1)
@@ -172,7 +174,7 @@ async def list_my_sessions(
         GROUP BY he.session_id, he.owner_user_id, owner.display_name, s.id, s.session_folder_id,
           sf.name, title_sources.title_source
         ORDER BY last_event_at DESC, user_name ASC, session_id ASC
-        LIMIT {int(limit)}
+        LIMIT {int(limit)} OFFSET {int(offset)}
         """,
         *args,
     )

--- a/frontend/src/app/(app)/sessions/page.tsx
+++ b/frontend/src/app/(app)/sessions/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
 import SessionUpload from "@/components/SessionUpload";
@@ -42,6 +42,10 @@ type ViewKey = "list" | "day" | "user" | "agent" | "ticket" | "folder";
 type SortKey = "recent" | "oldest" | "events" | "name";
 
 const VIEW_STORAGE_KEY = "stash_sessions_view";
+
+// One folder page. Drilled-in folders fetch this many at a time and load more
+// on scroll, so folders with thousands of sessions stay fully reachable.
+const SESSIONS_PAGE_SIZE = 100;
 
 const VIEWS: { key: ViewKey; label: string }[] = [
   { key: "list", label: "List" },
@@ -1118,20 +1122,62 @@ function FolderDrill({
   onDropSessions: (rowIds: string[], folderId: string) => void;
 }) {
   const [folderSessions, setFolderSessions] = useState<SessionSummary[] | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
 
   // Always fetch the folder's own sessions from the backend. The global recent
   // window the landing page loads can miss a folder's older sessions entirely,
   // so a folder-scoped query is the only thing that reliably fills the drill.
+  // Shared folders load in full from their own endpoint; own folders page
+  // through /me/sessions, so they need infinite scroll past the first page.
   useEffect(() => {
     setFolderSessions(null);
+    setHasMore(false);
     const request = folder.shared
       ? listSharedSessionFolderSessions(folder.id)
-      : listMySessions(200, folder.id);
+      : listMySessions(SESSIONS_PAGE_SIZE, folder.id, 0);
     request
-      .then(setFolderSessions)
+      .then((rows) => {
+        setFolderSessions(rows);
+        setHasMore(!folder.shared && rows.length === SESSIONS_PAGE_SIZE);
+      })
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load sessions"));
   }, [folder, refreshKey]);
+
+  const loadMore = useCallback(async () => {
+    if (folder.shared || loadingMore || !hasMore || folderSessions === null) return;
+    setLoadingMore(true);
+    try {
+      const rows = await listMySessions(
+        SESSIONS_PAGE_SIZE,
+        folder.id,
+        folderSessions.length
+      );
+      setFolderSessions((prev) => [...(prev ?? []), ...rows]);
+      setHasMore(rows.length === SESSIONS_PAGE_SIZE);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load more sessions");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [folder, loadingMore, hasMore, folderSessions]);
+
+  // Auto-load the next page when the sentinel scrolls into view; the button it
+  // wraps is the manual fallback if the observer can't fire.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "600px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
 
   const ownFolder = folder.folder;
   // Shared folders are read-only: render the same chronological browser, but
@@ -1210,16 +1256,30 @@ function FolderDrill({
       {folderSessions === null ? (
         <p className="text-[12.5px] text-muted">Loading…</p>
       ) : (
-        <SessionsView
-          view={view}
-          sessions={drillSessions}
-          folders={folders}
-          isPinned={isPinned}
-          onTogglePin={onTogglePin}
-          selectedIds={folder.shared ? EMPTY_SELECTION : selectedIds}
-          onToggleSelect={folder.shared ? noop : onToggleSelect}
-          drag={folder.shared ? NO_DRAG : drag}
-        />
+        <>
+          <SessionsView
+            view={view}
+            sessions={drillSessions}
+            folders={folders}
+            isPinned={isPinned}
+            onTogglePin={onTogglePin}
+            selectedIds={folder.shared ? EMPTY_SELECTION : selectedIds}
+            onToggleSelect={folder.shared ? noop : onToggleSelect}
+            drag={folder.shared ? NO_DRAG : drag}
+          />
+          {hasMore && (
+            <div ref={sentinelRef} className="flex justify-center py-4">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="cursor-pointer rounded-md border border-border px-3 py-1.5 text-[12.5px] text-muted hover:text-foreground disabled:cursor-default disabled:opacity-60"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1125,10 +1125,12 @@ export interface LinearTicketLabel {
 
 export async function listMySessions(
   limit = 50,
-  sessionFolderId?: string
+  sessionFolderId?: string,
+  offset = 0
 ): Promise<SessionSummary[]> {
   const qs = new URLSearchParams();
   qs.set("limit", String(limit));
+  if (offset) qs.set("offset", String(offset));
   if (sessionFolderId) qs.set("session_folder_id", sessionFolderId);
   const data = await apiFetch<{ sessions: SessionSummary[] }>(
     `${ME}/sessions?${qs.toString()}`


### PR DESCRIPTION
## Why

Follow-up to #675. That PR made folders fetch their own sessions, but still capped at a single page — for a folder with thousands of sessions you couldn't scroll past it. There was **no pagination anywhere** in the sessions UI.

## What

- **Backend** (`routers/sessions.py`): add an `offset` query param to `GET /me/sessions`, applied as `OFFSET` on the existing `last_event_at DESC` order.
- **Frontend** (`lib/api.ts`): `listMySessions(limit, sessionFolderId?, offset?)`.
- **Frontend** (`sessions/page.tsx`): the folder drill pages through `/me/sessions` `SESSIONS_PAGE_SIZE` (100) at a time. An `IntersectionObserver` sentinel auto-loads the next page as you scroll near the bottom, with a **"Load more"** button as the manual fallback. `hasMore` tracks whether the last page came back full.

Shared folders already load in full from their own (unpaginated) endpoint, so they're unaffected.

## Verification

Validated `LIMIT/OFFSET` paging against the **prod DB** for a real 4,342-session folder:

| page | newest → oldest in page | count |
|------|------------------------|-------|
| offset 0   | Jun 4 → May 27 | 100 |
| offset 100 | May 27 → May 14 | 100 |

Contiguous, non-overlapping, chaining cleanly through all ~4,342 (~44 pages).

`tsc`, `eslint`, `ruff` clean on changed files; frontend api tests (10) pass.

## Known limitation

Pagination follows the server's `last_event_at DESC` order. The client-side **sort** dropdown (oldest / events / name) reorders only the loaded pages, not the full folder — so "oldest" surfaces the oldest *of what's loaded*, not a true global oldest-first. Recent (the default) is exact. True global sort-while-paginating needs server-side sort, deferred as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)