### PR TITLE
Group connected sources under their provider in the VFS

### DIFF
--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1085,6 +1085,7 @@ async def list_sources(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     for s in await list_connected_sources(owner_user_id, user_id):
         item = {
             "source": s["id"],
+            "provider": SOURCE_TYPE_PROVIDER[s["source_type"]],
             "type": s["source_type"],
             "capability": s["capability"],
             "display_name": s["display_name"],
@@ -1319,6 +1320,52 @@ def _session_title(session: dict) -> str:
     return title or session.get("agent_name") or "session"
 
 
+async def _member_tree(source: dict, depth: int, per_dir: int) -> list[dict]:
+    """The document tree for one connected source (one repo, one account)."""
+    if source["capability"] == "queryable":
+        # Live-query source (Snowflake): no document table to walk.
+        return []
+    entries = await list_documents(source, limit=TREE_DOC_LIMIT)
+    return build_entry_tree(entries, depth, per_dir)
+
+
+async def _provider_tree_node(
+    provider: str, members: list[dict], depth: int, per_dir: int
+) -> dict:
+    """One provider folder for the sources filesystem. A single connection
+    collapses — its documents sit directly in the provider folder. Multiple
+    connections each become a subfolder named after the connection."""
+    members = sorted(members, key=lambda m: m["display_name"])
+    node = {
+        "source": provider,
+        "type": "provider",
+        "provider": provider,
+        "display_name": provider,
+        # Connection handles, so a caller drilling into the tree knows which
+        # source to read each path against (the provider key is not a handle).
+        "members": [{"handle": m["id"], "display_name": m["display_name"]} for m in members],
+    }
+    if len(members) == 1:
+        node["tree"] = await _member_tree(members[0], depth, per_dir)
+        node["sync_status"] = members[0]["sync_status"]
+        node["last_synced_at"] = members[0]["last_synced_at"]
+        return node
+
+    children = []
+    for member in members:
+        children.append(
+            {
+                "name": member["display_name"],
+                "kind": "folder",
+                "source": member["id"],
+                "sync_status": member["sync_status"],
+                "children": await _member_tree(member, max(1, depth - 1), per_dir),
+            }
+        )
+    node["tree"] = _capped_flat_tree(children, per_dir)
+    return node
+
+
 async def sources_tree(
     owner_user_id: UUID, user_id: UUID, depth: int = 3, per_dir: int = 50
 ) -> list[dict]:
@@ -1358,21 +1405,16 @@ async def sources_tree(
         },
     ]
 
+    # Group connected sources under their provider — the top tier of the
+    # filesystem. The provider folder is the unit ("github", "granola"); the
+    # individual connections (repos, accounts) live inside it.
+    by_provider: dict[str, list[dict]] = {}
     for source in await list_connected_sources(owner_user_id, user_id):
-        item = {
-            "source": source["id"],
-            "type": source["source_type"],
-            "display_name": source["display_name"],
-            "sync_status": source["sync_status"],
-            "last_synced_at": source["last_synced_at"],
-        }
-        if source["capability"] == "queryable":
-            # Live-query source (Snowflake): no document table to walk.
-            item["tree"] = []
-        else:
-            entries = await list_documents(source, limit=TREE_DOC_LIMIT)
-            item["tree"] = build_entry_tree(entries, depth, per_dir)
-        out.append(item)
+        provider = SOURCE_TYPE_PROVIDER[source["source_type"]]
+        by_provider.setdefault(provider, []).append(source)
+
+    for provider in sorted(by_provider):
+        out.append(await _provider_tree_node(provider, by_provider[provider], depth, per_dir))
 
     await _audit_source_read(
         action="source.tree_listed",

--- a/backend/tests/test_sources_tree.py
+++ b/backend/tests/test_sources_tree.py
@@ -114,14 +114,67 @@ async def test_sources_tree_includes_every_visible_source(monkeypatch):
 
     sources = await source_service.sources_tree(uuid4(), uuid4(), depth=3)
 
+    # Connected sources nest under their provider folder. A sole connection
+    # collapses — its documents sit directly in the provider folder.
     assert [s["display_name"] for s in sources] == [
         "Files",
         "Session transcripts",
-        "stash",
-        "warehouse",
+        "github",
+        "snowflake",
     ]
     session_names = [n["name"] for n in sources[1]["tree"]]
     assert session_names == ["Fix the onboarding wizard", "claude"]
+    assert sources[2]["type"] == "provider"
     assert sources[2]["tree"][0]["name"] == "docs"
     assert sources[3]["tree"] == []
     assert audits[0]["action"] == "source.tree_listed"
+
+
+async def test_sources_tree_nests_multiple_connections_under_one_provider(monkeypatch):
+    from backend.services import files_tree_service, memory_service
+
+    repos = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "source_type": "github_repo",
+            "display_name": "stash",
+            "capability": "navigable",
+            "sync_status": "idle",
+            "last_synced_at": None,
+        },
+        {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "source_type": "github_repo",
+            "display_name": "plugin",
+            "capability": "navigable",
+            "sync_status": "idle",
+            "last_synced_at": None,
+        },
+    ]
+
+    async def fake_empty(owner_user_id, user_id):
+        return []
+
+    async def fake_connected(owner_user_id, user_id):
+        return repos
+
+    async def fake_documents(source, prefix="", limit=200):
+        return [{"path": "README.md", "name": "README.md", "kind": "file"}]
+
+    async def fake_audit(**kwargs):
+        pass
+
+    monkeypatch.setattr(files_tree_service, "list_scope_pages", fake_empty)
+    monkeypatch.setattr(memory_service, "list_scope_sessions", fake_empty)
+    monkeypatch.setattr(source_service, "list_connected_sources", fake_connected)
+    monkeypatch.setattr(source_service, "list_documents", fake_documents)
+    monkeypatch.setattr(source_service, "_audit_source_read", fake_audit)
+
+    sources = await source_service.sources_tree(uuid4(), uuid4(), depth=3)
+
+    github = next(s for s in sources if s["display_name"] == "github")
+    # Two repos → each is a subfolder under /sources/github, not a sibling of it.
+    assert [n["name"] for n in github["tree"]] == ["plugin", "stash"]
+    assert github["tree"][0]["source"] == "22222222-2222-2222-2222-222222222222"
+    assert github["tree"][0]["children"][0]["name"] == "README.md"
+    assert {m["handle"] for m in github["members"]} == {repo["id"] for repo in repos}

