### PR TITLE
feat(vfs): surface real modified/created timestamps in ls -l and stat

### DIFF
--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -71,7 +71,7 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
     readable_file = permission_service.readable_content_condition("file", "fi", 2)
     folder_rows, page_rows, file_rows = await asyncio.gather(
         pool.fetch(
-            "SELECT f.id, f.name, f.parent_folder_id, "
+            "SELECT f.id, f.name, f.parent_folder_id, f.created_at, f.updated_at, "
             "       (SELECT COUNT(*) FROM pages p WHERE p.folder_id = f.id "
             "        AND p.deleted_at IS NULL) AS page_count, "
             "       (SELECT COUNT(*) FROM files fi WHERE fi.folder_id = f.id "
@@ -81,7 +81,8 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
             user_id,
         ),
         pool.fetch(
-            "SELECT p.id, p.name, p.content_type, p.folder_id FROM pages p "
+            "SELECT p.id, p.name, p.content_type, p.folder_id, p.created_at, p.updated_at "
+            "FROM pages p "
             f"WHERE p.owner_user_id = $1 AND p.deleted_at IS NULL AND {readable_page} "
             "ORDER BY p.name",
             owner_user_id,
@@ -110,6 +111,8 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
                 "parent_folder_id": str(r["parent_folder_id"]) if r["parent_folder_id"] else None,
                 "page_count": int(r["page_count"] or 0),
                 "file_count": int(r["file_count"] or 0),
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
             }
             for r in folder_rows
         ],
@@ -119,6 +122,8 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
                 "name": r["name"],
                 "content_type": r["content_type"],
                 "folder_id": str(r["folder_id"]) if r["folder_id"] else None,
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
             }
             for r in page_rows
         ],

--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -6,7 +6,9 @@ import fnmatch
 import posixpath
 import re
 import shlex
+import time
 from dataclasses import dataclass
+from datetime import datetime
 
 from .client import StashError
 from .mount import MountError, StashVfsModel
@@ -172,12 +174,14 @@ class SkillAppVfsShell:
         return "\n".join(block for block in blocks if block) + ("\n" if blocks else "")
 
     def _format_ls_entry(self, path: str, long: bool) -> str:
+        name = posixpath.basename(path) or "/"
         if not long:
-            return posixpath.basename(path) or "/"
+            return name
+        node = self.model._get_node(path)
         attrs = self.model.getattr(path)
-        mode = "d" if self.model._get_node(path).is_dir else "-"
+        mode = "d" if node.is_dir else "-"
         size = int(attrs.get("st_size", 0))
-        return f"{mode} {size:>8} {posixpath.basename(path) or '/'}"
+        return f"{mode} {size:>8} {_ls_time(node.updated_at)} {name}"
 
     def _cat(self, args: list[str]) -> str:
         if not args:
@@ -476,7 +480,13 @@ class SkillAppVfsShell:
         attrs = self.model.getattr(path)
         node = self.model._get_node(path)
         kind = "directory" if node.is_dir else "file"
-        return f"{path}\n  type: {kind}\n  size: {attrs.get('st_size', 0)}\n"
+        return (
+            f"{path}\n"
+            f"  type: {kind}\n"
+            f"  size: {attrs.get('st_size', 0)}\n"
+            f"  modified: {_iso_time(node.updated_at)}\n"
+            f"  created: {_iso_time(node.created_at)}\n"
+        )
 
     def _write_output(self, raw_path: str, output: str, append: bool) -> None:
         path = self._resolve_path(raw_path)
@@ -640,6 +650,26 @@ def _help_text() -> str:
             "",
         ]
     )
+
+
+_SIX_MONTHS_SECONDS = 182 * 24 * 3600
+
+
+def _ls_time(epoch: float | None) -> str:
+    """`ls -l`-style 12-wide modified-time column. Recent entries show the
+    time, older ones the year, exactly like coreutils. A node the backend
+    gave no timestamp for shows `-` rather than a fabricated date."""
+    if not epoch:
+        return f"{'-':>12}"
+    when = datetime.fromtimestamp(epoch)
+    tail = when.strftime("%H:%M") if abs(time.time() - epoch) < _SIX_MONTHS_SECONDS else when.strftime(" %Y")
+    return f"{when.strftime('%b'):>3} {when.day:>2} {tail}"
+
+
+def _iso_time(epoch: float | None) -> str:
+    if not epoch:
+        return "-"
+    return datetime.fromtimestamp(epoch).isoformat()
 
 
 def _name_matches(path: str, pattern: str, ignore_case: bool) -> bool:

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -15,6 +15,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 from .client import StashClient, StashError
@@ -36,8 +37,8 @@ class VfsNode:
     content: bytes | None = None
     size_hint: int | None = None
     children: dict[str, str] = field(default_factory=dict)
