### PR TITLE
Restore drive.readonly scope for Google Drive crawl

### DIFF
--- a/backend/integrations/google/provider.py
+++ b/backend/integrations/google/provider.py
@@ -25,17 +25,16 @@ USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
 class GoogleIntegration(Integration):
     name = "google"
     display_name = "Google"
-    # drive.file is the minimal Drive scope — it only grants access to files
-    # the user explicitly selects through the Drive Picker (for import) or
-    # files our app creates (for Slides export). Avoids the scary
-    # "read all your Drive files" consent screen.
+    # The indexer crawls the user's whole Drive (files.list over My Drive,
+    # "Shared with me", and drives.list for Shared Drives) and runs federated
+    # `fullText` search — all of which need read access across every file, not
+    # just app-picked ones. Only drive.readonly grants that. The narrower
+    # per-file scopes (drive.file / auth/docs) only see files the user opened
+    # with the app, so the crawl returns nothing and drives.list 403s.
+    # drive.readonly is a Google *restricted* scope: the OAuth consent screen
+    # must list it and clear a CASA Tier 2 assessment for production use.
     scopes = [
-        # Read access to the user's Drive for the folder crawl + federated
-        # `fullText` search. `auth/docs` is a *sensitive* scope (already
-        # approved on our consent screen), unlike the *restricted*
-        # `drive.readonly`, which requires a CASA assessment to clear the
-        # "unverified app" screen.
-        "https://www.googleapis.com/auth/docs",
+        "https://www.googleapis.com/auth/drive.readonly",
         "openid",
         "email",
         "profile",

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -67,6 +67,7 @@ async def _sync_source(source_id: UUID) -> dict:
             source_id,
             source["source_type"],
             type(exc).__name__,
+            exc_info=True,
         )
         await source_service.mark_sync_failed(source_id, SYNC_FAILED_MESSAGE)
         return {"status": "failed"}


### PR DESCRIPTION
ooopsie

we have to use the new scope after all I think






# Slop
## Problem
The connected **Google Drive** source is stuck at `failed · never synced · 0 items` ("Source sync failed; check server logs").

Root cause: #662 narrowed the Google OAuth scope from `drive.readonly` to `auth/docs` as a deliberate prod experiment — to test whether a docs-scoped token could still power the crawl. The answer is no. The indexer (`backend/integrations/google/indexer.py`) enumerates the user's **whole** Drive:
- `files.list` over all of My Drive
- `sharedWithMe`
- `drives.list` for Shared Drives

A per-file scope (`auth/docs`/`drive.file`) only sees files the user explicitly opened with the app, and `drives.list` 403s outright — so the crawl throws and the sync is marked failed. The failed source you see today *is* the result of that experiment.

## Change
- Revert the Google scope to `https://www.googleapis.com/auth/drive.readonly` (what the indexer is actually written for) and rewrite the stale comments to explain the requirement.
- Log `exc_info=True` on sync failure in `backend/tasks/sources.py` so the next failure carries a real traceback instead of just the exception class name. The missing detail is what made this slow to diagnose.

## Deploy / rollout notes
`drive.readonly` is a Google **restricted** scope. After deploy:
1. Add `https://www.googleapis.com/auth/drive.readonly` to the OAuth consent screen's registered scopes in GCP.
2. Reconnect Google (sign out → reconnect) to mint a token carrying the new scope, then re-sync.
3. **CASA Tier 2** is required to clear the "unverified app" screen for general availability. Until then, the scope works for **test users** / in-org installs — sufficient to confirm the crawl end-to-end before committing to CASA.

## Test
`pytest backend/tests/test_integration_sources.py` → 43 passed. No test pinned the `auth/docs` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)