### PR TITLE
Remove workspace membership/role fossils from scope access

### DIFF
--- a/backend/integrations/slack/agent.py
+++ b/backend/integrations/slack/agent.py
@@ -17,7 +17,7 @@ import logging
 import re
 
 from ...config import settings
-from ...services import ask_service, user_scope_service, user_service
+from ...services import ask_service, user_service
 from . import client, installs, links
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ async def respond_to_mention(team_id: str, event: dict) -> None:
         await client.post_message(bot_token, channel, _connect_prompt(), thread_ts)
         return
 
-    owner_user_id = await user_scope_service.scope_id_for_user(user["id"])
+    owner_user_id = user["id"]
     # The scope is the user, so its name is the user's display name.
     owner_name = user["display_name"] or user["name"]
     # One continuous session per user → memory accumulates across DMs/channels/time.

--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -213,8 +213,7 @@ async def _verify_scope_access(owner_user_id: UUID, user_id: UUID) -> None:
 
     from ..services import user_scope_service
 
-    role = await user_scope_service.get_member_role(owner_user_id, user_id)
-    if role is None:
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a member of this scope")
 
 

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -58,7 +58,7 @@ _FILE_FROM = "FROM files f JOIN users u ON u.id = f.uploaded_by"
 
 async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
     """Read gate: any member."""
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a scope member")
 
 

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -50,7 +50,7 @@ canonical_router = APIRouter(prefix="/api/v1", tags=["files"])
 
 async def _check_scope_access(owner_user_id: UUID, user_id: UUID) -> None:
     """Read gate: any member (viewer/editor/owner) is allowed."""
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a scope member")
 
 

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -29,7 +29,7 @@ _TITLE_EVENT_TYPES = {"user_message", "user_prompt", "prompt", "assistant_messag
 
 
 async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a scope member")
 
 
@@ -160,9 +160,6 @@ async def delete_agent(
     """Delete all events for an agent in this scope."""
     owner_user_id = current_user["id"]
     await _check_member(owner_user_id, current_user["id"])
-    role = await user_scope_service.get_member_role(owner_user_id, current_user["id"])
-    if role not in ("owner", "admin"):
-        raise HTTPException(status_code=403, detail="Scope admin required")
     await memory_service.delete_scope_agent_events(agent_name, owner_user_id)
 
 

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -17,15 +17,10 @@ async def publish(
 ):
     """Create a skill folder containing the content page and publish it."""
     if req.owner_user_id is None:
-        owner_user_id = await user_scope_service.scope_id_for_user(current_user["id"])
-        if owner_user_id is None:
-            raise HTTPException(
-                status_code=400,
-                detail="No primary scope; pass owner_user_id explicitly",
-            )
+        owner_user_id = current_user["id"]
     else:
         owner_user_id = req.owner_user_id
-        if not await user_scope_service.is_member(owner_user_id, current_user["id"]):
+        if not await user_scope_service.is_owner(owner_user_id, current_user["id"]):
             raise HTTPException(status_code=403, detail="Not a scope member")
 
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):

--- a/backend/routers/security_audit.py
+++ b/backend/routers/security_audit.py
@@ -20,8 +20,7 @@ async def list_security_events(
     current_user: dict = Depends(get_current_user),
 ):
     owner_user_id = current_user["id"]
-    role = await user_scope_service.get_member_role(owner_user_id, current_user["id"])
-    if role is None:
+    if not await user_scope_service.is_owner(owner_user_id, current_user["id"]):
         # Match the sibling scope routers: never confirm a scope's
         # existence to non-members.
         raise HTTPException(status_code=404, detail="Scope not found")
@@ -29,16 +28,6 @@ async def list_security_events(
         "action_filter_hash": security_audit_service.hash_value(action),
         "limit": limit,
     }
-    if not await user_scope_service.is_owner(owner_user_id, current_user["id"]):
-        await security_audit_service.record_event(
-            action="security_audit.read_denied",
-            actor_user_id=current_user["id"],
-            owner_user_id=owner_user_id,
-            target_type="security_audit_log",
-            metadata={**metadata, "role": role},
-        )
-        raise HTTPException(status_code=403, detail="Only scope admins can read security events")
-
     await security_audit_service.record_event(
         action="security_audit.read",
         actor_user_id=current_user["id"],

--- a/backend/routers/session_folders.py
+++ b/backend/routers/session_folders.py
@@ -23,7 +23,7 @@ GeneralPermission = str  # 'none' | 'read' | 'write' (validated in the service)
 
 
 async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=404, detail="Scope not found")
 
 
@@ -87,7 +87,7 @@ async def list_folders(current_user: dict = Depends(get_current_user)):
     owner_user_id = current_user["id"]
     # Non-members may still see folders shared with them, so this isn't gated on
     # membership. Members get a Default folder lazily ensured on first listing.
-    if await user_scope_service.is_member(owner_user_id, current_user["id"]):
+    if await user_scope_service.is_owner(owner_user_id, current_user["id"]):
         await session_folder_service.ensure_default_folder(owner_user_id)
     return {"folders": await session_folder_service.list_folders(owner_user_id, current_user["id"])}
 

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -33,7 +33,7 @@ _PUBLIC_ITEM_TYPES = {"page", "file", "table", "folder"}
 
 
 async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a scope member")
 
 

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/api/v1/me/sources", tags=["sources"])
 
 
 async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
-    if await user_scope_service.get_member_role(owner_user_id, user_id) is None:
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=404, detail="Scope not found")
 
 

