### PR TITLE
CI: fail PRs whose migrations fork the alembic graph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,20 @@ jobs:
       - run: ruff check backend/ cli/
       - run: ruff format --check backend/ cli/
 
+  migration-graph:
+    name: Migration graph (single head)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "$(grep '^alembic' backend/requirements.txt)"
+      # Two PRs merging migrations onto the same parent leave alembic with two
+      # heads and break every deploy (#712 + #713 both shipped "0125"). PR CI
+      # runs against the merge ref, so this reds the second PR before merge.
+      - run: python backend/migrations/check_heads.py
+
   plugin-test:
     name: Plugin tests
     runs-on: ubuntu-latest

--- a/backend/migrations/check_heads.py
+++ b/backend/migrations/check_heads.py
@@ -1,0 +1,50 @@
+"""Fail unless the migration graph has exactly one head.
+
+Two PRs that each add a migration on top of the same parent merge cleanly in
+git but leave alembic with two heads (or two files claiming the same revision
+id) — and every `alembic upgrade head` after that refuses to run: deploys,
+fresh test databases, local setups. That exact race shipped as #712 + #713
+(both "0125") and broke main for an hour; this check turns it into a red PR
+check instead of a broken deploy, because PR CI runs against the merge ref.
+
+Run from the repo root: `python backend/migrations/check_heads.py`.
+Needs only alembic installed — no database, no backend settings.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from alembic.util import CommandError
+
+FIX = (
+    "Fix: renumber this branch's migration to sit on main's current head — "
+    "bump its filename/revision to the next number and set down_revision to "
+    "the current head, then rebase."
+)
+
+
+def main() -> int:
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    try:
+        heads = script.get_heads()
+    except CommandError as e:
+        # Two files claiming the same revision id fail before heads can even
+        # be computed.
+        print(f"migration graph is broken: {e}\n{FIX}", file=sys.stderr)
+        return 1
+    if len(heads) != 1:
+        print(
+            f"migration graph has {len(heads)} heads ({', '.join(sorted(heads))}); "
+            f"every alembic upgrade will refuse to run.\n{FIX}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"migration graph ok: single head {heads[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Prevention for today's outage: #712 and #713 each added a migration with `revision = "0125"` on the same parent. Git merged both cleanly; alembic then saw multiple heads and refused every `upgrade head` — deploys and fresh test DBs were broken until #717 renumbered one.

**The guard:** `backend/migrations/check_heads.py` loads the migration graph via alembic's `ScriptDirectory` (no database, no backend imports) and fails unless there is exactly one head, with an actionable message (renumber onto the current head + rebase). A new `migration-graph` CI job runs it.

**Why this catches the race before merge:** `pull_request` CI runs against the merge ref, so a PR whose migration sits on a stale parent sees main's newer migration in the same tree and goes red — at review time, not deploy time.

Verified against all three graph states locally:
- current graph → passes (`single head 0126`)
- recreated today's exact collision (second file claiming `0125`) → fails
- distinct forked heads → fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)