### PR TITLE
Curator "Run now" enqueues on the worker instead of streaming SSE

### DIFF
--- a/backend/routers/agent_chat.py
+++ b/backend/routers/agent_chat.py
@@ -81,33 +81,24 @@ async def run_now(
     req: RunRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Run a scheduled agent on demand (e.g. to test the Memory curator without
-    waiting for its cron), streamed live like a chat turn. The server builds the
-    prompt — the curator's from its watermark, others' from schedule_prompt — so
-    the run is identical to what the beat task fires. The watermark is untouched,
-    so a manual run is safe to repeat while testing."""
+    """Run a prompt-scheduled agent on demand, streamed live like a chat turn.
+    The server builds the prompt from schedule_prompt, so the run is identical
+    to what the beat task fires.
+
+    Curator runs are refused here: a curation pass takes minutes and an SSE
+    run dies with the browser tab (the disconnect cancels the stream with no
+    trace). They enqueue on the worker via POST /me/memory/recompute — the
+    same path the daily schedule and the CLI use."""
     agent = await agent_service.get_agent(current_user["id"], UUID(req.agent_id))
     if agent["run_mode"] != "scheduled":
         raise HTTPException(status_code=400, detail="Only scheduled agents can be run on demand.")
-    if not agent["is_curator"] and not agent["schedule_prompt"]:
-        raise HTTPException(status_code=400, detail="This agent has no scheduled prompt to run.")
-    # Manual curator runs draw from the same monthly sleep-time allowance the
-    # scheduler enforces — otherwise "Run now" is unmetered sleep compute.
     if agent["is_curator"]:
-        from ..config import settings
-        from ..database import get_pool
-
-        if agent_service.month_runs_used(agent) >= settings.FREE_CURATOR_RUNS_PER_MONTH:
-            plan = await get_pool().fetchval(
-                "SELECT plan FROM users WHERE id = $1", current_user["id"]
-            )
-            if plan != "enterprise":
-                raise HTTPException(
-                    status_code=402,
-                    detail=f"Free accounts get {settings.FREE_CURATOR_RUNS_PER_MONTH} sleep-time "
-                    "curator runs per month; the enterprise plan is unlimited.",
-                )
-        await agent_service.mark_run(UUID(agent["id"]))
+        raise HTTPException(
+            status_code=400,
+            detail="Curator runs execute on the worker — use POST /me/memory/recompute.",
+        )
+    if not agent["schedule_prompt"]:
+        raise HTTPException(status_code=400, detail="This agent has no scheduled prompt to run.")
     try:
         auth = await agent_auth.resolve(current_user["id"], agent["model_provider"])
     except agent_auth.NeedsAuth:

--- a/backend/tests/test_plan_gate.py
+++ b/backend/tests/test_plan_gate.py
@@ -138,30 +138,16 @@ async def test_free_curator_credits_exhausted_skips_run(
 
 
 @pytest.mark.asyncio
-async def test_on_demand_curator_run_is_metered(client: AsyncClient, sprite_exec, _db_pool):
-    """The UI's "Run now" draws from the same monthly allowance as the beat —
-    otherwise it's an unmetered sleep-compute loophole for free accounts."""
+async def test_on_demand_curator_run_refused_on_sse_route(client: AsyncClient, _db_pool):
+    """The curator's "Run now" enqueues on the worker via /memory/recompute
+    (metered there — see test_recompute_metered_like_the_scheduler). The SSE
+    route refuses curators outright: a curation pass takes minutes, and an
+    SSE run dies silently when the browser tab closes."""
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
-    await _db_pool.execute(
-        "UPDATE agents SET month_run_count = $2, "
-        "month_run_anchor = date_trunc('month', now())::date WHERE id = $1",
-        UUID(curator["id"]),
-        settings.FREE_CURATOR_RUNS_PER_MONTH,
-    )
 
     r = await client.post(
         "/api/v1/me/agent-chat/run", json={"agent_id": curator["id"]}, headers=_auth(key)
     )
-    assert r.status_code == 402
-
-    # Enterprise → the same run streams, and is still counted.
-    await _db_pool.execute("UPDATE users SET plan = 'enterprise' WHERE id = $1", uid)
-    r = await client.post(
-        "/api/v1/me/agent-chat/run", json={"agent_id": curator["id"]}, headers=_auth(key)
-    )
-    assert r.status_code == 200
-    count = await _db_pool.fetchval(
-        "SELECT month_run_count FROM agents WHERE id = $1", UUID(curator["id"])
-    )
-    assert count == settings.FREE_CURATOR_RUNS_PER_MONTH + 1
+    assert r.status_code == 400
+    assert "recompute" in r.json()["detail"]

--- a/frontend/src/components/agents/AgentConfigPanel.tsx
+++ b/frontend/src/components/agents/AgentConfigPanel.tsx
@@ -7,9 +7,11 @@ import { takeCuratorRun } from "@/lib/agent-tab-view";
 import {
   type Agent,
   type AgentPrompt,
+  ApiError,
   deleteAgent,
   getAgentPrompt,
   listAgents,
+  recomputeMemory,
   updateAgent,
 } from "@/lib/api";
 
@@ -98,8 +100,58 @@ export default function AgentConfigPanel({
     onChanged?.();
   }
 
+  // Curator runs enqueue to the worker — the same path as the daily schedule
+  // and the CLI — so closing this tab doesn't kill the run mid-curation (a
+  // browser-tethered SSE run once died silently that way). The panel just
+  // polls the agent row for the outcome.
+  async function runCuratorNow(baseline: Agent) {
+    setRun({ streaming: true, status: "Queuing a curation pass…", text: "", tools: [], error: null });
+    try {
+      await recomputeMemory();
+    } catch (e) {
+      const nothingNew = e instanceof ApiError && e.status === 409;
+      setRun({
+        streaming: false,
+        status: null,
+        text: nothingNew ? "Nothing new to curate since the last run." : "",
+        tools: [],
+        error: nothingNew ? null : e instanceof Error ? e.message : String(e),
+      });
+      return;
+    }
+    // Poll until the worker picks it up and finishes: last_run_at advances at
+    // pickup (clearing last_run_error), curated_through advances on success.
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 3000));
+      const cur = (await listAgents().catch(() => [])).find((a) => a.id === baseline.id);
+      if (!cur || cur.last_run_at === baseline.last_run_at) continue;
+      setAgent(cur);
+      if (cur.last_run_error) {
+        setRun({ streaming: false, status: null, text: "", tools: [], error: cur.last_run_error });
+        return;
+      }
+      if (cur.curated_through && cur.last_run_at && cur.curated_through >= cur.last_run_at) {
+        setRun({ streaming: false, status: null, text: "Done — the Memory wiki is updated.", tools: [], error: null });
+        window.dispatchEvent(new Event("agents-changed"));
+        return;
+      }
+      setRun((r) => (r ? { ...r, status: "Curating on your cloud computer — safe to close this tab." } : r));
+    }
+    setRun({
+      streaming: false,
+      status: null,
+      text: "Still running — check back here or in `stash memory` for the outcome.",
+      tools: [],
+      error: null,
+    });
+  }
+
   async function runNow() {
     if (!agent || run?.streaming) return;
+    if (agent.is_curator) {
+      void runCuratorNow(agent);
+      return;
+    }
     const controller = new AbortController();
     abortRef.current = controller;
     setRun({ streaming: true, status: "Starting…", text: "", tools: [], error: null });
@@ -304,7 +356,7 @@ function RunOnDemand({
           <div className="text-[12.5px] font-medium text-foreground">Run on demand</div>
           <div className="text-[11.5px] text-muted-foreground">
             {isCurator
-              ? "Trigger a curation pass now instead of waiting for the daily schedule. Your watermark is untouched, so it's safe to repeat."
+              ? "Trigger a curation pass now instead of waiting for the daily schedule. It runs on your cloud computer — safe to close this tab."
               : "Run this scheduled agent now to test it."}
           </div>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2005,11 +2005,21 @@ export type Agent = {
   is_curator: boolean;
   slack_bound: boolean;
   telegram_bound: boolean;
+  last_run_at: string | null;
+  last_run_error: string | null;
+  curated_through: string | null;
 };
 
 export async function listAgents(): Promise<Agent[]> {
   const data = await apiFetch<{ agents: Agent[] }>("/api/v1/me/agents");
   return data.agents;
+}
+
+/** Enqueue a curation pass on the worker — the same path the daily schedule
+ *  and the CLI use, so the run survives the browser. 409 = nothing changed
+ *  since the watermark. */
+export async function recomputeMemory(): Promise<{ status: string; agent_id: string }> {
+  return apiFetch("/api/v1/me/memory/recompute", { method: "POST" });
 }
 
 export async function createAgent(fields: Partial<Agent>): Promise<Agent> {


### PR DESCRIPTION
## Problem

The curator's "Run now" executed the entire multi-minute curation inside the `/run` SSE response. Closing the tab (or navigating) cancels the response generator; `asyncio.CancelledError` is a `BaseException`, so `stream_chat`'s failure recording never fires — the run dies mid-curation with zero trace (no log line, no `last_run_error`, no session closure, credits consumed). A run today made 34 tool calls over 5½ minutes and vanished exactly this way.

## Change

- **Panel Run-now** (and the Memory explorer's "Curate wiki" button, which funnels into the same `runNow`) calls `POST /me/memory/recompute` — the worker-owned path the daily schedule and CLI already use — then polls the agent row: `last_run_at` advances at pickup, `last_run_error` on failure, `curated_through` catching up = success. 409 renders as "Nothing new to curate". The run survives the browser; the UI copy says so.
- **`/run` refuses curators** (400 pointing at recompute) — one execution path, fail loud. It still serves prompt-scheduled agents unchanged. Its curator metering block is deleted; recompute has its own quota gate (covered by `test_recompute_metered_like_the_scheduler`).
- Semantics change, deliberate: a manual pass now advances the watermark on success (like the CLI/schedule) instead of the old repeat-safe test mode.

## Tests
- `test_plan_gate`: the old "SSE run is metered" test's intent moved to recompute; rewritten as "SSE route refuses curators" (400 + pointer)
- Suites: test_plan_gate + test_curator + test_agent_chat 27 passed (and faster — the old test exercised a real streamed run); frontend 186 passed, lint/tsc clean
- Verified pieces: recompute+poll is the CLI pattern proven in prod this morning; full browser E2E needs a local celery worker, not run here

🤖 Generated with [Claude Code](https://claude.com/claude-code)