-    created_at: float = field(default_factory=time.time)
-    updated_at: float = field(default_factory=time.time)
+    created_at: float | None = None
+    updated_at: float | None = None
 
     @property
     def is_dir(self) -> bool:
@@ -136,8 +137,8 @@ class StashVfsModel:
             "st_uid": os.getuid(),
             "st_gid": os.getgid(),
             "st_size": size or 0,
-            "st_ctime": node.created_at,
-            "st_mtime": node.updated_at,
+            "st_ctime": node.created_at or 0.0,
+            "st_mtime": node.updated_at or 0.0,
             "st_atime": now,
         }
 
@@ -167,6 +168,8 @@ class StashVfsModel:
             path = self._add_dir_child(
                 parent_path,
                 _object_dir_name(folder.get("name") or "folder", folder_id),
+                created_at=folder.get("created_at"),
+                updated_at=folder.get("updated_at"),
             )
             folder_paths[folder_id] = path
             return path
@@ -191,6 +194,8 @@ class StashVfsModel:
                     body,
                 ),
                 writable=True,
+                created_at=page.get("created_at"),
+                updated_at=page.get("updated_at"),
             )
 
         for file in tree.get("files", []):
@@ -199,10 +204,15 @@ class StashVfsModel:
                 folder_path(str(file["folder_id"])) if file.get("folder_id") else root_path
             )
             name = _object_file_name(file.get("name") or "file", file_id, "")
+            # Uploaded files are immutable — there is no separate update event,
+            # so the file's last-modified time is its creation time.
+            created_at = file.get("created_at")
             self._add_file(
                 f"{parent_path}/{name}",
                 loader=lambda fid=file_id: self.client.download_file(fid),
                 size_hint=file.get("size_bytes"),
+                created_at=created_at,
+                updated_at=created_at,
             )
 
     def _add_skills(self, me_path: str, skills: list[dict]) -> None:
@@ -229,26 +239,31 @@ class StashVfsModel:
         for session in sessions:
             session_id = str(session["session_id"])
             row_id = str(session.get("id") or session_id)
+            updated_at = session.get("updated_at")
             session_path = self._add_dir_child(
                 sessions_path,
                 _object_dir_name(session.get("title") or session_id, row_id),
+                updated_at=updated_at,
             )
-            self._add_json_file(f"{session_path}/metadata.json", session)
+            self._add_json_file(f"{session_path}/metadata.json", session, updated_at=updated_at)
             self._add_file(
                 f"{session_path}/events.json",
                 loader=lambda sid=session_id: _json_bytes(
                     {"events": self.client.get_transcript_events(sid)}
                 ),
+                updated_at=updated_at,
             )
             self._add_file(
                 f"{session_path}/transcript.jsonl",
                 loader=lambda sid=session_id: _text_bytes(self.client.export_transcript_jsonl(sid)),
+                updated_at=updated_at,
             )
             self._add_file(
                 f"{session_path}/transcript.md",
                 loader=lambda sid=session_id: _text_bytes(
                     _session_markdown(self.client.get_transcript_events(sid))
                 ),
+                updated_at=updated_at,
             )
 
     def _add_tables(self, me_path: str) -> None:
@@ -258,23 +273,33 @@ class StashVfsModel:
         self._add_jsonl_file(f"{tables_path}/_index.jsonl", tables)
         for table in tables:
             table_id = str(table["id"])
+            created_at = table.get("created_at")
+            updated_at = table.get("updated_at")
             table_path = self._add_dir_child(
                 tables_path,
                 _object_dir_name(table.get("name") or "table", table_id),
+                created_at=created_at,
+                updated_at=updated_at,
             )
             self._add_file(
                 f"{table_path}/schema.json",
                 loader=lambda tid=table_id: _json_bytes(self.client.get_table(tid)),
+                created_at=created_at,
+                updated_at=updated_at,
             )
             self._add_file(
                 f"{table_path}/rows.json",
                 loader=lambda tid=table_id: _json_bytes(self._load_all_table_rows(tid)),
+                created_at=created_at,
+                updated_at=updated_at,
             )
             self._add_file(
                 f"{table_path}/rows.jsonl",
                 loader=lambda tid=table_id: _jsonl_bytes(
                     self._load_all_table_rows(tid).get("rows", [])
                 ),
+                created_at=created_at,
+                updated_at=updated_at,
             )
 
     def _add_sources(self, me_path: str) -> None:
