### PR TITLE
Pin managed OpenRouter routing to no-collection providers

### DIFF
--- a/backend/services/agent_auth.py
+++ b/backend/services/agent_auth.py
@@ -51,6 +51,24 @@ _API_KEY_ONLY = {"openrouter"}
 # The managed agent: opencode driving OpenRouter's GLM 5.2, on our key.
 MANAGED_HARNESS = harness_mod.OPENCODE
 
+# OpenRouter load-balances GLM across many third-party hosts, each with its own
+# data policy. data_collection "deny" makes OpenRouter route only to providers
+# that neither retain nor train on prompts — the basis of the no-training
+# guarantee we give customers, so it must ride on every managed turn.
+_OPENCODE_PRIVACY_CONFIG = json.dumps(
+    {
+        "provider": {
+            "openrouter": {
+                "models": {
+                    MANAGED_HARNESS.default_model: {
+                        "options": {"provider": {"data_collection": "deny"}}
+                    }
+                }
+            }
+        }
+    }
+)
+
 
 @dataclass
 class RunAuth:
@@ -150,7 +168,11 @@ async def _managed(user_id: UUID) -> RunAuth:
     key = settings.OPENROUTER_API_KEY
     if not key:
         raise ProviderNotConfigured
-    return RunAuth(harness=MANAGED_HARNESS, env={model_provider.OPENROUTER.env_var: key})
+    return RunAuth(
+        harness=MANAGED_HARNESS,
+        env={model_provider.OPENROUTER.env_var: key},
+        files={f"{_SPRITE_HOME}/.config/opencode/opencode.json": _OPENCODE_PRIVACY_CONFIG},
+    )
 
 
 def _byo_auth(cred: dict) -> RunAuth:

--- a/backend/tests/test_agent_auth.py
+++ b/backend/tests/test_agent_auth.py
@@ -1,5 +1,6 @@
 """Per-user harness + credential resolution: BYO keys, managed OpenRouter, gate."""
 
+import json
 import uuid
 
 import pytest
@@ -84,6 +85,11 @@ async def test_no_credential_pro_gets_managed_openrouter_glm(monkeypatch):
     assert auth.harness is h.OPENCODE
     assert auth.harness.default_model == "z-ai/glm-5.2"
     assert auth.env == {"OPENROUTER_API_KEY": "sk-managed-or"}
+    # The customer-facing no-training guarantee: every managed turn must pin
+    # OpenRouter routing to providers that don't retain or train on prompts.
+    opencode_config = json.loads(auth.files["/home/sprite/.config/opencode/opencode.json"])
+    model_options = opencode_config["provider"]["openrouter"]["models"]["z-ai/glm-5.2"]["options"]
+    assert model_options["provider"] == {"data_collection": "deny"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Ask openrouter to ensure our users' tokens are never trained on

## What

Every managed agent turn (curator + managed-tier chat) now writes `~/.config/opencode/opencode.json` on the sprite before the run, setting OpenRouter's provider preference `data_collection: "deny"` for the managed GLM model. OpenRouter then routes only to inference providers that neither retain prompts nor train on them.

## Why

OpenRouter load-balances `z-ai/glm-5.2` across ~27 third-party hosts (Novita, DeepInfra, Baidu, Alibaba, Together, …), each with its own data policy. Without this restriction, any of them could serve a curator run. We are giving customers a written guarantee that no model provider trains on their content (Heavi security letter); this is the code enforcement behind it.

## How

- Injected via `RunAuth.files`, which is written to the box **before every turn** — so sprites provisioned before this change get the guarantee immediately, no reseed/migration needed.
- Config is per-model under `provider.openrouter.models["z-ai/glm-5.2"].options.provider`, the documented opencode passthrough for OpenRouter provider preferences (same mechanism as `order`/`allow_fallbacks`).
- BYO-key runs unchanged — those run under the user's own provider agreement.

## Testing

- `test_no_credential_pro_gets_managed_openrouter_glm` now asserts the config rides on every managed `RunAuth` (commented as the basis of a customer-facing guarantee so it can't be silently dropped).
- All 10 `test_agent_auth` tests pass; `test_curator`, `test_agents`, `test_sprite_agent_mapping` pass. (`test_agent_oauth` has 4 pre-existing failures unrelated to this change — fail identically on main.)
- ruff check + format clean.

**Post-deploy verification:** OpenRouter's activity log shows the serving provider per request — after the first curator run, confirm requests only hit no-collection providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)