### PR TITLE
Drive folders copy their text, so the agent can read scanned catalogs

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -65,6 +65,10 @@ celery.conf.update(
             "task": "backend.tasks.extraction.enqueue_pending",
             "schedule": 60.0,
         },
+        "drive-extraction-enqueue-pending": {
+            "task": "backend.tasks.drive_extraction.enqueue_pending",
+            "schedule": 60.0,
+        },
         "session-title-reconcile": {
             "task": "backend.tasks.session_titles.reconcile_missing",
             "schedule": 60.0,

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -24,6 +24,7 @@ celery = Celery(
     backend=settings.REDIS_URL,
     include=[
         "backend.tasks.extraction",
+        "backend.tasks.drive_extraction",
         "backend.tasks.embeddings",
         "backend.tasks.linear_tickets",
         "backend.tasks.session_titles",

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -43,9 +43,21 @@ MIME_GOOGLE_SHEET = "application/vnd.google-apps.spreadsheet"
 MIME_GOOGLE_SLIDE = "application/vnd.google-apps.presentation"
 _XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 MAX_FOLDER_DEPTH = 8
-# Native (non-Google) files can be massive (terabyte videos). Cap downloads so
-# a stray click doesn't drag a huge file into the agent's response.
+# Native (non-Google) files can be massive (terabyte videos). A whole-Drive
+# source reads bodies inline on the request path, so it caps downloads tightly.
+# A folder source extracts in a memory-bounded child process at sync time and
+# can afford real catalogs — a 180 MB parts catalog is a normal thing to own.
 MAX_NATIVE_DOWNLOAD_BYTES = 25 * 1024 * 1024
+MAX_EXTRACTION_DOWNLOAD_BYTES = 256 * 1024 * 1024
+
+
+class DriveFileUnsupported(Exception):
+    """Drive returned bytes we cannot turn into text — a video, an archive, a
+    CAD drawing. Not an error to retry; the document has no text to index."""
+
+
+class DriveFileTooLarge(Exception):
+    pass
 
 
 def _parse_time(value: str | None) -> datetime | None:
@@ -157,6 +169,67 @@ async def index_google_drive(source: dict) -> str | None:
     return None
 
 
+async def index_google_drive_folder(source: dict) -> str | None:
+    """Crawl one picked folder and extract every file's text.
+
+    Unlike a whole-Drive source this copies bodies: the folder is bounded, and an
+    agent grepping a shelf of scanned parts catalogs cannot afford a Google round
+    trip and a pypdf pass per file per query. The walk only records rows; the
+    bodies are extracted by `backend.workers.extract_drive_one`, one child process
+    per file, because pypdf on a 180 MB catalog will OOM whatever it runs inside.
+    """
+    from ...tasks.drive_extraction import extract_drive_document
+
+    source_id = UUID(source["id"])
+    owner_user_id = UUID(source["owner_user_id"])
+    folder_id = source["external_ref"]
+
+    token = await get_valid_token(owner_user_id, "google")
+    headers = {"Authorization": f"Bearer {token}"}
+    present: list[str] = []
+    stale: list[UUID] = []
+    seen: set[str] = set()
+
+    async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+
+        async def _walk(parent_id: str, prefix: str, depth: int) -> None:
+            if depth > MAX_FOLDER_DEPTH:
+                return
+            for entry in await _list(client, f"'{parent_id}' in parents and trashed = false"):
+                if entry["id"] in seen:
+                    continue
+                seen.add(entry["id"])
+                name = entry["name"]
+                if entry["mimeType"] == MIME_FOLDER:
+                    await _walk(entry["id"], f"{prefix}{name}/", depth + 1)
+                    continue
+                path = f"{prefix}{name}"
+                present.append(path)
+                row_id = await source_service.upsert_drive_document(
+                    source_id=source_id,
+                    owner_user_id=owner_user_id,
+                    path=path,
+                    name=name,
+                    external_ref=entry["id"],
+                    external_updated_at=_parse_time(entry.get("modifiedTime")),
+                )
+                if row_id is not None:
+                    stale.append(row_id)
+
+        await _walk(folder_id, "", 0)
+
+    await source_service.remove_missing_documents("drive_documents", source_id, present)
+    for row_id in stale:
+        extract_drive_document.delay(str(row_id))
+    logger.info(
+        "google drive folder %s: indexed %d file(s), %d to extract",
+        source_id,
+        len(present),
+        len(stale),
+    )
+    return None
+
+
 def _drive_q_escape(text: str) -> str:
     return text.replace("\\", "\\\\").replace("'", "\\'")
 
@@ -196,17 +269,39 @@ async def search_drive(source: dict, query: str, limit: int = 25) -> list[dict]:
 
 
 async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
-    """Lazy read: route by Drive MIME type.
+    """Lazy read for a whole-Drive source, on the request path. Bounded by
+    MAX_NATIVE_DOWNLOAD_BYTES and never OCRs — see `extract_drive_text` for the
+    folder-source path, which runs at sync time in a child process."""
+    return await extract_drive_text(
+        owner_user_id,
+        file_id,
+        max_bytes=MAX_NATIVE_DOWNLOAD_BYTES,
+        ocr_scanned_pdfs=False,
+    )
+
+
+async def extract_drive_text(
+    owner_user_id: UUID,
+    file_id: str,
+    *,
+    max_bytes: int,
+    ocr_scanned_pdfs: bool,
+) -> str:
+    """A Drive file as text. Routes by MIME type:
 
     - Google Doc       → markdown export
-    - Google Sheet     → CSV export, rendered as a markdown table (first sheet)
+    - Google Sheet     → XLSX export, rendered as one TSV block per sheet
     - Google Slides    → text/plain export
-    - PDF              → bytes + pypdf extraction
-    - Office formats (docx/pptx/xlsx) and text/* → bytes + file_extraction
-    - Anything else    → empty string
+    - PDF              → pypdf; a PDF with no text layer is a scan, and is sent
+                         to Claude vision when `ocr_scanned_pdfs`
+    - Office formats (docx/pptx/xlsx) and text/* → file_extraction
+    - Anything else    → DriveFileUnsupported
 
-    The metadata lookup costs one extra round-trip per read but avoids storing
-    mime types on every index row (and avoids drift if a file is converted).
+    The metadata lookup costs one extra round-trip but avoids storing mime types
+    on every index row (and avoids drift if a file is converted).
+
+    Raises rather than returning a placeholder or an empty string: a caller that
+    cannot read a document must know it, not mistake it for a blank one.
     """
     token = await get_valid_token(owner_user_id, "google")
     headers = {"Authorization": f"Bearer {token}"}
@@ -215,48 +310,49 @@ async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
             DRIVE_FILE_URL.format(file_id=file_id),
             params={**ALL_DRIVES, "fields": "mimeType,name,size"},
         )
-        if meta.status_code != 200:
-            return ""
+        meta.raise_for_status()
         info = meta.json()
         mime = info.get("mimeType") or ""
+
+        from ...services.file_extraction import extract_text, is_pdf
 
         if mime == MIME_GOOGLE_DOC:
             return await _export(client, file_id, "text/markdown")
         if mime == MIME_GOOGLE_SHEET:
             # XLSX export keeps every visible sheet (Drive's CSV export drops
-            # everything except the first). file_extraction renders one TSV
-            # block per sheet.
+            # everything except the first).
             xlsx = await _export_bytes(client, file_id, _XLSX_MIME)
-            if not xlsx:
-                return ""
-            from ...services.file_extraction import extract_text
-
             return extract_text(xlsx, _XLSX_MIME) or ""
         if mime == MIME_GOOGLE_SLIDE:
             return await _export(client, file_id, "text/plain")
 
-        # Native files: cap by size, download bytes, route by mime to a text
-        # extractor.
         size = int(info.get("size") or 0)
-        if size and size > MAX_NATIVE_DOWNLOAD_BYTES:
-            return f"_(file too large to inline: {size // (1024 * 1024)} MB)_"
+        if size > max_bytes:
+            raise DriveFileTooLarge(
+                f"{size // (1024 * 1024)} MB exceeds the {max_bytes // (1024 * 1024)} MB limit"
+            )
 
         media = await client.get(
             DRIVE_FILE_URL.format(file_id=file_id),
             params={**ALL_DRIVES, "alt": "media"},
         )
-        if media.status_code != 200:
-            return ""
+        media.raise_for_status()
         content = media.content
-        if len(content) > MAX_NATIVE_DOWNLOAD_BYTES:
-            return f"_(file too large to inline: {len(content) // (1024 * 1024)} MB)_"
+        if len(content) > max_bytes:
+            raise DriveFileTooLarge(
+                f"{len(content) // (1024 * 1024)} MB exceeds the {max_bytes // (1024 * 1024)} MB limit"
+            )
 
         # Defer to the file-extraction service so docx/pptx/xlsx/pdf/text/*
         # share the same handler set as the direct-upload extraction queue.
-        from ...services.file_extraction import extract_text
-
         text = extract_text(content, mime)
-        return text or ""
+        if text is None and is_pdf(mime) and ocr_scanned_pdfs:
+            from ...services.pdf_ocr import ocr_pdf
+
+            text = await ocr_pdf(content) or None
+        if not text:
+            raise DriveFileUnsupported(f"no text could be extracted from {mime or 'unknown type'}")
+        return text
 
 
 async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -317,39 +317,43 @@ async def extract_drive_text(
         from ...services.file_extraction import extract_text, is_pdf
 
         if mime == MIME_GOOGLE_DOC:
-            return await _export(client, file_id, "text/markdown")
-        if mime == MIME_GOOGLE_SHEET:
+            text = await _export(client, file_id, "text/markdown")
+        elif mime == MIME_GOOGLE_SHEET:
             # XLSX export keeps every visible sheet (Drive's CSV export drops
             # everything except the first).
             xlsx = await _export_bytes(client, file_id, _XLSX_MIME)
-            return extract_text(xlsx, _XLSX_MIME) or ""
-        if mime == MIME_GOOGLE_SLIDE:
-            return await _export(client, file_id, "text/plain")
+            text = extract_text(xlsx, _XLSX_MIME)
+        elif mime == MIME_GOOGLE_SLIDE:
+            text = await _export(client, file_id, "text/plain")
+        else:
+            size = int(info.get("size") or 0)
+            if size > max_bytes:
+                raise DriveFileTooLarge(
+                    f"{size // (1024 * 1024)} MB exceeds the {max_bytes // (1024 * 1024)} MB limit"
+                )
 
-        size = int(info.get("size") or 0)
-        if size > max_bytes:
-            raise DriveFileTooLarge(
-                f"{size // (1024 * 1024)} MB exceeds the {max_bytes // (1024 * 1024)} MB limit"
+            media = await client.get(
+                DRIVE_FILE_URL.format(file_id=file_id),
+                params={**ALL_DRIVES, "alt": "media"},
             )
+            media.raise_for_status()
+            content = media.content
+            if len(content) > max_bytes:
+                raise DriveFileTooLarge(
+                    f"{len(content) // (1024 * 1024)} MB exceeds the "
+                    f"{max_bytes // (1024 * 1024)} MB limit"
+                )
 
-        media = await client.get(
-            DRIVE_FILE_URL.format(file_id=file_id),
-            params={**ALL_DRIVES, "alt": "media"},
-        )
-        media.raise_for_status()
-        content = media.content
-        if len(content) > max_bytes:
-            raise DriveFileTooLarge(
-                f"{len(content) // (1024 * 1024)} MB exceeds the {max_bytes // (1024 * 1024)} MB limit"
-            )
+            # Defer to the file-extraction service so docx/pptx/xlsx/pdf/text/*
+            # share the same handler set as the direct-upload extraction queue.
+            text = extract_text(content, mime)
+            if text is None and is_pdf(mime) and ocr_scanned_pdfs:
+                from ...services.pdf_ocr import ocr_pdf
 
-        # Defer to the file-extraction service so docx/pptx/xlsx/pdf/text/*
-        # share the same handler set as the direct-upload extraction queue.
-        text = extract_text(content, mime)
-        if text is None and is_pdf(mime) and ocr_scanned_pdfs:
-            from ...services.pdf_ocr import ocr_pdf
+                text = await ocr_pdf(content) or None
 
-            text = await ocr_pdf(content) or None
+        # Every branch lands here, Google-native exports included — an export
+        # that came back empty must not be stored as a blank 'done' document.
         if not text:
             raise DriveFileUnsupported(f"no text could be extracted from {mime or 'unknown type'}")
         return text
@@ -358,10 +362,14 @@ async def extract_drive_text(
 async def _export(client: httpx.AsyncClient, file_id: str, mime: str) -> str:
     url = DRIVE_EXPORT_URL.format(file_id=file_id)
     resp = await client.get(url, params={**ALL_DRIVES, "mimeType": mime})
-    return resp.text if resp.status_code == 200 else ""
+    # A failed export must raise, not read as an empty document — the folder
+    # extraction path would otherwise store "" as a successfully extracted body.
+    resp.raise_for_status()
+    return resp.text
 
 
 async def _export_bytes(client: httpx.AsyncClient, file_id: str, mime: str) -> bytes:
     url = DRIVE_EXPORT_URL.format(file_id=file_id)
     resp = await client.get(url, params={**ALL_DRIVES, "mimeType": mime})
-    return resp.content if resp.status_code == 200 else b""
+    resp.raise_for_status()
+    return resp.content

--- a/backend/migrations/versions/0141_drive_documents.py
+++ b/backend/migrations/versions/0141_drive_documents.py
@@ -1,0 +1,99 @@
+"""Folder-scoped Google Drive becomes a copied-content source.
+
+A Drive source used to be index-only: we stored the path and the Drive file id,
+and fetched the body from Google on every read. That is untenable for a picked
+folder of PDF catalogs — a 165-page catalog took 81 seconds to `cat`, anything
+over 25 MB returned a placeholder sentence instead of text, and a scanned PDF
+returned the empty string, because OCR only ever ran on uploaded files.
+
+So a picked folder is now its own source type, `google_drive_folder`, backed by
+`drive_documents`: a content table like `github_documents`. Its bodies are
+extracted once at sync (OCR included) and every read is a Postgres row.
+
+Whole-Drive sources keep `source_type = 'google_drive'` and stay index-only.
+`root` crawls My Drive plus Shared-with-me plus every Shared Drive — unbounded,
+and Google already full-text-indexes it. The guard is the type, not a branch.
+
+Revision ID: 0141
+Revises: 0140
+"""
+
+from alembic import op
+
+revision = "0141"
+down_revision = "0140"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE drive_documents (
+            id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            source_id           uuid NOT NULL REFERENCES user_sources(id) ON DELETE CASCADE,
+            path                text NOT NULL,
+            name                text NOT NULL,
+            kind                text NOT NULL DEFAULT 'file',
+            external_ref        text,
+            external_updated_at timestamptz,
+            created_at          timestamptz NOT NULL DEFAULT now(),
+            updated_at          timestamptz NOT NULL DEFAULT now(),
+            deleted_at          timestamptz,
+
+            content       text,
+            content_hash  text,
+            embedding     vector(384),
+            embed_stale   boolean NOT NULL DEFAULT FALSE,
+
+            -- Extraction runs in a child process after the sync walk, so a row
+            -- exists before its body does. `content` is NULL until the status is
+            -- 'done', and a read of anything else fails loud rather than handing
+            -- the agent an empty string.
+            extraction_status   text NOT NULL DEFAULT 'pending',
+            extraction_error    text,
+            extraction_attempts integer NOT NULL DEFAULT 0,
+            locked_at           timestamptz,
+
+            UNIQUE (source_id, path)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX drive_documents_source_idx ON drive_documents (source_id, path) "
+        "WHERE deleted_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX drive_documents_fts_idx ON drive_documents "
+        "USING gin (to_tsvector('english', coalesce(content, '')))"
+    )
+    op.execute(
+        "CREATE INDEX drive_documents_embed_stale_idx ON drive_documents (id) WHERE embed_stale"
+    )
+    op.execute(
+        "CREATE INDEX drive_documents_extraction_idx ON drive_documents (extraction_status) "
+        "WHERE deleted_at IS NULL"
+    )
+
+    # Existing picked folders become the new type in one shot. Their index rows
+    # carry no bodies, so they are dropped: the next sync rebuilds them in
+    # drive_documents and extracts each file.
+    op.execute("""
+        DELETE FROM drive_index
+        WHERE source_id IN (
+            SELECT id FROM user_sources
+            WHERE source_type = 'google_drive' AND external_ref <> 'root'
+        )
+    """)
+    op.execute("""
+        UPDATE user_sources
+        SET source_type = 'google_drive_folder', sync_status = 'idle', last_synced_at = NULL
+        WHERE source_type = 'google_drive' AND external_ref <> 'root'
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE user_sources SET source_type = 'google_drive' "
+        "WHERE source_type = 'google_drive_folder'"
+    )
+    op.execute("DROP TABLE drive_documents")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -209,6 +209,11 @@ async def read_source_doc(
         raise HTTPException(status_code=404, detail="Source not found")
     if doc is None:
         raise HTTPException(status_code=404, detail="Document not found")
+    # A document we cannot read is an error, not an empty document. The VFS turns
+    # this into a per-file warning on stderr, so a `grep` reports what it skipped
+    # instead of quietly reporting no matches.
+    if "http_status" in doc:
+        raise HTTPException(status_code=doc["http_status"], detail=doc["error"])
     return doc
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -56,6 +56,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "github_repo": 3600,
     "gmail": 1800,
     "google_drive": 1800,
+    "google_drive_folder": 1800,
     "notion": 1800,
     "slack": 21600,
     "granola": 21600,
@@ -70,6 +71,7 @@ SOURCE_CAPABILITY = {
     "github_repo": "navigable",
     "gmail": "searchable",
     "google_drive": "navigable",
+    "google_drive_folder": "navigable",
     "notion": "navigable",
     "slack": "searchable",
     "granola": "searchable",
@@ -82,7 +84,7 @@ SOURCE_CAPABILITY = {
 
 PROVIDER_SOURCE_TYPES = {
     "github": ("github_repo",),
-    "google": ("google_drive",),
+    "google": ("google_drive", "google_drive_folder"),
     "gmail": ("gmail",),
     "notion": ("notion",),
     "slack": ("slack",),
@@ -466,6 +468,7 @@ SOURCE_TABLE = {
     "github_repo": "github_documents",
     "gmail": "gmail_index",
     "google_drive": "drive_index",
+    "google_drive_folder": "drive_documents",
     "notion": "notion_index",
     "slack": "slack_messages",
     "granola": "granola_notes",
@@ -489,6 +492,9 @@ CONTENT_TABLES = {
     "granola_notes",
     "gong_documents",
     "notion_index",
+    # A picked Drive folder is bounded, so its bodies are extracted once at sync
+    # (OCR included) and stored. A whole-Drive source is not, and stays index-only.
+    "drive_documents",
 }
 
 # Index-only source types whose `search` is federated live to the provider's
@@ -643,6 +649,63 @@ async def upsert_index_row(
         external_updated_at,
     )
     return "inserted" if existing is None else "updated"
+
+
+async def upsert_drive_document(
+    *,
+    source_id: UUID,
+    owner_user_id: UUID,
+    path: str,
+    name: str,
+    external_ref: str,
+    external_updated_at,
+) -> UUID | None:
+    """Record a Drive folder file, and say whether its body needs extracting.
+
+    Returns the row id when the file is new or has changed in Drive since we last
+    extracted it, and None when the stored text is still current. Extraction is
+    expensive — a scanned catalog is a Claude-vision call — so it is keyed on
+    Drive's own `modifiedTime` rather than re-run on every sync."""
+    pool = get_pool()
+    existing = await pool.fetchrow(
+        "SELECT id, name, external_ref, external_updated_at, extraction_status, deleted_at "
+        "FROM drive_documents WHERE source_id = $1 AND path = $2",
+        source_id,
+        path,
+    )
+    unchanged = (
+        existing
+        and existing["deleted_at"] is None
+        and existing["name"] == name
+        and existing["external_ref"] == external_ref
+        and existing["external_updated_at"] == external_updated_at
+        and existing["extraction_status"] == "done"
+    )
+    if unchanged:
+        return None
+
+    row = await pool.fetchrow(
+        "INSERT INTO drive_documents "
+        "(source_id, owner_user_id, path, name, kind, external_ref, external_updated_at, "
+        " extraction_status, extraction_attempts) "
+        "VALUES ($1, $2, $3, $4, 'file', $5, $6, 'pending', 0) "
+        "ON CONFLICT (source_id, path) DO UPDATE SET "
+        "name = EXCLUDED.name, external_ref = EXCLUDED.external_ref, "
+        "external_updated_at = EXCLUDED.external_updated_at, "
+        # Any text we already hold stays put while the new extraction runs. It is
+        # at most one sync interval stale, which beats making the document
+        # unreadable for the minutes an OCR pass takes.
+        "extraction_status = 'pending', extraction_error = NULL, extraction_attempts = 0, "
+        "locked_at = NULL, deleted_at = NULL, updated_at = now() "
+        "RETURNING id",
+        source_id,
+        owner_user_id,
+        path,
+        name,
+        external_ref,
+        external_updated_at,
+    )
+    return row["id"]
 
 
 async def remove_missing_documents(table: str, source_id: UUID, present_paths: list[str]) -> int:
@@ -943,6 +1006,9 @@ async def read_document(source: dict, path: str) -> dict | None:
                 "external_ref": row["external_ref"],
             }
 
+        if table == "drive_documents":
+            return await _read_drive_document(UUID(source["id"]), path)
+
         row = await get_pool().fetchrow(
             f"SELECT path, name, kind, content, external_ref FROM {table} "
             f"WHERE source_id = $1 AND path = $2 AND deleted_at IS NULL",
@@ -988,6 +1054,54 @@ async def read_document(source: dict, path: str) -> dict | None:
         "name": row["name"],
         "kind": row["kind"],
         "content": content,
+        "external_ref": row["external_ref"],
+    }
+
+
+# extraction_status -> the HTTP status a read deserves when the row has no body.
+DRIVE_UNREADABLE_STATUS = {
+    "pending": 409,  # sync has seen it; the extraction child hasn't run yet
+    "processing": 409,
+    "unsupported": 415,  # a video, an archive — there is no text to read
+    "too_large": 413,
+    "failed": 422,  # extraction ran and blew up; the row records why
+}
+
+
+async def _read_drive_document(source_id: UUID, path: str) -> dict | None:
+    """A Drive folder document, or a loud explanation of why it has no body.
+
+    The row exists from the moment the sync walk sees the file; the body arrives
+    later, from a child process. Returning `content or ""` for a row that has no
+    content yet would tell the agent the catalog is blank — which is exactly the
+    bug this table was built to kill.
+
+    Text we already hold is served even while a re-extraction is pending: it is
+    one sync interval stale at worst, and that is the same contract every other
+    copied source has."""
+    row = await get_pool().fetchrow(
+        "SELECT path, name, kind, content, external_ref, extraction_status, extraction_error "
+        "FROM drive_documents WHERE source_id = $1 AND path = $2 AND deleted_at IS NULL",
+        source_id,
+        path,
+    )
+    if not row:
+        return None
+    if row["content"] is None:
+        status = row["extraction_status"]
+        return {
+            "path": row["path"],
+            "name": row["name"],
+            "kind": row["kind"],
+            "content": "",
+            "error": row["extraction_error"] or f"extraction {status}",
+            "http_status": DRIVE_UNREADABLE_STATUS[status],
+        }
+    return {
+        "path": row["path"],
+        "name": row["name"],
+        "kind": row["kind"],
+        "content": row["content"],
         "external_ref": row["external_ref"],
     }
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -651,6 +651,15 @@ async def upsert_index_row(
     return "inserted" if existing is None else "updated"
 
 
+# Extraction outcomes that are final for a given version of the file: re-running
+# on the same bytes reproduces the same outcome, so a sync re-queues these only
+# when Drive's `modifiedTime` moves. Without this, an unsupported 200 MB video
+# would be re-downloaded on every 30-minute sync, forever. 'pending' and
+# 'processing' are in-flight, not settled — the sweep and claim in
+# `tasks/drive_extraction.py` own their retry.
+SETTLED_EXTRACTION_STATUSES = ("done", "unsupported", "too_large", "failed")
+
+
 async def upsert_drive_document(
     *,
     source_id: UUID,
@@ -663,9 +672,10 @@ async def upsert_drive_document(
     """Record a Drive folder file, and say whether its body needs extracting.
 
     Returns the row id when the file is new or has changed in Drive since we last
-    extracted it, and None when the stored text is still current. Extraction is
+    extracted it, and None when its extraction is settled. Extraction is
     expensive — a scanned catalog is a Claude-vision call — so it is keyed on
-    Drive's own `modifiedTime` rather than re-run on every sync."""
+    Drive's own `modifiedTime` rather than re-run on every sync. A 'failed' row
+    rests once retries are spent; only a new version of the file revives it."""
     pool = get_pool()
     existing = await pool.fetchrow(
         "SELECT id, name, external_ref, external_updated_at, extraction_status, deleted_at "
@@ -679,7 +689,7 @@ async def upsert_drive_document(
         and existing["name"] == name
         and existing["external_ref"] == external_ref
         and existing["external_updated_at"] == external_updated_at
-        and existing["extraction_status"] == "done"
+        and existing["extraction_status"] in SETTLED_EXTRACTION_STATUSES
     )
     if unchanged:
         return None

--- a/backend/tasks/drive_extraction.py
+++ b/backend/tasks/drive_extraction.py
@@ -28,6 +28,12 @@ logger = logging.getLogger(__name__)
 CHILD_TIMEOUT_SECONDS = 1800
 MAX_ATTEMPTS = 3
 
+# A 'processing' lock older than this belongs to a worker that died: a live
+# extraction is killed at CHILD_TIMEOUT_SECONDS (30 min), so no healthy child
+# holds a lock longer. The sweep and the claim must agree on this cutoff, or
+# the sweep enqueues rows the claim then refuses.
+STALE_LOCK = "30 minutes"
+
 
 async def _run_child(row_id: UUID) -> int:
     proc = await asyncio.create_subprocess_exec(
@@ -49,7 +55,9 @@ async def _run_child(row_id: UUID) -> int:
 
 async def _claim(row_id: UUID) -> bool:
     """Take the row if nobody else has. A file can be enqueued twice — once by the
-    sync walk, once by the Beat sweep — and OCR is too expensive to do twice."""
+    sync walk, once by the Beat sweep — and OCR is too expensive to do twice.
+    A stale 'processing' lock is claimable: its worker died mid-extraction and
+    will never release it."""
     row = await get_pool().fetchrow(
         f"""
         UPDATE drive_documents
@@ -61,6 +69,7 @@ async def _claim(row_id: UUID) -> bool:
           AND (
                 extraction_status = 'pending'
              OR (extraction_status = 'failed' AND extraction_attempts < {MAX_ATTEMPTS})
+             OR (extraction_status = 'processing' AND locked_at < now() - INTERVAL '{STALE_LOCK}')
           )
         RETURNING id
         """,
@@ -119,7 +128,7 @@ async def _enqueue_pending() -> int:
           AND (
                 extraction_status = 'pending'
              OR (extraction_status = 'failed' AND extraction_attempts < {MAX_ATTEMPTS})
-             OR (extraction_status = 'processing' AND locked_at < now() - INTERVAL '30 minutes')
+             OR (extraction_status = 'processing' AND locked_at < now() - INTERVAL '{STALE_LOCK}')
           )
         LIMIT 100
         """,

--- a/backend/tasks/drive_extraction.py
+++ b/backend/tasks/drive_extraction.py
@@ -1,0 +1,134 @@
+"""Extract one Drive folder document's text, in a child process.
+
+Trigger: `index_google_drive_folder` enqueues a task per file whose Drive
+`modifiedTime` moved since we last extracted it.
+
+Memory isolation mirrors `tasks/extraction.py`: pypdf on a 180 MB parts catalog
+will exhaust whatever process it runs in, so the work happens in
+`python -m backend.workers.extract_drive_one <row_id>` under RLIMIT_AS. A blowup
+kills the child and the parent records it on the row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+from uuid import UUID
+
+from ..celery_app import celery
+from ..database import get_pool
+from ._celery_helpers import run_async
+
+logger = logging.getLogger(__name__)
+
+# Scanned catalogs go to Claude vision ten pages at a time, with a 120s per-request
+# timeout — a 100-page scan is ten of those.
+CHILD_TIMEOUT_SECONDS = 1800
+MAX_ATTEMPTS = 3
+
+
+async def _run_child(row_id: UUID) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "backend.workers.extract_drive_one",
+        str(row_id),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        await asyncio.wait_for(proc.communicate(), timeout=CHILD_TIMEOUT_SECONDS)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return -1
+    return proc.returncode or 0
+
+
+async def _claim(row_id: UUID) -> bool:
+    """Take the row if nobody else has. A file can be enqueued twice — once by the
+    sync walk, once by the Beat sweep — and OCR is too expensive to do twice."""
+    row = await get_pool().fetchrow(
+        f"""
+        UPDATE drive_documents
+        SET extraction_status = 'processing',
+            locked_at = now(),
+            extraction_attempts = extraction_attempts + 1
+        WHERE id = $1
+          AND deleted_at IS NULL
+          AND (
+                extraction_status = 'pending'
+             OR (extraction_status = 'failed' AND extraction_attempts < {MAX_ATTEMPTS})
+          )
+        RETURNING id
+        """,
+        row_id,
+    )
+    return row is not None
+
+
+async def _mark_failed_externally(row_id: UUID, error: str) -> None:
+    """Only when the child died without recording its own reason — a SIGKILL has
+    no chance to write anything."""
+    await get_pool().execute(
+        f"""
+        UPDATE drive_documents SET
+            extraction_status = CASE
+                WHEN extraction_attempts >= {MAX_ATTEMPTS} THEN 'failed'
+                ELSE 'pending'
+            END,
+            extraction_error = $2,
+            locked_at = NULL
+        WHERE id = $1 AND extraction_status = 'processing'
+        """,
+        row_id,
+        error[:2000],
+    )
+
+
+async def _extract(row_id: UUID) -> str:
+    if not await _claim(row_id):
+        return "skipped"
+
+    code = await _run_child(row_id)
+    if code == 0:
+        return "ok"
+
+    reason = "extraction ran out of memory" if code in (-9, 137) else f"extraction exited {code}"
+    if code == -1:
+        reason = "extraction timed out"
+    logger.warning("drive extraction child failed row=%s reason=%s", row_id, reason)
+    await _mark_failed_externally(row_id, reason)
+    return "failed"
+
+
+@celery.task(name="backend.tasks.drive_extraction.extract_drive_document")
+def extract_drive_document(row_id: str) -> str:
+    return run_async(_extract(UUID(row_id)))
+
+
+async def _enqueue_pending() -> int:
+    """Rows the sync walk marked but whose task never ran — a dropped `.delay()`,
+    a worker that died mid-extraction."""
+    rows = await get_pool().fetch(
+        f"""
+        SELECT id FROM drive_documents
+        WHERE deleted_at IS NULL
+          AND (
+                extraction_status = 'pending'
+             OR (extraction_status = 'failed' AND extraction_attempts < {MAX_ATTEMPTS})
+             OR (extraction_status = 'processing' AND locked_at < now() - INTERVAL '30 minutes')
+          )
+        LIMIT 100
+        """,
+    )
+    for r in rows:
+        extract_drive_document.delay(str(r["id"]))
+    return len(rows)
+
+
+@celery.task(name="backend.tasks.drive_extraction.enqueue_pending")
+def enqueue_pending() -> int:
+    return run_async(_enqueue_pending())

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -21,7 +21,7 @@ from ..integrations.asana.indexer import index_asana
 from ..integrations.github.indexer import index_github_repo
 from ..integrations.gmail.indexer import index_gmail
 from ..integrations.gong.indexer import index_gong
-from ..integrations.google.indexer import index_google_drive
+from ..integrations.google.indexer import index_google_drive, index_google_drive_folder
 from ..integrations.granola.indexer import index_granola
 from ..integrations.jira.indexer import index_jira
 from ..integrations.linear.indexer import index_linear
@@ -39,6 +39,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "github_repo": index_github_repo,
     "gmail": index_gmail,
     "google_drive": index_google_drive,
+    "google_drive_folder": index_google_drive_folder,
     "notion": index_notion,
     "slack": index_slack,
     "granola": index_granola,

--- a/backend/tests/test_drive_documents.py
+++ b/backend/tests/test_drive_documents.py
@@ -1,0 +1,182 @@
+"""A picked Drive folder stores its documents' text.
+
+The old index-only Drive source fetched each body from Google on every read, which
+meant a scanned parts catalog returned the empty string (OCR only ran on uploads)
+and anything over 25 MB returned the sentence "_(file too large to inline)_".
+Both looked, to an agent, exactly like a blank document.
+
+These tests pin the two properties that fix buys: a document with no body is an
+error the caller can see, and a body that has been extracted is served from
+Postgres without touching Google.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from backend.database import get_pool
+from backend.services import source_service
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("drive"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _folder_source(owner_id: UUID) -> dict:
+    return await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="google_drive_folder",
+        external_ref=f"folder-{uuid4().hex[:8]}",
+        display_name="Heavi Knowledge Base",
+    )
+
+
+async def _row(source_id: UUID, owner_id: UUID, path: str, **fields) -> UUID:
+    cols = {"content": None, "extraction_status": "pending", "extraction_error": None, **fields}
+    row = await get_pool().fetchrow(
+        "INSERT INTO drive_documents "
+        "(source_id, owner_user_id, path, name, external_ref, content, "
+        " extraction_status, extraction_error) "
+        "VALUES ($1, $2, $3, $4, 'drive-file-id', $5, $6, $7) RETURNING id",
+        source_id,
+        owner_id,
+        path,
+        path.split("/")[-1],
+        cols["content"],
+        cols["extraction_status"],
+        cols["extraction_error"],
+    )
+    return row["id"]
+
+
+async def test_a_folder_source_stores_content(client: AsyncClient):
+    """The whole point: reads come from Postgres, not from Google."""
+    api_key, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+    await _row(
+        UUID(src["id"]),
+        owner_id,
+        "Bendix Catalog.pdf",
+        content="BW1114 core charge waived",
+        extraction_status="done",
+    )
+
+    resp = await client.get(
+        f"/api/v1/me/sources/{src['id']}/doc",
+        params={"ref": "Bendix Catalog.pdf"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "BW1114 core charge waived"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        ("pending", 409),
+        ("processing", 409),
+        ("unsupported", 415),
+        ("too_large", 413),
+        ("failed", 422),
+    ],
+)
+async def test_a_document_without_a_body_is_an_error_not_an_empty_document(
+    client: AsyncClient, status: str, expected_code: int
+):
+    """This is the bug that started it. A scanned catalog used to read as "" with
+    exit 0, so an agent concluded the catalog was blank. Every state that carries
+    no text must reach the caller as a non-2xx it can report."""
+    api_key, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+    await _row(
+        UUID(src["id"]),
+        owner_id,
+        "Scanned.pdf",
+        extraction_status=status,
+        extraction_error="no text could be extracted",
+    )
+
+    resp = await client.get(
+        f"/api/v1/me/sources/{src['id']}/doc",
+        params={"ref": "Scanned.pdf"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == expected_code
+    assert "no text" in resp.json()["detail"]
+
+
+async def test_text_already_extracted_survives_a_pending_re_extraction(client: AsyncClient):
+    """A file edited in Drive is re-extracted, which takes minutes for a scan.
+    Serving the previous text meanwhile is one sync interval stale — the same
+    contract every copied source has — and beats going dark."""
+    api_key, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+    await _row(
+        UUID(src["id"]),
+        owner_id,
+        "Catalog.pdf",
+        content="older but real",
+        extraction_status="pending",
+    )
+
+    resp = await client.get(
+        f"/api/v1/me/sources/{src['id']}/doc",
+        params={"ref": "Catalog.pdf"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "older but real"
+
+
+async def test_search_uses_local_fts_not_google(client: AsyncClient):
+    """A folder's content lives in our table, so it is searchable without spending
+    the owner's Drive quota. A whole-Drive source stays federated."""
+    api_key, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+    await _row(
+        UUID(src["id"]),
+        owner_id,
+        "Wheel Seals.pdf",
+        content="STEMCO Scotseal interchange chart",
+        extraction_status="done",
+    )
+
+    resp = await client.get(
+        "/api/v1/me/sources/search",
+        params={"q": "Scotseal", "source": src["id"]},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    hits = resp.json()["results"]
+    assert any("Wheel Seals.pdf" in (h.get("name") or "") for h in hits)
+
+
+async def test_only_the_folder_type_copies_content():
+    """Whole-Drive stays index-only. `root` crawls My Drive plus Shared-with-me
+    plus every Shared Drive — copying that, and auto-OCRing it, is unbounded."""
+    assert source_service.SOURCE_TABLE["google_drive_folder"] == "drive_documents"
+    assert "drive_documents" in source_service.CONTENT_TABLES
+
+    assert source_service.SOURCE_TABLE["google_drive"] == "drive_index"
+    assert "drive_index" not in source_service.CONTENT_TABLES
+    assert "google_drive" in source_service.FEDERATED_SEARCH_TYPES
+    assert "google_drive_folder" not in source_service.FEDERATED_SEARCH_TYPES

--- a/backend/tests/test_drive_documents.py
+++ b/backend/tests/test_drive_documents.py
@@ -10,6 +10,7 @@ error the caller can see, and a body that has been extracted is served from
 Postgres without touching Google.
 """
 
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 import pytest
@@ -180,3 +181,66 @@ async def test_only_the_folder_type_copies_content():
     assert "drive_index" not in source_service.CONTENT_TABLES
     assert "google_drive" in source_service.FEDERATED_SEARCH_TYPES
     assert "google_drive_folder" not in source_service.FEDERATED_SEARCH_TYPES
+
+
+async def test_a_settled_unreadable_file_is_not_requeued_by_the_next_sync(client: AsyncClient):
+    """'unsupported' is a fact about the bytes: the same version of the file will
+    be unsupported next time too. If a sync treated it as work to redo, an
+    unsupported 200 MB video would be re-downloaded every 30 minutes forever.
+    Only a new Drive `modifiedTime` revives extraction."""
+    _, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+    modified = datetime(2026, 7, 1, tzinfo=UTC)
+    upsert = dict(
+        source_id=UUID(src["id"]),
+        owner_user_id=owner_id,
+        path="training.mp4",
+        name="training.mp4",
+        external_ref="drive-file-id",
+    )
+
+    row_id = await source_service.upsert_drive_document(**upsert, external_updated_at=modified)
+    assert row_id is not None  # first sight: extract it
+    await get_pool().execute(
+        "UPDATE drive_documents SET extraction_status = 'unsupported' WHERE id = $1", row_id
+    )
+
+    same_version = await source_service.upsert_drive_document(
+        **upsert, external_updated_at=modified
+    )
+    assert same_version is None
+
+    new_version = await source_service.upsert_drive_document(
+        **upsert, external_updated_at=datetime(2026, 7, 2, tzinfo=UTC)
+    )
+    assert new_version is not None
+
+
+async def test_a_stale_processing_lock_is_reclaimable(client: AsyncClient):
+    """A worker that dies mid-extraction leaves 'processing' behind forever. The
+    Beat sweep re-enqueues such rows, so the claim must accept them — while
+    refusing a live lock, whose worker is still extracting."""
+    from backend.tasks.drive_extraction import _claim
+
+    _, owner_id = await _register(client)
+    src = await _folder_source(owner_id)
+
+    stuck = await _row(UUID(src["id"]), owner_id, "Stuck.pdf", extraction_status="processing")
+    await get_pool().execute(
+        "UPDATE drive_documents SET locked_at = now() - INTERVAL '31 minutes' WHERE id = $1",
+        stuck,
+    )
+    assert await _claim(stuck) is True
+
+    live = await _row(UUID(src["id"]), owner_id, "Live.pdf", extraction_status="processing")
+    await get_pool().execute("UPDATE drive_documents SET locked_at = now() WHERE id = $1", live)
+    assert await _claim(live) is False
+
+
+async def test_the_recovery_sweep_is_scheduled():
+    """The sweep is the only rescue for a dropped `.delay()` or a dead worker.
+    A task that exists but is absent from `beat_schedule` never fires."""
+    from backend.celery_app import celery
+
+    scheduled = {entry["task"] for entry in celery.conf.beat_schedule.values()}
+    assert "backend.tasks.drive_extraction.enqueue_pending" in scheduled

--- a/backend/tests/test_drive_extraction_pipeline.py
+++ b/backend/tests/test_drive_extraction_pipeline.py
@@ -1,0 +1,278 @@
+"""The sync → enqueue → extract → store pipeline, end to end minus the two
+external calls (Drive's API and Claude vision), which are stubbed.
+
+Every other line runs for real: the folder walk, the row upsert, the staleness
+check that decides what to re-extract, the Celery task's claim guard, and the
+child process's status transitions. Without this the read-side tests only prove
+that a correctly populated table reads correctly — never that anything fills it.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from backend.database import get_pool
+from backend.integrations.google import indexer
+from backend.services import source_service
+from backend.tasks import drive_extraction
+from backend.workers import extract_drive_one
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+MODIFIED = datetime(2026, 7, 9, 12, 0, tzinfo=UTC)
+
+
+async def _owner(client: AsyncClient) -> UUID:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("pipe"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return UUID(resp.json()["id"])
+
+
+async def _folder_source(owner_id: UUID) -> dict:
+    return await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="google_drive_folder",
+        external_ref=f"folder-{uuid4().hex[:8]}",
+        display_name="Catalogs",
+    )
+
+
+def _stub_drive(monkeypatch, files: list[dict]) -> list[str]:
+    """Drive returns `files`; record every row id handed to the extraction queue."""
+
+    async def fake_token(*_a, **_k):
+        return "token"
+
+    async def fake_list(_client, q):
+        return files if "in parents" in q else []
+
+    enqueued: list[str] = []
+    monkeypatch.setattr(indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(indexer, "_list", fake_list)
+    monkeypatch.setattr(
+        drive_extraction.extract_drive_document, "delay", lambda row_id: enqueued.append(row_id)
+    )
+    return enqueued
+
+
+def _entry(name: str, modified: datetime = MODIFIED) -> dict:
+    return {
+        "id": f"drive-{name}",
+        "name": name,
+        "mimeType": "application/pdf",
+        "modifiedTime": modified.isoformat().replace("+00:00", "Z"),
+    }
+
+
+async def test_the_sync_walk_records_files_and_queues_each_for_extraction(
+    client: AsyncClient, monkeypatch
+):
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    enqueued = _stub_drive(monkeypatch, [_entry("Bendix.pdf"), _entry("Meritor.pdf")])
+
+    await indexer.index_google_drive_folder(src)
+
+    rows = await get_pool().fetch(
+        "SELECT path, extraction_status, content FROM drive_documents "
+        "WHERE source_id = $1 ORDER BY path",
+        UUID(src["id"]),
+    )
+    assert [r["path"] for r in rows] == ["Bendix.pdf", "Meritor.pdf"]
+    assert all(r["extraction_status"] == "pending" for r in rows)
+    assert all(r["content"] is None for r in rows)
+    assert len(enqueued) == 2
+
+
+async def test_an_unchanged_file_is_not_re_extracted(client: AsyncClient, monkeypatch):
+    """OCR of a scanned catalog is a Claude vision call. Re-running it every
+    thirty minutes for a file nobody touched would be the whole cost of this
+    feature, paid forever."""
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    _stub_drive(monkeypatch, [_entry("Bendix.pdf")])
+    await indexer.index_google_drive_folder(src)
+
+    await get_pool().execute(
+        "UPDATE drive_documents SET extraction_status = 'done', content = 'text' "
+        "WHERE source_id = $1",
+        UUID(src["id"]),
+    )
+
+    enqueued = _stub_drive(monkeypatch, [_entry("Bendix.pdf")])
+    await indexer.index_google_drive_folder(src)
+
+    assert enqueued == []
+
+
+async def test_a_file_edited_in_drive_is_re_extracted(client: AsyncClient, monkeypatch):
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    _stub_drive(monkeypatch, [_entry("Bendix.pdf")])
+    await indexer.index_google_drive_folder(src)
+    await get_pool().execute(
+        "UPDATE drive_documents SET extraction_status = 'done', content = 'old' "
+        "WHERE source_id = $1",
+        UUID(src["id"]),
+    )
+
+    later = datetime(2026, 7, 10, 9, 0, tzinfo=UTC)
+    enqueued = _stub_drive(monkeypatch, [_entry("Bendix.pdf", later)])
+    await indexer.index_google_drive_folder(src)
+
+    assert len(enqueued) == 1
+    row = await get_pool().fetchrow(
+        "SELECT extraction_status, content FROM drive_documents WHERE source_id = $1",
+        UUID(src["id"]),
+    )
+    assert row["extraction_status"] == "pending"
+    # The old text stays readable while the new extraction runs.
+    assert row["content"] == "old"
+
+
+async def _pending_row(client: AsyncClient, monkeypatch) -> tuple[UUID, UUID]:
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    _stub_drive(monkeypatch, [_entry("Scan.pdf")])
+    await indexer.index_google_drive_folder(src)
+    row = await get_pool().fetchrow(
+        "SELECT id FROM drive_documents WHERE source_id = $1", UUID(src["id"])
+    )
+    return row["id"], UUID(src["id"])
+
+
+def _stub_extract(monkeypatch, result):
+    """`result` is the text to return, or an exception to raise."""
+
+    async def fake(*_a, **_k):
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(indexer, "extract_drive_text", fake)
+    monkeypatch.setattr("backend.database.close_db", _noop)
+
+
+async def _noop(*_a, **_k):
+    """The child closes the pool on exit. In-process that would close the pool
+    the rest of the test session shares."""
+
+
+async def test_the_child_stores_extracted_text(client: AsyncClient, monkeypatch):
+    row_id, _ = await _pending_row(client, monkeypatch)
+    _stub_extract(monkeypatch, "STEMCO 2036 1036 382-8036")
+
+    assert await extract_drive_one._run(row_id) == 0
+
+    row = await get_pool().fetchrow(
+        "SELECT content, extraction_status, extraction_error, embed_stale "
+        "FROM drive_documents WHERE id = $1",
+        row_id,
+    )
+    assert row["content"] == "STEMCO 2036 1036 382-8036"
+    assert row["extraction_status"] == "done"
+    assert row["extraction_error"] is None
+    # The embeddings reconciler picks the row up from here.
+    assert row["embed_stale"] is True
+
+
+@pytest.mark.parametrize(
+    ("raised", "status"),
+    [
+        (indexer.DriveFileUnsupported("no text could be extracted"), "unsupported"),
+        (indexer.DriveFileTooLarge("300 MB exceeds the 256 MB limit"), "too_large"),
+    ],
+)
+async def test_the_child_records_why_a_file_has_no_text(
+    client: AsyncClient, monkeypatch, raised: Exception, status: str
+):
+    """Exit 0, because an unreadable document is a fact about the document, not a
+    crash to retry. The reason is what a later read reports to the agent."""
+    row_id, _ = await _pending_row(client, monkeypatch)
+    _stub_extract(monkeypatch, raised)
+
+    assert await extract_drive_one._run(row_id) == 0
+
+    row = await get_pool().fetchrow(
+        "SELECT content, extraction_status, extraction_error FROM drive_documents WHERE id = $1",
+        row_id,
+    )
+    assert row["content"] is None
+    assert row["extraction_status"] == status
+    assert str(raised) in row["extraction_error"]
+
+
+async def test_the_child_redacts_an_unexpected_failure_and_leaves_it_retryable(
+    client: AsyncClient, monkeypatch
+):
+    """The persisted error names the exception class only — its message could
+    carry document text or a provider response."""
+    row_id, _ = await _pending_row(client, monkeypatch)
+    _stub_extract(monkeypatch, RuntimeError("token abc123 leaked into the message"))
+
+    assert await extract_drive_one._run(row_id) == 1
+
+    row = await get_pool().fetchrow(
+        "SELECT extraction_status, extraction_error FROM drive_documents WHERE id = $1",
+        row_id,
+    )
+    assert row["extraction_status"] == "pending"  # attempts still under the cap
+    assert row["extraction_error"] == "Extraction failed: RuntimeError"
+    assert "abc123" not in row["extraction_error"]
+
+
+async def test_a_row_is_claimed_once(client: AsyncClient, monkeypatch):
+    """The sync walk enqueues, and so does the Beat sweep. Extracting twice would
+    pay for the same OCR twice."""
+    row_id, _ = await _pending_row(client, monkeypatch)
+    monkeypatch.setattr(drive_extraction, "_run_child", _child_ok)
+
+    assert await drive_extraction._extract(row_id) == "ok"
+    assert await drive_extraction._extract(row_id) == "skipped"
+
+
+async def _child_ok(_row_id):
+    return 0
+
+
+async def _child_oom(_row_id):
+    return 137
+
+
+async def test_a_child_killed_by_the_oom_killer_is_recorded(client: AsyncClient, monkeypatch):
+    """A SIGKILL leaves the child no chance to write its own reason, so the parent
+    writes one. Otherwise the row sits in 'processing' forever."""
+    row_id, _ = await _pending_row(client, monkeypatch)
+    monkeypatch.setattr(drive_extraction, "_run_child", _child_oom)
+
+    assert await drive_extraction._extract(row_id) == "failed"
+
+    row = await get_pool().fetchrow(
+        "SELECT extraction_status, extraction_error FROM drive_documents WHERE id = $1",
+        row_id,
+    )
+    assert row["extraction_status"] == "pending"  # retryable, attempts = 1
+    assert "out of memory" in row["extraction_error"]
+
+
+async def test_a_file_removed_from_drive_stops_being_readable(client: AsyncClient, monkeypatch):
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    _stub_drive(monkeypatch, [_entry("Bendix.pdf"), _entry("Meritor.pdf")])
+    await indexer.index_google_drive_folder(src)
+
+    _stub_drive(monkeypatch, [_entry("Bendix.pdf")])
+    await indexer.index_google_drive_folder(src)
+
+    live = await get_pool().fetch(
+        "SELECT path FROM drive_documents WHERE source_id = $1 AND deleted_at IS NULL",
+        UUID(src["id"]),
+    )
+    assert [r["path"] for r in live] == ["Bendix.pdf"]

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -54,6 +54,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "github_repo": "acme/widgets",
         "gmail": "cleanup@example.com",
         "google_drive": "drive-root",
+        "google_drive_folder": "drive-folder-1",
         "notion": "notion-root",
         "slack": "T123",
         "granola": "granola",

--- a/backend/workers/extract_drive_one.py
+++ b/backend/workers/extract_drive_one.py
@@ -1,0 +1,141 @@
+"""One-shot child process: extract one Drive folder document and exit.
+
+Invoked by the dispatcher as:
+
+    python -m backend.workers.extract_drive_one <drive_documents.id>
+
+Isolated in its own OS process so pypdf on a 180 MB parts catalog OOMs this
+child rather than the Celery worker. RLIMIT_AS is applied before any heavy
+library loads, exactly as `extract_one` does for uploads.
+
+The dispatcher discards stdout/stderr (parser libraries print document content),
+so the child never logs: its only output channels are the exit code and the row
+it updates.
+
+Exit codes:
+    0  success (the row carries the text, or a loud reason it has none)
+    1  failure (the row records a redacted error)
+    137 SIGKILL — typically the OOM killer. The parent records it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import resource
+import sys
+from uuid import UUID
+
+_MEM_LIMIT_BYTES = int(os.getenv("EXTRACTION_MEMORY_LIMIT_MB", "1024")) * 1024 * 1024
+
+# A catalog that extracts to more than this is stored truncated rather than
+# refused — the marker tells the reader the tail is missing.
+MAX_EXTRACTED_TEXT = 4 * 1024 * 1024
+
+
+def _apply_memory_limit() -> None:
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (_MEM_LIMIT_BYTES, _MEM_LIMIT_BYTES))
+    except (ValueError, OSError):
+        # macOS rejects RLIMIT_AS; dev boxes run without the bound.
+        pass
+
+
+async def _store_unreadable(conn, row_id: UUID, status: str, reason: str) -> None:
+    """A document with no text is a fact about the document, not a crash. Record
+    why, so a read of it can say so instead of returning an empty string."""
+    await conn.execute(
+        "UPDATE drive_documents SET extraction_status = $2, extraction_error = $3, "
+        "locked_at = NULL WHERE id = $1",
+        row_id,
+        status,
+        reason[:2000],
+    )
+
+
+async def _run(row_id: UUID) -> int:
+    # Lazy imports so the RLIMIT above applies to everything heavy.
+    import asyncpg
+
+    from ..config import settings
+    from ..database import close_db, init_pool
+    from ..integrations.google.indexer import (
+        MAX_EXTRACTION_DOWNLOAD_BYTES,
+        DriveFileTooLarge,
+        DriveFileUnsupported,
+        extract_drive_text,
+    )
+
+    # get_valid_token refreshes the OAuth token through the shared pool.
+    await init_pool()
+    conn = await asyncpg.connect(settings.DATABASE_URL)
+    try:
+        row = await conn.fetchrow(
+            "SELECT d.id, d.external_ref, d.owner_user_id "
+            "FROM drive_documents d WHERE d.id = $1 AND d.deleted_at IS NULL",
+            row_id,
+        )
+        if not row or not row["external_ref"]:
+            return 1
+
+        try:
+            text = await extract_drive_text(
+                row["owner_user_id"],
+                row["external_ref"],
+                max_bytes=MAX_EXTRACTION_DOWNLOAD_BYTES,
+                ocr_scanned_pdfs=True,
+            )
+        except DriveFileUnsupported as e:
+            await _store_unreadable(conn, row_id, "unsupported", str(e))
+            return 0
+        except DriveFileTooLarge as e:
+            await _store_unreadable(conn, row_id, "too_large", str(e))
+            return 0
+
+        if len(text) > MAX_EXTRACTED_TEXT:
+            text = text[:MAX_EXTRACTED_TEXT] + "\n\n[truncated]"
+
+        await conn.execute(
+            "UPDATE drive_documents SET "
+            "content = $2, content_hash = md5($2), extraction_status = 'done', "
+            "extraction_error = NULL, locked_at = NULL, embed_stale = TRUE, updated_at = now() "
+            "WHERE id = $1",
+            row_id,
+            text,
+        )
+        return 0
+    except Exception as e:
+        # The persisted error carries only the exception class — never the
+        # message, which may embed document text or provider responses.
+        try:
+            await conn.execute(
+                "UPDATE drive_documents SET "
+                "extraction_status = CASE WHEN extraction_attempts >= 3 THEN 'failed' "
+                "ELSE 'pending' END, "
+                "extraction_error = $2, locked_at = NULL WHERE id = $1",
+                row_id,
+                f"Extraction failed: {type(e).__name__}",
+            )
+        except Exception:
+            pass
+        return 1
+    finally:
+        await conn.close()
+        await close_db()
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: python -m backend.workers.extract_drive_one <row_id>", file=sys.stderr)
+        sys.exit(2)
+    try:
+        row_id = UUID(sys.argv[1])
+    except ValueError:
+        print("invalid uuid", file=sys.stderr)
+        sys.exit(2)
+    _apply_memory_limit()
+    sys.exit(asyncio.run(_run(row_id)))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -29,7 +29,7 @@ import {
   submitCredentials,
   type IntegrationStatus,
 } from "@/lib/integrations";
-import { connectorForProvider, connectorIcon } from "@/components/integrations/connectors";
+import { connectorForProvider, connectorIcon, providerForSourceType } from "@/components/integrations/connectors";
 import {
   AddSourceControls,
   CredentialForm,
@@ -77,7 +77,9 @@ export default function IntegrationPage() {
       listSources(),
     ]);
     setStatus(integrations.providers.find((p) => p.provider === provider) ?? null);
-    setSources(allSources.filter((s) => s.type === connector.sourceType));
+    // A provider can own more than one source type — a whole Drive and a
+    // picked folder are different types on the same Google connector.
+    setSources(allSources.filter((s) => providerForSourceType[s.type] === connector.provider));
   }, [connector, provider]);
 
   useEffect(() => {

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -112,6 +112,7 @@ export const providerForSourceType: Record<string, string> = {
   github_repo: "github",
   gmail: "gmail",
   google_drive: "google",
+  google_drive_folder: "google",
   notion: "notion",
   jira_project: "jira",
   asana_project: "asana",
@@ -163,6 +164,7 @@ export function labelForSourceType(type: string): string {
   if (type === "github_repo") return "GitHub";
   if (type === "gmail") return "Gmail";
   if (type === "google_drive") return "Google Drive";
+  if (type === "google_drive_folder") return "Google Drive folder";
   if (type === "notion") return "Notion";
   if (type === "slack") return "Slack";
   if (type === "granola") return "Granola";

--- a/frontend/src/components/integrations/pickers.test.tsx
+++ b/frontend/src/components/integrations/pickers.test.tsx
@@ -78,7 +78,7 @@ describe("DriveFolderControls", () => {
     fireEvent.click(screen.getByText("Add folder"));
 
     expect(addSource).toHaveBeenCalledWith({
-      source_type: "google_drive",
+      source_type: "google_drive_folder",
       external_ref: "1AbC_dEf-234567890",
       display_name: "Heavi Knowledge Base",
     });
@@ -94,7 +94,7 @@ describe("DriveFolderControls", () => {
     fireEvent.click(screen.getByText("Add folder"));
 
     expect(addSource).toHaveBeenCalledWith({
-      source_type: "google_drive",
+      source_type: "google_drive_folder",
       external_ref: "1AbC_dEf-234567890",
       display_name: "Google Drive folder",
     });

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -26,6 +26,10 @@ import { AsanaIcon, GitHubIcon, JiraIcon, NotionIcon, SlackIcon } from "./BrandI
 import type { Connector } from "./connectors";
 
 type AddSourceBody = {
+  // Overrides the connector's default type. A picked Drive folder is its own
+  // source type: its files are copied and extracted, where a whole Drive is
+  // indexed by name only.
+  source_type?: string;
   external_ref?: string;
   display_name?: string;
   settings?: Record<string, unknown>;
@@ -138,7 +142,11 @@ export function AddSourceControls({
           busy={busy}
           onAddMyDrive={() => add({ external_ref: "root", display_name: "Google Drive" })}
           onAddFolder={(folderId, displayName) =>
-            add({ external_ref: folderId, display_name: displayName })
+            add({
+              source_type: "google_drive_folder",
+              external_ref: folderId,
+              display_name: displayName,
+            })
           }
         />
         {errorRow}


### PR DESCRIPTION
## Why

A picked Google Drive folder was **index-only**: we stored the path and the Drive file id, and fetched the body from Google on every read.

| | count | what the agent got |
|---|---|---|
| over the 25 MB cap | 9 | the literal sentence `_(file too large to inline: 180 MB)_` |
| scans, no text layer | 6 | `""` — empty string, exit 0, no warning |
| readable | 14 | correct, but 81s for one 16 MB catalog |

The scans are the sharp edge. `extract_text` returns `None`, and `fetch_drive_content` ended with `return text or ""`. OCR existed and worked — `ocr_pdf`, Claude vision — but it is only ever called from `backend/workers/extract_one.py`, which reads the `files` table. A scanned PDF you **upload** gets OCR'd; the same PDF in Drive does not.

And `extract_text` is synchronous and CPU-bound while `fetch_drive_content` is `async def`, so **pypdf blocked the event loop for the whole backend process** — 9.9s for one catalog. Six concurrent reads produced HTTP 502 from the gateway on 23 of 29 files.

Wiring OCR into the read path would have been worse: Drive stores nothing, so every `cat` re-OCRs, and a `grep` OCRs the entire folder. There was nowhere to put the answer.

## What

A picked folder becomes its own source type, `google_drive_folder`, backed by a `drive_documents` **content table** like `github_documents`. Bodies are extracted once at sync, in the same `RLIMIT_AS` child process that upload extraction uses, and a PDF with no text layer goes to Claude vision there. Every read and every grep is then a Postgres row.

Whole-Drive sources keep `google_drive` and stay index-only. `root` crawls My Drive plus Shared-with-me plus every Shared Drive — unbounded, and Google already full-text-indexes it. **The guard is the source type, not an `if external_ref == "root"` branch**, so nobody turns on an unbounded auto-OCR crawl by editing a condition.

## Both silent paths are gone

`extract_drive_text` raises `DriveFileTooLarge` / `DriveFileUnsupported` instead of returning a placeholder or `""`. The row records why, and `GET /sources/{id}/doc` answers `409` (pending), `413` (too large), `415` (unsupported), or `422` (failed). `vfs_service` raises `VfsClientError` on any 4xx, which the shell prints as a per-file stderr line while grep keeps scanning — so a grep **reports what it skipped** instead of quietly reporting no matches.

Text already extracted is served while a re-extraction is pending. One sync interval stale beats going dark for the minutes an OCR pass takes.

## Verified against the customer's actual bytes

The four branches, run on the real files (only the Anthropic call stubbed — no key on this machine):

```
scan, folder path     -> OCR fired, fed the real 5.9 MB scan
scan, ocr disabled    -> DriveFileUnsupported (loud, not "")
65 MB catalog, folder -> 600,991 chars extracted
65 MB, whole-Drive    -> DriveFileTooLarge: 62 MB exceeds the 25 MB limit
```

I also rendered page 1 of `wheel-seals-bearings-pinion.pdf` and read it: a STEMCO seal-to-set cross-reference table, row `2036 / 1036 / 382-8036`. Claude vision handles these scans fine.

## Testing

- `backend/tests/test_drive_documents.py` — 9 new. The load-bearing one is parametrized over every no-body state, asserting a non-2xx rather than an empty document.
- `backend/tests/test_sources.py` — 95 pass. Its `test_provider_cleanup` is parametrized over `PROVIDER_SOURCE_TYPES` and failed loudly on the new type until I gave it a fixture, which is exactly what that test is for.
- 188 frontend tests, `tsc` clean, `ruff check` + `ruff format --check` clean.
- Migration `0141` applies against a fresh database.

## Known gaps, deliberately not in this PR

**Whole-Drive reads still run pypdf on the event loop.** `fetch_drive_content` is unchanged for `root`. Same disease; it needs the same treatment or a thread offload.

**Cost.** Only the 6 scans lack a text layer — about 60 pages, batched ten per request, so seven Claude vision calls, once. The nine big catalogs all have text layers and need no OCR.

**`search_drive` under-reports.** Searching this folder for `Bendix` returns zero hits: it runs `fullText contains` across the user's *entire* Drive, takes the top 50, then discards anything not in the source. Independent bug, separate PR.

No GUI changes beyond the folder picker now posting the new source type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)