### PR TITLE
Recover clipped tokens from the text layer, not the page image

### DIFF
--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -49,7 +49,10 @@ _PROMPT = (
 _LAYER_PROMPT = (
     "\n\nThe document's embedded text layer, extracted by machine, follows. Its characters "
     "are exact but its layout is unreliable. Trust it for characters - part numbers, digits, "
-    "codes - and trust the page images for structure, column grouping, and reading order.\n\n"
+    "codes - and trust the page images for structure, column grouping, and reading order. "
+    "Where the page renders a token visibly cut off - at a page edge, a clipped column, a "
+    "cropped scan - the text layer usually holds the whole string: output the complete string "
+    "from the text layer, never the truncated fragment you see in the image.\n\n"
     "<text_layer>\n{layer}\n</text_layer>"
 )
 

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -85,6 +85,10 @@ async def test_the_text_layer_rides_along_as_grounding(monkeypatch):
     )
     assert "288241R\tOR288241\t106113" in prompt
     assert "<text_layer>" in prompt
+    # A page can render a token cut off (page edge, cropped scan) while the
+    # layer holds the whole string; the instruction to recover it must ride
+    # along, or clipped part numbers come back as fragments.
+    assert "complete string" in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

First production result from #750 surfaced this: `slack-adjusters-clutches-brake-chambers.pdf` is cropped at its right edge (even the title reads "Quick Crossov"). Vision transcribed the visibly clipped Meritor Autocheck column as fragments — `MK4` where the value is `MK4310S` — while the grounding text layer, which isn't clipped, holds the full strings. pypdf had those characters; the reconciled parse lost them. Regression on exactly the axis the grounding exists to protect.

## What

One prompt change in `_LAYER_PROMPT`: where the page renders a token visibly cut off (page edge, clipped column, cropped scan), output the complete string from the text layer, never the truncated fragment in the image.

The existing grounding test now also pins that this instruction rides along with the layer.

## Verification plan

Prompt efficacy can't be unit-tested (no API key locally). After merge + deploy, I'll reset that one row and confirm the Meritor column comes back with full strings against the exact file that exposed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)