### PR TITLE
Warn when a VFS `find` listing is truncated

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -183,14 +183,17 @@ async def sources_tree(
 async def list_source_entries(
     source: str,
     path: str = "",
+    limit: int = source_service.ENTRIES_LIMIT,
     current_user: dict = Depends(get_current_user),
 ):
     """List a source's entries like a file system. `source` is 'files',
-    'sessions', or a connected-source id; `path` scopes connected sources."""
+    'sessions', or a connected-source id; `path` scopes connected sources.
+    `limit` caps the rows returned; callers detect truncation by requesting one
+    extra row and checking whether it comes back."""
     owner_user_id = current_user["id"]
     await _require_member(owner_user_id, current_user["id"])
     entries = await source_service.source_entries(
-        owner_user_id, current_user["id"], source, prefix=path
+        owner_user_id, current_user["id"], source, prefix=path, limit=limit
     )
     if entries is None:
         raise HTTPException(status_code=404, detail="Source not found")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -671,7 +671,10 @@ async def prune_index_rows(table: str, source_id: UUID, *, max_age_days: int) ->
     return int(result.split()[-1]) if result.startswith("DELETE") else 0
 
 
-async def list_documents(source: dict, prefix: str = "", limit: int = 200) -> list[dict]:
+ENTRIES_LIMIT = 200
+
+
+async def list_documents(source: dict, prefix: str = "", limit: int = ENTRIES_LIMIT) -> list[dict]:
     """List a source's live documents, optionally under a path prefix. `source`
     is the registry row (from get_owned_source / get_source_for_sync)."""
     table = _table_for(source["source_type"])
@@ -1193,7 +1196,7 @@ async def _audit_source_read(
 
 
 async def source_entries(
-    owner_user_id: UUID, user_id: UUID, source: str, prefix: str = ""
+    owner_user_id: UUID, user_id: UUID, source: str, prefix: str = "", limit: int = ENTRIES_LIMIT
 ) -> list[dict] | None:
     """List a source's entries like a file system. `source` is a handle from
     `list_sources` ('files', 'sessions', or a connected-source id); `prefix`
@@ -1233,9 +1236,11 @@ async def source_entries(
         elif connected["source_type"] == "twitter":
             from ..integrations.twitter.indexer import twitter_live_entries
 
-            entries = twitter_live_entries(prefix) + await list_documents(connected, prefix=prefix)
+            entries = twitter_live_entries(prefix) + await list_documents(
+                connected, prefix=prefix, limit=limit
+            )
         else:
-            entries = await list_documents(connected, prefix=prefix)
+            entries = await list_documents(connected, prefix=prefix, limit=limit)
 
     await _audit_source_read(
         action="source.entries_listed",

--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -241,6 +241,12 @@ class SkillAppVfsShell:
             if name_pattern and not _name_matches(node_path, name_pattern, ignore_name_case):
                 continue
             rows.append(node_path)
+        for source_root, shown in self.model.truncated_roots_under(root):
+            self._warn(
+                f"find: '{source_root}' has more than {shown} entries; only the first "
+                f"{shown} were listed. This result is INCOMPLETE — do not treat it as the "
+                "full set."
+            )
         return "\n".join(rows) + ("\n" if rows else "")
 
     def _tree(self, args: list[str]) -> str:

--- a/cli/client.py
+++ b/cli/client.py
@@ -17,6 +17,11 @@ class StashError(Exception):
         super().__init__(f"[{status_code}] {detail}")
 
 
+# How many entries the VFS materializes per source. The server caps listings;
+# matching that here lets us request one extra row to detect truncation.
+SOURCE_ENTRIES_PAGE = 200
+
+
 class StashClient:
     def __init__(self, base_url: str, api_key: str = ""):
         self._base_url = base_url.rstrip("/")
@@ -528,6 +533,20 @@ class StashClient:
 
     def list_source_entries(self, source: str, path: str = "") -> list:
         return self._list(f"/api/v1/me/sources/{source}/entries", "entries", path=path)
+
+    def list_source_entries_page(self, source: str, path: str = "") -> tuple[list, bool]:
+        """List a source's entries, reporting whether the server truncated them.
+
+        We ask for one row beyond the page size; if it comes back, more rows
+        exist than were returned, so the listing is incomplete."""
+        data = self._get(
+            f"/api/v1/me/sources/{source}/entries",
+            path=path,
+            limit=SOURCE_ENTRIES_PAGE + 1,
+        )
+        entries = data.get("entries", []) if isinstance(data, dict) else data
+        truncated = len(entries) > SOURCE_ENTRIES_PAGE
+        return entries[:SOURCE_ENTRIES_PAGE], truncated
 
     def read_source_doc(self, source: str, ref: str) -> dict:
         return self._get(f"/api/v1/me/sources/{source}/doc", ref=ref)

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -51,10 +51,14 @@ class StashVfsModel:
         # contents are materialized only when something first descends into it, so
         # listing source names stays cheap no matter how large the source is.
         self._expanders: dict[str, Callable[[], None]] = {}
+        # Source-root path -> entries shown, for sources the server truncated.
+        # Lets listing commands warn that the tree is incomplete.
+        self._truncated: dict[str, int] = {}
 
     def refresh(self) -> None:
         self.nodes = {}
         self._expanders = {}
+        self._truncated = {}
         self._add_dir("/")
         self._add_root()
         self._add_static_file(
@@ -312,10 +316,21 @@ class StashVfsModel:
 
     def _expand_source(self, source_root: str, handle: str) -> None:
         try:
-            entries = self.client.list_source_entries(handle, "")
+            entries, truncated = self.client.list_source_entries_page(handle, "")
         except StashError:
             return
+        if truncated:
+            self._truncated[source_root] = len(entries)
         self._add_source_entries(source_root, handle, entries)
+
+    def truncated_roots_under(self, root: str) -> list[tuple[str, int]]:
+        """Truncated source roots overlapping `root` (root contains the source,
+        or sits inside it). Returns (source_root, entries_shown) pairs."""
+        return sorted(
+            (s, shown)
+            for s, shown in self._truncated.items()
+            if s == root or s.startswith(root.rstrip("/") + "/") or root.startswith(s + "/")
+        )
 
     def _add_source_entries(self, source_root: str, handle: str, entries: list[dict]) -> None:
         parent_refs = _ancestor_refs(entries)

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -309,3 +309,34 @@ def test_app_vfs_cat_unreadable_transcript_reports_error_without_traceback():
     assert result.exit_code == 2
     assert result.stdout == ""
     assert "Transcript not found" in result.stderr
+
+
+class TruncatedSourceClient(FakeClient):
+    """The server caps a source's listing. The VFS must announce that the tree
+    is partial — silently returning the first page reads as "this is everything"
+    and produces confident-wrong conclusions about what a source contains."""
+
+    def list_source_entries_page(self, source, path=""):
+        return self.list_source_entries(source, path), True
+
+
+def test_find_warns_loudly_when_a_source_listing_is_truncated():
+    shell, _client = _shell(TruncatedSourceClient())
+
+    result = shell.run("find /sources/gmail -type f")
+
+    # The rows it did get still come back on stdout, uncorrupted by the warning.
+    assert "/sources/gmail/Welcome email" in result.stdout
+    # The incompleteness is surfaced on stderr — not hidden, not mixed into the
+    # file list where a pipe to `wc -l` would silently count it.
+    assert "INCOMPLETE" in result.stderr
+    assert "/sources/gmail" in result.stderr
+
+
+def test_find_is_silent_when_a_source_listing_is_complete():
+    shell, _client = _shell()  # base FakeClient reports not-truncated
+
+    result = shell.run("find /sources/gmail -type f")
+
+    assert "/sources/gmail/Welcome email" in result.stdout
+    assert "INCOMPLETE" not in result.stderr

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -79,6 +79,9 @@ class FakeClient:
             {"path": "threads/msg-2", "name": "Nested note", "kind": "message"},
         ]
 
+    def list_source_entries_page(self, source, path=""):
+        return self.list_source_entries(source, path), False
+
     def read_source_doc(self, source, ref):
         assert source == "src-gmail-1"
         return {"content": f"BODY of {ref}"}


### PR DESCRIPTION
Agents were making mistakes where they would think that a source only has 200 files in it because of our 200-file truncation (for API responsiveness). Now we explicitly tell agents that truncation happened.


# Slop
## Problem
Source listings are capped server-side at 200 entries (`source_service.list_documents`), and the `/entries` endpoint returned them with **no total, no cursor, no truncated flag**. A directory of 810 files was indistinguishable from one of 200, so `stash vfs "find …"` — whose entire job is to enumerate a tree — silently returned the first page and read as complete.

This surfaced in practice: a `find /sources/google -type f` returned exactly 200 results and led to a confident-but-wrong "the indexer only indexed a fraction of the files" conclusion. The source was fully synced (810 items); the listing was just silently truncated. Silent truncation produces confident-wrong conclusions, which is especially damaging for LLM callers reasoning over literal output.

## Change
Make truncation **detectable and loud**, without raising the cap:
- `routers/sources.py` — the `/entries` route accepts an optional `limit` (defaults to `ENTRIES_LIMIT`, so every existing caller behaves exactly as before).
- `source_service.py` — `source_entries`/`list_documents` thread the optional `limit` through; added `ENTRIES_LIMIT = 200`. No return-signature changes, so `agent_runtime` and other callers are untouched.
- `cli/client.py` — `list_source_entries_page()` requests **one row beyond** the page size; if it comes back, the listing is truncated. Precise, not a heuristic — exactly 200 entries does **not** false-alarm.
- `cli/mount.py` — records which source roots came back truncated (`truncated_roots_under`).
- `cli/app_vfs.py` — `find` emits a clear warning to **stderr** (not stdout, so `find | wc -l` stays clean):
  ```
  find: '/sources/google' has more than 200 entries; only the first 200 were
  listed. This result is INCOMPLETE — do not treat it as the full set.
  ```

This does **not** raise the 200 cap — it only stops the listing from lying. `ls`/`tree` share the same cap and are still silent; the plumbing is in place to wire them too in a follow-up.

## Tests
`cli/tests/test_app_vfs.py` — one asserting the warning fires (and stdout stays uncorrupted), one asserting silence when the listing is complete.

- CLI suite: 24 passed · Backend source suites (`test_sources.py`, `test_integration_sources.py`): 115 passed · `ruff`: clean.

## Rollout
Needs a backend deploy to take full effect in prod (the CLI's `limit+1` request only matters once the route honors `limit`); the CLI half ships with the next CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)