### PR TITLE
Set external_updated_at in the five indexers whose providers expose it

### DIFF
--- a/backend/integrations/asana/indexer.py
+++ b/backend/integrations/asana/indexer.py
@@ -9,6 +9,7 @@ builds the navigable index: one row per task keyed by its gid.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from uuid import UUID
 
 import httpx
@@ -25,6 +26,13 @@ TASK_FIELDS = "name,notes,completed,assignee.name,due_on,permalink_url"
 PAGE_SIZE = 100
 MAX_TASKS = 2000
 SEARCH_LIMIT = 25
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    """Asana returns ISO-8601 ('...Z'); the column is timestamptz."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _render_task(task: dict) -> str:
@@ -61,7 +69,7 @@ async def index_asana(source: dict) -> str | None:
     offset: str | None = None
     async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
         while len(present) < MAX_TASKS:
-            params = {"opt_fields": "name", "limit": PAGE_SIZE}
+            params = {"opt_fields": "name,modified_at", "limit": PAGE_SIZE}
             if offset:
                 params["offset"] = offset
             resp = await client.get(url, params=params)
@@ -79,6 +87,7 @@ async def index_asana(source: dict) -> str | None:
                     name=task.get("name") or "(untitled task)",
                     kind="task",
                     external_ref=gid,
+                    external_updated_at=_parse_time(task.get("modified_at")),
                 )
                 present.append(gid)
             next_page = payload.get("next_page")

--- a/backend/integrations/gong/indexer.py
+++ b/backend/integrations/gong/indexer.py
@@ -30,6 +30,14 @@ def _call_account_id(meta: dict) -> str:
     return str(meta.get("workspaceId") or "")
 
 
+def _parse_time(value: str | None) -> datetime | None:
+    """Gong returns ISO-8601 ('...Z'); the column is timestamptz. A call never
+    changes after it happened, so its start time is its modified time."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 def _render_call(meta: dict, monologues: list[dict]) -> str:
     title = meta.get("title") or "Untitled call"
     started = meta.get("started") or ""
@@ -123,6 +131,7 @@ async def index_gong(source: dict) -> str | None:
             kind="call",
             content=_render_call(meta, transcript_by_id.get(call_id, [])),
             external_ref=call_id,
+            external_updated_at=_parse_time(meta.get("started")),
             extra={"gong_account_id": call_account_id},
         )
         present.append(call_id)
@@ -175,6 +184,7 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
             kind="call",
             content=_render_call(meta, transcript_by_id.get(call_id, [])),
             external_ref=call_id,
+            external_updated_at=_parse_time(meta.get("started")),
             extra={"gong_account_id": call_account_id},
         )
         refs.append(call_id)

--- a/backend/integrations/granola/indexer.py
+++ b/backend/integrations/granola/indexer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime
 from uuid import UUID
 
 from ...database import get_pool
@@ -104,6 +105,19 @@ def _extract_transcript(td) -> str | list:
     if isinstance(td, str | list):
         return td
     return ""
+
+
+def _meeting_time(meeting: dict) -> datetime | None:
+    """The meeting's timestamp, if its date field parses as ISO-8601. Granola's
+    MCP tool returns free-form text, so an unparseable date yields None (the
+    document shows no timestamp) rather than failing the sync."""
+    when = meeting.get("date") or meeting.get("created_at") or meeting.get("start_time")
+    if not when or not isinstance(when, str):
+        return None
+    try:
+        return datetime.fromisoformat(when.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _render_meeting(meeting: dict, transcript) -> str:
@@ -221,6 +235,7 @@ async def index_granola(source: dict) -> str | None:
                 kind="note",
                 content=_render_meeting(meeting, transcript),
                 external_ref=meeting_id,
+                external_updated_at=_meeting_time(meeting),
             )
             present.append(meeting_id)
 

