### PR TITLE
Move source-row Share and Remove behind a "..." menu

### DIFF
--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -2,7 +2,8 @@
 
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MoreHorizontal } from "lucide-react";
 
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
@@ -37,7 +38,13 @@ import {
   secondaryButton,
 } from "@/components/integrations/pickers";
 import PaywallModal from "@/components/PaywallModal";
-import ResourceShareButton from "@/components/share/ResourceShareButton";
+import { ResourceShareDialog } from "@/components/share/ResourceShareButton";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { User } from "@/lib/types";
 
 // How often a row re-checks a source that is mid-sync, and how many times before
@@ -461,6 +468,10 @@ function SourceRow({
   // Why this row stopped tracking the sync. Distinct from `status.sync_error`,
   // which is the sync itself failing — this is us failing to observe it.
   const [pollStopped, setPollStopped] = useState<string | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
+  // Outside-click boundary for the share dialog: covers the "..." trigger so
+  // opening the menu doesn't immediately close the dialog.
+  const menuBoundaryRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -531,16 +542,6 @@ function SourceRow({
         )}
       </button>
       <div className="flex shrink-0 items-center gap-1.5">
-        {/* Share stays full-opacity (an open dialog must not inherit the row's
-            hover-dimming); Browse/Sync/Remove reveal on hover as before. */}
-        <ResourceShareButton
-          objectType="source"
-          objectId={source.source}
-          resourceName={source.display_name}
-          resourceUrlPath={`/integrations/${providerForSourceType[source.type]}?source=${source.source}`}
-          currentUser={currentUser}
-          variant="secondary"
-        />
         <div className="flex items-center gap-1.5 opacity-55 transition-opacity group-hover:opacity-100">
           <button type="button" onClick={onOpen} className={rowButton()}>
             {open ? "Close" : "Browse"}
@@ -550,21 +551,51 @@ function SourceRow({
               {busySync ? "Syncing..." : "Sync"}
             </button>
           )}
-          <button type="button" disabled={busyDelete} onClick={onRemove} className={rowButtonGhost()}>
-            Remove
-          </button>
+        </div>
+        {/* The menu and share dialog live outside the hover-dim group: an open
+            dialog must not inherit the row's hover-dimming. */}
+        <div ref={menuBoundaryRef} className="relative">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="More actions"
+                className="flex cursor-pointer items-center rounded-lg px-1.5 py-1.5 text-muted-foreground opacity-55 transition-opacity hover:bg-raised hover:text-foreground group-hover:opacity-100"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-max min-w-28">
+              <DropdownMenuItem onClick={() => setShareOpen(true)}>Share</DropdownMenuItem>
+              <DropdownMenuItem
+                variant="destructive"
+                disabled={busyDelete}
+                onClick={onRemove}
+              >
+                Remove
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {shareOpen && (
+            <ResourceShareDialog
+              objectType="source"
+              objectId={source.source}
+              resourceName={source.display_name}
+              resourceUrlPath={`/integrations/${providerForSourceType[source.type]}?source=${source.source}`}
+              currentUser={currentUser}
+              boundaryRef={menuBoundaryRef}
+              onClose={() => setShareOpen(false)}
+            />
+          )}
         </div>
       </div>
     </div>
   );
 }
 
