### PR TITLE
Google Drive: connect a single folder from the web UI

### DIFF
--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -39,7 +39,7 @@ export const CONNECTORS: Connector[] = [
     label: "Google Drive",
     sourceType: "google_drive",
     kind: "drive",
-    blurb: "Index My Drive and read docs on demand.",
+    blurb: "Index all of My Drive, or just one folder.",
   },
   {
     provider: "gmail",

--- a/frontend/src/components/integrations/pickers.test.tsx
+++ b/frontend/src/components/integrations/pickers.test.tsx
@@ -61,6 +61,58 @@ describe("AddSourceControls", () => {
   });
 });
 
+// A customer scopes the knowledge base by connecting one Drive folder — the
+// pasted link must become a source whose external_ref is that folder's id, so
+// the indexer (and therefore the curator) only ever sees that subtree.
+describe("DriveFolderControls", () => {
+  it("adds a folder-scoped source from a pasted link, with the given name", async () => {
+    addSource.mockResolvedValue({});
+    renderControls();
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a Drive folder link"), {
+      target: { value: "https://drive.google.com/drive/u/0/folders/1AbC_dEf-234567890?usp=sharing" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Name (e.g. Knowledge Base)"), {
+      target: { value: "Heavi Knowledge Base" },
+    });
+    fireEvent.click(screen.getByText("Add folder"));
+
+    expect(addSource).toHaveBeenCalledWith({
+      source_type: "google_drive",
+      external_ref: "1AbC_dEf-234567890",
+      display_name: "Heavi Knowledge Base",
+    });
+  });
+
+  it("accepts a bare folder id and defaults the name", async () => {
+    addSource.mockResolvedValue({});
+    renderControls();
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a Drive folder link"), {
+      target: { value: "1AbC_dEf-234567890" },
+    });
+    fireEvent.click(screen.getByText("Add folder"));
+
+    expect(addSource).toHaveBeenCalledWith({
+      source_type: "google_drive",
+      external_ref: "1AbC_dEf-234567890",
+      display_name: "Google Drive folder",
+    });
+  });
+
+  it("rejects non-folder input: button disabled, hint shown, nothing added", () => {
+    renderControls();
+
+    fireEvent.change(screen.getByPlaceholderText("Paste a Drive folder link"), {
+      target: { value: "https://drive.google.com/file/d/xyz/view" },
+    });
+    fireEvent.click(screen.getByText("Add folder"));
+
+    expect(addSource).not.toHaveBeenCalled();
+    expect(screen.getByText(/doesn't look like a folder link/)).toBeTruthy();
+  });
+});
+
 const githubConnector: Connector = {
   provider: "github",
   label: "GitHub",

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -134,14 +134,13 @@ export function AddSourceControls({
   if (connector.kind === "drive") {
     return (
       <div className="space-y-2">
-        <button
-          type="button"
-          onClick={() => void add({ external_ref: "root", display_name: "Google Drive" })}
-          disabled={busy}
-          className={secondaryButton()}
-        >
-          {busy ? "Adding..." : "Add My Drive"}
-        </button>
+        <DriveFolderControls
+          busy={busy}
+          onAddMyDrive={() => add({ external_ref: "root", display_name: "Google Drive" })}
+          onAddFolder={(folderId, displayName) =>
+            add({ external_ref: folderId, display_name: displayName })
+          }
+        />
         {errorRow}
       </div>
     );
@@ -243,6 +242,75 @@ export function AddSourceControls({
         {busy ? "Adding..." : "Add"}
       </button>
       {errorRow}
+    </div>
+  );
+}
+
+// A Drive source syncs one folder subtree (external_ref is the folder id;
+// "root" means all of My Drive). A pasted folder link reaches any folder the
+// account can read — nested or shared — without a Drive-listing endpoint.
+export function parseDriveFolderId(input: string): string | null {
+  const trimmed = input.trim();
+  const fromUrl = trimmed.match(/\/folders\/([A-Za-z0-9_-]+)/);
+  if (fromUrl) return fromUrl[1];
+  if (/^[A-Za-z0-9_-]{15,}$/.test(trimmed)) return trimmed;
+  return null;
+}
+
+function DriveFolderControls({
+  busy,
+  onAddMyDrive,
+  onAddFolder,
+}: {
+  busy: boolean;
+  onAddMyDrive: () => Promise<boolean>;
+  onAddFolder: (folderId: string, displayName: string) => Promise<boolean>;
+}) {
+  const [link, setLink] = useState("");
+  const [name, setName] = useState("");
+  const folderId = parseDriveFolderId(link);
+
+  async function addFolder() {
+    if (!folderId) return;
+    const added = await onAddFolder(folderId, name.trim() || "Google Drive folder");
+    if (added) {
+      setLink("");
+      setName("");
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={() => void onAddMyDrive()} disabled={busy} className={secondaryButton()}>
+          {busy ? "Adding..." : "Add My Drive"}
+        </button>
+        <span className="text-[11.5px] text-muted-foreground">or sync just one folder:</span>
+      </div>
+      <input
+        value={link}
+        onChange={(event) => setLink(event.target.value)}
+        placeholder="Paste a Drive folder link"
+        className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground"
+        disabled={busy}
+      />
+      <div className="flex items-center gap-2">
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Name (e.g. Knowledge Base)"
+          className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground"
+          disabled={busy}
+        />
+        <button type="button" onClick={() => void addFolder()} disabled={busy || !folderId} className={primaryButton()}>
+          {busy ? "Adding..." : "Add folder"}
+        </button>
+      </div>
+      {link.trim() !== "" && !folderId && (
+        <div className="text-[11.5px] text-muted-foreground">
+          That doesn&apos;t look like a folder link — expected drive.google.com/drive/folders/…
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
The backend has always scoped a Drive source to a folder subtree (`external_ref` is a folder id; `"root"` = all of My Drive — `backend/integrations/google/indexer.py`), but the connect UI hardcoded `"root"`. This adds folder choice: paste a Drive folder link (or bare id), optionally name it, click **Add folder**. The indexer — and therefore the sleep-time curator and the LLM wiki — only ever sees that subtree.

**Why now:** Heavi wants to hand-curate which documents form their knowledge base. "Make a folder, drag in what the brain should know, connect exactly that folder" is the interface. Deep links reach nested and shared folders, so no Drive-listing endpoint is needed.

- Keeps the one-click **Add My Drive** (`root`) path unchanged
- Parses `drive.google.com/drive/[u/N/]folders/<id>` URLs and bare ids; non-folder links (e.g. file links) disable the button with an inline hint
- Vitest coverage for the parse-and-add flow, defaults, and rejection path

## Screenshots

Filled state (pasted link + name): https://app.joinstash.ai/f/0b8e3efc-5d18-45d6-9abc-319dad86b9b3

After adding — folder appears in the FOLDERS list, scoped to the pasted id: https://app.joinstash.ai/f/a83af40e-a155-46e1-a529-7da652ef90a4

Verified end-to-end in the browser against a live local stack: pasted link → `user_sources` row with `external_ref = <folder id>`, `display_name = "Heavi Knowledge Base"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)