--- a/backend/integrations/jira/indexer.py
+++ b/backend/integrations/jira/indexer.py
@@ -10,6 +10,7 @@ The sync only builds the navigable index: one row per issue keyed by its key
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from uuid import UUID
 
 import httpx
@@ -20,6 +21,16 @@ from ..storage import get_valid_token
 logger = logging.getLogger(__name__)
 
 API_BASE = "https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    """Jira returns ISO-8601 with a compact offset ('...+0000'); the column is
+    timestamptz."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
 ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
 # cloud_id -> site base url (e.g. https://acme.atlassian.net). Cached because the
 # site url never changes for a cloud and the lookup costs a network round-trip.
@@ -203,7 +214,7 @@ async def index_jira(source: dict) -> str | None:
     next_page_token: str | None = None
     async with httpx.AsyncClient(timeout=60.0, headers=_headers(token)) as client:
         while len(present) < MAX_ISSUES:
-            params = {"jql": jql, "maxResults": PAGE_SIZE, "fields": "summary"}
+            params = {"jql": jql, "maxResults": PAGE_SIZE, "fields": "summary,updated"}
             if next_page_token:
                 params["nextPageToken"] = next_page_token
             resp = await client.get(f"{base}/search/jql", params=params)
@@ -213,7 +224,8 @@ async def index_jira(source: dict) -> str | None:
                 key = issue.get("key")
                 if not key:
                     continue
-                summary = (issue.get("fields") or {}).get("summary") or key
+                fields = issue.get("fields") or {}
+                summary = fields.get("summary") or key
                 await source_service.upsert_index_row(
                     table="jira_documents",
                     source_id=source_id,
@@ -222,6 +234,7 @@ async def index_jira(source: dict) -> str | None:
                     name=f"{key}: {summary}",
                     kind="issue",
                     external_ref=f"{cloud_id}:{key}",
+                    external_updated_at=_parse_time(fields.get("updated")),
                 )
                 present.append(key)
             if payload.get("isLast") or not payload.get("nextPageToken"):

--- a/backend/integrations/notion/indexer.py
+++ b/backend/integrations/notion/indexer.py
@@ -11,6 +11,7 @@ as the document body, which makes Notion full-text searchable for nearly free
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from uuid import UUID
 
 import httpx
