### PR TITLE
Expose the VFS over HTTP so shell-less agents can browse a Stash

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,6 +33,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 RUN playwright install chromium && chown -R stash:stash /opt/playwright
 
 COPY backend/ ./backend/
+# The VFS model + shell, shared verbatim with the `stash vfs` CLI command.
+COPY stashvfs/ ./stashvfs/
 COPY backend/entrypoint.sh ./entrypoint.sh
 COPY alembic.ini ./alembic.ini
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,7 @@ from .routers import (
     trash,
     user_knowledge,
     users,
+    vfs,
     webhooks,
 )
 from .services import demo_service
@@ -139,6 +140,7 @@ app.include_router(security_audit.router)
 app.include_router(tasks.router)
 app.include_router(integrations_router)
 app.include_router(sources.router)
+app.include_router(vfs.router)
 app.include_router(agent_chat.router)
 app.include_router(agent_credentials.router)
 app.include_router(agents.router)

--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -1,0 +1,49 @@
+"""The Stash VFS as an HTTP endpoint.
+
+Same surface as `stash vfs "<command>"`, for agents with no shell to install the
+CLI into. Read-only: the shell has no write commands and rejects redirects.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from stashvfs import MountError
+
+from ..auth import get_current_user
+from ..services import vfs_service
+from ..services.vfs_service import VfsBudgetExceeded
+
+router = APIRouter(prefix="/api/v1/me/vfs", tags=["vfs"])
+
+MAX_SCRIPT_LENGTH = 4096
+
+
+class VfsRequest(BaseModel):
+    script: str = Field(max_length=MAX_SCRIPT_LENGTH)
+    cwd: str = "/"
+
+
+@router.post("")
+async def run_vfs(
+    body: VfsRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    """Run one bash-shaped script (`ls`, `cat`, `find`, `grep`, pipes) over the
+    caller's Stash and return what a terminal would have shown.
+
+    A non-zero `exit_code` is a shell result, not a transport failure — `grep`
+    finding nothing exits 1. Callers read `stdout`/`stderr`, same as a shell.
+    """
+    authorization = request.headers.get("authorization")
+    if not authorization:
+        raise HTTPException(
+            status_code=401,
+            detail="The VFS runs every read as the calling credential; use an API key, not a cookie.",
+        )
+    try:
+        return await vfs_service.run_vfs_script(request.app, authorization, body.script, body.cwd)
+    except MountError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except VfsBudgetExceeded as e:
+        raise HTTPException(status_code=413, detail=str(e)) from e

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -1,0 +1,169 @@
+"""Server-side execution of the Stash VFS shell.
+
+`stash vfs "ls /"` builds the filesystem in the CLI process out of ordinary REST
+reads. Agents that have no shell to install a CLI into — a Vercel function, an
+MCP client — need the same thing over HTTP, so this module runs the identical
+`StashVfsModel` + `SkillAppVfsShell` inside the API.
+
+The model reads through `InProcessVfsClient`, which re-enters this FastAPI app
+over ASGI rather than calling services directly. That costs a routing hop per
+read and buys the thing that matters: every route's authorization runs exactly as
+it does for any other caller, so there is one implementation of who-can-read-what
+instead of two that drift.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import anyio
+import anyio.from_thread
+import anyio.to_thread
+import httpx
+
+from stashvfs import SkillAppVfsShell, StashVfsModel, VfsClientError
+
+# A `grep -r /` loads every document it walks, one nested request each. Past this
+# many the caller has asked for a scan, not a search — fail loud rather than sit
+# on an open connection until the client's own timeout fires.
+MAX_DOCUMENT_READS = 400
+
+SOURCE_ENTRIES_PAGE = 1000
+
+
+class VfsBudgetExceeded(Exception):
+    """More document reads than one shell invocation is allowed. Deliberately not
+    a VfsClientError: the shell downgrades those to per-file warnings, and this
+    must abort the whole command."""
+
+
+class InProcessVfsClient:
+    """`VfsClient` served by the running app over nested ASGI calls.
+
+    Every method mirrors the `cli.client.StashClient` method of the same name,
+    down to the query parameters — the two are alternate transports for one API.
+    """
+
+    def __init__(self, http: httpx.AsyncClient) -> None:
+        self._http = http
+        self._document_reads = 0
+
+    def _request(self, method: str, endpoint: str, **params) -> httpx.Response:
+        response = anyio.from_thread.run(
+            functools.partial(self._http.request, method, endpoint, params=params or None)
+        )
+        if response.status_code >= 400:
+            raise VfsClientError(_error_detail(response))
+        return response
+
+    def _get(self, endpoint: str, **params) -> dict | list:
+        return self._request("GET", endpoint, **params).json()
+
+    def _read_document(self, method: str, endpoint: str, **params) -> httpx.Response:
+        """A fetch of a node's bytes, as opposed to a listing. Only these are
+        budgeted: listings are bounded by the model's own entry ceiling."""
+        self._document_reads += 1
+        if self._document_reads > MAX_DOCUMENT_READS:
+            raise VfsBudgetExceeded(
+                f"command read more than {MAX_DOCUMENT_READS} documents; "
+                "scope it to a subdirectory or use search"
+            )
+        return self._request(method, endpoint, **params)
+
+    # ── Listings, walked during refresh() ──────────────────────────────
+
+    def get_overview(self) -> dict:
+        return self._get("/api/v1/me/overview")
+
+    def get_memory_folder(self) -> dict:
+        return self._get("/api/v1/me/memory-folder")
+
+    def list_tables(self) -> list:
+        return self._get("/api/v1/me/tables")["tables"]
+
+    def list_sources(self) -> list:
+        return self._get("/api/v1/me/sources")["sources"]
+
+    def list_source_entries_page(
+        self, source: str, path: str = "", after: str = ""
+    ) -> tuple[list, bool]:
+        data = self._get(
+            f"/api/v1/me/sources/{source}/entries",
+            path=path,
+            limit=SOURCE_ENTRIES_PAGE + 1,
+            after=after,
+        )
+        entries = data["entries"]
+        truncated = len(entries) > SOURCE_ENTRIES_PAGE
+        return entries[:SOURCE_ENTRIES_PAGE], truncated
+
+    # ── Node bodies, loaded lazily on read ─────────────────────────────
+
+    def get_page(self, page_id: str) -> dict:
+        return self._read_document("GET", f"/api/v1/pages/{page_id}").json()
+
+    def download_file(self, file_id: str) -> bytes:
+        return self._read_document("GET", f"/api/v1/me/files/{file_id}/download").content
+
+    def get_skill_text(self, slug: str) -> str:
+        return self._read_document("GET", f"/api/v1/skills/{slug}", format="text").text
+
+    def get_transcript_events(self, session_id: str) -> list:
+        path = f"/api/v1/me/transcripts/{session_id}/events"
+        return self._read_document("GET", path).json()["events"]
+
+    def export_transcript_jsonl(self, session_id: str) -> str:
+        path = f"/api/v1/me/transcripts/{session_id}/export.jsonl"
+        return self._read_document("GET", path).text
+
+    def get_table(self, table_id: str) -> dict:
+        return self._read_document("GET", f"/api/v1/me/tables/{table_id}").json()
+
+    def list_table_rows(self, table_id: str, limit: int = 50, offset: int = 0) -> dict:
+        path = f"/api/v1/me/tables/{table_id}/rows"
+        return self._read_document("GET", path, limit=limit, offset=offset, sort_order="asc").json()
+
+    def read_source_doc(self, source: str, ref: str) -> dict:
+        return self._read_document("GET", f"/api/v1/me/sources/{source}/doc", ref=ref).json()
+
+
+def _error_detail(response: httpx.Response) -> str:
+    """The route's `detail` when it raised HTTPException, else the status line.
+    This lands in the shell's stderr, so a 404 on one document reads as a warning
+    naming that document."""
+    if response.headers.get("content-type", "").startswith("application/json"):
+        body = response.json()
+        if isinstance(body, dict) and "detail" in body:
+            return str(body["detail"])
+    return f"HTTP {response.status_code}"
+
+
+def _run_script(http: httpx.AsyncClient, script: str, cwd: str) -> dict:
+    """Blocking: the model and shell are synchronous, and their lazy loaders reach
+    back into the event loop through `anyio.from_thread`. Runs in a worker thread
+    for that reason — see `run_vfs_script`."""
+    model = StashVfsModel(InProcessVfsClient(http), include_computer=False)
+    model.refresh()
+    result = SkillAppVfsShell(model, cwd=cwd).run(script)
+    return {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "exit_code": result.exit_code,
+        "cwd": result.cwd,
+    }
+
+
+async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict:
+    """Execute one read-only shell script against the caller's Stash.
+
+    `authorization` is forwarded verbatim onto every nested request, so the VFS
+    sees precisely what that credential sees anywhere else in the API.
+    """
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://vfs.internal",
+        headers={"Authorization": authorization},
+        timeout=None,
+    ) as http:
+        return await anyio.to_thread.run_sync(functools.partial(_run_script, http, script, cwd))

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -1,0 +1,170 @@
+"""The VFS shell, served over HTTP.
+
+The point of the endpoint is that an agent with no shell — a Vercel function, an
+MCP client — gets the same filesystem the `stash vfs` CLI command gives an agent
+that does. These tests pin the two properties that make that safe to hand a
+partner: reads run as the calling credential, and the caller's cloud computer is
+not part of the tree.
+"""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import source_service
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("vfs"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _vfs(client: AsyncClient, api_key: str, script: str, cwd: str = "/"):
+    return await client.post(
+        "/api/v1/me/vfs",
+        json={"script": script, "cwd": cwd},
+        headers=_auth(api_key),
+    )
+
+
+async def _make_page(client: AsyncClient, api_key: str, name: str, content: str) -> str:
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": name, "content": content},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _make_source_doc(owner_id: UUID, path: str, name: str, content: str) -> None:
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref=f"acme/{unique_name('repo')}",
+        display_name="Specs",
+    )
+    await source_service.upsert_content_document(
+        table="github_documents",
+        source_id=UUID(src["id"]),
+        owner_user_id=owner_id,
+        path=path,
+        name=name,
+        content=content,
+    )
+
+
+async def test_ls_root_lists_the_mounts(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "ls /")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exit_code"] == 0
+    listed = body["stdout"].split()
+    assert {"files", "sessions", "skills", "tables"} <= set(listed)
+
+
+async def test_computer_is_not_mounted_server_side(client: AsyncClient):
+    """A key handed to a partner's production agent must not reach through the
+    API into a real machine's disk. /computer exists only in the CLI's mount."""
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "ls /")
+
+    assert "computer" not in resp.json()["stdout"].split()
+
+
+async def test_cat_reads_a_page_body(client: AsyncClient):
+    """Page bodies load through a lazy loader that re-enters the app. If the
+    nested request loses the caller's credential, this is where it shows up."""
+    api_key, _ = await _register(client)
+    await _make_page(client, api_key, "Runbook", "# Deploy\nrun the migration first")
+
+    resp = await _vfs(client, api_key, "cat '/files/Runbook.md'")
+
+    assert resp.status_code == 200
+    assert "run the migration first" in resp.json()["stdout"]
+
+
+async def test_grep_searches_connected_source_documents(client: AsyncClient):
+    api_key, owner_id = await _register(client)
+    await _make_source_doc(owner_id, "specs/auth.md", "auth.md", "tokens rotate hourly")
+
+    resp = await _vfs(client, api_key, "grep -ri 'rotate hourly' /sources")
+
+    assert resp.status_code == 200
+    assert "auth.md" in resp.json()["stdout"]
+
+
+async def test_reads_are_scoped_to_the_calling_credential(client: AsyncClient):
+    """The whole authorization argument for this endpoint: it re-enters the app's
+    own routes, so one user's key cannot see another user's page."""
+    owner_key, _ = await _register(client)
+    await _make_page(client, owner_key, "Secrets", "the launch date is may fourth")
+
+    other_key, _ = await _register(client)
+    resp = await _vfs(client, other_key, "grep -ri 'launch date' /files")
+
+    assert resp.status_code == 200
+    assert "may fourth" not in resp.json()["stdout"]
+    assert "Secrets" not in resp.json()["stdout"]
+
+
+async def test_grep_with_no_match_exits_nonzero_without_failing_the_request(
+    client: AsyncClient,
+):
+    """A shell result, not a transport error. Callers must be able to tell the
+    difference between `grep` finding nothing and the endpoint breaking."""
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "grep -ri 'nothing matches this' /files")
+
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] != 0
+
+
+async def test_writes_are_rejected(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "echo hi > /files/x.md")
+
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] != 0
+
+
+async def test_unknown_cwd_is_a_client_error(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "ls", cwd="/nope")
+
+    assert resp.status_code == 400
+
+
+async def test_document_read_budget_aborts_the_command(client: AsyncClient, monkeypatch):
+    """An unscoped `grep -r /` would walk every document in every source. The
+    ceiling must abort the command, not degrade into a per-file warning that the
+    caller reads as 'no matches'."""
+    monkeypatch.setattr("backend.services.vfs_service.MAX_DOCUMENT_READS", 1)
+    api_key, _ = await _register(client)
+    await _make_page(client, api_key, "One", "alpha")
+    await _make_page(client, api_key, "Two", "beta")
+
+    resp = await _vfs(client, api_key, "grep -ri 'alpha' /files")
+
+    assert resp.status_code == 413

