### PR TITLE
Add source-sharing UI: Share button + read-only dialog on the integrations page

### DIFF
--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -37,6 +37,8 @@ import {
   secondaryButton,
 } from "@/components/integrations/pickers";
 import PaywallModal from "@/components/PaywallModal";
+import ResourceShareButton from "@/components/share/ResourceShareButton";
+import type { User } from "@/lib/types";
 
 // How often a row re-checks a source that is mid-sync, and how many times before
 // it gives up. A sync that hasn't settled in ~5 minutes is wedged; polling it for
@@ -327,6 +329,7 @@ export default function IntegrationPage() {
                 <SourceRow
                   key={source.source}
                   source={source}
+                  currentUser={user}
                   highlighted={source.source === highlightSourceId}
                   open={source.source === openSourceId}
                   busySync={busy === `sync:${source.source}`}
@@ -429,6 +432,7 @@ function shortRef(source: Source): string | null {
 
 function SourceRow({
   source,
+  currentUser,
   highlighted,
   open,
   busySync,
@@ -438,6 +442,7 @@ function SourceRow({
   onRemove,
 }: {
   source: Source;
+  currentUser: User;
   highlighted: boolean;
   open: boolean;
   busySync: boolean;
@@ -525,18 +530,29 @@ function SourceRow({
           <div className="mt-1 truncate text-[11.5px] text-muted-foreground">{pollStopped}</div>
         )}
       </button>
-      <div className="flex shrink-0 items-center gap-1.5 opacity-55 transition-opacity group-hover:opacity-100">
-        <button type="button" onClick={onOpen} className={rowButton()}>
-          {open ? "Close" : "Browse"}
-        </button>
-        {syncs && (
-          <button type="button" disabled={busySync} onClick={onSync} className={rowButton()}>
-            {busySync ? "Syncing..." : "Sync"}
+      <div className="flex shrink-0 items-center gap-1.5">
+        {/* Share stays full-opacity (an open dialog must not inherit the row's
+            hover-dimming); Browse/Sync/Remove reveal on hover as before. */}
+        <ResourceShareButton
+          objectType="source"
+          objectId={source.source}
+          resourceName={source.display_name}
+          resourceUrlPath={`/integrations/${providerForSourceType[source.type]}?source=${source.source}`}
+          currentUser={currentUser}
+        />
+        <div className="flex items-center gap-1.5 opacity-55 transition-opacity group-hover:opacity-100">
+          <button type="button" onClick={onOpen} className={rowButton()}>
+            {open ? "Close" : "Browse"}
           </button>
-        )}
-        <button type="button" disabled={busyDelete} onClick={onRemove} className={rowButtonGhost()}>
-          Remove
-        </button>
+          {syncs && (
+            <button type="button" disabled={busySync} onClick={onSync} className={rowButton()}>
+              {busySync ? "Syncing..." : "Sync"}
+            </button>
+          )}
+          <button type="button" disabled={busyDelete} onClick={onRemove} className={rowButtonGhost()}>
+            Remove
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/share/ResourceShareButton.test.tsx
+++ b/frontend/src/components/share/ResourceShareButton.test.tsx
@@ -160,4 +160,39 @@ describe("ResourceShareButton", () => {
     );
     expect(await screen.findByText("Access updated.")).toBeInTheDocument();
   });
+
+  it("shares a source read-only: no permission choices, invites at read", async () => {
+    // The backend rejects comment/write for sources, so the dialog must not
+    // offer a level to pick and must send read — otherwise the POST 400s.
+    render(
+      <ResourceShareButton
+        objectType="source"
+        objectId="src-1"
+        resourceName="Team Drive"
+        resourceUrlPath="/integrations/google?source=src-1"
+        currentUser={currentUser}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    await screen.findByRole("dialog", { name: "Share Team Drive" });
+    await screen.findByText("Ada Lovelace");
+
+    expect(screen.queryByLabelText("Invite permission")).toBeNull();
+    expect(screen.queryByLabelText("Change permission")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Add people"), {
+      target: { value: "grace@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(shareObjectByEmail).toHaveBeenCalledWith(
+        "source",
+        "src-1",
+        "grace@example.com",
+        "read",
+      ),
+    );
+  });
 });

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -65,6 +65,11 @@ export default function ResourceShareButton({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const supportsGeneralAccess = GENERAL_ACCESS_TYPES.includes(objectType);
+  // A connected source rides the owner's OAuth token, so the backend only
+  // grants recipients read access and rejects comment/write. Collapse the
+  // permission controls to a static "Can view" rather than offer a level the
+  // POST would 400 on.
+  const readOnlyShare = objectType === "source";
 
   useEscapeKey(open, () => setOpen(false));
 
@@ -249,21 +254,27 @@ export default function ResourceShareButton({
                 placeholder="Add people by email"
                 className="min-w-0 flex-1 rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-brand focus:outline-none"
               />
-              <select
-                value={permission}
-                onChange={(event) =>
-                  setPermission(event.target.value as SharePermission)
-                }
-                disabled={busy}
-                aria-label="Invite permission"
-                className="rounded-md border border-border bg-base px-2 py-2 text-[12px] text-foreground"
-              >
-                {PERMISSIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+              {readOnlyShare ? (
+                <span className="flex items-center rounded-md border border-border bg-surface px-2.5 py-2 text-[12px] text-muted-foreground">
+                  Can view
+                </span>
+              ) : (
+                <select
+                  value={permission}
+                  onChange={(event) =>
+                    setPermission(event.target.value as SharePermission)
+                  }
+                  disabled={busy}
+                  aria-label="Invite permission"
+                  className="rounded-md border border-border bg-base px-2 py-2 text-[12px] text-foreground"
+                >
+                  {PERMISSIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
               <button
                 type="submit"
                 disabled={busy || !email.trim()}
@@ -302,8 +313,9 @@ export default function ResourceShareButton({
                         : share.email ?? share.principal_type
                     }
                     permission={share.permission as SharePermission}
+                    permissionLabel={readOnlyShare ? "Can view" : undefined}
                     onChangePermission={
-                      share.email
+                      share.email && !readOnlyShare
                         ? (next) => void changePermission(share, next)
                         : undefined
                     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1797,7 +1797,14 @@ export async function getFolderContents(folderId: string): Promise<FolderContent
 
 // --- Shared with me ---
 
-export type SharedObjectType = "folder" | "session_folder" | "page" | "file" | "table" | "session";
+export type SharedObjectType =
+  | "folder"
+  | "session_folder"
+  | "page"
+  | "file"
+  | "table"
+  | "session"
+  | "source";
 
 export interface SharedWithMeItem {
   object_type: SharedObjectType;


### PR DESCRIPTION
## What & why

PR #696 made connected sources shareable server-side (`object_type="source"` — read-only, owner-only management, delegated via the owner's OAuth token) but **explicitly deferred the web UI**. This ships that UI, reusing the generic `ResourceShareButton` rather than building anything new.

## Changes

- **`SharedObjectType`** (`lib/api.ts`): add `"source"` so the existing `shareObjectByEmail` / `unshareObject` / `listObjectShares` helpers accept sources with no other change.
- **`ResourceShareButton`**: when `objectType === "source"`, collapse the permission controls to a static **"Can view"** (both the invite form and each person row). The backend rejects comment/write for sources, so offering a level to pick would only 400. General-access (public link) already excludes `source`, so it correctly stays **Restricted** — a source can't be made public.
- **Integrations page** (`integrations/[provider]`): render a **Share** button on each source row. It sits *outside* the row's `opacity-55 group-hover:opacity-100` action cluster, so an open dialog isn't stuck at the row's dimmed opacity; Browse/Sync/Remove keep their hover-reveal.

## Verified locally (real backend + Postgres, agent-browser)

Stood up the stack, seeded a Google Drive folder source, and exercised the flow:

- **Share button on the source row** → https://app.joinstash.ai/f/94155c22-b7b3-4280-ad71-1ea6e3f55ab2
- **Read-only share dialog** (static "Can view", Owner row, Restricted general access — no public-link option) → https://app.joinstash.ai/f/a084a3ff-6271-4b83-86a7-8940483769c4

Inviting a person on a source calls `shareObjectByEmail("source", id, email, "read")` — confirmed in the DOM and locked in by a unit test (`ResourceShareButton.test.tsx`: no permission selects rendered, invite sends `read`).

## Tests

- New unit test for the read-only source contract; full `ResourceShareButton.test.tsx` green (4 passed).
- Typecheck clean on touched files; `eslint` clean (only pre-existing warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)