--- a/cli/main.py
+++ b/cli/main.py
@@ -2379,18 +2379,22 @@ def sources_rm(source_id: str = typer.Argument(...)):
     console.print("[green]Source removed.[/green]")
 
 
+def _safe_slug(name: str) -> str:
+    import re as _re
+
+    return _re.sub(r"[^a-z0-9._-]+", "-", name.lower()).strip("-") or "source"
+
+
 def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
     """Stable filesystem-style directory name per source. Natives keep their
     handle ('files', 'sessions'); connected sources slug their display name,
     with -2/-3 suffixes on collisions."""
-    import re as _re
-
     names: dict[str, dict] = {}
     for s in sources:
         if s["type"].startswith("native_"):
             name = s["source"]
         else:
-            name = _re.sub(r"[^a-z0-9._-]+", "-", s["display_name"].lower()).strip("-") or "source"
+            name = _safe_slug(s["display_name"])
         candidate = name
         suffix = 2
         while candidate in names:
@@ -2401,7 +2405,7 @@ def _source_dir_names(sources: list[dict]) -> dict[str, dict]:
 
 
 def _source_annotation(s: dict) -> str:
-    note = f"  [dim]({s['type']})[/dim]"
+    note = "" if s["type"] == "provider" else f"  [dim]({s['type']})[/dim]"
     if s.get("sync_status") == "failed":
         note += "  [red]sync failed[/red]"
     elif s.get("sync_status") == "syncing":