--- a/cli/client.py
+++ b/cli/client.py
@@ -9,12 +9,16 @@ from pathlib import Path
 
 import httpx
 
+from stashvfs import VfsClientError
 
-class StashError(Exception):
+
+class StashError(VfsClientError):
     def __init__(self, status_code: int, detail):
         self.status_code = status_code
-        self.detail = detail
-        super().__init__(f"[{status_code}] {detail}")
+        super().__init__(detail)
+
+    def __str__(self) -> str:
+        return f"[{self.status_code}] {self.detail}"
 
 
 # Page size when the VFS walks a source's entries. Callers page with the

--- a/cli/main.py
+++ b/cli/main.py
@@ -4320,8 +4320,7 @@ def vfs_command(
     cwd: str = typer.Option("/", "--cwd", help="Virtual working directory."),
 ):
     """Run bash-shaped commands against Stash sources."""
-    from .app_vfs import SkillAppVfsShell
-    from .mount import MountError, StashVfsModel
+    from stashvfs import MountError, SkillAppVfsShell, StashVfsModel
 
     cfg = load_config()
     if not cfg.get("api_key"):
@@ -4330,7 +4329,7 @@ def vfs_command(
 
     client = StashClient(base_url=cfg["base_url"], api_key=cfg["api_key"])
     try:
-        model = StashVfsModel(client)
+        model = StashVfsModel(client, include_computer=True)
         model.refresh()
         shell = SkillAppVfsShell(model, cwd=cwd)
 

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -2,10 +2,10 @@ import re
 import shlex
 from datetime import datetime
 
-from cli.app_vfs import SkillAppVfsShell, _ls_time
 from cli.client import StashError
-from cli.mount import StashVfsModel
 from cli.tests.test_mount_vfs import FakeClient
+from stashvfs import StashVfsModel
+from stashvfs.shell import SkillAppVfsShell, _ls_time
 
 
 class DeadTranscriptClient(FakeClient):
@@ -70,7 +70,7 @@ class CountingClient(FakeClient):
 
 def _shell(client=None):
     client = client or FakeClient()
-    model = StashVfsModel(client)
+    model = StashVfsModel(client, include_computer=True)
     model.refresh()
     return SkillAppVfsShell(model), client
 
@@ -335,7 +335,7 @@ def test_source_listing_follows_pages_to_completion():
 
 
 def test_find_warns_loudly_when_a_source_exceeds_the_materialization_ceiling(monkeypatch):
-    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    monkeypatch.setattr("stashvfs.model.SOURCE_ENTRIES_MAX", 4)
     shell, _client = _shell(PagedSourceClient())
 
     result = shell.run("find /sources/gmail -type f")
@@ -374,7 +374,7 @@ def test_stat_omits_external_ref_when_the_entry_has_none():
 
 
 def test_tree_warns_when_a_source_exceeds_the_materialization_ceiling(monkeypatch):
-    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    monkeypatch.setattr("stashvfs.model.SOURCE_ENTRIES_MAX", 4)
     shell, _client = _shell(PagedSourceClient())
 
     result = shell.run("tree /sources/gmail")
@@ -384,7 +384,7 @@ def test_tree_warns_when_a_source_exceeds_the_materialization_ceiling(monkeypatc
 
 
 def test_ls_warns_inside_a_truncated_source_but_not_above_it(monkeypatch):
-    monkeypatch.setattr("cli.mount.SOURCE_ENTRIES_MAX", 4)
+    monkeypatch.setattr("stashvfs.model.SOURCE_ENTRIES_MAX", 4)
     shell, _client = _shell(PagedSourceClient())
 
     # Listing the source root — children come from the capped materialization.

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -1,4 +1,4 @@
-from cli.mount import StashVfsModel
+from stashvfs import StashVfsModel
 
 
 class FakeClient:
@@ -150,7 +150,7 @@ class FakeClient:
 
 
 def _model():
-    model = StashVfsModel(FakeClient())
+    model = StashVfsModel(FakeClient(), include_computer=True)
     model.refresh()
     return model
 
@@ -186,7 +186,7 @@ def test_vfs_loads_source_entries_lazily():
     # Listing source names must not fetch any source's contents — that's the
     # whole point: enumerating a 10k-doc source costs the same as a 1-doc one.
     client = FakeClient()
-    model = StashVfsModel(client)
+    model = StashVfsModel(client, include_computer=True)
     model.refresh()
     sources_path = "/sources"
 
@@ -228,7 +228,7 @@ def test_vfs_keeps_children_of_a_page_that_has_its_own_body():
     # A page that is both content and a parent must not swallow its children.
     # It becomes a directory; its body lives in a same-named index file so the
     # children stay reachable alongside it.
-    model = StashVfsModel(NestedPagesClient())
+    model = StashVfsModel(NestedPagesClient(), include_computer=True)
     model.refresh()
     # Sole notion connection collapses into /sources/notion (see _add_sources).
     parent = "/sources/notion/Parent"
@@ -277,7 +277,7 @@ class DuplicateNameClient(FakeClient):
 
 
 def test_vfs_suffixes_only_colliding_names():
-    model = StashVfsModel(DuplicateNameClient())
+    model = StashVfsModel(DuplicateNameClient(), include_computer=True)
     model.refresh()
 
     entries = set(model.list_dir("/tables"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ stash = "cli.main:app"
 stash-mcp = "cli.mcp_server:main"
 
 [tool.setuptools.packages.find]
-include = ["cli*", "stashai*"]
+include = ["cli*", "stashai*", "stashvfs*"]
 
 [tool.setuptools.package-data]
 stashai = ["plugin/assets/**/*"]

--- a/stashvfs/__init__.py
+++ b/stashvfs/__init__.py
@@ -1,0 +1,17 @@
+"""Read-only virtual filesystem over Stash — the model, the shell, and the client
+contract that backs them. Shared by the `stash vfs` CLI command and the
+`/api/v1/me/vfs` endpoint."""
+
+from .client import MachineVfsClient, VfsClient, VfsClientError
+from .model import MountError, StashVfsModel
+from .shell import SkillAppVfsShell, VfsCommandResult
+
+__all__ = [
+    "MachineVfsClient",
+    "MountError",
+    "SkillAppVfsShell",
+    "StashVfsModel",
+    "VfsClient",
+    "VfsClientError",
+    "VfsCommandResult",
+]

--- a/stashvfs/client.py
+++ b/stashvfs/client.py
@@ -1,0 +1,66 @@
+"""The read contract a VFS backend must satisfy.
+
+Two implementations exist: `cli.client.StashClient` (HTTP, for the `stash vfs`
+command) and `backend.services.vfs_service.InProcessVfsClient` (nested ASGI, for
+the `/api/v1/me/vfs` endpoint). `StashVfsModel` is written against this Protocol
+and knows about neither.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class VfsClientError(Exception):
+    """A VFS backend could not fetch a node.
+
+    Raised per-node, not per-command: the shell catches this so that one
+    unreadable document downgrades to a warning on stderr instead of failing the
+    whole `grep -r`. `detail` is what gets printed.
+    """
+
+    def __init__(self, detail: object) -> None:
+        self.detail = detail
+        super().__init__(str(detail))
+
+
+class VfsClient(Protocol):
+    """Everything `StashVfsModel` reads. Listing calls run during `refresh()`;
+    the rest are lazy loaders fired when a file's bytes are first read."""
+
+    def get_overview(self) -> dict: ...
+
+    def get_memory_folder(self) -> dict: ...
+
+    def get_page(self, page_id: str) -> dict: ...
+
+    def download_file(self, file_id: str) -> bytes: ...
+
+    def get_skill_text(self, slug: str) -> str: ...
+
+    def get_transcript_events(self, session_id: str) -> list: ...
+
+    def export_transcript_jsonl(self, session_id: str) -> str: ...
+
+    def list_tables(self) -> list: ...
+
+    def get_table(self, table_id: str) -> dict: ...
+
+    def list_table_rows(self, table_id: str, limit: int = 50, offset: int = 0) -> dict: ...
+
+    def list_sources(self) -> list: ...
+
+    def list_source_entries_page(
+        self, source: str, path: str = "", after: str = ""
+    ) -> tuple[list, bool]: ...
+
+    def read_source_doc(self, source: str, ref: str) -> dict: ...
+
+
+class MachineVfsClient(VfsClient, Protocol):
+    """A `VfsClient` that can also read the user's cloud computer. Only the CLI
+    implements this; it is what `include_computer=True` requires."""
+
+    def machine_fs_list(self, path: str) -> list: ...
+
+    def machine_fs_read(self, path: str) -> bytes: ...

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from .client import StashClient, StashError
+from .client import MachineVfsClient, VfsClient, VfsClientError
 
 BytesLoader = Callable[[], bytes]
 
@@ -52,8 +52,12 @@ class VfsNode:
 
 
 class StashVfsModel:
-    def __init__(self, client: StashClient):
+    def __init__(self, client: VfsClient | MachineVfsClient, *, include_computer: bool):
+        # `include_computer` mounts the user's cloud computer at /computer, which
+        # requires a MachineVfsClient. The server-side VFS leaves it off: an API
+        # key issued to a partner must not reach through to a real machine's disk.
         self.client = client
+        self.include_computer = include_computer
         self.nodes: dict[str, VfsNode] = {}
         # Source-root path -> thunk that fetches that source's entries. A source's
         # contents are materialized only when something first descends into it, so
@@ -69,6 +73,14 @@ class StashVfsModel:
         self._truncated = {}
         self._add_dir("/")
         self._add_root()
+        computer_lines = (
+            [
+                "- `computer` is a live, read-only view of your cloud "
+                "computer's disk (browsing may wake it).",
+            ]
+            if self.include_computer
+            else []
+        )
         self._add_static_file(
             "/README.md",
             "\n".join(
@@ -82,8 +94,7 @@ class StashVfsModel:
                     "- Sessions, skills, and tables are read-only projections.",
                     "- `sources` exposes connected integrations (Gmail, "
                     "GitHub, Slack, Jira, …) as read-only documents.",
-                    "- `computer` is a live, read-only view of your cloud "
-                    "computer's disk (browsing may wake it).",
+                    *computer_lines,
                     "",
                     "Listings are alphabetical by name; they carry no time meaning.",
                     "For recency use `ls -lt` (sort by modified time), "
@@ -147,7 +158,8 @@ class StashVfsModel:
         self._add_sessions(overview.get("sessions", []))
         self._add_tables()
         self._add_sources()
-        self._add_computer()
+        if self.include_computer:
+            self._add_computer()
 
     def _add_computer(self) -> None:
         """The user's cloud computer, projected read-through at /computer.
@@ -162,7 +174,7 @@ class StashVfsModel:
     def _expand_computer_dir(self, dir_path: str, rel_path: str) -> None:
         try:
             entries = self.client.machine_fs_list(rel_path)
-        except StashError:
+        except VfsClientError:
             return
         for entry in entries:
             child_rel = f"{rel_path}/{entry['name']}" if rel_path else entry["name"]
@@ -349,7 +361,7 @@ class StashVfsModel:
         document bodies load lazily on read."""
         try:
             sources = self.client.list_sources()
-        except StashError:
+        except VfsClientError:
             return
         connected = [s for s in sources if not str(s.get("type", "")).startswith("native_")]
         if not connected:
@@ -381,7 +393,7 @@ class StashVfsModel:
         while True:
             try:
                 page, truncated = self.client.list_source_entries_page(handle, "", after=after)
-            except StashError:
+            except VfsClientError:
                 break
             entries.extend(page)
             if not truncated:

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -10,8 +10,8 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 
-from .client import StashError
-from .mount import MountError, StashVfsModel
+from .client import VfsClientError
+from .model import MountError, StashVfsModel
 
 
 @dataclass
@@ -86,7 +86,7 @@ class SkillAppVfsShell:
             return self._stage_result(stderr=f"{name}: {message}\n", exit_code=1)
         except (MountError, ValueError) as e:
             return self._stage_result(stderr=f"{name}: {e}\n", exit_code=2)
-        except StashError as e:
+        except VfsClientError as e:
             return self._stage_result(stderr=f"{name}: {e}\n", exit_code=2)
 
     def _stage_result(
@@ -457,7 +457,7 @@ class SkillAppVfsShell:
             for file_path in file_paths:
                 try:
                     text = self._read_text(file_path)
-                except StashError as e:
+                except VfsClientError as e:
                     self._warn(f"{name}: {file_path}: {e.detail}")
                     continue
                 matches.append(


### PR DESCRIPTION
## Why

`stash vfs "ls /"` builds the filesystem **inside the CLI process**, out of ordinary REST reads. That only works somewhere the CLI is installed.

Heavi's production agent is a tool-calling loop on Vercel serverless — no shell, read-only filesystem, no Python. There is nowhere to `uv tool install stashai`. Same story for any MCP client. Today those agents get the four-endpoint read surface (`search` / `list_sources` / `browse` / `read_doc`) and cannot walk, `grep`, or `cat` anything.

This adds `POST /api/v1/me/vfs`, which runs the **same model and the same shell** inside the API.

```
POST /api/v1/me/vfs
{ "script": "grep -ri 'rotate hourly' /sources", "cwd": "/" }

→ { "stdout": "...", "stderr": "", "exit_code": 0, "cwd": "/" }
```

A non-zero `exit_code` is a shell result, not a transport failure — `grep` finding nothing exits 1, and the request is still a 200.

## Shape of the change

**The model and shell move out of `cli/` into a new top-level `stashvfs/` package**, shared verbatim by both callers. This wasn't optional: `backend/Dockerfile` only copies `backend/`, so the backend could never have imported `cli/`. `StashVfsModel` is now written against a `VfsClient` Protocol rather than against `StashClient`, which is what makes two transports possible. `git mv` preserves history; no logic was copied.

**`InProcessVfsClient` re-enters this FastAPI app over ASGI** rather than calling services directly. I originally planned the latter. Reading the handlers changed my mind: it would have meant reimplementing six authorization checks — `_check_overview_access`, `_can_access_file`, `_check_table_access`, `can_read_session`, `_require_member`, `_check_read` — in a parallel code path, where one mistake leaks another user's data. Going through the routes costs a routing hop per read and keeps a single implementation of who-can-read-what. The caller's `Authorization` header is forwarded verbatim onto every nested request.

The model is synchronous and its loaders are lazy, so the shell runs in a worker thread (`anyio.to_thread.run_sync`) and the adapter hops back to the loop per read (`anyio.from_thread.run`).

## Two safety properties, both tested

- **`/computer` is not mounted server-side.** It's a live read of a user's cloud computer disk, and an API key issued to a partner must not reach through to it. `include_computer` is now explicit at the call site — the CLI passes `True`, the endpoint passes `False`.
- **400-document read ceiling per invocation.** An unscoped `grep -r /` would otherwise walk every document in every connected source. `VfsBudgetExceeded` is deliberately *not* a `VfsClientError`, because the shell downgrades those to per-file warnings — which an agent would read as "no matches found." It aborts the command with a 413.

## Testing

- `backend/tests/test_vfs.py` — 9 new tests. The load-bearing one is `test_reads_are_scoped_to_the_calling_credential`: one user's key cannot `grep` another user's page.
- `cli/tests` — 105 pass unchanged against the moved package.
- `backend/tests/test_sources.py` — 85 pass, no regression.
- `ruff check` and `ruff format --check` clean.

Found and fixed while testing: `_get(self, path, **params)` shadowed the `path` query parameter the source-entries endpoint takes, which made every `find /sources` a 500. The CLI client sidesteps this by naming the argument `endpoint`; this one now does too.

## Note for callers

This shell's `grep` supports `-i`, `-r`, `-n`, `-A`/`-B`/`-C`. There is **no `-l`**. Recursive grep already prints `path:line`.

No GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)