### PR TITLE
Linear OAuth: store refresh tokens and refresh 24h access tokens

### DIFF
--- a/backend/integrations/linear/provider.py
+++ b/backend/integrations/linear/provider.py
@@ -1,9 +1,11 @@
 """Linear OAuth provider.
 
-Linear issues long-lived access tokens with no refresh token (like GitHub
-user tokens), so supports_refresh is False. The connected token is what reads
-issues for ticket enrichment (backend/services/linear_ticket_service.py); the
-inbound webhook in backend/routers/webhooks.py keeps those labels fresh.
+Linear migrated all OAuth apps to 24-hour access tokens with rotating refresh
+tokens on 2026-04-01, so supports_refresh is True; storage.get_valid_token
+refreshes on use and COALESCEs the rotated refresh token back in. The
+connected token is what reads issues for ticket enrichment
+(backend/services/linear_ticket_service.py); the inbound webhook in
+backend/routers/webhooks.py keeps those labels fresh.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ class LinearIntegration(Integration):
     display_name = "Linear"
     # `read` covers issue lookups; app-level webhooks are delivered regardless of scope.
     scopes = ["read"]
-    supports_refresh = False
+    supports_refresh = True
 
     def _client_id(self) -> str:
         if not settings.LINEAR_OAUTH_CLIENT_ID:
@@ -55,18 +57,9 @@ class LinearIntegration(Integration):
         }
         return f"{AUTHORIZE_URL}?{urlencode(params)}"
 
-    async def exchange_code(self, code: str) -> TokenSet:
+    async def _token_request(self, payload: dict) -> TokenSet:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.post(
-                TOKEN_URL,
-                data={
-                    "grant_type": "authorization_code",
-                    "client_id": self._client_id(),
-                    "client_secret": self._client_secret(),
-                    "redirect_uri": self._redirect_uri(),
-                    "code": code,
-                },
-            )
+            resp = await client.post(TOKEN_URL, data=payload)
             if resp.status_code >= 400:
                 raise RuntimeError(f"Linear token endpoint returned status_code={resp.status_code}")
             data = resp.json()
@@ -75,13 +68,31 @@ class LinearIntegration(Integration):
         scope = data.get("scope") or ""
         return TokenSet(
             access_token=data["access_token"],
-            refresh_token=None,
+            refresh_token=data.get("refresh_token"),
             expires_at=expires_at,
             scopes=scope.split(",") if scope else list(self.scopes),
         )
 
+    async def exchange_code(self, code: str) -> TokenSet:
+        return await self._token_request(
+            {
+                "grant_type": "authorization_code",
+                "client_id": self._client_id(),
+                "client_secret": self._client_secret(),
+                "redirect_uri": self._redirect_uri(),
+                "code": code,
+            }
+        )
+
     async def refresh(self, refresh_token: str) -> TokenSet:
-        raise RuntimeError("Linear OAuth tokens are not refreshable")
+        return await self._token_request(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self._client_id(),
+                "client_secret": self._client_secret(),
+                "refresh_token": refresh_token,
+            }
+        )
 
     async def revoke(self, access_token: str) -> None:
         async with httpx.AsyncClient(timeout=15.0) as client:

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -26,6 +26,8 @@ from backend.integrations.gong import indexer as gong_indexer
 from backend.integrations.gong.indexer import _render_call
 from backend.integrations.gong.provider import GongIntegration
 from backend.integrations.jira.indexer import _adf_to_text, _render_issue
+from backend.integrations.linear import provider as linear_provider
+from backend.integrations.linear.provider import LinearIntegration
 from backend.integrations.registry import list_providers
 from backend.integrations.twitter import indexer as twitter_indexer
 from backend.integrations.twitter import provider as twitter_provider
@@ -566,6 +568,49 @@ async def test_twitter_exchange_refresh_and_fetch_account(monkeypatch):
     account = await TwitterIntegration().fetch_account("tok")
     assert account.email is None
     assert account.display_name == "@stash"
+
+
+@pytest.mark.asyncio
+async def test_linear_exchange_and_refresh_keep_rotating_refresh_token(monkeypatch):
+    """Linear issues 24h access tokens with rotating refresh tokens (since its
+    2026-04-01 migration). Dropping the refresh token kills the connection
+    after a day — exactly the bug this pins against."""
+    monkeypatch.setattr(settings, "LINEAR_OAUTH_CLIENT_ID", "client-1")
+    monkeypatch.setattr(settings, "LINEAR_OAUTH_CLIENT_SECRET", "secret-1")
+    monkeypatch.setattr(settings, "LINEAR_OAUTH_REDIRECT_URI", "https://app.example.com/callback")
+
+    assert LinearIntegration().supports_refresh is True
+
+    exchange_client = _FakeClient(
+        {
+            "access_token": "tok",
+            "refresh_token": "refresh-1",
+            "expires_in": 86399,
+            "scope": "read",
+        }
+    )
+    monkeypatch.setattr(linear_provider.httpx, "AsyncClient", exchange_client)
+    token = await LinearIntegration().exchange_code("code-1")
+    assert token.access_token == "tok"
+    assert token.refresh_token == "refresh-1"
+    assert token.expires_at is not None
+    assert token.scopes == ["read"]
+    assert exchange_client.posts[0][1]["grant_type"] == "authorization_code"
+
+    refresh_client = _FakeClient(
+        {
+            "access_token": "tok-2",
+            "refresh_token": "refresh-2",
+            "expires_in": 86399,
+            "scope": "read",
+        }
+    )
+    monkeypatch.setattr(linear_provider.httpx, "AsyncClient", refresh_client)
+    refreshed = await LinearIntegration().refresh("refresh-1")
+    assert refreshed.access_token == "tok-2"
+    assert refreshed.refresh_token == "refresh-2"
+    assert refresh_client.posts[0][1]["grant_type"] == "refresh_token"
+    assert refresh_client.posts[0][1]["refresh_token"] == "refresh-1"
 
 
 def test_twitter_post_rendering_keeps_author_metrics_and_text():


### PR DESCRIPTION
stores refresh tokens for linear instead of randomly throwing them away

## Problem

Every Linear connection dies exactly 24 hours after consent. Linear migrated **all** OAuth apps to 24-hour access tokens with rotating refresh tokens on April 1, 2026 ([docs](https://linear.app/developers/oauth-2-0-authentication)), but our provider still assumes the old long-lived tokens:

- `supports_refresh = False`
- `exchange_code` hard-codes `refresh_token=None`, discarding the refresh token Linear returns
- `refresh()` raises `RuntimeError("Linear OAuth tokens are not refreshable")`

Observed in prod: the one connected Linear account (created June 19 14:54 UTC) expired June 20 14:54 UTC — 24h to the second — which also killed `session_linear_tickets` enrichment from that point, and blocks `stash sources add linear` with "401: linear token expired; reconnect required." (Follow-up to #710, which fixed the missing `linear_index` table.)

## Fix

Mirror the Asana provider (also rotating-refresh OAuth):

- Parse `refresh_token` from the token response in a shared `_token_request`
- Implement `refresh()` via `grant_type=refresh_token` against the same token endpoint
- `supports_refresh = True`

No storage changes needed: `storage.get_valid_token` already refreshes on use under an advisory lock and `COALESCE`s the rotated refresh token back in.

## After deploy

Existing Linear connections have no stored refresh token, so they need one reconnect through the UI. Connections made after this deploy stay alive.

## Verification

- New test `test_linear_exchange_and_refresh_keep_rotating_refresh_token` pins that exchange stores the refresh token and that `refresh()` sends `grant_type=refresh_token` and returns the rotated token — the exact bug being fixed.
- `pytest backend/tests/test_linear_ticket_service.py backend/tests/test_sources.py backend/tests/test_integration_sources.py` — 118 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)