### PR TITLE
GitHub all-repos mode: sync every visible repo with one click

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -83,6 +83,10 @@ celery.conf.update(
             "task": "backend.tasks.sources.reconcile_due",
             "schedule": 120.0,
         },
+        "sources-reconcile-github-sync-all": {
+            "task": "backend.tasks.sources.reconcile_github_sync_all",
+            "schedule": 3600.0,
+        },
         "cli-auth-cleanup-expired": {
             "task": "backend.tasks.cli_auth.cleanup_expired_sessions",
             "schedule": 300.0,

--- a/backend/integrations/github/account_sync.py
+++ b/backend/integrations/github/account_sync.py
@@ -1,0 +1,78 @@
+"""GitHub all-repos mode.
+
+When `user_integrations.sync_all` is set on a github connection, every repo
+the account can see (own, collaborations, org repos) gets a github_repo
+source. The hourly reconcile task re-runs `sync_all_repos` for flagged
+accounts so repos the user gains access to later join automatically.
+`create_source` is idempotent, so re-running is always safe.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import httpx
+
+from ...database import get_pool
+from ...services import source_service
+from ..storage import get_valid_token
+
+USER_REPOS_URL = "https://api.github.com/user/repos"
+REPOS_PAGE_SIZE = 100
+
+
+async def _fetch_repos_page(client: httpx.AsyncClient, page: int) -> list[dict]:
+    resp = await client.get(
+        USER_REPOS_URL,
+        params={
+            "per_page": REPOS_PAGE_SIZE,
+            "page": page,
+            "sort": "updated",
+            "affiliation": "owner,collaborator,organization_member",
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def list_visible_repos(access_token: str) -> list[dict]:
+    """Every repo the token can see, across all pages."""
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/vnd.github+json",
+    }
+    repos: list[dict] = []
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        page = 1
+        while True:
+            batch = await _fetch_repos_page(client, page)
+            repos.extend(batch)
+            if len(batch) < REPOS_PAGE_SIZE:
+                return repos
+            page += 1
+
+
+async def sync_all_repos(user_id: UUID) -> dict:
+    """Register a github_repo source for every visible repo the user doesn't
+    have yet. Each new source's first sync runs immediately via the scheduler."""
+    token = await get_valid_token(user_id, "github")
+    repos = await list_visible_repos(token)
+    rows = await get_pool().fetch(
+        "SELECT external_ref FROM user_sources "
+        "WHERE owner_user_id = $1 AND source_type = 'github_repo'",
+        user_id,
+    )
+    existing = {row["external_ref"] for row in rows}
+    created = 0
+    for repo in repos:
+        ref = repo["full_name"]
+        if ref in existing:
+            continue
+        await source_service.create_source(
+            owner_user_id=user_id,
+            source_type="github_repo",
+            external_ref=ref,
+            display_name=ref,
+        )
+        created += 1
+    return {"total": len(repos), "created": created}

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -32,6 +32,7 @@ from ..services import billing_service, security_audit_service, source_service
 from . import storage
 from .base import AccountInfo
 from .crypto import integration_fernet, integration_keyring_error
+from .github import account_sync as github_account_sync
 from .registry import get_provider, list_providers
 
 logger = logging.getLogger(__name__)
@@ -539,26 +540,10 @@ async def github_list_repos(
     current_user: dict = Depends(get_current_user),
     q: str = Query("", description="Substring filter on repo full_name"),
 ):
-    """List the user's GitHub repos (most-recently-updated first) so the
-    frontend can render a picker instead of asking the user to paste a URL."""
-    import httpx
-
+    """List every GitHub repo the user can see (most-recently-updated first)
+    so the frontend can render a picker instead of asking for a URL."""
     access_token = await storage.get_valid_token(current_user["id"], "github")
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/vnd.github+json",
-    }
-    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
-        resp = await client.get(
-            "https://api.github.com/user/repos",
-            params={
-                "per_page": 100,
-                "sort": "updated",
-                "affiliation": "owner,collaborator,organization_member",
-            },
-        )
-        resp.raise_for_status()
-        repos = resp.json()
+    repos = await github_account_sync.list_visible_repos(access_token)
 
     q_lower = q.lower().strip()
     out: list[GitHubRepoSummary] = []
