### PR TITLE
Memory curator runs nightly, inside the deploy-free quiet window

### DIFF
--- a/backend/migrations/versions/0142_curator_nightly_window.py
+++ b/backend/migrations/versions/0142_curator_nightly_window.py
@@ -1,0 +1,37 @@
+"""Move every Memory curator's cron into the nightly quiet window.
+
+Curator crons were staggered across all 24 hours, so some ran during US work
+hours — while users were actively adding content and while deploys were
+restarting the Celery worker (a killed run consumes its tick and is lost until
+the next day). Now they stagger within 08:00–11:59 UTC (midnight–4am Pacific),
+matching _staggered_nightly_cron for new signups. The SQL hash differs from
+the Python one; only the window has to match, any stable stagger works.
+
+Revision ID: 0142
+Revises: 0141
+"""
+
+from alembic import op
+
+revision = "0142"
+down_revision = "0141"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE agents
+        SET schedule_cron =
+            mod(('x' || substr(md5(user_id::text), 1, 7))::bit(28)::int, 60)::text
+              || ' '
+              || (8 + mod(('x' || substr(md5(user_id::text), 8, 7))::bit(28)::int, 4))::text
+              || ' * * *'
+        WHERE is_curator
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -23,11 +23,19 @@ _COLUMNS = (
 )
 
 
-# The daily curator's cron is staggered per user so sprite wakes spread across
-# the day rather than all firing at once.
-def _staggered_daily_cron(user_id: UUID) -> str:
+# The curator runs nightly, inside a quiet window (08:00–11:59 UTC = midnight–4am
+# Pacific): users are asleep so the wiki isn't chasing live edits, and no deploys
+# are restarting the worker mid-run (the cron tick is consumed up front, so a
+# killed run is lost until the next night). Staggered per user within the window
+# so sprite wakes don't all fire at once.
+CURATOR_WINDOW_START_HOUR_UTC = 8
+CURATOR_WINDOW_HOURS = 4
+
+
+def _staggered_nightly_cron(user_id: UUID) -> str:
     n = int.from_bytes(user_id.bytes, "big")
-    return f"{n % 60} {n % 24} * * *"
+    hour = CURATOR_WINDOW_START_HOUR_UTC + (n // 60) % CURATOR_WINDOW_HOURS
+    return f"{n % 60} {hour} * * *"
 
 
 _VALID_PROVIDERS = {"anthropic", "openai", "openrouter"}
@@ -97,7 +105,7 @@ CURATOR_BACKFILL_DAYS = 90
 async def get_or_create_curator(user_id: UUID) -> dict:
     """The user's reserved Memory-curator agent, created on first use.
 
-    Scheduled daily (staggered). Both the cron baseline (last_run_at) and the
+    Scheduled nightly (staggered). Both the cron baseline (last_run_at) and the
     delta watermark (curated_through) seed to a bounded backfill point, so the
     first run is due immediately and bootstraps from real history."""
     pool = get_pool()
@@ -117,7 +125,7 @@ async def get_or_create_curator(user_id: UUID) -> dict:
         RETURNING {_COLUMNS}
         """,
         user_id,
-        _staggered_daily_cron(user_id),
+        _staggered_nightly_cron(user_id),
         CURATOR_BACKFILL_DAYS,
     )
     if row is None:  # lost the race — read the winner.


### PR DESCRIPTION
make curator runs actually only happen at night to make them easier to reason about

# slop

## Why

Curator crons were staggered per user across all 24 hours (`n % 24`), so some runs landed during US work hours — exactly when users are actively adding content and when deploys are restarting the Celery worker. Since `run_due` consumes the cron tick *before* running (`backend/tasks/agent_schedules.py`), a run killed mid-flight by a deploy is silently lost until the next day.

## What

- `_staggered_daily_cron` → `_staggered_nightly_cron`: the per-user stagger is now constrained to **08:00–11:59 UTC** (midnight–4am Pacific / 3–7am Eastern) — hour is `8 + hash % 4`, minute unchanged. The window bounds are two named constants, so moving it is a one-line change.
- Migration `0142` rewrites every existing curator's `schedule_cron` into the same window (md5-based stagger in SQL; only the window has to match the Python formula, any stable stagger works). User-created scheduled agents are untouched.

## Rollout behavior

After the migration, each curator's next run is computed from its new cron, so everyone simply runs during the next 08:00–12:00 UTC window — no double-runs, no lost deltas (the `curated_through` watermark is independent of the schedule). The no-changes cost gate and free-tier monthly cap apply unchanged.

## Verified

- All 25 curator/agent tests pass against a fresh DB migrated through 0142.
- Confirmed both the SQL and Python formulas emit crons only in hours 8–11 UTC.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)