### PR TITLE
Require session_id on every history event; kill "bookkeeping rows"

### DIFF
--- a/backend/migrations/versions/0121_require_event_session_id.py
+++ b/backend/migrations/versions/0121_require_event_session_id.py
@@ -1,0 +1,29 @@
+"""Require session_id on every history event.
+
+Session-less history_events were never a designed concept: a plugin bug
+(hooks reading the session id from local state instead of the hook payload)
+silently pushed transcript events with no session pointer, and the access
+predicate grew a special "bookkeeping rows" carve-out to accommodate them.
+The plugin bug is fixed and the API now rejects events without a session_id,
+so the orphaned rows are deleted and the column becomes NOT NULL — one row
+shape, one access rule (an event is readable iff its session is readable).
+
+Revision ID: 0121
+Revises: 0120
+"""
+
+from alembic import op
+
+revision = "0121"
+down_revision = "0120"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM history_events WHERE session_id IS NULL")
+    op.execute("ALTER TABLE history_events ALTER COLUMN session_id SET NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE history_events ALTER COLUMN session_id DROP NOT NULL")

--- a/backend/models.py
+++ b/backend/models.py
@@ -471,7 +471,7 @@ class HistoryEventCreateRequest(BaseModel):
     agent_name: str = Field(..., min_length=1, max_length=64)
     event_type: str = Field(..., min_length=1, max_length=64)
     content: str = Field(..., min_length=1)
