### PR TITLE
Surface dead federated sources instead of silently returning no results

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -95,6 +95,7 @@ class IntegrationAccountItem(BaseModel):
     scopes: list[str]
     expires_at: str | None = None
     connected_at: str | None = None
+    needs_reconnect: bool = False
 
 
 class ProviderListItem(BaseModel):

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
+import httpx
 from fastapi import HTTPException
 
 from ..database import get_pool
@@ -199,6 +200,18 @@ async def revoke_stored(
             pass
 
 
+async def _account_needs_reconnect(user_id: UUID, provider: str, account_key: str) -> bool:
+    """Actively verify the stored token still works, refreshing if needed. A
+    connection row survives long after its OAuth grant dies (revoked access, an
+    expired refresh token), so only attempting to obtain a valid token tells a
+    live account apart from a silently dead one."""
+    try:
+        await get_valid_token(user_id, provider, account_key)
+        return False
+    except (HTTPException, httpx.HTTPError):
+        return True
+
+
 async def status(user_id: UUID, provider: str) -> dict:
     pool = get_pool()
     rows = await pool.fetch(
@@ -212,7 +225,13 @@ async def status(user_id: UUID, provider: str) -> dict:
     )
     if not rows:
         return {"connected": False, "accounts": []}
-    accounts = [_account_row(row) for row in rows]
+    accounts = []
+    for row in rows:
+        account = _account_row(row)
+        account["needs_reconnect"] = await _account_needs_reconnect(
+            user_id, provider, row["account_key"]
+        )
+        accounts.append(account)
     first = accounts[0]
     return {
         "connected": True,
@@ -240,6 +259,9 @@ async def list_connections(user_id: UUID) -> list[dict]:
     for row in rows:
         provider = row["provider"]
         account = _account_row(row)
+        account["needs_reconnect"] = await _account_needs_reconnect(
+            user_id, provider, row["account_key"]
+        )
         if provider not in connections:
             connections[provider] = {
                 "provider": provider,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -945,10 +945,11 @@ async def _federated_search(
 ) -> list[dict]:
     """Run a federated source's native provider search. Returns unified hits
     ({source, source_name, ref, name, snippet}). In the unscoped fan-out a
-    provider error (e.g. Asana on a free tier) logs and yields no hits so
-    search stays alive; a SCOPED search raises instead — when the user asked
-    for this one source, an empty result must mean "no matches", never a
-    silently dead connection (revoked token, rate limit, bad query)."""
+    provider error (revoked token, rate limit) is logged and returned as a
+    single error marker ({source, source_name, error, needs_reconnect}) so the
+    rest of the search stays alive while the dead source is still surfaced —
+    dropping it silently would read as "no matches" for that source. A SCOPED
+    search raises instead, so the API serves an explicit HTTP error."""
     source_type = source["source_type"]
     try:
         if source_type == "google_drive":
@@ -975,7 +976,23 @@ async def _federated_search(
             source_type,
             type(exc).__name__,
         )
-        return []
+        # Only the classified message is safe to surface — an unmapped exception
+        # may carry the token or query in its text, so it gets a generic label.
+        mapped = _scoped_search_error(source, exc)
+        if isinstance(mapped, HTTPException):
+            detail = mapped.detail
+            needs_reconnect = mapped.status_code == 409
+        else:
+            detail = f"{source['display_name'] or source_type} search failed"
+            needs_reconnect = False
+        return [
+            {
+                "source": source["id"],
+                "source_name": source["display_name"],
+                "error": detail,
+                "needs_reconnect": needs_reconnect,
+            }
+        ]
     return [
         {
             "source": source["id"],
@@ -1741,8 +1758,9 @@ async def search_all(
         # Federated sources search the provider's native API live. Scoped → the
         # one source, raising on provider errors so a dead connection is never
         # mistaken for "no matches"; unscoped → fan out across the user's
-        # federated sources (each call swallows its own errors, and scoped-only
-        # types are skipped — see SCOPED_ONLY_SEARCH_TYPES).
+        # federated sources (each call keeps search alive by returning its own
+        # error as a marker instead of raising, and scoped-only types are
+        # skipped — see SCOPED_ONLY_SEARCH_TYPES).
         if connected is not None:
             if connected["source_type"] in FEDERATED_SEARCH_TYPES:
                 results += await _federated_search(connected, query, limit, swallow_errors=False)

--- a/backend/tests/test_gmail_multi_account.py
+++ b/backend/tests/test_gmail_multi_account.py
@@ -95,6 +95,33 @@ async def test_gmail_status_flags_dead_account_for_reconnect(client: AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_integrations_list_exposes_needs_reconnect(client: AsyncClient):
+    """The /integrations list is what the settings UI reads — its account items
+    must carry needs_reconnect so a dead mailbox can render a reconnect prompt."""
+    api_key, user_id = await _register(client)
+
+    await _store_gmail(user_id, "htdowling@gmail.com", "token-live")
+    await storage.store_token(
+        user_id,
+        "gmail",
+        TokenSet(
+            access_token="token-dead",
+            refresh_token=None,
+            expires_at=datetime(2020, 1, 1, tzinfo=UTC),
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        ),
+        AccountInfo(email="henry@ferganalabs.com", display_name="Henry"),
+    )
+
+    resp = await client.get("/api/v1/integrations", headers=_auth(api_key))
+    assert resp.status_code == 200
+    gmail = next(p for p in resp.json()["providers"] if p["provider"] == "gmail")
+    by_key = {a["account_key"]: a for a in gmail["accounts"]}
+    assert by_key["htdowling@gmail.com"]["needs_reconnect"] is False
+    assert by_key["henry@ferganalabs.com"]["needs_reconnect"] is True
+
+
+@pytest.mark.asyncio
 async def test_gmail_sources_target_specific_mailboxes(client: AsyncClient):
     api_key, user_id = await _register(client)
     await _store_gmail(user_id, "htdowling@gmail.com", "token-personal")

--- a/backend/tests/test_gmail_multi_account.py
+++ b/backend/tests/test_gmail_multi_account.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from uuid import UUID
 
 import pytest
@@ -63,6 +64,34 @@ async def test_gmail_tokens_are_keyed_by_mailbox(client: AsyncClient):
         await storage.get_valid_token(user_id, "gmail", "htdowling@gmail.com") == "token-personal"
     )
     assert await storage.get_valid_token(user_id, "gmail", "henry@joinstash.ai") == "token-work"
+
+
+@pytest.mark.asyncio
+async def test_gmail_status_flags_dead_account_for_reconnect(client: AsyncClient):
+    """A connection row outlives its OAuth grant. Status must actively check
+    each token so a dead mailbox reports needs_reconnect instead of a bare
+    connected=true that hides why its search silently returns nothing."""
+    _, user_id = await _register(client)
+
+    await _store_gmail(user_id, "htdowling@gmail.com", "token-live")
+    # Expired long ago with no refresh token — get_valid_token can't revive it.
+    await storage.store_token(
+        user_id,
+        "gmail",
+        TokenSet(
+            access_token="token-dead",
+            refresh_token=None,
+            expires_at=datetime(2020, 1, 1, tzinfo=UTC),
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        ),
+        AccountInfo(email="henry@ferganalabs.com", display_name="Henry"),
+    )
+
+    status = await storage.status(user_id, "gmail")
+
+    by_key = {a["account_key"]: a for a in status["accounts"]}
+    assert by_key["htdowling@gmail.com"]["needs_reconnect"] is False
+    assert by_key["henry@ferganalabs.com"]["needs_reconnect"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1873,11 +1873,18 @@ async def test_federated_search_logs_only_failure_metadata(client: AsyncClient, 
     monkeypatch.setattr(indexer, "search_jira", fail_search)
     monkeypatch.setattr(source_service.logger, "warning", capture_warning)
 
-    # Unscoped fan-out swallows provider errors and logs them; a scoped search
-    # raises instead, so only the fan-out path exercises the redacted log line.
+    # Unscoped fan-out surfaces a redacted error marker (never raising) and logs
+    # only failure metadata; a scoped search raises instead.
     hits = await source_service.search_all(ws, owner_id, "customer transcript")
 
-    assert hits == []
+    assert hits == [
+        {
+            "source": src["id"],
+            "source_name": "PROJ",
+            "error": "PROJ search failed",
+            "needs_reconnect": False,
+        }
+    ]
     assert captured_logs == [
         (
             "federated search failed source=%s source_type=%s exception_type=%s",
@@ -1886,6 +1893,48 @@ async def test_federated_search_logs_only_failure_metadata(client: AsyncClient, 
     ]
     assert "secret-token" not in str(captured_logs)
     assert "customer transcript" not in str(captured_logs)
+    # An unmapped exception's raw text (token, query) must not leak into the
+    # surfaced marker either.
+    assert "secret-token" not in str(hits)
+    assert "customer transcript" not in str(hits)
+
+
+@pytest.mark.asyncio
+async def test_unscoped_search_surfaces_dead_federated_source(
+    client: AsyncClient, monkeypatch
+):
+    """A dead connection (expired/revoked token) must not vanish from unscoped
+    search as if it had no matches — it surfaces a needs_reconnect marker so the
+    caller can tell "reconnect me" apart from "nothing found"."""
+    from fastapi import HTTPException
+
+    from backend.integrations.gmail import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="gmail",
+        external_ref="henry@ferganalabs.com",
+        display_name="Gmail (henry@ferganalabs.com)",
+    )
+
+    async def dead_search(source, query, limit):
+        raise HTTPException(status_code=401, detail="gmail token expired; reconnect required")
+
+    monkeypatch.setattr(indexer, "search_gmail", dead_search)
+
+    results = await source_service.search_all(ws, owner_id, "anything")
+
+    markers = [r for r in results if r.get("source") == src["id"]]
+    assert markers == [
+        {
+            "source": src["id"],
+            "source_name": "Gmail (henry@ferganalabs.com)",
+            "error": "gmail token expired; reconnect required",
+            "needs_reconnect": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -106,6 +106,7 @@ export default function IntegrationPage() {
   const connected = !!status?.connected;
   const account = connectedAccountLabel(status);
   const canConnectAnother = connected && connector.provider === "gmail" && status?.auth_kind !== "api_key";
+  const staleAccounts = status?.accounts.filter((a) => a.needs_reconnect) ?? [];
 
   async function connect() {
     setBusy("connect");
@@ -259,6 +260,19 @@ export default function IntegrationPage() {
             Manage in Settings
           </Link>
         </div>
+
+        {staleAccounts.length > 0 && (
+          <div className="mt-4 flex items-center justify-between gap-3 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
+            <span>
+              {staleAccounts.length === 1
+                ? `${staleAccounts[0].account_email ?? staleAccounts[0].account_key} is connected but its access expired — search returns nothing until you reconnect.`
+                : `${staleAccounts.length} accounts are connected but their access expired — search returns nothing until you reconnect.`}
+            </span>
+            <button type="button" onClick={() => void connect()} disabled={busy === "connect"} className={secondaryButton()}>
+              {busy === "connect" ? "Connecting..." : "Reconnect"}
+            </button>
+          </div>
+        )}
 
         {showCreds && !connected && status?.auth_kind === "api_key" && status.credential_fields && (
           <CredentialForm

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -38,6 +38,9 @@ export type IntegrationAccount = {
   scopes: string[];
   expires_at: string | null;
   connected_at: string | null;
+  // True when the stored token no longer works (revoked access or an expired
+  // refresh token) — the account is listed as connected but must be reconnected.
+  needs_reconnect: boolean;
 };
 
 export type IntegrationStatus = {


### PR DESCRIPTION
make two fixes that cause sources to silently fail when you try to search them

## Problem

A second connected Gmail mailbox (`henry@ferganalabs.com`) was fully populated in the VFS but returned **zero** results in search, while the other mailbox worked. Root cause was silent-fallback bugs, not a crawl failure:

1. **Search swallowed the auth error.** Gmail search is federated live to the provider. When the ferganalabs OAuth token expired (`expires_at` ~17 days in the past, no longer refreshing), `get_valid_token` raised 401 → `_federated_search`'s unscoped fan-out caught it, logged a warning, and returned `[]`. A dead connection was indistinguishable from "no matches."
2. **Status reported `connected: true`.** `/integrations/gmail/status` derived `connected` from the mere existence of a token row, so a dead account looked healthy in the UI.

Both are the "silent fallback" pattern `CLAUDE.md` forbids — fail loud instead.

## Changes

- **`_federated_search`** (`backend/services/source_service.py`): in the unscoped fan-out, a provider error now returns a typed marker `{source, source_name, error, needs_reconnect}` instead of `[]`. The rest of the search stays alive; the dead source is surfaced. Only the classified (HTTP-mapped) message is exposed — an unmapped exception gets a generic label so raw exception text (token/query) can't leak. Scoped search is unchanged (still raises an explicit HTTP error).
- **`status` / `list_connections`** (`backend/integrations/storage.py`): each account is now actively verified by attempting to obtain a valid token, adding a per-account `needs_reconnect` boolean.
- **`IntegrationAccountItem`** (`backend/integrations/router.py`): declares `needs_reconnect` so the flag survives serialization on `GET /api/v1/integrations` (the payload the UI reads) — without this the banner never rendered.
- **Frontend** (`integrations/[provider]/page.tsx`, `lib/integrations.ts`): `IntegrationAccount.needs_reconnect` type + a reconnect banner on the per-integration page when an account is connected-but-dead.

## Tests

- `test_gmail_status_flags_dead_account_for_reconnect` — dead account reports `needs_reconnect: true`; healthy one `false`.
- `test_integrations_list_exposes_needs_reconnect` — the flag survives the router response model.
- `test_unscoped_search_surfaces_dead_federated_source` — a 401 from a federated source surfaces a `needs_reconnect` marker instead of vanishing.
- `test_federated_search_logs_only_failure_metadata` — updated for the new marker; asserts it does **not** leak the token/query from an unmapped exception.

Backend suites passing (`test_sources.py`, `test_integration_sources.py`, `test_gmail_multi_account.py`, callback/token-refresh); `ruff` clean; frontend `tsc`/`eslint` clean on changed files. Product screenshot of the reconnect banner + end-to-end verification in the thread below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)