### PR TITLE
Classify rejected Jira/Asana token refreshes as needs_reconnect, not 500

### DIFF
--- a/backend/integrations/asana/provider.py
+++ b/backend/integrations/asana/provider.py
@@ -56,8 +56,9 @@ class AsanaIntegration(Integration):
     async def _token_request(self, payload: dict) -> TokenSet:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(TOKEN_URL, data=payload)
-            if resp.status_code >= 400:
-                raise RuntimeError(f"Asana token endpoint returned status_code={resp.status_code}")
+            # httpx.HTTPStatusError so a dead grant is classified as
+            # needs_reconnect by _account_needs_reconnect instead of a 500.
+            resp.raise_for_status()
             data = resp.json()
         expires_in = data.get("expires_in")
         expires_at = datetime.now(UTC) + timedelta(seconds=expires_in) if expires_in else None

--- a/backend/integrations/jira/provider.py
+++ b/backend/integrations/jira/provider.py
@@ -62,10 +62,9 @@ class JiraIntegration(Integration):
     async def _token_request(self, payload: dict) -> TokenSet:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(TOKEN_URL, json=payload)
-            if resp.status_code >= 400:
-                raise RuntimeError(
-                    f"Atlassian token endpoint returned status_code={resp.status_code}"
-                )
+            # httpx.HTTPStatusError so a dead grant is classified as
+            # needs_reconnect by _account_needs_reconnect instead of a 500.
+            resp.raise_for_status()
             data = resp.json()
         expires_in = data.get("expires_in")
         expires_at = datetime.now(UTC) + timedelta(seconds=expires_in) if expires_in else None