@@ -34,6 +35,13 @@ MAX_PAGE_DEPTH = 8
 
 def _safe(segment: str) -> str:
     return (segment or "Untitled").replace("/", "-").strip() or "Untitled"
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    """Notion returns ISO-8601 ('...Z'); the column is timestamptz."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _row_title(props: dict) -> str:
@@ -61,7 +69,8 @@ async def _index_page(
     meta_resp = await client.get(PAGE_URL.format(id=page_id))
     if meta_resp.status_code != 200:
         return
-    title = _safe(_extract_title(meta_resp.json()))
+    meta = meta_resp.json()
+    title = _safe(_extract_title(meta))
     # Render the blocks to markdown — both to discover sub-pages and to store
     # the body for full-text search.
     lines, child_ids = await fetch_block_tree(client, page_id)
@@ -75,6 +84,7 @@ async def _index_page(
         kind="note",
         content="\n".join(lines),
         external_ref=page_id,
+        external_updated_at=_parse_time(meta.get("last_edited_time")),
     )
     present.append(path)
     for child_id in child_ids:
@@ -125,6 +135,7 @@ async def _index_database(
                 kind="note",
                 content=title,
                 external_ref=row.get("id"),
+                external_updated_at=_parse_time(row.get("last_edited_time")),
             )
             present.append(path)
         if not payload.get("has_more"):

--- a/backend/tests/test_indexer_external_updated_at.py
+++ b/backend/tests/test_indexer_external_updated_at.py
@@ -1,0 +1,194 @@
+"""Every indexer must map its provider's modified-timestamp into
+external_updated_at. That column is the VFS's only truthful mtime — without it
+a source's documents show `-` dates and are invisible to `ls -t`/`find -mtime`
+(see #713). These tests pin the provider-field → column wiring per indexer.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from backend.integrations.asana import indexer as asana_indexer
+from backend.integrations.gong import indexer as gong_indexer
+from backend.integrations.granola.indexer import _meeting_time
+from backend.integrations.jira import indexer as jira_indexer
+from backend.integrations.notion import indexer as notion_indexer
+
+SOURCE = {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "owner_user_id": "00000000-0000-0000-0000-000000000002",
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class _FakeAsyncClient:
+    """Answers every GET with the payload configured per URL substring."""
+
+    def __init__(self, payloads: dict[str, dict]):
+        self._payloads = payloads
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, *args, **kwargs):
+        for fragment, payload in self._payloads.items():
+            if fragment in url:
+                return _FakeResponse(payload)
+        raise AssertionError(f"unexpected GET {url}")
+
+
+async def _token(user_id, provider):
+    return "tok"
+
+
+@pytest.mark.asyncio
+async def test_jira_indexer_maps_issue_updated(monkeypatch):
+    captured: list[dict] = []
+
+    async def capture_upsert(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(jira_indexer, "get_valid_token", _token)
+    monkeypatch.setattr(
+        jira_indexer.httpx,
+        "AsyncClient",
+        _FakeAsyncClient(
+            {
+                "/search/jql": {
+                    "issues": [
+                        {
+                            "key": "ENG-1",
+                            "fields": {
+                                "summary": "Ship it",
+                                "updated": "2026-07-01T10:00:00.000-0400",
+                            },
+                        }
+                    ],
+                    "isLast": True,
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(jira_indexer.source_service, "upsert_index_row", capture_upsert)
+    monkeypatch.setattr(jira_indexer.source_service, "remove_missing_documents", _noop)
+
+    await jira_indexer.index_jira({**SOURCE, "external_ref": "cloud-1:ENG"})
+
+    assert captured[0]["external_updated_at"] == datetime(
+        2026, 7, 1, 10, 0, tzinfo=timezone(timedelta(hours=-4))
+    )
+
+
+@pytest.mark.asyncio
+async def test_asana_indexer_maps_task_modified_at(monkeypatch):
+    captured: list[dict] = []
+
+    async def capture_upsert(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(asana_indexer, "get_valid_token", _token)
+    monkeypatch.setattr(
+        asana_indexer.httpx,
+        "AsyncClient",
+        _FakeAsyncClient(
+            {
+                "/tasks": {
+                    "data": [
+                        {"gid": "42", "name": "Do thing", "modified_at": "2026-07-02T08:30:00.000Z"}
+                    ]
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(asana_indexer.source_service, "upsert_index_row", capture_upsert)
+    monkeypatch.setattr(asana_indexer.source_service, "remove_missing_documents", _noop)
+
+    await asana_indexer.index_asana({**SOURCE, "external_ref": "proj-1"})
+
+    assert captured[0]["external_updated_at"] == datetime(2026, 7, 2, 8, 30, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_notion_indexer_maps_last_edited_time(monkeypatch):
+    captured: list[dict] = []
+
+    async def capture_upsert(**kwargs):
+        captured.append(kwargs)
+
+    async def fake_block_tree(client, page_id):
+        return ["body"], []
+
+    monkeypatch.setattr(notion_indexer, "get_valid_token", _token)
+    monkeypatch.setattr(notion_indexer, "fetch_block_tree", fake_block_tree)
+    monkeypatch.setattr(notion_indexer, "_extract_title", lambda meta: "Doc")
+    monkeypatch.setattr(
+        notion_indexer,
+        "_notion_client",
+        _FakeAsyncClient({"/pages/": {"last_edited_time": "2026-07-03T12:00:00.000Z"}}),
+    )
+    monkeypatch.setattr(notion_indexer.source_service, "upsert_content_document", capture_upsert)
+    monkeypatch.setattr(notion_indexer.source_service, "remove_missing_documents", _noop)
+
+    await notion_indexer.index_notion(
+        {**SOURCE, "external_ref": "0123456789abcdef0123456789abcdef"}
+    )
+
+    assert captured[0]["external_updated_at"] == datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_gong_indexer_maps_call_started(monkeypatch):
+    captured: list[dict] = []
+
+    async def capture_upsert(**kwargs):
+        captured.append(kwargs)
+
+    async def gong_token(user_id, provider):
+        return '{"access_token": "tok", "api_base_url": "https://api.gong.io"}'
+
+    async def call_meta(client, from_dt, to_dt):
+        return {"c1": {"id": "c1", "workspaceId": "W1", "started": "2026-06-15T14:00:00Z"}}
+
+    async def transcripts(client, from_dt, to_dt):
+        return {"c1": []}
+
+    monkeypatch.setattr(gong_indexer, "get_valid_token", gong_token)
+    monkeypatch.setattr(gong_indexer, "_fetch_call_meta", call_meta)
+    monkeypatch.setattr(gong_indexer, "_fetch_transcripts", transcripts)
+    monkeypatch.setattr(gong_indexer.httpx, "AsyncClient", _FakeAsyncClient({}))
+    monkeypatch.setattr(gong_indexer.source_service, "upsert_content_document", capture_upsert)
+    monkeypatch.setattr(gong_indexer.source_service, "remove_missing_documents", _noop)
+    monkeypatch.setattr(gong_indexer.source_service, "purge_disallowed_copied_documents", _noop)
+
+    await gong_indexer.index_gong({**SOURCE, "settings": {"allowed_workspace_ids": ["W1"]}})
+
+    assert captured[0]["external_updated_at"] == datetime(2026, 6, 15, 14, 0, tzinfo=UTC)
+
+
+def test_granola_meeting_time_parses_iso_and_tolerates_free_text():
+    assert _meeting_time({"date": "2026-07-04T09:00:00Z"}) == datetime(2026, 7, 4, 9, 0, tzinfo=UTC)
+    # Granola's MCP tool returns free-form text; an unparseable date must yield
+    # no timestamp (rendered as `-`), never a crashed sync or a fabricated date.
+    assert _meeting_time({"date": "last Tuesday morning"}) is None
+    assert _meeting_time({}) is None
+
+
+async def _noop(*args, **kwargs):
+    return 0


### PR DESCRIPTION
Follow-up #1 from #713: the VFS now renders `external_updated_at` as a document's modified time (`ls -la`, `ls -t`, `find -mtime/-newer`, `stat`), but six indexers never populated it — their documents show `-` and are invisible to every time predicate.

This wires the provider timestamp through **in payloads each indexer already fetches** (zero additional API calls):

| Source | Field |
|---|---|
| Notion | `last_edited_time` (pages + database rows) |
| Jira | `fields.updated` (added to the search field list) |
| Asana | `modified_at` (added to `opt_fields`) |
| Gong | call `started` — a call never changes after it happened |
| Granola | meeting `date`, parsed tolerantly (free-form MCP text → unparseable yields `None`, never a failed sync or fabricated date) |

**GitHub is deliberately not wired.** Its crawl reads a snapshot archive whose entries all carry the ref's commit timestamp, so a per-file "modified" would claim every file changed on push day — wrong-but-plausible is worse than visibly missing (the same fail-honest rule as #713's `-` rendering). True per-file dates cost one commits-API call per file; not worth it.

Existing rows pick up timestamps on each source's next scheduled sync via the upsert freshness checks — no migration needed.

Tests: new `test_indexer_external_updated_at.py` pins the provider-field → column mapping per indexer (incl. Jira's compact `-0400` offset format and Granola's free-text tolerance). Adjacent suites (127 tests) pass; ruff clean. Rebased over #716 (Granola transcripts) and #717 (migration renumber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)