### PR TITLE
Add SESSION_INGEST_DISABLED backend kill-switch for plugin streaming

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -142,6 +142,15 @@ class Settings:
     # --- Server ---
     PORT: int = int(os.getenv("PORT", "3456"))
 
+    # --- Coding-agent session ingest kill-switch ---
+    # Global emergency stop for the plugin's session streaming. When true, the
+    # ingest endpoints (session upsert, events, transcripts, artifacts) accept
+    # requests but persist nothing, and session upsert returns a blank id and
+    # app_url so already-installed plugins suppress the "Session: {url}"
+    # postscript and skip every upload — no client update required. Flip back to
+    # false once the plugin default-change ships.
+    SESSION_INGEST_DISABLED: bool = os.getenv("SESSION_INGEST_DISABLED", "false").lower() == "true"
+
     # --- Auth0 (managed deployment only) ---
     # When AUTH0_ENABLED=true, password login/register is disabled and the
     # managed auth0 router is mounted at /api/v1/auth0/. Requires the

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -7,7 +7,7 @@ Hierarchy: Scope → Agent → Session → Events
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from ..auth import get_current_user
 from ..config import settings
@@ -46,6 +46,9 @@ async def push_event(
     req: HistoryEventCreateRequest,
     current_user: dict = Depends(get_current_user),
 ):
+    if settings.SESSION_INGEST_DISABLED:
+        return Response(status_code=204)
+
     owner_user_id = current_user["id"]
     await _check_write(owner_user_id, current_user["id"])
     attachments = [a.model_dump(mode="json") for a in req.attachments] if req.attachments else None
@@ -72,6 +75,9 @@ async def push_events_batch(
     req: HistoryEventBatchRequest,
     current_user: dict = Depends(get_current_user),
 ):
+    if settings.SESSION_INGEST_DISABLED:
+        return Response(status_code=204)
+
     owner_user_id = current_user["id"]
     await _check_write(owner_user_id, current_user["id"])
     events_data = [e.model_dump() for e in req.events]

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -10,7 +10,7 @@ session viewer can ship a Share button without involving the CLI.
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from pydantic import BaseModel, Field
 
 from ..auth import get_current_user
@@ -45,6 +45,30 @@ class SessionUpsertRequest(BaseModel):
 
 def _session_app_url(session_id: str) -> str:
     return f"{settings.PUBLIC_URL.rstrip('/')}/sessions/{session_id}"
+
+
+def _ingest_disabled_response(req: "SessionUpsertRequest") -> dict:
+    """Kill-switch stand-in for a session that was never persisted.
+
+    Blank id and app_url are the two fields the whole client-side upload chain
+    keys off: with them empty, existing plugins skip the "Session: {url}"
+    postscript, never spawn the live event watcher, and bail out of the
+    end-of-session transcript upload.
+    """
+    return {
+        "id": "",
+        "owner_user_id": "",
+        "session_id": req.session_id,
+        "app_url": "",
+        "title": "",
+        "linear_tickets": [],
+        "agent_name": req.agent_name,
+        "cwd": req.cwd,
+        "files_touched": req.files_touched,
+        "started_at": None,
+        "finished_at": None,
+        "created_by": None,
+    }
 
 
 def _session_response(row: dict, title: str | None = None) -> dict:
@@ -212,6 +236,9 @@ async def upsert_session(
     req: SessionUpsertRequest,
     current_user: dict = Depends(get_current_user),
 ):
+    if settings.SESSION_INGEST_DISABLED:
+        return _ingest_disabled_response(req)
+
     owner_user_id = current_user["id"]
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
         raise HTTPException(status_code=403, detail="Only the owner can create sessions")
@@ -423,6 +450,9 @@ async def upload_session_artifact(
     file_path: str = Form(...),
     current_user: dict = Depends(get_current_user),
 ):
+    if settings.SESSION_INGEST_DISABLED:
+        return Response(status_code=204)
+
     owner_user_id = current_user["id"]
     session = await session_service.get_session_by_id(session_row_id)
     if not session or session["owner_user_id"] != owner_user_id:

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -15,10 +15,11 @@ just to have the client parse it back — the rows are the source of truth.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, Form, HTTPException, Response, UploadFile
 from fastapi.responses import PlainTextResponse
 
 from ..auth import get_current_user
