### PR TITLE
Plugin: treat an edge 403 as permanent, not retryable

### DIFF
--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -23,6 +23,8 @@ class _Recorder:
         self.fail_first_n = fail_first_n
         # path → HTTP status to answer with (instead of 200).
         self.status_by_path: dict[str, int] = {}
+        # Paths the edge blocks: an HTML page, so .json() raises like httpx does.
+        self.edge_blocked_paths: set[str] = set()
 
     def request(self, method, path, **kwargs):
         self.calls.append(
@@ -35,14 +37,17 @@ class _Recorder:
         )
         if len(self.calls) <= self.fail_first_n:
             raise RuntimeError("simulated network failure")
-        status = self.status_by_path.get(path, 200)
+        edge_blocked = path in self.edge_blocked_paths
+        status = 403 if edge_blocked else self.status_by_path.get(path, 200)
 
         class _Resp:
             status_code = status
             is_success = status < 400
-            text = "simulated error"
+            text = "<!DOCTYPE html><title>Blocked</title>" if edge_blocked else "simulated error"
 
             def json(self_inner):
+                if edge_blocked:
+                    raise ValueError("not json")
                 return {"ok": True} if status < 400 else {"detail": "simulated error"}
 
         return _Resp()
@@ -189,6 +194,46 @@ def test_drain_drops_corrupt_lines(tmp_path):
     client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
 
     assert _queue_lines(tmp_path) == []
+
+
+def test_drain_drops_edge_blocked_entries(tmp_path):
+    """Render fronts us with a Cloudflare WAF that 403s bodies containing agent
+    shell text (`foo; curl -s bar`). No re-signin makes that body acceptable, so
+    the entry must be dropped — otherwise the drain stalls on it and every good
+    event queued behind it never sends."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    blocked = {
+        "path": "/api/v1/me/sessions/blocked",
+        "body": {"content": "foo; curl -s bar"},
+        "ts": 1.0,
+    }
+    good = {"path": "/api/v1/me/sessions/events", "body": {"content": "e0"}, "ts": 2.0}
+    qp.write_text(json.dumps(blocked) + "\n" + json.dumps(good) + "\n")
+    client._http.edge_blocked_paths.add("/api/v1/me/sessions/blocked")
+
+    client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    # Blocked entry dropped; the event queued behind it still went out.
+    assert _queue_lines(tmp_path) == []
+    sent = [c["path"] for c in client._http.calls]
+    assert sent.count("/api/v1/me/sessions/events") == 2  # live push + drained good entry
+
+
+def test_drain_keeps_entries_on_api_403(tmp_path):
+    """A 403 our API actually issued (JSON body) is a permission denial and
+    heals with a re-signin — it must stay queued. Only edge 403s are dropped."""
+    client = _make_client(tmp_path)
+    qp = tmp_path / QUEUE_FILENAME
+    entry = {"path": "/api/v1/me/sessions/events", "body": {"content": "e0"}, "ts": 1.0}
+    qp.write_text(json.dumps(entry) + "\n")
+    client._http.status_by_path["/api/v1/me/sessions/events"] = 403
+
+    with pytest.raises(Exception):
+        client.push_event(agent_name="a", event_type="t", content="live", session_id="s1")
+
+    queued = _queue_lines(tmp_path)
+    assert {q["body"]["content"] for q in queued} == {"e0", "live"}
 
 
 def test_no_data_dir_no_queue(tmp_path):

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -30,9 +30,12 @@ DRAIN_BATCH = 50  # how many backlog rows to flush per successful push
 
 
 class StashError(Exception):
-    def __init__(self, status_code: int, detail: str):
+    def __init__(self, status_code: int, detail: str, from_api: bool = True):
         self.status_code = status_code
         self.detail = detail
+        # False when the response body was not JSON — nothing behind our API
+        # answers that way, so the request died at an edge proxy.
+        self.from_api = from_api
         super().__init__(f"[{status_code}] {detail}")
 
 
@@ -42,11 +45,18 @@ def _is_permanent_rejection(e: Exception) -> bool:
     Auth (401/403) heals with a re-signin and 408/429 heal on their own, so
     those stay queued. Every other 4xx (404 dead route, 422 bad body, ...) is
     rejected forever — retrying it just wedges the queue.
+
+    An edge 403 is not our API's auth 403: Render fronts us with a Cloudflare
+    WAF whose command-injection rules match agent shell text (`foo; curl -s
+    bar`), and no re-signin makes that body acceptable. Retrying it stalls the
+    drain on the first blocked entry and every good event behind it.
     """
     if not isinstance(e, StashError):
         return False
