### PR TITLE
Follow Google Drive shortcuts when indexing Drive sources

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -38,6 +38,7 @@ DRIVE_DRIVES_URL = "https://www.googleapis.com/drive/v3/drives"
 # without them the API pretends Shared Drive content does not exist.
 ALL_DRIVES = {"supportsAllDrives": "true", "includeItemsFromAllDrives": "true"}
 MIME_FOLDER = "application/vnd.google-apps.folder"
+MIME_SHORTCUT = "application/vnd.google-apps.shortcut"
 MIME_GOOGLE_DOC = "application/vnd.google-apps.document"
 MIME_GOOGLE_SHEET = "application/vnd.google-apps.spreadsheet"
 MIME_GOOGLE_SLIDE = "application/vnd.google-apps.presentation"
@@ -75,7 +76,7 @@ async def _list(client: httpx.AsyncClient, q: str) -> list[dict]:
         params = {
             **ALL_DRIVES,
             "q": q,
-            "fields": "nextPageToken, files(id, name, mimeType, modifiedTime)",
+            "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, shortcutDetails)",
             "pageSize": 200,
         }
         if page_token:
@@ -87,6 +88,36 @@ async def _list(client: httpx.AsyncClient, q: str) -> list[dict]:
         page_token = body.get("nextPageToken")
         if not page_token:
             return out
+
+
+async def _target_modified_time(client: httpx.AsyncClient, file_id: str) -> str | None:
+    resp = await client.get(
+        DRIVE_FILE_URL.format(file_id=file_id),
+        params={**ALL_DRIVES, "fields": "modifiedTime"},
+    )
+    resp.raise_for_status()
+    return resp.json().get("modifiedTime")
+
+
+async def _resolve_shortcut(client: httpx.AsyncClient, entry: dict) -> dict:
+    """A shortcut's target as a plain entry, under the shortcut's display name.
+
+    Shortcuts are Drive's symlinks; the walks must index the target, never the
+    shortcut itself — a shortcut has no body (downloading one is a guaranteed
+    403) and a folder shortcut's contents live under the target id. The
+    shortcut's own modifiedTime is when the *shortcut* last moved, so a file
+    target's real modifiedTime costs one metadata fetch — without it, edits to
+    the target would never re-extract.
+    """
+    target = entry["shortcutDetails"]
+    if target["targetMimeType"] == MIME_FOLDER:
+        return {"id": target["targetId"], "name": entry["name"], "mimeType": MIME_FOLDER}
+    return {
+        "id": target["targetId"],
+        "name": entry["name"],
+        "mimeType": target["targetMimeType"],
+        "modifiedTime": await _target_modified_time(client, target["targetId"]),
+    }
 
 
 async def _shared_drives(client: httpx.AsyncClient) -> list[dict]:
@@ -142,6 +173,11 @@ async def index_google_drive(source: dict) -> str | None:
                 if entry["id"] in seen:
                     continue
                 seen.add(entry["id"])
+                if entry["mimeType"] == MIME_SHORTCUT:
+                    entry = await _resolve_shortcut(client, entry)
+                    if entry["id"] in seen:
+                        continue
+                    seen.add(entry["id"])
                 name = entry["name"]
                 if entry["mimeType"] == MIME_FOLDER:
                     await _walk(entry["id"], f"{prefix}{name}/", depth + 1)
@@ -156,6 +192,11 @@ async def index_google_drive(source: dict) -> str | None:
                 if entry["id"] in seen:
                     continue
                 seen.add(entry["id"])
+                if entry["mimeType"] == MIME_SHORTCUT:
+                    entry = await _resolve_shortcut(client, entry)
+                    if entry["id"] in seen:
+                        continue
+                    seen.add(entry["id"])
                 if entry["mimeType"] == MIME_FOLDER:
                     await _walk(entry["id"], f"Shared with me/{entry['name']}/", 1)
                     continue
@@ -199,6 +240,11 @@ async def index_google_drive_folder(source: dict) -> str | None:
                 if entry["id"] in seen:
                     continue
                 seen.add(entry["id"])
