### PR TITLE
Disclose federated search truncation instead of silently capping

### DIFF
--- a/backend/integrations/gmail/indexer.py
+++ b/backend/integrations/gmail/indexer.py
@@ -75,13 +75,21 @@ async def _list_message_refs(
     client: httpx.AsyncClient,
     query: str,
     limit: int,
-) -> list[dict]:
+) -> tuple[list[dict], str | None, int | None]:
+    """Returns (message refs, nextPageToken, resultSizeEstimate). A nextPageToken
+    means Gmail matched more than we fetched — the authoritative "there is more"
+    signal; resultSizeEstimate is Gmail's rough total-match count."""
     resp = await client.get(
         MESSAGES_URL,
         params={"q": query, "maxResults": min(limit, 100)},
     )
     resp.raise_for_status()
-    return resp.json().get("messages", []) or []
+    body = resp.json()
+    return (
+        body.get("messages", []) or [],
+        body.get("nextPageToken"),
+        body.get("resultSizeEstimate"),
+    )
 
 
 async def _get_message_metadata(client: httpx.AsyncClient, message_id: str) -> dict:
@@ -117,7 +125,7 @@ async def index_gmail(source: dict) -> str | None:
 
     present: list[str] = []
     async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
-        refs = await _list_message_refs(client, DEFAULT_INDEX_QUERY, MAX_INDEX_MESSAGES)
+        refs, _, _ = await _list_message_refs(client, DEFAULT_INDEX_QUERY, MAX_INDEX_MESSAGES)
         messages = await asyncio.gather(
             *(_get_message_metadata(client, ref["id"]) for ref in refs if ref.get("id"))
         )
@@ -131,12 +139,18 @@ async def index_gmail(source: dict) -> str | None:
     return None
 
 
-async def search_gmail(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
+async def search_gmail(source: dict, query: str, limit: int = SEARCH_LIMIT) -> dict:
+    """Live-search the mailbox, capped at SEARCH_LIMIT. Returns
+    {hits, truncated, estimated_total}: `truncated` is true when Gmail matched
+    more than the cap, so callers can disclose the cut instead of passing the
+    top slice off as the whole result."""
     owner_user_id = UUID(source["owner_user_id"])
     token = await get_valid_token(owner_user_id, "gmail", source["external_ref"])
 
     async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
-        refs = await _list_message_refs(client, query, min(limit, SEARCH_LIMIT))
+        refs, next_page_token, estimated_total = await _list_message_refs(
+            client, query, min(limit, SEARCH_LIMIT)
+        )
         messages = await asyncio.gather(
             *(_get_message_metadata(client, ref["id"]) for ref in refs if ref.get("id"))
         )
@@ -153,7 +167,11 @@ async def search_gmail(source: dict, query: str, limit: int = SEARCH_LIMIT) -> l
                 "snippet": message.get("snippet") or "",
             }
         )
