### PR TITLE
Recreate linear_index: prod never ran the collided 0116 migration

### DIFF
--- a/backend/migrations/versions/0124_recreate_linear_index.py
+++ b/backend/migrations/versions/0124_recreate_linear_index.py
@@ -1,0 +1,50 @@
+"""Recreate linear_index: production never got it.
+
+0116_linear_source collided with another migration that was also numbered 0116
+(later renumbered to 0117 in #659). Production had already recorded revision
+0116 when the collision was resolved, so alembic skipped the Linear DDL and
+`linear_index` was never created there — the Linear source has been broken in
+production since launch.
+
+Databases migrated after the renumber fix DO have the table (their 0116 ran),
+so this drops and recreates it for one deterministic outcome everywhere. The
+table is an index-only cache rebuilt from Linear on the next sync; dropping it
+loses nothing durable. The shape matches the other post-user-scope-collapse
+index tables (owner_user_id instead of workspace_id, FK to user_sources).
+
+Revision ID: 0124
+Revises: 0123
+"""
+
+from alembic import op
+
+revision = "0124"
+down_revision = "0123"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS linear_index")
+    # No extra (source_id, path) index: the UNIQUE constraint already provides
+    # the btree the upsert's ON CONFLICT and lookups use.
+    op.execute("""
+        CREATE TABLE linear_index (
+            id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            source_id           uuid NOT NULL REFERENCES user_sources(id) ON DELETE CASCADE,
+            path                text NOT NULL,
+            name                text NOT NULL,
+            kind                text NOT NULL DEFAULT 'issue',
+            external_ref        text,
+            external_updated_at timestamptz,
+            created_at          timestamptz NOT NULL DEFAULT now(),
+            updated_at          timestamptz NOT NULL DEFAULT now(),
+            deleted_at          timestamptz,
+            UNIQUE (source_id, path)
+        )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS linear_index")


### PR DESCRIPTION
looks like we had an orphaned migration?

## Problem

The Linear source (#652) has never worked in production: the `linear_index` table doesn't exist there, even though prod's alembic version is `0123`. Adding a Linear source today would crash on first sync, and no `/sources/linear` mount can appear.

Root cause is a migration numbering collision on June 15:

1. #651 merged with `0116_html_full_width_layout`. Prod deployed it and recorded alembic revision `0116`.
2. #652 merged the same day, adding a second migration with revision id `0116` (`0116_linear_source`, which creates `linear_index`).
3. #659 resolved the collision by renumbering the HTML migration to `0117` — but prod had already recorded `0116` as applied, so alembic never ran the Linear DDL, and every deploy since has skipped past it.

## Fix

New migration `0124` that drops and recreates `linear_index`:

- **Drop + create (not `IF NOT EXISTS`)** because databases migrated after the renumber fix *do* have the table from their 0116 run, while prod doesn't. Drop/create gives one deterministic outcome everywhere. Safe: `linear_index` is an index-only cache rebuilt from Linear on the next sync — nothing durable is lost.
- **Current schema shape**, not 0116's: migrations 0118–0120 collapsed workspace scope after 0116 was written, so the table uses `owner_user_id → users(id)` and `source_id → user_sources(id)`, matching `notion_index` and the other index tables.

## Verification

- `pytest backend/tests/test_migrations.py` — both tests pass: full chain (`0001 → 0124`) upgrades cleanly on a fresh Postgres, and history stays linear.
- Constraint set on the resulting table matches `notion_index` in prod exactly (PK, unique `(source_id, path)`, both FKs with `ON DELETE CASCADE`).
- Ticket enrichment (`session_linear_tickets`) is unaffected — it was never broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)