### PR TITLE
Tone down the Share button on integration source rows

### DIFF
--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -539,6 +539,7 @@ function SourceRow({
           resourceName={source.display_name}
           resourceUrlPath={`/integrations/${providerForSourceType[source.type]}?source=${source.source}`}
           currentUser={currentUser}
+          variant="secondary"
         />
         <div className="flex items-center gap-1.5 opacity-55 transition-opacity group-hover:opacity-100">
           <button type="button" onClick={onOpen} className={rowButton()}>

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -46,12 +46,17 @@ export default function ResourceShareButton({
   resourceName,
   resourceUrlPath,
   currentUser,
+  variant = "primary",
 }: {
   objectType: SharedObjectType;
   objectId: string;
   resourceName: string;
   resourceUrlPath: string;
   currentUser: User;
+  // "primary" is the filled brand button for page headers where Share is the
+  // main action; "secondary" is the quiet bordered style for list rows where
+  // Share sits among other row actions and must not dominate.
+  variant?: "primary" | "secondary";
 }) {
   const [open, setOpen] = useState(false);
   const [shares, setShares] = useState<ObjectShare[]>([]);
@@ -204,7 +209,11 @@ export default function ResourceShareButton({
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+        className={
+          variant === "primary"
+            ? "cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+            : "cursor-pointer rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised"
+        }
       >
         Share
       </button>


### PR DESCRIPTION
## What

The per-source Share button on the integrations page was a filled brand-orange button on every row, visually outweighing the row actions next to it. It now uses the same quiet bordered style as Browse/Sync.

`ResourceShareButton` gains a `variant` prop: `"primary"` (default) keeps the filled brand style used on page/file/session/table/skill headers — those are unchanged — and `"secondary"` is the quiet row style. Only the integrations source rows opt in.

## Screenshots

- [Source row with the toned-down Share button](https://app.joinstash.ai/f/0e52b5f6-d5be-45b2-8955-ba585543930b)
- [Share dialog still opens from the new button](https://app.joinstash.ai/f/7c154455-f5f5-474a-be01-ba38729be22b)

(Links go to our Stash workspace; captured against a seeded local stack.)

## Testing

- `ResourceShareButton` vitest suite passes (4/4)
- `npm run lint` clean (no new warnings)
- Manually verified in the browser: button renders in the secondary style and the share dialog opens and loads access as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)