### PR TITLE
Fix tab scrolling: bounded flex column for tab bodies

### DIFF
--- a/frontend/src/components/workspace/tab-body.tsx
+++ b/frontend/src/components/workspace/tab-body.tsx
@@ -92,25 +92,28 @@ export default function TabBody({ tab }: { tab: WorkbenchTab }) {
   if (tab.kind === "page") return <PageClient pageId={tab.refId} />;
   if (tab.kind === "file") return <FileClient fileId={tab.refId} />;
   if (tab.kind === "table") return <TableClient tableId={tab.refId} embedded />;
-  if (tab.kind === "sessions-home")
-    // SessionsPage's root is `flex-1` and needs a bounded flex-column parent to
-    // scroll (the standalone route's <main> is one; the tab host isn't).
-    return (
-      <div className="flex h-full min-h-0 flex-col">
-        <SessionsPage />
-      </div>
-    );
+  if (tab.kind === "sessions-home") return <SessionsPage />;
   if (tab.kind === "session") return <SessionClient sessionId={tab.refId} />;
   if (tab.kind === "skill") return <SkillFolderClient folderId={tab.refId} />;
   if (tab.kind === "folder") return <FolderClient folderId={tab.refId} />;
   if (tab.kind === "agent") return <AgentChatTab refId={tab.refId} />;
+  // Tool + agent-config bodies are plain document flows with no height or
+  // scroller of their own, so the tab gives them one (same as AgentChatTab
+  // does for the config side of a chat tab).
   if (tab.kind === "tool")
     return (
-      <div className="mx-auto w-full max-w-3xl px-6 py-6">
-        <IntegrationsSettings embedded />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-3xl px-6 py-6">
+          <IntegrationsSettings embedded />
+        </div>
       </div>
     );
-  if (tab.kind === "agent-config") return <AgentConfigPanel agentId={tab.refId} />;
+  if (tab.kind === "agent-config")
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <AgentConfigPanel agentId={tab.refId} />
+      </div>
+    );
   if (tab.kind === "machine-file") return <MachineFileView path={tab.refId} />;
   if (tab.kind === "terminal")
     return (

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -173,7 +173,11 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
               </div>
             );
           return (
-            <div key={active.id} className="h-full">
+            // A bounded flex column, so a tab body whose root is
+            // `flex-1 overflow-y-auto` actually gets a height to scroll
+            // within — as a plain block, those bodies grew past the host
+            // and were clipped by its overflow-hidden with no scrollbar.
+            <div key={active.id} className="flex h-full min-h-0 flex-col">
               <ShellChromeScope scopeId={active.id}>
                 <TabBody tab={active} />
               </ShellChromeScope>


### PR DESCRIPTION
## Problem

Content in workbench tabs frequently could not scroll (reported on the Memory-curator settings tab, but general). Two root causes, one shared origin:

1. The per-tab wrapper in `workbench.tsx` was a plain `h-full` **block** inside the tab host's `overflow-hidden`. Every tab body whose root relies on `flex-1 overflow-y-auto` — page, session, folder, skill, file — had `flex-1` silently ignored (no flex parent), grew to content height, and was clipped with no scrollbar.
2. The `agent-config` (curator settings) and `tool` tabs had no height or scroll container at all.

The codebase already documented the problem in a comment ("SessionsPage's root is flex-1 and needs a bounded flex-column parent to scroll … the tab host isn't") and hand-rolled the fix twice (sessions-home wrapper, AgentChatTab).

## Fix

- Per-tab wrapper → `flex h-full min-h-0 flex-col` (one line, fixes the whole flex-1 family; the sessions-home special case is now redundant and removed). No scroller added at the host level — each body still owns its own scroll, per the existing comment about contenteditable paint.
- `agent-config` and `tool` tabs get a `min-h-0 flex-1 overflow-y-auto` scroller, mirroring what AgentChatTab already does for the identical `AgentConfigPanel`.

## Verification

- Locally seeded a 40-item folder: before, the folder tab clipped with no scrollbar; after, it scrolls (screenshot in comment — view scrolled to bottom, `scrollTop` moves).
- Page tab, sessions-home render clean, no console errors.
- Frontend: 186 tests pass, eslint clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)