### PR TITLE
VFS: read file bodies concurrently

### DIFF
--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -14,10 +14,11 @@ instead of two that drift.
 
 from __future__ import annotations
 
+import asyncio
 import functools
+import threading
 
 import anyio
-import anyio.from_thread
 import anyio.to_thread
 import httpx
 
@@ -44,14 +45,21 @@ class InProcessVfsClient:
     down to the query parameters — the two are alternate transports for one API.
     """
 
-    def __init__(self, http: httpx.AsyncClient) -> None:
+    def __init__(self, http: httpx.AsyncClient, loop: asyncio.AbstractEventLoop) -> None:
         self._http = http
+        self._loop = loop
         self._document_reads = 0
+        self._reads_lock = threading.Lock()
 
     def _request(self, method: str, endpoint: str, **params) -> httpx.Response:
-        response = anyio.from_thread.run(
-            functools.partial(self._http.request, method, endpoint, params=params or None)
+        # Dispatched onto the app's event loop from whichever thread we are on.
+        # `StashVfsModel.prefetch` calls loaders from a pool, so this must work
+        # from an arbitrary thread — not just anyio's worker, which is all
+        # `anyio.from_thread.run` supports.
+        future = asyncio.run_coroutine_threadsafe(
+            self._http.request(method, endpoint, params=params or None), self._loop
         )
+        response = future.result()
         if response.status_code >= 400:
             raise VfsClientError(_error_detail(response))
         return response
@@ -62,8 +70,10 @@ class InProcessVfsClient:
     def _read_document(self, method: str, endpoint: str, **params) -> httpx.Response:
         """A fetch of a node's bytes, as opposed to a listing. Only these are
         budgeted: listings are bounded by the model's own entry ceiling."""
