### PR TITLE
Migrate Gong integration from API-key to OAuth

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -255,6 +255,12 @@ class Settings:
         "ASANA_OAUTH_REDIRECT_URI", AUTH0_ENABLED
     )
 
+    GONG_OAUTH_CLIENT_ID: str | None = os.getenv("GONG_OAUTH_CLIENT_ID")
+    GONG_OAUTH_CLIENT_SECRET: str | None = os.getenv("GONG_OAUTH_CLIENT_SECRET")
+    GONG_OAUTH_REDIRECT_URI: str | None = parse_oauth_redirect_uri(
+        "GONG_OAUTH_REDIRECT_URI", AUTH0_ENABLED
+    )
+
     SLACK_OAUTH_CLIENT_ID: str | None = os.getenv("SLACK_OAUTH_CLIENT_ID")
     SLACK_OAUTH_CLIENT_SECRET: str | None = os.getenv("SLACK_OAUTH_CLIENT_SECRET")
     SLACK_OAUTH_REDIRECT_URI: str | None = parse_oauth_redirect_uri(

--- a/backend/integrations/gong/__init__.py
+++ b/backend/integrations/gong/__init__.py
@@ -1,4 +1,4 @@
-"""Gong integration: api_key provider.
+"""Gong integration: OAuth provider (Gong Collective marketplace app).
 
 Connected Gong calls are indexed into gong_documents by
 backend/integrations/gong/indexer.py (dispatched from backend/tasks/sources) —

--- a/backend/integrations/gong/indexer.py
+++ b/backend/integrations/gong/indexer.py
@@ -18,7 +18,6 @@ import httpx
 
 from ...services import source_service
 from ..storage import get_valid_token
-from .provider import API_BASE, basic_auth_header
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +52,7 @@ async def _fetch_call_meta(client: httpx.AsyncClient, from_dt: str, to_dt: str) 
         params = {"fromDateTime": from_dt, "toDateTime": to_dt}
         if cursor:
             params["cursor"] = cursor
-        resp = await client.get(f"{API_BASE}/v2/calls", params=params)
+        resp = await client.get("/v2/calls", params=params)
         if resp.status_code == 404:
             break  # no calls in window
         resp.raise_for_status()
@@ -75,7 +74,7 @@ async def _fetch_transcripts(
         body: dict = {"filter": {"fromDateTime": from_dt, "toDateTime": to_dt}}
         if cursor:
             body["cursor"] = cursor
-        resp = await client.post(f"{API_BASE}/v2/calls/transcript", json=body)
+        resp = await client.post("/v2/calls/transcript", json=body)
         if resp.status_code == 404:
             break
         resp.raise_for_status()
@@ -100,11 +99,13 @@ async def index_gong(source: dict) -> str | None:
         raise RuntimeError("no allowed gong accounts configured")
 
     creds = json.loads(await get_valid_token(owner_user_id, "gong"))
-    headers = {"Authorization": basic_auth_header(creds["access_key"], creds["access_key_secret"])}
+    headers = {"Authorization": f"Bearer {creds['access_token']}"}
     to_dt = datetime.now(UTC).isoformat()
     from_dt = (datetime.now(UTC) - timedelta(days=LOOKBACK_DAYS)).isoformat()
 
-    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+    async with httpx.AsyncClient(
+        timeout=120.0, headers=headers, base_url=creds["api_base_url"]
+    ) as client:
         meta_by_id = await _fetch_call_meta(client, from_dt, to_dt)
         transcript_by_id = await _fetch_transcripts(client, from_dt, to_dt)
 
@@ -148,11 +149,13 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
         }
 
     creds = json.loads(await get_valid_token(owner_user_id, "gong"))
-    headers = {"Authorization": basic_auth_header(creds["access_key"], creds["access_key_secret"])}
+    headers = {"Authorization": f"Bearer {creds['access_token']}"}
     from_dt = since.isoformat()
     to_dt = (until or datetime.now(UTC)).isoformat()
 
-    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+    async with httpx.AsyncClient(
+        timeout=120.0, headers=headers, base_url=creds["api_base_url"]
+    ) as client:
         meta_by_id = await _fetch_call_meta(client, from_dt, to_dt)
         transcript_by_id = await _fetch_transcripts(client, from_dt, to_dt)
 

--- a/backend/integrations/gong/provider.py
+++ b/backend/integrations/gong/provider.py
@@ -1,64 +1,130 @@
-"""Gong api_key provider.
+"""Gong OAuth provider (Gong Collective marketplace app).
 
-Gong authenticates per customer with an Access Key + Secret (HTTP Basic),
-not OAuth — Gong OAuth is gated on marketplace-partner approval. The user
-pastes both in the connect form; we validate them against /v2/workspaces and
-store the bundle as the access token (see integrations/base.py for the
-api_key contract).
+Gong issues per-customer OAuth tokens: the token response carries an
+`api_base_url_for_customer` that every later API call for that customer must
+target — customers live on different data-center subdomains, so the generic
+api.gong.io host doesn't work. The storage layer only hands callers back the
+`access_token` string, so we bundle both values into it as JSON
+(`{"access_token", "api_base_url"}`) — the same json-bundle the indexer already
+json.loads(). Refresh re-bundles, so the base URL rides along for free.
+
+Token exchange authenticates with HTTP Basic (client_id:client_secret); the
+returned access token is then sent as a Bearer to the customer's base URL.
 """
 
 from __future__ import annotations
 
 import base64
 import json
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode
 
 import httpx
 
-from ..base import AccountInfo, CredentialField, TokenSet
+from ...config import settings
+from ..base import AccountInfo, Integration, TokenSet
 
-API_BASE = "https://api.gong.io"
+AUTHORIZE_URL = "https://app.gong.io/oauth2/authorize"
+TOKEN_URL = "https://app.gong.io/oauth2/generate-customer-token"
+
+# calls:read:basic lists calls + metadata; calls:read:transcript pulls the
+# transcript text; workspaces:read backs the workspace allowlist and the
+# connected-account label. These must match the scopes configured on the Gong
+# app in the developer hub, or the authorize step is rejected.
+SCOPES = [
+    "api:calls:read:basic",
+    "api:calls:read:transcript",
+    "api:workspaces:read",
+]
 
 
-def basic_auth_header(access_key: str, secret: str) -> str:
-    raw = f"{access_key}:{secret}".encode()
+def _basic_auth(client_id: str, client_secret: str) -> str:
+    raw = f"{client_id}:{client_secret}".encode()
     return "Basic " + base64.b64encode(raw).decode()
 
 
-class GongIntegration:
+class GongIntegration(Integration):
     name = "gong"
     display_name = "Gong"
-    scopes: list[str] = []
-    supports_refresh = False
-    auth_kind = "api_key"
-    credential_fields = [
-        CredentialField("access_key", "Access Key", secret=True, placeholder="Gong API access key"),
-        CredentialField(
-            "access_key_secret", "Access Key Secret", secret=True, placeholder="Gong API secret"
-        ),
-    ]
+    scopes = SCOPES
+    supports_refresh = True
 
-    async def connect_with_credentials(
-        self, values: dict[str, str]
-    ) -> tuple[TokenSet, AccountInfo]:
-        access_key = (values.get("access_key") or "").strip()
-        secret = (values.get("access_key_secret") or "").strip()
-        if not access_key or not secret:
-            raise ValueError("Both Access Key and Access Key Secret are required")
+    def _client_id(self) -> str:
+        if not settings.GONG_OAUTH_CLIENT_ID:
+            raise RuntimeError("GONG_OAUTH_CLIENT_ID is not set")
+        return settings.GONG_OAUTH_CLIENT_ID
 
-        headers = {"Authorization": basic_auth_header(access_key, secret)}
-        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
-            resp = await client.get(f"{API_BASE}/v2/workspaces")
-        # Any non-200 means we couldn't validate the keys — a client error, so
-        # surface it as ValueError (the router maps it to 400) rather than 500.
-        if resp.status_code != 200:
-            raise ValueError(f"Gong rejected these credentials (HTTP {resp.status_code})")
-        workspaces = resp.json().get("workspaces", [])
+    def _client_secret(self) -> str:
+        if not settings.GONG_OAUTH_CLIENT_SECRET:
+            raise RuntimeError("GONG_OAUTH_CLIENT_SECRET is not set")
+        return settings.GONG_OAUTH_CLIENT_SECRET
 
-        display_name = workspaces[0]["name"] if workspaces else "Gong"
-        token = TokenSet(
-            access_token=json.dumps({"access_key": access_key, "access_key_secret": secret}),
-            refresh_token=None,
-            expires_at=None,
-            scopes=[],
+    def _redirect_uri(self) -> str:
+        if not settings.GONG_OAUTH_REDIRECT_URI:
+            raise RuntimeError("GONG_OAUTH_REDIRECT_URI is not set")
+        return settings.GONG_OAUTH_REDIRECT_URI
+
+    def authorize_url(self, state: str) -> str:
+        params = {
+            "client_id": self._client_id(),
+            "response_type": "code",
+            "scope": " ".join(self.scopes),
+            "redirect_uri": self._redirect_uri(),
+            "state": state,
+        }
+        return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str) -> TokenSet:
+        return await self._token_request(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self._redirect_uri(),
+            }
         )
-        return token, AccountInfo(email=None, display_name=display_name)
+
+    async def refresh(self, refresh_token: str) -> TokenSet:
+        token = await self._token_request(
+            {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        )
+        # Gong may omit a new refresh token on refresh — preserve the existing one.
+        if token.refresh_token is None:
+            token.refresh_token = refresh_token
+        return token
+
+    async def _token_request(self, data: dict[str, str]) -> TokenSet:
+        headers = {"Authorization": _basic_auth(self._client_id(), self._client_secret())}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            resp = await client.post(TOKEN_URL, data=data)
+            resp.raise_for_status()
+            payload = resp.json()
+        return _payload_to_tokenset(payload)
+
+    async def revoke(self, access_token: str) -> None:
+        # Gong exposes no token-revocation endpoint; disconnect just drops our
+        # stored row (storage.revoke_stored). Nothing to call upstream.
+        return None
+
+    async def fetch_account(self, access_token: str) -> AccountInfo:
+        creds = json.loads(access_token)
+        headers = {"Authorization": f"Bearer {creds['access_token']}"}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            resp = await client.get(f"{creds['api_base_url']}/v2/workspaces")
+            resp.raise_for_status()
+            workspaces = resp.json().get("workspaces", [])
+        display_name = workspaces[0]["name"] if workspaces else "Gong"
+        return AccountInfo(email=None, display_name=display_name)
+
+
+def _payload_to_tokenset(payload: dict) -> TokenSet:
+    api_base_url = payload["api_base_url_for_customer"].rstrip("/")
+    bundle = json.dumps({"access_token": payload["access_token"], "api_base_url": api_base_url})
+    expires_in = payload.get("expires_in")
+    expires_at = datetime.now(UTC) + timedelta(seconds=int(expires_in)) if expires_in else None
+    scopes_raw = payload.get("scope") or ""
+    return TokenSet(
+        access_token=bundle,
+        refresh_token=payload.get("refresh_token"),
+        expires_at=expires_at,
+        scopes=[s for s in scopes_raw.split() if s],
+    )

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -157,6 +157,11 @@ def _provider_disabled_reason(provider: str) -> str | None:
             "SLACK_OAUTH_CLIENT_SECRET",
             "SLACK_OAUTH_REDIRECT_URI",
         ],
+        "gong": [
+            "GONG_OAUTH_CLIENT_ID",
+            "GONG_OAUTH_CLIENT_SECRET",
+            "GONG_OAUTH_REDIRECT_URI",
+        ],
         "twitter": [
             "TWITTER_OAUTH_CLIENT_ID",
             "TWITTER_OAUTH_REDIRECT_URI",
@@ -186,6 +191,7 @@ def _provider_disabled_reason(provider: str) -> str | None:
             "gmail": "Gmail",
             "notion": "Notion",
             "slack": "Slack",
+            "gong": "Gong",
             "twitter": "Twitter / X",
             "granola": "Granola",
             "jira": "Jira",

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -11,6 +11,7 @@ Two things worth pinning that don't need a DB or live OAuth:
    them — the exact bug that makes a source silently un-syncable.
 """
 
+import json
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -251,11 +252,15 @@ def test_render_call_labels_speakers_and_keeps_transcript():
     assert "[Speaker 1]: likewise" in text
 
 
-def test_gong_is_api_key_searchable_source():
+def test_gong_is_oauth_searchable_source():
     gong = GongIntegration()
-    assert gong.auth_kind == "api_key"
-    assert [f.name for f in gong.credential_fields] == ["access_key", "access_key_secret"]
-    assert all(f.secret for f in gong.credential_fields)
+    assert getattr(gong, "auth_kind", "oauth") == "oauth"
+    assert gong.supports_refresh is True
+    assert {
+        "api:calls:read:basic",
+        "api:calls:read:transcript",
+        "api:workspaces:read",
+    } <= set(gong.scopes)
     assert source_service.normalize_source_settings(
         "gong_calls",
         {"allowed_workspace_ids": ["W1", " W2 ", "W1"]},
@@ -265,12 +270,70 @@ def test_gong_is_api_key_searchable_source():
     assert source_service.SOURCE_CAPABILITY["gong_calls"] == "searchable"
 
 
+def test_gong_authorize_url_carries_scopes_and_redirect(monkeypatch):
+    monkeypatch.setattr(settings, "GONG_OAUTH_CLIENT_ID", "client-1")
+    monkeypatch.setattr(settings, "GONG_OAUTH_CLIENT_SECRET", "secret-1")
+    monkeypatch.setattr(
+        settings,
+        "GONG_OAUTH_REDIRECT_URI",
+        "https://app.example.com/api/v1/integrations/gong/callback",
+    )
+
+    parsed = urlparse(GongIntegration().authorize_url("state-1"))
+    assert parsed.netloc == "app.gong.io"
+    assert parsed.path == "/oauth2/authorize"
+    query = parse_qs(parsed.query)
+    assert query["client_id"] == ["client-1"]
+    assert query["state"] == ["state-1"]
+    assert query["response_type"] == ["code"]
+    assert "api:calls:read:transcript" in query["scope"][0].split()
+
+
 @pytest.mark.asyncio
-async def test_gong_rejects_missing_credentials():
-    with pytest.raises(ValueError):
-        await GongIntegration().connect_with_credentials(
-            {"access_key": "", "access_key_secret": ""}
-        )
+async def test_gong_exchange_refresh_and_fetch_account(monkeypatch):
+    from backend.integrations.gong import provider as gong_provider
+
+    monkeypatch.setattr(settings, "GONG_OAUTH_CLIENT_ID", "client-1")
+    monkeypatch.setattr(settings, "GONG_OAUTH_CLIENT_SECRET", "secret-1")
+    monkeypatch.setattr(settings, "GONG_OAUTH_REDIRECT_URI", "https://app.example.com/callback")
+
+    # The per-customer base URL must be bundled into the stored access token so
+    # later calls hit the customer's data-center subdomain, not api.gong.io.
+    exchange_client = _FakeClient(
+        {
+            "access_token": "tok",
+            "refresh_token": "refresh",
+            "expires_in": 86400,
+            "scope": "api:calls:read:basic api:calls:read:transcript",
+            "api_base_url_for_customer": "https://company-17.api.gong.io",
+        }
+    )
+    monkeypatch.setattr(gong_provider.httpx, "AsyncClient", exchange_client)
+    token = await GongIntegration().exchange_code("code-1")
+    bundle = json.loads(token.access_token)
+    assert bundle == {"access_token": "tok", "api_base_url": "https://company-17.api.gong.io"}
+    assert token.refresh_token == "refresh"
+    assert exchange_client.posts[0][1]["grant_type"] == "authorization_code"
+
+    # Gong omits a new refresh token on refresh — the old one must survive.
+    refresh_client = _FakeClient(
+        {
+            "access_token": "tok2",
+            "expires_in": 86400,
+            "api_base_url_for_customer": "https://company-17.api.gong.io",
+        }
+    )
+    monkeypatch.setattr(gong_provider.httpx, "AsyncClient", refresh_client)
+    refreshed = await GongIntegration().refresh("old-refresh")
+    assert json.loads(refreshed.access_token)["access_token"] == "tok2"
+    assert refreshed.refresh_token == "old-refresh"
+    assert refresh_client.posts[0][1]["grant_type"] == "refresh_token"
+
+    account_client = _FakeClient({"workspaces": [{"id": "W1", "name": "Acme"}]})
+    monkeypatch.setattr(gong_provider.httpx, "AsyncClient", account_client)
+    account = await GongIntegration().fetch_account(refreshed.access_token)
+    assert account.email is None
+    assert account.display_name == "Acme"
 
 
 @pytest.mark.asyncio
@@ -314,7 +377,7 @@ async def test_gong_indexer_filters_to_allowed_accounts(monkeypatch):
     soft_deleted: list[str] = []
 
     async def fake_get_valid_token(user_id, provider):
-        return '{"access_key": "ak", "access_key_secret": "secret"}'
+        return '{"access_token": "tok", "api_base_url": "https://company-17.api.gong.io"}'
 
     async def fake_fetch_call_meta(client, from_dt, to_dt):
         return {

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -228,7 +228,7 @@ function ConnectorAction({
     );
   }
   if (!connected) {
-    // api_key providers (Gong) reveal an inline credential form instead of
+    // api_key providers (Snowflake) reveal an inline credential form instead of
     // redirecting to an OAuth consent screen.
     if (authKind === "api_key") {
       return (

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -53,7 +53,7 @@ export type IntegrationStatus = {
   connected_at: string | null;
   accounts: IntegrationAccount[];
   // "oauth" (redirect flow), "mcp_oauth" (DCR+PKCE via an MCP server, e.g.
-  // Granola), or "api_key" (pasted credentials, e.g. Gong).
+  // Granola), or "api_key" (pasted credentials, e.g. Snowflake).
   auth_kind: "oauth" | "mcp_oauth" | "api_key";
   // Present only for api_key providers — the fields to render in the connect form.
   credential_fields: CredentialField[] | null;
@@ -92,7 +92,7 @@ export async function disconnectIntegration(provider: IntegrationProvider): Prom
 }
 
 /**
- * Connect an api_key provider (e.g. Gong) by POSTing the pasted credential
+ * Connect an api_key provider (e.g. Snowflake) by POSTing the pasted credential
  * values. The backend validates them upstream and stores them encrypted.
  */
 export async function submitCredentials(


### PR DESCRIPTION
Gong uses OAuth now! Snowflake is the last non-OAuth integration


# Slop
## What

Migrates the Gong integration from API-key auth (Access Key + Secret, HTTP Basic) to **OAuth** via the Gong Collective marketplace app, and enables it as an OAuth provider.

## Why

Gong's Collective marketplace app issues **per-customer** OAuth tokens. The token response carries an `api_base_url_for_customer` that every subsequent API call for that customer must target — customers live on different data-center subdomains, so the generic `api.gong.io` host doesn't work.

## How

- **`provider.py`** — `GongIntegration` now subclasses `Integration` and implements the OAuth contract (`authorize_url`, `exchange_code`, `refresh`, `revoke`, `fetch_account`). Token exchange uses HTTP Basic (`client_id:client_secret`); subsequent calls use the token as a Bearer against the customer base URL. The per-customer base URL is bundled with the token as JSON (`{"access_token", "api_base_url"}`) in the stored `access_token`. Refresh preserves the prior refresh token when Gong omits a new one.
- **`indexer.py`** — Reads the bundle, sends Bearer auth, sets `base_url` on the httpx client.
- **`config.py`** — Adds `GONG_OAUTH_CLIENT_ID`, `GONG_OAUTH_CLIENT_SECRET`, `GONG_OAUTH_REDIRECT_URI`.
- **`router.py`** — Registers Gong in the OAuth disabled-reason map (marked unavailable when the env vars are missing).
- **frontend** — Comment-only: swaps the api_key example provider from Gong to Snowflake.

## Tests

`backend/tests/test_integration_sources.py` — replaces api-key tests with OAuth coverage: authorize-URL scopes/redirect, exchange→refresh→fetch_account (base-URL bundling + refresh-token survival), and the indexer's stored-credential shape. All Gong tests pass locally.

## Config note

Enabling in an environment requires setting `GONG_OAUTH_CLIENT_ID`, `GONG_OAUTH_CLIENT_SECRET`, and `GONG_OAUTH_REDIRECT_URI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)