--- a/backend/tests/test_integration_reconnect.py
+++ b/backend/tests/test_integration_reconnect.py
@@ -1,0 +1,82 @@
+"""A dead OAuth grant must degrade to needs_reconnect, never a 500.
+
+GET /api/v1/integrations actively refreshes every expired token to compute
+needs_reconnect. When the provider's token endpoint rejects the refresh
+(revoked grant, expired refresh token), that rejection must be classified as
+a dead account — one bad Jira row must not take down the whole integrations
+list the settings UI reads.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from backend.integrations import crypto as integration_crypto
+from backend.integrations import storage
+from backend.integrations.base import AccountInfo, TokenSet
+from backend.integrations.jira import provider as jira_provider
+
+from .conftest import unique_name
+
+TEST_FERNET_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+@pytest.fixture(autouse=True)
+def _integration_encryption(monkeypatch):
+    monkeypatch.setattr(integration_crypto.settings, "INTEGRATIONS_ENCRYPTION_KEY", TEST_FERNET_KEY)
+
+
+class _RefreshRejectedClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+    async def post(self, url, *args, **kwargs):
+        return httpx.Response(400, text="invalid_grant", request=httpx.Request("POST", url))
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("jira"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+@pytest.mark.asyncio
+async def test_rejected_refresh_surfaces_needs_reconnect_not_500(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr(jira_provider.settings, "JIRA_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setattr(jira_provider.settings, "JIRA_OAUTH_CLIENT_SECRET", "csecret")
+    monkeypatch.setattr(jira_provider.httpx, "AsyncClient", _RefreshRejectedClient)
+
+    api_key, user_id = await _register(client)
+    # Expired access token WITH a refresh token — the list endpoint attempts a
+    # refresh, and Atlassian rejects it.
+    await storage.store_token(
+        user_id,
+        "jira",
+        TokenSet(
+            access_token="token-dead",
+            refresh_token="refresh-dead",
+            expires_at=datetime(2020, 1, 1, tzinfo=UTC),
+            scopes=["read:jira-work"],
+        ),
+        AccountInfo(email="henry@ferganalabs.com", display_name="Henry"),
+    )
+
+    resp = await client.get("/api/v1/integrations", headers={"Authorization": f"Bearer {api_key}"})
+
+    assert resp.status_code == 200
+    jira = next(p for p in resp.json()["providers"] if p["provider"] == "jira")
+    assert jira["connected"] is True
+    assert all(a["needs_reconnect"] is True for a in jira["accounts"])

--- a/backend/tests/test_oauth_provider_security.py
+++ b/backend/tests/test_oauth_provider_security.py
@@ -1,12 +1,10 @@
+import httpx
 import pytest
 
 from backend.integrations.asana import provider as asana_provider
 from backend.integrations.jira import provider as jira_provider
 
-
-class _FakeResponse:
-    status_code = 400
-    text = "invalid_grant token=secret-token customer transcript"
+_BODY = "invalid_grant token=secret-token customer transcript"
 
 
 class _FakeAsyncClient:
@@ -19,19 +17,18 @@ class _FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, traceback):
         return None
 
-    async def post(self, *args, **kwargs):
-        return _FakeResponse()
+    async def post(self, url, *args, **kwargs):
+        return httpx.Response(400, text=_BODY, request=httpx.Request("POST", url))
 
 
 @pytest.mark.asyncio
 async def test_asana_token_errors_do_not_include_provider_response(monkeypatch):
     monkeypatch.setattr(asana_provider.httpx, "AsyncClient", _FakeAsyncClient)
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
         await asana_provider.AsanaIntegration()._token_request({"grant_type": "refresh_token"})
 
     message = str(exc_info.value)
-    assert message == "Asana token endpoint returned status_code=400"
     assert "secret-token" not in message
     assert "customer transcript" not in message
     assert "invalid_grant" not in message
@@ -41,11 +38,10 @@ async def test_asana_token_errors_do_not_include_provider_response(monkeypatch):
 async def test_jira_token_errors_do_not_include_provider_response(monkeypatch):
     monkeypatch.setattr(jira_provider.httpx, "AsyncClient", _FakeAsyncClient)
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
         await jira_provider.JiraIntegration()._token_request({"grant_type": "refresh_token"})
 
     message = str(exc_info.value)
-    assert message == "Atlassian token endpoint returned status_code=400"
     assert "secret-token" not in message
     assert "customer transcript" not in message
     assert "invalid_grant" not in message


### PR DESCRIPTION
## Problem

`GET /api/v1/integrations` returns **500 "Internal server error"** for any user whose Jira (or Asana) refresh token has been revoked or expired — which breaks the entire integrations/connect UI (reproduced in production; the settings modal just shows a red "Internal server error" banner).

Since #704, the list endpoint actively refreshes every expired token to compute `needs_reconnect`. That check catches `HTTPException` and `httpx.HTTPError`, but Jira and Asana's `_token_request` raised a bare `RuntimeError` on a provider 4xx, which sailed through the catch:

```python
raise RuntimeError(f"Atlassian token endpoint returned status_code={resp.status_code}")
```

One dead Jira row → the whole list 500s.

## Fix

`_token_request` in the Jira and Asana providers now raises via `resp.raise_for_status()` (`httpx.HTTPStatusError`), matching every other provider — so a rejected refresh is classified as a dead account and surfaces as `needs_reconnect: true` with a reconnect prompt.

Deliberately **not** fixed by widening the catch to `RuntimeError`: that would misclassify genuine config errors (e.g. `JIRA_OAUTH_CLIENT_ID` unset) as "needs reconnect".

The security property the old `RuntimeError` encoded — provider response bodies (which can contain tokens) never leak into error messages — still holds: `httpx.HTTPStatusError` carries only the status and URL. `test_oauth_provider_security.py` is updated to pin that against the new exception type.

Not touched: Linear/Slack/GitHub/Notion also raise `RuntimeError` in `refresh()`/`exchange_code`, but those paths are unreachable from the reconnect check (no stored refresh token → clean 401 first) or already wrapped by the callback's broad catch.

## Tests

- New `backend/tests/test_integration_reconnect.py`: expired Jira token with a refresh token that Atlassian rejects → `/integrations` returns 200 with `needs_reconnect: true` (this test 500s without the fix).
- Updated `test_oauth_provider_security.py` fakes to real `httpx.Response` objects; still asserts no response-body leakage.
- 128 tests across the touched and adjacent suites pass; ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)