### PR TITLE
Only suffix vfs names with an id when they collide

### DIFF
--- a/cli/mount.py
+++ b/cli/mount.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 import stat
 import time
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -128,7 +129,13 @@ class StashVfsModel:
         root_path = "/files"
         self._add_dir(root_path)
         folders = {str(folder["id"]): folder for folder in tree.get("folders", [])}
+        pages = tree.get("pages", [])
+        files = tree.get("files", [])
+        ambiguous = _files_ambiguity(folders.values(), pages, files)
         folder_paths: dict[str, str] = {}
+
+        def siblings(parent_id) -> set[str]:
+            return ambiguous.get(str(parent_id or ""), set())
 
         def folder_path(folder_id: str) -> str:
             if folder_id in folder_paths:
@@ -136,9 +143,10 @@ class StashVfsModel:
             folder = folders[folder_id]
             parent_id = folder.get("parent_folder_id")
             parent_path = folder_path(str(parent_id)) if parent_id else root_path
+            name = _dir_display_name(folder.get("name") or "folder", folder_id, siblings(parent_id))
             path = self._add_dir_child(
                 parent_path,
-                _object_dir_name(folder.get("name") or "folder", folder_id),
+                name,
                 created_at=folder.get("created_at"),
                 updated_at=folder.get("updated_at"),
             )
@@ -148,14 +156,13 @@ class StashVfsModel:
         for folder_id in folders:
             folder_path(folder_id)
 
-        for page in tree.get("pages", []):
+        for page in pages:
             page_id = str(page["id"])
