### PR TITLE
Granola: sync transcripts and full meeting history

### DIFF
--- a/backend/integrations/granola/indexer.py
+++ b/backend/integrations/granola/indexer.py
@@ -18,6 +18,7 @@ import logging
 import re
 from uuid import UUID
 
+from ...database import get_pool
 from ...services import source_service
 from .client import call_tool_data, granola_session
 from .oauth import get_valid_access_token
@@ -93,6 +94,17 @@ def _parse_meetings_text(text: str) -> list[dict]:
     return meetings
 
 
+def _extract_transcript(td) -> str | list:
+    """get_meeting_transcript returns JSON text — {"id", "title", "transcript":
+    "<the whole transcript as one string>"} — which call_tool_data parses to a
+    dict. Unwrap it; a bare string or segment list is already usable."""
+    if isinstance(td, dict):
+        td = td.get("transcript")
+    if isinstance(td, str | list):
+        return td
+    return ""
+
+
 def _render_meeting(meeting: dict, transcript) -> str:
     """A meeting's markdown: title + participants + the transcript. `transcript`
     may be a plain string (Granola returns text) or a list of segments."""
@@ -142,6 +154,16 @@ async def index_granola(source: dict) -> str | None:
     access_token = await get_valid_access_token(owner_user_id)
     present: list[str] = []
 
+    # Transcripts are immutable once a meeting ends, and Granola rate-limits
+    # transcript fetches hard — so only fetch for meetings whose stored doc
+    # doesn't already carry one. Meetings that get rate-limited land with just
+    # title + participants and pick up their transcript on a later sync.
+    rows = await get_pool().fetch(
+        "SELECT path FROM granola_notes WHERE source_id = $1 AND content LIKE '%## Transcript%'",
+        source_id,
+    )
+    have_transcript = {r["path"] for r in rows}
+
     async with granola_session(access_token) as session:
         tools = (await session.list_tools()).tools
         names = [t.name for t in tools]
@@ -153,7 +175,14 @@ async def index_granola(source: dict) -> str | None:
             return None
         transcript_tool = _pick_tool([n for n in names if n != list_tool], _TRANSCRIPT_HINTS)
 
-        data = await call_tool_data(session, list_tool, {"limit": MAX_MEETINGS})
+        # list_meetings defaults to last_30_days; anything older would then be
+        # soft-deleted by remove_missing_documents on every sync. Ask for the
+        # full history with an explicit wide range.
+        data = await call_tool_data(
+            session,
+            list_tool,
+            {"time_range": "custom", "custom_start": "2000-01-01", "custom_end": "2100-01-01"},
+        )
         # Granola returns an XML-ish text blob; other shapes (JSON list/dict) are
         # handled too for resilience.
         if isinstance(data, str):
@@ -168,15 +197,14 @@ async def index_granola(source: dict) -> str | None:
             meeting_id = _meeting_id(meeting)
             if not meeting_id:
                 continue
+            if meeting_id in have_transcript:
+                present.append(meeting_id)
+                continue
             transcript = ""
             if transcript_tool:
                 try:
                     td = await call_tool_data(session, transcript_tool, {"meeting_id": meeting_id})
