### PR TITLE
Add bulk export: whole scope as one zip of standard files (FER-299)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from .routers import (
     analytics,
     batch,
     billing,
+    bulk_export,
     collab,
     demo,
     discover,
@@ -148,6 +149,7 @@ app.include_router(session_folders.public_router)
 app.include_router(shares.router)
 app.include_router(webhooks.router)
 app.include_router(billing.router)
+app.include_router(bulk_export.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
 

--- a/backend/routers/bulk_export.py
+++ b/backend/routers/bulk_export.py
@@ -1,0 +1,126 @@
+"""Bulk export: download everything you own as one zip of standard files.
+
+This is the no-lock-in escape hatch we promise customers: folders become
+directories, pages become plain .md/.html files, and uploads keep their
+original bytes — nothing proprietary, so a customer can take their whole
+company brain and leave (or just keep backups) at any time.
+"""
+
+import asyncio
+import io
+import zipfile
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+
+from ..auth import get_current_user
+from ..database import get_pool
+from ..services import storage_service
+
+router = APIRouter(prefix="/api/v1/me", tags=["export"])
+
+
+def _clean(name: str) -> str:
+    """A DB name must stay a single path segment inside the zip."""
+    cleaned = name.replace("/", "_").replace("\\", "_").strip()
+    return cleaned or "untitled"
+
+
+def _folder_paths(folders: list) -> dict[UUID, str]:
+    """Folder id -> zip directory path, mirroring the folder tree."""
+    by_id = {f["id"]: f for f in folders}
+    paths: dict[UUID, str] = {}
+
+    def path_of(folder_id: UUID) -> str:
+        if folder_id in paths:
+            return paths[folder_id]
+        folder = by_id[folder_id]
+        parent_id = folder["parent_folder_id"]
+        prefix = f"{path_of(parent_id)}/" if parent_id in by_id else ""
+        paths[folder_id] = f"{prefix}{_clean(folder['name'])}"
+        return paths[folder_id]
+
+    for folder_id in by_id:
+        path_of(folder_id)
+    return paths
+
+
+def _entry_path(folder_paths: dict[UUID, str], folder_id: UUID | None, filename: str) -> str:
+    if folder_id in folder_paths:
+        return f"{folder_paths[folder_id]}/{filename}"
+    return filename
+
+
+def _reserve(taken: set[str], path: str) -> str:
+    """Zip entries silently shadow each other on duplicate names; number them."""
+    candidate = path
+    n = 2
+    while candidate in taken:
+        stem, dot, ext = path.rpartition(".")
+        candidate = f"{stem} ({n}).{ext}" if dot else f"{path} ({n})"
+        n += 1
+    taken.add(candidate)
+    return candidate
+
+
+@router.get("/export")
+async def export_everything(current_user: dict = Depends(get_current_user)):
+    """The caller's entire scope as a zip.
+
+    Embedded files (images pasted into pages) go under attachments/, named by
+    the file id that page bodies reference in their download URLs, so the
+    links inside exported markdown stay traceable to the exported bytes.
+    """
+    owner_user_id = current_user["id"]
+    pool = get_pool()
+    folder_rows, page_rows, file_rows = await asyncio.gather(
+        pool.fetch(
+            "SELECT id, name, parent_folder_id FROM folders WHERE owner_user_id = $1",
+            owner_user_id,
+        ),
+        pool.fetch(
+            "SELECT name, folder_id, content_type, content_markdown, content_html "
+            "FROM pages WHERE owner_user_id = $1 AND deleted_at IS NULL",
+            owner_user_id,
+        ),
+        pool.fetch(
+            "SELECT id, name, folder_id, owner_page_id, storage_key "
+            "FROM files WHERE owner_user_id = $1 AND deleted_at IS NULL",
+            owner_user_id,
+        ),
+    )
+
+    folder_paths = _folder_paths(folder_rows)
+    taken: set[str] = set()
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for dir_path in folder_paths.values():
+            archive.writestr(f"{dir_path}/", b"")
+
+        for page in page_rows:
+            is_html = page["content_type"] == "html"
+            ext = ".html" if is_html else ".md"
+            name = _clean(page["name"])
+            # Uploaded pages keep their extension in the page name; don't
+            # double it (guide.md must round-trip as guide.md, not guide.md.md).
+            filename = name if name.endswith(ext) else f"{name}{ext}"
+            content = page["content_html"] if is_html else page["content_markdown"]
+            path = _reserve(taken, _entry_path(folder_paths, page["folder_id"], filename))
+            archive.writestr(path, content.encode())
+
+        for file in file_rows:
+            blob = await storage_service.download_file(file["storage_key"])
+            if file["owner_page_id"]:
+                path = f"attachments/{file['id']}-{_clean(file['name'])}"
+            else:
+                path = _entry_path(folder_paths, file["folder_id"], _clean(file["name"]))
+            archive.writestr(_reserve(taken, path), blob)
+
+    stamp = datetime.now(UTC).strftime("%Y-%m-%d")
+    return Response(
+        content=buffer.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="stash-export-{stamp}.zip"'},
+    )

--- a/backend/tests/test_bulk_export.py
+++ b/backend/tests/test_bulk_export.py
@@ -1,0 +1,159 @@
+"""Bulk export (`GET /api/v1/me/export`).
+
+The no-lock-in promise: the zip must contain every folder, page, and upload
+the caller owns — as plain files mirroring the tree — and nothing owned by
+anyone else.
+"""
+
+import io
+import zipfile
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import storage_service
+from backend.tasks import extraction
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient, prefix: str) -> str:
+    name = unique_name(prefix)
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1", "email": f"{name}@test.local"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+@pytest.fixture
+def stub_storage(monkeypatch):
+    """Uploads and the export both hit S3; CI has none, so blobs live in a dict."""
+    blobs: dict[str, bytes] = {}
+
+    async def _upload(owner_user_id, filename, content, content_type):
+        key = f"test/{owner_user_id}/{filename}"
+        blobs[key] = content
+        return key
+
+    async def _url(storage_key, expires_in=3600):
+        return f"https://files.test/{storage_key}"
+
+    async def _download(storage_key):
+        return blobs[storage_key]
+
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_file", _upload)
+    monkeypatch.setattr(storage_service, "get_file_url", _url)
+    monkeypatch.setattr(storage_service, "download_file", _download)
+    monkeypatch.setattr(extraction.extract_file_text, "delay", lambda *a, **k: None)
+
+
+async def _folder(client: AsyncClient, api_key: str, name: str, parent: str | None = None) -> str:
+    body: dict = {"name": name}
+    if parent:
+        body["parent_folder_id"] = parent
+    resp = await client.post("/api/v1/me/folders", json=body, headers=_auth(api_key))
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _page(
+    client: AsyncClient, api_key: str, name: str, content: str, folder_id: str | None = None
+) -> str:
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": name, "content": content, "folder_id": folder_id},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _upload_binary(
+    client: AsyncClient, api_key: str, name: str, content: bytes, folder_id: str | None = None
+) -> str:
+    resp = await client.post(
+        "/api/v1/me/files",
+        files={"file": (name, content, "application/pdf")},
+        data={"folder_id": folder_id} if folder_id else {},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _export(client: AsyncClient, api_key: str) -> zipfile.ZipFile:
+    resp = await client.get("/api/v1/me/export", headers=_auth(api_key))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    assert "attachment" in resp.headers["content-disposition"]
+    return zipfile.ZipFile(io.BytesIO(resp.content))
+
+
+@pytest.mark.asyncio
+async def test_export_mirrors_the_whole_tree(client: AsyncClient, stub_storage):
+    api_key = await _register(client, "export_tree")
+    docs = await _folder(client, api_key, "Docs")
+    brakes = await _folder(client, api_key, "Brakes", parent=docs)
+    empty = await _folder(client, api_key, "Empty")
+    await _page(client, api_key, "Guide", "# Brake pads\n", folder_id=brakes)
+    await _page(client, api_key, "Notes", "root notes\n")
+    await _page(client, api_key, "readme.md", "uploaded page\n")
+    await _upload_binary(client, api_key, "manual.pdf", b"%PDF fake", folder_id=docs)
+    assert empty
+
+    archive = await _export(client, api_key)
+    names = set(archive.namelist())
+
+    assert "Docs/" in names
+    assert "Empty/" in names
+    assert "Docs/Brakes/Guide.md" in names
+    assert "Notes.md" in names
+    # A page name that already carries the extension must not double it.
+    assert "readme.md" in names
+    assert "Docs/manual.pdf" in names
+    assert archive.read("Docs/Brakes/Guide.md") == b"# Brake pads\n"
+    assert archive.read("Docs/manual.pdf") == b"%PDF fake"
+
+
+@pytest.mark.asyncio
+async def test_embedded_files_export_under_attachments(client: AsyncClient, stub_storage):
+    api_key = await _register(client, "export_embed")
+    file_id = await _upload_binary(client, api_key, "shot.png", b"\x89PNG fake")
+    await _page(
+        client,
+        api_key,
+        "Doc",
+        f"![shot](/api/v1/me/files/{file_id}/download)\n",
+    )
+
+    archive = await _export(client, api_key)
+
+    # Named by the file id the page body references, so links stay traceable.
+    assert archive.read(f"attachments/{file_id}-shot.png") == b"\x89PNG fake"
+
+
+@pytest.mark.asyncio
+async def test_export_excludes_other_users_content(client: AsyncClient, stub_storage):
+    owner_key = await _register(client, "export_owner")
+    other_key = await _register(client, "export_other")
+    await _page(client, other_key, "Secret", "not yours\n")
+    await _page(client, owner_key, "Mine", "mine\n")
+
+    archive = await _export(client, owner_key)
+    names = set(archive.namelist())
+
+    assert "Mine.md" in names
+    assert "Secret.md" not in names
+
+
+@pytest.mark.asyncio
+async def test_export_requires_auth(client: AsyncClient):
+    resp = await client.get("/api/v1/me/export")
+    assert resp.status_code == 401

--- a/cli/client.py
+++ b/cli/client.py
@@ -515,6 +515,13 @@ class StashClient:
     def download_file(self, file_id: str) -> bytes:
         return self._request("GET", f"/api/v1/me/files/{file_id}/download").content
 
+    def export_zip(self) -> bytes:
+        """The whole scope (folders, pages, uploaded files) as one zip.
+
+        Big scopes take a while to package server-side, so this call gets a
+        much longer timeout than the client default."""
+        return self._request("GET", "/api/v1/me/export", timeout=600).content
+
     # --- The user's cloud computer (read-through machine filesystem) ---
 
     def machine_fs_list(self, path: str) -> list[dict]:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1221,6 +1221,36 @@ def upload(
         )
 
 
+@app.command("export")
+def export(
+    output: str = typer.Option(
+        "",
+        "--output",
+        "-o",
+        help="Path for the zip (default: stash-export-<timestamp>.zip in the current directory).",
+    ),
+):
+    """Download your entire Stash as a zip of standard files.
+
+    Folders become directories, pages become plain .md/.html files, and
+    uploads keep their original bytes — no proprietary formats, no lock-in."""
+    _require_auth()
+    telemetry.record("export")
+    destination = (
+        Path(output) if output else Path(f"stash-export-{time.strftime('%Y%m%d-%H%M%S')}.zip")
+    )
+    console.print("[dim]Packaging your Stash…[/dim]")
+    with _client() as c:
+        try:
+            data = c.export_zip()
+        except StashError as e:
+            _err(e)
+    destination.write_bytes(data)
+    console.print(
+        f"[green bold]Exported![/green bold]  {destination}  [dim]{len(data):,} bytes[/dim]"
+    )
+
+
 def _parse_skill_slug(url_or_slug: str) -> str:
     """Extract a Skill slug from a full URL or bare slug."""
     url_or_slug = url_or_slug.strip().rstrip("/")

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import WorkspaceShell from "@/components/workspace/workspace-shell";
 import IntegrationsSettings from "../../components/integrations/IntegrationsSettings";
 import SubscriptionSection from "../../components/settings/SubscriptionSection";
 import AgentModelSection from "../../components/settings/AgentModelSection";
+import ExportSection from "../../components/settings/ExportSection";
 import { AccountSettingsSkeleton, ApiKeysSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import {
@@ -56,6 +57,7 @@ export default function SettingsPage() {
           <AgentModelSection />
           <IntegrationsSettings embedded />
           <ActiveSessions />
+          <ExportSection />
           {!AUTH0_ENABLED && <ChangePassword />}
         </div>
       </main>

--- a/frontend/src/components/settings/ExportSection.tsx
+++ b/frontend/src/components/settings/ExportSection.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { fetchAuthed } from "../../lib/api";
+
+export default function ExportSection() {
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleExport() {
+    setExporting(true);
+    setError("");
+    try {
+      const res = await fetchAuthed("/api/v1/me/export");
+      if (!res.ok) throw new Error(`Export failed (${res.status})`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `stash-export-${new Date().toISOString().slice(0, 10)}.zip`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border bg-surface p-6 space-y-4">
+      <div>
+        <h2 className="text-base font-semibold text-foreground">Export everything</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Download your whole Stash as a zip of standard files — pages as Markdown/HTML,
+          uploads as their original bytes. Your data is never locked in.
+        </p>
+      </div>
+      {error && <p className="text-xs text-error">{error}</p>}
+      <button
+        type="button"
+        onClick={handleExport}
+        disabled={exporting}
+        className="cursor-pointer bg-brand hover:bg-brand-hover disabled:opacity-60 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+      >
+        {exporting ? "Packaging…" : "Download export"}
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## What

Bulk export — the no-lock-in commitment in the Heavi contract (FER-299). A customer can download their entire company brain as one zip of standard files at any time:

- **Backend**: `GET /api/v1/me/export` (`backend/routers/bulk_export.py`) — every folder, live page, and upload the caller owns. Folders become directories, pages become plain `.md`/`.html`, uploads keep their original bytes. Embedded page images land in `attachments/<file_id>-<name>` so the download URLs inside exported markdown stay traceable. Duplicate entry names are numbered; empty folders are preserved.
- **CLI**: `stash export [-o path]` — downloads the zip (10-minute timeout for big scopes).
- **Frontend**: "Export everything" card on the settings page with a Download button.

## Screenshot

[Settings → Export everything section](https://app.joinstash.ai/f/72941f3f-b97d-4e4c-aa53-0ed24b7ceeb0)

## Verification

- E2E on the local stack: `stash upload` of a nested folder → `stash export` → unzipped tree is **byte-identical** to the uploaded files (this caught and fixed a `guide.md.md` double-extension bug for pages whose names already carry the extension).
- Settings button drives the same endpoint from the browser: 200, `PK` zip, correct `Content-Disposition`.
- Probes: no auth → 401, bad key → 401, wrong method → 405, empty scope → valid zip, page named `weird/name` → `weird_name.md`.
- Tests in `backend/tests/test_bulk_export.py`: tree mirroring, extension round-trip, embedded attachments, cross-user isolation, auth required. Full backend suite: 694 passed (4 pre-existing `test_agent_oauth.py` failures also fail on a clean tree).

## Notes

- The uploaded-binary path is covered by tests with stubbed storage; local dev has no S3, so worth one manual export against staging/prod before telling Heavi it's done.
- Zip is built in memory per request — fine at Heavi's ~50-PDF scale; revisit (streaming/Celery) if a workspace grows to gigabytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)