### PR TITLE
General access ("anyone with the link") for pages/files/folders + SVG sanitizer fix

### DIFF
--- a/backend/migrations/versions/0139_content_public_permission.py
+++ b/backend/migrations/versions/0139_content_public_permission.py
@@ -1,0 +1,35 @@
+"""Per-object "anyone with the link" access for pages, files, folders, tables.
+
+Google-Docs-style general access: each row carries a public_permission granting
+everyone (including anonymous readers) access at that level and above —
+read < comment < write. A folder's grant cascades to its descendants, resolved
+at read time in permission_service. Person shares (the `shares` table) are
+unchanged; this is the link-level grant that sits alongside them.
+
+Revision ID: 0139
+Revises: 0138
+"""
+
+from alembic import op
+
+revision = "0139"
+down_revision = "0138"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("pages", "files", "folders", "tables")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"ADD COLUMN public_permission varchar(16) NOT NULL DEFAULT 'none', "
+            f"ADD CONSTRAINT {table}_public_permission_check "
+            f"CHECK (public_permission IN ('none', 'read', 'comment', 'write'))"
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN public_permission")

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -349,10 +349,12 @@ async def list_my_files(
 @canonical_router.get("/{file_id}", response_model=FileResponse)
 async def get_file_by_id(
     file_id: UUID,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    """Any failure is a 404: an unscoped lookup must not confirm that a
-    file the caller can't read exists."""
+    """Optional auth: a file with a public link is readable while logged out. Any
+    failure is a 404: an unscoped lookup must not confirm that a file the caller
+    can't read exists."""
+    viewer_id = current_user["id"] if current_user else None
     pool = get_pool()
     row = await pool.fetchrow(
         f"SELECT {_FILE_COLS} {_FILE_FROM} WHERE f.id = $1 AND f.deleted_at IS NULL",
@@ -360,7 +362,7 @@ async def get_file_by_id(
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
-    if not await _can_access_file(file_id, row["owner_user_id"], current_user["id"]):
+    if not await _can_access_file(file_id, row["owner_user_id"], viewer_id):
         raise HTTPException(status_code=404, detail="File not found")
     return await _file_to_response(dict(row))
 
@@ -385,9 +387,9 @@ async def download_my_file(
     current_user: dict | None = Depends(get_current_user_optional),
 ):
     """Permanent URL for file links embedded in wiki pages. Resolves the file's
-    real owner so recipients of a shared page can load its embedded images."""
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Authentication required")
+    real owner so recipients of a shared page — or a public link, logged out —
+    can load its embedded images."""
+    viewer_id = current_user["id"] if current_user else None
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT owner_user_id, name, content_type, storage_key FROM files "
@@ -396,7 +398,7 @@ async def download_my_file(
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
-    if not await _can_access_file(file_id, row["owner_user_id"], current_user["id"]):
+    if not await _can_access_file(file_id, row["owner_user_id"], viewer_id):
         raise HTTPException(status_code=404, detail="File not found")
     content = await _download_storage_file_or_502(row["storage_key"], "file download")
     content_type = row["content_type"] or "application/octet-stream"

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
-from ..auth import get_current_user
+from ..auth import get_current_user, get_current_user_optional
 from ..database import get_pool
 from ..models import (
     CommentReconcileRequest,
@@ -607,11 +607,13 @@ async def search_pages(
 @canonical_router.get("/pages/{page_id}", response_model=PageResponse)
 async def get_page_by_id(
     page_id: UUID,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    """Any failure is a 404: an unscoped lookup must not confirm that a
-    page the caller can't read exists."""
-    page = await files_tree_service.get_page_by_id(page_id, current_user["id"])
+    """Optional auth: a page with a public link ("anyone with the link") is
+    readable while logged out. Any failure is a 404: an unscoped lookup must not
+    confirm that a page the caller can't read exists."""
+    viewer_id = current_user["id"] if current_user else None
+    page = await files_tree_service.get_page_by_id(page_id, viewer_id)
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
     return PageResponse(**page)

--- a/backend/routers/shares.py
+++ b/backend/routers/shares.py
@@ -39,6 +39,12 @@ class PendingInviteRevokeRequest(BaseModel):
     email: str
 
 
+class GeneralAccessRequest(BaseModel):
+    object_type: str
+    object_id: UUID
+    public_permission: str
+
+
 @router.post("")
 async def create_share(req: ShareRequest, current_user: dict = Depends(get_current_user)):
     return await share_service.share_with_user_by_email(
@@ -95,6 +101,20 @@ async def list_shared_session_folder_sessions(
     }
 
 
+@router.patch("/general-access")
+async def set_general_access(
+    req: GeneralAccessRequest, current_user: dict = Depends(get_current_user)
+):
+    """Set the "anyone with the link" level for a page/file/folder/table."""
+    public_permission = await share_service.set_general_access(
+        object_type=req.object_type,
+        object_id=req.object_id,
+        public_permission=req.public_permission,
+        user_id=current_user["id"],
+    )
+    return {"public_permission": public_permission}
+
+
 @router.get("")
 async def list_shares(
     object_type: str,
@@ -102,5 +122,10 @@ async def list_shares(
     current_user: dict = Depends(get_current_user),
 ):
     return {
-        "shares": await share_service.list_object_shares(object_type, object_id, current_user["id"])
+        "shares": await share_service.list_object_shares(
+            object_type, object_id, current_user["id"]
+        ),
+        "general_access": await share_service.get_general_access(
+            object_type, object_id, current_user["id"]
+        ),
     }

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -41,36 +41,106 @@ def detect_page_kind(filename: str, content_type: str) -> str | None:
 # javascript: + data:text/html URLs on write so an agent- or attacker-authored
 # page can't run hostile JS for a public viewer. The trusted resize/slide
 # bootstrap is injected at render time (not stored), so this never touches it.
-_SANITIZE_TAGS = nh3.ALLOWED_TAGS | {
-    "section",
-    "style",
-    "div",
-    "span",
-    "header",
-    "footer",
-    "main",
-    "article",
-    "aside",
-    "nav",
-    "figure",
-    "figcaption",
-    "video",
-    "audio",
-    "source",
-    "picture",
-    "details",
-    "summary",
-    "mark",
+# Inline SVG diagrams. html5ever parses these in the SVG namespace, so it
+# preserves the camelCase of foreign attributes (viewBox, refX) — the allowlist
+# below must match that casing, not a lowercased form.
+_SVG_TAGS = {
     "svg",
-    "path",
     "g",
+    "defs",
+    "marker",
+    "path",
     "circle",
+    "ellipse",
     "rect",
     "line",
     "polyline",
     "polygon",
     "text",
+    "tspan",
+    "linearGradient",
+    "radialGradient",
+    "stop",
+    "clipPath",
 }
+_SVG_ATTRS = {
+    "viewBox",
+    "xmlns",
+    "preserveAspectRatio",
+    "transform",
+    "d",
+    "points",
+    "x",
+    "y",
+    "x1",
+    "y1",
+    "x2",
+    "y2",
+    "cx",
+    "cy",
+    "r",
+    "rx",
+    "ry",
+    "dx",
+    "dy",
+    "fill",
+    "fill-opacity",
+    "fill-rule",
+    "stroke",
+    "stroke-width",
+    "stroke-dasharray",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-opacity",
+    "opacity",
+    "text-anchor",
+    "dominant-baseline",
+    "font-size",
+    "font-family",
+    "font-weight",
+    "letter-spacing",
+    "marker-start",
+    "marker-mid",
+    "marker-end",
+    "markerWidth",
+    "markerHeight",
+    "markerUnits",
+    "refX",
+    "refY",
+    "orient",
+    "gradientUnits",
+    "gradientTransform",
+    "offset",
+    "stop-color",
+    "stop-opacity",
+    "clip-path",
+    "clip-rule",
+}
+_SANITIZE_TAGS = (
+    nh3.ALLOWED_TAGS
+    | {
+        "section",
+        "style",
+        "div",
+        "span",
+        "header",
+        "footer",
+        "main",
+        "article",
+        "aside",
+        "nav",
+        "figure",
+        "figcaption",
+        "video",
+        "audio",
+        "source",
+        "picture",
+        "details",
+        "summary",
+        "mark",
+    }
+    | _SVG_TAGS
+)
 _SANITIZE_ATTRS = {
     "*": {"class", "id", "style", "title", "lang", "dir", "role", "width", "height"},
     "span": {"data-comment-id"},  # inline comment anchors depend on this
@@ -82,6 +152,7 @@ _SANITIZE_ATTRS = {
     "td": {"colspan", "rowspan"},
     "th": {"colspan", "rowspan", "scope"},
     "section": {"data-slide"},
+    **{tag: _SVG_ATTRS for tag in _SVG_TAGS},
 }
 _SANITIZE_URL_SCHEMES = {"http", "https", "mailto", "tel", "data"}
 
@@ -444,14 +515,20 @@ async def create_page(
     return page
 
 
-async def get_page_by_id(page_id: UUID, user_id: UUID) -> dict | None:
-    """Access semantics match get_page; the scope comes from the row."""
+async def get_page_by_id(page_id: UUID, user_id: UUID | None) -> dict | None:
+    """Canonical cross-scope read: the scope comes from the row. Enforces
+    check_access for the viewer (user_id None = anonymous), so a page is returned
+    only to its owner, someone it's shared with, or via a public link/skill —
+    this is the public read path, so it can't lean on get_page's trusted-None
+    bypass, which exists for in-scope agent callers."""
     pool = get_pool()
     owner_user_id = await pool.fetchval(
         f"SELECT owner_user_id FROM pages WHERE id = $1 AND {_PAGE_FILTER}",
         page_id,
     )
     if owner_user_id is None:
+        return None
+    if not await permission_service.check_access("page", page_id, user_id, owner_user_id):
         return None
     return await get_page(page_id, owner_user_id, user_id)
 

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -120,6 +120,39 @@ _LEVEL_SHARE_FILTER = {
     "write": " AND content_share.permission = 'write'",
 }
 
+# public_permission ("anyone with the link") values that satisfy each required
+# level. A 'write' link grants read+comment+write; 'comment' grants read+comment.
+_PUBLIC_LEVELS_FOR = {
+    "read": ("read", "comment", "write"),
+    "comment": ("comment", "write"),
+    "write": ("write",),
+}
+
+
+def _public_permission_condition(object_type: str, object_alias: str, require: str) -> str:
+    """SQL predicate: does the per-object public link grant `require`-level access
+    to everyone? True when the row's own public_permission is high enough, or —
+    cascading like a folder share — any ancestor folder's is. Content rows read
+    the ancestor chain from their folder_id; a folder reads it from its own id
+    (the recursive CTE includes the folder itself)."""
+    levels = ", ".join(f"'{lvl}'" for lvl in _PUBLIC_LEVELS_FOR[require])
+    if object_type == "folder":
+        chain = _folder_chain_sql(f"{object_alias}.id")
+        return (
+            f"EXISTS (SELECT 1 FROM folders public_folder "
+            f"WHERE public_folder.id IN ({chain}) "
+            f"AND public_folder.public_permission IN ({levels}))"
+        )
+    chain = _folder_chain_sql(f"{object_alias}.folder_id")
+    own = f"{object_alias}.public_permission IN ({levels})"
+    ancestor = (
+        f"({object_alias}.folder_id IS NOT NULL AND EXISTS ("
+        f"SELECT 1 FROM folders public_folder "
+        f"WHERE public_folder.id IN ({chain}) "
+        f"AND public_folder.public_permission IN ({levels})))"
+    )
+    return f"({own} OR {ancestor})"
+
 
 def _public_read_container_condition(
     object_type: str, object_alias: str, user_arg: int
@@ -156,6 +189,10 @@ def readable_content_condition(
         f"AND (content_share.expires_at IS NULL OR content_share.expires_at > now()) "
         f"AND {share_target}{_LEVEL_SHARE_FILTER[require]})",
     ]
+    # The per-object public link grants read/comment/write to everyone, so it
+    # applies at every require level — unlike publishing, which is read-only.
+    if object_type in ("page", "file", "table", "folder"):
+        parts.append(_public_permission_condition(object_type, object_alias, require))
     if require == "read":
         parts.append(_skill_grant_condition(object_type, object_alias, user_arg))
         public_container = _public_read_container_condition(object_type, object_alias, user_arg)
@@ -385,18 +422,45 @@ async def check_access(
     )
 
 
-async def get_visibility(object_type: str, object_id: UUID) -> str:
-    """'public' if in any public skill, 'shared' if shared with anyone,
-    else 'private'."""
+async def _has_public_link(object_type: str, object_id: UUID) -> bool:
+    """Does a per-object public link (own row or an ancestor folder) grant
+    anyone access? Mirrors the SQL public_permission clause for the Python path."""
+    if object_type not in ("page", "file", "table", "folder"):
+        return False
     pool = get_pool()
-    skills = await _containing_skills(object_type, object_id)
-    if skills:
+    table = _OWNER_LOOKUP[object_type][0]
+    own = await pool.fetchval(f"SELECT public_permission FROM {table} WHERE id = $1", object_id)
+    if own and own != "none":
+        return True
+    ancestor_folder_ids = [
+        target_id
+        for target_type, target_id in await _object_targets(object_type, object_id)
+        if target_type == "folder"
+    ]
+    if not ancestor_folder_ids:
+        return False
+    return bool(
+        await pool.fetchval(
+            "SELECT 1 FROM folders WHERE id = ANY($1::uuid[]) "
+            "AND public_permission <> 'none' LIMIT 1",
+            ancestor_folder_ids,
+        )
+    )
+
+
+async def get_visibility(object_type: str, object_id: UUID) -> str:
+    """'public' if reachable by anyone (a public link or a published skill),
+    'shared' if shared with a named principal, else 'private'."""
+    pool = get_pool()
+    if await _containing_skills(object_type, object_id) or await _has_public_link(
+        object_type, object_id
+    ):
         return "public"
     shared = await pool.fetchrow(
         "SELECT 1 FROM shares WHERE object_type = $1 AND object_id = $2 LIMIT 1",
         object_type,
         object_id,
     )
-    if shared or skills:
+    if shared:
         return "shared"
     return "private"

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -22,6 +22,11 @@ from . import permission_service, security_audit_service, user_scope_service
 _SHAREABLE = {"file", "page", "folder", "session", "session_folder", "table", "source"}
 _PERMISSIONS = {"read", "comment", "write"}
 
+# Objects that carry a per-object public link ("anyone with the link"). Session
+# folders keep their own public-link flow; these are the content types.
+_GENERAL_ACCESS_TABLE = {"page": "pages", "file": "files", "folder": "folders", "table": "tables"}
+_PUBLIC_PERMISSIONS = {"none", "read", "comment", "write"}
+
 
 async def _require_owner(object_type: str, object_id: UUID, user_id: UUID) -> UUID:
     """The caller must be an owner of the object's scope."""
@@ -316,6 +321,46 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
         for inv in invites
     )
     return shares
+
+
+async def get_general_access(object_type: str, object_id: UUID, user_id: UUID) -> str:
+    """The object's current public link level ('none' when only owner/shares can
+    reach it). Owner-only, so it sits behind the same gate as the share list."""
+    if object_type not in _GENERAL_ACCESS_TABLE:
+        return "none"
+    await _require_owner(object_type, object_id, user_id)
+    table = _GENERAL_ACCESS_TABLE[object_type]
+    value = await get_pool().fetchval(
+        f"SELECT public_permission FROM {table} WHERE id = $1", object_id
+    )
+    return value or "none"
+
+
+async def set_general_access(
+    *, object_type: str, object_id: UUID, public_permission: str, user_id: UUID
+) -> str:
+    """Set the "anyone with the link" level for a page/file/folder/table. Only the
+    scope owner may change publicity, mirroring session-folder general access."""
+    if object_type not in _GENERAL_ACCESS_TABLE:
+        raise HTTPException(status_code=400, detail=f"{object_type} has no general access link")
+    if public_permission not in _PUBLIC_PERMISSIONS:
+        raise HTTPException(status_code=400, detail="invalid public_permission")
+    owner_user_id = await _require_owner(object_type, object_id, user_id)
+    table = _GENERAL_ACCESS_TABLE[object_type]
+    await get_pool().execute(
+        f"UPDATE {table} SET public_permission = $1 WHERE id = $2",
+        public_permission,
+        object_id,
+    )
+    await _record_share_event(
+        action="general_access.set",
+        actor_user_id=user_id,
+        owner_user_id=owner_user_id,
+        object_type=object_type,
+        object_id=object_id,
+        metadata={"public_permission": public_permission},
+    )
+    return public_permission
 
 
 async def list_shared_with_user(user_id: UUID) -> list[dict]:

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -57,6 +57,37 @@ async def test_create_page_strips_scripts_keeps_structure(scope, _db_pool):
 
 
 @pytest.mark.asyncio
+async def test_inline_svg_keeps_geometry(scope, _db_pool):
+    """Diagrams ship as inline SVG. The shapes' geometry and paint live in
+    attributes (viewBox, d, x/y, fill, marker-end) — if the sanitizer keeps the
+    tags but drops those, every shape collapses and the diagram renders blank.
+    html5ever preserves camelCase for SVG attrs, so the allowlist must too."""
+    scope_id, user_id = scope
+    diagram = (
+        '<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">'
+        '<defs><marker id="a" markerWidth="9" refX="7" orient="auto">'
+        '<path d="M0,0 L7,3 L0,6 Z" fill="#5b6672"/></marker></defs>'
+        '<rect x="16" y="20" width="80" height="40" rx="10" fill="#fff" stroke="#ccc"/>'
+        '<path d="M100 40 L160 40" stroke="#c026d3" marker-end="url(#a)"/>'
+        '<text x="30" y="45" font-size="11" text-anchor="middle">Brain</text>'
+        "</svg>"
+    )
+    page = await files_tree_service.create_page(
+        owner_user_id=scope_id,
+        name="Diagram",
+        created_by=user_id,
+        content_type="html",
+        content_html=diagram,
+    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
+    for attr in ('viewBox="0 0 200 100"', 'refX="7"', 'markerWidth="9"'):
+        assert attr in stored  # camelCased foreign attrs survive with casing intact
+    for attr in ('d="M100 40 L160 40"', 'x="16"', 'rx="10"', 'marker-end="url(#a)"'):
+        assert attr in stored  # geometry + paint survive
+    assert "<marker" in stored and "<defs" in stored
+
+
+@pytest.mark.asyncio
 async def test_title_text_does_not_leak_into_body(scope, _db_pool):
     """A full HTML document carries a <title>. nh3 drops the (disallowed) tag,
     but without clean_content_tags it would keep the title's text and render it

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -1351,3 +1351,168 @@ async def test_session_folder_owner_reads_sessions_they_do_not_own(pool):
         boolean = await permission_service.check_access("session", session_row, viewer)
         predicate = await _predicate_says(pool, "session", session_row, viewer, "read")
         assert boolean == predicate
+
+
+# --- Per-object public link ("anyone with the link", read < comment < write) ---
+
+
+async def _set_public(pool, table, object_id, permission):
+    await pool.execute(
+        f"UPDATE {table} SET public_permission = $1 WHERE id = $2", permission, object_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_read_link_grants_stranger_and_anonymous(pool):
+    """A read link must let anyone — logged in or not — read but never write."""
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    page = await _make_page(pool, owner, owner)
+    await _set_public(pool, "pages", page, "read")
+
+    assert await permission_service.check_access("page", page, stranger)
+    assert await permission_service.check_access("page", page, None)
+    assert not await permission_service.check_access("page", page, stranger, require="write")
+    assert not await permission_service.check_access("page", page, None, require="comment")
+
+
+@pytest.mark.asyncio
+async def test_public_comment_link_grants_comment_not_write(pool):
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    page = await _make_page(pool, owner, owner)
+    await _set_public(pool, "pages", page, "comment")
+
+    assert await permission_service.check_access("page", page, stranger, require="read")
+    assert await permission_service.check_access("page", page, stranger, require="comment")
+    assert not await permission_service.check_access("page", page, stranger, require="write")
+
+
+@pytest.mark.asyncio
+async def test_public_write_link_grants_every_level(pool):
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    page = await _make_page(pool, owner, owner)
+    await _set_public(pool, "pages", page, "write")
+
+    for require in ("read", "comment", "write"):
+        assert await permission_service.check_access("page", page, stranger, require=require)
+
+
+@pytest.mark.asyncio
+async def test_public_folder_cascades_to_contents(pool):
+    """A public folder grants its level to descendant pages/files/tables — the
+    same cascade a folder share gets."""
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    folder = await _make_folder(pool, owner, owner)
+    page = await _make_page(pool, owner, owner, folder_id=folder)
+    file_id = await _make_file(pool, owner, owner, folder_id=folder)
+    await _set_public(pool, "folders", folder, "write")
+
+    assert await permission_service.check_access("page", page, stranger, require="write")
+    assert await permission_service.check_access("file", file_id, None, require="read")
+    assert await permission_service.check_access("folder", folder, None, require="read")
+
+
+@pytest.mark.asyncio
+async def test_public_folder_read_does_not_grant_write_to_contents(pool):
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    folder = await _make_folder(pool, owner, owner)
+    page = await _make_page(pool, owner, owner, folder_id=folder)
+    await _set_public(pool, "folders", folder, "read")
+
+    assert await permission_service.check_access("page", page, stranger, require="read")
+    assert not await permission_service.check_access("page", page, stranger, require="write")
+
+
+@pytest.mark.asyncio
+async def test_no_public_link_stays_private(pool):
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    page = await _make_page(pool, owner, owner)  # public_permission defaults to 'none'
+    assert not await permission_service.check_access("page", page, stranger)
+    assert not await permission_service.check_access("page", page, None)
+
+
+@pytest.mark.asyncio
+async def test_public_link_visibility_and_predicate_agree(pool):
+    owner = await _make_user(pool)
+    stranger = await _make_user(pool)
+    page = await _make_page(pool, owner, owner)
+    assert await permission_service.get_visibility("page", page) == "private"
+
+    await _set_public(pool, "pages", page, "comment")
+    assert await permission_service.get_visibility("page", page) == "public"
+    # check_access and the SQL predicate answer identically for every viewer/level.
+    for viewer in (owner, stranger, None):
+        for require in ("read", "comment", "write"):
+            boolean = await permission_service.check_access("page", page, viewer, require=require)
+            predicate = await _predicate_says(pool, "page", page, viewer, require)
+            assert boolean == predicate
+
+
+@pytest.mark.asyncio
+async def test_general_access_endpoint_makes_page_anonymously_readable(client: AsyncClient, pool):
+    """End-to-end: owner sets 'anyone with the link', then a logged-out client
+    (no Authorization header) reads the page through the canonical route."""
+    owner_key, _ = await _register(client)
+    page_id = (
+        await client.post(
+            "/api/v1/me/pages/new",
+            json={"name": "Schematic", "content": "public diagram"},
+            headers=_auth(owner_key),
+        )
+    ).json()["id"]
+    page_url = f"/api/v1/pages/{page_id}"
+
+    # Restricted by default: an anonymous read (no auth header) is a 404.
+    assert (await client.get(page_url)).status_code == 404
+
+    grant = await client.patch(
+        "/api/v1/share/general-access",
+        json={"object_type": "page", "object_id": page_id, "public_permission": "read"},
+        headers=_auth(owner_key),
+    )
+    assert grant.status_code == 200
+    assert grant.json()["public_permission"] == "read"
+
+    # Now anyone with the link — logged out — can read it.
+    anon = await client.get(page_url)
+    assert anon.status_code == 200
+    assert anon.json()["name"] == "Schematic"
+
+    # The share list reports the current general-access level to the owner UI.
+    shares = await client.get(
+        "/api/v1/share",
+        params={"object_type": "page", "object_id": page_id},
+        headers=_auth(owner_key),
+    )
+    assert shares.json()["general_access"] == "read"
+
+
+@pytest.mark.asyncio
+async def test_general_access_owner_only(client: AsyncClient, pool):
+    """Only the scope owner may change publicity; a stranger gets a 404 (the
+    same not-found guard the share endpoints use)."""
+    owner_key, _ = await _register(client)
+    page_id = (
+        await client.post(
+            "/api/v1/me/pages/new",
+            json={"name": "Plan", "content": "roadmap"},
+            headers=_auth(owner_key),
+        )
+    ).json()["id"]
+    stranger_key, _ = await _register(client)
+
+    denied = await client.patch(
+        "/api/v1/share/general-access",
+        json={"object_type": "page", "object_id": page_id, "public_permission": "write"},
+        headers=_auth(stranger_key),
+    )
+    assert denied.status_code == 404
+    # And the page is still private to the stranger.
+    assert (
+        await client.get(f"/api/v1/pages/{page_id}", headers=_auth(stranger_key))
+    ).status_code == 404

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -27,9 +27,15 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
   const { user, loading, logout } = useAuth();
   const isSkillItemRoute = searchParams.has("skill");
+  // Page and file viewers may hold content with an "anyone with the link"
+  // public grant, so anonymous visitors must reach the viewer instead of being
+  // bounced to /login; the viewer's own read (getPage/getFile) is the gate and
+  // shows an error if the link isn't actually public.
   const isPublicSkillRoute =
     pathname.startsWith("/skills/") ||
     pathname.startsWith("/session-folders/") ||
+    pathname.startsWith("/p/") ||
+    pathname.startsWith("/f/") ||
     isSkillItemRoute;
 
   useEffect(() => {

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -263,6 +263,12 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       ) {
         if (await loadSkillFallback()) return;
       }
+      // A logged-out visitor who can't read this page (it has no public link)
+      // is sent to sign in rather than shown a raw error.
+      if (!user) {
+        router.push("/login");
+        return;
+      }
       setError(e instanceof Error ? e.message : "Failed to load page");
       return;
     }
@@ -283,7 +289,7 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       setFolderChain([]);
     }
     refreshThreads().catch(() => {});
-  }, [pageId, refreshThreads, skillSlug, loadSkillFallback]);
+  }, [pageId, refreshThreads, skillSlug, loadSkillFallback, user, router]);
 
   const reconcileAfterSave = useCallback(
     (savedContent: string, contentType: "markdown" | "html") => {
@@ -426,17 +432,12 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
   );
 
   useEffect(() => {
-    // Anonymous viewers can load this page when ?skill=<slug> is set —
-    // the skill payload is the read source. Authenticated viewers always
-    // try the canonical page endpoint first.
-    if (user) load();
-    else if (!loading && skillSlug) void loadSkillFallback();
-  }, [user, loading, load, loadSkillFallback, skillSlug]);
-
-  useEffect(() => {
-    // Only bounce to login if there's no skill fallback path available.
-    if (!loading && !user && !skillSlug) router.push("/login");
-  }, [user, loading, router, skillSlug]);
+    // Everyone attempts the canonical read: an authenticated viewer via their
+    // token, a logged-out viewer anonymously (which succeeds only for a page
+    // with a public link). load()'s catch handles the skill fallback and, for a
+    // logged-out viewer who can't read a non-public page, the bounce to login.
+    if (!loading) void load();
+  }, [loading, load]);
 
   const handleHtmlAnchorTops = useCallback((iframeAnchorTops: Record<string, number>) => {
     const layout = pageLayoutRef.current;
@@ -499,8 +500,35 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
     return <PageAccessDeniedScreen accountLabel={user?.email ?? user?.name ?? null} />;
   }
   if (!user) {
-    // Login bounce is already firing for the no-skill case.
-    if (!skillSlug) return null;
+    // Anonymous viewer of a public-link page: render read-only, with no editor
+    // chrome. load() has already bounced non-public pages to login.
+    if (page) {
+      return (
+        <div className="scroll-thin flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-[920px] px-12 pb-20 pt-6">
+            <h1 className="m-0 font-display text-[22px] font-bold leading-tight tracking-[-0.015em] text-foreground">
+              {page.name || "(untitled)"}
+            </h1>
+            <div className="mt-6">
+              <PageBody
+                page={{
+                  id: page.id,
+                  name: page.name,
+                  content_type: page.content_type,
+                  content_markdown: page.content_markdown,
+                  content_html: page.content_html,
+                  html_layout: page.html_layout,
+                  updated_at: page.updated_at,
+                  folder_path: [],
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    }
+    // No page yet: load() is still resolving (and bounces to login on failure).
+    if (!skillSlug) return <DocumentPageSkeleton />;
     // Skill mode: waiting on the fallback to land, or it failed.
     if (!error) return <DocumentPageSkeleton />;
     return (

--- a/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ShellChromeContext";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 import {
+  getGeneralAccess,
   getPublicSkill,
   listObjectShares,
   shareObjectByEmail,
@@ -62,6 +63,8 @@ vi.mock("../../../../lib/api", () => ({
   githubOwner: (url: string) =>
     url.replace("https://github.com/", "").split("/")[0],
   listObjectShares: vi.fn(),
+  getGeneralAccess: vi.fn(),
+  updateGeneralAccess: vi.fn(),
   publishSkillFolder: vi.fn(),
   shareObjectByEmail: vi.fn(),
   unpublishSkill: vi.fn(),
@@ -156,6 +159,7 @@ describe("SkillPageClient", () => {
       can_write: true,
     });
     vi.mocked(listObjectShares).mockResolvedValue([]);
+    vi.mocked(getGeneralAccess).mockResolvedValue("none");
     vi.mocked(updateSkill).mockImplementation(async (_skillId, updates) => ({
       ...skillDetail().skill,
       ...updates,

--- a/frontend/src/components/share/ResourceShareButton.test.tsx
+++ b/frontend/src/components/share/ResourceShareButton.test.tsx
@@ -3,15 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ResourceShareButton from "./ResourceShareButton";
 import {
+  getGeneralAccess,
   listObjectShares,
   shareObjectByEmail,
   unshareObject,
+  updateGeneralAccess,
 } from "../../lib/api";
 
 vi.mock("../../lib/api", () => ({
   listObjectShares: vi.fn(),
   shareObjectByEmail: vi.fn(),
   unshareObject: vi.fn(),
+  getGeneralAccess: vi.fn(),
+  updateGeneralAccess: vi.fn(),
 }));
 
 const currentUser = {
@@ -43,6 +47,10 @@ describe("ResourceShareButton", () => {
     ]);
     vi.mocked(shareObjectByEmail).mockResolvedValue(undefined);
     vi.mocked(unshareObject).mockResolvedValue(undefined);
+    vi.mocked(getGeneralAccess).mockResolvedValue("none");
+    vi.mocked(updateGeneralAccess).mockImplementation(
+      async (_type, _id, permission) => permission,
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -10,9 +10,11 @@ import {
 
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import {
+  getGeneralAccess,
   listObjectShares,
   shareObjectByEmail,
   unshareObject,
+  updateGeneralAccess,
   type GeneralPermission,
   type ObjectShare,
   type SharedObjectType,
@@ -26,6 +28,17 @@ const PERMISSIONS: { value: SharePermission; label: string }[] = [
   { value: "comment", label: "Can comment" },
   { value: "write", label: "Can edit" },
 ];
+
+// "Anyone with the link" role labels, mirroring Google Docs.
+const LINK_ROLES: { value: SharePermission; label: string }[] = [
+  { value: "read", label: "Viewer" },
+  { value: "comment", label: "Commenter" },
+  { value: "write", label: "Editor" },
+];
+
+// Object types that carry a per-object public link. Sessions and skills manage
+// visibility through their own flows, so the dropdown is theirs-only.
+const GENERAL_ACCESS_TYPES: SharedObjectType[] = ["page", "file", "folder", "table"];
 
 export default function ResourceShareButton({
   objectType,
@@ -47,7 +60,11 @@ export default function ResourceShareButton({
   const [busy, setBusy] = useState(false);
   const [loadingShares, setLoadingShares] = useState(false);
   const [message, setMessage] = useState("");
+  const [generalAccess, setGeneralAccess] = useState<GeneralPermission>("none");
+  const [savingAccess, setSavingAccess] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const supportsGeneralAccess = GENERAL_ACCESS_TYPES.includes(objectType);
 
   useEscapeKey(open, () => setOpen(false));
 
@@ -61,13 +78,35 @@ export default function ResourceShareButton({
     setLoadingShares(true);
     setMessage("");
     try {
-      setShares(await listObjectShares(objectType, objectId));
+      const [shareRows, access] = await Promise.all([
+        listObjectShares(objectType, objectId),
+        supportsGeneralAccess
+          ? getGeneralAccess(objectType, objectId)
+          : Promise.resolve<GeneralPermission>("none"),
+      ]);
+      setShares(shareRows);
+      setGeneralAccess(access);
     } catch (e) {
       setMessage(e instanceof Error ? e.message : "Could not load access.");
     } finally {
       setLoadingShares(false);
     }
-  }, [objectId, objectType]);
+  }, [objectId, objectType, supportsGeneralAccess]);
+
+  async function changeGeneralAccess(next: GeneralPermission) {
+    const previous = generalAccess;
+    setGeneralAccess(next);
+    setSavingAccess(true);
+    setMessage("");
+    try {
+      setGeneralAccess(await updateGeneralAccess(objectType, objectId, next));
+    } catch (e) {
+      setGeneralAccess(previous);
+      setMessage(e instanceof Error ? e.message : "Could not update access.");
+    } finally {
+      setSavingAccess(false);
+    }
+  }
 
   useEffect(() => {
     if (!open) return;
@@ -285,26 +324,87 @@ export default function ResourceShareButton({
             </h3>
             <div className="mt-2 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2.5">
               <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-base text-muted-foreground ring-1 ring-border">
-                <svg
-                  aria-hidden="true"
-                  className="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
-                  <rect x="5" y="11" width="14" height="10" rx="2" />
-                  <path d="M8 11V8a4 4 0 0 1 8 0v3" />
-                </svg>
+                {generalAccess === "none" ? (
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <rect x="5" y="11" width="14" height="10" rx="2" />
+                    <path d="M8 11V8a4 4 0 0 1 8 0v3" />
+                  </svg>
+                ) : (
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
+                  </svg>
+                )}
               </span>
               <span className="min-w-0 flex-1">
-                <span className="block text-[13px] font-medium text-foreground">
-                  Restricted
-                </span>
-                <span className="block truncate text-[12px] text-muted-foreground">
-                  Only people with access can open this link
-                </span>
+                {supportsGeneralAccess ? (
+                  <>
+                    <select
+                      aria-label="General access"
+                      value={generalAccess === "none" ? "none" : "link"}
+                      disabled={savingAccess}
+                      onChange={(e) =>
+                        void changeGeneralAccess(
+                          e.target.value === "none"
+                            ? "none"
+                            : generalAccess === "none"
+                              ? "read"
+                              : generalAccess,
+                        )
+                      }
+                      className="-ml-1 block cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-[13px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
+                    >
+                      <option value="none">Restricted</option>
+                      <option value="link">Anyone with the link</option>
+                    </select>
+                    <span className="block truncate px-1 text-[12px] text-muted-foreground">
+                      {generalAccess === "none"
+                        ? "Only people with access can open this link"
+                        : "Anyone on the internet with the link can access"}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="block text-[13px] font-medium text-foreground">
+                      Restricted
+                    </span>
+                    <span className="block truncate text-[12px] text-muted-foreground">
+                      Only people with access can open this link
+                    </span>
+                  </>
+                )}
               </span>
+              {supportsGeneralAccess && generalAccess !== "none" && (
+                <select
+                  aria-label="Link role"
+                  value={generalAccess}
+                  disabled={savingAccess}
+                  onChange={(e) =>
+                    void changeGeneralAccess(e.target.value as GeneralPermission)
+                  }
+                  className="shrink-0 cursor-pointer rounded border border-border bg-base px-2 py-1 text-[12px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
+                >
+                  {LINK_ROLES.map((role) => (
+                    <option key={role.value} value={role.value}>
+                      {role.label}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
           </section>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1843,6 +1843,37 @@ export async function listObjectShares(
   return res.shares;
 }
 
+// The object's current "anyone with the link" level ('none' when it's only
+// reachable by the owner and named shares).
+export async function getGeneralAccess(
+  objectType: SharedObjectType,
+  objectId: string,
+): Promise<GeneralPermission> {
+  const res = await apiFetch<{ general_access: GeneralPermission }>(
+    `/api/v1/share?object_type=${objectType}&object_id=${objectId}`,
+  );
+  return res.general_access;
+}
+
+export async function updateGeneralAccess(
+  objectType: SharedObjectType,
+  objectId: string,
+  publicPermission: GeneralPermission,
+): Promise<GeneralPermission> {
+  const res = await apiFetch<{ public_permission: GeneralPermission }>(
+    `/api/v1/share/general-access`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        object_type: objectType,
+        object_id: objectId,
+        public_permission: publicPermission,
+      }),
+    },
+  );
+  return res.public_permission;
+}
+
 export async function shareObjectByEmail(
   objectType: SharedObjectType,
   objectId: string,


### PR DESCRIPTION
## What & why

Two changes:

### 1. Google-Docs-style **General access** for pages / files / folders / tables
A per-object "anyone with the link" grant (`read` < `comment` < `write`) that sits alongside the existing per-person shares. Setting it on a folder cascades to everything inside.

- **Migration 0139** — `public_permission` column (CHECK-constrained) on `pages`, `files`, `folders`, `tables`.
- **Permission core** — new level-aware `_public_permission_condition` (cascades via the existing folder-chain CTE), wired into `readable_content_condition` at *every* require level (publishing stays read-only). `get_visibility` now reports public links. `check_access` is unchanged — it already runs that predicate and is `None`-aware for anonymous callers.
- **API** — `PATCH /api/v1/share/general-access` (owner-gated, mirrors session-folder publicity); `GET /api/v1/share` now returns `general_access`.
- **Anonymous read** — `get_page_by_id` / `get_file_by_id` / file-download switch to `get_current_user_optional`; the canonical page read now enforces `check_access` for the anonymous (`None`) viewer instead of leaning on `get_page`'s trusted-`None` bypass (which exists for in-scope agent callers).
- **Frontend** — the `(app)` layout and `PageClient` let a logged-out visitor reach a public page (read-only render) instead of bouncing to `/login`; a non-public page still routes anonymous viewers to sign in. `ResourceShareButton` replaces the static "Restricted" card with a **Restricted / Anyone-with-the-link + Viewer·Commenter·Editor** dropdown.

**Design decision:** the permission SQL grants write/comment to anyone with the link, but the **write & comment routes still require sign-in** (edits/comments need an author). So an "Editor" link = read while logged out, edit after a free sign-in — matching Docs when attribution matters.

### 2. SVG sanitizer fix
The HTML-page sanitizer allowed SVG *tags* but stripped their geometry/paint *attributes* (`viewBox`, `d`, `x/y`, `fill`, `marker-end`, …) and `<defs>`/`<marker>`, so inline diagrams rendered blank. Adds the SVG attribute + container-tag allowlist (camelCase preserved for `viewBox`/`refX`).

## Testing
- **Backend:** 46 existing permission tests + 9 new (public read/comment/write, folder cascade, owner-gating, end-to-end anonymous HTTP read) + SVG sanitizer test. Migration up/down verified. `ruff` clean.
- **Frontend:** component + `PageClient` tests pass; `tsc`/eslint clean on touched files.
- **Browser QA (live stack):** logged-out viewing of a public page (SVG renders with arrowhead markers), owner dropdown persisting `read`/`comment`/`write`/`none`, role select toggling with scope, and restricted pages 404ing anonymous readers. This QA surfaced and fixed two real bugs static review missed (PageClient eagerly redirected anonymous users to login, and rendered `null` instead of a read-only view).

_Screenshots (public page render + share dropdown) added in the next comment._

## Out of scope
- Session folders keep their existing `none`/`read` model (0109 untouched).
- Logged-out folder **content listing** is deferred (folder read routes are owner-scoped); a public folder still cascades so its pages/files are publicly linkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)