### PR TITLE
Drive folder PDFs: vision transcription grounded by the text layer

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -270,13 +270,14 @@ async def search_drive(source: dict, query: str, limit: int = 25) -> list[dict]:
 
 async def fetch_drive_content(owner_user_id: UUID, file_id: str) -> str:
     """Lazy read for a whole-Drive source, on the request path. Bounded by
-    MAX_NATIVE_DOWNLOAD_BYTES and never OCRs — see `extract_drive_text` for the
-    folder-source path, which runs at sync time in a child process."""
+    MAX_NATIVE_DOWNLOAD_BYTES and never calls Claude vision — see
+    `extract_drive_text` for the folder-source path, which runs at sync time
+    in a child process."""
     return await extract_drive_text(
         owner_user_id,
         file_id,
         max_bytes=MAX_NATIVE_DOWNLOAD_BYTES,
-        ocr_scanned_pdfs=False,
+        transcribe_pdfs=False,
     )
 
 
@@ -285,15 +286,17 @@ async def extract_drive_text(
     file_id: str,
     *,
     max_bytes: int,
-    ocr_scanned_pdfs: bool,
+    transcribe_pdfs: bool,
 ) -> str:
     """A Drive file as text. Routes by MIME type:
 
     - Google Doc       → markdown export
     - Google Sheet     → XLSX export, rendered as one TSV block per sheet
     - Google Slides    → text/plain export
