### PR TITLE
Raise upload limit to 100MB and surface upload errors in the UI

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -44,7 +44,11 @@ logger = logging.getLogger(__name__)
 me_router = APIRouter(prefix="/api/v1/me/files", tags=["files"])
 canonical_router = APIRouter(prefix="/api/v1/files", tags=["files"])
 
-MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+# Render's proxy rejects request bodies around 100 MB, so this is the
+# practical ceiling for uploads that pass through our servers. Keep in
+# sync with the Next proxy limit (frontend/next.config.ts) and the
+# client guard (frontend/src/lib/api.ts).
+MAX_FILE_SIZE = 100 * 1024 * 1024
 
 # File rows are always read joined to their uploader so responses can show
 # attribution ("Uploaded by Sam") without a second round trip.
@@ -181,7 +185,7 @@ async def upload_my_file(
 
     content = await file.read()
     if len(content) > MAX_FILE_SIZE:
-        raise HTTPException(status_code=413, detail="File too large (max 50 MB)")
+        raise HTTPException(status_code=413, detail="File too large (max 100 MB)")
 
     content_type = file.content_type or "application/octet-stream"
     filename = file.filename or "upload"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -24,6 +24,13 @@ const nextConfig: NextConfig = {
   // open → close → reopen its WebSocket on every load (slow, flaky first paint).
   // Production never double-mounts; turning it off keeps dev in parity.
   reactStrictMode: false,
+  // Because a middleware exists, Next buffers every request body and caps it
+  // at 10MB by default — larger uploads were silently truncated before they
+  // reached the backend. Keep in sync with MAX_FILE_SIZE in
+  // backend/routers/files.py and the guard in src/lib/api.ts.
+  experimental: {
+    middlewareClientMaxBodySize: "100mb",
+  },
   async rewrites() {
     return {
       // These run before App Router pages so `.md` and `.json` are content

--- a/frontend/src/components/workspace/files-explorer.test.tsx
+++ b/frontend/src/components/workspace/files-explorer.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/lib/workspace-store", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn() },
 }));
 
 vi.mock("@/lib/api", () => ({

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -215,7 +215,14 @@ export default function FilesExplorer({
   async function newFolder(folder: string | null) { await createFolder("New folder", folder); await load(); }
   async function runNewRootItem() { if (!newRootItem) return; await newRootItem.run(); await load(); }
   async function uploadFiles(files: File[], folder: string | null) {
-    for (const f of files) await uploadFileOrPage(f, folder ?? undefined);
+    const label = files.length === 1 ? files[0].name : `${files.length} files`;
+    const toastId = toast.loading(`Uploading ${label}…`);
+    try {
+      for (const f of files) await uploadFileOrPage(f, folder ?? undefined);
+      toast.success(`Uploaded ${label}`, { id: toastId });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Upload failed", { id: toastId });
+    }
     await load();
   }
   function onUpload(e: React.ChangeEvent<HTMLInputElement>) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -872,10 +872,18 @@ type UploadApiResponse = {
   created_by?: string;
 };
 
+// Matches MAX_FILE_SIZE in backend/routers/files.py and the Next proxy
+// limit in next.config.ts. Rejecting here gives an instant, clear error
+// instead of uploading for many seconds and failing downstream.
+export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
 async function uploadAny(
   file: File,
   folderId?: string | null
 ): Promise<UploadApiResponse> {
+  if (file.size > MAX_UPLOAD_BYTES) {
+    throw new Error(`${file.name} is too large (max 100 MB)`);
+  }
   const token = await getAuthToken();
   const formData = new FormData();
   formData.append("file", file);


### PR DESCRIPTION
## Problem

Uploading any file over 10MB through the UI silently did nothing. Chain of failure (from prod logs, 21:05 UTC today):

1. A middleware exists, so Next.js buffers every request body — capped at **10MB** by default. It logged *"Request body exceeded 10MB for /api/v1/me/files"* and truncated the multipart body.
2. The backend reset the connection mid-read (`ECONNRESET`); the proxy returned 500 after 18s.
3. `uploadFiles` in the files explorer had no loading state and no catch — the error evaporated.

## Changes

- **`next.config.ts`**: `experimental.middlewareClientMaxBodySize: "100mb"` (key verified against Next 16.2.7's config schema).
- **`backend/routers/files.py`**: `MAX_FILE_SIZE` 50MB → 100MB. Render's own proxy rejects bodies around 100MB, so this is the practical ceiling for any upload that passes through our servers.
- **`src/lib/api.ts`**: files >100MB are rejected client-side instantly with a clear message instead of uploading for many seconds and dying.
- **`files-explorer.tsx`**: uploads now show a loading toast and report success/failure (same pattern as the GitHub import next to it).

## Beyond 100MB

Not possible through the current proxy path. The right architecture for genuinely large files is presigned direct-to-R2 uploads (browser → storage, servers never touch the bytes) — proposed as a follow-up, not attempted 30 minutes before client onboarding.

## Testing

- Frontend: 186/186 vitest, lint clean, production build passes with the new config key.
- Backend: ruff clean.
- Post-deploy: will verify with a >10MB scanned PDF end-to-end in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)