-// The quiet bordered row action (Browse/Sync) and its borderless ghost (Remove).
+// The quiet bordered row action (Browse/Sync).
 function rowButton(): string {
   return "cursor-pointer rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised disabled:opacity-60";
-}
-function rowButtonGhost(): string {
-  return "cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted-foreground hover:bg-raised hover:text-error disabled:opacity-60";
 }
 
 function BrowsePanel({

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -2,6 +2,7 @@
 
 import {
   FormEvent,
+  RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -46,19 +47,65 @@ export default function ResourceShareButton({
   resourceName,
   resourceUrlPath,
   currentUser,
-  variant = "primary",
 }: {
   objectType: SharedObjectType;
   objectId: string;
   resourceName: string;
   resourceUrlPath: string;
   currentUser: User;
-  // "primary" is the filled brand button for page headers where Share is the
-  // main action; "secondary" is the quiet bordered style for list rows where
-  // Share sits among other row actions and must not dominate.
-  variant?: "primary" | "secondary";
 }) {
   const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+      >
+        Share
+      </button>
+
+      {open && (
+        <ResourceShareDialog
+          objectType={objectType}
+          objectId={objectId}
+          resourceName={resourceName}
+          resourceUrlPath={resourceUrlPath}
+          currentUser={currentUser}
+          boundaryRef={containerRef}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// The share popover on its own, for callers that open it from something other
+// than the standard Share button (e.g. a row's "..." menu). Render inside a
+// `relative` container; `boundaryRef` is the element clicks may land in
+// without closing the dialog (it should include whatever toggles it, so a
+// toggle click doesn't close-then-reopen).
+export function ResourceShareDialog({
+  objectType,
+  objectId,
+  resourceName,
+  resourceUrlPath,
+  currentUser,
+  boundaryRef,
+  onClose,
+}: {
+  objectType: SharedObjectType;
+  objectId: string;
+  resourceName: string;
+  resourceUrlPath: string;
+  currentUser: User;
+  boundaryRef: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+}) {
   const [shares, setShares] = useState<ObjectShare[]>([]);
   const [email, setEmail] = useState("");
   const [permission, setPermission] = useState<SharePermission>("read");
@@ -67,7 +114,6 @@ export default function ResourceShareButton({
   const [message, setMessage] = useState("");
   const [generalAccess, setGeneralAccess] = useState<GeneralPermission>("none");
   const [savingAccess, setSavingAccess] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const supportsGeneralAccess = GENERAL_ACCESS_TYPES.includes(objectType);
   // A connected source rides the owner's OAuth token, so the backend only
@@ -76,7 +122,7 @@ export default function ResourceShareButton({
   // POST would 400 on.
   const readOnlyShare = objectType === "source";
 
-  useEscapeKey(open, () => setOpen(false));
+  useEscapeKey(true, onClose);
 
   const resourceUrl =
     typeof window === "undefined"
@@ -119,21 +165,18 @@ export default function ResourceShareButton({
   }
 
   useEffect(() => {
-    if (!open) return;
     void loadShares();
-  }, [open, loadShares]);
+  }, [loadShares]);
 
   useEffect(() => {
-    if (!open) return;
-
     function onDown(event: MouseEvent) {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(event.target as Node)) setOpen(false);
+      if (!boundaryRef.current) return;
+      if (!boundaryRef.current.contains(event.target as Node)) onClose();
     }
 
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
+  }, [boundaryRef, onClose]);
 
   async function addPerson(event: FormEvent) {
     event.preventDefault();
@@ -203,39 +246,133 @@ export default function ResourceShareButton({
   }
 
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        className={
-          variant === "primary"
-            ? "cursor-pointer rounded-md bg-[var(--color-brand-600)] px-2.5 py-1 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-            : "cursor-pointer rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised"
-        }
-      >
-        Share
-      </button>
-
-      {open && (
-        <div
-          role="dialog"
-          aria-label={`Share ${displayName}`}
-          className="absolute right-0 top-full z-40 mt-1.5 w-[420px] max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-base p-4 shadow-lg"
+    <div
+      role="dialog"
+      aria-label={`Share ${displayName}`}
+      className="absolute right-0 top-full z-40 mt-1.5 w-[420px] max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-base p-4 shadow-lg"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="m-0 truncate text-[18px] font-semibold text-foreground">
+            {`Share "${displayName}"`}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-raised hover:text-foreground"
+          aria-label="Close share dialog"
         >
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <h2 className="m-0 truncate text-[18px] font-semibold text-foreground">
-                {`Share "${displayName}"`}
-              </h2>
-            </div>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-raised hover:text-foreground"
-              aria-label="Close share dialog"
+          <svg
+            aria-hidden="true"
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <form onSubmit={addPerson} className="mt-4">
+        <label className="sr-only" htmlFor="resource-share-email">
+          Add people
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="resource-share-email"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="Add people by email"
+            className="min-w-0 flex-1 rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-brand focus:outline-none"
+          />
+          {readOnlyShare ? (
+            <span className="flex items-center rounded-md border border-border bg-surface px-2.5 py-2 text-[12px] text-muted-foreground">
+              Can view
+            </span>
+          ) : (
+            <select
+              value={permission}
+              onChange={(event) =>
+                setPermission(event.target.value as SharePermission)
+              }
+              disabled={busy}
+              aria-label="Invite permission"
+              className="rounded-md border border-border bg-base px-2 py-2 text-[12px] text-foreground"
             >
+              {PERMISSIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          )}
+          <button
+            type="submit"
+            disabled={busy || !email.trim()}
+            className="cursor-pointer rounded-md bg-foreground px-3 py-2 text-[12.5px] font-medium text-background disabled:opacity-45"
+          >
+            Invite
+          </button>
+        </div>
+      </form>
+
+      <section className="mt-5">
+        <h3 className="m-0 text-[13px] font-semibold text-foreground">
+          People with access
+        </h3>
+        <div className="mt-2 flex flex-col gap-2">
+          <AccessRow
+            label={`${currentUser.display_name || currentUser.name} (you)`}
+            sublabel={currentUser.email ?? `@${currentUser.name}`}
+            permissionLabel="Owner"
+          />
+
+          {loadingShares && (
+            <div className="rounded-md border border-border bg-surface px-3 py-2 text-[12.5px] text-muted-foreground">
+              Loading access...
+            </div>
+          )}
+
+          {!loadingShares &&
+            shares.map((share, index) => (
+              <AccessRow
+                key={`${share.principal_id ?? share.email}-${index}`}
+                label={share.label || share.email || "Invited user"}
+                sublabel={
+                  share.pending
+                    ? "Invited"
+                    : share.email ?? share.principal_type
+                }
+                permission={share.permission as SharePermission}
+                permissionLabel={readOnlyShare ? "Can view" : undefined}
+                onChangePermission={
+                  share.email && !readOnlyShare
+                    ? (next) => void changePermission(share, next)
+                    : undefined
+                }
+                onRemove={
+                  share.pending || !share.principal_id
+                    ? undefined
+                    : () => void removePerson(share)
+                }
+                busy={busy}
+              />
+            ))}
+        </div>
+      </section>
+
+      <section className="mt-5">
+        <h3 className="m-0 text-[13px] font-semibold text-foreground">
+          General access
+        </h3>
+        <div className="mt-2 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2.5">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-base text-muted-foreground ring-1 ring-border">
+            {generalAccess === "none" ? (
               <svg
                 aria-hidden="true"
                 className="h-4 w-4"
@@ -244,213 +381,101 @@ export default function ResourceShareButton({
                 stroke="currentColor"
                 strokeWidth="2"
               >
-                <path d="M18 6 6 18" />
-                <path d="m6 6 12 12" />
+                <rect x="5" y="11" width="14" height="10" rx="2" />
+                <path d="M8 11V8a4 4 0 0 1 8 0v3" />
               </svg>
-            </button>
-          </div>
-
-          <form onSubmit={addPerson} className="mt-4">
-            <label className="sr-only" htmlFor="resource-share-email">
-              Add people
-            </label>
-            <div className="flex gap-2">
-              <input
-                id="resource-share-email"
-                type="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                placeholder="Add people by email"
-                className="min-w-0 flex-1 rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-brand focus:outline-none"
-              />
-              {readOnlyShare ? (
-                <span className="flex items-center rounded-md border border-border bg-surface px-2.5 py-2 text-[12px] text-muted-foreground">
-                  Can view
-                </span>
-              ) : (
-                <select
-                  value={permission}
-                  onChange={(event) =>
-                    setPermission(event.target.value as SharePermission)
-                  }
-                  disabled={busy}
-                  aria-label="Invite permission"
-                  className="rounded-md border border-border bg-base px-2 py-2 text-[12px] text-foreground"
-                >
-                  {PERMISSIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              )}
-              <button
-                type="submit"
-                disabled={busy || !email.trim()}
-                className="cursor-pointer rounded-md bg-foreground px-3 py-2 text-[12.5px] font-medium text-background disabled:opacity-45"
+            ) : (
+              <svg
+                aria-hidden="true"
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
               >
-                Invite
-              </button>
-            </div>
-          </form>
-
-          <section className="mt-5">
-            <h3 className="m-0 text-[13px] font-semibold text-foreground">
-              People with access
-            </h3>
-            <div className="mt-2 flex flex-col gap-2">
-              <AccessRow
-                label={`${currentUser.display_name || currentUser.name} (you)`}
-                sublabel={currentUser.email ?? `@${currentUser.name}`}
-                permissionLabel="Owner"
-              />
-
-              {loadingShares && (
-                <div className="rounded-md border border-border bg-surface px-3 py-2 text-[12.5px] text-muted-foreground">
-                  Loading access...
-                </div>
-              )}
-
-              {!loadingShares &&
-                shares.map((share, index) => (
-                  <AccessRow
-                    key={`${share.principal_id ?? share.email}-${index}`}
-                    label={share.label || share.email || "Invited user"}
-                    sublabel={
-                      share.pending
-                        ? "Invited"
-                        : share.email ?? share.principal_type
-                    }
-                    permission={share.permission as SharePermission}
-                    permissionLabel={readOnlyShare ? "Can view" : undefined}
-                    onChangePermission={
-                      share.email && !readOnlyShare
-                        ? (next) => void changePermission(share, next)
-                        : undefined
-                    }
-                    onRemove={
-                      share.pending || !share.principal_id
-                        ? undefined
-                        : () => void removePerson(share)
-                    }
-                    busy={busy}
-                  />
-                ))}
-            </div>
-          </section>
-
-          <section className="mt-5">
-            <h3 className="m-0 text-[13px] font-semibold text-foreground">
-              General access
-            </h3>
-            <div className="mt-2 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2.5">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-base text-muted-foreground ring-1 ring-border">
-                {generalAccess === "none" ? (
-                  <svg
-                    aria-hidden="true"
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <rect x="5" y="11" width="14" height="10" rx="2" />
-                    <path d="M8 11V8a4 4 0 0 1 8 0v3" />
-                  </svg>
-                ) : (
-                  <svg
-                    aria-hidden="true"
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <circle cx="12" cy="12" r="9" />
-                    <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
-                  </svg>
-                )}
-              </span>
-              <span className="min-w-0 flex-1">
-                {supportsGeneralAccess ? (
-                  <>
-                    <select
-                      aria-label="General access"
-                      value={generalAccess === "none" ? "none" : "link"}
-                      disabled={savingAccess}
-                      onChange={(e) =>
-                        void changeGeneralAccess(
-                          e.target.value === "none"
-                            ? "none"
-                            : generalAccess === "none"
-                              ? "read"
-                              : generalAccess,
-                        )
-                      }
-                      className="-ml-1 block cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-[13px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
-                    >
-                      <option value="none">Restricted</option>
-                      <option value="link">Anyone with the link</option>
-                    </select>
-                    <span className="block truncate px-1 text-[12px] text-muted-foreground">
-                      {generalAccess === "none"
-                        ? "Only people with access can open this link"
-                        : "Anyone on the internet with the link can access"}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <span className="block text-[13px] font-medium text-foreground">
-                      Restricted
-                    </span>
-                    <span className="block truncate text-[12px] text-muted-foreground">
-                      Only people with access can open this link
-                    </span>
-                  </>
-                )}
-              </span>
-              {supportsGeneralAccess && generalAccess !== "none" && (
+                <circle cx="12" cy="12" r="9" />
+                <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
+              </svg>
+            )}
+          </span>
+          <span className="min-w-0 flex-1">
+            {supportsGeneralAccess ? (
+              <>
                 <select
-                  aria-label="Link role"
-                  value={generalAccess}
+                  aria-label="General access"
+                  value={generalAccess === "none" ? "none" : "link"}
                   disabled={savingAccess}
                   onChange={(e) =>
-                    void changeGeneralAccess(e.target.value as GeneralPermission)
+                    void changeGeneralAccess(
+                      e.target.value === "none"
+                        ? "none"
+                        : generalAccess === "none"
+                          ? "read"
+                          : generalAccess,
+                    )
                   }
-                  className="shrink-0 cursor-pointer rounded border border-border bg-base px-2 py-1 text-[12px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
+                  className="-ml-1 block cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-[13px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
                 >
-                  {LINK_ROLES.map((role) => (
-                    <option key={role.value} value={role.value}>
-                      {role.label}
-                    </option>
-                  ))}
+                  <option value="none">Restricted</option>
+                  <option value="link">Anyone with the link</option>
                 </select>
-              )}
-            </div>
-          </section>
-
-          <div className="mt-5 flex items-center justify-between gap-3">
-            <button
-              type="button"
-              onClick={() => void copyLink()}
-              className="cursor-pointer rounded-full border border-border bg-base px-4 py-2 text-[13px] font-medium text-foreground hover:bg-raised"
+                <span className="block truncate px-1 text-[12px] text-muted-foreground">
+                  {generalAccess === "none"
+                    ? "Only people with access can open this link"
+                    : "Anyone on the internet with the link can access"}
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="block text-[13px] font-medium text-foreground">
+                  Restricted
+                </span>
+                <span className="block truncate text-[12px] text-muted-foreground">
+                  Only people with access can open this link
+                </span>
+              </>
+            )}
+          </span>
+          {supportsGeneralAccess && generalAccess !== "none" && (
+            <select
+              aria-label="Link role"
+              value={generalAccess}
+              disabled={savingAccess}
+              onChange={(e) =>
+                void changeGeneralAccess(e.target.value as GeneralPermission)
+              }
+              className="shrink-0 cursor-pointer rounded border border-border bg-base px-2 py-1 text-[12px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
             >
-              Copy link
-            </button>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="cursor-pointer rounded-full bg-[var(--color-brand-600)] px-5 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)]"
-            >
-              Done
-            </button>
-          </div>
-
-          {message && (
-            <div className="mt-3 text-[12px] text-muted-foreground" role="status">
-              {message}
-            </div>
+              {LINK_ROLES.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </select>
           )}
+        </div>
+      </section>
+
+      <div className="mt-5 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => void copyLink()}
+          className="cursor-pointer rounded-full border border-border bg-base px-4 py-2 text-[13px] font-medium text-foreground hover:bg-raised"
+        >
+          Copy link
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="cursor-pointer rounded-full bg-[var(--color-brand-600)] px-5 py-2 text-[13px] font-medium text-white hover:bg-[var(--color-brand-700)]"
+        >
+          Done
+        </button>
+      </div>
+
+      {message && (
+        <div className="mt-3 text-[12px] text-muted-foreground" role="status">
+          {message}
         </div>
       )}
     </div>


### PR DESCRIPTION
## What

Follow-up to #756. The quiet Share button on integration source rows becomes an overflow menu: rows now show **Browse · Sync · ⋯**, with the menu holding **Share** and **Remove** (as a destructive item). Sharing stays fully functional — the menu item opens the same share dialog as before.

## How

- The share popover is extracted from `ResourceShareButton` into an exported `ResourceShareDialog`, so the row's menu item and the standard Share button open the same component. Page/file/session/table/skill headers keep the filled Share button, unchanged.
- The menu uses the existing radix `DropdownMenu` (`components/ui/dropdown-menu`), matching the file-explorer idiom.
- The `variant` prop from #756 and the `rowButtonGhost` style are removed — nothing renders them anymore.

## Screenshots

- [Row with Browse / Sync / ⋯](https://app.joinstash.ai/f/e0f875cc-04e1-4871-a4e2-fc73733c623d)
- [Open menu: Share + Remove](https://app.joinstash.ai/f/815cce92-bd6c-4f2a-a2e9-ae2518122faa)
- [Share dialog opened from the menu](https://app.joinstash.ai/f/acf3b8cd-7edb-4706-9963-cba5a0f6ffec)

(Links go to our Stash workspace; captured against a seeded local stack.)

## Testing

- `ResourceShareButton` vitest suite passes (4/4)
- Lint and `tsc` clean on the changed files
- Manually verified in the browser: menu opens, Share item opens the dialog and loads access, Remove renders as destructive

🤖 Generated with [Claude Code](https://claude.com/claude-code)