### PR TITLE
Fix sign-out: stop rolling sessions from resurrecting the deleted session cookie

### DIFF
--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { API_BASE, getAuth0AccessToken, revokeStoredApiKey } from "@/lib/api";
+import { auth0LogoutUrl } from "@/lib/authLogout";
 
 type Props = {
   cliSession?: string | null;
@@ -107,7 +108,7 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
         >
           {submitting ? "Authorizing..." : "Authorize CLI"}
         </button>
-        <a href="/auth/logout" className="text-[11px] text-muted hover:text-foreground">
+        <a href={auth0LogoutUrl()} className="text-[11px] text-muted hover:text-foreground">
           Use a different account
         </a>
       </div>

--- a/frontend/managed/auth0/client.ts
+++ b/frontend/managed/auth0/client.ts
@@ -13,4 +13,12 @@ const { audience } = requireManagedAuth0Config();
 
 export const auth0 = new Auth0Client({
   authorizationParameters: { audience },
+  // Rolling sessions re-write the session cookie on every response, so a
+  // request in flight while /auth/logout deletes the cookie can resurrect it
+  // and undo the sign-out. Fixed-duration sessions only write the cookie at
+  // login and token refresh.
+  session: {
+    rolling: false,
+    absoluteDuration: 60 * 60 * 24 * 30, // 30 days, then re-login
+  },
 });

--- a/frontend/managed/auth0/loggedOut.ts
+++ b/frontend/managed/auth0/loggedOut.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+// Auth0 sends the browser here after /auth/logout (the URL must be listed in
+// the Auth0 application's Allowed Logout URLs). The logout response already
+// deleted the session cookie, but a request that was in flight at that moment
+// can carry a response that re-sets it, resurrecting the session. Deleting the
+// cookie again here — after the Auth0 round trip — closes that window.
+export function sweepAuth0SessionAndRedirectToLogin(request: NextRequest) {
+  const response = NextResponse.redirect(new URL("/login", request.url));
+  for (const cookie of request.cookies.getAll()) {
+    // Covers the SDK's base cookie (__session) and its chunks (__session__0…).
+    if (cookie.name.startsWith("__session")) {
+      response.cookies.delete(cookie.name);
+    }
+  }
+  return response;
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,9 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { sweepAuth0SessionAndRedirectToLogin } from "@managed/auth0/loggedOut";
+
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
 export async function middleware(request: NextRequest) {
   if (!AUTH0_ENABLED) return NextResponse.next();
+  if (request.nextUrl.pathname === "/logged-out") {
+    return sweepAuth0SessionAndRedirectToLogin(request);
+  }
   const { runAuth0Middleware } = await import("@managed/auth0/middleware");
   return runAuth0Middleware(request);
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { ApiError, clearToken, getMe, getToken, revokeStoredApiKey } from "../lib/api";
-import { markManualAuth0Logout } from "../lib/authLogout";
+import { auth0LogoutUrl, markManualAuth0Logout } from "../lib/authLogout";
 import { User } from "../lib/types";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
@@ -67,7 +67,7 @@ export function useAuth() {
     // Hard navigation so module-level caches reset. We intentionally do NOT use
     // `?federated` — that would tell Auth0 to clear the upstream identity provider
     // (e.g. Google) session, signing the user out of Google itself, not just Stash.
-    window.location.href = AUTH0_ENABLED ? "/auth/logout" : "/login";
+    window.location.href = AUTH0_ENABLED ? auth0LogoutUrl() : "/login";
   }, []);
 
   return {

--- a/frontend/src/lib/auth0LoggedOut.test.ts
+++ b/frontend/src/lib/auth0LoggedOut.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { sweepAuth0SessionAndRedirectToLogin } from "../../managed/auth0/loggedOut";
+
+// Sign-out bug regression: rolling responses from requests in flight during
+// /auth/logout can re-set the session cookie the logout just deleted. The
+// /logged-out landing must delete every session cookie variant again so the
+// user actually ends up signed out.
+describe("sweepAuth0SessionAndRedirectToLogin", () => {
+  it("deletes all __session cookies (base + chunks) and redirects to /login", () => {
+    const request = new NextRequest("https://app.example.com/logged-out", {
+      headers: { cookie: "__session=a; __session__0=b; __session__1=c; other=keep" },
+    });
+
+    const response = sweepAuth0SessionAndRedirectToLogin(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://app.example.com/login");
+    const setCookies = response.headers.getSetCookie();
+    for (const name of ["__session", "__session__0", "__session__1"]) {
+      expect(setCookies.some((c) => c.startsWith(`${name}=;`))).toBe(true);
+    }
+    expect(setCookies.some((c) => c.startsWith("other="))).toBe(false);
+  });
+});

--- a/frontend/src/lib/authLogout.test.ts
+++ b/frontend/src/lib/authLogout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { consumeManualAuth0Logout, markManualAuth0Logout } from "./authLogout";
+import { auth0LogoutUrl, consumeManualAuth0Logout, markManualAuth0Logout } from "./authLogout";
 
 describe("Auth0 manual logout marker", () => {
   beforeEach(() => {
@@ -11,5 +11,15 @@ describe("Auth0 manual logout marker", () => {
 
     expect(consumeManualAuth0Logout()).toBe(true);
     expect(consumeManualAuth0Logout()).toBe(false);
+  });
+});
+
+describe("auth0LogoutUrl", () => {
+  // Logout must land on /logged-out (an Allowed Logout URL) so the middleware
+  // can sweep session cookies resurrected by requests in flight mid-logout.
+  it("sends Auth0 back to this origin's /logged-out sweep route", () => {
+    expect(auth0LogoutUrl()).toBe(
+      `/auth/logout?returnTo=${encodeURIComponent(`${window.location.origin}/logged-out`)}`,
+    );
   });
 });

--- a/frontend/src/lib/authLogout.ts
+++ b/frontend/src/lib/authLogout.ts
@@ -1,5 +1,13 @@
 const AUTH0_MANUAL_LOGOUT_KEY = "stash_auth0_manual_logout";
 
+// Sends Auth0 back to /logged-out, where the middleware deletes any session
+// cookie a concurrent request resurrected mid-logout, then forwards to /login.
+// The absolute /logged-out URL must be listed in the Auth0 application's
+// Allowed Logout URLs.
+export function auth0LogoutUrl() {
+  return `/auth/logout?returnTo=${encodeURIComponent(`${window.location.origin}/logged-out`)}`;
+}
+
 export function markManualAuth0Logout() {
   sessionStorage.setItem(AUTH0_MANUAL_LOGOUT_KEY, "1");
 }


### PR DESCRIPTION
## ⚠️ Deploy prerequisite (do this first)

Add **`https://app.joinstash.ai/logged-out`** to **Allowed Logout URLs** in the Auth0 application (tenant `stash-prod`, client `Vfp5ABypIm6Pk0pG0AscxLyWhXe7af1j`) **before** deploying this. Auth0 validates the post-logout URL strictly (verified: query strings are rejected too), so without this entry logout will 400 at Auth0.

## Symptom

Clicking **Sign out** in the managed deployment bounced you straight back to the homepage, still signed in.

## Root cause

`@auth0/nextjs-auth0` v4 defaults to **rolling sessions**: every middleware-matched response re-issues the full `__session__0`/`__session__1` cookies (confirmed against prod — a plain `GET /` response carries fresh session Set-Cookie headers). `/auth/logout` deletes the cookies correctly, and Auth0's own session is cleared correctly — but any request that was already in flight when you clicked Sign out (a second Stash tab, a link prefetch, an access-token refresh) completes a moment later and its response **re-sets the session cookies**. By the time Auth0 redirects back to `/`, the session is alive again.

Reproduced deterministically on prod: with a second tab making periodic requests, Sign out → back on the homepage signed in, `/auth/profile` 200, both cookies restored. With a single quiet tab, logout works — which is why it slipped through.

## Fix (two layers)

1. **`rolling: false`, `absoluteDuration: 30 days`** on the `Auth0Client`. Only login and token refresh ever write the session cookie now, removing the resurrection vector at the source. Note this changes session semantics: previously 1-day idle timeout / 3-day absolute cap (SDK defaults); now a fixed 30-day session.
2. **Logout lands on `/logged-out`** (`returnTo` on `/auth/logout`), where the middleware deletes any `__session*` cookie a still-in-flight request resurrected during the Auth0 round trip, then forwards to `/login`. This is handled before the Auth0 SDK middleware, so the sweep response can never re-set cookies itself.

The `Use a different account` link in the CLI-authorize flow goes through the same `auth0LogoutUrl()` helper. Self-hosted/password mode is untouched.

## Verification

- Unit tests: sweep deletes `__session`, `__session__0`, `__session__1`, leaves other cookies, redirects to `/login`; logout URL helper shape.
- E2E against a production build running in Auth0 mode: `GET /logged-out` with mixed cookies → `307 /login` + expired Set-Cookie for all three session cookies, unrelated cookie untouched.
- Local password-mode sign-out regression-tested in the browser (lands on `/login`, token cleared).
- `npm test` (191 passed), `npm run lint` (pre-existing warnings only), `npm run build` clean in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)