-    - PDF              → pypdf; a PDF with no text layer is a scan, and is sent
-                         to Claude vision when `ocr_scanned_pdfs`
+    - PDF              → with `transcribe_pdfs`, Claude vision grounded by the
+                         embedded text layer (structure from the page images,
+                         characters from the layer; a scan just has no layer);
+                         without it, the raw pypdf text layer
     - Office formats (docx/pptx/xlsx) and text/* → file_extraction
     - Anything else    → DriveFileUnsupported
 
@@ -344,13 +347,19 @@ async def extract_drive_text(
                     f"{max_bytes // (1024 * 1024)} MB limit"
                 )
 
-            # Defer to the file-extraction service so docx/pptx/xlsx/pdf/text/*
-            # share the same handler set as the direct-upload extraction queue.
-            text = extract_text(content, mime)
-            if text is None and is_pdf(mime) and ocr_scanned_pdfs:
-                from ...services.pdf_ocr import ocr_pdf
+            if is_pdf(mime) and transcribe_pdfs:
+                # One codepath for every PDF: vision reads the pages, the
+                # embedded text layer (empty for a scan) grounds the characters.
+                # pypdf alone scrambles multi-column tables, and a scrambled
+                # parts table reads fine while crossing the wrong part numbers.
+                from ...services.pdf_ocr import transcribe_pdf
 
-                text = await ocr_pdf(content) or None
+                text = await transcribe_pdf(content)
+            else:
+                # Defer to the file-extraction service so docx/pptx/xlsx/pdf/
+                # text/* share the same handler set as the direct-upload
+                # extraction queue.
+                text = extract_text(content, mime)
 
         # Every branch lands here, Google-native exports included — an export
         # that came back empty must not be stored as a blank 'done' document.

--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -1,11 +1,20 @@
-"""OCR for scanned PDFs via Claude vision.
+"""PDF transcription via Claude vision, grounded by the embedded text layer.
 
-A scanned PDF has no embedded text layer, so pypdf yields nothing.
-This module sends the PDF itself to the configured fast-tier model
-(`ANTHROPIC_FAST_MODEL`), which reads the page images and transcribes
-them. Pages go up in chunks of PAGES_PER_REQUEST, all chunks in
-parallel, capped at MAX_OCR_PAGES so one giant scan can't burn
-unbounded API spend.
+pypdf reads a PDF's embedded text layer: exact characters, unreliable
+layout — a three-column parts table comes out as one undifferentiated
+stream. Claude vision reads the page images: reliable layout, but a
+transcribed character can be wrong, and a misread digit in a part
+number ships the wrong part. So each request carries both. The model
+is instructed to take structure from the images and characters from
+the text layer; a scanned PDF simply has no layer to attach and the
+same call degrades to pure OCR.
+
+Pages go up in chunks of PAGES_PER_REQUEST to the configured fast-tier
+model (`ANTHROPIC_FAST_MODEL`), all chunks in parallel, with vision
+capped at MAX_VISION_PAGES so one giant catalog can't burn unbounded
+API spend. Pages past the cap contribute their raw text layer under an
+explicit marker — the cap bounds spend, it must not discard text that
+pypdf reads for free.
 
 Unlike `file_extraction.extract_text`, this module raises on failure
 (missing API key, API errors) so the extraction pipeline's retry
@@ -23,17 +32,25 @@ import pypdf
 from anthropic import AsyncAnthropic
 
 from ..config import settings
+from .file_extraction import extract_text
 
-MAX_OCR_PAGES = 100
+MAX_VISION_PAGES = 100
 PAGES_PER_REQUEST = 10
 MAX_OUTPUT_TOKENS = 16000
 REQUEST_TIMEOUT_SECONDS = 120.0
 
 _PROMPT = (
-    "Transcribe all text in this scanned document exactly as it appears, in reading order. "
+    "Transcribe all text in this document exactly as it appears, in reading order. "
     "Output only the transcribed text - no commentary, no code fences. "
     "Preserve paragraph breaks. Render table rows as lines with cells separated by tabs. "
     "If a page contains no text, output nothing for it."
+)
+
+_LAYER_PROMPT = (
+    "\n\nThe document's embedded text layer, extracted by machine, follows. Its characters "
+    "are exact but its layout is unreliable. Trust it for characters - part numbers, digits, "
+    "codes - and trust the page images for structure, column grouping, and reading order.\n\n"
+    "<text_layer>\n{layer}\n</text_layer>"
 )
 
 
@@ -46,7 +63,9 @@ def _slice_pdf(reader: pypdf.PdfReader, start: int, end: int) -> bytes:
     return buf.getvalue()
 
 
-async def _ocr_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
+async def _transcribe_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
+    layer = extract_text(chunk, "application/pdf")
+    prompt = _PROMPT + (_LAYER_PROMPT.format(layer=layer) if layer else "")
     response = await client.messages.create(
         model=settings.ANTHROPIC_FAST_MODEL,
         max_tokens=MAX_OUTPUT_TOKENS,
@@ -62,7 +81,7 @@ async def _ocr_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
                             "data": base64.standard_b64encode(chunk).decode("ascii"),
                         },
                     },
-                    {"type": "text", "text": _PROMPT},
+                    {"type": "text", "text": prompt},
                 ],
             }
         ],
@@ -73,25 +92,33 @@ async def _ocr_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
     return text
 
 
-async def ocr_pdf(content: bytes) -> str:
+async def transcribe_pdf(content: bytes) -> str:
     if not settings.ANTHROPIC_API_KEY:
-        raise RuntimeError("ANTHROPIC_API_KEY is required to OCR scanned PDFs")
+        raise RuntimeError("ANTHROPIC_API_KEY is required to transcribe PDFs")
 
     reader = pypdf.PdfReader(io.BytesIO(content))
     total_pages = len(reader.pages)
-    ocr_pages = min(total_pages, MAX_OCR_PAGES)
+    vision_pages = min(total_pages, MAX_VISION_PAGES)
     chunks = [
-        _slice_pdf(reader, start, min(start + PAGES_PER_REQUEST, ocr_pages))
-        for start in range(0, ocr_pages, PAGES_PER_REQUEST)
+        _slice_pdf(reader, start, min(start + PAGES_PER_REQUEST, vision_pages))
+        for start in range(0, vision_pages, PAGES_PER_REQUEST)
     ]
 
     client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY, timeout=REQUEST_TIMEOUT_SECONDS)
     try:
-        texts = await asyncio.gather(*(_ocr_chunk(client, chunk) for chunk in chunks))
+        texts = await asyncio.gather(*(_transcribe_chunk(client, chunk) for chunk in chunks))
     finally:
         await client.close()
 
     parts = [t for t in texts if t]
-    if total_pages > MAX_OCR_PAGES:
-        parts.append(f"[OCR stopped at page {MAX_OCR_PAGES} of {total_pages}]")
+    if total_pages > vision_pages:
+        tail = extract_text(_slice_pdf(reader, vision_pages, total_pages), "application/pdf")
+        if tail:
+            parts.append(
+                f"[vision transcription stopped at page {vision_pages} of {total_pages}; "
+                "the rest is the embedded text layer, characters exact but layout flattened]"
+            )
+            parts.append(tail)
+        else:
+            parts.append(f"[transcription stopped at page {vision_pages} of {total_pages}]")
     return "\n\n".join(parts)

--- a/backend/tasks/drive_extraction.py
+++ b/backend/tasks/drive_extraction.py
@@ -23,8 +23,8 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
-# Scanned catalogs go to Claude vision ten pages at a time, with a 120s per-request
-# timeout — a 100-page scan is ten of those.
+# PDFs go to Claude vision ten pages at a time, with a 120s per-request
+# timeout — a 100-page catalog is ten of those.
 CHILD_TIMEOUT_SECONDS = 1800
 MAX_ATTEMPTS = 3
 

--- a/backend/tests/test_drive_extraction_pipeline.py
+++ b/backend/tests/test_drive_extraction_pipeline.py
@@ -8,6 +8,7 @@ that a correctly populated table reads correctly — never that anything fills i
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
@@ -15,7 +16,7 @@ from httpx import AsyncClient
 
 from backend.database import get_pool
 from backend.integrations.google import indexer
-from backend.services import source_service
+from backend.services import file_extraction, pdf_ocr, source_service
 from backend.tasks import drive_extraction
 from backend.workers import extract_drive_one
 
@@ -276,3 +277,89 @@ async def test_a_file_removed_from_drive_stops_being_readable(client: AsyncClien
         UUID(src["id"]),
     )
     assert [r["path"] for r in live] == ["Bendix.pdf"]
+
+
+# --- PDF routing: which parser a Drive PDF gets --------------------------------
+#
+# A folder source's PDFs go through Claude vision grounded by the embedded text
+# layer (structure from the images, characters from the layer). A whole-Drive
+# source reads on the request path and must never pay for an API call.
+
+
+class _FakeResponse:
+    def __init__(self, *, json_body=None, content=b""):
+        self._json = json_body
+        self.content = content
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+class _FakeDriveHttp:
+    """Stands in for httpx.AsyncClient: a metadata lookup, then a media download."""
+
+    def __init__(self, *_a, **_k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def get(self, _url, params=None):
+        if "fields" in (params or {}):
+            return _FakeResponse(json_body={"mimeType": "application/pdf", "size": "9"})
+        return _FakeResponse(content=b"%PDF-fake")
+
+
+def _stub_drive_http(monkeypatch):
+    async def fake_token(*_a, **_k):
+        return "token"
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(indexer, "httpx", SimpleNamespace(AsyncClient=_FakeDriveHttp))
+
+
+async def test_a_folder_pdf_is_vision_reconciled_not_raw_pypdf(monkeypatch):
+    """The behavior this feature adds: a text-layer PDF in a folder source does
+    not stop at pypdf — it goes to vision with the layer as grounding, because
+    pypdf alone flattens a three-column parts table into a stream that crosses
+    part numbers between columns."""
+    _stub_drive_http(monkeypatch)
+    seen = {}
+
+    async def fake_transcribe(content):
+        seen["bytes"] = content
+        return "288241R\tOR288241\t106113"
+
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fake_transcribe)
+
+    text = await indexer.extract_drive_text(
+        uuid4(), "file-1", max_bytes=10_000, transcribe_pdfs=True
+    )
+
+    assert text == "288241R\tOR288241\t106113"
+    assert seen["bytes"] == b"%PDF-fake"
+
+
+async def test_a_whole_drive_pdf_never_pays_for_vision(monkeypatch):
+    """Whole-Drive reads run per-request against an unbounded corpus; an API
+    call per read is an unbounded bill. They get the raw text layer only."""
+    _stub_drive_http(monkeypatch)
+
+    async def fail_transcribe(content):
+        raise AssertionError("a whole-Drive read must not call the vision API")
+
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
+    monkeypatch.setattr(file_extraction, "extract_text", lambda _c, _ct: "raw text layer")
+
+    text = await indexer.extract_drive_text(
+        uuid4(), "file-1", max_bytes=10_000, transcribe_pdfs=False
+    )
+
+    assert text == "raw text layer"

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -1,14 +1,20 @@
-"""Scanned PDFs must reach the knowledge base via OCR.
+"""PDFs reach the knowledge base via vision transcription grounded by the text layer.
 
-A scanned PDF has no embedded text layer, so pypdf extraction yields
-nothing — before OCR existed those files sat invisible to the agent.
-These tests pin the contract: textless PDFs go through `ocr_pdf`,
-OCR failures surface loudly (never a silent empty row), and OCR is
-never triggered when the cheap embedded-text path already worked.
+pypdf alone has exact characters but scrambles multi-column tables; vision
+alone has the layout but can misread a digit — and a misread digit in a part
+number ships the wrong part. `transcribe_pdf` sends both in one request:
+structure from the page images, characters from the embedded text layer. A
+scanned PDF simply has no layer to attach and degrades to pure OCR.
+
+These tests pin that contract: the layer rides along as grounding, pages past
+the vision cap keep their raw text layer (the cap bounds API spend, it must not
+discard free text), failures surface loudly, and the upload path never pays for
+a vision call when plain extraction already worked.
 """
 
 import io
 import uuid
+from types import SimpleNamespace
 
 import asyncpg
 import pypdf
@@ -31,44 +37,119 @@ def _blank_pdf(pages: int) -> bytes:
 
 
 @pytest.mark.asyncio
-async def test_ocr_pdf_fails_loud_without_api_key(monkeypatch):
+async def test_transcribe_pdf_fails_loud_without_api_key(monkeypatch):
     monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", None)
 
     with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
-        await pdf_ocr.ocr_pdf(_blank_pdf(1))
+        await pdf_ocr.transcribe_pdf(_blank_pdf(1))
 
 
 @pytest.mark.asyncio
-async def test_ocr_pdf_chunks_pages_and_joins_transcriptions(monkeypatch):
+async def test_transcribe_pdf_chunks_pages_and_joins_transcriptions(monkeypatch):
     monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
 
-    async def fake_ocr_chunk(client, chunk):
+    async def fake_chunk(client, chunk):
         pages = len(pypdf.PdfReader(io.BytesIO(chunk)).pages)
         return f"pages={pages}"
 
-    monkeypatch.setattr(pdf_ocr, "_ocr_chunk", fake_ocr_chunk)
+    monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
 
-    result = await pdf_ocr.ocr_pdf(_blank_pdf(25))
+    result = await pdf_ocr.transcribe_pdf(_blank_pdf(25))
 
     assert result == "pages=10\n\npages=10\n\npages=5"
 
 
 @pytest.mark.asyncio
-async def test_ocr_pdf_page_cap_is_marked_not_silent(monkeypatch):
-    """Bounding API spend is fine; pretending we read the whole document
-    is not — the stored text must say where OCR stopped."""
+async def test_the_text_layer_rides_along_as_grounding(monkeypatch):
+    """The whole point of reconciliation: the request must carry the embedded
+    text layer so the model takes characters from it, not from its own read
+    of the page image."""
+    captured = {}
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="reconciled")],
+                stop_reason="end_turn",
+            )
+
+    client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: "288241R\tOR288241\t106113")
+
+    result = await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
+
+    assert result == "reconciled"
+    prompt = "".join(
+        block["text"] for block in captured["messages"][0]["content"] if block["type"] == "text"
+    )
+    assert "288241R\tOR288241\t106113" in prompt
+    assert "<text_layer>" in prompt
+
+
+@pytest.mark.asyncio
+async def test_a_scan_sends_no_grounding_block(monkeypatch):
+    """A scan has no text layer. The prompt must not carry an empty
+    <text_layer> block that invites the model to treat 'nothing' as truth."""
+    captured = {}
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="ocr")], stop_reason="end_turn"
+            )
+
+    client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
+
+    prompt = "".join(
+        block["text"] for block in captured["messages"][0]["content"] if block["type"] == "text"
+    )
+    assert "<text_layer>" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_pages_past_the_vision_cap_keep_their_text_layer(monkeypatch):
+    """The cap bounds vision spend on giant catalogs. It must not discard text
+    pypdf reads for free — the tail is appended raw, under a marker that says
+    exactly where reconciliation stopped."""
     monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
-    monkeypatch.setattr(pdf_ocr, "MAX_OCR_PAGES", 4)
+    monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 4)
     monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 2)
 
-    async def fake_ocr_chunk(client, chunk):
+    async def fake_chunk(client, chunk):
         return "chunk"
 
-    monkeypatch.setattr(pdf_ocr, "_ocr_chunk", fake_ocr_chunk)
+    monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: "tail layer text")
 
-    result = await pdf_ocr.ocr_pdf(_blank_pdf(6))
+    result = await pdf_ocr.transcribe_pdf(_blank_pdf(6))
 
-    assert result == "chunk\n\nchunk\n\n[OCR stopped at page 4 of 6]"
+    assert result.startswith("chunk\n\nchunk\n\n[vision transcription stopped at page 4 of 6")
+    assert result.endswith("tail layer text")
+
+
+@pytest.mark.asyncio
+async def test_the_vision_cap_is_marked_not_silent(monkeypatch):
+    """A scan past the cap has no text layer to fall back on. Bounding API
+    spend is fine; pretending we read the whole document is not — the stored
+    text must say where transcription stopped."""
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 4)
+    monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 2)
+
+    async def fake_chunk(client, chunk):
+        return "chunk"
+
+    monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    result = await pdf_ocr.transcribe_pdf(_blank_pdf(6))
+
+    assert result == "chunk\n\nchunk\n\n[transcription stopped at page 4 of 6]"
 
 
 class _FakeConnection:
@@ -108,51 +189,51 @@ def _wire_extract_one(monkeypatch, conn, content):
 
 
 @pytest.mark.asyncio
-async def test_textless_pdf_is_ocred_and_stored(monkeypatch):
+async def test_textless_pdf_is_transcribed_and_stored(monkeypatch):
     conn = _FakeConnection(uuid.uuid4(), "application/pdf")
     _wire_extract_one(monkeypatch, conn, _blank_pdf(2))
 
-    async def fake_ocr(content):
+    async def fake_transcribe(content):
         return "transcribed scan"
 
-    monkeypatch.setattr(pdf_ocr, "ocr_pdf", fake_ocr)
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fake_transcribe)
 
     assert await extract_one._run(conn.file_id) == 0
     assert conn.persisted_text == "transcribed scan"
 
 
 @pytest.mark.asyncio
-async def test_pdf_with_text_layer_skips_ocr(monkeypatch):
-    """OCR costs an API call per chunk — a PDF the embedded-text path
+async def test_upload_with_text_layer_skips_vision(monkeypatch):
+    """Vision costs an API call per chunk — an upload the embedded-text path
     already handled must never hit the API."""
     conn = _FakeConnection(uuid.uuid4(), "text/plain")
     _wire_extract_one(monkeypatch, conn, b"plain text body")
 
-    async def fail_ocr(content):
-        raise AssertionError("ocr_pdf must not be called")
+    async def fail_transcribe(content):
+        raise AssertionError("transcribe_pdf must not be called")
 
-    monkeypatch.setattr(pdf_ocr, "ocr_pdf", fail_ocr)
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
 
     assert await extract_one._run(conn.file_id) == 0
     assert conn.persisted_text == "plain text body"
 
 
 @pytest.mark.asyncio
-async def test_non_pdf_without_text_never_ocrs(monkeypatch):
+async def test_non_pdf_without_text_never_transcribes(monkeypatch):
     conn = _FakeConnection(uuid.uuid4(), "image/png")
     _wire_extract_one(monkeypatch, conn, b"\x89PNG....")
 
-    async def fail_ocr(content):
-        raise AssertionError("ocr_pdf must not be called")
+    async def fail_transcribe(content):
+        raise AssertionError("transcribe_pdf must not be called")
 
-    monkeypatch.setattr(pdf_ocr, "ocr_pdf", fail_ocr)
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
 
     assert await extract_one._run(conn.file_id) == 0
     assert conn.persisted_text is None
 
 
 @pytest.mark.asyncio
-async def test_ocr_failure_marks_row_for_retry(monkeypatch):
+async def test_transcription_failure_marks_row_for_retry(monkeypatch):
     """An API blowup must land in extraction_error via the redacted-error
     path, not resolve to a 'done' row with NULL text."""
     file_id = uuid.uuid4()
@@ -165,10 +246,10 @@ async def test_ocr_failure_marks_row_for_retry(monkeypatch):
     conn = FailingConnection(file_id, "application/pdf")
     _wire_extract_one(monkeypatch, conn, _blank_pdf(1))
 
-    async def fail_ocr(content):
+    async def fail_transcribe(content):
         raise RuntimeError("api exploded with document contents inside")
 
-    monkeypatch.setattr(pdf_ocr, "ocr_pdf", fail_ocr)
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
 
     assert await extract_one._run(file_id) == 1
     assert persisted_errors == ["Extraction failed: RuntimeError"]

--- a/backend/workers/extract_drive_one.py
+++ b/backend/workers/extract_drive_one.py
@@ -83,7 +83,7 @@ async def _run(row_id: UUID) -> int:
                 row["owner_user_id"],
                 row["external_ref"],
                 max_bytes=MAX_EXTRACTION_DOWNLOAD_BYTES,
-                ocr_scanned_pdfs=True,
+                transcribe_pdfs=True,
             )
         except DriveFileUnsupported as e:
             await _store_unreadable(conn, row_id, "unsupported", str(e))

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -52,7 +52,7 @@ async def _run(file_id: UUID) -> int:
     from ..config import settings
     from ..services import storage_service
     from ..services.file_extraction import extract_text, is_pdf
-    from ..services.pdf_ocr import ocr_pdf
+    from ..services.pdf_ocr import transcribe_pdf
 
     MAX_EXTRACTED_TEXT = 1 * 1024 * 1024
 
@@ -72,7 +72,7 @@ async def _run(file_id: UUID) -> int:
             # A PDF with no embedded text layer is a scan. OCR errors
             # propagate to the except below so the row records the
             # failure and the retry machinery re-runs it.
-            text = await ocr_pdf(content) or None
+            text = await transcribe_pdf(content) or None
         if text and len(text) > MAX_EXTRACTED_TEXT:
             text = text[:MAX_EXTRACTED_TEXT] + "\n\n[truncated]"
 


### PR DESCRIPTION
## Why

Follow-up to #749. That PR made a picked Drive folder copy its text, with pypdf for PDFs that have a text layer and Claude vision only for scans. The gap: pypdf is layout-blind. The customer's `Bendix - Reman Valves new part numbers.pdf` is three side-by-side tables of part-number mappings; pypdf returns every value but flattens the visual structure into one stream. This document survives because every cell is filled (`N/A`, never blank) — but a table with genuinely empty or merged cells scrambles under pypdf, and **a scrambled parts table reads fine while crossing the wrong part numbers.**

Going all-vision instead would trade one failure mode for a worse one: vision transcribes from the picture, and a misread digit in a dense page of 118 six-digit part numbers ships the wrong valve.

## What

Use both, in one request. `transcribe_pdf` (was `ocr_pdf`) attaches each 10-page chunk's pypdf text layer to the vision call:

> *Its characters are exact but its layout is unreliable. Trust it for characters — part numbers, digits, codes — and trust the page images for structure, column grouping, and reading order.*

Structure from the images, characters from the layer. A scanned PDF has no layer to attach and the same call degrades to exactly what OCR did before — **one codepath for every PDF**, no scan-vs-text branch left in the extraction path.

Folder-source extraction (`extract_drive_text(..., transcribe_pdfs=True)`) now routes every PDF through it, not just scans.

## Cost, bounded the same way OCR was

- Fast-tier model (`ANTHROPIC_FAST_MODEL`), ten pages per request, all chunks in parallel.
- Vision capped at `MAX_VISION_PAGES` (100) per document. **Pages past the cap now keep their raw text layer** under an explicit marker instead of being dropped — the cap bounds API spend, it must not discard text pypdf reads for free.
- Paid once per file version: extraction runs at sync and is stored, which is the whole reason #749's architecture makes this affordable.
- Whole-Drive reads never call the API (per-request reads against an unbounded corpus) — pinned by a test.
- Uploads unchanged: scans transcribe, text-layer files stay on the free path.

## What this does NOT do

Already-extracted `drive_documents` rows keep their pypdf text until their file changes in Drive. Extraction quality is frozen at extraction time by design (we persist the parse, not the PDF); upgrading existing rows is a manual reset + resync.

## Testing

- `test_pdf_ocr.py` — the layer rides along as grounding; a scan sends no empty `<text_layer>` block; pages past the cap keep their layer; the cap is marked, never silent; upload behavior unchanged.
- `test_drive_extraction_pipeline.py` — routing pinned from `extract_drive_text`: a folder PDF goes to vision-with-grounding, a whole-Drive PDF must never pay for an API call.
- Full backend suite: 757 passed. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)