### PR TITLE
feat(vfs): cap command output so a single read can't flood an agent's context

### DIFF
--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -13,6 +13,11 @@ from datetime import datetime
 from .client import StashError
 from .mount import MountError, StashVfsModel
 
+# Agents read command output into a finite context window. Cap what a single
+# command returns so `cat` of a long transcript or `ls` of a 1000-message Slack
+# channel can't flood it; the footer tells the agent how to page the rest.
+MAX_OUTPUT_LINES = 500
+
 
 @dataclass
 class VfsCommandResult:
@@ -43,12 +48,14 @@ class SkillAppVfsShell:
                 if result.stderr:
                     stderr_parts.append(result.stderr)
                 if result.exit_code != 0:
-                    result.stdout = "".join(stdout_parts)
+                    result.stdout = _cap_output(script, "".join(stdout_parts))
                     result.stderr = "".join(stderr_parts)
                     result.cwd = self.cwd
                     return result
         return VfsCommandResult(
-            stdout="".join(stdout_parts), stderr="".join(stderr_parts), cwd=self.cwd
+            stdout=_cap_output(script, "".join(stdout_parts)),
+            stderr="".join(stderr_parts),
+            cwd=self.cwd,
         )
 
     def _run_pipeline(self, script: str) -> VfsCommandResult:
@@ -641,12 +648,30 @@ def _split_unquoted(text: str, separator: str) -> list[str]:
     return parts
 
 
+def _cap_output(script: str, text: str) -> str:
+    """Cap the final output a command returns to the agent. Only the terminal
+    result is capped — pipeline stages still see full output, so paging the
+    truncated result back through `sed -n` returns the next page intact."""
+    body = text[:-1] if text.endswith("\n") else text
+    if not body:
+        return text
+    lines = body.split("\n")
+    if len(lines) <= MAX_OUTPUT_LINES:
+        return text
+    footer = (
+        f"[showing lines 1-{MAX_OUTPUT_LINES} of {len(lines)} "
+        f"— page with: {script.strip()} | sed -n '{MAX_OUTPUT_LINES + 1},{MAX_OUTPUT_LINES * 2}p']"
+    )
+    return "\n".join(lines[:MAX_OUTPUT_LINES]) + "\n" + footer + "\n"
+
+
 def _help_text() -> str:
     return "\n".join(
         [
             "Supported commands:",
             "  pwd, cd, ls, cat, find, tree, rg, grep, sed -n, head, tail, wc, echo, printf, tee, stat",
             "  pipes with |, command chaining with && or ;, and > / >> writes to existing writable files",
+            f"  output is capped at {MAX_OUTPUT_LINES} lines; page the rest with | sed -n 'N,Mp'",
             "",
         ]
     )

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -1,7 +1,7 @@
 import shlex
 from datetime import datetime
 
-from cli.app_vfs import SkillAppVfsShell, _ls_time
+from cli.app_vfs import MAX_OUTPUT_LINES, SkillAppVfsShell, _cap_output, _ls_time
 from cli.client import StashError
 from cli.mount import StashVfsModel
 from cli.tests.test_mount_vfs import FakeClient
@@ -250,3 +250,39 @@ def test_app_vfs_cat_unreadable_transcript_reports_error_without_traceback():
     assert result.exit_code == 2
     assert result.stdout == ""
     assert "Transcript not found" in result.stderr
+
+
+def test_cap_output_truncates_long_output_with_paging_footer():
+    text = "".join(f"line{i}\n" for i in range(MAX_OUTPUT_LINES + 100))
+
+    capped = _cap_output("cat /big.md", text)
+
+    lines = capped.splitlines()
+    assert lines[:MAX_OUTPUT_LINES] == [f"line{i}" for i in range(MAX_OUTPUT_LINES)]
+    footer = lines[MAX_OUTPUT_LINES]
+    assert f"of {MAX_OUTPUT_LINES + 100}" in footer
+    assert f"cat /big.md | sed -n '{MAX_OUTPUT_LINES + 1},{MAX_OUTPUT_LINES * 2}p'" in footer
+
+
+def test_cap_output_leaves_output_within_budget_untouched():
+    text = "a\nb\nc\n"
+
+    assert _cap_output("ls /", text) == text
+
+
+def test_app_vfs_output_cap_is_terminal_only_so_sed_paging_returns_next_page(monkeypatch):
+    # Cap low so a small fixture exercises the boundary.
+    monkeypatch.setattr("cli.app_vfs.MAX_OUTPUT_LINES", 2)
+    shell, _client = _shell()
+    page_path = _page_path(shell)
+    shell.run(f"printf 'l1\\nl2\\nl3\\nl4\\nl5\\n' > {shlex.quote(page_path)}")
+
+    capped = shell.run(f"cat {shlex.quote(page_path)}")
+    assert capped.stdout.splitlines()[:2] == ["l1", "l2"]
+    assert "of 5" in capped.stdout
+    assert "sed -n '3,4p'" in capped.stdout
+
+    # The stage feeding sed is not capped, so the footer's own paging command
+    # returns the next page intact rather than a doubly-truncated fragment.
+    page2 = shell.run(f"cat {shlex.quote(page_path)} | sed -n '3,4p'")
+    assert page2.stdout == "l3\nl4\n"


### PR DESCRIPTION
## Why

The `stash vfs` shell is an agent-facing surface, and agents read command output into a finite context window. But every command returned **unbounded** output — `cat` of a long session transcript, or `ls` of a 1000-message Slack channel, dumped the entire thing into the agent's context. (Inspired by how Mesa's `path_content` pages large reads — same problem, agent-context protection.)

## What

One output budget applied at the shell boundary, covering **every** read command (`cat`, `ls`, `grep`, `tree`, `find`) in a single chokepoint inside `run()`:

- `MAX_OUTPUT_LINES = 500` caps the **final** result returned to the agent.
- A loud, copy-pasteable footer tells the agent how to page the rest:
  ```
  [showing lines 1-500 of 1000 — page with: ls /sources/slack/general | sed -n '501,1000p']
  ```
- The cap is **terminal-only**: pipeline stages still produce full output, so `cat big | sed -n '501,1000p'` returns the next page intact instead of a doubly-truncated fragment. Paging is fully stateless — each page is a self-contained call.

No new flags, no hidden state — it leans on the `sed -n` paging the shell already ships.

## Design notes

- Chose a single global output budget over per-command `--limit/--offset` flags: one codepath, protects `grep`/`tree`/`find` too, and one paging idiom (`sed`) instead of two.
- Cap is **line-based** so paging maps cleanly to `sed -n 'N,Mp'`. The edge case it doesn't cover is a single pathologically long line (e.g. a one-line giant JSON blob); a secondary byte ceiling would be the follow-up, left out to keep one codepath.
- The footer uses the **no-space** `'N,Mp'` form, because this shell's `_sed` only accepts that (not GNU sed's `'N,M p'`). A test enforces the hint is runnable in this shell.

## Tests

Three new tests in `cli/tests/test_app_vfs.py`:
- `_cap_output` truncates long output with a correct footer (range, total count, runnable command).
- Output within budget passes through untouched.
- The cap is terminal-only: `cat big | sed -n '3,4p'` returns the next page intact, proving pipelines aren't capped and the footer's advice actually works.

All `cli/tests/test_app_vfs.py` tests pass except one **pre-existing** failure (`test_app_vfs_surfaces_backend_timestamps_and_marks_unknown`) that references the `/me/files` path removed in c8e391ea — confirmed failing independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)