-            parent_path = (
-                folder_path(str(page["folder_id"])) if page.get("folder_id") else root_path
+            parent_id = page.get("folder_id")
+            parent_path = folder_path(str(parent_id)) if parent_id else root_path
+            name = _file_display_name(
+                page.get("name") or "page", page_id, _page_extension(page), siblings(parent_id)
             )
-            content_type = page.get("content_type") or "markdown"
-            extension = ".html" if content_type == "html" else ".md"
-            name = _object_file_name(page.get("name") or "page", page_id, extension)
             self._add_file(
                 f"{parent_path}/{name}",
                 loader=lambda pid=page_id: self._load_page(pid),
@@ -163,12 +170,11 @@ class StashVfsModel:
                 updated_at=page.get("updated_at"),
             )
 
-        for file in tree.get("files", []):
+        for file in files:
             file_id = str(file["id"])
-            parent_path = (
-                folder_path(str(file["folder_id"])) if file.get("folder_id") else root_path
-            )
-            name = _object_file_name(file.get("name") or "file", file_id, "")
+            parent_id = file.get("folder_id")
+            parent_path = folder_path(str(parent_id)) if parent_id else root_path
+            name = _file_display_name(file.get("name") or "file", file_id, "", siblings(parent_id))
             # Uploaded files are immutable — there is no separate update event,
             # so the file's last-modified time is its creation time.
             created_at = file.get("created_at")
@@ -184,11 +190,13 @@ class StashVfsModel:
         skills_path = "/skills"
         self._add_dir(skills_path)
         self._add_jsonl_file(f"{skills_path}/_index.jsonl", skills)
-        for skill in skills:
-            folder_id = str(skill.get("folder_id") or "")
-            if not folder_id:
-                continue
-            basename = _object_basename(skill.get("name") or "skill", folder_id)
+        published = [skill for skill in skills if skill.get("folder_id")]
+        ambiguous = _ambiguous_basenames(
+            [_safe_name(skill.get("name") or "skill") for skill in published]
+        )
+        for skill in published:
+            folder_id = str(skill["folder_id"])
+            basename = _dir_display_name(skill.get("name") or "skill", folder_id, ambiguous)
             self._add_json_file(f"{skills_path}/{basename}.json", skill)
             slug = (skill.get("published") or {}).get("slug")
             if slug:
@@ -201,15 +209,15 @@ class StashVfsModel:
         sessions_path = "/sessions"
         self._add_dir(sessions_path)
         self._add_jsonl_file(f"{sessions_path}/_index.jsonl", sessions)
+        ambiguous = _ambiguous_basenames(
+            [_safe_name(session.get("title") or str(session["session_id"])) for session in sessions]
+        )
         for session in sessions:
             session_id = str(session["session_id"])
             row_id = str(session.get("id") or session_id)
             updated_at = session.get("updated_at")
-            session_path = self._add_dir_child(
-                sessions_path,
-                _object_dir_name(session.get("title") or session_id, row_id),
-                updated_at=updated_at,
-            )
+            name = _dir_display_name(session.get("title") or session_id, row_id, ambiguous)
+            session_path = self._add_dir_child(sessions_path, name, updated_at=updated_at)
             self._add_json_file(f"{session_path}/metadata.json", session, updated_at=updated_at)
             self._add_file(
                 f"{session_path}/events.json",
@@ -236,13 +244,15 @@ class StashVfsModel:
         self._add_dir(tables_path)
         tables = self.client.list_tables()
         self._add_jsonl_file(f"{tables_path}/_index.jsonl", tables)
+        ambiguous = _ambiguous_basenames([_safe_name(table.get("name") or "table") for table in tables])
         for table in tables:
             table_id = str(table["id"])
             created_at = table.get("created_at")
             updated_at = table.get("updated_at")
+            name = _dir_display_name(table.get("name") or "table", table_id, ambiguous)
             table_path = self._add_dir_child(
                 tables_path,
-                _object_dir_name(table.get("name") or "table", table_id),
+                name,
                 created_at=created_at,
                 updated_at=updated_at,
             )
@@ -476,20 +486,55 @@ def _source_doc_text(doc: dict) -> str:
     return doc.get("content") or doc.get("transcript") or ""
 
 
-def _object_basename(name: str, object_id: str) -> str:
-    return f"{_safe_name(name)}--{object_id[:8]}"
+def _ambiguous_basenames(names: list[str]) -> set[str]:
+    """Display names that occur more than once in a directory. Only these get an
+    id suffix; unique names render clean. Every member of a colliding name is
+    suffixed (not just the later ones), so a path never depends on listing order."""
+    counts = Counter(names)
+    return {name for name, count in counts.items() if count > 1}
 
 
-def _object_dir_name(name: str, object_id: str) -> str:
-    return _object_basename(name, object_id)
+def _dir_display_name(name: str, object_id: str, ambiguous: set[str]) -> str:
+    base = _safe_name(name)
+    return f"{base}--{object_id[:8]}" if base in ambiguous else base
 
 
-def _object_file_name(name: str, object_id: str, default_extension: str) -> str:
-    safe = _safe_name(name)
-    stem, extension = posixpath.splitext(safe)
-    if not extension:
-        extension = default_extension
-    return f"{stem or 'untitled'}--{object_id[:8]}{extension}"
+def _split_filename(name: str, default_extension: str) -> tuple[str, str]:
+    stem, extension = posixpath.splitext(_safe_name(name))
+    return stem or "untitled", extension or default_extension
+
+
+def _file_display_name(
+    name: str, object_id: str, default_extension: str, ambiguous: set[str]
+) -> str:
+    stem, extension = _split_filename(name, default_extension)
+    if f"{stem}{extension}" in ambiguous:
+        return f"{stem}--{object_id[:8]}{extension}"
+    return f"{stem}{extension}"
+
+
+def _page_extension(page: dict) -> str:
+    return ".html" if (page.get("content_type") or "markdown") == "html" else ".md"
+
+
+def _files_ambiguity(folders, pages: list[dict], files: list[dict]) -> dict[str, set[str]]:
+    """Map each parent folder (keyed by id, "" for root) to the set of colliding
+    display names among its folders, pages, and uploaded files combined — paths
+    in one directory must be unique across all three kinds."""
+    by_parent: dict[str, list[str]] = {}
+
+    def record(parent_id, base: str) -> None:
+        by_parent.setdefault(str(parent_id or ""), []).append(base)
+
+    for folder in folders:
+        record(folder.get("parent_folder_id"), _safe_name(folder.get("name") or "folder"))
+    for page in pages:
+        stem, extension = _split_filename(page.get("name") or "page", _page_extension(page))
+        record(page.get("folder_id"), f"{stem}{extension}")
+    for file in files:
+        stem, extension = _split_filename(file.get("name") or "file", "")
+        record(file.get("folder_id"), f"{stem}{extension}")
+    return {parent: _ambiguous_basenames(names) for parent, names in by_parent.items()}
 
 
 def _parse_iso(value: str | None) -> float | None:

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -77,11 +77,11 @@ def _shell(client=None):
 def _page_path(shell: SkillAppVfsShell) -> str:
     files_path = "/files"
     folder_name = next(
-        name for name in shell.model.list_dir(files_path) if name.startswith("Notes--")
+        name for name in shell.model.list_dir(files_path) if name.startswith("Notes")
     )
     folder_path = f"{files_path}/{folder_name}"
     page_name = next(
-        name for name in shell.model.list_dir(folder_path) if name.startswith("Plan--")
+        name for name in shell.model.list_dir(folder_path) if name.startswith("Plan")
     )
     return f"{folder_path}/{page_name}"
 
@@ -234,7 +234,7 @@ def test_app_vfs_grep_skips_unreadable_transcript_and_warns():
 def test_app_vfs_cat_unreadable_transcript_reports_error_without_traceback():
     shell, _client = _shell(DeadTranscriptClient())
 
-    result = shell.run("cat '/sessions/Fix login--session-/transcript.md'")
+    result = shell.run("cat '/sessions/Fix login/transcript.md'")
 
     assert result.exit_code == 2
     assert result.stdout == ""

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -129,9 +129,9 @@ def test_vfs_exposes_user_sections():
         "tables",
         "sources",
     }
-    assert model.read_file("/skills/Demo Skill--skillfol.md") == b"# Demo Stash\n"
-    assert b"hello" in model.read_file("/sessions/Fix login--session-/transcript.md")
-    assert b'"Name": "Mount"' in model.read_file("/tables/Ideas--table-12/rows.json")
+    assert model.read_file("/skills/Demo Skill.md") == b"# Demo Stash\n"
+    assert b"hello" in model.read_file("/sessions/Fix login/transcript.md")
+    assert b'"Name": "Mount"' in model.read_file("/tables/Ideas/rows.json")
 
     # Connected sources are mounted read-only; native sources are skipped
     # (files/sessions already appear above). Document bodies load lazily.
@@ -163,11 +163,37 @@ def test_vfs_loads_source_entries_lazily():
 def test_vfs_reads_files_and_pages():
     model = _model()
     files_path = "/files"
-    upload_name = next(name for name in model.list_dir(files_path) if name.startswith("diagram--"))
+    upload_name = next(name for name in model.list_dir(files_path) if name.startswith("diagram"))
 
     assert model.read_file(f"{files_path}/{upload_name}") == b"diagram body"
 
-    folder_name = next(name for name in model.list_dir(files_path) if name.startswith("Notes--"))
+    folder_name = next(name for name in model.list_dir(files_path) if name.startswith("Notes"))
     folder_path = f"{files_path}/{folder_name}"
-    page_name = next(name for name in model.list_dir(folder_path) if name.startswith("Plan--"))
+    page_name = next(name for name in model.list_dir(folder_path) if name.startswith("Plan"))
     assert model.read_file(f"{folder_path}/{page_name}") == b"# Plan\n"
+
+
+class DuplicateNameClient(FakeClient):
+    """Two tables share a name — the backend allows it. Only the colliding pair
+    should carry an id suffix; the uniquely-named table stays clean."""
+
+    def list_tables(self):
+        return [
+            {"id": "aaaaaaaa-1111", "name": "Untitled table"},
+            {"id": "bbbbbbbb-2222", "name": "Untitled table"},
+            {"id": "cccccccc-3333", "name": "Roadmap"},
+        ]
+
+
+def test_vfs_suffixes_only_colliding_names():
+    model = StashVfsModel(DuplicateNameClient())
+    model.refresh()
+
+    entries = set(model.list_dir("/tables"))
+
+    # The unique name is clean; both members of the collision are suffixed with
+    # their own id (not just the second one), so neither path depends on order.
+    assert "Roadmap" in entries
+    assert "Untitled table--aaaaaaaa" in entries
+    assert "Untitled table--bbbbbbbb" in entries
+    assert "Untitled table" not in entries


### PR DESCRIPTION
I used to always add UUIDs in front of every file, and they looked ugly, so now we only add a UUID if there is a name collision. 

# slop 
## The problem

Every object projected into `stash vfs` carried a `--<id[:8]>` suffix on its path — unconditionally. So a uniquely-named table listed as `Roadmap--cccccccc`, a page as `Plan--12345678.md`, and a session as `Fix login--ab12cd34`. Ugly, and pointless when the name is already unique (the common case).

```
$ stash vfs "cd tables && ls"
B2B Outreach--336ec986
Hiring Outreach CRM--572f2924
Untitled table--468db1b9
Untitled table--c1d49621
linkedin_corpus--5170f32d
post_ideas--1be27d2c
```

## The change

Names render **clean**, and the id suffix is added **only when a name actually collides** within its directory:

```
$ stash vfs "cd tables && ls"
B2B Outreach
Hiring Outreach CRM
Untitled table--468db1b9
Untitled table--c1d49621
linkedin_corpus
post_ideas
```

## Why id suffixes (not positional `(1)`, `(2)`)

The VFS is a **projection rebuilt on every call** (`model.refresh()` re-fetches), and the backend permits duplicate names. A positional scheme would assign `(1)`/`(2)` by list order, so `Untitled table (1)` could silently re-bind to a *different* table when the backend's order changed or a sibling was added/removed — breaking any agent that reads a path in one command and uses it in the next. An identity-derived suffix keeps every path **stable**.

For the same reason, **all** members of a colliding name are suffixed, not just the later ones — otherwise which one stays clean would depend on order.

## Scope detail

Collision scope is the parent directory. For `files/`, that spans folders, pages, and uploaded files **together**, since all three share one directory namespace. Sources are unchanged (they were never id-suffixed). The model's existing `-2` uniqueness net remains as a backstop for any exotic residual collision.

## Tests

- New `test_vfs_suffixes_only_colliding_names`: two same-named tables both get suffixed; the uniquely-named one stays clean.
- Updated existing path assertions to expect clean names (the fakes use unique names).
- `ruff` clean; `test_mount_vfs.py` + `test_app_vfs.py` pass (the one `/me/files` failure is the pre-existing bug fixed in #688, not present on `main` yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)