-    session_id: str | None = Field(None, max_length=64)
+    session_id: str = Field(..., min_length=1, max_length=64)
     session_folder_id: UUID | None = Field(
         None, description="Pinned folder for this session (from the repo manifest)"
     )

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -96,7 +96,7 @@ async def push_event(
     event_type: str,
     content: str,
     created_by: UUID,
-    session_id: str | None = None,
+    session_id: str,
     session_folder_id: UUID | None = None,
     tool_name: str | None = None,
     metadata: dict | None = None,
@@ -252,15 +252,13 @@ def readable_session_event_condition(event_alias: str, user_arg: int) -> str:
     """SQL predicate: may user ${user_arg} read the session this history_events
     row belongs to? Resolves the row to its session and delegates to the one
     access predicate for 'session' (owner / a live session or session-folder
-    share / a public session folder) — no duplicated share logic. Events with no
-    session_id are bookkeeping rows scoped to their owner by the outer query."""
+    share / a public session folder) — no duplicated share logic."""
     session_access = permission_service.readable_content_condition(
         "session", "readable_session", user_arg
     )
     return f"""
         (
-          {event_alias}.session_id IS NULL
-          OR EXISTS (
+          EXISTS (
             SELECT 1
             FROM sessions readable_session
             WHERE readable_session.owner_user_id = {event_alias}.owner_user_id

--- a/backend/tests/test_history_pagination.py
+++ b/backend/tests/test_history_pagination.py
@@ -113,3 +113,25 @@ async def test_all_history_events_before_cursor(client: AsyncClient):
     older_body = older.json()
     assert [e["content"] for e in older_body["events"]] == ["event-1"]
     assert older_body["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_event_without_session_id_is_rejected(client: AsyncClient):
+    """Every history event belongs to a session — access control resolves an
+    event to its session, so a session-less event would be unreachable by the
+    permission predicate. The API must reject it loudly, not store an orphan
+    (a plugin bug once produced thousands of these; see migration 0121)."""
+    api_key = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={"agent_name": "tester", "event_type": "note", "content": "orphan"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 422
+
+    resp = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={"events": [{"agent_name": "tester", "event_type": "note", "content": "orphan"}]},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 422

--- a/cli/client.py
+++ b/cli/client.py
@@ -336,15 +336,18 @@ class StashClient:
         agent_name: str,
         event_type: str,
         content: str,
-        session_id: str | None = None,
+        session_id: str,
         tool_name: str | None = None,
         metadata: dict | None = None,
         attachments: list[dict] | None = None,
         created_at: str | None = None,
     ) -> dict:
-        body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
-        if session_id:
-            body["session_id"] = session_id
+        body: dict = {
+            "agent_name": agent_name,
+            "event_type": event_type,
+            "content": content,
+            "session_id": session_id,
+        }
         if tool_name:
             body["tool_name"] = tool_name
         if metadata:

--- a/cli/main.py
+++ b/cli/main.py
@@ -2095,7 +2095,7 @@ def hist_push(
     content: str = typer.Argument(...),
     agent_name: str = typer.Option("cli", "--agent"),
     event_type: str = typer.Option("message", "--type"),
-    session_id: str = typer.Option(None, "--session"),
+    session_id: str = typer.Option(..., "--session"),
     tool_name: str = typer.Option(None, "--tool"),
     attach: list[str] = typer.Option(
         None, "--attach", help="Local file path to upload and attach (repeatable)."

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -112,16 +112,16 @@ def stash_push_event(
     agent_name: str,
     event_type: str,
     content: str,
-    session_id: str = "",
+    session_id: str,
     tool_name: str = "",
 ) -> str:
-    """Push a new event into your sessions."""
+    """Push a new event into a session's stream."""
     return _json(
         _client().push_event(
             agent_name=agent_name,
             event_type=event_type,
             content=content,
-            session_id=session_id or None,
+            session_id=session_id,
             tool_name=tool_name or None,
         )
     )

--- a/plugins/tests/test_adapters.py
+++ b/plugins/tests/test_adapters.py
@@ -193,6 +193,7 @@ def test_push_event_stamps_client_into_metadata():
         agent_name="henry",
         event_type="tool_use",
         content="...",
+        session_id="s1",
         tool_name="edit",
         metadata={"cwd": "/tmp"},
         client="cursor",
@@ -205,6 +206,7 @@ def test_push_event_stamps_client_into_metadata():
         agent_name="henry",
         event_type="user_message",
         content="hi",
+        session_id="s1",
         client="claude_code",
     )
     body = calls[-1][1]["json"]
@@ -214,6 +216,7 @@ def test_push_event_stamps_client_into_metadata():
         agent_name="henry",
         event_type="user_message",
         content="hi",
+        session_id="s1",
     )
     body = calls[-1][1]["json"]
     assert "metadata" not in body

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -64,6 +64,7 @@ def test_failed_push_enqueues(tmp_path):
             agent_name="a",
             event_type="tool_use",
             content="x",
+            session_id="s1",
         )
     queued = _queue_lines(tmp_path)
     assert len(queued) == 1
@@ -84,11 +85,11 @@ def test_successful_push_drains_backlog(tmp_path):
     client = _make_client(tmp_path, fail_first_n=2)
     for i in range(2):
         with pytest.raises(Exception):
-            client.push_event(agent_name="a", event_type="t", content=f"e{i}")
+            client.push_event(agent_name="a", event_type="t", content=f"e{i}", session_id="s1")
     assert len(_queue_lines(tmp_path)) == 2
 
     # Third push: succeeds + drains backlog.
-    client.push_event(agent_name="a", event_type="t", content="e2")
+    client.push_event(agent_name="a", event_type="t", content="e2", session_id="s1")
 
     # Queue should be empty after drain.
     assert _queue_lines(tmp_path) == []
@@ -105,13 +106,13 @@ def test_drain_stops_on_first_failure(tmp_path):
     """If backend is still down during drain, leftover entries stay queued."""
     client = _make_client(tmp_path, fail_first_n=1)
     with pytest.raises(Exception):
-        client.push_event(agent_name="a", event_type="t", content="e0")
+        client.push_event(agent_name="a", event_type="t", content="e0", session_id="s1")
     assert len(_queue_lines(tmp_path)) == 1
 
     # Force the recorder to fail the next 5 POSTs (live push + drain attempts).
     client._http.fail_first_n = len(client._http.calls) + 5
     with pytest.raises(Exception):
-        client.push_event(agent_name="a", event_type="t", content="e1")
+        client.push_event(agent_name="a", event_type="t", content="e1", session_id="s1")
 
     # Both events should still be queued (live push failed; drain never ran).
     queued = _queue_lines(tmp_path)
@@ -124,5 +125,5 @@ def test_no_data_dir_no_queue(tmp_path):
     client = StashClient(base_url="https://example.test", api_key="k")
     client._http = _Recorder(fail_first_n=1)
     with pytest.raises(Exception):
-        client.push_event(agent_name="a", event_type="t", content="x")
+        client.push_event(agent_name="a", event_type="t", content="x", session_id="s1")
     assert not (tmp_path / QUEUE_FILENAME).exists()

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -275,12 +275,15 @@ def stream_user_message(
         return
     if not prompt_text or not prompt_text.strip():
         return
+    sid = (event.session_id if event is not None else "") or state.get("session_id", "")
+    if not sid:
+        return
     try:
         client.push_event(
             agent_name=cfg["agent_name"],
             event_type="user_message",
             content=prompt_text,
-            session_id=state.get("session_id", ""),
+            session_id=sid,
             session_folder_id=cfg.get("session_folder_id") or None,
             metadata=_event_metadata(event),
             client=cfg.get("client") or None,
@@ -299,6 +302,9 @@ def stream_tool_use(
         return
     if not event.tool_name:
         return
+    sid = event.session_id or state.get("session_id", "")
+    if not sid:
+        return
 
     content, metadata = summarize_tool_use(
         event.tool_name, event.tool_input, event.tool_response,
@@ -314,7 +320,7 @@ def stream_tool_use(
             agent_name=cfg["agent_name"],
             event_type="tool_use",
             content=content,
-            session_id=state.get("session_id", ""),
+            session_id=sid,
             session_folder_id=cfg.get("session_folder_id") or None,
             tool_name=event.tool_name,
             metadata=metadata,
@@ -336,12 +342,15 @@ def stream_assistant_message(
         return
     if not event.last_assistant_message:
         return
+    sid = event.session_id or state.get("session_id", "")
+    if not sid:
+        return
     try:
         client.push_event(
             agent_name=cfg["agent_name"],
             event_type="assistant_message",
             content=event.last_assistant_message,
-            session_id=state.get("session_id", ""),
+            session_id=sid,
             session_folder_id=cfg.get("session_folder_id") or None,
             metadata=_event_metadata(event),
             client=cfg.get("client") or None,

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -96,13 +96,14 @@ class StashClient:
     def push_event(
         self,
         agent_name: str, event_type: str, content: str,
-        session_id: str | None = None, tool_name: str | None = None,
+        session_id: str, tool_name: str | None = None,
         metadata: dict | None = None, client: str | None = None,
         session_folder_id: str | None = None,
     ) -> dict:
-        body: dict = {"agent_name": agent_name, "event_type": event_type, "content": content}
-        if session_id:
-            body["session_id"] = session_id
+        body: dict = {
+            "agent_name": agent_name, "event_type": event_type,
+            "content": content, "session_id": session_id,
+        }
         # Pin streamed on every event so the session lands in the right folder
         # no matter which event creates the row (agents without a session-start
         # hook create it from the first event, not from create_session).


### PR DESCRIPTION
We had this problem where we would have orphaned events with no session id, clogging up our database and never being consumed anywhere.This would confuse AI models because they would think that these have some purpose (it at some point, thought they were "bookkeeping rows"), but they're really completely useless. Now we don't allow these events to be created.

Why were we not adding session_id sometimes? Was it not available? nope. The old code just forgot to.


# Slop 
## What & why

Session-less `history_events` ("bookkeeping rows") were never a designed concept — they were the output of a plugin bug, later rationalized into the access layer:

- Three hook functions (`stream_user_message`, `stream_tool_use`, `stream_assistant_message`) read the session id from **local state** instead of the hook payload, so whenever state wasn't populated they silently pushed transcript events with no session pointer. Prod had **14,268 orphaned rows** (~9% of all events), produced as recently as June 23. Their sibling functions already read `event.session_id or state` — this was a plain bug.
- `readable_session_event_condition` then grew a carve-out: `session_id IS NULL` rows pass the predicate, with owner-scoping delegated to an *implicit* contract that every caller filters by owner.
- `query_all_events` broke that contract: its owner filter is the coarse `accessible_scope_ids` prefilter ("anyone who shared **anything** with me"), and the predicate's NULL branch never narrowed it. **Sharing a single page with someone exposed all of your session-less events to them.**

Nothing in the backend ever consumed session-less rows on purpose. So instead of patching the carve-out, this removes the concept.

## Changes

- **Root fix:** the three hook functions resolve `event.session_id or state.get(...)` like their siblings, and skip the push when there is no session id.
- **`session_id` required end-to-end:** both client libraries always send it; the MCP tool and `stash events push --session` require it; `HistoryEventCreateRequest` requires it (covers single + batch endpoints); `memory_service.push_event` signature matches. A session-less push now fails loudly (422) at every layer.
- **Migration 0121:** deletes orphaned rows, sets `history_events.session_id NOT NULL`.
- **Predicate:** the `IS NULL` branch and the "bookkeeping rows" docstring are deleted. One row shape, one rule: an event is readable iff its session is readable. The `query_all_events` over-exposure is structurally impossible now.

Prod orphans were already deleted directly (approved); the migration mops up anything stale plugins push before their next update — those pushes 422 and are dropped, which is acceptable for the current alpha user base.

## Conflicts

Trivially conflicts with #696, which rewrites `readable_session_event_condition` to delegate to the unified predicate. Whoever merges second keeps the delegation **without** re-adding a NULL branch.

## Test plan

- New API test: pushing an event without `session_id` returns 422 on both single and batch endpoints (docstring encodes why: the permission predicate resolves events through their session, so an orphan would be unreachable).
- Backend suite: 576 passed (1 pre-existing failure on `main`: `test_gong_index_success_logs_internal_source_id_only`, unrelated Gong OAuth issue).
- Plugin + CLI suites: 178 passed. `ruff` clean on all touched files.

Backend + plugin + CLI, no GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)