### PR TITLE
Make the VFS self-sufficient for agents: time, size, authorship, day transcripts

### DIFF
--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -3,8 +3,10 @@
 `index_slack` backfills recent history for the source's explicit channel
 allowlist. Live updates arrive via the Events API webhook, which enqueues
 `ingest_slack_message` per message. Each message is a row at `{channel}/{ts}`
-(with native channel_id/channel_name/ts columns) so the agent can navigate by
-channel and search across allowed channels.
+(with native channel_id/channel_name/ts and author columns); the *document
+projection* over these rows is one transcript per channel per UTC day (see
+source_service.list_documents/read_document), so agents read coherent,
+attributed conversations instead of one-line files.
 """
 
 from __future__ import annotations
@@ -22,10 +24,15 @@ logger = logging.getLogger(__name__)
 
 CONVERSATIONS_LIST_URL = "https://slack.com/api/conversations.list"
 CONVERSATIONS_HISTORY_URL = "https://slack.com/api/conversations.history"
+USERS_INFO_URL = "https://slack.com/api/users.info"
 
 CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
 MAX_CHANNELS = 100
 MAX_MESSAGES_PER_CHANNEL = 200
+
+# Sorts before any real YYYY-MM-DD transcript, so the cap disclosure is the
+# first entry an agent sees when listing a capped channel.
+CAP_MARKER_LEAF = "0000-history-cap"
 
 
 async def _slack_get(client: httpx.AsyncClient, url: str, params: dict) -> dict:
@@ -35,6 +42,38 @@ async def _slack_get(client: httpx.AsyncClient, url: str, params: dict) -> dict:
     if not payload.get("ok"):
         raise RuntimeError("Slack API returned ok=false")
     return payload
+
+
+async def _author_of(
+    client: httpx.AsyncClient, names: dict[str, str], msg: dict
+) -> tuple[str | None, str]:
+    """(author_id, display name) for a message. Human messages resolve the
+    display name via users.info (cached per run); bot messages carry their
+    username inline. A message with neither (rare system subtypes) gets no
+    author and renders unattributed."""
+    user_id = msg.get("user")
+    if user_id:
+        return user_id, await _user_display_name(client, names, user_id)
+    bot_id = msg.get("bot_id")
+    if bot_id:
+        return bot_id, msg.get("username") or bot_id
+    return None, ""
+
+
+async def _user_display_name(client: httpx.AsyncClient, names: dict[str, str], user_id: str) -> str:
+    if user_id in names:
+        return names[user_id]
+    # One unresolvable user (deleted account, transient API error) must not
+    # abort a whole sync — record the raw id so the message stays attributed.
+    try:
+        payload = await _slack_get(client, USERS_INFO_URL, {"user": user_id})
+        profile = payload["user"].get("profile") or {}
+        name = profile.get("display_name") or profile.get("real_name") or payload["user"]["name"]
+    except (RuntimeError, httpx.HTTPError, KeyError) as e:
+        logger.info("slack: users.info failed user=%s exception_type=%s", user_id, type(e).__name__)
+        name = user_id
+    names[user_id] = name
+    return name
 
 
 async def index_slack(source: dict) -> str | None:
@@ -49,6 +88,7 @@ async def index_slack(source: dict) -> str | None:
 
     token = await get_valid_token(owner_user_id, "slack")
     headers = {"Authorization": f"Bearer {token}"}
+    names: dict[str, str] = {}
 
     async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
         channels_payload = await _slack_get(
@@ -80,6 +120,7 @@ async def index_slack(source: dict) -> str | None:
             for msg in history.get("messages", []):
                 if msg.get("type") != "message" or not msg.get("ts"):
                     continue
+                author_id, author = await _author_of(client, names, msg)
                 await _upsert_message(
                     source_id=source_id,
                     owner_user_id=owner_user_id,
@@ -87,7 +128,16 @@ async def index_slack(source: dict) -> str | None:
                     channel_name=channel_name,
                     ts=msg["ts"],
                     text=msg.get("text") or "",
+                    author_id=author_id,
+                    author=author,
                 )
+            await _sync_cap_marker(
+                source_id=source_id,
+                owner_user_id=owner_user_id,
+                channel_id=channel_id,
+                channel_name=channel_name,
+                capped=bool(history.get("has_more")),
+            )
 
     logger.info("slack source %s: backfill complete", source_id)
     return None
@@ -113,6 +163,7 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
     latest = f"{until.timestamp():.6f}" if until else None
 
     refs: list[str] = []
+    names: dict[str, str] = {}
     async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
         channels = (
             await _slack_get(
@@ -141,6 +192,7 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
             for msg in history.get("messages", []):
                 if msg.get("type") != "message" or not msg.get("ts"):
                     continue
+                author_id, author = await _author_of(client, names, msg)
                 await _upsert_message(
                     source_id=source_id,
                     owner_user_id=owner_user_id,
@@ -148,6 +200,8 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
                     channel_name=channel_name,
                     ts=msg["ts"],
                     text=msg.get("text") or "",
+                    author_id=author_id,
+                    author=author,
                 )
                 refs.append(f"{channel_name}/{msg['ts']}")
                 if len(refs) >= limit:
@@ -169,6 +223,8 @@ async def _upsert_message(
     channel_name: str,
     ts: str,
     text: str,
+    author_id: str | None,
+    author: str,
 ) -> None:
     existing = await get_pool().fetchrow(
         "SELECT path, name FROM slack_messages "
@@ -188,7 +244,51 @@ async def _upsert_message(
         kind="message",
         content=text,
         external_ref=f"{channel_id}:{ts}",
-        extra={"channel_id": channel_id, "channel_name": channel_name, "ts": ts},
+        extra={
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "ts": ts,
+            "author_id": author_id,
+            "author": author,
+        },
+    )
+
+
+async def _sync_cap_marker(
+    *,
+    source_id: UUID,
+    owner_user_id: UUID,
+    channel_id: str,
+    channel_name: str,
+    capped: bool,
+) -> None:
+    """Keep the channel's history-cap disclosure in step with reality. A capped
+    channel gets a notice document that lists first in its directory; a channel
+    whose full history fit gets any stale notice removed."""
+    path = f"{channel_name}/{CAP_MARKER_LEAF}"
+    if not capped:
+        await get_pool().execute(
+            "DELETE FROM slack_messages WHERE source_id = $1 AND path = $2",
+            source_id,
+            path,
+        )
+        return
+    await source_service.upsert_content_document(
+        table="slack_messages",
+        source_id=source_id,
+        owner_user_id=owner_user_id,
+        path=path,
+        name=f"#{channel_name} older history is NOT indexed",
+        kind="notice",
+        content=(
+            f"Only the {MAX_MESSAGES_PER_CHANNEL} most recent messages of #{channel_name} "
+            "are indexed. Older messages exist in Slack but are not searchable here — "
+            "an empty search result does not mean the topic was never discussed. "
+            "Pull a specific time range into the index with "
+            "POST /api/v1/me/sources/{source_id}/history {since, until}."
+        ),
+        external_ref=None,
+        extra={"channel_id": channel_id, "channel_name": channel_name, "ts": None},
     )
 
 
@@ -239,6 +339,12 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
         "AND ws.sync_enabled",
         team_id,
     )
+    # The webhook has no user token to resolve a display name with, so live
+    # messages carry the raw Slack id as their author. The next sync's
+    # freshness check sees the resolved name differs and rewrites the row.
+    author_id = event.get("user") or event.get("bot_id")
+    author = event.get("username") or author_id or ""
+
     ingested = 0
     for row in rows:
         if channel_id not in source_service.slack_allowed_channel_ids(
@@ -252,6 +358,8 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
             channel_name=channel_id,
             ts=event["ts"],
             text=event.get("text") or "",
+            author_id=author_id,
+            author=author,
         )
         ingested += 1
     return ingested

--- a/backend/migrations/versions/0125_slack_message_authors.py
+++ b/backend/migrations/versions/0125_slack_message_authors.py
@@ -1,0 +1,28 @@
+"""Add author identity to slack_messages.
+
+The indexer previously dropped `msg["user"]`, so no indexed Slack message was
+attributable to anyone — "who said this" was unanswerable across search,
+ask-the-stash, and the VFS. Rows now carry the Slack user/bot id and the
+resolved display name; the transcript projection renders them inline.
+
+Existing rows get authors on the next sync (the upsert's extra-column
+freshness check sees NULL != resolved author and rewrites the row).
+
+Revision ID: 0125
+Revises: 0124
+"""
+
+from alembic import op
+
+revision = "0125"
+down_revision = "0124"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE slack_messages ADD COLUMN author_id text, ADD COLUMN author text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE slack_messages DROP COLUMN author_id, DROP COLUMN author")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -30,6 +30,7 @@ import asyncio
 import hashlib
 import logging
 import re
+from datetime import UTC, datetime
 from urllib.parse import quote
 from uuid import UUID
 
@@ -700,11 +701,40 @@ async def list_documents(
         allowed_channel_ids = slack_allowed_channel_ids(source)
         if not allowed_channel_ids:
             return []
+        # Slack's document projection is one transcript per channel per UTC day
+        # (rows stay per-message). Cap-disclosure notices pass through as their
+        # own documents; their 0000- leaf sorts them first in the channel.
         rows = await get_pool().fetch(
-            f"SELECT path, name, kind, external_ref FROM {table} "
-            f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
-            f"AND channel_id = ANY($5::text[]) "
-            f"ORDER BY path LIMIT $3",
+            """
+            SELECT * FROM (
+                SELECT channel_name || '/' || day AS path,
+                       '#' || channel_name || ' ' || day AS name,
+                       'transcript' AS kind,
+                       NULL AS external_ref,
+                       to_timestamp(last_ts) AS external_updated_at,
+                       size
+                FROM (
+                    SELECT channel_name,
+                           to_char(to_timestamp(ts::float8) AT TIME ZONE 'UTC',
+                                   'YYYY-MM-DD') AS day,
+                           max(ts::float8) AS last_ts,
+                           sum(length(coalesce(content, ''))) AS size
+                    FROM slack_messages
+                    WHERE source_id = $1 AND deleted_at IS NULL AND kind = 'message'
+                      AND channel_id = ANY($5::text[])
+                    GROUP BY channel_name, day
+                ) days
+                UNION ALL
+                SELECT path, name, kind, external_ref,
+                       external_updated_at,
+                       length(coalesce(content, '')) AS size
+                FROM slack_messages
+                WHERE source_id = $1 AND deleted_at IS NULL AND kind = 'notice'
+                  AND channel_id = ANY($5::text[])
+            ) docs
+            WHERE path LIKE $2 AND path > $4
+            ORDER BY path LIMIT $3
+            """,
             UUID(source["id"]),
             f"{prefix}%",
             limit,
@@ -718,7 +748,8 @@ async def list_documents(
         if not allowed_workspace_ids:
             return []
         rows = await get_pool().fetch(
-            f"SELECT path, name, kind, external_ref FROM {table} "
+            f"SELECT path, name, kind, external_ref, external_updated_at, "
+            f"length(coalesce(content, '')) AS size FROM {table} "
             f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
             f"AND gong_account_id = ANY($5::text[]) "
             f"ORDER BY path LIMIT $3",
@@ -730,8 +761,10 @@ async def list_documents(
         )
         return [_entry_row(r) for r in rows]
 
+    size_column = "length(coalesce(content, ''))" if table in CONTENT_TABLES else "NULL::bigint"
     rows = await get_pool().fetch(
-        f"SELECT path, name, kind, external_ref FROM {table} "
+        f"SELECT path, name, kind, external_ref, external_updated_at, "
+        f"{size_column} AS size FROM {table} "
         f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
         f"ORDER BY path LIMIT $3",
         UUID(source["id"]),
@@ -743,11 +776,84 @@ async def list_documents(
 
 
 def _entry_row(r) -> dict:
+    external_updated_at = r["external_updated_at"]
     return {
         "path": r["path"],
         "name": r["name"],
         "kind": r["kind"],
         "external_ref": r["external_ref"],
+        "external_updated_at": (external_updated_at.isoformat() if external_updated_at else None),
+        "size": r["size"],
+    }
+
+
+_SLACK_DAY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SLACK_TS_RE = re.compile(r"^\d+\.\d+$")
+
+
+async def _read_slack_document(
+    source: dict, path: str, allowed_channel_ids: list[str]
+) -> dict | None:
+    """Read one Slack document. `{channel}/{YYYY-MM-DD}` returns that day's
+    transcript; a per-message ref `{channel}/{ts}` (what search and
+    fetch-history return) resolves to the transcript of the day it belongs to;
+    anything else (cap-disclosure notices) reads its row directly."""
+    channel, _, leaf = path.rpartition("/")
+    if channel and _SLACK_TS_RE.match(leaf):
+        day = datetime.fromtimestamp(float(leaf), UTC).strftime("%Y-%m-%d")
+        return await _render_slack_day(source, channel, day, allowed_channel_ids)
+    if channel and _SLACK_DAY_RE.match(leaf):
+        return await _render_slack_day(source, channel, leaf, allowed_channel_ids)
+
+    row = await get_pool().fetchrow(
+        "SELECT path, name, kind, content FROM slack_messages "
+        "WHERE source_id = $1 AND path = $2 AND deleted_at IS NULL "
+        "AND channel_id = ANY($3::text[])",
+        UUID(source["id"]),
+        path,
+        allowed_channel_ids,
+    )
+    if not row:
+        return None
+    return {
+        "path": row["path"],
+        "name": row["name"],
+        "kind": row["kind"],
+        "content": row["content"] or "",
+    }
+
+
+async def _render_slack_day(
+    source: dict, channel: str, day: str, allowed_channel_ids: list[str]
+) -> dict | None:
+    rows = await get_pool().fetch(
+        """
+        SELECT ts, author, content FROM slack_messages
+        WHERE source_id = $1 AND deleted_at IS NULL AND kind = 'message'
+          AND channel_id = ANY($2::text[]) AND channel_name = $3
+          AND to_char(to_timestamp(ts::float8) AT TIME ZONE 'UTC', 'YYYY-MM-DD') = $4
+        ORDER BY ts::float8
+        """,
+        UUID(source["id"]),
+        allowed_channel_ids,
+        channel,
+        day,
+    )
+    if not rows:
+        return None
+    lines = [f"# #{channel} — {day} (UTC)", ""]
+    for row in rows:
+        clock = datetime.fromtimestamp(float(row["ts"]), UTC).strftime("%H:%M")
+        # Continuation lines are indented so a line-leading HH:MM always means
+        # a new message.
+        text = (row["content"] or "").replace("\n", "\n    ")
+        author = row["author"] or ""
+        lines.append(f"{clock} {author}: {text}" if author else f"{clock} {text}")
+    return {
+        "path": f"{channel}/{day}",
+        "name": f"#{channel} {day}",
+        "kind": "transcript",
+        "content": "\n".join(lines) + "\n",
     }
 
 
@@ -813,22 +919,7 @@ async def read_document(source: dict, path: str) -> dict | None:
             allowed_channel_ids = slack_allowed_channel_ids(source)
             if not allowed_channel_ids:
                 return None
-            row = await get_pool().fetchrow(
-                f"SELECT path, name, kind, content FROM {table} "
-                f"WHERE source_id = $1 AND path = $2 AND deleted_at IS NULL "
-                f"AND channel_id = ANY($3::text[])",
-                UUID(source["id"]),
-                path,
-                allowed_channel_ids,
-            )
-            if not row:
-                return None
-            return {
-                "path": row["path"],
-                "name": row["name"],
-                "kind": row["kind"],
-                "content": row["content"] or "",
-            }
+            return await _read_slack_document(source, path, allowed_channel_ids)
 
         if table == "gong_documents":
             allowed_workspace_ids = gong_allowed_workspace_ids(source)

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1249,8 +1249,10 @@ async def test_slack_visibility_requires_channel_allowlist(client: AsyncClient):
         extra={"channel_id": "C2", "channel_name": "exec", "ts": "1"},
     )
 
+    # Messages project as one transcript per channel per UTC day; ts=1 epoch
+    # lands on 1970-01-01. The blocked channel contributes no document.
     docs = await source_service.list_documents(configured)
-    assert [doc["path"] for doc in docs] == ["general/1"]
+    assert [doc["path"] for doc in docs] == ["general/1970-01-01"]
     assert await source_service.read_document(configured, "exec/1") is None
     assert await source_service.source_item_count(configured) == 1
     allowed_hits = await source_service.search_documents(user_id=owner_id, query="allowed roadmap")
@@ -1514,7 +1516,7 @@ async def test_slack_indexer_backfills_only_allowed_channels(
         == 0
     )
     docs = await source_service.list_documents(src)
-    assert [doc["path"] for doc in docs] == ["general/1"]
+    assert [doc["path"] for doc in docs] == ["general/1970-01-01"]
 
 
 @pytest.mark.asyncio
@@ -1723,6 +1725,164 @@ async def test_slack_event_ingest_updates_changed_messages_without_duplicate(
     assert rows[0]["path"] == "general/1717.0001"
     assert rows[0]["name"] == "#general"
     assert rows[0]["content"] == "updated confidential Slack message"
+
+
+@pytest.mark.asyncio
+async def test_slack_projects_day_transcripts_with_authors(client: AsyncClient):
+    """The agent-facing projection is one attributed transcript per channel per
+    UTC day — not one file per message. Chronology and authorship must survive
+    into both the listing (external_updated_at/size) and the rendered body,
+    and a per-message ref (what search returns) must resolve to its day."""
+    api_key, owner_id = await _register(client, "slack_days")
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_DAYS",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+    # 2026-07-05 18:17/18:18 UTC and 2026-07-06 01:24 UTC — two UTC days.
+    messages = [
+        ("1783275420.000100", "henry", "interesting treehacks project"),
+        ("1783275480.000200", "sam", "lol"),
+        ("1783301040.000300", "henry", "I'm gonna try these three"),
+    ]
+    for ts, author, text in messages:
+        await source_service.upsert_content_document(
+            table="slack_messages",
+            source_id=UUID(src["id"]),
+            owner_user_id=ws,
+            path=f"random/{ts}",
+            name="#random",
+            kind="message",
+            content=text,
+            external_ref=f"C1:{ts}",
+            extra={
+                "channel_id": "C1",
+                "channel_name": "random",
+                "ts": ts,
+                "author_id": f"U_{author}",
+                "author": author,
+            },
+        )
+
+    docs = await source_service.list_documents(src)
+    assert [d["path"] for d in docs] == ["random/2026-07-05", "random/2026-07-06"]
+    assert [d["kind"] for d in docs] == ["transcript", "transcript"]
+    day_one = docs[0]
+    assert day_one["name"] == "#random 2026-07-05"
+    assert day_one["external_updated_at"].startswith("2026-07-05")
+    assert day_one["size"] == len("interesting treehacks project") + len("lol")
+
+    doc = await source_service.read_document(src, "random/2026-07-05")
+    assert doc["kind"] == "transcript"
+    lines = doc["content"].splitlines()
+    assert lines[0] == "# #random — 2026-07-05 (UTC)"
+    assert "henry: interesting treehacks project" in lines[2]
+    assert "sam: lol" in lines[3]
+    assert lines[2] < lines[3]  # HH:MM prefixes keep the transcript chronological
+
+    # A search/history ref (channel/ts) reads as the day it belongs to.
+    by_ref = await source_service.read_document(src, "random/1783301040.000300")
+    assert by_ref["path"] == "random/2026-07-06"
+
+
+@pytest.mark.asyncio
+async def test_slack_backfill_resolves_authors_and_caches_lookups(
+    client: AsyncClient, monkeypatch, pool
+):
+    """Backfilled messages must be attributable: msg["user"] resolves to a
+    display name via users.info, one lookup per distinct user per sync."""
+    from backend.integrations.slack import indexer
+
+    api_key, owner_id = await _register(client, "slack_authors")
+    await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_AUTHORS",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+    users_info_calls: list[str] = []
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.CONVERSATIONS_LIST_URL:
+            return {"channels": [{"id": "C1", "name": "general"}]}
+        if url == indexer.USERS_INFO_URL:
+            users_info_calls.append(params["user"])
+            return {"ok": True, "user": {"name": "hdowling", "profile": {"display_name": "henry"}}}
+        return {
+            "messages": [
+                {"type": "message", "ts": "1783362000.1", "text": "one", "user": "U_HENRY"},
+                {"type": "message", "ts": "1783362001.1", "text": "two", "user": "U_HENRY"},
+            ]
+        }
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+    await indexer.index_slack(src)
+
+    assert users_info_calls == ["U_HENRY"]  # cached after the first resolution
+    rows = await pool.fetch(
+        "SELECT author_id, author FROM slack_messages WHERE source_id = $1 ORDER BY ts",
+        UUID(src["id"]),
+    )
+    assert [(r["author_id"], r["author"]) for r in rows] == [
+        ("U_HENRY", "henry"),
+        ("U_HENRY", "henry"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slack_backfill_discloses_history_cap(client: AsyncClient, monkeypatch):
+    """A channel whose history exceeds the backfill cap must say so in its
+    listing — an agent must be able to tell "never discussed" apart from
+    "not indexed". The notice lists first and clears when history fits."""
+    from backend.integrations.slack import indexer
+
+    api_key, owner_id = await _register(client, "slack_cap")
+    await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_CAP",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+    has_more = True
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.CONVERSATIONS_LIST_URL:
+            return {"channels": [{"id": "C1", "name": "general"}]}
+        return {
+            "messages": [{"type": "message", "ts": "1783362000.1", "text": "hi"}],
+            "has_more": has_more,
+        }
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+    await indexer.index_slack(src)
+    docs = await source_service.list_documents(src)
+    assert [d["kind"] for d in docs] == ["notice", "transcript"]
+    assert docs[0]["path"] == f"general/{indexer.CAP_MARKER_LEAF}"
+    notice = await source_service.read_document(src, docs[0]["path"])
+    assert "not searchable here" in notice["content"]
+
+    # Full history now fits — the stale notice must disappear.
+    has_more = False
+    await indexer.index_slack(src)
+    docs = await source_service.list_documents(src)
+    assert [d["kind"] for d in docs] == ["transcript"]
 
 
 @pytest.mark.asyncio

--- a/cli/app_vfs.py
+++ b/cli/app_vfs.py
@@ -153,11 +153,14 @@ class SkillAppVfsShell:
 
     def _ls(self, args: list[str]) -> str:
         long = False
+        by_time = False
         paths: list[str] = []
         for arg in args:
             if arg.startswith("-"):
                 if "l" in arg:
                     long = True
+                if "t" in arg:
+                    by_time = True
                 continue
             paths.append(arg)
         if not paths:
@@ -171,6 +174,15 @@ class SkillAppVfsShell:
                 blocks.append(self._format_ls_entry(path, long))
                 continue
             names = self.model.list_dir(path)
+            if by_time:
+                # Newest first, like `ls -t`; entries with no known mtime sort
+                # last so real timestamps are never buried under unknowns.
+                names.sort(
+                    key=lambda name: (
+                        self.model._get_node(posixpath.join(path, name)).updated_at or 0.0
+                    ),
+                    reverse=True,
+                )
             lines = [self._format_ls_entry(posixpath.join(path, name), long) for name in names]
             blocks.append("\n".join(lines))
             hit = self.model.truncated_root_containing(path)
@@ -203,6 +215,8 @@ class SkillAppVfsShell:
         name_pattern = ""
         ignore_name_case = False
         type_filter = ""
+        mtime_spec = ""
+        newer_than: float | None = None
         index = 0
         if args and not args[0].startswith("-"):
             path = args[0]
@@ -230,6 +244,24 @@ class SkillAppVfsShell:
                 index += 1
                 name_pattern = args[index]
                 ignore_name_case = option == "-iname"
+            elif option == "-mtime":
+                if index + 1 >= len(args):
+                    raise VfsShellError("-mtime requires a value", exit_code=2)
+                index += 1
+                mtime_spec = args[index]
+                if not re.fullmatch(r"[+-]?\d+", mtime_spec):
+                    raise VfsShellError("-mtime value must be [+-]N days", exit_code=2)
+            elif option == "-newer":
+                if index + 1 >= len(args):
+                    raise VfsShellError("-newer requires a path", exit_code=2)
+                index += 1
+                reference = self.model._get_node(self._resolve_path(args[index]))
+                if not reference.updated_at:
+                    raise VfsShellError(
+                        f"-newer reference has no modification time: {args[index]}",
+                        exit_code=2,
+                    )
+                newer_than = reference.updated_at
             else:
                 raise VfsShellError(f"unsupported find option: {option}")
             index += 1
@@ -246,6 +278,14 @@ class SkillAppVfsShell:
             if type_filter == "d" and not node.is_dir:
                 continue
             if name_pattern and not _name_matches(node_path, name_pattern, ignore_name_case):
+                continue
+            # A time predicate can only match a node whose mtime is known —
+            # sources that don't report one are excluded, never guessed at.
+            if (mtime_spec or newer_than is not None) and not node.updated_at:
+                continue
+            if mtime_spec and not _mtime_matches(node.updated_at, mtime_spec):
+                continue
+            if newer_than is not None and node.updated_at <= newer_than:
                 continue
             rows.append(node_path)
         for source_root, shown in self.model.truncated_roots_under(root):
@@ -931,6 +971,17 @@ def _iso_time(epoch: float | None) -> str:
     if not epoch:
         return "-"
     return datetime.fromtimestamp(epoch).isoformat()
+
+
+def _mtime_matches(epoch: float, spec: str) -> bool:
+    """GNU find -mtime semantics in whole 24h units: `-N` = modified within the
+    last N days, `+N` = older than N+1 days, `N` = age rounds to exactly N."""
+    age_days = int((time.time() - epoch) // 86400)
+    if spec.startswith("-"):
+        return age_days < int(spec[1:])
+    if spec.startswith("+"):
+        return age_days > int(spec[1:])
+    return age_days == int(spec)
 
 
 def _name_matches(path: str, pattern: str, ignore_case: bool) -> bool:

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -82,6 +82,13 @@ class StashVfsModel:
                     "- `sources` exposes connected integrations (Gmail, "
                     "GitHub, Slack, Jira, …) as read-only documents.",
                     "",
+                    "Listings are alphabetical by name; they carry no time meaning.",
+                    "For recency use `ls -lt` (sort by modified time), "
+                    "`find -mtime -N` / `find -newer <path>`, or `stat <path>`.",
+                    "Slack renders as one transcript per channel per UTC day; a "
+                    "`0000-history-cap` entry in a channel means older history "
+                    "exists in Slack but is not indexed here.",
+                    "",
                 ]
             ),
         )
@@ -368,6 +375,7 @@ class StashVfsModel:
 
     def _add_source_entries(self, source_root: str, handle: str, entries: list[dict]) -> None:
         parent_refs = _ancestor_refs(entries)
+        aliases: list[tuple[str, str]] = []
         for entry in entries:
             ref = str(entry.get("path") or "")
             segments = [_safe_name(seg) for seg in ref.split("/") if seg]
@@ -383,22 +391,30 @@ class StashVfsModel:
             # A page that also has child pages becomes a directory holding its own
             # body in a same-named index file, so the children nest under it
             # instead of being dropped on the file/dir name collision.
-            external_ref = entry.get("external_ref") or None
             if ref in parent_refs:
                 page_dir = self._add_dir(f"{parent}/{display}")
-                self._add_source_doc_file(f"{page_dir}/{display}", handle, ref, external_ref)
-                continue
-            self._add_source_doc_file(f"{parent}/{display}", handle, ref, external_ref)
+                added = self._add_source_doc_file(f"{page_dir}/{display}", handle, ref, entry)
+            else:
+                added = self._add_source_doc_file(f"{parent}/{display}", handle, ref, entry)
+            aliases.append((f"{source_root}/{ref}", added))
+        # The backend ref is what search results and history responses hand the
+        # agent — make it resolve too. Registered after all real entries so an
+        # alias can never shadow a real path; a ref that IS the display path
+        # (identical name) is simply already present.
+        for alias, target in aliases:
+            alias = self._clean_path(alias)
+            if alias not in self.nodes:
+                self.nodes[alias] = self.nodes[target]
 
-    def _add_source_doc_file(
-        self, path: str, handle: str, ref: str, external_ref: str | None = None
-    ) -> str:
+    def _add_source_doc_file(self, path: str, handle: str, ref: str, entry: dict) -> str:
         return self._add_file(
             path,
             loader=lambda h=handle, r=ref: _text_bytes(
                 _source_doc_text(self.client.read_source_doc(h, r))
             ),
-            external_ref=external_ref,
+            size_hint=entry.get("size"),
+            updated_at=entry.get("external_updated_at"),
+            external_ref=entry.get("external_ref") or None,
         )
 
     def _load_page(self, page_id: str) -> bytes:

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -1,3 +1,4 @@
+import re
 import shlex
 from datetime import datetime
 
@@ -404,3 +405,63 @@ def test_ls_is_silent_when_a_source_listing_is_complete():
 
     assert "Welcome email" in result.stdout
     assert "INCOMPLETE" not in result.stderr
+
+
+def test_source_docs_carry_backend_timestamps_and_sizes():
+    """Connected-source entries ship external_updated_at + size, so an agent
+    can judge recency and weight from `ls -la`/`stat` without reading bodies.
+    An entry the backend has no timestamp for stays `-` — never fabricated."""
+    shell, _client = _shell()
+
+    listing = shell.run("ls -la /sources/gmail").stdout
+    dated = next(line for line in listing.splitlines() if "Welcome email" in line)
+    assert "      13 " in dated  # size known before the body is ever read
+    assert " - " not in dated
+
+    stat_out = shell.run("stat '/sources/gmail/Welcome email'").stdout
+    assert "size: 13" in stat_out
+    assert "modified: 2026-05-04T" in stat_out
+
+    undated = shell.run("ls -la /sources/gmail/threads").stdout
+    assert re.search(r"-\s+0\s+-\s+Nested note", undated)
+
+
+def test_ls_t_sorts_by_modified_time_newest_first():
+    shell, _client = _shell()
+
+    names = shell.run("ls -t /sources/gmail").stdout.splitlines()
+
+    # "Welcome email" has a 2026 mtime; "threads" (dir) has none and sorts last.
+    assert names.index("Welcome email") < names.index("threads")
+
+
+def test_find_mtime_and_newer_filter_by_modified_time():
+    shell, _client = _shell()
+
+    recent = shell.run("find /sources/gmail -mtime -100000").stdout
+    assert "/sources/gmail/Welcome email" in recent
+    # A node with no known mtime can never satisfy a time predicate.
+    assert "Nested note" not in recent
+
+    ancient = shell.run("find /sources/gmail -mtime +100000").stdout
+    assert "Welcome email" not in ancient
+
+    newer = shell.run("find /files -newer '/sources/gmail/Welcome email'")
+    assert newer.exit_code == 0
+    assert "Welcome email" not in newer.stdout
+
+    no_reference_time = shell.run("find /files -newer /sources/gmail/threads")
+    assert no_reference_time.exit_code == 2
+    assert "no modification time" in no_reference_time.stderr
+
+
+def test_cat_resolves_raw_backend_refs_as_aliases():
+    """search/history/ask-the-stash hand the agent backend refs, not display
+    names — those refs must be readable directly."""
+    shell, _client = _shell()
+
+    by_ref = shell.run("cat /sources/gmail/threads/msg-2")
+    by_display = shell.run("cat '/sources/gmail/threads/Nested note'")
+
+    assert by_ref.exit_code == 0
+    assert by_ref.stdout == by_display.stdout == "BODY of threads/msg-2"

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -75,7 +75,14 @@ class FakeClient:
         assert source == "src-gmail-1"
         self.source_entry_calls += 1
         return [
-            {"path": "msg-1", "name": "Welcome email", "kind": "message", "external_ref": "gm-1"},
+            {
+                "path": "msg-1",
+                "name": "Welcome email",
+                "kind": "message",
+                "external_ref": "gm-1",
+                "external_updated_at": "2026-05-04T10:00:00+00:00",
+                "size": 13,
+            },
             {"path": "threads/msg-2", "name": "Nested note", "kind": "message"},
         ]
 


### PR DESCRIPTION
Implements all five fixes from the [VFS ergonomics proposal](https://app.joinstash.ai/p/c52cebdc-f52b-416b-b3aa-78798d6a8224). Motivating incident: an agent with full VFS access was asked *"what are my last three Slack messages?"* and confidently reported a February message as sent yesterday — no timestamps under `/sources`, misleading `-N` name suffixes, and no authorship stored at all.

## Fix 1 — timestamps + sizes for source documents
- `list_documents` ships `external_updated_at` + content length in every branch; `_entry_row` serializes them.
- CLI populates `VfsNode.updated_at`/`size_hint` (the fields already existed, empty) → `ls -la` and `stat` render real values with no rendering changes.
- New shell support: `ls -t`, `find -mtime [+-]N`, `find -newer <path>`. A node with no known mtime never matches a time predicate and sorts last — unknown is disclosed, never fabricated.
- Root `README.md` documents the ordering contract.

## Fix 2 — Slack authorship (migration 0125)
`slack_messages` gains `author_id`/`author`. Backfill + fetch-history resolve display names via `users.info` (one lookup per distinct user per sync, cached). Webhook ingest has no user token, so it stores the raw Slack id; the next sync's extra-column freshness check rewrites it with the resolved name. Existing rows get authors on next sync the same way — no backfill migration needed.

## Fix 3 — day-transcript projection
Slack's document projection becomes **one transcript per channel per UTC day** (`{channel}/{YYYY-MM-DD}`), rendered as `HH:MM author: text` lines with continuations indented. Rows stay per-message (embeddings, deletes, edits unchanged). Consequences:
- names are unique + chronologically sortable → the order-dependent `-N` suffixes disappear for Slack
- one `cat` returns a coherent attributed conversation instead of "Yep"
- ~50× fewer documents to page through per model rebuild
- per-message refs (what search/fetch-history return) resolve to their containing day, so search hits now read with full context

## Fix 4 — raw refs are shell addresses
The CLI registers each entry's backend ref as an alias next to its display path, so refs handed out by search/history/ask-the-stash `cat` directly. Aliases register after all real entries and never shadow a real path.

## Fix 5 — index-time caps disclosed
A channel whose history exceeds the backfill cap gets a `kind="notice"` document ("older history exists but is not indexed", with the fetch-history escape hatch), removed automatically when history fits. Complements the VFS's existing 10k materialization warnings and #704/#708's disclosure work.

## Verification
- New tests: day projection + authorship + ts-ref resolution, users.info caching, cap-marker lifecycle (backend); metadata propagation, `ls -t`, `-mtime`/`-newer`, ref aliases (CLI).
- Full suite: 702 passed. The one failure (`test_gong_index_success_logs_internal_source_id_only`) **fails on main too** — pre-existing, looks like #698 fallout; left alone.
- Driven end-to-end against a local backend with seeded rows:

```
$ stash vfs "ls -la /sources/slack/random"
-       32 Jul  5 14:18 #random 2026-07-05
-       45 Jul  5 21:24 #random 2026-07-06
-      116            - #random older history is NOT indexed

$ stash vfs "cat /sources/slack/random/2026-07-05"   # raw ref, not display name
# #random — 2026-07-05 (UTC)

18:17 henry: interesting treehacks project
18:18 sam: lol
```

## Deploy note
Slack sources need a re-sync after deploy to populate authors (happens on the next scheduled sync automatically; `stash sources sync <id>` to force). Known follow-ups, deliberately out of scope: events-API messages record `channel_id` as `channel_name` (pre-existing wart — they'll appear as an id-named channel dir until synced), and several indexers still don't set `external_updated_at` (their entries keep showing `-` until they do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)