### PR TITLE
Consolidate Python formatting into ruff; drop black

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: frontend
 
   backend-lint:
-    name: Backend lint (ruff + black)
+    name: Backend lint (ruff)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,9 +45,11 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: backend/requirements-dev.txt
-      - run: pip install ruff black
+      # Pinned to requirements-dev.txt so CI and local runs format identically —
+      # an unpinned formatter drifts style across releases and re-reds every PR.
+      - run: pip install "$(grep '^ruff==' backend/requirements-dev.txt)"
       - run: ruff check backend/ cli/
-      - run: black --check backend/ cli/
+      - run: ruff format --check backend/ cli/
 
   plugin-test:
     name: Plugin tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ By default `stash` is the released PyPI build (`uv tool` install, self-updating)
 - Migrate DB: `alembic upgrade head`
 - Run server: `uvicorn backend.main:app --host 0.0.0.0 --port 3456 --proxy-headers --forwarded-allow-ips '*'`
 - Tests: `pytest`
-- Lint: `ruff check .`
+- Lint (matches CI exactly): `ruff check backend/ cli/ && ruff format --check backend/ cli/`
+  - Fix formatting with `ruff format backend/ cli/`. There is no black; ruff is the only linter *and* formatter.
 
 ### Frontend (`frontend/`)
 - Install: `cd frontend && npm ci`

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -60,7 +60,7 @@ async def create_api_key(user_id, name: str = "default", key_type: str = "manual
     pool = get_pool()
     api_key = generate_api_key()
     await pool.execute(
-        "INSERT INTO user_api_keys (user_id, key_hash, name, key_type) " "VALUES ($1, $2, $3, $4)",
+        "INSERT INTO user_api_keys (user_id, key_hash, name, key_type) VALUES ($1, $2, $3, $4)",
         user_id,
         hash_api_key(api_key),
         name[:128],

--- a/backend/exports/native/cli.py
+++ b/backend/exports/native/cli.py
@@ -39,7 +39,7 @@ log = logging.getLogger("native-export")
 async def _load_page(page_id: UUID) -> tuple[str, str]:
     pool = database.get_pool()
     row = await pool.fetchrow(
-        "SELECT name, content_html, content_type, html_layout " "FROM pages WHERE id = $1",
+        "SELECT name, content_html, content_type, html_layout FROM pages WHERE id = $1",
         page_id,
     )
     if not row:
@@ -67,7 +67,6 @@ async def main_async(args: argparse.Namespace) -> None:
         name, html = await _load_page(UUID(args.page_id))
         log.info("loaded %s — %d bytes (from db)", name, len(html))
     try:
-
         specs = await probe(html)
         log.info("probed %d slide(s)", len(specs))
 

--- a/backend/exports/native/diff.py
+++ b/backend/exports/native/diff.py
@@ -164,7 +164,6 @@ async def main_async(args: argparse.Namespace) -> None:
         slug = args.page_id
 
     try:
-
         log.info("rendering original screenshots…")
         screenshot_pngs = await _render_slides(html)
 
@@ -216,12 +215,12 @@ def _render_diff_html(
         aspose = _b64(asposes[i]) if i < len(asposes) else ""
         cells = [
             f"<td><div style='width:540px;height:304px;overflow:hidden;border:1px solid #ccc;'><iframe srcdoc='{_iframe_doc(html, i)}' style='width:1920px;height:1080px;border:0;transform:scale(0.28125);transform-origin:top left;'></iframe></div></td>",
-            f"<td>{f'<img src=\"{shot}\" style=\"width:540px;height:auto;\">' if shot else '(missing)'}</td>",
-            f"<td>{f'<img src=\"{native}\" style=\"width:540px;height:auto;\">' if native else '(install libreoffice + poppler)'}</td>",
+            f"<td>{f'<img src="{shot}" style="width:540px;height:auto;">' if shot else '(missing)'}</td>",
+            f"<td>{f'<img src="{native}" style="width:540px;height:auto;">' if native else '(install libreoffice + poppler)'}</td>",
         ]
         if show_aspose:
             cells.append(
-                f"<td>{f'<img src=\"{aspose}\" style=\"width:540px;height:auto;\">' if aspose else '(missing)'}</td>"
+                f"<td>{f'<img src="{aspose}" style="width:540px;height:auto;">' if aspose else '(missing)'}</td>"
             )
         rows.append(f"<tr>{''.join(cells)}</tr>")
 
@@ -245,7 +244,7 @@ def _render_diff_html(
 <table>
 <thead><tr>{header_row}</tr></thead>
 <tbody>
-{''.join(rows)}
+{"".join(rows)}
 </tbody></table>
 </body></html>"""
 

--- a/backend/migrations/versions/0007_remove_personas.py
+++ b/backend/migrations/versions/0007_remove_personas.py
@@ -38,6 +38,4 @@ def downgrade() -> None:
     )
     op.execute("ALTER TABLE users ADD COLUMN history_id UUID")
     op.execute("ALTER TABLE users ADD COLUMN notebook_id UUID")
-    op.execute(
-        "ALTER TABLE users ADD COLUMN owner_id UUID " "REFERENCES users(id) ON DELETE CASCADE"
-    )
+    op.execute("ALTER TABLE users ADD COLUMN owner_id UUID REFERENCES users(id) ON DELETE CASCADE")

--- a/backend/migrations/versions/0016_embedding_content_hash.py
+++ b/backend/migrations/versions/0016_embedding_content_hash.py
@@ -36,8 +36,7 @@ def upgrade() -> None:
         "ON notebook_pages(id) WHERE embed_stale"
     )
     op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_table_rows_embed_stale "
-        "ON table_rows(id) WHERE embed_stale"
+        "CREATE INDEX IF NOT EXISTS idx_table_rows_embed_stale ON table_rows(id) WHERE embed_stale"
     )
     op.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_events_embed_stale "

--- a/backend/migrations/versions/0020_unique_transcript_session.py
+++ b/backend/migrations/versions/0020_unique_transcript_session.py
@@ -25,6 +25,5 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.execute("DROP INDEX IF EXISTS idx_transcripts_ws_session")
     op.execute(
-        "CREATE INDEX idx_transcripts_ws_session "
-        "ON session_transcripts(workspace_id, session_id)"
+        "CREATE INDEX idx_transcripts_ws_session ON session_transcripts(workspace_id, session_id)"
     )

--- a/backend/migrations/versions/0023_html_pages.py
+++ b/backend/migrations/versions/0023_html_pages.py
@@ -23,8 +23,7 @@ def upgrade() -> None:
         "CHECK (content_type IN ('markdown', 'html'))"
     )
     op.execute(
-        "ALTER TABLE notebook_pages ADD COLUMN IF NOT EXISTS content_html "
-        "TEXT NOT NULL DEFAULT ''"
+        "ALTER TABLE notebook_pages ADD COLUMN IF NOT EXISTS content_html TEXT NOT NULL DEFAULT ''"
     )
 
 

--- a/backend/migrations/versions/0029_files_link_table.py
+++ b/backend/migrations/versions/0029_files_link_table.py
@@ -18,8 +18,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.execute(
-        "ALTER TABLE files ADD COLUMN linked_table_id UUID "
-        "REFERENCES tables(id) ON DELETE SET NULL"
+        "ALTER TABLE files ADD COLUMN linked_table_id UUID REFERENCES tables(id) ON DELETE SET NULL"
     )
     op.execute(
         "CREATE INDEX idx_files_linked_table ON files(linked_table_id) "

--- a/backend/migrations/versions/0032_ask_threads_backfill.py
+++ b/backend/migrations/versions/0032_ask_threads_backfill.py
@@ -43,8 +43,7 @@ def upgrade() -> None:
         ")"
     )
     op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_ask_messages_thread "
-        "ON ask_messages(thread_id, created_at)"
+        "CREATE INDEX IF NOT EXISTS idx_ask_messages_thread ON ask_messages(thread_id, created_at)"
     )
 
 

--- a/backend/migrations/versions/0036_unify_sharing_and_permissions.py
+++ b/backend/migrations/versions/0036_unify_sharing_and_permissions.py
@@ -117,8 +117,7 @@ def upgrade() -> None:
     op.execute("ALTER TABLE session_artifacts DROP COLUMN IF EXISTS stash_id")
     step("2e. idx_session_artifacts_session")
     op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_session_artifacts_session "
-        "ON session_artifacts(session_id)"
+        "CREATE INDEX IF NOT EXISTS idx_session_artifacts_session ON session_artifacts(session_id)"
     )
 
     # ──────────────────────────────────────────────────────────────────
@@ -160,8 +159,7 @@ def upgrade() -> None:
         "ON share_links(slug) WHERE slug IS NOT NULL"
     )
     op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_share_links_target "
-        "ON share_links(target_type, target_id)"
+        "CREATE INDEX IF NOT EXISTS idx_share_links_target ON share_links(target_type, target_id)"
     )
 
     # ──────────────────────────────────────────────────────────────────

--- a/backend/migrations/versions/0072_ensure_session_titles.py
+++ b/backend/migrations/versions/0072_ensure_session_titles.py
@@ -28,8 +28,7 @@ def upgrade() -> None:
         )
     """)
     op.execute(
-        "CREATE INDEX IF NOT EXISTS idx_session_titles_updated "
-        "ON session_titles(updated_at DESC)"
+        "CREATE INDEX IF NOT EXISTS idx_session_titles_updated ON session_titles(updated_at DESC)"
     )
 
 

--- a/backend/migrations/versions/0075_rewrite_legacy_r2_image_urls.py
+++ b/backend/migrations/versions/0075_rewrite_legacy_r2_image_urls.py
@@ -57,12 +57,14 @@ def _rewrite_body(body: str, lookup_file_id) -> str:
 def upgrade() -> None:
     bind = op.get_bind()
 
-    rows = bind.execute(text("""
+    rows = bind.execute(
+        text("""
             SELECT id, content_markdown, content_html
             FROM pages
             WHERE content_markdown LIKE '%r2.cloudflarestorage.com%'
                OR content_html LIKE '%r2.cloudflarestorage.com%'
-            """)).fetchall()
+            """)
+    ).fetchall()
 
     if not rows:
         return

--- a/backend/migrations/versions/0076_files_embedding_and_metadata.py
+++ b/backend/migrations/versions/0076_files_embedding_and_metadata.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
         "AND deleted_at IS NULL"
     )
     # Partial index matches the reconciler's hot path.
-    op.execute("CREATE INDEX IF NOT EXISTS idx_files_embed_stale " "ON files(id) WHERE embed_stale")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_files_embed_stale ON files(id) WHERE embed_stale")
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/0080_sources.py
+++ b/backend/migrations/versions/0080_sources.py
@@ -96,8 +96,7 @@ def upgrade() -> None:
     )
     # Semantic search hot path, mirroring pages/files.
     op.execute(
-        "CREATE INDEX source_documents_embed_stale_idx "
-        "ON source_documents (id) WHERE embed_stale"
+        "CREATE INDEX source_documents_embed_stale_idx ON source_documents (id) WHERE embed_stale"
     )
 
 

--- a/backend/migrations/versions/0088_jira_asana_sources.py
+++ b/backend/migrations/versions/0088_jira_asana_sources.py
@@ -40,8 +40,7 @@ def upgrade() -> None:
     for table in _TABLES:
         op.execute(f"CREATE TABLE {table} ({_BASE_COLUMNS}, UNIQUE (source_id, path))")
         op.execute(
-            f"CREATE INDEX {table}_source_idx ON {table} (source_id, path) "
-            f"WHERE deleted_at IS NULL"
+            f"CREATE INDEX {table}_source_idx ON {table} (source_id, path) WHERE deleted_at IS NULL"
         )
         op.execute(
             f"CREATE INDEX {table}_fts_idx ON {table} "

--- a/backend/migrations/versions/0094_multi_account_integrations.py
+++ b/backend/migrations/versions/0094_multi_account_integrations.py
@@ -40,8 +40,7 @@ def upgrade() -> None:
         ADD PRIMARY KEY (user_id, provider, account_key)
         """)
     op.execute(
-        "CREATE INDEX user_integrations_user_provider_idx "
-        "ON user_integrations (user_id, provider)"
+        "CREATE INDEX user_integrations_user_provider_idx ON user_integrations (user_id, provider)"
     )
 
 

--- a/backend/migrations/versions/0103_skills_are_folders.py
+++ b/backend/migrations/versions/0103_skills_are_folders.py
@@ -190,9 +190,7 @@ def _adopt_folder(bind, skill) -> str:
         elif item.object_type in ("page", "file", "table"):
             table = {"page": "pages", "file": "files", "table": "tables"}[item.object_type]
             bind.execute(
-                text(
-                    f"UPDATE {table} SET folder_id = :fid " "WHERE id = :oid AND workspace_id = :ws"
-                ),
+                text(f"UPDATE {table} SET folder_id = :fid WHERE id = :oid AND workspace_id = :ws"),
                 {"fid": folder_id, "oid": item.object_id, "ws": skill.workspace_id},
             )
         elif item.object_type == "session":

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,5 +2,6 @@
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
 pytest-cov>=6.0.0
-ruff>=0.4.0
-black>=24.0.0
+# Exact pin: ruff is also the formatter, and formatting style drifts across
+# releases. CI installs this same pin.
+ruff==0.15.6

--- a/backend/routers/agent_docs.py
+++ b/backend/routers/agent_docs.py
@@ -9,7 +9,8 @@ router = APIRouter(tags=["skill"])
 
 SKILL_PATH = Path(__file__).parent.parent / "static" / "SKILL.md"
 
-LLMS_TEXT = """# Stash
+LLMS_TEXT = (
+    """# Stash
 
 Stash is shared memory for AI-agent work. Public Stash URLs are agent-readable.
 
@@ -28,7 +29,10 @@ Use these forms:
 The markdown homepage lists the Stash contents and links to item-level markdown
 and JSON views for progressive disclosure.
 
-""" + agent_install_pitch("https://app.joinstash.ai/skills/example") + "\n"
+"""
+    + agent_install_pitch("https://app.joinstash.ai/skills/example")
+    + "\n"
+)
 
 
 @router.get("/skill/stash/SKILL.md", response_class=PlainTextResponse)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -134,7 +134,7 @@ async def list_my_sessions(
             he_title.session_id,
             LEFT(he_title.content, 240) AS title_source
           FROM history_events he_title
-          WHERE {' AND '.join(title_where)}
+          WHERE {" AND ".join(title_where)}
           ORDER BY
             he_title.owner_user_id,
             he_title.session_id,
@@ -153,7 +153,7 @@ async def list_my_sessions(
           sf.name AS session_folder_name,
           he.owner_user_id,
           owner.display_name AS owner_name,
-          {linear_ticket_service.sql_json_agg('s')} AS linear_tickets,
+          {linear_ticket_service.sql_json_agg("s")} AS linear_tickets,
           (ARRAY_AGG(NULLIF(u.display_name, '') ORDER BY he.created_at)
            FILTER (WHERE NULLIF(u.display_name, '') IS NOT NULL))[1] AS user_name,
           MAX(he.agent_name) AS agent_name,
@@ -170,7 +170,7 @@ async def list_my_sessions(
           AND s.session_id = he.session_id
           AND s.deleted_at IS NULL
         LEFT JOIN session_folders sf ON sf.id = s.session_folder_id
-        WHERE {' AND '.join(where)}
+        WHERE {" AND ".join(where)}
         GROUP BY he.session_id, he.owner_user_id, owner.display_name, s.id, s.session_folder_id,
           sf.name, title_sources.title_source
         ORDER BY last_event_at DESC, user_name ASC, session_id ASC

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -66,13 +66,10 @@ async def upload_transcript(
         raise HTTPException(status_code=400, detail="Session uploads must be .JSONL files")
     if not session_id.strip():
         raise HTTPException(status_code=400, detail="session_id is required")
-    if (
-        session_folder_id is not None
-        and not await session_folder_service.can_add_session_to_folder(
-            owner_user_id=owner_user_id,
-            user_id=current_user["id"],
-            folder_id=session_folder_id,
-        )
+    if session_folder_id is not None and not await session_folder_service.can_add_session_to_folder(
+        owner_user_id=owner_user_id,
+        user_id=current_user["id"],
+        folder_id=session_folder_id,
     ):
         raise HTTPException(status_code=404, detail="Session folder not found")
 
@@ -82,7 +79,7 @@ async def upload_transcript(
 
     pool = get_pool()
     existing = await pool.fetchval(
-        "SELECT COUNT(*) FROM history_events " "WHERE owner_user_id = $1 AND session_id = $2",
+        "SELECT COUNT(*) FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
         owner_user_id,
         session_id,
     )

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -376,24 +376,24 @@ async def _sidebar_etag(owner_user_id: UUID, user_id: UUID) -> str:
              ))                                                                   AS s,
           (SELECT MAX(he.created_at) FROM history_events he
             WHERE he.owner_user_id = $1 AND he.session_id IS NOT NULL
-            AND {memory_service.readable_session_event_condition('he', 2)})        AS he,
+            AND {memory_service.readable_session_event_condition("he", 2)})        AS he,
           (SELECT COUNT(*) FROM history_events he
             WHERE he.owner_user_id = $1 AND he.session_id IS NOT NULL
-            AND {memory_service.readable_session_event_condition('he', 2)})        AS hc,
+            AND {memory_service.readable_session_event_condition("he", 2)})        AS hc,
           (SELECT MAX(stt.updated_at) FROM session_titles stt
            JOIN sessions stt_session
              ON stt_session.owner_user_id = stt.owner_user_id
             AND stt_session.session_id = stt.session_id
            WHERE stt.owner_user_id = $1
              AND stt_session.deleted_at IS NULL
-             AND {memory_service.readable_session_event_condition('stt_session', 2)}) AS tt,
+             AND {memory_service.readable_session_event_condition("stt_session", 2)}) AS tt,
           (SELECT COUNT(*) FROM session_titles stt
            JOIN sessions stt_session
              ON stt_session.owner_user_id = stt.owner_user_id
             AND stt_session.session_id = stt.session_id
            WHERE stt.owner_user_id = $1
              AND stt_session.deleted_at IS NULL
-             AND {memory_service.readable_session_event_condition('stt_session', 2)}) AS tc,
+             AND {memory_service.readable_session_event_condition("stt_session", 2)}) AS tc,
           (SELECT MAX(updated_at) FROM skills WHERE owner_user_id = $1)            AS st,
           (SELECT MAX(sh.created_at) FROM shares sh
            WHERE sh.owner_user_id = $1 AND sh.principal_type = 'user'

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -97,7 +97,7 @@ async def logout(current_user: dict = Depends(get_current_user)):
 
     pool = get_pool()
     await pool.execute(
-        "UPDATE user_api_keys SET revoked_at = now() " "WHERE id = $1 AND revoked_at IS NULL",
+        "UPDATE user_api_keys SET revoked_at = now() WHERE id = $1 AND revoked_at IS NULL",
         key_id,
     )
     return None

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -395,7 +395,7 @@ async def _create_skill(args: dict) -> dict:
 
 @tool(
     "publish_skill",
-    "Publish a skill folder: make it publicly readable at /skills/<slug> and " "return the URL.",
+    "Publish a skill folder: make it publicly readable at /skills/<slug> and return the URL.",
     {
         "type": "object",
         "properties": {
@@ -424,7 +424,7 @@ async def _publish_skill(args: dict) -> dict:
 
 @tool(
     "update_skill",
-    "Update a published skill's share settings (title, description, access, " "Discover listing).",
+    "Update a published skill's share settings (title, description, access, Discover listing).",
     {
         "type": "object",
         "properties": {

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -188,7 +188,8 @@ async def get_activity_timeline(
         scope_idx = 5
 
     rows = await pool.fetch(
-        _accessible_events_cte(scope_idx=scope_idx) + """
+        _accessible_events_cte(scope_idx=scope_idx)
+        + """
         , timeline_events AS (
             SELECT
                 me.owner_user_id,
@@ -539,7 +540,8 @@ async def compute_knowledge_density(
 
     # One scan per source: stem → doc_count + newest_at.
     page_rows = await pool.fetch(
-        _accessible_pages_cte(scope_idx=content_scope_idx) + """
+        _accessible_pages_cte(scope_idx=content_scope_idx)
+        + """
         SELECT stem, COUNT(DISTINCT doc_id) AS ndoc, MAX(ts) AS newest_at
         FROM (
             SELECT word AS stem, np.id AS doc_id, np.updated_at AS ts
@@ -557,7 +559,8 @@ async def compute_knowledge_density(
         *content_args,
     )
     table_rows_res = await pool.fetch(
-        _accessible_tables_cte(scope_idx=content_scope_idx) + """
+        _accessible_tables_cte(scope_idx=content_scope_idx)
+        + """
         SELECT stem, COUNT(DISTINCT doc_id) AS ndoc, MAX(ts) AS newest_at
         FROM (
             SELECT word AS stem, tr.id AS doc_id, tr.updated_at AS ts
@@ -575,7 +578,8 @@ async def compute_knowledge_density(
         *content_args,
     )
     event_rows = await pool.fetch(
-        _accessible_events_cte(scope_idx=event_scope_idx) + """
+        _accessible_events_cte(scope_idx=event_scope_idx)
+        + """
         SELECT stem, COUNT(DISTINCT doc_id) AS ndoc, MAX(ts) AS newest_at
         FROM (
             SELECT word AS stem, he.id AS doc_id, he.created_at AS ts
@@ -619,7 +623,8 @@ async def compute_knowledge_density(
     # source) maps top stems → their most frequent original word. ts_lexize
     # returns the same stems Postgres tsvector produced, so the join is exact.
     word_rows = await pool.fetch(
-        _accessible_pages_cte(scope_idx=content_scope_idx) + """
+        _accessible_pages_cte(scope_idx=content_scope_idx)
+        + """
         SELECT w AS word, ts_lexize('english_stem', w) AS stems, COUNT(*) AS freq
         FROM pages np,
              LATERAL regexp_split_to_table(lower(COALESCE(np.content_markdown, '')), '[^a-z]+') AS w
@@ -753,7 +758,8 @@ async def get_embedding_projection(
     total_count = 0
     if source is None or source == "pages":
         row = await pool.fetchval(
-            _accessible_pages_cte(scope_idx=content_count_scope_idx) + """
+            _accessible_pages_cte(scope_idx=content_count_scope_idx)
+            + """
             SELECT COUNT(*) FROM pages np
             WHERE np.id IN (SELECT page_id FROM accessible_pages)
               AND np.embedding IS NOT NULL
@@ -764,7 +770,8 @@ async def get_embedding_projection(
 
     if source is None or source == "table_rows":
         row = await pool.fetchval(
-            _accessible_tables_cte(scope_idx=content_count_scope_idx) + """
+            _accessible_tables_cte(scope_idx=content_count_scope_idx)
+            + """
             SELECT COUNT(*) FROM table_rows tr
             WHERE tr.table_id IN (SELECT table_id FROM accessible_tables)
               AND tr.embedding IS NOT NULL
@@ -775,7 +782,8 @@ async def get_embedding_projection(
 
     if source is None or source == "history_events":
         row = await pool.fetchval(
-            _accessible_events_cte(scope_idx=event_scope_idx) + """
+            _accessible_events_cte(scope_idx=event_scope_idx)
+            + """
             SELECT COUNT(*) FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
             WHERE me.embedding IS NOT NULL
@@ -786,7 +794,8 @@ async def get_embedding_projection(
 
     if source is None or source == "files":
         row = await pool.fetchval(
-            _accessible_files_cte(scope_idx=content_count_scope_idx) + """
+            _accessible_files_cte(scope_idx=content_count_scope_idx)
+            + """
             SELECT COUNT(*) FROM files f
             WHERE f.id IN (SELECT file_id FROM accessible_files)
               AND f.embedding IS NOT NULL
@@ -826,7 +835,8 @@ async def get_embedding_projection(
 
     if source is None or source == "pages":
         rows = await pool.fetch(
-            _accessible_pages_cte(scope_idx=content_fetch_scope_idx) + """
+            _accessible_pages_cte(scope_idx=content_fetch_scope_idx)
+            + """
             SELECT np.id, np.name AS label, np.embedding, np.created_at
             FROM pages np
             WHERE np.id IN (SELECT page_id FROM accessible_pages)
@@ -849,7 +859,8 @@ async def get_embedding_projection(
 
     if source is None or source == "table_rows":
         rows = await pool.fetch(
-            _accessible_tables_cte(scope_idx=content_fetch_scope_idx) + """
+            _accessible_tables_cte(scope_idx=content_fetch_scope_idx)
+            + """
             SELECT tr.id, t.name AS table_name, tr.embedding, tr.created_at
             FROM table_rows tr
             JOIN tables t ON t.id = tr.table_id
@@ -873,7 +884,8 @@ async def get_embedding_projection(
 
     if source is None or source == "history_events":
         rows = await pool.fetch(
-            _accessible_events_cte(scope_idx=event_fetch_scope_idx) + """
+            _accessible_events_cte(scope_idx=event_fetch_scope_idx)
+            + """
             SELECT me.id, me.agent_name, me.event_type, me.embedding, me.created_at
             FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
@@ -896,7 +908,8 @@ async def get_embedding_projection(
 
     if source is None or source == "files":
         rows = await pool.fetch(
-            _accessible_files_cte(scope_idx=content_fetch_scope_idx) + """
+            _accessible_files_cte(scope_idx=content_fetch_scope_idx)
+            + """
             SELECT f.id, f.name AS label, f.embedding, f.created_at
             FROM files f
             WHERE f.id IN (SELECT file_id FROM accessible_files)

--- a/backend/services/cohort_service.py
+++ b/backend/services/cohort_service.py
@@ -157,8 +157,7 @@ def compute_engagement_cohorts(
 # metadata.source = "history_import". "Active" events are the rest —
 # CLI commands and any custom-typed events.
 _ACTIVE_EVENTS_PREDICATE = (
-    "(he.metadata->>'client') IS NULL "
-    "AND COALESCE(he.metadata->>'source', '') <> 'history_import'"
+    "(he.metadata->>'client') IS NULL AND COALESCE(he.metadata->>'source', '') <> 'history_import'"
 )
 
 

--- a/backend/services/embeddings/auto.py
+++ b/backend/services/embeddings/auto.py
@@ -55,8 +55,7 @@ def get_embedder() -> BaseEmbedder:
 
     else:
         raise ValueError(
-            f"Unknown EMBEDDING_PROVIDER={provider!r}. "
-            "Choose: openai, huggingface, local, or auto."
+            f"Unknown EMBEDDING_PROVIDER={provider!r}. Choose: openai, huggingface, local, or auto."
         )
 
     logger.info("Embedding provider: %s", _embedder.name)

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -739,7 +739,7 @@ async def purge_page(page_id: UUID, owner_user_id: UUID) -> bool:
     """Permanent delete — only callable on a page already in trash."""
     pool = get_pool()
     result = await pool.execute(
-        "DELETE FROM pages WHERE id = $1 AND owner_user_id = $2  " "AND deleted_at IS NOT NULL",
+        "DELETE FROM pages WHERE id = $1 AND owner_user_id = $2  AND deleted_at IS NOT NULL",
         page_id,
         owner_user_id,
     )

--- a/backend/services/github_skill_import.py
+++ b/backend/services/github_skill_import.py
@@ -282,7 +282,7 @@ async def remove_repo_skills(repo_url: str) -> int:
     base = f"https://github.com/{owner}/{repo}"
     pool = get_pool()
     rows = await pool.fetch(
-        "SELECT folder_id FROM skills " "WHERE source_github_url = $1 OR source_github_url LIKE $2",
+        "SELECT folder_id FROM skills WHERE source_github_url = $1 OR source_github_url LIKE $2",
         base,
         f"{base}/tree/%",
     )

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -410,8 +410,7 @@ async def get_scope_event(event_id: UUID, owner_user_id: UUID, user_id: UUID) ->
 async def get_personal_event(event_id: UUID, user_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT * FROM history_events "
-        "WHERE id = $1 AND owner_user_id IS NULL AND created_by = $2",
+        "SELECT * FROM history_events WHERE id = $1 AND owner_user_id IS NULL AND created_by = $2",
         event_id,
         user_id,
     )

--- a/backend/services/session_folder_service.py
+++ b/backend/services/session_folder_service.py
@@ -167,8 +167,7 @@ async def user_can_manage(folder_id: UUID, user_id: UUID) -> bool:
 async def update_folder(folder_id: UUID, user_id: UUID, updates: dict) -> dict | None:
     pool = get_pool()
     folder = await pool.fetchrow(
-        "SELECT owner_user_id, public_permission, discoverable "
-        "FROM session_folders WHERE id = $1",
+        "SELECT owner_user_id, public_permission, discoverable FROM session_folders WHERE id = $1",
         folder_id,
     )
     if not folder or not await user_can_manage(folder_id, user_id):

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1063,7 +1063,8 @@ async def search_documents(
         return ""
 
     source_readable = permission_service.readable_content_condition("source", "s", 1)
-    parts = [f"""
+    parts = [
+        f"""
         SELECT d.source_id, d.path, d.name, LEFT(d.content, 400) AS snippet,
                ts_rank(to_tsvector('english', coalesce(d.content, '')),
                        websearch_to_tsquery('english', $2)) AS rank
@@ -1074,7 +1075,9 @@ async def search_documents(
           AND to_tsvector('english', coalesce(d.content, ''))
               @@ websearch_to_tsquery('english', $2)
           {visibility_clause(t)}
-        """ for t in tables]
+        """
+        for t in tables
+    ]
     union = " UNION ALL ".join(parts)
     rows = await get_pool().fetch(
         f"SELECT u.source_id, ws.display_name AS source_name, u.path, u.name, u.snippet "

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -138,7 +138,7 @@ async def test_skill_tools_create_publish_update_and_unpublish(scope: UUID, _db_
     )
     assert record is None
     skill_md = await _db_pool.fetchval(
-        "SELECT 1 FROM pages WHERE folder_id = $1 AND name = 'SKILL.md' " "AND deleted_at IS NULL",
+        "SELECT 1 FROM pages WHERE folder_id = $1 AND name = 'SKILL.md' AND deleted_at IS NULL",
         UUID(created["folder_id"]),
     )
     assert skill_md == 1

--- a/backend/tests/test_image_url_rewrite.py
+++ b/backend/tests/test_image_url_rewrite.py
@@ -37,7 +37,7 @@ def test_rewrite_swaps_presigned_r2_for_proxy_url():
         return fid
 
     rewritten = mig._rewrite_body(body, lookup)
-    expected = "![cap](/api/v1/me/" f"files/{fid}/download)"
+    expected = f"![cap](/api/v1/me/files/{fid}/download)"
     assert rewritten == expected
 
 

--- a/backend/tests/test_migration_members_to_shares.py
+++ b/backend/tests/test_migration_members_to_shares.py
@@ -42,9 +42,9 @@ def _alembic(target: str) -> None:
         capture_output=True,
         text=True,
     )
-    assert (
-        result.returncode == 0
-    ), f"alembic upgrade {target} failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"alembic upgrade {target} failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
 
 
 async def _create_db() -> None:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -23,9 +23,9 @@ def test_alembic_upgrade_head():
         capture_output=True,
         text=True,
     )
-    assert (
-        result.returncode == 0
-    ), f"alembic upgrade head failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
 
 
 def test_alembic_history_is_linear():

--- a/backend/tests/test_slides_skill_seed.py
+++ b/backend/tests/test_slides_skill_seed.py
@@ -82,12 +82,12 @@ async def test_slides_skill_body_covers_canvas(client: AsyncClient, enable_seed)
     assert resp.status_code == 200, resp.text
     body = resp.json()
     combined = body.get("combined", "") or body.get("body", "")
-    assert (
-        "1920" in combined and "1080" in combined
-    ), "slides skill must spell out the canvas dimensions so agents stop overflowing"
-    assert (
-        '<section class="slide">' in combined or "section.slide" in combined
-    ), "slides skill must spell out the slide element format"
+    assert "1920" in combined and "1080" in combined, (
+        "slides skill must spell out the canvas dimensions so agents stop overflowing"
+    )
+    assert '<section class="slide">' in combined or "section.slide" in combined, (
+        "slides skill must spell out the slide element format"
+    )
 
 
 @pytest.mark.asyncio

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -242,7 +242,7 @@ def _extract_composer_ids(ws_db_path: Path) -> list[str]:
     try:
         # composerChatViewPane entries contain inner aichat.view.<composer-uuid> refs
         cur = db.execute(
-            "SELECT value FROM ItemTable " "WHERE key LIKE 'workbench.panel.composerChatViewPane.%'"
+            "SELECT value FROM ItemTable WHERE key LIKE 'workbench.panel.composerChatViewPane.%'"
         )
         for (val,) in cur:
             try:

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -311,8 +311,8 @@ class StashVfsModel:
                 # Sole connection collapses — its documents sit directly in the
                 # provider folder (e.g. /sources/granola/<call>).
                 handle = str(members[0].get("source") or "")
-                self._expanders[provider_root] = (
-                    lambda root=provider_root, h=handle: self._expand_source(root, h)
+                self._expanders[provider_root] = lambda root=provider_root, h=handle: (
+                    self._expand_source(root, h)
                 )
                 continue
             for member in members:
@@ -320,8 +320,8 @@ class StashVfsModel:
                 member_root = self._add_dir_child(
                     provider_root, _source_slug(member.get("display_name") or handle)
                 )
-                self._expanders[member_root] = (
-                    lambda root=member_root, h=handle: self._expand_source(root, h)
+                self._expanders[member_root] = lambda root=member_root, h=handle: (
+                    self._expand_source(root, h)
                 )
 
     def _expand_source(self, source_root: str, handle: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,3 @@ ignore = ["E501"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["backend", "cli", "stashai"]
-
-[tool.black]
-line-length = 100
-target-version = ["py312"]


### PR DESCRIPTION
## Problem

Every PR was arriving with a red black check. Three compounding causes:

1. CLAUDE.md documented lint as `ruff check .` only, while CI enforced ruff **and** `black --check` — so agents (Claude, Codex) always pushed ruff-green, black-red code.
2. CI installed unpinned `ruff black`, so the authoritative formatter version changed under us.
3. The two formatters' styles have drifted: with identical line-length config, current black and `ruff format` disagree on 38 of 406 files.

## Changes

- **CI**: `ruff format --check backend/ cli/` replaces black; ruff is installed from the exact pin in `requirements-dev.txt` (`ruff==0.15.6`), so CI and local runs format identically.
- **Deps/config**: black removed from `requirements-dev.txt`; `[tool.black]` removed from `pyproject.toml` (`ruff format` reads the existing `[tool.ruff]` line-length = 100).
- **CLAUDE.md**: lint command now matches CI exactly, with the fix command documented.
- **One-shot reformat**: `ruff format backend/ cli/` — 38 files, purely mechanical (see repo rule: format changes happen everywhere in one shot).

## Verification

- `ruff check` + `ruff format --check` pass on the tree.
- Full suites: 677 backend + CLI tests pass; the only failure is the pre-existing Gong `access_token` test that also fails on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)