--- a/backend/routers/tables.py
+++ b/backend/routers/tables.py
@@ -39,7 +39,7 @@ async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
     Most table endpoints mutate state, so the default is safe-by-default
     write. Read-only endpoints opt into `_check_read` instead."""
     if not await user_scope_service.can_write(owner_user_id, user_id):
-        if not await user_scope_service.is_member(owner_user_id, user_id):
+        if not await user_scope_service.is_owner(owner_user_id, user_id):
             raise HTTPException(status_code=403, detail="Not a scope member")
         raise HTTPException(
             status_code=403,
@@ -49,7 +49,7 @@ async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
 
 async def _check_read(owner_user_id: UUID, user_id: UUID) -> None:
     """Read gate: any scope member (viewer/editor/owner)."""
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=403, detail="Not a scope member")
 
 

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -347,7 +347,7 @@ async def get_scope_sidebar(
 
 
 async def _check_overview_access(owner_user_id: UUID, user_id: UUID) -> None:
-    if not await user_scope_service.is_member(owner_user_id, user_id):
+    if not await user_scope_service.is_owner(owner_user_id, user_id):
         raise HTTPException(status_code=404, detail="Scope not found")
 
 

--- a/backend/services/batch_service.py
+++ b/backend/services/batch_service.py
@@ -156,7 +156,7 @@ async def batch_restore(owner_user_id: UUID, user_id: UUID, items: list[dict]) -
             raise ValueError(f"batch restore supports pages and files, not {object_type}")
         # Trashed rows can't be permission-checked the normal way (live-only
         # queries skip them); scope membership + write is the gate.
-        if not await user_scope_service.is_member(owner_user_id, user_id):
+        if not await user_scope_service.is_owner(owner_user_id, user_id):
             raise ValueError("no write access")
         return await _restore_one(object_type, object_id, owner_user_id, user_id)
 

--- a/backend/services/user_scope_service.py
+++ b/backend/services/user_scope_service.py
@@ -14,11 +14,6 @@ from . import skill_seeds
 logger = logging.getLogger(__name__)
 
 
-async def scope_id_for_user(user_id: UUID) -> UUID:
-    """The user's scope id is just the user id."""
-    return user_id
-
-
 def _is_owner(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
     return owner_user_id is not None and owner_user_id == user_id
 
@@ -29,20 +24,12 @@ async def is_owner(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
     return _is_owner(owner_user_id, user_id)
 
 
-async def is_member(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
-    return _is_owner(owner_user_id, user_id)
-
-
 async def can_read(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
     return _is_owner(owner_user_id, user_id)
 
 
 async def can_write(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
     return _is_owner(owner_user_id, user_id)
-
-
-async def get_member_role(owner_user_id: UUID | None, user_id: UUID | None) -> str | None:
-    return "owner" if _is_owner(owner_user_id, user_id) else None
 
 
 async def seed_user_scope(user_id: UUID) -> None:

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -16,7 +16,6 @@ from backend.managed.auth0 import router as auth0_router
 from backend.managed.auth0 import users as auth0_users
 from backend.managed.auth0.jwt import validate_auth0_token
 from backend.managed.auth0.users import get_or_create_user_row_from_auth0
-from backend.services import user_scope_service
 
 from .conftest import unique_name
 
@@ -54,10 +53,6 @@ async def test_first_session_provision_reports_created(pool):
         auth0_sub=sub, email=None, name="New Person"
     )
     assert created is True
-    # First sign-in provisions the user's scope, so a scope lookup alone can't
-    # tell new from returning — only `created` can. The scope is the user.
-    scope_id = await user_scope_service.scope_id_for_user(user["id"])
-    assert scope_id == user["id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Delete some dead code around workspace membership access that was not deleted in the workspace removal PR last week. 

## What

Workspaces were removed last week — each user is now their own single-member scope. That left behind access helpers in `user_scope_service` that had all collapsed into "is this your own scope?", plus several role-era guards that became dead code.

This removes the fossils. No behavior change.

### Removed helpers (`user_scope_service.py`)
- **`is_member`** — a pure synonym of `is_owner` now that a scope has one member. → `is_owner` (11 sites)
- **`get_member_role`** — only ever returned `"owner"` or `None`. → `is_owner` (4 sites)
- **`scope_id_for_user`** — identity function returning `user_id`. → inlined (3 sites)

`user_scope_service` now exposes just `is_owner` / `can_read` / `can_write` + `seed_user_scope`.

### Dead role-system code removed
- `memory.py` — the `("owner", "admin")` check + "Scope admin required" guard, unreachable after `_check_member` (and `"admin"` can never occur)
- `security_audit.py` — the `security_audit.read_denied` block, unreachable after the owner guard and referencing the deleted `role`
- `publish.py` — the `if owner_user_id is None` raise, dead once `scope_id_for_user` is inlined to `current_user["id"]`
- `test_auth0_provision.py` — tautological `scope_id == user["id"]` assertion + unused import; unused import in `slack/agent.py`

## What this does *not* touch

`permission_service` + the `shares` table are left alone — that's the **live peer-to-peer sharing engine** (share a file/folder/session with another user by email, public publishing via skills), not a workspace fossil. "Non-owner access" is a real, current feature; it just flows through shares, not membership.

## Test plan
- `ruff check .` — clean
- `test_auth0_provision`, `test_permissions`, `test_collab`, `test_sources`, `test_security_audit`, `test_publish` — **149 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)