@@ -357,19 +382,37 @@ class StashVfsModel:
             offset += limit
         return {"rows": rows, "total_count": total_count}
 
-    def _add_dir(self, path: str) -> str:
+    def _add_dir(
+        self,
+        path: str,
+        *,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ) -> str:
         path = self._clean_path(path)
         if path in self.nodes:
             return path
-        self.nodes[path] = VfsNode(path=path, mode=stat.S_IFDIR | 0o755)
+        self.nodes[path] = VfsNode(
+            path=path,
+            mode=stat.S_IFDIR | 0o755,
+            created_at=_parse_iso(created_at),
+            updated_at=_parse_iso(updated_at),
+        )
         if path != "/":
             parent, name = self._split_parent(path)
             self.nodes[parent].children[name] = path
         return path
 
-    def _add_dir_child(self, parent: str, name: str) -> str:
+    def _add_dir_child(
+        self,
+        parent: str,
+        name: str,
+        *,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ) -> str:
         name = self._unique_child_name(parent, name)
-        return self._add_dir(f"{parent}/{name}")
+        return self._add_dir(f"{parent}/{name}", created_at=created_at, updated_at=updated_at)
 
     def _add_file(
         self,
@@ -380,6 +423,8 @@ class StashVfsModel:
         content: bytes | None = None,
         size_hint: int | None = None,
         writable: bool = False,
+        created_at: str | None = None,
+        updated_at: str | None = None,
     ) -> str:
         path = self._clean_path(path)
         parent, requested_name = self._split_parent(path)
@@ -397,6 +442,8 @@ class StashVfsModel:
                 if size_hint is not None
                 else (len(content) if content is not None else None)
             ),
+            created_at=_parse_iso(created_at),
+            updated_at=_parse_iso(updated_at),
         )
         self.nodes[parent].children[name] = path
         return path
@@ -404,8 +451,8 @@ class StashVfsModel:
     def _add_static_file(self, path: str, content: str) -> str:
         return self._add_file(path, content=_text_bytes(content))
 
-    def _add_json_file(self, path: str, payload: dict) -> str:
-        return self._add_file(path, content=_json_bytes(payload))
+    def _add_json_file(self, path: str, payload: dict, *, updated_at: str | None = None) -> str:
+        return self._add_file(path, content=_json_bytes(payload), updated_at=updated_at)
 
     def _add_jsonl_file(self, path: str, rows: list[dict]) -> str:
         return self._add_file(path, content=_jsonl_bytes(rows))
@@ -820,6 +867,14 @@ def _object_file_name(name: str, object_id: str, default_extension: str) -> str:
     if not extension:
         extension = default_extension
     return f"{stem or 'untitled'}--{object_id[:8]}{extension}"
