### PR TITLE
style(cli): black-format app_vfs.py and main.py

### DIFF
--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -626,7 +626,11 @@ def _ls_time(epoch: float | None) -> str:
     if not epoch:
         return f"{'-':>12}"
     when = datetime.fromtimestamp(epoch)
-    tail = when.strftime("%H:%M") if abs(time.time() - epoch) < _SIX_MONTHS_SECONDS else when.strftime(" %Y")
+    tail = (
+        when.strftime("%H:%M")
+        if abs(time.time() - epoch) < _SIX_MONTHS_SECONDS
+        else when.strftime(" %Y")
+    )
     return f"{when.strftime('%b'):>3} {when.day:>2} {tail}"
 
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -4130,7 +4130,9 @@ def vfs_command(
 
         command = " ".join(ctx.args).strip()
         if not command:
-            console.print('[red]Usage: stash vfs "<command>" (e.g. [bold]stash vfs "ls /me"[/bold]).[/red]')
+            console.print(
+                '[red]Usage: stash vfs "<command>" (e.g. [bold]stash vfs "ls /me"[/bold]).[/red]'
+            )
             raise typer.Exit(2)
 
         result = shell.run(command)


### PR DESCRIPTION
## What

CI lints `backend/ cli/` with `black==26.5.1`, which flags two over-long lines in `cli/app_vfs.py` and `cli/main.py`. This makes the **Backend lint (ruff + black)** check red on `main` and on every open PR.

This PR applies the black reformat — pure line-wrapping, no behavior change — to turn that check green again.

## Verification
- `black --check backend/ cli/` → all clean.
- `ruff check backend/ cli/` → all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)