### PR TITLE
Fix the two backend CI failures (red main)

### DIFF
--- a/backend/tests/test_agent_oauth.py
+++ b/backend/tests/test_agent_oauth.py
@@ -6,8 +6,17 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet
 
+from backend.config import settings
 from backend.services import agent_auth, agent_oauth
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch):
+    """OAuth state is Fernet-encrypted; CI has no INTEGRATIONS_ENCRYPTION_KEY
+    in its environment, so give the suite its own (same as test_billing)."""
+    monkeypatch.setattr(settings, "INTEGRATIONS_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
 
 def test_claude_authorize_url_shape():

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -251,6 +251,7 @@ async def test_failed_run_records_error_and_refunds_credit(
     async def boom(agent, stamp):
         raise RuntimeError("sprite exploded")
 
+    real_run_scheduled = sprite_agent_service.run_scheduled
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", boom)
     await _run_due()
 
@@ -261,8 +262,11 @@ async def test_failed_run_records_error_and_refunds_credit(
     assert "sprite exploded" in row["last_run_error"]
     assert row["month_run_count"] == 0  # consumed by mark_run, refunded on failure
 
-    # The next successful run clears the error.
-    monkeypatch.undo()
+    # The next successful run clears the error. Re-patch the real function
+    # rather than monkeypatch.undo() — the fixture is shared with sprite_exec,
+    # so undo() would also drop the fake sprite exec and this "successful run"
+    # would exec a real `claude` binary (passes on a dev machine, dies in CI).
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", real_run_scheduled)
     await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
     ran = await _run_due()
     assert ran == 1


### PR DESCRIPTION
Main's backend pytest has been red — two unrelated causes:

1. **test_curator (mine, from #732)**: `monkeypatch.undo()` doesn't scope to your own patches — the fixture instance is shared with `sprite_exec`, so undo() also removed the fake sprite exec, and the test's "successful run" exec'd a **real `claude` binary**. Green on dev machines (a real model turn — the reason the file took 2+ minutes locally), FileNotFoundError → `ran == 0` in CI. Fixed by re-patching the saved real function; the suite drops from 143s to ~8s.
2. **test_agent_oauth (pre-existing, failing since ≥16:52 today)**: OAuth state encryption needs `INTEGRATIONS_ENCRYPTION_KEY`; local `.env`s provide it, CI doesn't. The suite now sets its own Fernet key on settings (the `test_billing` pattern).

Verified with a CI-like env (`unset INTEGRATIONS_ENCRYPTION_KEY`): both suites, 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)