### PR TITLE
fix(vfs): don't crash grep when a session transcript can't be read

### DIFF
--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -8,6 +8,7 @@ import re
 import shlex
 from dataclasses import dataclass
 
+from .client import StashError
 from .mount import MountError, StashVfsModel
 
 
@@ -23,10 +24,12 @@ class SkillAppVfsShell:
     def __init__(self, model: StashVfsModel, cwd: str = "/"):
         self.model = model
         self.cwd = self._resolve_path(cwd)
+        self._warnings: list[str] = []
         self._require_dir(self.cwd)
 
     def run(self, script: str) -> VfsCommandResult:
         stdout_parts = []
+        stderr_parts = []
         for command in _split_unquoted(script, "&&"):
             for part in _split_unquoted(command, ";"):
                 part = part.strip()
@@ -35,29 +38,39 @@ class SkillAppVfsShell:
                 result = self._run_pipeline(part)
                 if result.stdout:
                     stdout_parts.append(result.stdout)
+                if result.stderr:
+                    stderr_parts.append(result.stderr)
                 if result.exit_code != 0:
                     result.stdout = "".join(stdout_parts)
+                    result.stderr = "".join(stderr_parts)
                     result.cwd = self.cwd
                     return result
-        return VfsCommandResult(stdout="".join(stdout_parts), cwd=self.cwd)
+        return VfsCommandResult(
+            stdout="".join(stdout_parts), stderr="".join(stderr_parts), cwd=self.cwd
+        )
 
     def _run_pipeline(self, script: str) -> VfsCommandResult:
         stdin = ""
+        stderr_parts = []
         stages = _split_unquoted(script, "|")
         for index, stage in enumerate(stages):
             result = self._run_stage(stage.strip(), stdin if index else None)
+            if result.stderr:
+                stderr_parts.append(result.stderr)
             if result.exit_code != 0:
+                result.stderr = "".join(stderr_parts)
                 return result
             stdin = result.stdout
-        return VfsCommandResult(stdout=stdin, cwd=self.cwd)
+        return VfsCommandResult(stdout=stdin, stderr="".join(stderr_parts), cwd=self.cwd)
 
     def _run_stage(self, stage: str, stdin: str | None) -> VfsCommandResult:
         name = "shell"
+        self._warnings = []
         try:
             command, redirect = _split_redirect(stage)
             args = shlex.split(command)
             if not args:
-                return VfsCommandResult(cwd=self.cwd)
+                return self._stage_result()
 
             name = args[0]
             output = self._dispatch(name, args[1:], stdin)
@@ -65,16 +78,31 @@ class SkillAppVfsShell:
                 path, append = redirect
                 self._write_output(path, output, append)
                 output = ""
-            return VfsCommandResult(stdout=output, cwd=self.cwd)
+            return self._stage_result(stdout=output)
         except VfsShellExit as e:
-            return VfsCommandResult(exit_code=e.exit_code, cwd=self.cwd)
+            return self._stage_result(exit_code=e.exit_code)
         except VfsShellError as e:
-            return VfsCommandResult(stderr=f"{name}: {e}\n", exit_code=e.exit_code, cwd=self.cwd)
+            return self._stage_result(stderr=f"{name}: {e}\n", exit_code=e.exit_code)
         except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError) as e:
             message = e.args[0] if e.args else str(e)
-            return VfsCommandResult(stderr=f"{name}: {message}\n", exit_code=1, cwd=self.cwd)
+            return self._stage_result(stderr=f"{name}: {message}\n", exit_code=1)
         except (MountError, ValueError) as e:
-            return VfsCommandResult(stderr=f"{name}: {e}\n", exit_code=2, cwd=self.cwd)
+            return self._stage_result(stderr=f"{name}: {e}\n", exit_code=2)
+        except StashError as e:
+            return self._stage_result(stderr=f"{name}: {e}\n", exit_code=2)
+
+    def _stage_result(
+        self, *, stdout: str = "", stderr: str = "", exit_code: int = 0
+    ) -> VfsCommandResult:
+        return VfsCommandResult(
+            stdout=stdout,
+            stderr="".join(self._warnings) + stderr,
+            exit_code=exit_code,
+            cwd=self.cwd,
+        )
+
+    def _warn(self, message: str) -> None:
+        self._warnings.append(f"{message}\n")
 
     def _dispatch(self, name: str, args: list[str], stdin: str | None) -> str:
         if name == "pwd":
