### PR TITLE
Chat tab restore shows the run's tool calls as citations

### DIFF
--- a/backend/routers/agent_chat.py
+++ b/backend/routers/agent_chat.py
@@ -17,7 +17,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
-from ..services import agent_auth, agent_service, sprite_agent_service
+from ..services import agent_auth, agent_service, memory_service, sprite_agent_service
 
 router = APIRouter(prefix="/api/v1/me/agent-chat", tags=["agent-chat"])
 
@@ -143,9 +143,24 @@ async def get_chat(
     session_id: str,
     current_user: dict = Depends(get_current_user),
 ):
-    """The chat's turns as [{role, content}], for restoring a tab."""
+    """The chat's turns for restoring a tab: [{role, content}] plus the turn's
+    tool calls as {role: "tool", tool_name, metadata} rows in order — the
+    client folds them into the citations strip, matching the live stream."""
     owner_user_id = current_user["id"]
-    messages = await sprite_agent_service._load_history(
-        owner_user_id, session_id, current_user["id"]
-    )
+    events = await memory_service.read_session_events(owner_user_id, session_id, current_user["id"])
+    messages = []
+    for e in events:
+        content = (e.get("content") or "").strip()
+        kind = e["event_type"]
+        if kind in ("user_message", "assistant_message") and content:
+            messages.append({"role": kind.removesuffix("_message"), "content": content})
+        elif kind == "tool_use":
+            messages.append(
+                {
+                    "role": "tool",
+                    "content": content,
+                    "tool_name": e.get("tool_name"),
+                    "metadata": e.get("metadata") or {},
+                }
+            )
     return {"session_id": session_id, "messages": messages}

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -211,3 +211,11 @@ async def test_tool_calls_persist_as_history_events(client: AsyncClient, sprite_
     assert row is not None
     assert row["tool_name"] == "Bash"
     assert row["content"] == "Ran: stash changes --json"
+
+    # Restoring the tab returns the tool call in order, so the client can
+    # rebuild the citations strip the live stream showed.
+    got = await client.get(f"/api/v1/me/agent-chat/{session_id}", headers=_auth(key))
+    tool_rows = [m for m in got.json()["messages"] if m["role"] == "tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0]["tool_name"] == "Bash"
+    assert tool_rows[0]["metadata"]["command"] == "stash changes --json"

--- a/frontend/src/lib/agentChat.test.ts
+++ b/frontend/src/lib/agentChat.test.ts
@@ -1,0 +1,73 @@
+// Restoring a chat tab folds stored tool rows into the citations of the
+// assistant message that follows them — the same strip the live SSE stream
+// builds turn by turn, so a reopened tab looks like the run did live.
+
+import { describe, expect, it, vi } from "vitest";
+
+const apiFetch = vi.fn();
+vi.mock("@/lib/api", () => ({
+  API_BASE: "",
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+  getAuthToken: () => "k",
+}));
+
+import { getAgentChat } from "./agentChat";
+
+describe("getAgentChat", () => {
+  it("folds tool rows into the next assistant message's citations", async () => {
+    apiFetch.mockResolvedValueOnce({
+      messages: [
+        { role: "user", content: "curate" },
+        {
+          role: "tool",
+          content: "Ran: stash changes --json",
+          tool_name: "Bash",
+          metadata: { command: "stash changes --json" },
+        },
+        {
+          role: "tool",
+          content: "Read /memory/index.md",
+          tool_name: "Read",
+          metadata: { file_path: "/memory/index.md" },
+        },
+        { role: "assistant", content: "done" },
+      ],
+    });
+
+    const messages = await getAgentChat("agent-curate-1");
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ role: "user", content: "curate" });
+    expect(messages[1].role).toBe("assistant");
+    expect(messages[1].citations?.map((c) => c.label)).toEqual([
+      "stash changes --json",
+      "index.md",
+    ]);
+  });
+
+  it("parses generic args_preview and skips unciteable tools", async () => {
+    apiFetch.mockResolvedValueOnce({
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "tool",
+          content: 'Grep: {"pattern": "quokka"}',
+          tool_name: "Grep",
+          metadata: { args_preview: '{"pattern": "quokka"}' },
+        },
+        {
+          role: "tool",
+          content: "Edited /tmp/x",
+          tool_name: "Edit",
+          metadata: { file_path: "/tmp/x" },
+        },
+        { role: "assistant", content: "found" },
+      ],
+    });
+
+    const messages = await getAgentChat("s1");
+
+    // Grep grounds the answer; an Edit is work, not grounding.
+    expect(messages[1].citations?.map((c) => c.label)).toEqual(['search "quokka"']);
+  });
+});

--- a/frontend/src/lib/agentChat.ts
+++ b/frontend/src/lib/agentChat.ts
@@ -47,11 +47,49 @@ export function citationFor(
   return null;
 }
 
+type StoredMessage = {
+  role: ChatRole | "tool";
+  content: string;
+  tool_name?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Rebuild citationFor's args shape from a stored tool event's metadata
+ *  ({command} for Bash, {file_path} for file tools, {args_preview} JSON for
+ *  the rest). */
+function argsFromMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  if (typeof metadata.args_preview === "string") {
+    try {
+      return JSON.parse(metadata.args_preview) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  return metadata;
+}
+
 export async function getAgentChat(sessionId: string): Promise<ChatMessage[]> {
-  const data = await apiFetch<{ messages: { role: ChatRole; content: string }[] }>(
+  const data = await apiFetch<{ messages: StoredMessage[] }>(
     `/api/v1/me/agent-chat/${encodeURIComponent(sessionId)}`,
   );
-  return data.messages.map((m) => ({ role: m.role, content: m.content }));
+  // Fold stored tool rows into the citations of the assistant message that
+  // follows them — the same shape the live stream builds turn by turn.
+  const messages: ChatMessage[] = [];
+  let pending: Citation[] = [];
+  for (const [i, m] of data.messages.entries()) {
+    if (m.role === "tool") {
+      const label = citationFor(m.tool_name ?? "tool", argsFromMetadata(m.metadata ?? {}));
+      if (label) pending.push({ id: `stored-${i}`, tool: m.tool_name ?? "tool", label });
+      continue;
+    }
+    if (m.role === "assistant") {
+      messages.push({ role: m.role, content: m.content, citations: pending });
+      pending = [];
+    } else {
+      messages.push({ role: m.role, content: m.content });
+    }
+  }
+  return messages;
 }
 
 type StreamHandlers = {


### PR DESCRIPTION
## Problem

Reopening a chat tab — most visibly a Memory-curator run — showed only the user prompt and final answer. The tool calls recorded for cloud runs (since #732) never reached the client: `get_chat` reused `_load_history`, whose user/assistant filter exists for harness reseeds, not for display.

## Change

- `GET /me/agent-chat/{session_id}` returns the session's `tool_use` events as ordered `{role: "tool", tool_name, metadata}` rows (reseeds still use `_load_history`, untouched).
- `getAgentChat` folds those rows into the citations of the assistant message that follows — the same "Grounded on" strip the live SSE stream builds, so a restored tab looks like the run did live. Bash/file tools cite from their stored metadata; generic tools parse `args_preview`; work-not-grounding tools (Edit/Write) stay out of the strip, matching `citationFor`.

## Tests
- Backend: tool row returned in order with tool_name + metadata (extends the tool-persistence test); 5 chat tests pass
- Frontend: new agentChat unit tests for the folding + args reconstruction; 188 pass; both linters clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)