### PR TITLE
Fix gong log-security test broken by the OAuth migration

### DIFF
--- a/backend/tests/test_integration_indexer_log_security.py
+++ b/backend/tests/test_integration_indexer_log_security.py
@@ -287,7 +287,9 @@ async def test_gong_index_success_logs_internal_source_id_only(monkeypatch):
             return None
 
     async def gong_token(user_id, provider):
-        return '{"access_key":"key","access_key_secret":"secret"}'
+        # The post-OAuth stored shape (#698): a JSON bundle of the bearer token
+        # and the per-customer API base URL.
+        return '{"access_token":"gong-oauth-secret","api_base_url":"https://api.gong.io"}'
 
     monkeypatch.setattr(gong_indexer, "get_valid_token", gong_token)
     monkeypatch.setattr(gong_indexer.httpx, "AsyncClient", lambda *args, **kwargs: GongClient())
@@ -308,6 +310,7 @@ async def test_gong_index_success_logs_internal_source_id_only(monkeypatch):
     ]
     assert "gong-account-secret" not in str(captured_logs)
     assert "call-webflow-secret" not in str(captured_logs)
+    assert "gong-oauth-secret" not in str(captured_logs)
     assert "Webflow acquisition call" not in str(captured_logs)
     assert "customer transcript" not in str(captured_logs)
 


### PR DESCRIPTION
`test_gong_index_success_logs_internal_source_id_only` has been failing on every CI run since #698: its fake `get_valid_token` still returned the old API-key credential shape (`{"access_key", "access_key_secret"}`), while `index_gong` now parses the OAuth bundle (`{"access_token", "api_base_url"}`) — so the indexer raised `KeyError: 'access_token'` before reaching the logging under test.

- Update the fake to the post-OAuth stored shape (matching `gong/provider.py`'s documented json-bundle).
- Extend the log-leak assertion to the bearer token itself (`"gong-oauth-secret" not in logs`), since that's now the secret flowing through the indexer.

The full `test_integration_indexer_log_security.py` file passes locally. (The other red CI check on main — the frontend dependency audit — is separate; happy to fix that next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)