### PR TITLE
Fix wiki-flow breakages found in production E2E test

### DIFF
--- a/backend/migrations/versions/0138_agent_last_run_error.py
+++ b/backend/migrations/versions/0138_agent_last_run_error.py
@@ -1,0 +1,25 @@
+"""Record the outcome of an agent's last scheduled run.
+
+A curator run that dies in the worker was previously invisible: the API had
+already answered 202, and the agent row carried no trace of the failure.
+`last_run_error` holds the last run's error (NULL after a successful run) so
+the API and CLI can surface it.
+
+Revision ID: 0138
+Revises: 0137
+"""
+
+from alembic import op
+
+revision = "0138"
+down_revision = "0137"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN last_run_error TEXT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN last_run_error")

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -243,11 +243,15 @@ def month_runs_used(agent: dict) -> int:
 async def mark_run(agent_id: UUID) -> int:
     """Consume the cron tick and meter the run against the calendar month.
     Returns the run count within the current month (including this one) —
-    the free-tier curator credit gate reads it."""
+    the free-tier curator credit gate reads it.
+
+    Also clears last_run_error, so after last_run_at advances the error state
+    is unambiguous: non-null means THIS run failed (clients poll on that)."""
     return await get_pool().fetchval(
         """
         UPDATE agents SET
             last_run_at = now(),
+            last_run_error = NULL,
             month_run_count = CASE
                 WHEN month_run_anchor = date_trunc('month', now())::date
                 THEN month_run_count + 1 ELSE 1 END,
@@ -273,10 +277,6 @@ async def mark_run_failed(agent_id: UUID, error: str) -> None:
         agent_id,
         error,
     )
-
-
-async def mark_run_succeeded(agent_id: UUID) -> None:
-    await get_pool().execute("UPDATE agents SET last_run_error = NULL WHERE id = $1", agent_id)
 
 
 async def mark_curated(agent_id: UUID, through) -> None:

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -18,8 +18,8 @@ from ..database import get_pool
 _COLUMNS = (
     "id, user_id, name, model_provider, system_prompt, run_mode, "
     "schedule_cron, schedule_prompt, is_default, is_curator, slack_bound, "
-    "telegram_bound, last_run_at, curated_through, month_run_count, "
-    "month_run_anchor, created_at"
+    "telegram_bound, last_run_at, last_run_error, curated_through, "
+    "month_run_count, month_run_anchor, created_at"
 )
 
 
@@ -257,6 +257,26 @@ async def mark_run(agent_id: UUID) -> int:
         """,
         agent_id,
     )
+
+
+async def mark_run_failed(agent_id: UUID, error: str) -> None:
+    """Stamp the failure where the API can surface it, and refund the month
+    credit — an outage shouldn't eat the free allowance. The tick itself stays
+    consumed (last_run_at), so the beat won't re-fire the same window."""
+    await get_pool().execute(
+        """
+        UPDATE agents SET
+            last_run_error = left($2, 500),
+            month_run_count = greatest(month_run_count - 1, 0)
+        WHERE id = $1
+        """,
+        agent_id,
+        error,
+    )
+
+
+async def mark_run_succeeded(agent_id: UUID) -> None:
+    await get_pool().execute("UPDATE agents SET last_run_error = NULL WHERE id = $1", agent_id)
 
 
 async def mark_curated(agent_id: UUID, through) -> None:

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -132,9 +132,9 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
   history/chats, changed pages, new files, and connected sources. This IS your
   work set; do not re-scan the whole corpus.
 - `stash memory --json` — confirms the Memory folder id (`{memory_folder_id}`).
-- `stash ls /files --json` under the Memory folder and `stash read <page_id>`
-  to inspect existing wiki pages. `stash search "<topic>" --json` to pull
-  related source/file context on demand.
+- `stash ls /memory --json` and `stash read <page_id>` to inspect existing
+  wiki pages. `stash search "<topic>" --json` to pull related source/file
+  context on demand.
 
 ## Operating principles
 - **Bootstrap vs. maintain — know which mode you're in.** If the Memory folder

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -146,8 +146,15 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - **Scope by diff, not by corpus.** Only touch pages whose topic appears in this
   delta. Leave untouched pages alone.
 - **Category-first, pages-second.** Every page belongs to a category (a subfolder
-  under Memory). A concept gets its own page only when it appears in >=2 distinct
-  events. One-shot mentions stay as bullets on the category index page.
+  under Memory). A concept from chat history gets its own page only when it
+  appears in >=2 distinct events; one-shot mentions stay as bullets on the
+  category index page.
+- **Uploaded documents are content, not context.** The changed pages and new
+  files in the delta are material the user deliberately added — represent every
+  distinct document or document set in the wiki: a topic page, or bullets under
+  the best-fit category, adding a new category when none fits. The >=2 rule
+  above is for chat mentions and never applies to documents. After curation,
+  each upload must be findable by searching the wiki.
 - **Tag confidence.** Mark facts `(extracted)` when stated directly, `(inferred)`
   when derived, `(ambiguous)` when uncertain. Never create a page from
   ambiguous-only material.
@@ -173,6 +180,9 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Report
 One line per action: created / updated / merged / skipped, with page titles.
