### PR TITLE
Fix extraction pipeline: broken since May 21 in production

### DIFF
--- a/backend/tests/test_extraction_security.py
+++ b/backend/tests/test_extraction_security.py
@@ -141,6 +141,37 @@ async def extraction_file(_db_pool):
 
 
 @pytest.mark.asyncio
+async def test_successful_extraction_persists_text_against_real_db(
+    monkeypatch, extraction_file, _db_pool
+):
+    """The success-path UPDATE must run against real Postgres. The mocked
+    connection used elsewhere can't catch SQL-level failures — the #408
+    embed_stale CASE shipped with an AmbiguousParameterError that broke
+    every production extraction until this path had DB coverage."""
+
+    async def download_file(storage_key):
+        return b"file body"
+
+    async def close_storage():
+        pass
+
+    monkeypatch.setattr(storage_service, "download_file", download_file)
+    monkeypatch.setattr(storage_service, "close", close_storage)
+
+    assert await extract_one._run(extraction_file) == 0
+
+    row = await _db_pool.fetchrow(
+        "SELECT extracted_text, extraction_status, extraction_error, embed_stale "
+        "FROM files WHERE id = $1",
+        extraction_file,
+    )
+    assert row["extraction_status"] == "done"
+    assert row["extracted_text"] == "file body"
+    assert row["extraction_error"] is None
+    assert row["embed_stale"] is True
+
+
+@pytest.mark.asyncio
 async def test_parent_preserves_child_persisted_error(monkeypatch, extraction_file, _db_pool):
     """When the child persists its redacted error, the parent's external
     failure marking must not overwrite it with a bare exit-code marker —

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -85,7 +85,7 @@ class _FakeConnection:
             "extraction_attempts": 0,
         }
 
-    async def execute(self, query, file_id, text):
+    async def execute(self, query, file_id, text, embed_stale=None):
         self.persisted_text = text
 
     async def close(self):

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -30,10 +30,11 @@ import resource
 import sys
 from uuid import UUID
 
-# Cap address space BEFORE importing any extraction libs. 350 MB leaves
-# headroom on Render Starter's 512 MB dyno while giving pypdf room for
-# large arxiv-style documents.
-_MEM_LIMIT_BYTES = int(os.getenv("EXTRACTION_MEMORY_LIMIT_MB", "350")) * 1024 * 1024
+# Cap address space BEFORE importing any extraction libs. The old 350 MB
+# default OOM'd in production: OpenBLAS (via numpy) sizes per-thread
+# buffers from the host's core count, and RLIMIT_AS only applies on Linux
+# so local runs never caught it. The worker runs on a 2 GB instance now.
+_MEM_LIMIT_BYTES = int(os.getenv("EXTRACTION_MEMORY_LIMIT_MB", "1024")) * 1024 * 1024
 
 
 def _apply_memory_limit() -> None:
@@ -77,16 +78,20 @@ async def _run(file_id: UUID) -> int:
 
         # embed_stale flips on if there's text to embed. The reconciler
         # in backend/tasks/embeddings.py picks files up from there.
+        # The flag is computed in Python and passed as its own parameter:
+        # reusing $2 inside a CASE makes Postgres unable to infer the
+        # parameter's type (AmbiguousParameterError).
         await conn.execute(
             "UPDATE files SET "
             "extracted_text = $2, "
             "extraction_status = 'done', "
             "extraction_error = NULL, "
             "locked_at = NULL, "
-            "embed_stale = CASE WHEN $2 IS NOT NULL AND $2 <> '' THEN TRUE ELSE embed_stale END "
+            "embed_stale = embed_stale OR $3 "
             "WHERE id = $1",
             file_id,
             text,
+            bool(text),
         )
         return 0
     except Exception as e:


### PR DESCRIPTION
## What broke

While verifying #725 in production, extraction failed for a scanned PDF — and digging in revealed **every file extraction has failed in production since May 21** (newest `done` row in the prod DB). ~180 files uploaded since then never reached the knowledge base. Two independent, pre-existing causes:

### 1. `AmbiguousParameterError` on the success-path UPDATE (58 files)
The `embed_stale` CASE from #408 reuses `$2`:
```sql
embed_stale = CASE WHEN $2 IS NOT NULL AND $2 <> '' THEN TRUE ELSE embed_stale END
```
Postgres cannot infer `$2`'s type from this statement — asyncpg raises `AmbiguousParameterError: could not determine data type of parameter $2` on **every** execution, string or NULL (reproduced against a clean local DB). Fixed by computing the flag in Python and passing it as `$3` (`embed_stale = embed_stale OR $3`).

### 2. OpenBLAS OOM under the 350MB child cap (85 files)
The extraction child applies `RLIMIT_AS = 350MB` before imports. OpenBLAS (pulled in via numpy) sizes per-thread buffers from the **host's** visible core count, which on Render's shared hosts blows the address-space cap at import time. Default raised to 1024MB (the worker runs a 2GB Standard instance); I already set `EXTRACTION_MEMORY_LIMIT_MB=1024` on the worker in Render, so the code default is belt-and-braces.

## Why nobody noticed
- `RLIMIT_AS` is rejected on macOS, so the cap never applied in local dev.
- The child's stdout/stderr are discarded by design; failures surfaced only as `exit_1` markers in the files table.
- Extraction tests used a mocked DB connection, so SQL-level failures were invisible. **This PR adds a success-path test that runs `extract_one._run` against real Postgres** — it fails with `AmbiguousParameterError` without the query fix.

## After merge
The ~180 stuck rows are at `extraction_attempts >= 3` and won't self-heal; they need a one-time reset to `pending` (I'll run it once this deploys).

## Testing
- New real-DB test passes; full extraction + OCR test files: 14/14.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)