### PR TITLE
Add bottom whitespace to the sidebar file tree

### DIFF
--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -286,7 +286,7 @@ export default function FilesExplorer({
 
       {/* List — root is also a drop target (move to root) */}
       <div
-        className="min-h-0 flex-1 overflow-y-auto py-1"
+        className="min-h-0 flex-1 overflow-y-auto pt-1 pb-24"
         onDragOver={(e) => e.preventDefault()}
         onDrop={(e) => { const raw = e.dataTransfer.getData(DND); if (raw) void move(JSON.parse(raw) as Item, folderId); }}
       >


### PR DESCRIPTION
## What

The explorer file tree's scroll container ended flush at the bottom edge of the sidebar, so a full list always looked cut off — it felt like there was more to scroll even when you were at the end. This swaps the container's `py-1` for `pt-1 pb-24`, letting the last row scroll ~96px clear of the bottom edge.

Applies to all trees rendered by `FilesExplorer` (Files, Memory, Skills, Sessions).

## Screenshot

Tree scrolled to the very bottom — the last row now sits clearly above the edge:

![file tree with bottom whitespace](https://gist.githubusercontent.com/henry-dowling/055021668eefb4e94767b61b72ed1366/raw/filetree-bottom-whitespace.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)