### PR TITLE
Rename stale workspace/member/role prose to user/owner terms

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v1/me", tags=["aggregate"])
 
 @router.get("/pages", response_model=UserPageListResponse)
 async def list_all_pages(current_user: dict = Depends(get_current_user)):
-    """Every page across every scope the user is a member of."""
+    """Every page across every scope the user can access."""
     rows = await files_tree_service.list_user_pages(current_user["id"])
     return UserPageListResponse(pages=[UserPageEntry(**r) for r in rows])
 
@@ -53,7 +53,7 @@ async def list_all_session_events(
 async def list_my_recents(current_user: dict = Depends(get_current_user)):
     """Recently-viewed objects across all scopes, most recent first.
 
-    Includes objects in scopes the user isn't a member of (shared items),
+    Includes objects in other users' scopes (shared items),
     which the Shared-with-me Recent strip resolves against the share list.
     """
     pool = get_pool()
@@ -208,13 +208,13 @@ async def overview_counts(current_user: dict = Depends(get_current_user)):
 
 
 async def _verify_scope_access(owner_user_id: UUID, user_id: UUID) -> None:
-    """Raise 403 if the user isn't a member of the scope."""
+    """Raise 403 if the user doesn't own the scope."""
     from fastapi import HTTPException
 
     from ..services import user_scope_service
 
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a member of this scope")
+        raise HTTPException(status_code=403, detail="Not the owner of this scope")
 
 
 @router.get("/activity-timeline")

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -57,17 +57,17 @@ _FILE_FROM = "FROM files f JOIN users u ON u.id = f.uploaded_by"
 
 
 async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
-    """Read gate: any member."""
+    """Read gate: owner only."""
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a scope member")
+        raise HTTPException(status_code=403, detail="Not the scope owner")
 
 
 async def _check_write(owner_user_id: UUID, user_id: UUID) -> None:
-    """Write gate: owner or editor only."""
+    """Write gate: owner only."""
     if not await user_scope_service.can_write(owner_user_id, user_id):
         raise HTTPException(
             status_code=403,
-            detail="Viewers can read but not modify files",
+            detail="Only the owner can modify files",
         )
 
 
@@ -157,7 +157,7 @@ async def upload_my_file(
     current_user: dict = Depends(get_current_user),
 ):
     owner_user_id = current_user["id"]
-    # Scope writers can upload anywhere; non-members can upload into a
+    # Scope writers can upload anywhere; other users can upload into a
     # specific folder shared with them with write permission.
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
         can_write_folder = folder_id is not None and await permission_service.check_access(
@@ -170,7 +170,7 @@ async def upload_my_file(
         if not can_write_folder:
             raise HTTPException(
                 status_code=403,
-                detail="Viewers can read but not modify files",
+                detail="Only the owner can modify files",
             )
 
     content = await file.read()

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -49,17 +49,17 @@ canonical_router = APIRouter(prefix="/api/v1", tags=["files"])
 
 
 async def _check_scope_access(owner_user_id: UUID, user_id: UUID) -> None:
-    """Read gate: any member (viewer/editor/owner) is allowed."""
+    """Read gate: only the scope owner is allowed."""
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a scope member")
+        raise HTTPException(status_code=403, detail="Not the scope owner")
 
 
 async def _check_scope_write(owner_user_id: UUID, user_id: UUID) -> None:
-    """Write gate: owner or editor only. Viewer is blocked."""
+    """Write gate: owner only."""
     if not await user_scope_service.can_write(owner_user_id, user_id):
         raise HTTPException(
             status_code=403,
-            detail="Viewers can read but not edit this scope",
+            detail="Only the scope owner can edit this scope",
         )
 
 
@@ -575,7 +575,7 @@ async def download_page(
     Returns the page's markdown source (or HTML, for html-typed pages) so
     callers can export, diff, or feed it to other tools the same way they
     would a binary file. Permission is the existing page-read check —
-    members of the scope plus anyone the page is shared with.
+    the scope owner plus anyone the page is shared with.
     """
     owner_user_id = current_user["id"]
     page = await files_tree_service.get_page(page_id, owner_user_id, current_user["id"])
@@ -732,8 +732,8 @@ async def create_comment_thread(
     current_user: dict = Depends(get_current_user),
 ):
     owner_user_id = current_user["id"]
-    # Commenting needs at least the 'comment' share level (scope members
-    # always qualify); a plain read-only share can view but not comment.
+    # Commenting needs at least the 'comment' share level (the scope owner
+    # always qualifies); a plain read-only share can view but not comment.
     await _check_content_access(
         "page", page_id, owner_user_id, current_user["id"], require="comment"
     )

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -30,12 +30,12 @@ _TITLE_EVENT_TYPES = {"user_message", "user_prompt", "prompt", "assistant_messag
 
 async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a scope member")
+        raise HTTPException(status_code=403, detail="Not the scope owner")
 
 
 async def _check_write(owner_user_id: UUID, user_id: UUID) -> None:
     if not await user_scope_service.can_write(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Viewers can read but not write sessions")
+        raise HTTPException(status_code=403, detail="Only the owner can write sessions")
 
 
 # ===== Scope event endpoints =====

--- a/backend/routers/pins.py
+++ b/backend/routers/pins.py
@@ -3,7 +3,7 @@
 Pins are an explicit per-kind set the user curates (skills / sessions /
 files); recents are stamped automatically as the user opens things. Both are
 private to the user. Pins require access to the owner scope; recents can also
-be stamped by non-members for objects shared with them.
+be stamped by other users for objects shared with them.
 """
 
 import json

--- a/backend/routers/publish.py
+++ b/backend/routers/publish.py
@@ -21,10 +21,10 @@ async def publish(
     else:
         owner_user_id = req.owner_user_id
         if not await user_scope_service.is_owner(owner_user_id, current_user["id"]):
-            raise HTTPException(status_code=403, detail="Not a scope member")
+            raise HTTPException(status_code=403, detail="Not the scope owner")
 
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Viewers can read but not publish")
+        raise HTTPException(status_code=403, detail="Only the owner can publish")
 
     # Gate before any side effects: publish_folder would reject non-owners
     # anyway, but only after the folder and page were already created.

--- a/backend/routers/security_audit.py
+++ b/backend/routers/security_audit.py
@@ -22,7 +22,7 @@ async def list_security_events(
     owner_user_id = current_user["id"]
     if not await user_scope_service.is_owner(owner_user_id, current_user["id"]):
         # Match the sibling scope routers: never confirm a scope's
-        # existence to non-members.
+        # existence to non-owners.
         raise HTTPException(status_code=404, detail="Scope not found")
     metadata = {
         "action_filter_hash": security_audit_service.hash_value(action),

--- a/backend/routers/session_folders.py
+++ b/backend/routers/session_folders.py
@@ -29,7 +29,7 @@ async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
 
 async def _require_write(owner_user_id: UUID, user_id: UUID) -> None:
     if not await user_scope_service.can_write(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Viewers can read but not edit this scope")
+        raise HTTPException(status_code=403, detail="Only the scope owner can edit this scope")
 
 
 class CreateFolderRequest(BaseModel):
@@ -43,7 +43,7 @@ async def _require_owner_for_folder_visibility(
     user_id: UUID,
     body: CreateFolderRequest,
 ) -> None:
-    """Scope-visible folders are the everyday default any editor may create;
+    """Scope-visible folders are the everyday default the owner may create;
     only publishing a folder beyond the scope is owner-gated."""
     is_public = body.public_permission != "none" or body.discoverable
     if is_public and not await user_scope_service.is_owner(owner_user_id, user_id):
@@ -85,8 +85,8 @@ async def create_folder(body: CreateFolderRequest, current_user: dict = Depends(
 @me_router.get("")
 async def list_folders(current_user: dict = Depends(get_current_user)):
     owner_user_id = current_user["id"]
-    # Non-members may still see folders shared with them, so this isn't gated on
-    # membership. Members get a Default folder lazily ensured on first listing.
+    # Non-owners may still see folders shared with them, so this isn't gated on
+    # ownership. Owners get a Default folder lazily ensured on first listing.
     if await user_scope_service.is_owner(owner_user_id, current_user["id"]):
         await session_folder_service.ensure_default_folder(owner_user_id)
     return {"folders": await session_folder_service.list_folders(owner_user_id, current_user["id"])}

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -206,7 +206,7 @@ async def upsert_session(
 ):
     owner_user_id = current_user["id"]
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Viewers can read but not create sessions")
+        raise HTTPException(status_code=403, detail="Only the owner can create sessions")
 
     # A session always lands in a folder: the one it was pushed to, or the
     # scope's Default folder (resolved by upsert_session when unset).
@@ -237,8 +237,8 @@ async def _session_detail_payload(
 ) -> dict | None:
     """Full session detail if the user may read it, else None.
 
-    No scope-membership pre-gate: a session may be shared with a
-    non-member. can_read_session enforces check_access (owner OR share OR
+    No ownership pre-gate: a session may be shared with a
+    user who does not own the scope. can_read_session enforces check_access (owner OR share OR
     open skill).
     """
     if not await memory_service.can_read_session(owner_user_id, session_id, user_id):
@@ -493,7 +493,7 @@ async def materialize_session(
     on it. Re-materializing the same session updates the existing page rather
     than spawning duplicates."""
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Viewers can read but not materialize sessions")
+        raise HTTPException(status_code=403, detail="Only the owner can materialize sessions")
     if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
         raise HTTPException(status_code=404, detail="No events for that session in this scope")
 

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -34,7 +34,7 @@ _PUBLIC_ITEM_TYPES = {"page", "file", "table", "folder"}
 
 async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a scope member")
+        raise HTTPException(status_code=403, detail="Not the scope owner")
 
 
 @me_router.post("/skills", response_model=SkillResponse, status_code=201)
@@ -102,7 +102,7 @@ async def get_skill_contents(
     current_user: dict = Depends(get_current_user),
 ):
     """The skill folder's full subtree, inlined — same shape as the public
-    skill payload, but for scope members on unpublished skills. This is
+    skill payload, but for the scope owner on unpublished skills. This is
     what `stash skills sync` pulls."""
     owner_user_id = current_user["id"]
     folder = await _require_skill_folder(owner_user_id, folder_id, current_user["id"])
@@ -219,7 +219,7 @@ async def materialize_session(
     how sessions travel into skills (sessions can't live in folders)."""
     owner_user_id = current_user["id"]
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Viewers can read but not materialize sessions")
+        raise HTTPException(status_code=403, detail="Only the owner can materialize sessions")
     page = await shared_skill_service.materialize_session_page(
         owner_user_id, session_id, req.folder_id, current_user["id"]
     )
@@ -350,7 +350,7 @@ async def fork_skill(
     # Forking writes new pages/files/sessions into the scope — same bar as
     # creating a Skill.
     if not await user_scope_service.can_write(req.owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Viewers can read but not create Skills")
+        raise HTTPException(status_code=403, detail="You have read-only access and cannot create Skills")
     forked = await shared_skill_service.fork_skill(req.owner_user_id, slug, current_user["id"])
     if not forked:
         raise HTTPException(status_code=404, detail="Skill not found")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -1,6 +1,6 @@
 """Connected-source registry endpoints.
 
-A source is added per scope and per user. It belongs to the member who
+A source is added per scope and per user. It belongs to the user who
 connects it (`owner_user_id = current_user`) inside that scope, and only they
 can list, read, or remove it there. The agent reaches a source's indexed content
 through the source tools; these endpoints just manage the registry. Indexing

--- a/backend/routers/tables.py
+++ b/backend/routers/tables.py
@@ -40,17 +40,17 @@ async def _check_member(owner_user_id: UUID, user_id: UUID) -> None:
     write. Read-only endpoints opt into `_check_read` instead."""
     if not await user_scope_service.can_write(owner_user_id, user_id):
         if not await user_scope_service.is_owner(owner_user_id, user_id):
-            raise HTTPException(status_code=403, detail="Not a scope member")
+            raise HTTPException(status_code=403, detail="Not the scope owner")
         raise HTTPException(
             status_code=403,
-            detail="Viewers can read but not modify tables",
+            detail="Only the owner can modify tables",
         )
 
 
 async def _check_read(owner_user_id: UUID, user_id: UUID) -> None:
-    """Read gate: any scope member (viewer/editor/owner)."""
+    """Read gate: only the scope owner."""
     if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not a scope member")
+        raise HTTPException(status_code=403, detail="Not the scope owner")
 
 
 async def _check_ws_table(

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -42,7 +42,7 @@ def _is_jsonl(filename: str | None) -> bool:
 
 async def _check_write(owner_user_id: UUID, user_id: UUID) -> None:
     if not await user_scope_service.can_write(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Viewers can read but not upload transcripts")
+        raise HTTPException(status_code=403, detail="Only the owner can upload transcripts")
 
 
 @router.post("", status_code=201)
@@ -190,8 +190,8 @@ async def get_transcript_metadata(
     current_user: dict = Depends(get_current_user),
 ):
     """Metadata-only response. The frontend follows up with /events for
-    the bytes. No membership gate: read_session_events enforces
-    can_read_session, so a non-member with a share can read it."""
+    the bytes. No ownership gate: read_session_events enforces
+    can_read_session, so a non-owner with a share can read it."""
     resolved = await _resolve_readable_events(session_id, current_user["id"])
     if not resolved:
         raise HTTPException(status_code=404, detail="Transcript not found")
@@ -228,8 +228,8 @@ async def get_transcript_events(
     fetches more as the reader scrolls. offset is a turn ordinal, so a future
     in-session search can jump straight to a match's window.
 
-    No membership gate: can_read_session is enforced per scope below, so a
-    non-member the session is shared with can read it."""
+    No ownership gate: can_read_session is enforced per scope below, so
+    another user the session is shared with can read it."""
     for row in await session_service.list_sessions_for_session_id(session_id):
         owner_user_id = row["owner_user_id"]
         if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
@@ -251,8 +251,8 @@ async def export_transcript_jsonl(
     session_id: str,
     current_user: dict = Depends(get_current_user),
 ):
-    """JSONL projection of the session — one event per line. No membership
-    gate: read_session_events enforces can_read_session, so a non-member with
+    """JSONL projection of the session — one event per line. No ownership
+    gate: read_session_events enforces can_read_session, so a user with
     a share can export it."""
     import json as json_mod
 

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -61,7 +61,7 @@ def _activity_bucket_step(bucket: str) -> timedelta:
 
 # Shared CTE for scope access filtering on history_events.
 #   scope_idx -> narrow to a single scope's events (caller has already
-#                authorized membership).
+#                authorized access).
 #   None      -> every event the user can see across all their scopes.
 def _accessible_events_cte(
     scope_idx: int | None = None,
@@ -460,7 +460,7 @@ async def _get_source_counts(user_id: UUID, owner_user_id: UUID | None = None) -
 async def get_overview_counts(user_id: UUID) -> dict:
     """Counts for the 'Your brain' vitals, spanning the user's own content plus
     everything shared with them. Pages/files run through readable_content_condition
-    so a share only surfaces the specific shared rows. Sessions stay member-scoped —
+    so a share only surfaces the specific shared rows. Sessions stay owner-scoped —
     session sharing isn't reflected in these counts yet."""
     pool = get_pool()
     accessible_scopes = permission_service.accessible_scope_ids_sql(1)
@@ -665,9 +665,9 @@ async def get_knowledge_density(
     """Topic clusters for the key topics treemap.
 
     Reads from knowledge_density_cache (migration 0017/0018) only for explicit
-    scopes. User-wide results depend on the user's current scope memberships,
+    scopes. User-wide results depend on which scopes the user can currently access,
     so they are recomputed to avoid serving stale customer data after
-    offboarding."""
+    access is revoked."""
     pool = get_pool()
     max_clusters = min(max_clusters, 50)
 
@@ -717,7 +717,7 @@ async def get_embedding_projection(
     Pass ``owner_user_id`` to scope to one user.
 
     Only explicit scope-scoped requests use the embedding_projections cache.
-    User-wide results depend on current scope memberships."""
+    User-wide results depend on current scope access."""
     pool = get_pool()
     max_points = min(max_points, 2000)
 
@@ -735,8 +735,8 @@ async def get_embedding_projection(
         event_scope_idx = 2
 
     # Cache row keyed by (user_id, source_type, owner_user_id), explicit
-    # scopes only: user-wide results depend on the user's current memberships
-    # and must be recomputed (offboarding).
+    # scopes only: user-wide results depend on the user's current scope access
+    # and must be recomputed when access changes.
     cache = None
     use_cache = owner_user_id is not None
     if use_cache:

--- a/backend/services/batch_service.py
+++ b/backend/services/batch_service.py
@@ -29,7 +29,7 @@ _TRASHABLE = {"page", "file"}
 async def _authorize(object_type: str, object_id: UUID, owner_user_id: UUID, user_id: UUID) -> None:
     """Raise ValueError unless the object lives in this scope and the user
     may write it. Resolving the real scope closes the cross-scope hole
-    where membership in the request's scope would otherwise pass."""
+    where having write access in the request's scope would otherwise pass."""
     obj_owner = await permission_service.resolve_owner_user_id(object_type, object_id)
     if obj_owner != owner_user_id:
         raise ValueError("not found")
@@ -155,7 +155,7 @@ async def batch_restore(owner_user_id: UUID, user_id: UUID, items: list[dict]) -
         if object_type not in _TRASHABLE:
             raise ValueError(f"batch restore supports pages and files, not {object_type}")
         # Trashed rows can't be permission-checked the normal way (live-only
-        # queries skip them); scope membership + write is the gate.
+        # queries skip them); scope write access (owner-only) is the gate.
         if not await user_scope_service.is_owner(owner_user_id, user_id):
             raise ValueError("no write access")
         return await _restore_one(object_type, object_id, owner_user_id, user_id)

--- a/backend/services/session_folder_service.py
+++ b/backend/services/session_folder_service.py
@@ -109,7 +109,7 @@ async def ensure_default_folder(owner_user_id: UUID) -> dict:
     pushed to a specific folder land here (chat-UI + un-targeted CLI sessions).
 
     The folder is owned by the scope owner — not whoever happened to push the
-    first session — so its access never leaks to a member who later leaves.
+    first session — so its access never leaks to a user who later loses access.
     """
     pool = get_pool()
     existing = await pool.fetchrow(
@@ -149,8 +149,8 @@ async def get_folder(folder_id: UUID) -> dict | None:
 
 
 async def user_can_manage(folder_id: UUID, user_id: UUID) -> bool:
-    """Folder management (rename/delete/visibility) is for the folder owner and
-    scope owners/editors — never public-link or explicit-share writers."""
+    """Folder management (rename/delete/visibility) is for the folder owner —
+    never public-link or explicit-share writers."""
     row = await get_pool().fetchrow(
         "SELECT owner_user_id FROM session_folders WHERE id = $1",
         folder_id,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -2,7 +2,7 @@
 
 A *source* is anything the agent can read. Two are native and always present
 per scope — the **file system** and **session transcripts** (scope-wide,
-visible to all members). The rest are **connected sources** (GitHub / Drive /
+visible to the user). The rest are **connected sources** (GitHub / Drive /
 Gmail / Notion / Slack / Granola) — rows in `user_sources`, USER-SCOPED so
 only the owner sees them.
 
@@ -327,7 +327,7 @@ async def purge_disallowed_copied_documents(source: dict) -> int:
 
 async def list_connected_sources(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     """The user's own connected sources in this scope. User-scoped: a
-    member never sees another member's connected sources."""
+    user never sees another user's connected sources."""
     rows = await get_pool().fetch(
         "SELECT * FROM user_sources "
         "WHERE owner_user_id = $1 AND owner_user_id = $2 "

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -364,7 +364,7 @@ async def test_user_activity_paginates_with_before_cursor(client: AsyncClient):
         )
 
     # Page through one event at a time using the last event's ts as the cursor.
-    # The feed also contains member.joined events, so only the session events
+    # The feed may also contain page/file events, so only the session events
     # have a known count and order.
     seen: list[tuple[str, str, str]] = []
     before: str | None = None

--- a/backend/tests/test_collab.py
+++ b/backend/tests/test_collab.py
@@ -88,12 +88,12 @@ async def test_collab_authorizes_read_share_as_read_only(
 
 
 @pytest.mark.asyncio
-async def test_collab_authorizes_non_member_with_page_share(
+async def test_collab_authorizes_non_owner_with_page_share(
     client: AsyncClient,
     pool,
 ):
-    """A page shared directly with a non-member grants live-edit access:
-    membership is not required, the share decides read/write."""
+    """A page shared directly with another user grants live-edit access:
+    the share alone decides read/write."""
     owner_key, _owner = await _register(client)
     editor_key, editor = await _register(client)
     owner_scope_id = await _scope_id(client, owner_key)
@@ -130,7 +130,7 @@ async def test_collab_authorizes_non_member_with_page_share(
 async def test_collab_rejects_user_without_access(
     client: AsyncClient,
 ):
-    """A user who is neither a member nor a sharee is rejected outright."""
+    """A user who is neither the owner nor a sharee is rejected outright."""
     owner_key, _owner = await _register(client)
     outsider_key, _outsider = await _register(client)
     owner_scope_id = await _scope_id(client, owner_key)

--- a/backend/tests/test_item_canonical_lookup.py
+++ b/backend/tests/test_item_canonical_lookup.py
@@ -1,6 +1,6 @@
 """The canonical page/file/session endpoints resolve the scope
 server-side so item links carry only the item ID and can never go stale.
-Same contract as the canonical table endpoint: membership-gated, and every
+Same contract as the canonical table endpoint: scope-gated, and every
 failure is a 404 so an unscoped probe can't confirm an item exists."""
 
 import uuid
@@ -68,7 +68,7 @@ async def _create_session(client: AsyncClient, api_key: str, owner_user_id: str)
 
 
 @pytest.mark.asyncio
-async def test_member_resolves_page_by_id_alone(client: AsyncClient):
+async def test_owner_resolves_page_by_id_alone(client: AsyncClient):
     api_key = await _register(client)
     owner_user_id = await _scope_id(client, api_key)
     page_id = await _create_page(client, api_key, owner_user_id)
@@ -81,7 +81,7 @@ async def test_member_resolves_page_by_id_alone(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_non_member_page_lookup_is_404_not_403(client: AsyncClient):
+async def test_outsider_page_lookup_is_404_not_403(client: AsyncClient):
     owner_key = await _register(client)
     owner_user_id = await _scope_id(client, owner_key)
     page_id = await _create_page(client, owner_key, owner_user_id)
@@ -93,7 +93,7 @@ async def test_non_member_page_lookup_is_404_not_403(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_non_member_file_lookup_is_404_not_403(client: AsyncClient, pool):
+async def test_outsider_file_lookup_is_404_not_403(client: AsyncClient, pool):
     owner_key = await _register(client)
     owner_user_id = await _scope_id(client, owner_key)
     file_id = await _insert_file_row(pool, owner_user_id)
@@ -105,7 +105,7 @@ async def test_non_member_file_lookup_is_404_not_403(client: AsyncClient, pool):
 
 
 @pytest.mark.asyncio
-async def test_member_resolves_session_by_external_id_alone(client: AsyncClient):
+async def test_user_resolves_session_by_external_id_alone(client: AsyncClient):
     api_key = await _register(client)
     owner_user_id = await _scope_id(client, api_key)
     session_id = await _create_session(client, api_key, owner_user_id)
@@ -146,7 +146,7 @@ async def test_session_id_in_two_scopes_resolves_to_readable_one(client: AsyncCl
 
 
 @pytest.mark.asyncio
-async def test_non_member_session_lookup_is_404(client: AsyncClient):
+async def test_non_owner_session_lookup_is_404(client: AsyncClient):
     owner_key = await _register(client)
     owner_user_id = await _scope_id(client, owner_key)
     session_id = await _create_session(client, owner_key, owner_user_id)

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -301,7 +301,7 @@ async def test_table_folder_share_cascades_and_write_inherits(pool):
     table = await _make_table(pool, scope, owner, folder_id=folder)
     root_table = await _make_table(pool, scope, owner, name="root-table")
 
-    # Before any share the non-member can't see either table.
+    # Before any share the friend can't see either table.
     assert not await permission_service.check_access("table", table, friend)
 
     await _share(pool, scope, "folder", folder, friend, "read", by=owner)
@@ -447,8 +447,8 @@ async def test_share_by_email_grants_page_read_over_http(client: AsyncClient, po
     is private to its owner until shared by email; the grantee (not the owner)
     then reads it, and a stranger still cannot.
 
-    Regression for the single-item read endpoints gating on scope
-    membership and so ignoring shares."""
+    Regression for the single-item read endpoints gating on
+    ownership and so ignoring shares."""
     owner_key, _ = await _register(client)
     page_id = (
         await client.post(
@@ -483,7 +483,7 @@ async def test_share_by_email_grants_page_read_over_http(client: AsyncClient, po
     )
     assert share.status_code == 200
 
-    # The share grants the non-member read access; the stranger is still denied.
+    # The share grants the other user read access; the stranger is still denied.
     assert (await client.get(page_url, headers=_auth(grantee_key))).status_code == 200
     assert (await client.get(page_url, headers=_auth(stranger_key))).status_code == 404
 
@@ -513,7 +513,7 @@ async def test_unshared_file_read_returns_not_found_over_http(client: AsyncClien
 @pytest.mark.asyncio
 async def test_folder_share_by_email_cascades_read_to_children_over_http(client: AsyncClient):
     """A folder share must cascade read to the folder's nested contents for a
-    non-member: end-to-end over the share-by-email HTTP path, the grantee can't
+    non-owner: end-to-end over the share-by-email HTTP path, the grantee can't
     reach a child page until the parent folder is shared, then reads it via the
     canonical object route. Guards the cascade against gating on ownership."""
     owner_key, _ = await _register(client)
@@ -556,7 +556,7 @@ async def test_folder_share_by_email_cascades_read_to_children_over_http(client:
 
 
 @pytest.mark.asyncio
-async def test_write_share_by_email_grants_non_member_write_over_http(
+async def test_write_share_by_email_grants_non_owner_write_over_http(
     client: AsyncClient,
 ):
     """A write share, set up end-to-end over the share-by-email HTTP path, is a
@@ -726,7 +726,7 @@ async def test_public_write_session_folder_requests_are_rejected(client: AsyncCl
 
 
 @pytest.mark.asyncio
-async def test_session_folder_share_by_email_lists_for_non_member(client: AsyncClient):
+async def test_session_folder_share_by_email_lists_for_non_recipient(client: AsyncClient):
     owner_key, _ = await _register(client)
     folder_id = (
         await client.post(
@@ -749,7 +749,7 @@ async def test_session_folder_share_by_email_lists_for_non_member(client: AsyncC
     assert assigned.status_code == 200
 
     grantee_key, _ = await _register_with_email(client, "session-folder-grantee@example.com")
-    # A non-member sees another user's session folder only once it's shared with
+    # Another user sees this user's session folder only once it's shared with
     # them — it surfaces on their "Shared with me" list, not in their own scope.
     before = await client.get("/api/v1/share/with-me", headers=_auth(grantee_key))
     assert before.status_code == 200
@@ -1214,13 +1214,13 @@ async def test_overview_counts_span_shared_not_unshared(pool):
     """The "Your brain" vitals (analytics_service.get_overview_counts) span the
     user's own content plus content shared with them — but a share only surfaces
     the specific shared rows, never the whole sharing scope, and an unrelated
-    user sees nothing. Guards the widened member∪shared prefilter against leaks."""
+    user sees nothing. Guards the widened owned∪shared prefilter against leaks."""
     from backend.services import analytics_service
 
     owner = await _make_user(pool)
     friend = await _make_user(pool)  # gets one folder shared
     stranger = await _make_user(pool)  # gets nothing
-    scope = await _make_scope(pool, owner)  # friend/stranger are NOT members
+    scope = await _make_scope(pool, owner)  # friend/stranger don't own this scope
     folder = await _make_folder(pool, scope, owner)
     await _make_page(pool, scope, owner, folder_id=folder, name="shared-page")
     await _make_page(pool, scope, owner, name="private-root-page")

--- a/backend/tests/test_session_rename.py
+++ b/backend/tests/test_session_rename.py
@@ -111,7 +111,7 @@ async def test_rename_session_rejects_unknown_session(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_rename_session_blocks_non_member(client: AsyncClient):
+async def test_rename_session_blocks_non_owner(client: AsyncClient):
     owner_key, _owner = await _register(client)
     _scope, _session = await _make_scope_with_session(client, owner_key, "sess-rename-5")
 

--- a/backend/tests/test_skill_contents_sync.py
+++ b/backend/tests/test_skill_contents_sync.py
@@ -2,7 +2,7 @@
 skill's full subtree (published or not), PUT replaces the folder's
 contents with an uploaded file set. These lock in the replace semantics —
 exact filenames kept, nesting from relative paths, no orphaned rows — and the
-auth boundary (members only, write access to push)."""
+auth boundary (owner only, write access to push)."""
 
 import pytest
 from httpx import AsyncClient
@@ -61,7 +61,7 @@ async def test_get_contents_inlines_unpublished_skill(client: AsyncClient):
     names = {p["name"] for p in body["contents"]["pages"]}
     assert names == {"SKILL.md"}
 
-    # Members only — anonymous reads are for published slugs, not folders.
+    # Authenticated only — anonymous reads are for published slugs, not folders.
     anon = await client.get(f"/api/v1/me/skills/{folder_id}/contents")
     assert anon.status_code in (401, 403)
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1503,7 +1503,7 @@ async def test_slack_sync_without_channels_records_sync_error(client: AsyncClien
 async def test_slack_event_ingest_fans_out_per_owner(client: AsyncClient):
     from backend.integrations.slack.indexer import ingest_slack_message
 
-    # Two members each connect the same Slack team, but only the source that
+    # Two users each connect the same Slack team, but only the source that
     # explicitly allowed the event channel stores the message.
     owner_a_key, owner_a = await _register(client, "a")
     owner_b_key, owner_b = await _register(client, "b")
@@ -2146,7 +2146,7 @@ async def test_read_source_rejects_unowned_connected_source(client: AsyncClient)
         content="top secret",
     )
 
-    # The other member, asking with their own context, cannot read it.
+    # The other user, asking with their own context, cannot read it.
     scope_token = agent_runtime._scope_ctx.set(ws)
     utoken = agent_runtime._user_ctx.set(other_id)
     try:

--- a/backend/tests/test_table_canonical_lookup.py
+++ b/backend/tests/test_table_canonical_lookup.py
@@ -71,7 +71,7 @@ async def test_column_width_updates_table_metadata(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_non_member_gets_404_not_403(client: AsyncClient):
+async def test_outsider_gets_404_not_403(client: AsyncClient):
     owner_key = await _register(client)
     _, table_id = await _table_in_new_scope(client, owner_key)
     outsider_key = await _register(client)

--- a/frontend/src/components/CustomSelect.test.tsx
+++ b/frontend/src/components/CustomSelect.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import CustomSelect, { CustomSelectOption } from "./CustomSelect";
 
 const OPTIONS: CustomSelectOption[] = [
-  { value: "", label: "All workspaces" },
+  { value: "", label: "All folders" },
   { value: "ws-1", label: "Engineering" },
   { value: "ws-2", label: "Design" },
   { value: "ws-3", label: "Marketing" },
@@ -20,7 +20,7 @@ function Harness({ searchable }: { searchable?: boolean }) {
         value={value}
         options={OPTIONS}
         onChange={setValue}
-        ariaLabel="Workspace"
+        ariaLabel="Folder"
         searchable={searchable}
       />
       <output>{value || "none"}</output>
@@ -33,9 +33,9 @@ afterEach(cleanup);
 describe("CustomSelect searchable", () => {
   it("filters options by the typed query", () => {
     render(<Harness searchable />);
-    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Folder" }));
 
-    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+    fireEvent.change(screen.getByLabelText("Search Folder"), {
       target: { value: "des" },
     });
 
@@ -45,9 +45,9 @@ describe("CustomSelect searchable", () => {
 
   it("selects a filtered match and reports its value", () => {
     render(<Harness searchable />);
-    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Folder" }));
 
-    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+    fireEvent.change(screen.getByLabelText("Search Folder"), {
       target: { value: "mark" },
     });
     fireEvent.click(screen.getByRole("option", { name: /Marketing/ }));
@@ -58,9 +58,9 @@ describe("CustomSelect searchable", () => {
 
   it("selects the first match on Enter from the search input", () => {
     render(<Harness searchable />);
-    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Folder" }));
 
-    const input = screen.getByLabelText("Search Workspace");
+    const input = screen.getByLabelText("Search Folder");
     fireEvent.change(input, { target: { value: "eng" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
@@ -70,9 +70,9 @@ describe("CustomSelect searchable", () => {
 
   it("shows an empty state when nothing matches", () => {
     render(<Harness searchable />);
-    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Folder" }));
 
-    fireEvent.change(screen.getByLabelText("Search Workspace"), {
+    fireEvent.change(screen.getByLabelText("Search Folder"), {
       target: { value: "zzz" },
     });
 
@@ -82,9 +82,9 @@ describe("CustomSelect searchable", () => {
 
   it("renders no search input when not searchable", () => {
     render(<Harness />);
-    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Folder" }));
 
-    expect(screen.queryByLabelText("Search Workspace")).toBeNull();
+    expect(screen.queryByLabelText("Search Folder")).toBeNull();
     expect(screen.getAllByRole("option")).toHaveLength(OPTIONS.length);
   });
 });


### PR DESCRIPTION
## What

Renames stale **prose** that still implied the product has native workspaces / members / membership / viewer-editor roles. Those concepts were removed (each user is now their own single-member scope; cross-user access is the peer-to-peer **shares** engine), but comments, docstrings, `HTTPException` copy, and test names hadn't caught up.

**No behavior changes.** Access gates (`is_owner` / `can_write` / shares) are untouched — only wording.

## How it was found

A multi-agent sweep over all live code (migrations excluded as append-only history): finders flagged candidate prose, then independent skeptics re-read the surrounding code to confirm each was truly the removed concept — ruling out legitimate look-alikes. A follow-up grep caught files the first inventory missed (`tables.py`, `test_table_canonical_lookup.py`, `test_session_rename.py`, plus several `"Viewers can read but not …"` strings).

## Vocabulary mapping

| Fossil | Now |
|---|---|
| "member / non-member / membership" | "user / non-owner / ownership" |
| "Viewer" / "editor" role copy | "owner-only" / "read-only" |
| "scope memberships" | "scope access" |
| fake `"All workspaces"` test fixture | `"All folders"` |

100 prose replacements across 26 files; 11 test functions renamed (each referenced only at its definition).

## Deliberately kept

- External **Slack/Gong** "workspace"/"member" terms.
- The live **shares** / `permission_service` engine wording.
- Chat-message **roles**; UI "viewer" (the page-viewer component / a person viewing).
- `test_migration_members_to_shares.py` and `test_shared_folder_writes.py` — they document the *removal* of the concept, so the old vocabulary is correct there.

## Verification

- `ruff check` — clean
- backend: **144 affected tests pass** (`test_permissions`, `test_collab`, `test_item_canonical_lookup`, `test_table_canonical_lookup`, `test_session_rename`, `test_activity`, `test_skill_contents_sync`, `test_sources`)
- frontend: `CustomSelect.test.tsx` — **5/5 pass**

No product UI behavior changed (the only frontend file is a test fixture), so no screenshots apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