@@ -2464,23 +2468,59 @@ def _print_ls_path(c: StashClient, sources: list[dict], path: str, as_json: bool
         console.print(f"[red]No source named '{dir_name}'. Run `stash ls` to see them.[/red]")
         raise typer.Exit(1)
 
+    if source["type"] == "provider":
+        _print_provider_path(c, source, rest, as_json)
+        return
+
     entries = c.list_source_entries(source["source"], path=rest)
     if _use_json(as_json):
         output_json({"entries": entries})
         return
+    for entry in entries:
+        console.print(f"  {entry['name']}  [dim]({entry.get('id', '')})[/dim]")
 
-    if source["type"].startswith("native_"):
-        for entry in entries:
-            console.print(f"  {entry['name']}  [dim]({entry.get('id', '')})[/dim]")
+
+def _print_provider_path(c: StashClient, provider: dict, rest: str, as_json: bool) -> None:
+    """Drill into a provider folder. A sole connection collapses, so `rest` is a
+    document path read straight against it; otherwise the first segment selects
+    the connection (repo, account) and the remainder is the document path."""
+    members = provider.get("members") or []
+    if len(members) == 1:
+        handle, doc_path = members[0]["handle"], rest
+    else:
+        member_slug, _, doc_path = rest.partition("/")
+        if not member_slug:
+            _print_connection_dirs(members, as_json)
+            return
+        member = next((m for m in members if _safe_slug(m["display_name"]) == member_slug), None)
+        if member is None:
+            console.print(f"[red]No connection '{member_slug}' under '{provider['source']}'.[/red]")
+            raise typer.Exit(1)
+        handle = member["handle"]
+
+    entries = c.list_source_entries(handle, path=doc_path)
+    if _use_json(as_json):
+        output_json({"entries": entries})
         return
+    _print_dir_children(entries, doc_path)
 
-    # Entries are a recursive prefix listing; collapse to this directory's
-    # immediate children.
-    base = f"{rest}/" if rest else ""
+
+def _print_connection_dirs(members: list[dict], as_json: bool) -> None:
+    if _use_json(as_json):
+        output_json({"entries": [{"name": m["display_name"], "kind": "folder"} for m in members]})
+        return
+    for member in members:
+        console.print(f"  [bold]{_safe_slug(member['display_name'])}/[/bold]")
+
+
+def _print_dir_children(entries: list[dict], base_path: str) -> None:
+    """Entries are a recursive prefix listing; collapse to this directory's
+    immediate children."""
+    base = f"{base_path}/" if base_path else ""
     children: dict[str, str] = {}
     for entry in entries:
         entry_path = entry.get("path") or ""
-        if entry_path == rest:
+        if entry_path == base_path:
             children[entry_path.rsplit("/", 1)[-1]] = entry.get("kind", "file")
             continue
         if not entry_path.startswith(base):

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -281,16 +281,24 @@ class StashVfsModel:
             return
 
         sources_path = self._add_dir("/sources")
-        for source in connected:
-            handle = str(source.get("source") or "")
-            if not handle:
+        for provider, members in _group_by_provider(connected).items():
+            provider_root = self._add_dir_child(sources_path, _source_slug(provider))
+            if len(members) == 1:
+                # Sole connection collapses — its documents sit directly in the
+                # provider folder (e.g. /sources/granola/<call>).
+                handle = str(members[0].get("source") or "")
+                self._expanders[provider_root] = (
+                    lambda root=provider_root, h=handle: self._expand_source(root, h)
+                )
                 continue
-            source_root = self._add_dir_child(
-                sources_path, _source_slug(source.get("display_name") or handle)
-            )
-            self._expanders[source_root] = lambda root=source_root, h=handle: self._expand_source(
-                root, h
-            )
+            for member in members:
+                handle = str(member.get("source") or "")
+                member_root = self._add_dir_child(
+                    provider_root, _source_slug(member.get("display_name") or handle)
+                )
+                self._expanders[member_root] = (
+                    lambda root=member_root, h=handle: self._expand_source(root, h)
+                )
 
     def _expand_source(self, source_root: str, handle: str) -> None:
         try:
@@ -470,6 +478,17 @@ def _safe_name(value: str) -> str:
 def _source_slug(name: str) -> str:
     slug = re.sub(r"[^a-z0-9._-]+", "-", name.lower()).strip("-")
     return slug or "source"
+
+
+def _group_by_provider(connected: list[dict]) -> dict[str, list[dict]]:
+    """Connected sources grouped under their provider key, the top tier of the
+    /sources filesystem. Sources with no handle are dropped."""
+    groups: dict[str, list[dict]] = {}
+    for source in connected:
+        if not source.get("source"):
+            continue
+        groups.setdefault(str(source.get("provider") or "source"), []).append(source)
+    return groups
 
 
 def _source_doc_text(doc: dict) -> str:

--- a/cli/tests/test_ls_cmd.py
+++ b/cli/tests/test_ls_cmd.py
@@ -14,9 +14,11 @@ SOURCES = [
         "tree": [{"name": "claude", "kind": "session", "ref": "s1"}],
     },
     {
-        "source": "11111111-1111-1111-1111-111111111111",
-        "type": "github_repo",
-        "display_name": "stash",
+        "source": "github",
+        "type": "provider",
+        "provider": "github",
+        "display_name": "github",
+        "members": [{"handle": "11111111-1111-1111-1111-111111111111", "display_name": "stash"}],
         "sync_status": "idle",
         "tree": [
             {
@@ -30,9 +32,11 @@ SOURCES = [
         ],
     },
     {
-        "source": "22222222-2222-2222-2222-222222222222",
-        "type": "gong_calls",
-        "display_name": "Gong",
+        "source": "gong",
+        "type": "provider",
+        "provider": "gong",
+        "display_name": "gong",
+        "members": [{"handle": "22222222-2222-2222-2222-222222222222", "display_name": "Gong"}],
         "sync_status": "failed",
         "tree": [],
     },
@@ -72,7 +76,8 @@ def test_ls_overview_shows_every_source_as_a_directory(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "files/" in out
     assert "sessions/" in out
-    assert "stash/" in out
+    # The github repo nests under its provider folder, not at the top level.
+    assert "github/" in out
     assert "gong/" in out
     assert "api.md" in out
     assert "+7 more" in out
@@ -82,7 +87,7 @@ def test_ls_overview_shows_every_source_as_a_directory(monkeypatch, capsys):
 def test_ls_path_collapses_prefix_listing_to_one_level(monkeypatch, capsys):
     _setup(monkeypatch)
 
-    main.ls_cmd(path="stash/docs", depth=2, as_json=False)
+    main.ls_cmd(path="github/docs", depth=2, as_json=False)
 
     out = capsys.readouterr().out
     assert "api.md" in out
@@ -101,3 +106,55 @@ def test_ls_unknown_source_fails_loudly(monkeypatch, capsys):
         assert type(e).__name__ == "Exit"
     out = capsys.readouterr().out
     assert "No source named 'nope'" in out
+
+
+# A provider with several connections: the first path segment selects the
+# connection (repo), and reads must hit that connection's handle — never the
+# provider key, which is not a readable source.
+MULTI_SOURCES = [
+    {
+        "source": "github",
+        "type": "provider",
+        "provider": "github",
+        "display_name": "github",
+        "members": [
+            {"handle": "aaaa", "display_name": "stash"},
+            {"handle": "bbbb", "display_name": "plugin"},
+        ],
+        "tree": [
+            {"name": "plugin", "kind": "folder", "source": "bbbb", "children": []},
+            {"name": "stash", "kind": "folder", "source": "aaaa", "children": []},
+        ],
+    },
+]
+
+
+class MultiClient(FakeClient):
+    def sources_tree(self, depth=3):
+        return MULTI_SOURCES
+
+    def list_source_entries(self, source, path=""):
+        assert source == "aaaa"
+        assert path == "docs"
+        return [{"path": "docs/api.md", "name": "api.md", "kind": "file"}]
+
+
+def test_ls_provider_lists_its_connections(monkeypatch, capsys):
+    _setup(monkeypatch)
+    monkeypatch.setattr(main, "_client", lambda: MultiClient())
+
+    main.ls_cmd(path="github", depth=2, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "stash/" in out
+    assert "plugin/" in out
+
+
+def test_ls_drills_into_a_named_connection(monkeypatch, capsys):
+    _setup(monkeypatch)
+    monkeypatch.setattr(main, "_client", lambda: MultiClient())
+
+    main.ls_cmd(path="github/stash/docs", depth=2, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "api.md" in out

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -63,7 +63,12 @@ class FakeClient:
     def list_sources(self):
         return [
             {"type": "native_files", "source": "files", "display_name": "Files"},
-            {"type": "gmail", "source": "src-gmail-1", "display_name": "Gmail (demo@x.com)"},
+            {
+                "type": "gmail",
+                "provider": "gmail",
+                "source": "src-gmail-1",
+                "display_name": "Gmail (demo@x.com)",
+            },
         ]
 
     def list_source_entries(self, source, path=""):
@@ -133,10 +138,11 @@ def test_vfs_exposes_user_sections():
     assert b"hello" in model.read_file("/sessions/Fix login--session-/transcript.md")
     assert b'"Name": "Mount"' in model.read_file("/tables/Ideas--table-12/rows.json")
 
-    # Connected sources are mounted read-only; native sources are skipped
-    # (files/sessions already appear above). Document bodies load lazily.
-    assert model.list_dir("/sources") == ["gmail-demo-x.com"]
-    gmail = "/sources/gmail-demo-x.com"
+    # Connected sources are mounted read-only under their provider folder;
+    # native sources are skipped (files/sessions already appear above). A sole
+    # connection collapses — its documents sit directly in the provider folder.
+    assert model.list_dir("/sources") == ["gmail"]
+    gmail = "/sources/gmail"
     assert "Welcome email" in model.list_dir(gmail)
     assert model.read_file(f"{gmail}/Welcome email") == b"BODY of msg-1"
     assert model.read_file(f"{gmail}/threads/Nested note") == b"BODY of threads/msg-2"
@@ -150,13 +156,13 @@ def test_vfs_loads_source_entries_lazily():
     model.refresh()
     sources_path = "/sources"
 
-    assert model.list_dir(sources_path) == ["gmail-demo-x.com"]
+    assert model.list_dir(sources_path) == ["gmail"]
     assert client.source_entry_calls == 0
 
     # Descending into a source materializes only that source, once.
-    model.list_dir(f"{sources_path}/gmail-demo-x.com")
+    model.list_dir(f"{sources_path}/gmail")
     assert client.source_entry_calls == 1
-    model.list_dir(f"{sources_path}/gmail-demo-x.com")
+    model.list_dir(f"{sources_path}/gmail")
     assert client.source_entry_calls == 1
 
 


### PR DESCRIPTION
It used to be like "granola" was a top-level source, but each github repo was also a top-level source in the vfs. Now each provider is a top-level folder under "sources"


# slop
## Problem

Every connected source was listed flat under `/sources`, so whatever granularity an integration happens to connect at became a top-level sibling. The connection unit differs per provider:

| Provider | One source row is… |
|---|---|
| github | a **repo** |
| notion | a **page/db** |
| jira | a **project** |
| granola / gmail / drive | the **whole account** |

So `granola` (an entire account) ended up sitting next to `henry-dowling-twitter-tool` (a single repo *within* github) — a category error in the filesystem.

## Fix

Group rows by provider so the **provider is the top tier** of `/sources`, with individual connections nested inside:

```
/sources/github/<repo>/<files>     ← repos nest, no longer top-level siblings
/sources/granola/<call>            ← unchanged (was already right)
/sources/gmail/<account>/<email>   ← multiple accounts become subfolders
```

Collapse rule (deterministic, no per-provider special-casing):
- **One** connection → its documents sit directly in the provider folder (`/sources/granola/<call>`).
- **Multiple** connections → each becomes a subfolder (`/sources/github/<repo>/<files>`).

Reads still resolve to each connection's real handle (`user_sources.id`); the provider key is display-only, so path resolution, deep links, and the agent read tools are untouched.

### Accepted tradeoff
A single-repo github collapses to files-directly; connecting a second repo restructures `/sources/github` into repo subfolders. Discussed and chosen to keep the common case flat.

## Changes
- **`backend/services/source_service.py`** — `sources_tree()` groups by provider (new `_provider_tree_node` / `_member_tree`); `list_sources()` gains an additive `provider` field.
- **`cli/mount.py`** — `_add_sources()` groups by provider (new `_group_by_provider`); reads still bind to per-connection handles, lazy loading unchanged.
- **`cli/main.py`** — `stash ls` resolves `provider/<connection>/<doc-path>` → connection handle.
- **Tests** — updated tree/ls/mount shapes; added coverage for multi-connection nesting and drilling.

## Verification
- Affected suites pass (`test_sources_tree.py`, `test_sources.py`, `test_ls_cmd.py`, `test_mount_vfs.py`), ruff clean.
- One pre-existing `test_app_vfs.py` failure (`/me/files`) confirmed unrelated — fails on a clean tree too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)