-    return hits
+    return {
+        "hits": hits,
+        "truncated": bool(next_page_token),
+        "estimated_total": estimated_total,
+    }
 
 
 def _decode_body_data(data: str) -> str:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -986,7 +986,12 @@ async def _federated_search(
     single error marker ({source, source_name, error, needs_reconnect}) so the
     rest of the search stays alive while the dead source is still surfaced —
     dropping it silently would read as "no matches" for that source. A SCOPED
-    search raises instead, so the API serves an explicit HTTP error."""
+    search raises instead, so the API serves an explicit HTTP error.
+
+    Providers cap results (SEARCH_LIMIT); when a provider reports it matched
+    more than it returned, a trailing truncation marker ({source, source_name,
+    truncated, returned, estimated_total}) is appended so callers disclose the
+    cut instead of presenting the top slice as the whole result."""
     source_type = source["source_type"]
     try:
         if source_type == "google_drive":
@@ -1003,7 +1008,7 @@ async def _federated_search(
             from ..integrations.twitter.indexer import search_twitter as fn
         else:
             return []
-        hits = await fn(source, query, limit)
+        result = await fn(source, query, limit)
     except Exception as exc:
         if not swallow_errors:
             raise _scoped_search_error(source, exc) from exc
@@ -1030,7 +1035,17 @@ async def _federated_search(
                 "needs_reconnect": needs_reconnect,
             }
         ]
-    return [
+    # Gmail reports truncation as {hits, truncated, estimated_total}; the other
+    # providers still return a plain hit list (no truncation signal yet).
+    if isinstance(result, dict):
+        hits = result["hits"]
+        truncated = result["truncated"]
+        estimated_total = result.get("estimated_total")
+    else:
+        hits = result
+        truncated = False
+        estimated_total = None
+    output = [
         {
             "source": source["id"],
             "source_name": source["display_name"],
@@ -1040,6 +1055,17 @@ async def _federated_search(
         }
         for h in hits
     ]
+    if truncated:
+        output.append(
+            {
+                "source": source["id"],
+                "source_name": source["display_name"],
+                "truncated": True,
+                "returned": len(hits),
+                "estimated_total": estimated_total,
+            }
+        )
+    return output
 
 
 async def search_documents(

--- a/backend/tests/test_integration_indexer_log_security.py
+++ b/backend/tests/test_integration_indexer_log_security.py
@@ -181,7 +181,7 @@ async def test_gmail_index_success_logs_internal_source_id_only(monkeypatch):
         return "provider-token"
 
     async def list_refs(client, query, limit):
-        return [{"id": "msg-webflow-secret"}]
+        return [{"id": "msg-webflow-secret"}], None, 1
 
     async def get_metadata(client, message_id):
         return {

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1936,9 +1936,7 @@ async def test_federated_search_logs_only_failure_metadata(client: AsyncClient, 
 
 
 @pytest.mark.asyncio
-async def test_unscoped_search_surfaces_dead_federated_source(
-    client: AsyncClient, monkeypatch
-):
+async def test_unscoped_search_surfaces_dead_federated_source(client: AsyncClient, monkeypatch):
     """A dead connection (expired/revoked token) must not vanish from unscoped
     search as if it had no matches — it surfaces a needs_reconnect marker so the
     caller can tell "reconnect me" apart from "nothing found"."""
@@ -1971,6 +1969,132 @@ async def test_unscoped_search_surfaces_dead_federated_source(
             "needs_reconnect": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_search_appends_truncation_marker_when_provider_caps(
+    client: AsyncClient, monkeypatch
+):
+    """A capped federated result must disclose the cut: search appends a
+    truncation marker so callers don't present the top slice as the whole set."""
+    from backend.integrations.gmail import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="gmail",
+        external_ref="henry@ferganalabs.com",
+        display_name="Gmail (henry@ferganalabs.com)",
+    )
+
+    async def capped_search(source, query, limit):
+        return {
+            "hits": [{"ref": f"m{i}", "name": f"msg {i}", "snippet": ""} for i in range(2)],
+            "truncated": True,
+            "estimated_total": 213,
+        }
+
+    monkeypatch.setattr(indexer, "search_gmail", capped_search)
+    results = await source_service.search_all(ws, owner_id, "anything", source=src["id"])
+
+    assert [r for r in results if r.get("ref")] == [
+        {
+            "source": src["id"],
+            "source_name": "Gmail (henry@ferganalabs.com)",
+            "ref": "m0",
+            "name": "msg 0",
+            "snippet": "",
+        },
+        {
+            "source": src["id"],
+            "source_name": "Gmail (henry@ferganalabs.com)",
+            "ref": "m1",
+            "name": "msg 1",
+            "snippet": "",
+        },
+    ]
+    assert [r for r in results if r.get("truncated")] == [
+        {
+            "source": src["id"],
+            "source_name": "Gmail (henry@ferganalabs.com)",
+            "truncated": True,
+            "returned": 2,
+            "estimated_total": 213,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_omits_truncation_marker_when_not_capped(client: AsyncClient, monkeypatch):
+    from backend.integrations.gmail import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="gmail",
+        external_ref="henry@ferganalabs.com",
+        display_name="Gmail (henry@ferganalabs.com)",
+    )
+
+    async def complete_search(source, query, limit):
+        return {
+            "hits": [{"ref": "m0", "name": "only", "snippet": ""}],
+            "truncated": False,
+            "estimated_total": 1,
+        }
+
+    monkeypatch.setattr(indexer, "search_gmail", complete_search)
+    results = await source_service.search_all(ws, owner_id, "anything", source=src["id"])
+
+    assert not any(r.get("truncated") for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_gmail_reports_truncation_from_next_page_token(monkeypatch):
+    """search_gmail maps Gmail's nextPageToken to truncated and surfaces the
+    resultSizeEstimate — the authoritative "there is more" signal, not a
+    len(hits) == limit guess."""
+    from backend.integrations.gmail import indexer
+
+    class GmailClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+    async def token(*args, **kwargs):
+        return "tok"
+
+    async def get_metadata(client, message_id):
+        return {"id": message_id, "payload": {"headers": [{"name": "Subject", "value": "hi"}]}}
+
+    async def upsert(source, message):
+        return message["id"]
+
+    monkeypatch.setattr(indexer, "get_valid_token", token)
+    monkeypatch.setattr(indexer.httpx, "AsyncClient", lambda *a, **k: GmailClient())
+    monkeypatch.setattr(indexer, "_get_message_metadata", get_metadata)
+    monkeypatch.setattr(indexer, "_upsert_message_metadata", upsert)
+    source = {"id": str(uuid4()), "owner_user_id": str(uuid4()), "external_ref": "e@x.com"}
+
+    async def more_pages(client, query, limit):
+        return [{"id": "m1"}, {"id": "m2"}], "PAGE_2", 213
+
+    monkeypatch.setattr(indexer, "_list_message_refs", more_pages)
+    result = await indexer.search_gmail(source, "q", 25)
+    assert result["truncated"] is True
+    assert result["estimated_total"] == 213
+    assert len(result["hits"]) == 2
+
+    async def last_page(client, query, limit):
+        return [{"id": "m1"}], None, 1
+
+    monkeypatch.setattr(indexer, "_list_message_refs", last_page)
+    result = await indexer.search_gmail(source, "q", 25)
+    assert result["truncated"] is False
 
 
 @pytest.mark.asyncio

--- a/cli/main.py
+++ b/cli/main.py
@@ -2308,6 +2308,17 @@ def _print_search(query: str, source: str, limit: int, as_json: bool) -> None:
         return
     for hit in data:
         label = hit.get("source_name") or hit.get("source")
+        if hit.get("error"):
+            console.print(f"  [yellow]⚠ {label}: {hit['error']}[/yellow]")
+            continue
+        if hit.get("truncated"):
+            estimate = hit.get("estimated_total")
+            of_total = f" of ~{estimate}" if estimate else ""
+            console.print(
+                f"  [dim]… {label}: showing first {hit.get('returned')}{of_total} matches — "
+                f"narrow the query to see more.[/dim]"
+            )
+            continue
         name = hit.get("name") or hit.get("ref") or ""
         console.print(f"  [bold]{name}[/bold]  [dim]({label}: {hit.get('ref')})[/dim]")
         snippet = (hit.get("snippet") or "").replace("\n", " ").strip()

--- a/cli/tests/test_sources_cli.py
+++ b/cli/tests/test_sources_cli.py
@@ -79,3 +79,41 @@ def test_list_source_entries_sends_path_as_query_param(monkeypatch) -> None:
     entries = client.list_source_entries("src-9", path="specs/")
     assert entries == [{"path": "a.md"}]
     assert requests == [("GET", "/api/v1/me/sources/src-9/entries", {"path": "specs/"})]
+
+
+def test_search_renders_error_and_truncation_markers(monkeypatch, capsys) -> None:
+    """Non-JSON `stash search` must render marker entries as disclosures — a
+    dead source as a warning, a capped result as a "showing first N" note — not
+    as blank hit rows."""
+
+    class _MarkerClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def search_sources(self, query, source=None, limit=20):
+            return [
+                {"source_name": "Gmail (a@b.com)", "ref": "m1", "name": "Hello", "snippet": "hi"},
+                {
+                    "source_name": "Gmail (a@b.com)",
+                    "truncated": True,
+                    "returned": 25,
+                    "estimated_total": 213,
+                },
+                {
+                    "source_name": "Jira (PROJ)",
+                    "error": "reconnect it in Settings",
+                    "needs_reconnect": True,
+                },
+            ]
+
+    monkeypatch.setattr(main, "_require_auth", lambda: None)
+    monkeypatch.setattr(main, "_client", lambda: _MarkerClient())
+    main.search("q", source="", limit=30, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "Hello" in out
+    assert "213" in out
+    assert "reconnect it in Settings" in out

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -783,23 +783,34 @@ function SearchablePanel({
         <div className="mb-2 px-1.5 py-1 text-[12.5px] text-error">{searchError}</div>
       )}
 
-      {hits !== null && (
-        <div className="mb-2">
-          {hits.length === 0 ? (
-            <div className="px-1.5 py-1 text-[12.5px] text-muted">No matches.</div>
-          ) : (
-            hits.map((hit) => (
-              <HitRow
-                key={hit.ref}
-                hitKey={hit.ref}
-                label={hit.name}
-                snippet={hit.snippet}
-                onOpen={() => setOpenDoc({ ref: hit.ref, name: hit.name })}
-              />
-            ))
-          )}
-        </div>
-      )}
+      {hits !== null && (() => {
+        const realHits = hits.filter((hit) => hit.ref);
+        const truncation = hits.find((hit) => hit.truncated);
+        return (
+          <div className="mb-2">
+            {realHits.length === 0 ? (
+              <div className="px-1.5 py-1 text-[12.5px] text-muted">No matches.</div>
+            ) : (
+              realHits.map((hit) => (
+                <HitRow
+                  key={hit.ref}
+                  hitKey={hit.ref!}
+                  label={hit.name}
+                  snippet={hit.snippet}
+                  onOpen={() => setOpenDoc({ ref: hit.ref!, name: hit.name })}
+                />
+              ))
+            )}
+            {truncation && (
+              <div className="px-1.5 py-1 text-[12px] text-muted">
+                Showing the first {truncation.returned}
+                {truncation.estimated_total ? ` of ~${truncation.estimated_total}` : ""} matches —
+                narrow your search to see more.
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       {hits === null && recent && recent.length > 0 && (
         <div className="mb-2">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -360,9 +360,15 @@ export async function readSourceDoc(
 export interface SourceSearchHit {
   source: string;
   source_name?: string;
-  ref: string;
+  // A real hit carries a ref; marker entries (see below) omit it.
+  ref?: string;
   name?: string;
   snippet?: string;
+  // Marker: a federated source hit its result cap — `returned` of ~`estimated_total`
+  // matches are shown. `truncated` distinguishes it from a real hit.
+  truncated?: boolean;
+  returned?: number;
+  estimated_total?: number | null;
 }
 
 export async function searchSource(


### PR DESCRIPTION
warn that we're truncating results in gmail search

# Slop
## Problem

Gmail search is federated live and caps at `SEARCH_LIMIT = 25` results per mailbox. We returned that top slice as a bare list, so a caller — the **agent's `_search` tool** especially — couldn't tell "these are all your matches" from "here are the first 25 of hundreds." It would confidently answer as if it had seen everything.

And we were throwing away the exact signal to fix it: Gmail's `messages.list` returns `nextPageToken` (⟺ more matches exist) and `resultSizeEstimate` (rough total), both discarded in `_list_message_refs`.

## Changes

- **Gmail indexer**: `_list_message_refs` now returns `(refs, nextPageToken, resultSizeEstimate)`; `search_gmail` returns `{hits, truncated, estimated_total}` where `truncated = bool(nextPageToken)` — the authoritative "there is more" signal, **not** a `len(hits) == limit` guess (which can't work here, since the cap is *below* the requested limit).
- **`_federated_search`**: normalizes Gmail's richer return and appends a trailing truncation marker `{source, source_name, truncated, returned, estimated_total}` when the provider capped. Consistent with the error-marker pattern from #704.
- **CLI `stash search`**: renders the truncation marker as a `… showing first N of ~M matches` note, and the (previously unhandled) error marker as a warning — instead of blank rows.
- **Frontend** per-integration search box: filters marker entries out of the hit list and shows a `Showing the first N of ~M matches` notice.

## Scope

Gmail-only for now (it has a clean `nextPageToken`). The other federated providers (Jira/Asana/Drive/Linear) share the same silent-cap and still return plain lists — a fast-follow can add their per-provider "more exists" signal through the same marker path. Raising `SEARCH_LIMIT` / paginating is a separate lever, orthogonal to *disclosing* the cut.

## Tests

- `test_search_gmail_reports_truncation_from_next_page_token` — `nextPageToken` → `truncated: true`, `None` → `false`; surfaces `resultSizeEstimate`.
- `test_search_appends_truncation_marker_when_provider_caps` / `..._omits_..._when_not_capped` — marker wiring through `search_all`.
- `test_search_renders_error_and_truncation_markers` (CLI) — both marker kinds render.
- Existing gmail index test updated for the new `_list_message_refs` tuple.

Full lint CI-equivalent (`ruff check` + `ruff format --check` on `backend/ cli/`) clean; frontend `tsc`/`eslint` clean on changed files. Backend suites green (one **pre-existing, unrelated** Gong failure — `test_gong_index_success...`, fails on `origin/main` too).

**Real-world evidence this fires:** live prod queries against the reconnected `henry@ferganalabs.com` mailbox already return exactly 25 for `Docusign`/`Coleman`/`workspace-noreply` (i.e. capped) — those will now surface the truncation notice on deploy. UI screenshot in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)