@@ -575,6 +560,50 @@ async def github_list_repos(
             )
         )
     return out
+
+
+class GitHubRepoAccess(BaseModel):
+    # "All repositories" mode: every visible repo is kept registered as a
+    # github_repo source. total/created are only present right after a PUT
+    # that enabled the mode.
+    all_repos: bool
+    total: int | None = None
+    created: int | None = None
+
+
+class GitHubRepoAccessUpdate(BaseModel):
+    all_repos: bool
+
+
+@router.get("/github/repo-access", response_model=GitHubRepoAccess)
+async def github_get_repo_access(current_user: dict = Depends(get_current_user)):
+    return GitHubRepoAccess(all_repos=await storage.get_sync_all(current_user["id"], "github"))
+
+
+@router.put("/github/repo-access", response_model=GitHubRepoAccess)
+async def github_set_repo_access(
+    body: GitHubRepoAccessUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    """Switch between all-repos and select-repos mode. Enabling registers a
+    source for every visible repo right away; the hourly reconcile keeps the
+    set current after that. Disabling stops auto-registration but keeps the
+    sources already created."""
+    updated = await storage.set_sync_all(current_user["id"], "github", body.all_repos)
+    if not updated:
+        raise HTTPException(status_code=404, detail="GitHub is not connected")
+    await security_audit_service.record_user_event(
+        action="integration.repo_access_changed",
+        actor_user_id=current_user["id"],
+        target_type="integration",
+        target_id="github",
+        provider="github",
+        metadata={"all_repos": body.all_repos},
+    )
+    if not body.all_repos:
+        return GitHubRepoAccess(all_repos=False)
+    result = await github_account_sync.sync_all_repos(current_user["id"])
+    return GitHubRepoAccess(all_repos=True, total=result["total"], created=result["created"])
 
 
 class NotionPageSummary(BaseModel):

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -244,6 +244,36 @@ async def status(user_id: UUID, provider: str) -> dict:
     }
 
 
+async def get_sync_all(user_id: UUID, provider: str) -> bool:
+    row = await get_pool().fetchrow(
+        "SELECT bool_or(sync_all) AS sync_all FROM user_integrations "
+        "WHERE user_id = $1 AND provider = $2",
+        user_id,
+        provider,
+    )
+    return bool(row and row["sync_all"])
+
+
+async def set_sync_all(user_id: UUID, provider: str, enabled: bool) -> bool:
+    """Returns False when the provider has no stored connection to flag."""
+    result = await get_pool().execute(
+        "UPDATE user_integrations SET sync_all = $3, updated_at = now() "
+        "WHERE user_id = $1 AND provider = $2",
+        user_id,
+        provider,
+        enabled,
+    )
+    return result != "UPDATE 0"
+
+
+async def sync_all_user_ids(provider: str) -> list[UUID]:
+    rows = await get_pool().fetch(
+        "SELECT DISTINCT user_id FROM user_integrations WHERE provider = $1 AND sync_all",
+        provider,
+    )
+    return [row["user_id"] for row in rows]
+
+
 async def list_connections(user_id: UUID) -> list[dict]:
     pool = get_pool()
     rows = await pool.fetch(

--- a/backend/migrations/versions/0125_github_sync_all.py
+++ b/backend/migrations/versions/0125_github_sync_all.py
@@ -1,0 +1,24 @@
+"""GitHub all-repos mode: user_integrations.sync_all.
+
+When set on a github connection, every repo the account can see gets a
+github_repo source, and the hourly reconcile picks up repos the user gains
+access to later.
+
+Revision ID: 0125
+Revises: 0124
+"""
+
+from alembic import op
+
+revision = "0125"
+down_revision = "0124"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE user_integrations ADD COLUMN sync_all boolean NOT NULL DEFAULT false")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE user_integrations DROP COLUMN sync_all")

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -99,6 +99,29 @@ def reconcile_due() -> int:
     return run_async(_reconcile_due())
 
 
