### PR TITLE
refactor(vfs): drop the interactive REPL, require a command

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4178,26 +4178,15 @@ def vfs_command(
         shell = SkillAppVfsShell(model, cwd=cwd)
 
         command = " ".join(ctx.args).strip()
-        if command:
-            result = shell.run(command)
-            sys.stdout.write(result.stdout)
-            sys.stderr.write(result.stderr)
-            if result.exit_code:
-                raise typer.Exit(result.exit_code)
-            return
+        if not command:
+            console.print('[red]Usage: stash vfs "<command>" (e.g. [bold]stash vfs "ls /me"[/bold]).[/red]')
+            raise typer.Exit(2)
 
-        while True:
-            try:
-                command = input(f"stash:{shell.cwd}$ ").strip()
-            except EOFError:
-                return
-            if command in ("exit", "quit"):
-                return
-            if not command:
-                continue
-            result = shell.run(command)
-            sys.stdout.write(result.stdout)
-            sys.stderr.write(result.stderr)
+        result = shell.run(command)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.exit_code:
+            raise typer.Exit(result.exit_code)
     except MountError as e:
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1)


### PR DESCRIPTION
## What

`stash vfs` with no argument dropped into an interactive REPL — an `input()` loop printing a `stash:/$` prompt. This removes it; a missing command now fails loud with a usage hint.

```
$ stash vfs
Usage: stash vfs "<command>" (e.g. stash vfs "ls /me").   # exit 2
```

## Why

`stash vfs` is an **agent-facing** surface. Agents drive the CLI through one-shot tool calls — strict request/response, no live stdin to feed a running process. A REPL's whole value is the interactive loop (see output → decide next command in the same process), which the tool boundary can't express. So agents structurally can't use it: bare `stash vfs` just hits `EOFError` on closed stdin and exits immediately.

The REPL only served a human at a terminal, and this command isn't for humans. Cutting it removes a code path nothing real exercises.

## Scope

- Only `vfs_command` in `cli/main.py` (−20/+9). The shared interpreter (`SkillAppVfsShell.run`) and the one-shot path are unchanged.
- No tests covered the REPL loop; `cli/tests/test_app_vfs.py` exercises the interpreter directly and still passes (11/11).

## Verification

- Bare `stash vfs` → usage error, exit 2 ✅
- `stash vfs "ls /me"`, `&&` chaining, `cd` within one call → unchanged ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)