-        self._document_reads += 1
-        if self._document_reads > MAX_DOCUMENT_READS:
+        with self._reads_lock:
+            self._document_reads += 1
+            over_budget = self._document_reads > MAX_DOCUMENT_READS
+        if over_budget:
             raise VfsBudgetExceeded(
                 f"command read more than {MAX_DOCUMENT_READS} documents; "
                 "scope it to a subdirectory or use search"
@@ -138,11 +148,13 @@ def _error_detail(response: httpx.Response) -> str:
     return f"HTTP {response.status_code}"
 
 
-def _run_script(http: httpx.AsyncClient, script: str, cwd: str) -> dict:
+def _run_script(
+    http: httpx.AsyncClient, loop: asyncio.AbstractEventLoop, script: str, cwd: str
+) -> dict:
     """Blocking: the model and shell are synchronous, and their lazy loaders reach
-    back into the event loop through `anyio.from_thread`. Runs in a worker thread
-    for that reason — see `run_vfs_script`."""
-    model = StashVfsModel(InProcessVfsClient(http), include_computer=False)
+    back into `loop` to issue their requests. Runs in a worker thread for that
+    reason — see `run_vfs_script`."""
+    model = StashVfsModel(InProcessVfsClient(http, loop), include_computer=False)
     model.refresh()
     result = SkillAppVfsShell(model, cwd=cwd).run(script)
     return {
@@ -159,6 +171,7 @@ async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict
     `authorization` is forwarded verbatim onto every nested request, so the VFS
     sees precisely what that credential sees anywhere else in the API.
     """
+    loop = asyncio.get_running_loop()
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(
         transport=transport,
@@ -166,4 +179,6 @@ async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict
         headers={"Authorization": authorization},
         timeout=None,
     ) as http:
-        return await anyio.to_thread.run_sync(functools.partial(_run_script, http, script, cwd))
+        return await anyio.to_thread.run_sync(
+            functools.partial(_run_script, http, loop, script, cwd)
+        )

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -1,4 +1,6 @@
-from stashvfs import StashVfsModel
+import threading
+
+from stashvfs import StashVfsModel, VfsClientError
 
 
 class FakeClient:
@@ -288,3 +290,134 @@ def test_vfs_suffixes_only_colliding_names():
     assert "Untitled table--aaaaaaaa" in entries
     assert "Untitled table--bbbbbbbb" in entries
     assert "Untitled table" not in entries
+
+
+class CountingLoaderClient(FakeClient):
+    """Records every document body fetched, and whether two fetches ever overlapped.
+
+    `prefetch` exists to turn one round trip per file into one batch of round
+    trips. If it ever double-fetched, a `grep -r` over Drive would double the
+    calls we make to Google — so the call count, not just the output, is the
+    thing under test.
+
+    Overlap is detected with a two-party barrier rather than by counting threads:
+    a pool whose work finishes instantly may serve every task on one worker, so
+    thread identity proves nothing."""
+
+    def __init__(self):
+        super().__init__()
+        self.doc_reads: list[str] = []
+        self.overlapped = False
+        self._lock = threading.Lock()
+        self._barrier = threading.Barrier(2, timeout=1.0)
+
+    def read_source_doc(self, source, ref):
+        with self._lock:
+            self.doc_reads.append(ref)
+        try:
+            self._barrier.wait()
+        except threading.BrokenBarrierError:
+            return {"content": f"needle in {ref}"}
+        with self._lock:
+            self.overlapped = True
+        return {"content": f"needle in {ref}"}
+
+
+def _grep_gmail(concurrency: int) -> tuple[str, CountingLoaderClient]:
+    import stashvfs.model as model_module
+    from stashvfs import SkillAppVfsShell
+
+    original = model_module.PREFETCH_CONCURRENCY
+    model_module.PREFETCH_CONCURRENCY = concurrency
+    try:
+        client = CountingLoaderClient()
+        model = StashVfsModel(client, include_computer=True)
+        model.refresh()
+        result = SkillAppVfsShell(model).run("grep -ri needle /sources/gmail")
+        return result.stdout, client
+    finally:
+        model_module.PREFETCH_CONCURRENCY = original
+
+
+def test_prefetch_does_not_change_what_grep_finds():
+    """Concurrency is an optimization. If it altered results — dropped a file,
+    reordered matches — a `grep` would silently answer differently depending on
+    how many workers happened to run."""
+    serial_output, serial_client = _grep_gmail(1)
+    parallel_output, parallel_client = _grep_gmail(12)
+
+    assert serial_output == parallel_output
+    assert serial_output != ""
+    assert sorted(serial_client.doc_reads) == sorted(parallel_client.doc_reads)
+
+
+def test_prefetch_reads_each_file_exactly_once():
+    _, client = _grep_gmail(12)
+
+    assert len(client.doc_reads) == len(set(client.doc_reads))
+    assert len(client.doc_reads) > 1
+
+
+def test_prefetch_fetches_bodies_concurrently():
+    """Guards the fix itself: a `prefetch` that quietly ran serially would still
+    pass every other test here, and Drive would still take a minute. Two loaders
+    must be in flight at once for the barrier to release."""
+    _, client = _grep_gmail(12)
+
+    assert client.overlapped
+
+
+def test_prefetch_left_serial_does_not_overlap():
+    """The control. Proves the barrier above is actually detecting concurrency
+    rather than always releasing."""
+    _, client = _grep_gmail(1)
+
+    assert not client.overlapped
+
+
+class FailingLoaderClient(FakeClient):
+    """A source whose bodies cannot be read — an expired token, a Drive file with
+    no export, a provider 500. The listing still works; every read fails."""
+
+    def __init__(self):
+        super().__init__()
+        self.doc_reads: list[str] = []
+        self._lock = threading.Lock()
+
+    def read_source_doc(self, source, ref):
+        with self._lock:
+            self.doc_reads.append(ref)
+        raise VfsClientError(f"cannot read {ref}")
+
+
+def test_a_failed_read_is_not_retried_by_the_grep_loop():
+    """prefetch and the read that follows it must not both hit the provider.
+
+    Server-side each read spends one unit of the document budget, charged before
+    the request is issued — so a file fetched twice on failure spends two units.
+    A directory of unreadable files could then abort a command that was well
+    inside its ceiling, throwing away matches already found in the readable ones."""
+    from stashvfs import SkillAppVfsShell
+
+    client = FailingLoaderClient()
+    model = StashVfsModel(client, include_computer=True)
+    model.refresh()
+
+    result = SkillAppVfsShell(model).run("grep -ri needle /sources/gmail")
+
+    assert len(client.doc_reads) == len(set(client.doc_reads))
+    assert "cannot read" in result.stderr
+
+
+def test_a_failed_read_still_warns_per_file_and_does_not_abort():
+    """The old behavior, preserved: an unreadable file is a warning on stderr, not
+    a dead command. Caching the error must not turn it into something else."""
+    from stashvfs import SkillAppVfsShell
+
+    model = StashVfsModel(FailingLoaderClient(), include_computer=True)
+    model.refresh()
+
+    result = SkillAppVfsShell(model).run("grep -ri needle /sources/gmail")
+
+    assert result.exit_code == 1  # grep found nothing, rather than crashing
+    assert result.stderr.count("cannot read") == 2

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -11,6 +11,7 @@ import stat
 import time
 from collections import Counter
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -22,6 +23,11 @@ BytesLoader = Callable[[], bytes]
 # gets a truncation warning from the listing commands rather than an
 # ever-growing tree walk.
 SOURCE_ENTRIES_MAX = 10_000
+
+# How many file bodies `prefetch` loads at once. Each load is one request to the
+# backend, and for an index-only source (Drive, Notion, Gmail) the backend then
+# makes one request to the provider — so this is also how hard we hit Google.
+PREFETCH_CONCURRENCY = 12
 
 
 class MountError(Exception):
@@ -41,6 +47,10 @@ class VfsNode:
     # Provider-side id of a connected-source document (a Drive file id, a Gmail
     # message id, …), so `stat` can tie a VFS path back to the provider object.
     external_ref: str | None = None
+    # Set when `prefetch` already tried this loader and it failed. `read_file`
+    # re-raises it rather than fetching again — a second fetch would hit the
+    # provider twice and, server-side, spend the document budget twice.
+    error: VfsClientError | None = None
 
     @property
     def is_dir(self) -> bool:
@@ -122,6 +132,8 @@ class StashVfsModel:
         node = self._get_node(path)
         if not node.is_file:
             raise IsADirectoryError(path)
+        if node.error is not None:
+            raise node.error
         if node.content is None:
             if node.loader is None:
                 node.content = b""
@@ -129,6 +141,49 @@ class StashVfsModel:
                 node.content = node.loader()
                 node.size_hint = len(node.content)
         return node.content
+
+    def prefetch(self, paths: list[str]) -> None:
+        """Load these files' bodies concurrently, so a later `read_file` on each
+        is a cache hit. A whole-directory `grep` reads every file it walks; done
+        one at a time that is a round trip per file, and for Drive a round trip
+        to Google per file.
+
+        Nodes are resolved on this thread — expanding a lazy subtree mutates the
+        tree — and only the loaders run in the pool.
+
+        Every file is fetched exactly once, whether it succeeds or fails. A
+        loader that raises has its error parked on the node so `read_file` can
+        re-raise it at the file the caller was actually reading, without going
+        back to the provider. Fetching a failed file a second time would hit the
+        provider twice and, server-side, spend two units of the document budget
+        for one document — enough to abort a command that was within its ceiling."""
+        pending: list[VfsNode] = []
+        seen: set[int] = set()
+        for path in paths:
+            node = self._get_node(path)
+            if not (node.is_file and node.content is None and node.error is None):
+                continue
+            if node.loader is None or id(node) in seen:
+                continue
+            seen.add(id(node))
+            pending.append(node)
+        if len(pending) < 2:
+            return
+
+        def load(node: VfsNode) -> tuple[VfsNode, bytes | VfsClientError]:
+            try:
+                return node, node.loader()
+            except VfsClientError as e:
+                return node, e
+
+        workers = min(PREFETCH_CONCURRENCY, len(pending))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for node, result in pool.map(load, pending):
+                if isinstance(result, VfsClientError):
+                    node.error = result
+                    continue
+                node.content = result
+                node.size_hint = len(result)
 
     def getattr(self, path: str) -> dict:
         node = self._get_node(path)

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -454,6 +454,7 @@ class SkillAppVfsShell:
             file_paths = [path] if node.is_file else self._file_paths(path) if recursive else []
             if node.is_dir and not recursive:
                 raise VfsShellError(f"{raw_path}: is a directory")
+            self.model.prefetch(file_paths)
             for file_path in file_paths:
                 try:
                     text = self._read_text(file_path)


### PR DESCRIPTION
## Why

`grep -r` read one file body at a time.

For Google Drive — an **index-only** source whose bodies are fetched live from Google on every read (`fetch_drive_content`, `backend/integrations/google/indexer.py`) — that meant 60 seconds for 66 files. Heavi's production agent is about to point at exactly this surface.

But it wasn't only a Drive problem. **256 documents already sitting in our own Postgres took 21 seconds**, because each was a separate serial round trip. The index-only sources just made the existing serialization impossible to ignore.

## What

`StashVfsModel.prefetch(paths)` loads bodies in a pool of 12 before the grep loop reads them. Nodes are resolved on the calling thread — expanding a lazy subtree mutates the tree — and only the loaders run in the pool.

Measured against production data, same query, same account:

| source | docs | before | after |
|---|---|---|---|
| `/sources/google` (Drive, live fetch per read) | 66 | 60.2s | **4.94s** |
| `/sources/granola` (stored in Postgres) | 256 | 21.5s | **2.25s** |

Identical results both times — 2 matches and 90 matches respectively.

`InProcessVfsClient` had to change to allow it. It used `anyio.from_thread.run`, which only works from anyio's own worker thread; it now captures the event loop and uses `asyncio.run_coroutine_threadsafe`, which works from any thread. `MAX_DOCUMENT_READS` is incremented under a lock now that twelve threads race on it.

## A bug the tests did not catch

Adversarial review of the first draft found this, and it's the reason for the `VfsNode.error` field.

`prefetch` originally caught `VfsClientError` and left the node uncached, so the serial loop called `read_file`, which **re-invoked the loader**. Meanwhile `_read_document` charges the budget *before* issuing the request. So an unreadable file was fetched twice and spent two units of the 400-document ceiling.

A grep over 150 readable and 130 unreadable files — 280 distinct documents, well inside the ceiling — would hit 401 on the re-reads, raise `VfsBudgetExceeded`, and abort with a spurious 413, **discarding the 150 files' worth of matches already collected**. On `main` that same grep returns results plus per-file warnings.

Now a failed loader parks its error on the node and `read_file` re-raises it without going back to the provider. Every file is fetched exactly once, success or failure.

## Testing

- `test_a_failed_read_is_not_retried_by_the_grep_loop` — the regression above. Verified it **fails** with the fix removed.
- `test_prefetch_fetches_bodies_concurrently` — a two-party barrier, because a pool whose work finishes instantly serves every task on one worker, so counting threads proves nothing. Paired with a serial control test proving the barrier detects concurrency rather than always releasing.
- `test_prefetch_does_not_change_what_grep_finds`, `test_prefetch_reads_each_file_exactly_once`.
- 111 CLI tests, 94 backend tests, `ruff check` + `ruff format --check` clean.
- **Under a real uvicorn** (pytest's ASGI harness is not uvicorn): 8 concurrent greps × 12 reads = 96 simultaneous nested requests against an asyncpg pool of max 20. All correct, 630ms, zero tracebacks. The 413 budget abort still fires correctly now that it is raised from a pool thread.

## Notes

`PREFETCH_CONCURRENCY = 12` is also how hard we hit Google for an index-only source. Each nested read holds a DB connection only for its query, so concurrent commands queue on the pool rather than failing.

Not fixed here: `refresh()` takes 5.5s on a large account before grep even starts, listing every source's entries serially. Same disease, different loop.

No GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)