@@ -328,7 +356,11 @@ class SkillAppVfsShell:
             if node.is_dir and not recursive:
                 raise VfsShellError(f"{raw_path}: is a directory")
             for file_path in file_paths:
-                text = self._read_text(file_path)
+                try:
+                    text = self._read_text(file_path)
+                except StashError as e:
+                    self._warn(f"{name}: {file_path}: {e.detail}")
+                    continue
                 matches.append(
                     _grep_text(
                         regex,

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -1,8 +1,20 @@
 import shlex
 
 from cli.app_vfs import SkillAppVfsShell
+from cli.client import StashError
 from cli.mount import StashVfsModel
 from cli.tests.test_mount_vfs import FakeClient
+
+
+class DeadTranscriptClient(FakeClient):
+    """A session whose transcript bodies 404 on fetch — the backend lists it
+    but can no longer serve it. Mirrors the inconsistency that crashed grep."""
+
+    def get_transcript_events(self, session_id):
+        raise StashError(404, "Transcript not found")
+
+    def export_transcript_jsonl(self, session_id):
+        raise StashError(404, "Transcript not found")
 
 
 class CountingClient(FakeClient):
@@ -192,3 +204,23 @@ def test_app_vfs_cd_updates_virtual_working_directory():
 
     assert result.stdout == "/me\n"
     assert result.cwd == "/me"
+
+
+def test_app_vfs_grep_skips_unreadable_transcript_and_warns():
+    shell, _client = _shell(DeadTranscriptClient())
+
+    result = shell.run("grep -r Plan /me")
+
+    assert result.exit_code == 0
+    assert "Plan" in result.stdout
+    assert "Transcript not found" in result.stderr
+
+
+def test_app_vfs_cat_unreadable_transcript_reports_error_without_traceback():
+    shell, _client = _shell(DeadTranscriptClient())
+
+    result = shell.run("cat '/me/sessions/Fix login--session-/transcript.md'")
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "Transcript not found" in result.stderr


### PR DESCRIPTION
## Problem

`stash vfs "grep -r … /me/sessions"` crashed with a raw Python traceback:

```
StashError: [404] Transcript not found
```

Recursive grep reads each session transcript through a lazy backend loader. When the backend lists a transcript it can no longer serve, the fetch raises `StashError [404]`. Nothing in the VFS shell caught `StashError` (only `MountError`), so it escaped as an unhandled traceback — and a single dead transcript aborted the entire grep, so `grep -r` over sessions returned nothing.

## Fix

`cli/app_vfs.py`:

1. **grep skips unreadable files and warns** — `_grep` catches `StashError` per file, prints `grep: <path>: Transcript not found` to stderr, and continues. Matches real `grep -r` behavior (report the unreadable file, keep scanning) and stays loud — the error is surfaced, not swallowed.
2. **`StashError` safety net at the stage level** — `_run_stage` maps `StashError` to a clean stderr message + exit 2, so non-recursive commands like `cat` on a deleted transcript print an error instead of a traceback.
3. **stderr propagates on success** — `run` / `_run_pipeline` were dropping stderr from successful stages (latent bug); without this, the new warnings would vanish on a grep that still found matches (exit 0). They now flow through pipelines and `;`/`&&` chains.

## Verification

- Original repro against the real backend now exits 0 with no traceback.
- Two new regression tests (`DeadTranscriptClient` whose transcript fetches 404):
  - recursive grep skips the dead transcript, still returns other matches, warns on stderr, exit 0;
  - `cat` on the dead transcript reports a clean error (exit 2), no traceback.
- Full `cli` VFS suite: 19 passed. `ruff` clean.

No GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)