### PR TITLE
Renumber github sync_all migration: 0125 collided with slack authors

### DIFF
--- a/backend/migrations/versions/0126_github_sync_all.py
+++ b/backend/migrations/versions/0126_github_sync_all.py
@@ -4,14 +4,14 @@ When set on a github connection, every repo the account can see gets a
 github_repo source, and the hourly reconcile picks up repos the user gains
 access to later.
 
-Revision ID: 0125
-Revises: 0124
+Revision ID: 0126
+Revises: 0125
 """
 
 from alembic import op
 
-revision = "0125"
-down_revision = "0124"
+revision = "0126"
+down_revision = "0125"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
we really need a better system for alembic conflicts

**Merge this ASAP — every deploy and fresh test DB on main is currently broken.**

#712 (GitHub all-repos) and #713 (VFS/Slack authors) merged within an hour of each other, both carrying a migration with `revision = "0125"`, `down_revision = "0124"`. Alembic now reports multiple heads and refuses `upgrade head`, which fails:
- any production/staging deploy that runs migrations,
- every CI/test-suite run that builds a fresh database (this is why backend tests are newly red on main).

**Fix:** production applied `0125 = slack_message_authors` before #712 merged (verified live earlier today), so the later-merged GitHub migration is renumbered to `0126` on top of it. File renamed, `revision`/`down_revision` updated — no DDL changes.

**Verified:** a from-scratch database migrates cleanly to head and the sources test suite passes (85/85).

Process thought for later: a CI check that fails a PR when its migration's `down_revision` is no longer the head of main would have caught this at merge time instead of at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)