### PR TITLE
Restore pointer cursor on buttons (Tailwind v4 preflight)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -173,6 +173,15 @@ body {
   font-size: 14px;
 }
 
+/* Tailwind v4 preflight sets `cursor: default` on buttons; we want web-app
+   pointer affordance on everything clickable. */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* Notion-style sidebar primitives */
 .scroll-thin::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Why

Tailwind v4's preflight changed buttons to `cursor: default` (matching native OS buttons), and the app has essentially no `cursor-pointer` utility classes — so every button, including the file-browser breadcrumb toolbar icons (new file / new folder / upload / share / sort), showed the arrow cursor.

## What

One global base-layer rule in `globals.css` restoring the web-app convention:

```css
@layer base {
  button:not(:disabled),
  [role="button"]:not(:disabled) {
    cursor: pointer;
  }
}
```

This fixes the toolbar icons and every other button app-wide in one shot, while disabled buttons keep the default cursor.

## Verification

Ran this checkout's frontend and confirmed via browser automation that enabled buttons now compute `cursor: pointer`.

No screenshots: the change is cursor-only, and the OS cursor doesn't render in static captures — there's no visible pixel diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)