### PR TITLE
feat(sessions): paginate the session transcript viewer

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -141,9 +141,9 @@ def _event_role(event_type: str | None) -> str | None:
 
     tool_use events fold into 'assistant' so the timeline shows tool calls
     inline with assistant turns instead of dropping them silently."""
-    if event_type in ("user_message", "prompt", "user"):
+    if event_type in memory_service.USER_EVENT_TYPES:
         return "user"
-    if event_type in ("assistant_message", "assistant", "tool_use", "tool_call", "tool_result"):
+    if event_type in memory_service.ASSISTANT_EVENT_TYPES:
         return "assistant"
     return None
 
@@ -219,18 +219,31 @@ async def get_transcript_metadata(
 @router.get("/{session_id}/events")
 async def get_transcript_events(
     session_id: str,
+    limit: int = 100,
+    offset: int = 0,
     current_user: dict = Depends(get_current_user),
 ):
-    """Chat-thread turns for a session, in render order. Sourced directly
-    from history_events — no JSONL serialization round-trip.
+    """One page of chat-thread turns for a session, oldest first, sourced
+    directly from history_events. The viewer loads the first page on open and
+    fetches more as the reader scrolls. offset is a turn ordinal, so a future
+    in-session search can jump straight to a match's window.
 
-    No membership gate: read_session_events enforces
-    can_read_session, so a non-member the session is shared with can read it."""
-    resolved = await _resolve_readable_events(session_id, current_user["id"])
-    if not resolved:
-        raise HTTPException(status_code=404, detail="Transcript not found")
-    _, events = resolved
-    return {"events": _events_to_viewer_shape(events)}
+    No membership gate: can_read_session is enforced per scope below, so a
+    non-member the session is shared with can read it."""
+    for row in await session_service.list_sessions_for_session_id(session_id):
+        owner_user_id = row["owner_user_id"]
+        if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
+            continue
+        events, total = await memory_service.read_session_events_page(
+            owner_user_id, session_id, limit, offset
+        )
+        if total:
+            return {
+                "events": _events_to_viewer_shape(events),
+                "total": total,
+                "has_more": offset + len(events) < total,
+            }
+    raise HTTPException(status_code=404, detail="Transcript not found")
 
 
 @router.get("/{session_id}/export.jsonl")

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -301,6 +301,15 @@ async def can_read_session(owner_user_id: UUID, session_id: str, user_id: UUID) 
     )
 
 
+# Event types the session viewer renders as turns. The user/assistant split
+# lives in transcripts._event_role; this is the single source of truth for
+# which rows count as renderable turns, shared by the paginated reader's
+# LIMIT/OFFSET so a page offset equals a turn ordinal.
+USER_EVENT_TYPES = ("user_message", "prompt", "user")
+ASSISTANT_EVENT_TYPES = ("assistant_message", "assistant", "tool_use", "tool_call", "tool_result")
+RENDERABLE_EVENT_TYPES = USER_EVENT_TYPES + ASSISTANT_EVENT_TYPES
+
+
 async def read_session_events(
     owner_user_id: UUID,
     session_id: str,
@@ -321,6 +330,38 @@ async def read_session_events(
         session_id,
     )
     return [dict(r) for r in rows]
+
+
+async def read_session_events_page(
+    owner_user_id: UUID,
+    session_id: str,
+    limit: int,
+    offset: int,
+) -> tuple[list[dict], int]:
+    """One page of renderable session events (oldest first) plus the total
+    renderable count, for the lazily-loaded transcript viewer. Filtering to
+    renderable event types keeps the offset aligned with the turn ordinal the
+    viewer shows. Callers enforce readability."""
+    pool = get_pool()
+    total = await pool.fetchval(
+        "SELECT COUNT(*) FROM history_events "
+        "WHERE owner_user_id = $1 AND session_id = $2 AND event_type = ANY($3::text[])",
+        owner_user_id,
+        session_id,
+        list(RENDERABLE_EVENT_TYPES),
+    )
+    rows = await pool.fetch(
+        "SELECT id, agent_name, event_type, tool_name, content, metadata, created_at "
+        "FROM history_events "
+        "WHERE owner_user_id = $1 AND session_id = $2 AND event_type = ANY($3::text[]) "
+        "ORDER BY created_at, id LIMIT $4 OFFSET $5",
+        owner_user_id,
+        session_id,
+        list(RENDERABLE_EVENT_TYPES),
+        limit,
+        offset,
+    )
+    return [dict(r) for r in rows], total
 
 
 async def list_scope_sessions(owner_user_id: UUID, user_id: UUID) -> list[dict]:

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -99,6 +99,58 @@ async def test_upload_inserts_events_and_events_roundtrip(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_events_endpoint_paginates(client: AsyncClient):
+    """The viewer loads the transcript a page at a time. offset is a turn
+    ordinal, total is the full turn count, and has_more drives infinite scroll —
+    so a long session never loads every event up front."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    body = (
+        "\n".join(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"content": f"msg-{i}"},
+                    "timestamp": f"2026-05-10T20:00:0{i}Z",
+                }
+            )
+            for i in range(5)
+        )
+        + "\n"
+    ).encode()
+    up = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(body), "application/jsonl")},
+        data={"session_id": "sess-page", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert up.status_code == 201, up.text
+
+    first = await client.get(
+        "/api/v1/me/transcripts/sess-page/events",
+        params={"limit": 2, "offset": 0},
+        headers=headers,
+    )
+    assert first.status_code == 200
+    page = first.json()
+    assert page["total"] == 5
+    assert page["has_more"] is True
+    assert [e["content"] for e in page["events"]] == ["msg-0", "msg-1"]
+
+    last = await client.get(
+        "/api/v1/me/transcripts/sess-page/events",
+        params={"limit": 2, "offset": 4},
+        headers=headers,
+    )
+    assert last.status_code == 200
+    tail = last.json()
+    assert tail["total"] == 5
+    assert tail["has_more"] is False
+    assert [e["content"] for e in tail["events"]] == ["msg-4"]
+
+
+@pytest.mark.asyncio
 async def test_reupload_is_noop_when_events_exist(client: AsyncClient):
     key = await _register(client)
     headers = {"Authorization": f"Bearer {key}"}

--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -16,7 +16,7 @@ import { useEscapeKey } from "@/hooks/useEscapeKey";
 import {
   fetchAuthed,
   getSessionDetail,
-  getSessionEvents,
+  getSessionEventsPage,
   listSkills,
   materializeSession,
   renameSession,
@@ -26,6 +26,10 @@ import {
   type Skill,
 } from "@/lib/api";
 import EditableTitle from "@/components/content/EditableTitle";
+
+// One transcript page. The viewer loads this many turns at a time and fetches
+// more on scroll, so long sessions don't load every event up front.
+const TRANSCRIPT_PAGE_SIZE = 100;
 
 interface MessageTurn {
   kind: "message";
@@ -125,6 +129,9 @@ export default function SessionViewerPage() {
   const [agentName, setAgentName] = useState("");
   const [sessionDetail, setSessionDetail] = useState<SessionDetail | null>(null);
   const [turns, setTurns] = useState<MessageTurn[]>([]);
+  const [totalTurns, setTotalTurns] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
 
   useBreadcrumbs(
@@ -152,10 +159,14 @@ export default function SessionViewerPage() {
   const load = useCallback(async () => {
     try {
       const detail = await getSessionDetail(sessionId);
-      const events = await getSessionEvents(sessionId);
-      setAgentName(detail.agent_name || events.find((event) => event.agent_name)?.agent_name || "");
+      const page = await getSessionEventsPage(sessionId, TRANSCRIPT_PAGE_SIZE, 0);
+      setAgentName(
+        detail.agent_name || page.events.find((event) => event.agent_name)?.agent_name || ""
+      );
       setSessionDetail(detail);
-      setTurns(events.map(eventToTurn));
+      setTurns(page.events.map(eventToTurn));
+      setTotalTurns(page.total);
+      setHasMore(page.has_more);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load session");
     }
@@ -164,6 +175,36 @@ export default function SessionViewerPage() {
   useEffect(() => {
     if (user) load();
   }, [user, load]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await getSessionEventsPage(sessionId, TRANSCRIPT_PAGE_SIZE, turns.length);
+      setTurns((prev) => [...prev, ...page.events.map(eventToTurn)]);
+      setHasMore(page.has_more);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load more messages");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [sessionId, loadingMore, hasMore, turns.length]);
+
+  // Auto-load the next page when the sentinel scrolls into view; the button it
+  // wraps is the manual fallback if the observer can't fire.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "600px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
@@ -202,12 +243,12 @@ export default function SessionViewerPage() {
                   }}
                 />
               </h1>
-              {turns.length > 0 && (
+              {totalTurns > 0 && (
                 <div className="mt-1.5 flex flex-wrap items-center gap-2.5 text-[12px] text-muted">
                   {sessionDate && <span>{sessionDate}</span>}
                   {sessionDate && <span>·</span>}
                   <span>
-                    {turns.length} message{turns.length === 1 ? "" : "s"}
+                    {totalTurns} message{totalTurns === 1 ? "" : "s"}
                   </span>
                 </div>
               )}
@@ -299,7 +340,19 @@ export default function SessionViewerPage() {
                 </div>
               );
             })}
-            {!error && turns.length === 0 && (
+            {hasMore && (
+              <div ref={sentinelRef} className="flex justify-center py-4">
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="cursor-pointer rounded-md border border-border px-3 py-1.5 text-[12.5px] text-muted hover:text-foreground disabled:cursor-default disabled:opacity-60"
+                >
+                  {loadingMore ? "Loading…" : "Load more"}
+                </button>
+              </div>
+            )}
+            {!error && totalTurns === 0 && (
               <div className="rounded-lg border border-dashed border-border bg-surface/30 px-4 py-6 text-center text-[12.5px] text-muted">
                 No transcript events yet.
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1549,11 +1549,35 @@ export interface SessionEvent {
   created_at: string | null;
 }
 
-export async function getSessionEvents(sessionId: string): Promise<SessionEvent[]> {
-  const res = await apiFetch<{ events: SessionEvent[] }>(
-    `${ME}/transcripts/${encodeURIComponent(sessionId)}/events`
+export interface SessionEventsPage {
+  events: SessionEvent[];
+  total: number;
+  has_more: boolean;
+}
+
+export async function getSessionEventsPage(
+  sessionId: string,
+  limit = 100,
+  offset = 0
+): Promise<SessionEventsPage> {
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (offset) qs.set("offset", String(offset));
+  return apiFetch<SessionEventsPage>(
+    `${ME}/transcripts/${encodeURIComponent(sessionId)}/events?${qs}`
   );
-  return res.events;
+}
+
+// Drains every page. For consumers that search a whole session client-side;
+// the viewer uses getSessionEventsPage directly for lazy loading.
+export async function getSessionEvents(sessionId: string): Promise<SessionEvent[]> {
+  const all: SessionEvent[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await getSessionEventsPage(sessionId, 500, offset);
+    all.push(...page.events);
+    if (!page.has_more || page.events.length === 0) return all;
+    offset += page.events.length;
+  }
 }
 
 export interface HistoryEvent {


### PR DESCRIPTION
Previously we didn't paginate session transcripts in our session transcript view UI. Now, we do.


# Slop.

## Problem

The session transcript viewer fetched **every** event up front (`GET /transcripts/{id}/events` returned the whole transcript, unpaginated) and rendered all of them with no virtualization. Long sessions loaded the entire history into memory on open. This is also the prerequisite for an in-session Ctrl-F that can jump to a match in an unfetched part of the transcript.

## What changed

**Backend**
- `GET /transcripts/{id}/events` now takes `limit` (default 100) + `offset` and returns `{ events, total, has_more }`. Readability (`can_read_session`) is enforced per scope inline.
- New `memory_service.read_session_events_page(owner, session_id, limit, offset) → (rows, total)`, filtered to renderable event types so **`offset` equals a turn ordinal** — this is what lets a future in-session search jump straight to a match's window via the same offset paging.
- Hoisted the renderable event-type lists into shared constants (`USER_EVENT_TYPES` / `ASSISTANT_EVENT_TYPES` / `RENDERABLE_EVENT_TYPES`) as the single source of truth; `transcripts._event_role` now reuses them. Metadata/export endpoints are untouched (they still read all events).

**Frontend**
- New `getSessionEventsPage(sessionId, limit, offset)`. `getSessionEvents(sessionId)` keeps its original `SessionEvent[]` contract by **draining all pages internally**, so the search page's client-side in-session find is unchanged.
- `SessionClient` loads the first 100 turns on open and auto-loads more via an `IntersectionObserver` sentinel with a "Load more" fallback (mirrors the folder-drill pattern from #676). The header message count now uses the server's `total`.

## Testing

- **Added** `test_events_endpoint_paginates` (limit/offset, `total`, `has_more`, ordering).
- **API E2E against the live stack + real DB**: seeded a 600-event session and paged through it — `total=600`, `has_more` flips correctly at the last page, ordering/continuity intact across pages.
- **UI**: verified by @henry in-browser — first 100 load, "600 messages" in the header, infinite scroll loads the rest 100 at a time. _(Screenshot to follow — could not capture headlessly; the local dev server didn't hydrate under headless Chromium.)_
- `ruff` + `eslint` clean on changed files; `tsc` clean.

## Follow-ups (not in this PR)
- In-session Ctrl-F endpoint that returns match anchors (event id + ordinal), navigating via this offset paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)