+
+
+def _parse_iso(value: str | None) -> float | None:
+    """ISO-8601 timestamp from the backend → epoch seconds. None when the
+    backend doesn't carry a timestamp for this node (e.g. synthetic dirs)."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value).timestamp()
 
 
 def _text_bytes(text: str) -> bytes:

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -1,6 +1,7 @@
 import shlex
+from datetime import datetime
 
-from cli.app_vfs import SkillAppVfsShell
+from cli.app_vfs import SkillAppVfsShell, _ls_time
 from cli.client import StashError
 from cli.mount import StashVfsModel
 from cli.tests.test_mount_vfs import FakeClient
@@ -103,6 +104,31 @@ def test_app_vfs_supports_common_agent_listing_patterns():
 
     assert "files" in tree_output
     assert client.lazy_loads == 0
+
+
+def test_app_vfs_surfaces_backend_timestamps_and_marks_unknown():
+    """A node's modified time comes from the backend payload and flows through
+    to `ls -l` and `stat`. A node the backend gave no timestamp for shows `-`,
+    never a fabricated "now" — that distinction is the whole point of the
+    feature, so it must hold even when some content lacks timestamps."""
+    shell, _client = _shell()
+
+    # A page carries distinct created/updated times straight from the backend.
+    page_path = _page_path(shell)
+    page_node = shell.model._get_node(page_path)
+    expected = datetime.fromtimestamp(page_node.updated_at).isoformat()
+    assert f"modified: {expected}" in shell.run(f"stat {page_path}").stdout
+    assert _ls_time(page_node.updated_at) in shell.run(f"ls -l {page_path}").stdout
+
+    # An uploaded file is immutable, so its modified-time is its creation time.
+    file_name = next(
+        name for name in shell.model.list_dir("/me/files") if name.startswith("diagram")
+    )
+    file_node = shell.model._get_node(f"/me/files/{file_name}")
+    assert file_node.updated_at == file_node.created_at is not None
+
+    # A synthetic directory the backend never timestamps shows "-", not a faked now.
+    assert "modified: -" in shell.run("stat /me/files").stdout
 
 
 def test_app_vfs_pipes_cat_to_sed_and_grep():

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -24,6 +24,8 @@ class FakeClient:
                         "name": "Plan",
                         "content_type": "markdown",
                         "folder_id": "folder-12345678",
+                        "created_at": "2026-05-01T09:00:00Z",
+                        "updated_at": "2026-05-02T10:30:00Z",
                     }
                 ],
                 "files": [
@@ -32,6 +34,7 @@ class FakeClient:
                         "name": "diagram.txt",
                         "folder_id": None,
                         "size_bytes": 12,
+                        "created_at": "2026-04-20T12:00:00Z",
                     }
                 ],
             },
@@ -49,6 +52,7 @@ class FakeClient:
                     "session_id": "session-abc",
                     "title": "Fix login",
                     "agent_name": "codex",
+                    "updated_at": "2026-05-03T08:15:00Z",
                 }
             ],
         }


### PR DESCRIPTION
## What

The VFS exposed essentially no file metadata. `ls -l` and `stat` showed only **type + size**, and the timestamps that *did* exist in the model were fabricated — every `VfsNode` defaulted `created_at`/`updated_at` to `time.time()` at construction, so every file reported the same fake "now". You couldn't ask "the most recent session" or "what changed lately" — the time dimension was invisible.

This plumbs **real** created/modified timestamps end to end and surfaces them.

### Before / after

```
# before
$ stash vfs "stat /me/sessions/<sess>"
/me/sessions/<sess>
  type: directory
  size: 0

$ stash vfs "ls -l /me/sessions"
d        0 Fix login--e72f5612

# after
$ stash vfs "stat /me/sessions/<sess>"
/me/sessions/<sess>
  type: directory
  size: 0
  modified: 2026-04-14T20:16:53.148000
  created: -

$ stash vfs "ls -l /me/sessions"
d        0 Apr 14 20:16 Fix login--e72f5612
```

## How (three layers)

1. **Backend** (`routers/user_knowledge.py`): the `/me/overview` payload now carries `created_at`/`updated_at` for **pages** and **folders** — the DB columns existed, the SELECTs just didn't ask for them. Uploaded **files** keep `created_at` only: the `files` table has no `updated_at` column because uploads are immutable. (Caught mid-review — an earlier draft selected `fi.updated_at` and would have thrown a Postgres error in prod.)
2. **CLI model** (`cli/mount.py`): `VfsNode` timestamps are now **nullable** — `None` means "the backend gave no timestamp for this node" (synthetic dirs, generated index files), rendered honestly rather than as a faked `now`. The tree builders thread each object's real timestamps through. A file's modified-time is mapped to its creation time (it can't be updated).
3. **CLI display** (`cli/app_vfs.py`): `ls -l` gains a coreutils-style date column (time for recent entries, year for older ones); `stat` gains `modified:`/`created:` lines. Unknown timestamps render `-`.

## Deliberately *not* included

Permissions and owner. Every node is single-user and `0644`/`0444`, so `rwxr--r-- henry staff` would *look* like real metadata while carrying zero signal — exactly the decorative fallback this repo's conventions reject. The metadata worth adding is **time** (size was already there).

## Rollout note

The CLI half degrades honestly ahead of the backend deploy: sessions, tables, and uploaded files already get real dates from the deployed backend; **pages and folders** show `-` until the backend change ships, then light up automatically. No fake dates at any point.

## Tests

- New `test_app_vfs_surfaces_backend_timestamps_and_marks_unknown`: asserts a page's real backend timestamp flows through to `ls -l` + `stat`, an immutable file's modified == created, and a synthetic dir shows `-` (never a faked now).
- Full CLI VFS suite green (20 passed); `ruff` clean.
- Verified live against the deployed backend (sessions/tables/files show real dates; screenshots of terminal output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)