### PR TITLE
Fix stale /me/files path in vfs timestamp test

### DIFF
--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -122,13 +122,13 @@ def test_app_vfs_surfaces_backend_timestamps_and_marks_unknown():
 
     # An uploaded file is immutable, so its modified-time is its creation time.
     file_name = next(
-        name for name in shell.model.list_dir("/me/files") if name.startswith("diagram")
+        name for name in shell.model.list_dir("/files") if name.startswith("diagram")
     )
-    file_node = shell.model._get_node(f"/me/files/{file_name}")
+    file_node = shell.model._get_node(f"/files/{file_name}")
     assert file_node.updated_at == file_node.created_at is not None
 
     # A synthetic directory the backend never timestamps shows "-", not a faked now.
-    assert "modified: -" in shell.run("stat /me/files").stdout
+    assert "modified: -" in shell.run("stat /files").stdout
 
 
 def test_app_vfs_pipes_cat_to_sed_and_grep():


### PR DESCRIPTION
## The bug

`test_app_vfs_surfaces_backend_timestamps_and_marks_unknown` has been failing on `main` (it surfaced as a known pre-existing failure during the recent read-only `vfs` work in #684/#685/#686).

## Root cause

Two PRs crossed:

- **#680** (`feat(vfs): mount Stash contents at root, drop the /me folder`) moved everything from `/me/files` to `/files`.
- **#682** (`feat(vfs): surface real modified/created timestamps…`) added this test still referencing the old `/me/files` path.

So the test asserted against a path the model no longer builds (`_get_node("/me/files")` → `FileNotFoundError`). It's a stale test path, not a product bug — the live model has built content at root since #680.

## Fix

Point the three `/me/files` references at `/files`. The assertions still hold:
- the uploaded `diagram.txt` has `folder_id: None`, so it lands directly under `/files`
- `/files` is a synthetic dir the backend never timestamps, so `stat /files` still shows `modified: -`

## Verification

- `test_app_vfs.py` + `test_mount_vfs.py`: 25 passed (was 24 passed / 1 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)