-                    transcript = (
-                        td
-                        if isinstance(td, str)
-                        else _as_list(td, "transcript", "segments", "entries")
-                    )
+                    transcript = _extract_transcript(td)
                 except Exception as exc:
                     logger.info(
                         "granola transcript fetch failed source=%s exception_type=%s",

--- a/backend/integrations/granola/indexer.py
+++ b/backend/integrations/granola/indexer.py
@@ -97,7 +97,8 @@ def _parse_meetings_text(text: str) -> list[dict]:
 def _extract_transcript(td) -> str | list:
     """get_meeting_transcript returns JSON text — {"id", "title", "transcript":
     "<the whole transcript as one string>"} — which call_tool_data parses to a
-    dict. Unwrap it; a bare string or segment list is already usable."""
+    dict, so unwrap the inner string. A bare string (non-JSON tool output) or a
+    segment list needs no unwrapping: _render_meeting renders both directly."""
     if isinstance(td, dict):
         td = td.get("transcript")
     if isinstance(td, str | list):

--- a/backend/tests/test_granola.py
+++ b/backend/tests/test_granola.py
@@ -141,3 +141,31 @@ async def test_integrations_are_unavailable_with_invalid_encryption_key(
 # `call_tool_json` entrypoint, which no longer exists (the indexer now picks
 # tools dynamically and calls `call_tool_data`). The list-blob parsing it
 # covered is exercised in test_integration_sources.
+
+
+def test_transcript_envelope_lands_in_rendered_doc():
+    """get_meeting_transcript returns {"id", "title", "transcript": "<text>"} —
+    the transcript is a string inside a JSON envelope. If the indexer treats it
+    as anything else, every meeting doc silently loses its transcript (which is
+    the whole point of the integration)."""
+    from backend.integrations.granola.indexer import _extract_transcript, _render_meeting
+
+    envelope = {"id": "m1", "title": "Standup", "transcript": " Me: shipped it  Them: nice"}
+    meeting = {"id": "m1", "title": "Standup", "date": "Jul 5, 2026", "participants": "Henry"}
+
+    doc = _render_meeting(meeting, _extract_transcript(envelope))
+
+    assert "## Transcript" in doc
+    assert "Them: nice" in doc
+
+
+def test_extract_transcript_is_empty_when_granola_has_none():
+    """A meeting with no recording still gets indexed (title + participants),
+    just without a transcript section."""
+    from backend.integrations.granola.indexer import _extract_transcript, _render_meeting
+
+    assert _extract_transcript({"id": "m1", "title": "Note only"}) == ""
+    assert _extract_transcript(None) == ""
+
+    meeting = {"id": "m1", "title": "Note only", "date": "Jul 5, 2026", "participants": "Henry"}
+    assert "## Transcript" not in _render_meeting(meeting, "")


### PR DESCRIPTION
## Problem

Every synced Granola doc in Stash contained only the header — title, date, participants. No notes, no transcripts. Meetings older than 30 days were also missing entirely (40 of 247 meetings synced).

## Root causes (verified against the live Granola MCP server)

1. **Transcripts silently dropped.** `get_meeting_transcript` returns `{"id", "title", "transcript": "<one string>"}`. The indexer handled a bare string or a dict holding a *list*, but the real shape — a string inside the envelope — fell through `_as_list` and became `[]`. Every transcript was fetched successfully, then thrown away.

2. **History capped at 30 days.** The indexer passed `{"limit": 1000}` to `list_meetings`, but that arg isn't in the tool's schema; the server silently applies its `last_30_days` default. `remove_missing_documents` then deleted anything older from Stash on every sync.

3. **Rate limiting would corrupt a full sync.** Granola rate-limits transcript fetches aggressively (~a dozen rapid calls trips it). A 247-meeting sync would rate-limit partway through and overwrite previously-good docs with transcript-less ones.

## Fixes

- `_extract_transcript` unwraps the transcript envelope (dict → `transcript` string; bare string / segment list still accepted).
- `list_meetings` is called with an explicit wide custom range (`2000-01-01` → `2100-01-01`), which the server honors — 247 meetings back to Sep 2025.
- Transcript fetches are skipped for meetings whose stored doc already carries one (transcripts are immutable once a meeting ends). Rate-limited meetings land header-only and pick up their transcript on later syncs, so the backlog drains incrementally and steady-state syncs only fetch new meetings.

## Verification

- Ran the actual indexer code path (`_pick_tool` → `list_meetings` → `_parse_meetings_text` → `get_meeting_transcript` → `_extract_transcript` → `_render_meeting`) against live Granola with a dev OAuth token: 3/3 sampled meetings rendered with full transcripts (7k–31k chars each).
- Two new unit tests encode the envelope contract and the no-transcript case.
- `pytest` granola + source suites: 121 passed. `ruff check` + `ruff format --check`: clean.

## Note for after deploy

Backfilling all 247 transcripts takes several sync cycles because of Granola's rate limit — recent meetings fill in first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)