+Account for every changed page and new file in the delta — anything you chose
+not to represent in the wiki gets a `skipped` line with a one-line reason,
+never a silent drop.
 
 Begin now.
 """

--- a/backend/services/sprite_agent_service.py
+++ b/backend/services/sprite_agent_service.py
@@ -137,6 +137,43 @@ def _redact_event(event: dict, provider_env: dict[str, str]) -> dict:
     return event
 
 
+def _tool_event_summary(event: dict) -> tuple[str, dict]:
+    """A compact tool_use content + metadata, matching the local plugin's
+    format so cloud and local session transcripts render the same way."""
+    name = event.get("name") or "tool"
+    args = event.get("args") or {}
+    if name == "Bash" and args.get("command"):
+        command = str(args["command"])[:300]
+        return f"Ran: {command}", {"command": command}
+    if name in ("Edit", "Write") and args.get("file_path"):
+        return f"{'Edited' if name == 'Edit' else 'Created/wrote'} {args['file_path']}", {
+            "file_path": args["file_path"]
+        }
+    if name == "Read" and args.get("file_path"):
+        return f"Read {args['file_path']}", {"file_path": args["file_path"]}
+    preview = json.dumps(args)[:300]
+    return f"{name}: {preview}", {"args_preview": preview}
+
+
+async def _record_tool_event(
+    owner_user_id: UUID, user_id: UUID, session_id: str, event: dict, provider_env: dict[str, str]
+) -> None:
+    """Persist a harness tool call as a history event. Cloud runs have no
+    plugin hooks streaming these, so without this the stored session is just
+    prompt + final answer — unauditable."""
+    content, metadata = _tool_event_summary(event)
+    await memory_service.push_event(
+        owner_user_id,
+        AGENT_NAME,
+        "tool_use",
+        _redact(content, provider_env),
+        user_id,
+        session_id=session_id,
+        tool_name=event.get("name") or "tool",
+        metadata=metadata,
+    )
+
+
 async def _turn_events(
     auth: agent_auth.RunAuth,
     sprite: sprite_service.Sprite,
@@ -313,6 +350,8 @@ async def stream_chat(
             ):
                 if event["type"] == "end":
                     final = event.pop("_result_text")
+                elif event["type"] == "tool":
+                    await _record_tool_event(owner_user_id, user_id, session_id, event, auth.env)
                 yield _sse(event)
 
             if final:
@@ -395,6 +434,8 @@ async def run_chat(
                 final = event.pop("_result_text")
             elif event["type"] == "error":
                 error = event["message"]
+            elif event["type"] == "tool":
+                await _record_tool_event(owner_user_id, user_id, session_id, event, auth.env)
         if error:
             raise RuntimeError(f"agent turn failed: {error}")
 

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -57,7 +57,6 @@ async def _run_curator_now(agent_id: UUID) -> None:
     except Exception as e:
         await agent_service.mark_run_failed(agent_id, str(e))
         raise
-    await agent_service.mark_run_succeeded(agent_id)
     await agent_service.mark_curated(agent_id, now)
 
 
@@ -105,7 +104,6 @@ async def _run_due() -> int:
                 # `now` predates the run, so changes made during it stay ahead
                 # of the watermark and are picked up next time.
                 await agent_service.mark_curated(agent["id"], now)
-            await agent_service.mark_run_succeeded(agent["id"])
             ran += 1
         except Exception as e:
             logger.exception("agent schedule: run failed for agent %s", agent["id"])

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -50,9 +50,14 @@ async def _run_curator_now(agent_id: UUID) -> None:
     agent = await agent_service.get_agent_by_id(agent_id)
     now = datetime.now(UTC)
     await agent_service.mark_run(agent_id)
-    # Seconds-resolution stamp so a manual run never shares a session with the
-    # beat's minute-stamped run.
-    await sprite_agent_service.run_scheduled(agent, now.strftime("%Y%m%d%H%M%S"))
+    try:
+        # Seconds-resolution stamp so a manual run never shares a session with
+        # the beat's minute-stamped run.
+        await sprite_agent_service.run_scheduled(agent, now.strftime("%Y%m%d%H%M%S"))
+    except Exception as e:
+        await agent_service.mark_run_failed(agent_id, str(e))
+        raise
+    await agent_service.mark_run_succeeded(agent_id)
     await agent_service.mark_curated(agent_id, now)
 
 
@@ -100,7 +105,9 @@ async def _run_due() -> int:
                 # `now` predates the run, so changes made during it stay ahead
                 # of the watermark and are picked up next time.
                 await agent_service.mark_curated(agent["id"], now)
+            await agent_service.mark_run_succeeded(agent["id"])
             ran += 1
-        except Exception:
+        except Exception as e:
             logger.exception("agent schedule: run failed for agent %s", agent["id"])
+            await agent_service.mark_run_failed(agent["id"], str(e))
     return ran

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -40,16 +40,27 @@ async def _reconcile_pages() -> int:
     )
     if not rows:
         return 0
+    # An empty input 400s the whole OpenAI batch, wedging every page in it.
+    # An empty page simply has no embedding.
+    empty_ids = [r["id"] for r in rows if not r["content_markdown"]]
+    if empty_ids:
+        await pool.execute(
+            "UPDATE pages SET embedding = NULL, embed_stale = FALSE WHERE id = ANY($1)",
+            empty_ids,
+        )
+    rows = [r for r in rows if r["content_markdown"]]
+    if not rows:
+        return len(empty_ids)
     ids = [r["id"] for r in rows]
-    texts = [r["content_markdown"] or "" for r in rows]
+    texts = [r["content_markdown"] for r in rows]
     vecs = await embedding_service.embed_batch(texts)
     if not vecs:
-        return 0
+        return len(empty_ids)
     await pool.executemany(
         "UPDATE pages SET embedding = $1, embed_stale = FALSE WHERE id = $2",
         list(zip(vecs, ids)),
     )
-    return len(ids)
+    return len(empty_ids) + len(ids)
 
 
 async def _reconcile_table_rows() -> int:
@@ -64,6 +75,9 @@ async def _reconcile_table_rows() -> int:
     )
     if not rows:
         return 0
+    # An empty input 400s the whole OpenAI batch — a row whose embed columns
+    # are all blank simply has no embedding.
+    empty = []
     ids = []
     texts = []
     hashes = []
@@ -71,17 +85,28 @@ async def _reconcile_table_rows() -> int:
         text = embedding_service.clip_text(
             _build_embedding_text(r["data"], r["embedding_config"], r["columns"])
         )
+        if not text:
+            empty.append((_text_hash(text), r["id"]))
+            continue
         ids.append(r["id"])
         texts.append(text)
         hashes.append(_text_hash(text))
+    if empty:
+        await pool.executemany(
+            "UPDATE table_rows SET embedding = NULL, content_hash = $1, embed_stale = FALSE "
+            "WHERE id = $2",
+            empty,
+        )
+    if not ids:
+        return len(empty)
     vecs = await embedding_service.embed_batch(texts)
     if not vecs:
-        return 0
+        return len(empty)
     await pool.executemany(
         "UPDATE table_rows SET embedding = $1, content_hash = $2, embed_stale = FALSE WHERE id = $3",
         [(v, h, rid) for rid, v, h in zip(ids, vecs, hashes)],
     )
-    return len(ids)
+    return len(empty) + len(ids)
 
 
 async def _reconcile_history_events() -> int:
@@ -93,17 +118,29 @@ async def _reconcile_history_events() -> int:
     )
     if not rows:
         return 0
+    # An empty input 400s the whole OpenAI batch — an empty event simply has
+    # no embedding.
+    empty = [(_text_hash(""), r["id"]) for r in rows if not r["content"]]
+    if empty:
+        await pool.executemany(
+            "UPDATE history_events SET embedding = NULL, content_hash = $1, embed_stale = FALSE "
+            "WHERE id = $2",
+            empty,
+        )
+    rows = [r for r in rows if r["content"]]
+    if not rows:
+        return len(empty)
     ids = [r["id"] for r in rows]
-    texts = [r["content"] or "" for r in rows]
+    texts = [r["content"] for r in rows]
     hashes = [_text_hash(t) for t in texts]
     vecs = await embedding_service.embed_batch(texts)
     if not vecs:
-        return 0
+        return len(empty)
     await pool.executemany(
         "UPDATE history_events SET embedding = $1, content_hash = $2, embed_stale = FALSE WHERE id = $3",
         [(v, h, eid) for eid, v, h in zip(ids, vecs, hashes)],
     )
-    return len(ids)
+    return len(empty) + len(ids)
 
 
 async def _reconcile_files() -> int:

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -162,3 +162,49 @@ async def test_agent_failure_surfaces_error_event(client: AsyncClient, sprite_ex
     session_id = evts[0]["session_id"]
     got = await client.get(f"/api/v1/me/agent-chat/{session_id}", headers=_auth(key))
     assert [m["role"] for m in got.json()["messages"]] == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_persist_as_history_events(client: AsyncClient, sprite_exec, _db_pool):
+    """Cloud runs have no plugin hooks, so the backend itself must record the
+    harness's tool calls — otherwise the stored session is prompt + answer
+    only and a run's behavior can't be audited after the fact."""
+    key, _ = await _register(client)
+
+    sprite_exec.replies.append(
+        (
+            [
+                json.dumps({"type": "system", "subtype": "init"}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "tu1",
+                                    "name": "Bash",
+                                    "input": {"command": "stash changes --json"},
+                                }
+                            ]
+                        },
+                    }
+                ),
+                json.dumps({"type": "result", "subtype": "success", "result": "done"}),
+            ],
+            0,
+        )
+    )
+    r = await client.post("/api/v1/me/agent-chat", json={"message": "curate"}, headers=_auth(key))
+    evts = _events(r.text)
+    assert any(e["type"] == "tool" for e in evts)  # still streamed live
+    session_id = evts[0]["session_id"]
+
+    row = await _db_pool.fetchrow(
+        "SELECT content, tool_name FROM history_events "
+        "WHERE session_id = $1 AND event_type = 'tool_use'",
+        session_id,
+    )
+    assert row is not None
+    assert row["tool_name"] == "Bash"
+    assert row["content"] == "Ran: stash changes --json"

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -109,6 +109,11 @@ def test_curator_prompt_embeds_folder_and_window():
     assert "stash changes --json" in boot and "--since" not in boot
     maint = prompts.render_curator_prompt("folder-123", "2026-07-06T09:00:00")
     assert "2026-07-06T09:00:00" in maint and "stash changes --since" in maint
+    # The onboarding promise is upload → recompute → see it in the wiki: the
+    # prompt must make uploads first-class content and forbid silent drops
+    # (a bootstrap run once ignored a fresh upload entirely).
+    assert "content, not context" in boot
+    assert "never a silent drop" in boot
 
 
 async def _make_due(pool, agent_id: str, watermark: datetime) -> None:

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -222,6 +222,49 @@ async def test_failed_curator_run_preserves_watermark(
     assert after == watermark  # delta window intact
 
 
+@pytest.mark.asyncio
+async def test_failed_run_records_error_and_refunds_credit(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
+    """A failed run must be visible (last_run_error) and must not eat the
+    free monthly allowance — an infra outage would otherwise silently burn
+    all credits."""
+    from backend.services import sprite_agent_service
+    from backend.tasks.agent_schedules import _run_due
+
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+    await client.post(
+        "/api/v1/me/pages/new", json={"name": "N", "content": "x"}, headers=_auth(key)
+    )
+    await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
+
+    async def boom(agent, stamp):
+        raise RuntimeError("sprite exploded")
+
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", boom)
+    await _run_due()
+
+    row = await _db_pool.fetchrow(
+        "SELECT last_run_error, month_run_count FROM agents WHERE id = $1",
+        UUID(curator["id"]),
+    )
+    assert "sprite exploded" in row["last_run_error"]
+    assert row["month_run_count"] == 0  # consumed by mark_run, refunded on failure
+
+    # The next successful run clears the error.
+    monkeypatch.undo()
+    await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
+    ran = await _run_due()
+    assert ran == 1
+    row = await _db_pool.fetchrow(
+        "SELECT last_run_error, month_run_count FROM agents WHERE id = $1",
+        UUID(curator["id"]),
+    )
+    assert row["last_run_error"] is None
+    assert row["month_run_count"] == 1
+
+
 # --- Manual recompute (POST /me/memory/recompute) ---
 
 
@@ -250,6 +293,38 @@ async def test_recompute_runs_curator_now(client: AsyncClient, sprite_exec, _db_
     )
     assert sprite_exec.calls  # the run actually woke the sprite
     assert row["curated_through"] >= before - timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_failed_manual_recompute_records_error(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
+    """The recompute endpoint answers 202 before the worker runs, so the
+    agent row is the only place a crash can surface."""
+    from backend.services import sprite_agent_service
+    from backend.tasks.agent_schedules import _run_curator_now
+
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+
+    async def boom(agent, stamp):
+        raise RuntimeError("harness missing")
+
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", boom)
+    with pytest.raises(RuntimeError):
+        await _run_curator_now(UUID(curator["id"]))
+
+    row = await _db_pool.fetchrow(
+        "SELECT last_run_error, month_run_count FROM agents WHERE id = $1",
+        UUID(curator["id"]),
+    )
+    assert "harness missing" in row["last_run_error"]
+    assert row["month_run_count"] == 0
+
+    # The error is visible through the API the CLI reads.
+    r = await client.get("/api/v1/me/agents", headers=_auth(key))
+    fetched = next(a for a in r.json()["agents"] if a["is_curator"])
+    assert fetched["last_run_error"] == "harness missing"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,9 +1,12 @@
+from uuid import uuid4
+
 import numpy as np
 import pytest
 
 from backend.services import embeddings as embedding_service
 from backend.services.embeddings.base import BaseEmbedder
 from backend.services.embeddings.openai_compat import OpenAICompatEmbedder
+from backend.tasks.embeddings import _reconcile_pages
 
 
 class CapturingEmbedder(BaseEmbedder):
@@ -14,7 +17,7 @@ class CapturingEmbedder(BaseEmbedder):
 
     async def embed_batch(self, texts: list[str]) -> list[np.ndarray]:
         self.batches.append(texts)
-        return [np.array([float(i)], dtype=np.float32) for i, _text in enumerate(texts)]
+        return [np.full(384, float(i), dtype=np.float32) for i, _text in enumerate(texts)]
 
 
 @pytest.mark.asyncio
@@ -34,6 +37,52 @@ async def test_embedding_wrapper_clips_texts_before_provider_call():
         embedding_service.MAX_TEXT_CHARS,
         len("short"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_pages_clears_empty_pages_without_embedding_call(pool):
+    """An empty input 400s the whole OpenAI batch, so empty pages must be
+    cleared (embedding NULL, embed_stale FALSE) instead of sent — otherwise
+    one empty page wedges every other page in its batch forever."""
+    user_id = uuid4()
+    await pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    empty_id, full_id = uuid4(), uuid4()
+    for page_id, content in ((empty_id, ""), (full_id, "real content")):
+        await pool.execute(
+            "INSERT INTO pages (id, owner_user_id, name, content_markdown, created_by, "
+            "embed_stale) VALUES ($1, $2, $3, $4, $5, TRUE)",
+            page_id,
+            user_id,
+            f"p_{page_id.hex[:6]}",
+            content,
+            user_id,
+        )
+
+    embedder = CapturingEmbedder()
+    embedding_service.set_embedder(embedder)
+    try:
+        done = await _reconcile_pages()
+    finally:
+        await embedding_service.close()
+
+    assert done == 2
+    # Only the non-empty page reached the provider.
+    assert embedder.batches == [["real content"]]
+    rows = {
+        r["id"]: r
+        for r in await pool.fetch(
+            "SELECT id, embedding, embed_stale FROM pages WHERE id = ANY($1)",
+            [empty_id, full_id],
+        )
+    }
+    assert rows[empty_id]["embed_stale"] is False
+    assert rows[empty_id]["embedding"] is None
+    assert rows[full_id]["embed_stale"] is False
+    assert rows[full_id]["embedding"] is not None
 
 
 @pytest.mark.asyncio

--- a/cli/client.py
+++ b/cli/client.py
@@ -291,6 +291,10 @@ class StashClient:
     def recompute_memory(self) -> dict:
         return self._post("/api/v1/me/memory/recompute")
 
+    def get_curator(self) -> dict | None:
+        agents = self._get("/api/v1/me/agents")["agents"]
+        return next((a for a in agents if a["is_curator"]), None)
+
     # --- Pages (user-scoped) ---
 
     def create_page(

--- a/cli/main.py
+++ b/cli/main.py
@@ -2375,6 +2375,28 @@ def search(
     _print_search(query, source, limit, as_json)
 
 
+def _poll_recompute_outcome(
+    c: StashClient, before: dict | None, attempts: int = 15
+) -> tuple[str, str | None]:
+    """Watch the enqueued curator run get picked up by the worker.
+
+    The recompute API answers 202 before anything executes — the web service
+    can't see the worker's world, so "started" is only real once last_run_at
+    advances on the agent row. mark_run clears last_run_error at pickup, so an
+    error present after that means THIS run died (crashes happen within
+    seconds; the multi-minute happy path reports "running")."""
+    baseline = (before or {}).get("last_run_at")
+    for _ in range(attempts):
+        time.sleep(2)
+        curator = c.get_curator()
+        if not curator or curator["last_run_at"] == baseline:
+            continue
+        if curator["last_run_error"]:
+            return "failed", curator["last_run_error"]
+        return "running", None
+    return "queued", None
+
+
 @app.command("memory")
 def memory(
     recompute: bool = typer.Option(
@@ -2387,14 +2409,25 @@ def memory(
     """Show your reserved Memory folder (its id is where the wiki lives)."""
     with _client() as c:
         if recompute:
+            before = c.get_curator()
             data = c.recompute_memory()
+            outcome, run_error = _poll_recompute_outcome(c, before)
             if _use_json(as_json):
-                output_json(data)
-                return
-            console.print(
-                "Curator run started — the Memory wiki will update shortly. "
-                "Check `stash memory` for the outcome."
-            )
+                output_json({**data, "outcome": outcome, "last_run_error": run_error})
+            elif outcome == "failed":
+                console.print(f"[red]Curator run failed:[/red] {run_error}")
+            elif outcome == "queued":
+                console.print(
+                    "[yellow]Curator run was enqueued but no worker picked it up "
+                    "within 30s — it may still run; check `stash memory` later.[/yellow]"
+                )
+            else:
+                console.print(
+                    "Curator run started — the Memory wiki will update shortly. "
+                    "Check `stash memory` for the outcome."
+                )
+            if outcome == "failed":
+                raise typer.Exit(1)
             return
         folder = c.get_memory_folder()
         curator = c.get_curator()

--- a/cli/main.py
+++ b/cli/main.py
@@ -1101,8 +1101,9 @@ def upload(
 
     A single file lands directly in your Files (Markdown/HTML become
     editable pages, everything else a binary file) and the returned
-    ``app_url`` is the share link. A directory becomes a folder.
-    **No Skill is created.**
+    ``app_url`` is the share link. A directory becomes a folder, and
+    every text file in it — Markdown, HTML, code, CSV, and friends —
+    becomes an editable page. **No Skill is created.**
 
     Pass ``--skill <title>`` to *also* bundle the upload into a shareable
     Skill. Use a Skill when you're publishing a folder of related
@@ -2390,13 +2391,22 @@ def memory(
             if _use_json(as_json):
                 output_json(data)
                 return
-            console.print("Curator run started — the Memory wiki will update shortly.")
+            console.print(
+                "Curator run started — the Memory wiki will update shortly. "
+                "Check `stash memory` for the outcome."
+            )
             return
         folder = c.get_memory_folder()
+        curator = c.get_curator()
     if _use_json(as_json):
-        output_json(folder)
+        output_json({**folder, "curator": curator})
         return
     console.print(f"Memory folder: [cyan]{folder['name']}[/cyan] (id {folder['id']})")
+    if curator:
+        last_run = curator["last_run_at"] or "never"
+        console.print(f"Curator last run: {last_run}")
+        if curator["last_run_error"]:
+            console.print(f"[red]Curator last run failed:[/red] {curator['last_run_error']}")
 
 
 @app.command("changes")

--- a/cli/mount.py
+++ b/cli/mount.py
@@ -78,6 +78,7 @@ class StashVfsModel:
                     "This is a read-only virtual filesystem view over Stash.",
                     "",
                     "- `files` exposes folders, pages, and uploaded files.",
+                    "- `memory` is the agent-curated Memory wiki (stored separately from `files`).",
                     "- Sessions, skills, and tables are read-only projections.",
                     "- `sources` exposes connected integrations (Gmail, "
                     "GitHub, Slack, Jira, …) as read-only documents.",
@@ -139,8 +140,9 @@ class StashVfsModel:
 
     def _add_root(self) -> None:
         overview = self.client.get_overview()
+        memory_folder_id = str(self.client.get_memory_folder()["id"])
 
-        self._add_files_tree(overview.get("files", {}))
+        self._add_files_tree(overview.get("files", {}), memory_folder_id)
         self._add_skills(overview.get("skills", []))
         self._add_sessions(overview.get("sessions", []))
         self._add_tables()
@@ -176,9 +178,13 @@ class StashVfsModel:
                     size_hint=entry.get("size"),
                 )
 
-    def _add_files_tree(self, tree: dict) -> None:
+    def _add_files_tree(self, tree: dict, memory_folder_id: str) -> None:
         root_path = "/files"
         self._add_dir(root_path)
+        # The Memory wiki is stored as a reserved folder in the files tree but
+        # presented as its own root — /files and /memory are MECE, mirroring
+        # the app Explorer's sections.
+        self._add_dir("/memory")
         folders = {str(folder["id"]): folder for folder in tree.get("folders", [])}
         pages = tree.get("pages", [])
         # Files embedded in a page are internals of that document, not tree
@@ -194,6 +200,9 @@ class StashVfsModel:
         def folder_path(folder_id: str) -> str:
             if folder_id in folder_paths:
                 return folder_paths[folder_id]
+            if folder_id == memory_folder_id:
+                folder_paths[folder_id] = "/memory"
+                return "/memory"
             folder = folders[folder_id]
             parent_id = folder.get("parent_folder_id")
             parent_path = folder_path(str(parent_id)) if parent_id else root_path

--- a/cli/tests/test_memory_recompute_poll.py
+++ b/cli/tests/test_memory_recompute_poll.py
@@ -1,0 +1,67 @@
+"""`stash memory --recompute` polls the curator instead of trusting the 202.
+
+The web service enqueues and answers 202 before the worker executes — the two
+can disagree (env drift, worker down), so the CLI watches the agent row for
+what actually happened: picked up + error = this run failed; picked up clean =
+running; never picked up = queued warning.
+"""
+
+from __future__ import annotations
+
+from cli import main as cli_main
+from cli.main import _poll_recompute_outcome
+
+
+class _FakeClient:
+    def __init__(self, states: list[dict | None]):
+        self._states = states
+        self.calls = 0
+
+    def get_curator(self) -> dict | None:
+        state = self._states[min(self.calls, len(self._states) - 1)]
+        self.calls += 1
+        return state
+
+
+BEFORE = {"last_run_at": "t0", "last_run_error": None}
+
+
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(cli_main.time, "sleep", lambda _s: None)
+
+
+def test_run_crash_is_reported(monkeypatch):
+    _no_sleep(monkeypatch)
+    client = _FakeClient(
+        [
+            {"last_run_at": "t0", "last_run_error": None},  # not picked up yet
+            {"last_run_at": "t1", "last_run_error": "No such file: claude"},
+        ]
+    )
+    outcome, error = _poll_recompute_outcome(client, BEFORE)
+    assert outcome == "failed"
+    assert "claude" in error
+
+
+def test_clean_pickup_reports_running(monkeypatch):
+    _no_sleep(monkeypatch)
+    client = _FakeClient([{"last_run_at": "t1", "last_run_error": None}])
+    assert _poll_recompute_outcome(client, BEFORE) == ("running", None)
+
+
+def test_never_picked_up_reports_queued(monkeypatch):
+    _no_sleep(monkeypatch)
+    client = _FakeClient([{"last_run_at": "t0", "last_run_error": None}])
+    outcome, error = _poll_recompute_outcome(client, BEFORE, attempts=3)
+    assert outcome == "queued"
+    assert error is None
+    assert client.calls == 3
+
+
+def test_stale_error_from_previous_run_is_not_reported(monkeypatch):
+    """mark_run clears last_run_error at pickup, so an old failure visible
+    before the run starts must not read as a new one."""
+    _no_sleep(monkeypatch)
+    before = {"last_run_at": "t0", "last_run_error": "old failure"}
+    client = _FakeClient([{"last_run_at": "t1", "last_run_error": None}])
+    assert _poll_recompute_outcome(client, before) == ("running", None)

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -5,10 +5,21 @@ class FakeClient:
     def __init__(self):
         self.source_entry_calls = 0
 
+    def get_memory_folder(self):
+        return {"id": "memfolder-12345678", "name": "Memory"}
+
     def get_overview(self):
         return {
             "files": {
-                "folders": [{"id": "folder-12345678", "name": "Notes", "parent_folder_id": None}],
+                "folders": [
+                    {"id": "folder-12345678", "name": "Notes", "parent_folder_id": None},
+                    {"id": "memfolder-12345678", "name": "Memory", "parent_folder_id": None},
+                    {
+                        "id": "memcat-12345678",
+                        "name": "Projects",
+                        "parent_folder_id": "memfolder-12345678",
+                    },
+                ],
                 "pages": [
                     {
                         "id": "page-12345678",
@@ -17,7 +28,15 @@ class FakeClient:
                         "folder_id": "folder-12345678",
                         "created_at": "2026-05-01T09:00:00Z",
                         "updated_at": "2026-05-02T10:30:00Z",
-                    }
+                    },
+                    {
+                        "id": "wikipage-12345678",
+                        "name": "Memory Wiki",
+                        "content_type": "markdown",
+                        "folder_id": "memfolder-12345678",
+                        "created_at": "2026-05-01T09:00:00Z",
+                        "updated_at": "2026-05-02T10:30:00Z",
+                    },
                 ],
                 "files": [
                     {
@@ -49,7 +68,7 @@ class FakeClient:
         }
 
     def get_page(self, page_id):
-        assert page_id == "page-12345678"
+        assert page_id in ("page-12345678", "wikipage-12345678")
         return {"content_type": "markdown", "content_markdown": "# Plan\n", "content_html": ""}
 
     def download_file(self, file_id):
@@ -143,6 +162,7 @@ def test_vfs_exposes_user_sections():
         "README.md",
         "computer",
         "files",
+        "memory",
         "sessions",
         "skills",
         "tables",
@@ -217,6 +237,18 @@ def test_vfs_keeps_children_of_a_page_that_has_its_own_body():
     assert model.read_file(f"{parent}/Parent") == b"BODY of Parent"
     assert model.read_file(f"{parent}/Child A") == b"BODY of Parent/Child A"
     assert model.read_file(f"{parent}/Child B") == b"BODY of Parent/Child B"
+
+
+def test_vfs_memory_is_its_own_root_not_under_files():
+    """/files and /memory are MECE, mirroring the app Explorer's sections —
+    the Memory wiki is stored as a reserved files-tree folder but must not
+    show up when browsing /files."""
+    model = _model()
+
+    assert not any(name.startswith("Memory") for name in model.list_dir("/files"))
+    memory_entries = model.list_dir("/memory")
+    assert any(name.startswith("Projects") for name in memory_entries)
+    assert any(name.startswith("Memory Wiki") for name in memory_entries)
 
 
 def test_vfs_reads_files_and_pages():

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -28,6 +28,7 @@ import FileContentRenderer, {
   isText,
 } from "@/components/content/FileContentRenderer";
 import FileViewerHeader from "@/components/content/FileViewerHeader";
+import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import ResourceShareButton from "@/components/share/ResourceShareButton";
 
 function isCsv(ct: string) {
@@ -73,20 +74,20 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
   // via ?skill= still gets full edit affordances.
   const [readOnly, setReadOnly] = useState(false);
 
+  const memoryFolderId = useMemoryFolderId();
+  const ancestorCrumbs = useMemo(
+    () =>
+      readOnly
+        ? [
+            { label: "Skills", href: "/skills" },
+            { label: skillTitle ?? "Skill", href: skillSlug ? `/skills/${skillSlug}` : "/skills" },
+          ]
+        : sectionCrumbs(folderChain, memoryFolderId),
+    [readOnly, skillTitle, skillSlug, folderChain, memoryFolderId],
+  );
+
   useBreadcrumbs(
-    readOnly
-      ? [
-          { label: "Skills", href: "/skills" },
-          { label: skillTitle ?? "Skill", href: skillSlug ? `/skills/${skillSlug}` : "/skills" },
-          { label: file ? file.name : "File" },
-        ]
-      : [
-          ...folderChain.map((c) => ({
-            label: c.name,
-            href: `/folders/${c.id}`,
-          })),
-          { label: file ? file.name : "File" },
-        ],
+    [...ancestorCrumbs, { label: file ? file.name : "File" }],
     `file/${fileId}/${file?.name ?? ""}/${folderChain.map((c) => c.id).join(",")}/${skillSlug ?? ""}`
   );
 
@@ -234,6 +235,7 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
         <FileViewerHeader
           icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
           iconColor={kindIconColor(file?.content_type ?? "")}
+          breadcrumbs={ancestorCrumbs}
           title={file?.name ?? "File"}
           onRenameTitle={
             file

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -14,6 +14,7 @@ import {
   createPage,
   getFolderContents,
   getPublicSkill,
+  type FolderBreadcrumb,
   type PublicSkillContents,
   type PublicSkillSubfolder,
 } from "@/lib/api";
@@ -22,6 +23,7 @@ import {
   SKILL_MD,
   skillMdTemplate,
 } from "@/lib/localSkill";
+import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
 
 export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?: string }) {
@@ -36,9 +38,20 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
   // Small auxiliary breadcrumb fetch so the top bar is correct before the
   // file browser shell finishes its own load. The shell still owns the main
   // folder-contents fetch.
-  const [crumbs, setCrumbs] = useState<{ label: string; href?: string }[]>([
-    { label: "Folder" },
-  ]);
+  const [chain, setChain] = useState<{
+    breadcrumbs: FolderBreadcrumb[];
+    name: string;
+    id: string;
+  } | null>(null);
+  const memoryFolderId = useMemoryFolderId();
+  const crumbs = useMemo(() => {
+    if (!chain) return [{ label: "Folder" }];
+    if (chain.id === memoryFolderId) return [{ label: "Memory" }];
+    return [
+      ...sectionCrumbs(chain.breadcrumbs.slice(0, -1), memoryFolderId),
+      { label: chain.name },
+    ];
+  }, [chain, memoryFolderId]);
   const [folderName, setFolderName] = useState<string | null>(null);
   const [skillFallback, setSkillFallback] = useState<{
     skillSlug: string;
@@ -79,6 +92,7 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
     }
     let cancelled = false;
     setFolderName(null);
+    setChain(null);
     getFolderContents(folderId)
       .then((c) => {
         if (cancelled) return;
@@ -87,15 +101,7 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
           router.replace(`/skills/${folderId}`);
           return;
         }
-        const trail = c.breadcrumbs.slice(0, -1).map((cr) => ({
-          label: cr.name,
-          href: `/folders/${cr.id}`,
-        }));
-        setCrumbs([
-          { label: "Files", href: `/files` },
-          ...trail,
-          { label: c.folder.name },
-        ]);
+        setChain({ breadcrumbs: c.breadcrumbs, name: c.folder.name, id: c.folder.id });
         setFolderName(c.folder.name);
         setSkillFallback(null);
       })

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
@@ -25,6 +25,7 @@ const api = vi.hoisted(() => {
     deleteCommentMessage: vi.fn(),
     deleteCommentThread: vi.fn(),
     getFolderContents: vi.fn(),
+    getMemoryFolder: vi.fn().mockResolvedValue({ id: "memory-folder-1", name: "Memory" }),
     getPage: vi.fn(),
     getPublicSkill: vi.fn(),
     listCommentThreads: vi.fn(),

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -22,6 +22,7 @@ import HtmlPageView, {
 import ExportDeckButton from "@/components/export/ExportDeckButton";
 import ResourceShareButton from "@/components/share/ResourceShareButton";
 import FileViewerHeader from "@/components/content/FileViewerHeader";
+import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import MarkdownEditor, {
   extractCommentIdsFromMarkdown,
   type SaveStatus,
@@ -186,12 +187,15 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
     });
   }, [scopeId, pageId, user, skillSlug]);
 
+  const memoryFolderId = useMemoryFolderId();
+  const ancestorCrumbs = useMemo(
+    () => sectionCrumbs(folderChain, memoryFolderId),
+    [folderChain, memoryFolderId],
+  );
+
   useBreadcrumbs(
     [
-      ...folderChain.map((c) => ({
-        label: c.name,
-        href: `/folders/${c.id}`,
-      })),
+      ...ancestorCrumbs,
       { label: page ? page.name.replace(/\.md$/, "") : "Page" },
     ],
     `page/${pageId}/${page?.name ?? ""}/${folderChain.map((c) => c.id).join(",")}`
@@ -550,6 +554,7 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
         compact
         icon={isHtml ? <HtmlGlyph /> : <PageGlyph />}
         iconColor={isHtml ? "var(--color-brand-600)" : "var(--text-muted)"}
+        breadcrumbs={ancestorCrumbs}
         title={baseName}
         onRenameTitle={
           page

--- a/frontend/src/components/content/FileViewerHeader.tsx
+++ b/frontend/src/components/content/FileViewerHeader.tsx
@@ -13,6 +13,11 @@ interface BackLink {
   href: string;
 }
 
+interface Breadcrumb {
+  label: string;
+  href: string;
+}
+
 interface Tag {
   label: string;
   tone?: "brand" | "muted";
@@ -33,6 +38,9 @@ interface FileViewerHeaderProps {
   readOnlyLabel?: string;
   /** Back link rendered above the title (e.g. "← Demo Skill"). */
   backLink?: BackLink;
+  /** Ancestor trail rendered before the title in the compact bar
+   *  (e.g. Files / Research / — the title itself is the last crumb). */
+  breadcrumbs?: Breadcrumb[];
   /** Small label chips before the meta items. */
   tags?: Tag[];
   /**
@@ -72,6 +80,7 @@ export default function FileViewerHeader({
   readOnly,
   readOnlyLabel = "read-only",
   backLink,
+  breadcrumbs,
   tags,
   meta,
   saveStatus,
@@ -91,6 +100,12 @@ export default function FileViewerHeader({
         <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border bg-base text-[14px]" style={iconStyle}>
           {icon}
         </span>
+        {breadcrumbs?.map((crumb) => (
+          <span key={crumb.href} className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
+            <Link href={crumb.href} className="max-w-[160px] truncate hover:text-foreground">{crumb.label}</Link>
+            <span className="text-muted-foreground/50">/</span>
+          </span>
+        ))}
         <span className="min-w-0 shrink truncate text-[13.5px] font-semibold text-foreground">
           {readOnly || !onRenameTitle ? title : <EditableTitle value={title} onSave={onRenameTitle} />}
         </span>
@@ -129,6 +144,16 @@ export default function FileViewerHeader({
           >
             &larr; {backLink.label}
           </Link>
+        )}
+        {!backLink && breadcrumbs && breadcrumbs.length > 0 && (
+          <div className="mb-2 flex flex-wrap items-center gap-1.5 text-[12px] text-muted-foreground">
+            {breadcrumbs.map((crumb, i) => (
+              <span key={crumb.href} className="inline-flex items-center gap-1.5">
+                {i > 0 && <span className="text-muted-foreground/50">/</span>}
+                <Link href={crumb.href} className="hover:text-foreground">{crumb.label}</Link>
+              </span>
+            ))}
+          </div>
         )}
         <span
           className="inline-flex h-14 w-14 items-center justify-center rounded-[12px] border border-border bg-base"

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { nanoid } from "nanoid";
 import { Bot, ChevronRight, File, Folder, Loader2, MessagesSquare, GraduationCap, Monitor, Plus, Settings, FolderTree, Brain, Plug, SquareTerminal } from "lucide-react";
-import { getMemoryFolder, listMySessions, listSessionFolders, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
+import { listMySessions, listSessionFolders, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
+import { useMemoryFolderId } from "@/lib/memory-folder";
 import { SKILL_MD, skillMdTemplate } from "@/lib/localSkill";
 import { requestAgentConfigView } from "@/lib/agent-tab-view";
 import { cn } from "@/lib/utils";
@@ -243,18 +244,6 @@ function AgentsExplorer() {
   );
 }
 
-/** Memory is its own space — a reserved system folder (backend-enforced: one per
- *  user, hidden from Files, can't be renamed/moved/deleted). */
-function useMemoryFolder(): string | null {
-  const [id, setId] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    getMemoryFolder().then((f) => { if (!cancelled) setId(f.id); }).catch(() => {});
-    return () => { cancelled = true; };
-  }, []);
-  return id;
-}
-
 /** The left panel. Agents is a chat list. Every other section is shown fully
  *  (no accordion) with a breadcrumb up to Home, which lists the sections. Files
  *  and Memory are VFS file managers (breadcrumbs, context menu, drag, upload);
@@ -263,7 +252,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
   const router = useRouter();
   const open = useOpenTab();
   const [atRoot, setAtRoot] = useState(false);
-  const memoryFolderId = useMemoryFolder();
+  const memoryFolderId = useMemoryFolderId();
   // A rail-section change means we're back to viewing that section, not Home.
   useEffect(() => { setAtRoot(false); }, [section]);
 
@@ -315,6 +304,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
           rootLabel={LABEL[section]}
           rootFolderId={section === "memory" ? memoryFolderId : null}
           hideFolderId={section === "files" ? memoryFolderId : null}
+          tabSection={section === "memory" ? "memory" : undefined}
           loadRoot={section === "skills" ? skillsRoot : isSessions ? sessionsRoot : undefined}
           loadFolder={isSessions ? sessionsFolder : undefined}
           newRootItem={

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -43,6 +43,7 @@ export default function FilesExplorer({
   openRootTab,
   showImport = true,
   vfsWritable = true,
+  tabSection,
 }: {
   onRoot: () => void;
   rootLabel?: string;
@@ -50,6 +51,10 @@ export default function FilesExplorer({
   rootFolderId?: string | null;
   /** A root-level folder to hide from the listing (e.g. Memory hidden from Files). */
   hideFolderId?: string | null;
+  /** Workspace section stamped on opened tab URLs (?section=) — without it the
+   *  shell derives the section from the path, which lands Memory items in
+   *  Files (all folder/page routes are files-shaped). */
+  tabSection?: string;
   /** Custom root listing (e.g. Skills lists skill folders). Default = the VFS tree. */
   loadRoot?: () => Promise<Item[]>;
   /** Custom folder navigation (e.g. Sessions folders aren't VFS folders). Default =
@@ -129,7 +134,8 @@ export default function FilesExplorer({
     if (item.kind === "session-folder") { setFolderId(item.id); return; }
     const kind = item.kind === "folder" ? "folder" : item.kind === "skill" ? "skill" : item.kind === "session" ? "session" : item.kind === "table" ? "table" : item.kind === "page" ? "page" : "file";
     openTab(kind, item.id, item.name);
-    router.replace(urlForTab({ kind, refId: item.id }));
+    const suffix = tabSection ? `?section=${tabSection}` : "";
+    router.replace(urlForTab({ kind, refId: item.id }) + suffix);
   }
 
   // Single-click a folder (or skill/session folder) → browse into it in the

--- a/frontend/src/lib/memory-folder.ts
+++ b/frontend/src/lib/memory-folder.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getMemoryFolder, type FolderBreadcrumb } from "@/lib/api";
+
+/** Memory is its own space — a reserved system folder (backend-enforced: one
+ *  per user, hidden from Files, can't be renamed/moved/deleted). */
+export function useMemoryFolderId(): string | null {
+  const [id, setId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getMemoryFolder().then((f) => { if (!cancelled) setId(f.id); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  return id;
+}
+
+export interface SectionCrumb {
+  label: string;
+  href: string;
+}
+
+/** Ancestor crumbs for a folder chain, rooted at the section the chain lives
+ *  in. Files and Memory are MECE sections over one folder tree, so a chain
+ *  containing the memory folder roots at Memory (and its links carry
+ *  ?section=memory so the shell keeps the Memory panel open) — everything
+ *  else roots at Files. */
+export function sectionCrumbs(
+  chain: FolderBreadcrumb[],
+  memoryFolderId: string | null,
+): SectionCrumb[] {
+  const inMemory = !!memoryFolderId && chain.some((b) => b.id === memoryFolderId);
+  const suffix = inMemory ? "?section=memory" : "";
+  const root = inMemory
+    ? { label: "Memory", href: "/memory" }
+    : { label: "Files", href: "/files" };
+  return [
+    root,
+    ...chain
+      .filter((b) => b.id !== memoryFolderId)
+      .map((b) => ({ label: b.name, href: `/folders/${b.id}${suffix}` })),
+  ];
+}

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -21,6 +21,8 @@ class _Recorder:
     def __init__(self, fail_first_n: int = 0):
         self.calls: list[dict] = []
         self.fail_first_n = fail_first_n
+        # path → HTTP status to answer with (instead of 200).
+        self.status_by_path: dict[str, int] = {}
 
     def request(self, method, path, **kwargs):
         self.calls.append(
@@ -33,13 +35,15 @@ class _Recorder:
         )
         if len(self.calls) <= self.fail_first_n:
             raise RuntimeError("simulated network failure")
+        status = self.status_by_path.get(path, 200)
 
         class _Resp:
-            status_code = 200
-            is_success = True
+            status_code = status
+            is_success = status < 400
+            text = "simulated error"
 
             def json(self_inner):
-                return {"ok": True}
+                return {"ok": True} if status < 400 else {"detail": "simulated error"}
 
         return _Resp()
 
@@ -118,6 +122,73 @@ def test_drain_stops_on_first_failure(tmp_path):
     queued = _queue_lines(tmp_path)
     assert len(queued) == 2
     assert {q["body"]["content"] for q in queued} == {"e0", "e1"}
+
+
+def test_drain_drops_permanently_rejected_entries(tmp_path):
+    """Entries the backend rejects with a non-retryable 4xx (dead route,
+    bad body) can never send — they must be dropped so they don't wedge
+    the queue in front of good entries forever."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    dead = {"path": "/api/v1/workspaces/w1/memory/events", "body": {"content": "old"}, "ts": 1.0}
+    good = {"path": "/api/v1/me/sessions/events", "body": {"content": "new"}, "ts": 2.0}
+    qp.write_text(json.dumps(dead) + "\n" + json.dumps(good) + "\n")
+    client._http.status_by_path["/api/v1/workspaces/w1/memory/events"] = 404
+
+    client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    # Dead entry dropped, good entry sent, queue empty.
+    assert _queue_lines(tmp_path) == []
+    sent_paths = [c["path"] for c in client._http.calls]
+    assert sent_paths.count("/api/v1/me/sessions/events") == 2  # live push + drained entry
+    status = read_upload_status(tmp_path)
+    assert status["queued_events"] == 0
+
+
+def test_drain_keeps_entries_on_auth_failure(tmp_path):
+    """401 heals with a re-signin, so entries stay queued instead of
+    being dropped."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    entry = {"path": "/api/v1/me/sessions/events", "body": {"content": "e0"}, "ts": 1.0}
+    qp.write_text(json.dumps(entry) + "\n")
+    client._http.status_by_path["/api/v1/me/sessions/events"] = 401
+
+    with pytest.raises(Exception):
+        client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    # Live push failed (401) and got enqueued; the original entry survives.
+    queued = _queue_lines(tmp_path)
+    assert {q["body"]["content"] for q in queued} == {"e0", "live"}
+
+
+def test_live_push_success_recorded_despite_stuck_backlog(tmp_path):
+    """A landed live event is a success even when the backlog can't drain
+    (health still reports failing while anything is queued)."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    stuck = {"path": "/api/v1/me/sessions/stuck", "body": {"content": "e0"}, "ts": 1.0}
+    qp.write_text(json.dumps(stuck) + "\n")
+    client._http.status_by_path["/api/v1/me/sessions/stuck"] = 500
+
+    client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    status = read_upload_status(tmp_path)
+    assert status["last_success_operation"] == "event"
+    assert status["queued_events"] == 1
+    assert status["health"] == "failing"
+
+
+def test_drain_drops_corrupt_lines(tmp_path):
+    """A line that isn't valid queue JSON can never send — drop it."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    good = {"path": "/api/v1/me/sessions/events", "body": {"content": "e0"}, "ts": 1.0}
+    qp.write_text("not-json\n" + json.dumps(good) + "\n")
+
+    client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    assert _queue_lines(tmp_path) == []
 
 
 def test_no_data_dir_no_queue(tmp_path):

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -26,7 +26,7 @@ from stashai.plugin.upload_status import (
 
 QUEUE_FILENAME = "event_queue.jsonl"
 QUEUE_MAX_ENTRIES = 1000  # cap so a long backend outage doesn't fill the disk
-DRAIN_BATCH = 50          # how many backlog rows to flush per successful push
+DRAIN_BATCH = 50  # how many backlog rows to flush per successful push
 
 
 class StashError(Exception):
@@ -34,6 +34,20 @@ class StashError(Exception):
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"[{status_code}] {detail}")
+
+
+def _is_permanent_rejection(e: Exception) -> bool:
+    """A 4xx the backend will never accept no matter when we retry.
+
+    Auth (401/403) heals with a re-signin and 408/429 heal on their own, so
+    those stay queued. Every other 4xx (404 dead route, 422 bad body, ...) is
+    rejected forever — retrying it just wedges the queue.
+    """
+    if not isinstance(e, StashError):
+        return False
+    if e.status_code in (401, 403, 408, 429):
+        return False
+    return 400 <= e.status_code < 500
 
 
 class StashClient:
@@ -95,14 +109,20 @@ class StashClient:
 
     def push_event(
         self,
-        agent_name: str, event_type: str, content: str,
-        session_id: str, tool_name: str | None = None,
-        metadata: dict | None = None, client: str | None = None,
+        agent_name: str,
+        event_type: str,
+        content: str,
+        session_id: str,
+        tool_name: str | None = None,
+        metadata: dict | None = None,
+        client: str | None = None,
         session_folder_id: str | None = None,
     ) -> dict:
         body: dict = {
-            "agent_name": agent_name, "event_type": event_type,
-            "content": content, "session_id": session_id,
+            "agent_name": agent_name,
+            "event_type": event_type,
+            "content": content,
+            "session_id": session_id,
         }
         # Pin streamed on every event so the session lands in the right folder
         # no matter which event creates the row (agents without a session-start
@@ -125,9 +145,12 @@ class StashClient:
             self._enqueue(path, body)
             record_upload_failure(self._data_dir, "event", e)
             raise
+        # The live push landed — that's a success regardless of how the
+        # backlog drain below fares (drain failures are recorded on their own
+        # as "event_queue", and health stays failing while anything is queued).
+        record_upload_success(self._data_dir, "event")
         # Backend reachable — try to flush some of the backlog while we're here.
-        if self._drain_queue():
-            record_upload_success(self._data_dir, "event")
+        self._drain_queue()
         return result
 
     # --- Failed-event queue ---
@@ -189,14 +212,27 @@ class StashClient:
                         continue
                     try:
                         entry = json.loads(line)
-                        self._post(entry["path"], json=entry["body"])
+                        path, body = entry["path"], entry["body"]
+                    except (ValueError, KeyError):
+                        # Corrupt line — it can never send, so drop it rather
+                        # than wedge the queue behind it forever.
+                        continue
+                    try:
+                        self._post(path, json=body)
                         sent += 1
                     except Exception as e:
-                        # Backend still unhappy. Stop now; keep this and the rest.
-                        remaining.append(line)
                         record_upload_failure(self._data_dir, "event_queue", e)
+                        if _is_permanent_rejection(e):
+                            # The backend will never accept this entry (e.g. a
+                            # 404 for a route that no longer exists). Drop it
+                            # and keep draining the rest.
+                            sent += 1
+                            continue
+                        # Retryable (network, 5xx, auth) — keep this and the
+                        # rest for a later drain; further entries would likely
+                        # fail the same way.
+                        remaining.append(line)
                         drained = False
-                        # Don't try further entries — likely all will fail.
                         sent = DRAIN_BATCH
                 f.seek(0)
                 f.truncate()
@@ -208,9 +244,12 @@ class StashClient:
 
     def query_events(
         self,
-        agent_name: str | None = None, event_type: str | None = None,
+        agent_name: str | None = None,
+        event_type: str | None = None,
         session_id: str | None = None,
-        limit: int = 50, after: str | None = None, order: str | None = None,
+        limit: int = 50,
+        after: str | None = None,
+        order: str | None = None,
     ) -> list:
         params: dict = {"limit": limit}
         if agent_name:
@@ -228,7 +267,9 @@ class StashClient:
     def search_events(self, query: str, limit: int = 50) -> list:
         return self._list(
             f"{self._EVENTS_PATH}/search",
-            "events", q=query, limit=limit,
+            "events",
+            q=query,
+            limit=limit,
         )
 
     # --- Transcript upload: gzip the .jsonl client-side (compresses 5-10x),
@@ -236,8 +277,12 @@ class StashClient:
     # timeout is 2s — way too short for a big file — so we override per-
     # request.
     def upload_transcript(
-        self, session_id: str, transcript_path: Path,
-        agent_name: str, cwd: str | None = None, session_folder_id: str | None = None,
+        self,
+        session_id: str,
+        transcript_path: Path,
+        agent_name: str,
+        cwd: str | None = None,
+        session_folder_id: str | None = None,
     ) -> dict:
         import gzip
 
@@ -273,8 +318,11 @@ class StashClient:
     # --- Sessions ---
 
     def create_session(
-        self, session_id: str, agent_name: str,
-        cwd: str | None = None, files_touched: list[str] | None = None,
+        self,
+        session_id: str,
+        agent_name: str,
+        cwd: str | None = None,
+        files_touched: list[str] | None = None,
         session_folder_id: str | None = None,
     ) -> dict:
         body = {
@@ -289,7 +337,10 @@ class StashClient:
         return self._post("/api/v1/me/sessions", json=body)
 
     def upload_session_artifact(
-        self, session_row_id: str, file_path: str, content: bytes,
+        self,
+        session_row_id: str,
+        file_path: str,
+        content: bytes,
     ) -> dict:
         """Upload a file the agent touched during a session."""
         record_upload_attempt(self._data_dir, "artifact")
@@ -313,7 +364,9 @@ class StashClient:
     # --- History aggregate (optional) ---
 
     def list_all_history_events(
-        self, agent_name: str | None = None, event_type: str | None = None,
+        self,
+        agent_name: str | None = None,
+        event_type: str | None = None,
         limit: int = 50,
     ) -> list:
         params: dict = {"limit": limit}


### PR DESCRIPTION
## Context

E2E test of the production flow — upload files → generate the Memory wiki — surfaced one infra break and several code bugs. The infra break (celery worker missing `AGENT_EXEC_MODE`/`SPRITES_*`/`OPENROUTER_API_KEY`, so the curator exec'd a nonexistent local `claude` binary) was fixed directly on Render; the wiki now generates end to end. This PR fixes what the outage exposed in code.

## Changes

**Curator failures are now visible and don't burn credits** (`agents.last_run_error`, migration 0138)
- The recompute endpoint answers 202 before the worker runs, so a worker crash previously left zero user-visible trace — the Memory folder just stayed empty while `month_run_count` still incremented and the nightly cron kept failing (and burning the 10 free runs/month).
- Failures now stamp `last_run_error` (cleared on the next success) and refund the month credit. The tick itself stays consumed, so the beat still won't re-fire a failed window.
- Exposed via `GET /me/agents`; `stash memory` prints the curator's last run and error.

**Embedding reconciler no longer wedges on empty inputs** (`backend/tasks/embeddings.py`)
- OpenAI 400s any batch containing an empty string. Prod had 13 empty pages poisoning every batch — 119 pages stuck `embed_stale`, retried every 60s (`OpenAI-compat embedding rejected status_code=400` in worker logs). Empty pages/rows/events now clear `embed_stale` with a NULL embedding; the stuck prod rows self-heal on the first deploy.

**Plugin event queue no longer wedges behind poison entries** (`stashai/plugin/stash_client.py`)
- The local machine had 29 events queued forever: 23 addressed to the removed workspace-scoped events route blocked the drain, trapping 6 good entries behind them. Non-retryable 4xx rejections and corrupt lines are now dropped during drain (401/403/408/429 still retry — those heal); a landed live push records success even when backlog remains (health still reports failing while anything is queued).
- The stuck local queue was migrated to the new route and drained — all 29 events landed.

**Docs**: `stash upload --help` claimed only Markdown/HTML become pages; directory uploads actually turn every text file (code, CSV, …) into a page. Note the single-file path (server-routed, md/html only) and the directory path (client list) intentionally differ — flagging in case we want to unify.

## Tests
- `backend/tests/test_curator.py`: failed scheduled run records error + refunds credit + next success clears it; failed manual recompute records error and surfaces through `/me/agents` (16 pass)
- `backend/tests/test_embeddings.py`: empty pages cleared without reaching the provider (3 pass)
- `plugins/tests/test_event_queue.py`: poison-drop, keep-on-401, success-despite-backlog, corrupt-line drop (8 pass)
- `cli/tests` 100 pass; ruff check + format clean (CI-exact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)