### PR TITLE
Extend the truncation warning to `ls` and `tree`

### DIFF
--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -173,6 +173,13 @@ class SkillAppVfsShell:
             names = self.model.list_dir(path)
             lines = [self._format_ls_entry(posixpath.join(path, name), long) for name in names]
             blocks.append("\n".join(lines))
+            hit = self.model.truncated_root_containing(path)
+            if hit:
+                source_root, shown = hit
+                self._warn(
+                    f"ls: '{source_root}' was truncated at {shown} entries; this listing "
+                    "may be INCOMPLETE."
+                )
         return "\n".join(block for block in blocks if block) + ("\n" if blocks else "")
 
     def _format_ls_entry(self, path: str, long: bool) -> str:
@@ -274,6 +281,11 @@ class SkillAppVfsShell:
         self.model._get_node(root)
         lines = [root]
         lines.extend(self._tree_lines(root, prefix="", depth=1, max_depth=max_depth))
+        for source_root, shown in self.model.truncated_roots_under(root):
+            self._warn(
+                f"tree: '{source_root}' has more than {shown} entries; only the first "
+                f"{shown} were listed. This tree is INCOMPLETE."
+            )
         return "\n".join(lines) + "\n"
 
     def _tree_lines(

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -345,12 +345,23 @@ class StashVfsModel:
 
     def truncated_roots_under(self, root: str) -> list[tuple[str, int]]:
         """Truncated source roots overlapping `root` (root contains the source,
-        or sits inside it). Returns (source_root, entries_shown) pairs."""
+        or sits inside it). For subtree enumeration (find/tree): any overlap
+        means the enumeration is incomplete. Returns (source_root, shown) pairs."""
         return sorted(
             (s, shown)
             for s, shown in self._truncated.items()
             if s == root or s.startswith(root.rstrip("/") + "/") or root.startswith(s + "/")
         )
+
+    def truncated_root_containing(self, path: str) -> tuple[str, int] | None:
+        """The truncated source root that CONTAINS `path` (path is at or below
+        it), or None. For single-directory listing (ls): an ancestor like
+        /sources — whose own children are complete — must not match, so this is
+        narrower than truncated_roots_under."""
+        for s, shown in self._truncated.items():
+            if path == s or path.startswith(s + "/"):
+                return s, shown
+        return None
 
     def _add_source_entries(self, source_root: str, handle: str, entries: list[dict]) -> None:
         parent_refs = _ancestor_refs(entries)

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -370,3 +370,37 @@ def test_stat_omits_external_ref_when_the_entry_has_none():
     result = shell.run("stat '/sources/gmail/threads/Nested note'")
 
     assert "external_ref" not in result.stdout
+
+
+def test_tree_warns_when_a_source_exceeds_the_materialization_ceiling(monkeypatch):
+    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    shell, _client = _shell(PagedSourceClient())
+
+    result = shell.run("tree /sources/gmail")
+
+    assert "Message 0" in result.stdout
+    assert "INCOMPLETE" in result.stderr
+
+
+def test_ls_warns_inside_a_truncated_source_but_not_above_it(monkeypatch):
+    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    shell, _client = _shell(PagedSourceClient())
+
+    # Listing the source root — children come from the capped materialization.
+    inside = shell.run("ls /sources/gmail")
+    assert "INCOMPLETE" in inside.stderr
+
+    # Listing /sources — children are the complete provider list, not the capped
+    # entries — must NOT warn, even though a truncated source sits below it.
+    above = shell.run("ls /sources")
+    assert "gmail" in above.stdout
+    assert "INCOMPLETE" not in above.stderr
+
+
+def test_ls_is_silent_when_a_source_listing_is_complete():
+    shell, _client = _shell()  # base FakeClient reports not-truncated
+
+    result = shell.run("ls /sources/gmail")
+
+    assert "Welcome email" in result.stdout
+    assert "INCOMPLETE" not in result.stderr


### PR DESCRIPTION
we forgot to add truncation warnings to tree and ls

# Slop
Follow-up to #697 (the `find` truncation warning, now merged). `ls` and `tree` sit on the same materialization ceiling (`SOURCE_ENTRIES_MAX`) and were still silent when a source's tree was incomplete — so `ls /sources/google` or `tree /sources/google` could present a partial view as if it were complete.

## Change
Reuse the plumbing from #697 (`self._truncated`, per-source shown counts):
- **`tree`** enumerates a subtree exactly like `find`, so it reuses `truncated_roots_under(root)` and warns on any overlapping truncated source.
- **`ls`** asks a narrower question — *"are the immediate children of THIS directory complete?"* — so it uses a new `truncated_root_containing(path)` helper: warn only when the listed path is **at or below** a truncated source root, never above it. Without this, `ls /sources` (whose children are the complete provider list from `list_sources`, not the capped entries) would false-alarm.

Resulting behavior:

| command | warns? | why |
|---|---|---|
| `ls /sources` | no | provider list is complete |
| `ls /sources/google` | yes | children drawn from the capped materialization |
| `ls /sources/google/sub` | yes | can't guarantee all children present |
| `tree /sources/google` | yes | subtree enumeration is incomplete |
| `tree /files` | no | no truncated source in scope |

Warnings go to **stderr**, matching `find`, so piped stdout stays clean. The `ls` wording is deliberately conservative (*"may be INCOMPLETE"*) because the ceiling is on the source's flat path-ordered materialization, so we can't cheaply prove a specific subfolder is whole.

## Tests
`cli/tests/test_app_vfs.py` (reusing the `PagedSourceClient` + `SOURCE_ENTRIES_MAX` monkeypatch pattern): `tree` warns past the ceiling; `ls` warns inside a truncated source but **not** above it; `ls` stays silent when the listing is complete.

- CLI suite: 30 passed · `ruff`: clean.

Rebased onto current `main` (picks up #701's keyset-cursor paging; the truncation primitives it introduced are reused unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)