-    if e.status_code in (401, 403, 408, 429):
+    if e.status_code in (401, 408, 429):
         return False
+    if e.status_code == 403:
+        return not e.from_api
     return 400 <= e.status_code < 500
 
 
@@ -79,11 +89,12 @@ class StashClient:
         headers.update(self._headers())
         resp = self._http.request(method, path, headers=headers, **kwargs)
         if not resp.is_success:
-            detail = ""
             try:
-                detail = resp.json().get("detail", resp.text)
-            except Exception:
-                detail = resp.text
+                payload = resp.json()
+            except ValueError:
+                # An HTML error page — an edge proxy answered, not our API.
+                raise StashError(resp.status_code, resp.text, from_api=False) from None
+            detail = payload.get("detail", resp.text) if isinstance(payload, dict) else resp.text
             raise StashError(resp.status_code, detail)
         return resp
 


### PR DESCRIPTION
we had this problem where cloudflare rejects a small % of transcripts (kinda bad) but then we kept retrying uploading them, blocking *literally all* transcript uploads after one fails (really bad). This eliminates the really bad, but not hte kinda bad, problem. We might need to get off Render altogether if we can't find a workaround re: kinda bad.

Render fronts our API with a Cloudflare WAF we cannot configure ([open feature request](https://feedback.render.com/features/p/let-us-disable-the-cloudflare-waf)). Its OWASP command-injection rules match agent shell text.

It is not `curl` — it's a shell-injection *shape*:

```
"curl -s x"        -> 201
"echo hi; ls -la"  -> 201
"foo; curl -s bar" -> 403   ← Cloudflare HTML block page, never reaches us
```

Content-based, not client fingerprint: identical bytes 403 from both curl and httpx. Every ingest path is exposed — `/me/sessions/events`, `/events/batch`, and `/me/transcripts` (multipart, including form fields).

## How much this actually costs

Measured against 1,500 local transcripts (21,522 unique bash commands). The WAF runs before auth, so a bogus token returns 401 when a payload passes the edge and 403 when it's blocked — that let me measure real payloads without writing anything:

| Sample | Blocked at edge |
|---|---|
| 400 random unique bash commands | 6 (**1.5%**) |
| 120 random session transcripts | 19 (**16%**) |

The transcript rate is so much higher because a transcript is one multipart body: a single offending command anywhere in the file kills the whole upload. (Cloudflare only inspects ~the first 128KB, so 16% is what production does today, not the ceiling.)

## What this PR fixes

Not the WAF — that needs a payload-encoding change (see below). This fixes the client turning a 1.5% event loss into a **total stall**.

`_is_permanent_rejection` classifies 403 as retryable, on the reasoning that auth failures heal with a re-signin. A WAF 403 never heals. So a blocked event gets queued, `_drain_queue` stops on the first retryable failure, and every good event queued behind it never sends again. Health reports `failing` until someone clears the queue by hand. That is exactly the state my machine was in: 973 entries stuck behind one blocked entry.

The signal is clean: **our API answers with JSON, an edge proxy answers with an HTML page.** `_request` now decides that at the boundary and records it on `StashError.from_api`. A 403 that never reached our API is permanent and gets dropped; a genuine API 403 stays queued, because that one really does heal.

## Testing

- `test_drain_drops_edge_blocked_entries` — fails on the old code, passes here.
- `test_drain_keeps_entries_on_api_403` — new guard: a JSON 403 from our API is still retryable, so this change can't silently widen into dropping real permission denials.
- `test_drain_keeps_entries_on_auth_failure` (401) unchanged and passing.
- 96 plugin tests pass; `ruff check` / `ruff format --check` clean.
- Verified against the live edge: a real Cloudflare block now yields `status=403 from_api=False permanent=True`.

## Follow-up, not in this PR

The WAF still eats those payloads. The fix is to stop shipping raw shell text through a body the edge inspects — base64-wrapping the ingest payload returns 201 (verified). That's a wire-format change across `stashai`, the CLI, and three backend routes, and it breaks already-installed clients the moment the server requires it. Worth deciding deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