+from ..config import settings
 from ..database import get_pool
 from ..services import (
     memory_service,
@@ -60,6 +61,9 @@ async def upload_transcript(
     Existing sessions are left alone unless the caller explicitly asks to
     replace them.
     """
+    if settings.SESSION_INGEST_DISABLED:
+        return Response(status_code=204)
+
     owner_user_id = current_user["id"]
     await _check_write(owner_user_id, current_user["id"])
     if not _is_jsonl(file.filename):

--- a/backend/tests/test_session_ingest_disabled.py
+++ b/backend/tests/test_session_ingest_disabled.py
@@ -1,0 +1,101 @@
+"""The SESSION_INGEST_DISABLED kill-switch.
+
+When set, the plugin's five ingest endpoints must accept requests but persist
+nothing, and session upsert must return a blank id/app_url so already-installed
+plugins stop emitting the "Session: {url}" postscript and skip every upload.
+The point of these tests: prove the switch stops storage AND blanks the two
+fields the client keys the postscript off — the reason it works with no client
+update at all.
+"""
+
+import io
+
+import pytest
+
+from backend.config import settings
+
+from .conftest import unique_name
+
+
+async def _register(client) -> str:
+    r = await client.post(
+        "/api/v1/users/register", json={"name": unique_name(), "password": "securepassword1"}
+    )
+    assert r.status_code == 201
+    return r.json()["api_key"]
+
+
+@pytest.fixture
+def ingest_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "SESSION_INGEST_DISABLED", True)
+
+
+async def test_upsert_returns_blank_id_and_url_and_persists_nothing(client, pool, ingest_disabled):
+    headers = {"Authorization": f"Bearer {await _register(client)}"}
+
+    r = await client.post(
+        "/api/v1/me/sessions",
+        json={"session_id": "sess-off", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert r.status_code == 201
+    body = r.json()
+    # Blank id + app_url are what make the plugin drop the postscript and skip
+    # the watcher / transcript upload — assert both, not just "no row".
+    assert body["id"] == ""
+    assert body["app_url"] == ""
+
+    assert await pool.fetchval("SELECT COUNT(*) FROM sessions") == 0
+
+
+async def test_events_are_dropped(client, pool, ingest_disabled):
+    headers = {"Authorization": f"Bearer {await _register(client)}"}
+
+    single = await client.post(
+        "/api/v1/me/sessions/events",
+        json={"agent_name": "claude", "event_type": "prompt", "content": "hi", "session_id": "s"},
+        headers=headers,
+    )
+    assert single.status_code == 204
+
+    batch = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={
+            "events": [
+                {"agent_name": "claude", "event_type": "prompt", "content": "hi", "session_id": "s"}
+            ]
+        },
+        headers=headers,
+    )
+    assert batch.status_code == 204
+
+    assert await pool.fetchval("SELECT COUNT(*) FROM history_events") == 0
+
+
+async def test_transcript_upload_is_dropped(client, pool, ingest_disabled):
+    headers = {"Authorization": f"Bearer {await _register(client)}"}
+
+    r = await client.post(
+        "/api/v1/me/transcripts",
+        data={"session_id": "sess-off", "agent_name": "claude"},
+        files={"file": ("t.jsonl", io.BytesIO(b'{"type":"user","message":{"content":"hi"}}\n'))},
+        headers=headers,
+    )
+    assert r.status_code == 204
+    assert await pool.fetchval("SELECT COUNT(*) FROM history_events") == 0
+
+
+async def test_switch_off_by_default_still_persists(client, pool):
+    """Guard against the switch defaulting on: normal ingest must still store."""
+    headers = {"Authorization": f"Bearer {await _register(client)}"}
+
+    r = await client.post(
+        "/api/v1/me/sessions",
+        json={"session_id": "sess-on", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["id"]
+    assert body["app_url"].endswith("/sessions/sess-on")
+    assert await pool.fetchval("SELECT COUNT(*) FROM sessions") == 1


### PR DESCRIPTION
## Why

A teammate flagged the "Session: {url}" postscript that gets appended to every agent turn, and we want to be able to turn off session records/uploads **for the whole user base without waiting on the plugin auto-update** (which only propagates through Claude Code's marketplace refresh — unreliable for a same-day fix).

Existing plugins key the postscript, the live event watcher, and the transcript upload off the `create_session` response and the ingest endpoints. So a **backend-only** change can turn all of it off on everyone's *next session* — no client update required.

## What

A single env flag, `SESSION_INGEST_DISABLED` (default `false`), gating the five write paths the plugin hits.

When `true`:

| Endpoint | Behavior | Effect |
|---|---|---|
| `POST /me/sessions` | returns blank `id` + `app_url`, no DB write | **suppresses the postscript** + the live watcher + the end-of-session transcript upload (all client-side, keyed off these two fields) |
| `POST /me/sessions/events` + `/events/batch` | `204`, no write | no live event storage |
| `POST /me/transcripts` | `204`, no write | no transcript rows |
| `POST /me/sessions/{id}/artifacts` | `204`, no write | no touched-file blobs |

`204` keeps it **silent**: the client's `_post` treats it as success (`stash_client.py`), so no "uploads failing" warnings surface to users.

## Rollout

- Activate: set `SESSION_INGEST_DISABLED=true` on the backend and redeploy. Effective on everyone's next session start.
- Reverse: set it back to `false`.
- **Blast radius is global** — this is an intentional emergency stop for the entire user base, not scoped to one team. It's a stopgap; the durable fix is the plugin default-change (postscript off / uploads opt-in), after which this flag goes back to `false`.
- Edge case (self-healing): a session already in flight when the flag flips keeps its cached postscript until the user's next fresh session.

## Tests

`backend/tests/test_session_ingest_disabled.py` — 4 tests: upsert returns blank id/url and persists nothing, events (single + batch) dropped, transcript upload dropped, and a guard that the flag defaults off so normal ingest still persists. All pass; the 33 adjacent existing session/transcript tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)