+                if entry["mimeType"] == MIME_SHORTCUT:
+                    entry = await _resolve_shortcut(client, entry)
+                    if entry["id"] in seen:
+                        continue
+                    seen.add(entry["id"])
                 name = entry["name"]
                 if entry["mimeType"] == MIME_FOLDER:
                     await _walk(entry["id"], f"{prefix}{name}/", depth + 1)

--- a/backend/tests/test_drive_extraction_pipeline.py
+++ b/backend/tests/test_drive_extraction_pipeline.py
@@ -63,12 +63,54 @@ def _stub_drive(monkeypatch, files: list[dict]) -> list[str]:
     return enqueued
 
 
+def _stub_drive_listings(monkeypatch, listings: dict[str, list[dict]]) -> list[str]:
+    """Like `_stub_drive`, but keyed by parent folder id so a walk that descends
+    into subfolders (or shortcut targets) sees each folder's own children.
+    Shortcut targets report MODIFIED as their modifiedTime."""
+
+    async def fake_token(*_a, **_k):
+        return "token"
+
+    async def fake_list(_client, q):
+        if "in parents" not in q:
+            return []
+        return listings.get(q.split("'")[1], [])
+
+    async def fake_target_time(_client, _file_id):
+        return _iso(MODIFIED)
+
+    enqueued: list[str] = []
+    monkeypatch.setattr(indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(indexer, "_list", fake_list)
+    monkeypatch.setattr(indexer, "_target_modified_time", fake_target_time)
+    monkeypatch.setattr(
+        drive_extraction.extract_drive_document, "delay", lambda row_id: enqueued.append(row_id)
+    )
+    return enqueued
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat().replace("+00:00", "Z")
+
+
 def _entry(name: str, modified: datetime = MODIFIED) -> dict:
     return {
         "id": f"drive-{name}",
         "name": name,
         "mimeType": "application/pdf",
-        "modifiedTime": modified.isoformat().replace("+00:00", "Z"),
+        "modifiedTime": _iso(modified),
+    }
+
+
+def _shortcut(name: str, target_id: str, target_mime: str) -> dict:
+    # The shortcut's own modifiedTime is deliberately ancient: anything that
+    # leaks it into a row would fail the freshness assertions.
+    return {
+        "id": f"shortcut-{name}",
+        "name": name,
+        "mimeType": "application/vnd.google-apps.shortcut",
+        "modifiedTime": _iso(datetime(2020, 1, 1, tzinfo=UTC)),
+        "shortcutDetails": {"targetId": target_id, "targetMimeType": target_mime},
     }
 
 
@@ -136,6 +178,81 @@ async def test_a_file_edited_in_drive_is_re_extracted(client: AsyncClient, monke
     assert row["extraction_status"] == "pending"
     # The old text stays readable while the new extraction runs.
     assert row["content"] == "old"
+
+
+async def test_a_shortcut_to_a_folder_indexes_the_targets_files(client: AsyncClient, monkeypatch):
+    """A Drive shortcut is how a customer symlinks a live folder into the synced
+    one without copying it. The walk must descend into the target folder; the
+    shortcut itself must get no row — it has no body, so its row could only ever
+    be a permanently failed extraction."""
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    listings = {
+        src["external_ref"]: [
+            _shortcut("Transcripts", "tgt-folder", "application/vnd.google-apps.folder")
+        ],
+        "tgt-folder": [_entry("Bendix.pdf")],
+    }
+    enqueued = _stub_drive_listings(monkeypatch, listings)
+
+    await indexer.index_google_drive_folder(src)
+
+    rows = await get_pool().fetch(
+        "SELECT path, external_ref FROM drive_documents WHERE source_id = $1 ORDER BY path",
+        UUID(src["id"]),
+    )
+    assert [r["path"] for r in rows] == ["Transcripts/Bendix.pdf"]
+    assert rows[0]["external_ref"] == "drive-Bendix.pdf"
+    assert len(enqueued) == 1
+
+
+async def test_a_shortcut_to_a_file_extracts_the_target(client: AsyncClient, monkeypatch):
+    """The row must carry the target's id and the target's modifiedTime.
+    Downloading the shortcut id is a guaranteed 403, and the shortcut's own
+    modifiedTime only moves when the link moves — keyed on it, edits to the
+    target would never re-extract."""
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    listings = {src["external_ref"]: [_shortcut("Catalog.pdf", "tgt-file", "application/pdf")]}
+    enqueued = _stub_drive_listings(monkeypatch, listings)
+
+    await indexer.index_google_drive_folder(src)
+
+    row = await get_pool().fetchrow(
+        "SELECT path, external_ref, external_updated_at FROM drive_documents WHERE source_id = $1",
+        UUID(src["id"]),
+    )
+    assert row["path"] == "Catalog.pdf"
+    assert row["external_ref"] == "tgt-file"
+    assert row["external_updated_at"] == MODIFIED
+    assert len(enqueued) == 1
+
+
+async def test_a_shortcut_to_an_already_walked_folder_is_skipped(client: AsyncClient, monkeypatch):
+    """A folder and a shortcut to that same folder in one tree must index its
+    files once, and a shortcut cycle must not recurse forever."""
+    owner_id = await _owner(client)
+    src = await _folder_source(owner_id)
+    listings = {
+        src["external_ref"]: [
+            {
+                "id": "tgt-folder",
+                "name": "Transcripts",
+                "mimeType": "application/vnd.google-apps.folder",
+            },
+            _shortcut("Transcripts", "tgt-folder", "application/vnd.google-apps.folder"),
+        ],
+        "tgt-folder": [_entry("Bendix.pdf")],
+    }
+    enqueued = _stub_drive_listings(monkeypatch, listings)
+
+    await indexer.index_google_drive_folder(src)
+
+    rows = await get_pool().fetch(
+        "SELECT path FROM drive_documents WHERE source_id = $1", UUID(src["id"])
+    )
+    assert [r["path"] for r in rows] == ["Transcripts/Bendix.pdf"]
+    assert len(enqueued) == 1
 
 
 async def _pending_row(client: AsyncClient, monkeypatch) -> tuple[UUID, UUID]:


### PR DESCRIPTION
## Problem

"Google Drive folders as symlinks" don't work — reported by Heavi during their first onboarding round.

A Drive **shortcut** (`application/vnd.google-apps.shortcut`) was invisible to the indexer walks:

- A shortcut to a **folder** was never followed, so the target folder's contents never appeared in Stash.
- The shortcut itself was upserted as a regular document; extraction then tried `GET files/{id}?alt=media`, which is a guaranteed 403 for shortcuts → a permanently `failed` row (an unreadable phantom file named like the folder).

Confirmed live in the `stash@heaviai.com` account: "Heavi Stash Memory Folder" has exactly three permanently failed rows — "Expert Call Transcripts", "Offline Data Scans", "Part Cheat Sheets" — all folder shortcuts. Heavi worked around it by hand-copying files in ("Copy of ..." everywhere), so their synced data is static snapshots instead of their live folders.

## Fix

- `_list` now requests `shortcutDetails`.
- New `_resolve_shortcut`: a shortcut becomes a plain entry for its **target**, under the shortcut's display name. Folder targets come back as folder entries; file targets carry the target's id and the target's real `modifiedTime` (one metadata fetch — the shortcut's own `modifiedTime` only moves when the link moves, so staleness keyed on it would never re-extract target edits).
- All three walk sites (folder-source walk, whole-Drive walk, Shared-with-me pass) resolve shortcuts before the folder/file branch, deduping on the target id so a folder plus a shortcut to it indexes once and shortcut cycles can't loop.

On the next sync after deploy, Heavi's three failed shortcut rows drop out of the present list (removed), and the live folders behind the shortcuts get indexed.

## Notes

- A dangling shortcut (target deleted or inaccessible to the connected account) fails that sync cycle loudly (`sync_error` on the source, traceback in server logs) rather than being skipped silently — per the fail-loud rule. If dangling shortcuts turn out to be common in shared folders, we can move that to a row-level failure in a follow-up.

## Tests

Three new pipeline tests: folder shortcut → target's files indexed and no row for the shortcut; file shortcut → row carries target id + target modifiedTime; folder + shortcut to the same folder → indexed once. Both drive suites (27) and the adjacent indexer/sources suites (94) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)