### PR TITLE
Reword stash vfs command description

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4113,7 +4113,7 @@ def vfs_command(
     ctx: typer.Context,
     cwd: str = typer.Option("/", "--cwd", help="Virtual working directory."),
 ):
-    """Run bash-shaped commands against Stash without mounting a filesystem."""
+    """Run bash-shaped commands against Stash sources."""
     from .app_vfs import SkillAppVfsShell
     from .mount import MountError, StashVfsModel
 


### PR DESCRIPTION
Changes the `stash vfs` help text from "Run bash-shaped commands against Stash without mounting a filesystem." to "Run bash-shaped commands against Stash sources."

🤖 Generated with [Claude Code](https://claude.com/claude-code)