+async def _reconcile_github_sync_all() -> int:
+    """For every account in all-repos mode, register sources for repos the
+    user gained access to since the last pass. One account's dead token must
+    not starve the rest, so failures are logged per user and the loop goes on."""
+    from ..integrations import storage
+    from ..integrations.github.account_sync import sync_all_repos
+
+    user_ids = await storage.sync_all_user_ids("github")
+    reconciled = 0
+    for user_id in user_ids:
+        try:
+            await sync_all_repos(user_id)
+            reconciled += 1
+        except Exception:
+            logger.error("github sync-all reconcile failed user=%s", user_id, exc_info=True)
+    return reconciled
+
+
+@celery.task(name="backend.tasks.sources.reconcile_github_sync_all")
+def reconcile_github_sync_all() -> int:
+    return run_async(_reconcile_github_sync_all())
+
+
 @celery.task(name="backend.tasks.sources.ingest_slack_event")
 def ingest_slack_event(team_id: str, event: dict) -> int:
     """Upsert a single Slack Events-API message (enqueued by the webhook)."""

--- a/backend/tests/test_github_repo_access.py
+++ b/backend/tests/test_github_repo_access.py
@@ -1,0 +1,174 @@
+"""All-repos mode for the GitHub integration.
+
+PUT /integrations/github/repo-access with {"all_repos": true} must register a
+github_repo source for every repo the account can see, the hourly reconcile
+must pick up repos granted later, and switching back to select mode must stop
+auto-registration without deleting the sources already created.
+
+GitHub itself is faked at the account_sync seam (token + repo listing);
+everything downstream runs against the real services and DB.
+"""
+
+import uuid
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.integrations.github import account_sync
+from backend.tasks import sources as sources_tasks
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"ghall_{uuid.uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _connect_github(pool, user_id: UUID) -> None:
+    await pool.execute(
+        "INSERT INTO user_integrations "
+        "(user_id, provider, access_token_encrypted, account_key) VALUES ($1, 'github', $2, 'default')",
+        user_id,
+        b"\x00",
+    )
+
+
+@pytest.fixture
+def fake_github(monkeypatch):
+    """Fake the GitHub seam: a mutable repo list and a token that always works."""
+    repos = [{"full_name": "acme/api"}, {"full_name": "acme/web"}]
+
+    async def fake_token(user_id, provider):
+        return "tok"
+
+    async def fake_list(access_token):
+        return list(repos)
+
+    monkeypatch.setattr(account_sync, "get_valid_token", fake_token)
+    monkeypatch.setattr(account_sync, "list_visible_repos", fake_list)
+    return repos
+
+
+async def _source_refs(pool, user_id: UUID) -> set[str]:
+    rows = await pool.fetch(
+        "SELECT external_ref FROM user_sources "
+        "WHERE owner_user_id = $1 AND source_type = 'github_repo'",
+        user_id,
+    )
+    return {row["external_ref"] for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_enable_registers_every_visible_repo(client, pool, fake_github):
+    api_key, user_id = await _register(client)
+    await _connect_github(pool, user_id)
+
+    resp = await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"all_repos": True, "total": 2, "created": 2}
+    assert await _source_refs(pool, user_id) == {"acme/api", "acme/web"}
+
+    status = await client.get("/api/v1/integrations/github/repo-access", headers=_auth(api_key))
+    assert status.json()["all_repos"] is True
+
+
+@pytest.mark.asyncio
+async def test_enable_is_idempotent(client, pool, fake_github):
+    api_key, user_id = await _register(client)
+    await _connect_github(pool, user_id)
+
+    first = await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+    assert first.json()["created"] == 2
+    second = await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+    assert second.json() == {"all_repos": True, "total": 2, "created": 0}
+    assert await _source_refs(pool, user_id) == {"acme/api", "acme/web"}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_picks_up_later_granted_repos(client, pool, fake_github):
+    api_key, user_id = await _register(client)
+    await _connect_github(pool, user_id)
+    await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+
+    fake_github.append({"full_name": "acme/new-service"})
+    reconciled = await sources_tasks._reconcile_github_sync_all()
+
+    assert reconciled == 1
+    assert await _source_refs(pool, user_id) == {"acme/api", "acme/web", "acme/new-service"}
+
+
+@pytest.mark.asyncio
+async def test_disable_stops_auto_registration_but_keeps_sources(client, pool, fake_github):
+    api_key, user_id = await _register(client)
+    await _connect_github(pool, user_id)
+    await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+
+    off = await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": False},
+        headers=_auth(api_key),
+    )
+    assert off.json()["all_repos"] is False
+
+    fake_github.append({"full_name": "acme/new-service"})
+    reconciled = await sources_tasks._reconcile_github_sync_all()
+
+    assert reconciled == 0
+    assert await _source_refs(pool, user_id) == {"acme/api", "acme/web"}
+
+
+@pytest.mark.asyncio
+async def test_put_requires_a_github_connection(client, fake_github):
+    api_key, _ = await _register(client)
+    resp = await client.put(
+        "/api/v1/integrations/github/repo-access",
+        json={"all_repos": True},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_visible_repos_walks_every_page(monkeypatch):
+    pages_requested = []
+
+    async def fake_page(http_client, page):
+        pages_requested.append(page)
+        if page == 1:
+            return [{"full_name": f"acme/repo-{i}"} for i in range(account_sync.REPOS_PAGE_SIZE)]
+        return [{"full_name": "acme/tail"}]
+
+    monkeypatch.setattr(account_sync, "_fetch_repos_page", fake_page)
+    repos = await account_sync.list_visible_repos("tok")
+
+    assert pages_requested == [1, 2]
+    assert len(repos) == account_sync.REPOS_PAGE_SIZE + 1

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -289,10 +289,12 @@ export default function IntegrationPage() {
 
         {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
 
-        {/* Add a <thing> */}
+        {/* Add a <thing> (for GitHub: the all-vs-select repository access chooser) */}
         {connected && (
           <section className="mt-6">
-            <SectionLabel>Add a {itemNoun}</SectionLabel>
+            <SectionLabel>
+              {connector.kind === "github" ? "Repository access" : `Add a ${itemNoun}`}
+            </SectionLabel>
             <AddSourceControls
               connector={connector}
               connected={connected}

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -32,7 +32,7 @@ export const CONNECTORS: Connector[] = [
     label: "GitHub",
     sourceType: "github_repo",
     kind: "github",
-    blurb: "Pick repos your agent can navigate.",
+    blurb: "Sync every repo you can see, or pick specific ones.",
   },
   {
     provider: "google",

--- a/frontend/src/components/integrations/pickers.test.tsx
+++ b/frontend/src/components/integrations/pickers.test.tsx
@@ -14,6 +14,20 @@ vi.mock("@/lib/api", async (importOriginal) => {
   };
 });
 
+const getGitHubRepoAccess = vi.fn();
+const setGitHubRepoAccess = vi.fn();
+const listGitHubRepos = vi.fn();
+
+vi.mock("@/lib/integrations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/integrations")>();
+  return {
+    ...actual,
+    getGitHubRepoAccess: (...args: unknown[]) => getGitHubRepoAccess(...args),
+    setGitHubRepoAccess: (...args: unknown[]) => setGitHubRepoAccess(...args),
+    listGitHubRepos: (...args: unknown[]) => listGitHubRepos(...args),
+  };
+});
+
 const driveConnector: Connector = {
   provider: "google",
   label: "Google Drive",
@@ -44,5 +58,52 @@ describe("AddSourceControls", () => {
 
     expect(await screen.findByText("external_ref is required")).toBeTruthy();
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+const githubConnector: Connector = {
+  provider: "github",
+  label: "GitHub",
+  sourceType: "github_repo",
+  kind: "github",
+  blurb: "",
+};
+
+function renderGitHubControls() {
+  return render(
+    <AddSourceControls connector={githubConnector} connected onAdded={() => {}} />
+  );
+}
+
+// The product promise is "your agent can see everything you can see" in one
+// click: enabling all-repos mode is a single button, and leaving it is a
+// single radio click that must actually turn the server-side mode off.
+describe("GitHubAccessControls", () => {
+  it("enables all-repos mode with one click", async () => {
+    getGitHubRepoAccess.mockResolvedValue({ all_repos: false, total: null, created: null });
+    listGitHubRepos.mockResolvedValue([
+      { full_name: "acme/api", description: null, private: false, html_url: "", updated_at: null },
+      { full_name: "acme/web", description: null, private: false, html_url: "", updated_at: null },
+    ]);
+    setGitHubRepoAccess.mockResolvedValue({ all_repos: true, total: 2, created: 2 });
+    renderGitHubControls();
+
+    fireEvent.click(await screen.findByRole("radio", { name: /All repositories/ }));
+    fireEvent.click(await screen.findByText("Sync all 2 repositories"));
+
+    expect(await screen.findByText(/sync automatically/)).toBeTruthy();
+    expect(setGitHubRepoAccess).toHaveBeenCalledWith(true);
+  });
+
+  it("switching back to select repositories turns the mode off", async () => {
+    getGitHubRepoAccess.mockResolvedValue({ all_repos: true, total: null, created: null });
+    listGitHubRepos.mockResolvedValue([]);
+    setGitHubRepoAccess.mockResolvedValue({ all_repos: false, total: null, created: null });
+    renderGitHubControls();
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Only select repositories/ }));
+
+    expect(await screen.findByPlaceholderText("Search repositories...")).toBeTruthy();
+    expect(setGitHubRepoAccess).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -6,13 +6,16 @@ import type { ReactNode } from "react";
 import { addSource } from "@/lib/api";
 import {
   type IntegrationAccount,
+  getGitHubRepoAccess,
   listAsanaProjects,
   listGitHubRepos,
   listJiraProjects,
   listNotionPages,
   listSlackChannels,
+  setGitHubRepoAccess,
   type AsanaProjectSummary,
   type CredentialField,
+  type GitHubRepoAccess,
   type GitHubRepoSummary,
   type JiraProjectSummary,
   type NotionPageSummary,
@@ -80,9 +83,10 @@ export function AddSourceControls({
   if (connector.kind === "github") {
     return (
       <div className="space-y-2">
-        <GitHubRepoPicker
+        <GitHubAccessControls
           busy={busy}
-          onAdd={(repo) => add({ external_ref: repo.full_name, display_name: repo.full_name })}
+          onAddRepo={(repo) => add({ external_ref: repo.full_name, display_name: repo.full_name })}
+          onChanged={onAdded}
         />
         {errorRow}
       </div>
@@ -336,19 +340,37 @@ export function SlackChannelPicker({
   );
 }
 
-export function GitHubRepoPicker({
+// The "Repository access" block: all-repos mode vs. hand-picked repos, in the
+// style of GitHub's own App-install screen. Enabling all-repos registers a
+// source per visible repo server-side and keeps the set current hourly;
+// switching back to select stops auto-registration but keeps existing sources.
+export function GitHubAccessControls({
   busy,
-  onAdd,
+  onAddRepo,
+  onChanged,
 }: {
   busy: boolean;
-  onAdd: (repo: GitHubRepoSummary) => Promise<boolean>;
+  onAddRepo: (repo: GitHubRepoSummary) => Promise<boolean>;
+  onChanged: () => void;
 }) {
+  const [view, setView] = useState<"all" | "select" | null>(null);
+  const [enabled, setEnabled] = useState(false);
   const [repos, setRepos] = useState<GitHubRepoSummary[] | null>(null);
-  const [query, setQuery] = useState("");
+  const [syncResult, setSyncResult] = useState<GitHubRepoAccess | null>(null);
+  const [busyAll, setBusyAll] = useState(false);
   const [error, setError] = useState("");
 
   useEffect(() => {
     let cancelled = false;
+    getGitHubRepoAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setEnabled(access.all_repos);
+        setView(access.all_repos ? "all" : "select");
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load repo access");
+      });
     listGitHubRepos()
       .then((next) => {
         if (!cancelled) setRepos(next);
@@ -360,6 +382,132 @@ export function GitHubRepoPicker({
       cancelled = true;
     };
   }, []);
+
+  async function chooseSelect() {
+    setView("select");
+    if (!enabled) return;
+    setError("");
+    try {
+      await setGitHubRepoAccess(false);
+      setEnabled(false);
+      setSyncResult(null);
+    } catch (e) {
+      setView("all");
+      setError(e instanceof Error ? e.message : "Could not update repo access");
+    }
+  }
+
+  async function syncAll() {
+    setBusyAll(true);
+    setError("");
+    try {
+      const result = await setGitHubRepoAccess(true);
+      setEnabled(true);
+      setSyncResult(result);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not sync repositories");
+    } finally {
+      setBusyAll(false);
+    }
+  }
+
+  if (view === null && !error) {
+    return <div className="py-2 text-[12px] text-muted">Loading…</div>;
+  }
+
+  const count = repos?.length ?? null;
+  return (
+    <div className="space-y-2">
+      <div role="radiogroup" aria-label="Repository access" className="space-y-2">
+        <AccessChoice
+          checked={view === "all"}
+          onClick={() => setView("all")}
+          title={<>All repositories{count !== null && <span className="font-medium text-dim"> · {count}</span>}</>}
+          description="Everything you can see — your own repos, collaborations, and org repos. Repos you gain access to later sync automatically."
+        />
+        <AccessChoice
+          checked={view === "select"}
+          onClick={() => void chooseSelect()}
+          title="Only select repositories"
+          description="Pick individual repos to sync. You can add more anytime."
+        />
+      </div>
+
+      {view === "all" &&
+        (enabled ? (
+          <div className="flex items-center gap-2 rounded-md bg-surface px-3 py-2.5 text-[12.5px] text-dim">
+            <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-success" aria-hidden />
+            <span>
+              {syncResult?.created != null && `${syncResult.created} added · `}
+              All repositories sync automatically — new repos you gain access to are added within
+              an hour.
+            </span>
+          </div>
+        ) : (
+          <button type="button" disabled={busyAll} onClick={() => void syncAll()} className={primaryButton()}>
+            {busyAll ? "Syncing..." : `Sync all${count !== null ? ` ${count}` : ""} repositories`}
+          </button>
+        ))}
+
+      {view === "select" && <GitHubRepoPicker repos={repos} busy={busy} onAdd={onAddRepo} />}
+
+      {error && (
+        <div className="rounded-md bg-error/10 px-2 py-1.5 text-[11.5px] text-error">{error}</div>
+      )}
+    </div>
+  );
+}
+
+function AccessChoice({
+  checked,
+  onClick,
+  title,
+  description,
+}: {
+  checked: boolean;
+  onClick: () => void;
+  title: ReactNode;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      onClick={onClick}
+      className={
+        "flex w-full cursor-pointer items-start gap-2.5 rounded-lg border p-3 text-left transition-colors " +
+        (checked ? "border-brand bg-[var(--color-brand-50)]" : "border-border hover:bg-surface")
+      }
+    >
+      <span
+        aria-hidden
+        className={
+          "mt-0.5 grid h-[15px] w-[15px] shrink-0 place-items-center rounded-full border-[1.5px] " +
+          (checked ? "border-brand" : "border-muted")
+        }
+      >
+        {checked && <span className="h-[7px] w-[7px] rounded-full bg-brand" />}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-[13px] font-semibold text-foreground">{title}</span>
+        <span className="mt-0.5 block text-[12px] text-dim">{description}</span>
+      </span>
+    </button>
+  );
+}
+
+export function GitHubRepoPicker({
+  repos,
+  busy,
+  onAdd,
+}: {
+  repos: GitHubRepoSummary[] | null;
+  busy: boolean;
+  onAdd: (repo: GitHubRepoSummary) => Promise<boolean>;
+}) {
+  const [query, setQuery] = useState("");
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -373,8 +521,8 @@ export function GitHubRepoPicker({
 
   return (
     <PickerShell
-      error={error}
-      loading={repos === null && !error}
+      error=""
+      loading={repos === null}
       query={query}
       placeholder="Search repositories..."
       onQuery={setQuery}

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -120,6 +120,24 @@ export async function listGitHubRepos(q: string = ""): Promise<GitHubRepoSummary
   return apiFetch<GitHubRepoSummary[]>(`/api/v1/integrations/github/repos${query}`);
 }
 
+export type GitHubRepoAccess = {
+  all_repos: boolean;
+  // Only present right after a PUT that enabled all-repos mode.
+  total: number | null;
+  created: number | null;
+};
+
+export async function getGitHubRepoAccess(): Promise<GitHubRepoAccess> {
+  return apiFetch<GitHubRepoAccess>("/api/v1/integrations/github/repo-access");
+}
+
+export async function setGitHubRepoAccess(allRepos: boolean): Promise<GitHubRepoAccess> {
+  return apiFetch<GitHubRepoAccess>("/api/v1/integrations/github/repo-access", {
+    method: "PUT",
+    body: JSON.stringify({ all_repos: allRepos }),
+  });
+}
+
 export type NotionPageSummary = {
   id: string;
   title: string;


### PR DESCRIPTION
## What

Our promise is that your agent can see everything you can see. For GitHub, the `repo` OAuth scope already grants that — but connecting repos was one click *per repo*. This adds an **All repositories** mode, modeled on GitHub's own App-install screen:

- **All repositories** — one click registers a `github_repo` source for every repo the account can see (own, collaborations, org repos). An hourly reconcile re-enumerates the account, so repos you gain access to later join automatically.
- **Only select repositories** — today's picker, unchanged. Switching back turns off auto-registration but keeps existing sources.

## Screenshots

The chooser, defaulting to select mode (note the real count — 146 — from an account that used to be capped at 100 in the picker):
https://app.joinstash.ai/f/ee78be1d-6713-4e63-bc90-1c338b879b65

"All repositories" selected, one button to sync everything:
https://app.joinstash.ai/f/31a152e1-1887-4b51-9c61-a5a656b0400f

After the click — 146 sources created, mode active, repos listed:
https://app.joinstash.ai/f/303fe4c6-52e8-48ee-ac87-bd1ef2733fb5

## How

- **Migration 0125**: `user_integrations.sync_all boolean NOT NULL DEFAULT false`.
- **`integrations/github/account_sync.py`**: full pagination of `GET /user/repos` (the picker endpoint previously stopped silently at the first 100) + `sync_all_repos(user_id)`, which registers a source per missing repo via the already-idempotent `create_source`.
- **`GET/PUT /integrations/github/repo-access`**: PUT `{all_repos: true}` sets the flag and runs the sync inline, returning `{total, created}`; PUT false just clears the flag. 404 when GitHub isn't connected.
- **Celery beat** `reconcile_github_sync_all` (hourly): re-runs `sync_all_repos` for every flagged account; a dead token on one account logs loudly and doesn't starve the rest.
- **Frontend**: `GitHubAccessControls` replaces the bare repo picker under a new "Repository access" section on `/integrations/github`. The radio is a new primitive, styled with the existing brand-tint highlight; the select pane is the untouched `GitHubRepoPicker` (now parent-fetched so the repo list loads once).

## Testing

- 6 new backend tests (`test_github_repo_access.py`): enable registers every visible repo, idempotent re-run, hourly reconcile picks up later-granted repos, disable stops auto-registration but keeps sources, 404 without a connection, pagination walks every page.
- 2 new frontend tests: one-click enable calls the API and shows the active state; switching back to select turns the mode off server-side.
- Full backend suite: same single pre-existing failure as `main` (unrelated Gong log test), nothing new. Frontend: 195/195, lint and build clean.
- Verified end-to-end against real GitHub (screenshots above): 146 repos enumerated across 2 pages, one click created 146 sources, flag + rows confirmed in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)