### PR TITLE
Page source entries with a keyset cursor; expose external_ref

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -350,7 +350,9 @@ async def fork_skill(
     # Forking writes new pages/files/sessions into the scope — same bar as
     # creating a Skill.
     if not await user_scope_service.can_write(req.owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="You have read-only access and cannot create Skills")
+        raise HTTPException(
+            status_code=403, detail="You have read-only access and cannot create Skills"
+        )
     forked = await shared_skill_service.fork_skill(req.owner_user_id, slug, current_user["id"])
     if not forked:
         raise HTTPException(status_code=404, detail="Skill not found")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -184,16 +184,18 @@ async def list_source_entries(
     source: str,
     path: str = "",
     limit: int = source_service.ENTRIES_LIMIT,
+    after: str = "",
     current_user: dict = Depends(get_current_user),
 ):
     """List a source's entries like a file system. `source` is 'files',
     'sessions', or a connected-source id; `path` scopes connected sources.
     `limit` caps the rows returned; callers detect truncation by requesting one
-    extra row and checking whether it comes back."""
+    extra row and checking whether it comes back. `after` is a keyset cursor
+    (the last path of the previous page) for paging through big sources."""
     owner_user_id = current_user["id"]
     await _require_member(owner_user_id, current_user["id"])
     entries = await source_service.source_entries(
-        owner_user_id, current_user["id"], source, prefix=path, limit=limit
+        owner_user_id, current_user["id"], source, prefix=path, limit=limit, after=after
     )
     if entries is None:
         raise HTTPException(status_code=404, detail="Source not found")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -691,51 +691,68 @@ async def prune_index_rows(table: str, source_id: UUID, *, max_age_days: int) ->
 ENTRIES_LIMIT = 200
 
 
-async def list_documents(source: dict, prefix: str = "", limit: int = ENTRIES_LIMIT) -> list[dict]:
+async def list_documents(
+    source: dict, prefix: str = "", limit: int = ENTRIES_LIMIT, after: str = ""
+) -> list[dict]:
     """List a source's live documents, optionally under a path prefix. `source`
-    is the registry row (from get_owned_source / get_source_for_sync)."""
+    is the registry row (from get_owned_source / get_source_for_sync). `after`
+    is a keyset cursor: only paths strictly greater (in the ORDER BY path
+    ordering) are returned, so callers page through big sources by passing the
+    last path of the previous page."""
     table = _table_for(source["source_type"])
     if table == "slack_messages":
         allowed_channel_ids = slack_allowed_channel_ids(source)
         if not allowed_channel_ids:
             return []
         rows = await get_pool().fetch(
-            f"SELECT path, name, kind FROM {table} "
-            f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 "
-            f"AND channel_id = ANY($4::text[]) "
+            f"SELECT path, name, kind, external_ref FROM {table} "
+            f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
+            f"AND channel_id = ANY($5::text[]) "
             f"ORDER BY path LIMIT $3",
             UUID(source["id"]),
             f"{prefix}%",
             limit,
+            after,
             allowed_channel_ids,
         )
-        return [{"path": r["path"], "name": r["name"], "kind": r["kind"]} for r in rows]
+        return [_entry_row(r) for r in rows]
 
     if table == "gong_documents":
         allowed_workspace_ids = gong_allowed_workspace_ids(source)
         if not allowed_workspace_ids:
             return []
         rows = await get_pool().fetch(
-            f"SELECT path, name, kind FROM {table} "
-            f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 "
-            f"AND gong_account_id = ANY($4::text[]) "
+            f"SELECT path, name, kind, external_ref FROM {table} "
+            f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
+            f"AND gong_account_id = ANY($5::text[]) "
             f"ORDER BY path LIMIT $3",
             UUID(source["id"]),
             f"{prefix}%",
             limit,
+            after,
             allowed_workspace_ids,
         )
-        return [{"path": r["path"], "name": r["name"], "kind": r["kind"]} for r in rows]
+        return [_entry_row(r) for r in rows]
 
     rows = await get_pool().fetch(
-        f"SELECT path, name, kind FROM {table} "
-        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 "
+        f"SELECT path, name, kind, external_ref FROM {table} "
+        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
         f"ORDER BY path LIMIT $3",
         UUID(source["id"]),
         f"{prefix}%",
         limit,
+        after,
     )
-    return [{"path": r["path"], "name": r["name"], "kind": r["kind"]} for r in rows]
+    return [_entry_row(r) for r in rows]
+
+
+def _entry_row(r) -> dict:
+    return {
+        "path": r["path"],
+        "name": r["name"],
+        "kind": r["kind"],
+        "external_ref": r["external_ref"],
+    }
 
 
 async def _read_twitter_live_ref(source: dict, ref: str) -> dict:
@@ -1217,21 +1234,30 @@ async def _audit_source_read(
 
 
 async def source_entries(
-    owner_user_id: UUID, user_id: UUID, source: str, prefix: str = "", limit: int = ENTRIES_LIMIT
+    owner_user_id: UUID,
+    user_id: UUID,
+    source: str,
+    prefix: str = "",
+    limit: int = ENTRIES_LIMIT,
+    after: str = "",
 ) -> list[dict] | None:
     """List a source's entries like a file system. `source` is a handle from
     `list_sources` ('files', 'sessions', or a connected-source id); `prefix`
-    scopes connected sources to a path. Returns None for an unknown source."""
+    scopes connected sources to a path. `after` pages through path-ordered
+    document listings (see list_documents); listings that aren't path-ordered
+    (native files/sessions, queryable tables, twitter's live refs) return
+    everything on the first page, so any later page is empty for them.
+    Returns None for an unknown source."""
     connected = None
     if source == NATIVE_FILES:
         from .files_tree_service import list_scope_pages
 
-        pages = await list_scope_pages(owner_user_id, user_id)
+        pages = [] if after else await list_scope_pages(owner_user_id, user_id)
         entries = [{"id": str(p["id"]), "name": p["name"], "kind": "page"} for p in pages]
     elif source == NATIVE_SESSIONS:
         from .memory_service import list_scope_sessions
 
-        sessions = await list_scope_sessions(owner_user_id, user_id)
+        sessions = [] if after else await list_scope_sessions(owner_user_id, user_id)
         entries = [
             {"id": s["session_id"], "name": s.get("agent_name") or "session", "kind": "session"}
             for s in sessions
@@ -1245,7 +1271,7 @@ async def source_entries(
             from ..integrations.snowflake.client import SnowflakeMetadataError, list_tables
 
             try:
-                entries = await list_tables(connected)
+                entries = [] if after else await list_tables(connected)
             except SnowflakeMetadataError as e:
                 logger.warning(
                     "source entries failed source=%s source_type=%s exception_type=%s",
@@ -1257,11 +1283,12 @@ async def source_entries(
         elif connected["source_type"] == "twitter":
             from ..integrations.twitter.indexer import twitter_live_entries
 
-            entries = twitter_live_entries(prefix) + await list_documents(
-                connected, prefix=prefix, limit=limit
+            live = [] if after else twitter_live_entries(prefix)
+            entries = live + await list_documents(
+                connected, prefix=prefix, limit=limit, after=after
             )
         else:
-            entries = await list_documents(connected, prefix=prefix, limit=limit)
+            entries = await list_documents(connected, prefix=prefix, limit=limit, after=after)
 
     await _audit_source_read(
         action="source.entries_listed",
@@ -1698,6 +1725,37 @@ async def fetch_history(
     return result
 
 
+async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> list[dict]:
+    """Documents whose provider id (`external_ref`) exactly equals the query,
+    across the given sources' document tables."""
+    query = query.strip()
+    if not query:
+        return []
+    hits: list[dict] = []
+    for s in sources:
+        table = SOURCE_TABLE.get(s["source_type"])
+        if table is None:
+            continue
+        rows = await get_pool().fetch(
+            f"SELECT path, name FROM {table} "
+            f"WHERE source_id = $1 AND external_ref = $2 AND deleted_at IS NULL LIMIT $3",
+            UUID(s["id"]),
+            query,
+            limit,
+        )
+        hits += [
+            {
+                "source": s["id"],
+                "source_name": s["display_name"],
+                "ref": r["path"],
+                "name": r["name"],
+                "snippet": "",
+            }
+            for r in rows
+        ]
+    return hits
+
+
 async def search_all(
     owner_user_id: UUID,
     user_id: UUID,
@@ -1744,6 +1802,15 @@ async def search_all(
         if connected is None:
             return None
     if source is None or connected is not None:
+        searched_sources = (
+            [connected] if connected is not None else await list_connected_sources(user_id)
+        )
+
+        # A query that IS a provider id (a Drive file id, a Gmail message id, …)
+        # resolves to the indexed document directly. This is how an agent holding
+        # only a provider URL finds the document's Stash path.
+        results += await _external_ref_matches(searched_sources, query, limit)
+
         # Copied-content sources go through our FTS (returns [] for index-only /
         # federated sources, which have no stored content to match).
         docs = await search_documents(
@@ -1774,7 +1841,7 @@ async def search_all(
         else:
             federated = [
                 s
-                for s in await list_connected_sources(user_id)
+                for s in searched_sources
                 if s["source_type"] in FEDERATED_SEARCH_TYPES
                 and s["source_type"] not in SCOPED_ONLY_SEARCH_TYPES
             ]

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1382,9 +1382,7 @@ async def _member_tree(source: dict, depth: int, per_dir: int) -> list[dict]:
     return build_entry_tree(entries, depth, per_dir)
 
 
-async def _provider_tree_node(
-    provider: str, members: list[dict], depth: int, per_dir: int
-) -> dict:
+async def _provider_tree_node(provider: str, members: list[dict], depth: int, per_dir: int) -> dict:
     """One provider folder for the sources filesystem. A single connection
     collapses — its documents sit directly in the provider folder. Multiple
     connections each become a subfolder named after the connection."""

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -627,6 +627,70 @@ async def test_missing_index_only_rows_are_soft_deleted(client: AsyncClient, poo
     assert await source_service.list_documents(src) == []
 
 
+@pytest.mark.asyncio
+async def test_list_documents_pages_with_after_cursor(client: AsyncClient):
+    """A source bigger than one page must be fully reachable by walking the
+    `after` keyset cursor — before this, everything past the first page was
+    invisible to the VFS (a 6k-message Gmail showed 200 messages)."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="google_drive",
+        external_ref="drive-root",
+        display_name="Drive",
+    )
+    sid = UUID(src["id"])
+    for i in range(5):
+        await source_service.upsert_index_row(
+            table="drive_index",
+            source_id=sid,
+            owner_user_id=ws,
+            path=f"doc-{i}",
+            name=f"Doc {i}",
+            external_ref=f"file-id-{i}",
+        )
+
+    page_one = await source_service.list_documents(src, limit=2)
+    page_two = await source_service.list_documents(src, limit=2, after=page_one[-1]["path"])
+    page_three = await source_service.list_documents(src, limit=2, after=page_two[-1]["path"])
+
+    assert [d["path"] for d in page_one] == ["doc-0", "doc-1"]
+    assert [d["path"] for d in page_two] == ["doc-2", "doc-3"]
+    assert [d["path"] for d in page_three] == ["doc-4"]
+    # The provider id rides along so callers can tie a path to the provider object.
+    assert page_one[0]["external_ref"] == "file-id-0"
+
+
+@pytest.mark.asyncio
+async def test_search_all_resolves_a_provider_id_to_its_document(client: AsyncClient):
+    """An agent holding only a provider URL (a Drive link, a GitHub blob) must
+    be able to resolve the id inside it to the document's Stash path — the
+    external_ref is the only join key between the provider's world and ours."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref="acme/widgets",
+        display_name="acme/widgets",
+    )
+    await source_service.upsert_content_document(
+        table="github_documents",
+        source_id=UUID(src["id"]),
+        owner_user_id=ws,
+        path="docs/status.md",
+        name="status.md",
+        content="quarterly integration status",
+        external_ref="gh-blob-1a2b3c",
+    )
+
+    results = await source_service.search_all(ws, owner_id, "gh-blob-1a2b3c", source=src["id"])
+
+    assert [(r["ref"], r["name"]) for r in results] == [("docs/status.md", "status.md")]
+    assert await source_service.search_all(ws, owner_id, "no-such-id", source=src["id"]) == []
+
+
 # --- search-driven sources (twitter) -----------------------------------------
 
 

--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -673,13 +673,16 @@ class SkillAppVfsShell:
         attrs = self.model.getattr(path)
         node = self.model._get_node(path)
         kind = "directory" if node.is_dir else "file"
-        return (
+        out = (
             f"{path}\n"
             f"  type: {kind}\n"
             f"  size: {attrs.get('st_size', 0)}\n"
             f"  modified: {_iso_time(node.updated_at)}\n"
             f"  created: {_iso_time(node.created_at)}\n"
         )
+        if node.external_ref:
+            out += f"  external_ref: {node.external_ref}\n"
+        return out
 
     def _read_text(self, path: str) -> str:
         return self.model.read_file(path).decode("utf-8", errors="replace")

--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -381,8 +381,13 @@ class SkillAppVfsShell:
 
         if stdin is not None and not paths:
             output = _grep_text(
-                regex, stdin, "", show_line_numbers=False, prefix_path=False,
-                before=before, after=after,
+                regex,
+                stdin,
+                "",
+                show_line_numbers=False,
+                prefix_path=False,
+                before=before,
+                after=after,
             )
             if not output:
                 raise VfsShellExit(1)

--- a/cli/client.py
+++ b/cli/client.py
@@ -17,9 +17,9 @@ class StashError(Exception):
         super().__init__(f"[{status_code}] {detail}")
 
 
-# How many entries the VFS materializes per source. The server caps listings;
-# matching that here lets us request one extra row to detect truncation.
-SOURCE_ENTRIES_PAGE = 200
+# Page size when the VFS walks a source's entries. Callers page with the
+# `after` cursor until a page comes back non-full.
+SOURCE_ENTRIES_PAGE = 1000
 
 
 class StashClient:
@@ -537,15 +537,19 @@ class StashClient:
     def list_source_entries(self, source: str, path: str = "") -> list:
         return self._list(f"/api/v1/me/sources/{source}/entries", "entries", path=path)
 
-    def list_source_entries_page(self, source: str, path: str = "") -> tuple[list, bool]:
-        """List a source's entries, reporting whether the server truncated them.
+    def list_source_entries_page(
+        self, source: str, path: str = "", after: str = ""
+    ) -> tuple[list, bool]:
+        """One page of a source's entries, reporting whether more pages exist.
 
         We ask for one row beyond the page size; if it comes back, more rows
-        exist than were returned, so the listing is incomplete."""
+        exist. `after` is the keyset cursor: pass the last path of the previous
+        page to fetch the next one."""
         data = self._get(
             f"/api/v1/me/sources/{source}/entries",
             path=path,
             limit=SOURCE_ENTRIES_PAGE + 1,
+            after=after,
         )
         entries = data.get("entries", []) if isinstance(data, dict) else data
         truncated = len(entries) > SOURCE_ENTRIES_PAGE

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -256,7 +256,9 @@ class StashVfsModel:
         self._add_dir(tables_path)
         tables = self.client.list_tables()
         self._add_jsonl_file(f"{tables_path}/_index.jsonl", tables)
-        ambiguous = _ambiguous_basenames([_safe_name(table.get("name") or "table") for table in tables])
+        ambiguous = _ambiguous_basenames(
+            [_safe_name(table.get("name") or "table") for table in tables]
+        )
         for table in tables:
             table_id = str(table["id"])
             created_at = table.get("created_at")

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -18,6 +18,11 @@ from .client import StashClient, StashError
 
 BytesLoader = Callable[[], bytes]
 
+# Hard ceiling on entries materialized per source. A source bigger than this
+# gets a truncation warning from the listing commands rather than an
+# ever-growing tree walk.
+SOURCE_ENTRIES_MAX = 10_000
+
 
 class MountError(Exception):
     pass
@@ -33,6 +38,9 @@ class VfsNode:
     children: dict[str, str] = field(default_factory=dict)
     created_at: float | None = None
     updated_at: float | None = None
+    # Provider-side id of a connected-source document (a Drive file id, a Gmail
+    # message id, …), so `stat` can tie a VFS path back to the provider object.
+    external_ref: str | None = None
 
     @property
     def is_dir(self) -> bool:
@@ -315,12 +323,22 @@ class StashVfsModel:
                 )
 
     def _expand_source(self, source_root: str, handle: str) -> None:
-        try:
-            entries, truncated = self.client.list_source_entries_page(handle, "")
-        except StashError:
-            return
-        if truncated:
-            self._truncated[source_root] = len(entries)
+        entries: list[dict] = []
+        after = ""
+        while True:
+            try:
+                page, truncated = self.client.list_source_entries_page(handle, "", after=after)
+            except StashError:
+                break
+            entries.extend(page)
+            if not truncated:
+                break
+            after = str(page[-1].get("path") or "")
+            if not after or len(entries) >= SOURCE_ENTRIES_MAX:
+                # No cursor to continue from (a listing that isn't path-keyed),
+                # or the source is beyond what we'll materialize in one tree.
+                self._truncated[source_root] = len(entries)
+                break
         self._add_source_entries(source_root, handle, entries)
 
     def truncated_roots_under(self, root: str) -> list[tuple[str, int]]:
@@ -349,18 +367,22 @@ class StashVfsModel:
             # A page that also has child pages becomes a directory holding its own
             # body in a same-named index file, so the children nest under it
             # instead of being dropped on the file/dir name collision.
+            external_ref = entry.get("external_ref") or None
             if ref in parent_refs:
                 page_dir = self._add_dir(f"{parent}/{display}")
-                self._add_source_doc_file(f"{page_dir}/{display}", handle, ref)
+                self._add_source_doc_file(f"{page_dir}/{display}", handle, ref, external_ref)
                 continue
-            self._add_source_doc_file(f"{parent}/{display}", handle, ref)
+            self._add_source_doc_file(f"{parent}/{display}", handle, ref, external_ref)
 
-    def _add_source_doc_file(self, path: str, handle: str, ref: str) -> str:
+    def _add_source_doc_file(
+        self, path: str, handle: str, ref: str, external_ref: str | None = None
+    ) -> str:
         return self._add_file(
             path,
             loader=lambda h=handle, r=ref: _text_bytes(
                 _source_doc_text(self.client.read_source_doc(h, r))
             ),
+            external_ref=external_ref,
         )
 
     def _load_page(self, page_id: str) -> bytes:
@@ -425,6 +447,7 @@ class StashVfsModel:
         size_hint: int | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,
+        external_ref: str | None = None,
     ) -> str:
         path = self._clean_path(path)
         parent, requested_name = self._split_parent(path)
@@ -442,6 +465,7 @@ class StashVfsModel:
             ),
             created_at=_parse_iso(created_at),
             updated_at=_parse_iso(updated_at),
+            external_ref=external_ref,
         )
         self.nodes[parent].children[name] = path
         return path

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -80,9 +80,7 @@ def _page_path(shell: SkillAppVfsShell) -> str:
         name for name in shell.model.list_dir(files_path) if name.startswith("Notes")
     )
     folder_path = f"{files_path}/{folder_name}"
-    page_name = next(
-        name for name in shell.model.list_dir(folder_path) if name.startswith("Plan")
-    )
+    page_name = next(name for name in shell.model.list_dir(folder_path) if name.startswith("Plan"))
     return f"{folder_path}/{page_name}"
 
 
@@ -121,9 +119,7 @@ def test_app_vfs_surfaces_backend_timestamps_and_marks_unknown():
     assert _ls_time(page_node.updated_at) in shell.run(f"ls -l {page_path}").stdout
 
     # An uploaded file is immutable, so its modified-time is its creation time.
-    file_name = next(
-        name for name in shell.model.list_dir("/files") if name.startswith("diagram")
-    )
+    file_name = next(name for name in shell.model.list_dir("/files") if name.startswith("diagram"))
     file_node = shell.model._get_node(f"/files/{file_name}")
     assert file_node.updated_at == file_node.created_at is not None
 

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -311,22 +311,40 @@ def test_app_vfs_cat_unreadable_transcript_reports_error_without_traceback():
     assert "Transcript not found" in result.stderr
 
 
-class TruncatedSourceClient(FakeClient):
-    """The server caps a source's listing. The VFS must announce that the tree
-    is partial — silently returning the first page reads as "this is everything"
-    and produces confident-wrong conclusions about what a source contains."""
+class PagedSourceClient(FakeClient):
+    """A source whose listing spans several server pages. The VFS must keep
+    following the `after` cursor until the listing is complete — stopping at
+    one page silently hides most of a big source (a 6k-message Gmail, an
+    800-file Drive)."""
 
-    def list_source_entries_page(self, source, path=""):
-        return self.list_source_entries(source, path), True
+    ENTRIES = [
+        {"path": f"msg-{i:02d}", "name": f"Message {i}", "kind": "message"} for i in range(5)
+    ]
+
+    def list_source_entries_page(self, source, path="", after=""):
+        assert source == "src-gmail-1"
+        remaining = [e for e in self.ENTRIES if e["path"] > after]
+        return remaining[:2], len(remaining) > 2
 
 
-def test_find_warns_loudly_when_a_source_listing_is_truncated():
-    shell, _client = _shell(TruncatedSourceClient())
+def test_source_listing_follows_pages_to_completion():
+    shell, _client = _shell(PagedSourceClient())
+
+    result = shell.run("find /sources/gmail -type f")
+
+    for i in range(5):
+        assert f"/sources/gmail/Message {i}" in result.stdout
+    assert "INCOMPLETE" not in result.stderr
+
+
+def test_find_warns_loudly_when_a_source_exceeds_the_materialization_ceiling(monkeypatch):
+    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    shell, _client = _shell(PagedSourceClient())
 
     result = shell.run("find /sources/gmail -type f")
 
     # The rows it did get still come back on stdout, uncorrupted by the warning.
-    assert "/sources/gmail/Welcome email" in result.stdout
+    assert "/sources/gmail/Message 0" in result.stdout
     # The incompleteness is surfaced on stderr — not hidden, not mixed into the
     # file list where a pipe to `wc -l` would silently count it.
     assert "INCOMPLETE" in result.stderr
@@ -340,3 +358,19 @@ def test_find_is_silent_when_a_source_listing_is_complete():
 
     assert "/sources/gmail/Welcome email" in result.stdout
     assert "INCOMPLETE" not in result.stderr
+
+
+def test_stat_shows_external_ref_for_source_documents():
+    shell, _client = _shell()
+
+    result = shell.run("stat '/sources/gmail/Welcome email'")
+
+    assert "external_ref: gm-1" in result.stdout
+
+
+def test_stat_omits_external_ref_when_the_entry_has_none():
+    shell, _client = _shell()
+
+    result = shell.run("stat '/sources/gmail/threads/Nested note'")
+
+    assert "external_ref" not in result.stdout

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -75,11 +75,11 @@ class FakeClient:
         assert source == "src-gmail-1"
         self.source_entry_calls += 1
         return [
-            {"path": "msg-1", "name": "Welcome email", "kind": "message"},
+            {"path": "msg-1", "name": "Welcome email", "kind": "message", "external_ref": "gm-1"},
             {"path": "threads/msg-2", "name": "Nested note", "kind": "message"},
         ]
 
-    def list_source_entries_page(self, source, path=""):
+    def list_source_entries_page(self, source, path="", after=""):
         return self.list_source_entries(source, path), False
 
     def read_source_doc(self, source, ref):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -297,6 +297,7 @@ export interface SourceEntry {
   id?: string;
   name: string;
   kind: string;
+  external_ref?: string | null;
 }
 
 const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);


### PR DESCRIPTION
Two bugs are fixed here:

(1) Previously, for pagination of VFS outputs, we didn't have anyway to request a page other than page 1. Pretty bad pagination!

(2) We now have a way to find a google doc in Stash via its ID (it's available in `stat` in bash). This is a workaround so that I can paste in a google doc URL eg https://docs.google.com/spreadsheets/d/1ImCmRRaELR7lw9S_y2SY_ko8mQ_FgWEFqfH57r7DDxU/edit?gid=0#gid=0 and my coding agent can find it via Stash even if no separate Google Drive MCP is available.

# Slop
## Problem

The VFS materialized a connected source from a **single 200-row page** of `/sources/{source}/entries` — truncation was detected (the CLI requests limit+1) but there was no way to fetch page two, so everything past row 200 in path order was invisible to `ls`/`cat`/`find`/`grep`:

- Henry's 815-file Drive showed 129 top-level entries; the "Stash Integrations Status" sheet (row 682 by path) didn't exist as far as the agent could tell.
- A 6,221-message Gmail showed 200 messages.
- Only `find` warned about truncation; `ls` silently looked complete.

Separately, an agent holding only a provider URL (e.g. a Google Sheets link) had **no way to resolve it to a document**: the ID↔path mapping lives in `drive_index.external_ref` but was never exposed through entries, stat, or search.

## Changes

**Keyset pagination**
- `list_documents` / `source_entries` / the entries endpoint take an `after` cursor (`AND path > $after` on the existing `ORDER BY path`). Listings that aren't path-ordered (native files/sessions, Snowflake tables, Twitter live refs) return everything on page one and empty later pages, so pagers can't loop on them.
- The CLI's `_expand_source` follows the cursor (1000-row pages) until the listing is complete, with a 10,000-entry per-source ceiling that reuses the existing loud INCOMPLETE warning.

**external_ref exposure**
- Entries include each document's provider id (the column was in every index table, just never selected).
- `stash vfs "stat <path>"` prints it.
- `stash search "<provider id>"` resolves an exact `external_ref` match to its Stash path.

## Verification

- New tests: cursor paging over `drive_index`, external_ref in entries, search-by-provider-id, CLI multi-page expansion + ceiling warning, stat output.
- Full suites: 677 backend + 91 CLI tests pass (one pre-existing, unrelated failure in `test_integration_indexer_log_security.py` fails identically on the clean tree).
- Live against production: `ls /sources/google` went 129 → 281 top-level entries and `cat '/sources/google/Stash Integrations Status'` now returns the sheet that started this investigation.

## Deploy note

Deploy the backend before releasing the CLI: a new CLI against the old server would pass `after`, get it ignored, and re-fetch the same page until the ceiling. Old CLI against new server is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)