### PR TITLE
Memory lands on the brain dashboard (moved from the orphaned /activity)

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -164,6 +164,15 @@ async def get_memory_folder(
     return FolderResponse(**folder)
 
 
+@router.get("/memory-graph")
+async def get_memory_graph(
+    current_user: dict = Depends(get_current_user),
+):
+    """The Memory wiki as a graph — pages in the Memory subtree plus the
+    links between them. Drives the dashboard's context-graph visual."""
+    return await files_tree_service.memory_wiki_graph(current_user["id"])
+
+
 @router.get("/changes")
 async def get_changes(
     since: str | None = None,

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -340,6 +340,45 @@ async def memory_subtree_folder_ids(owner_user_id: UUID) -> set[UUID]:
     return {r["id"] for r in rows}
 
 
+# The curator links wiki pages as `[Title](/p/<page_id>)` (markdown) or
+# `href="/p/<page_id>"` (HTML layout), so any /p/<uuid> reference is a link.
+_WIKI_PAGE_LINK = re.compile(
+    r"/p/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", re.IGNORECASE
+)
+
+
+async def memory_wiki_graph(owner_user_id: UUID) -> dict:
+    """The Memory wiki as a graph: every live page in the Memory subtree is a
+    node; a page-body reference to another wiki page is an undirected edge."""
+    pool = get_pool()
+    folder_ids = await memory_subtree_folder_ids(owner_user_id)
+    if not folder_ids:
+        return {"nodes": [], "edges": []}
+    rows = await pool.fetch(
+        "SELECT id, name, content_markdown, content_html FROM pages "
+        "WHERE folder_id = ANY($1::uuid[]) AND deleted_at IS NULL",
+        list(folder_ids),
+    )
+    page_ids = {r["id"] for r in rows}
+    edges: set[tuple[str, str]] = set()
+    for r in rows:
+        body = (r["content_markdown"] or "") + (r["content_html"] or "")
+        for match in _WIKI_PAGE_LINK.finditer(body):
+            target = UUID(match.group(1))
+            if target in page_ids and target != r["id"]:
+                edges.add(tuple(sorted((str(r["id"]), str(target)))))
+    degree = {str(r["id"]): 0 for r in rows}
+    for a, b in edges:
+        degree[a] += 1
+        degree[b] += 1
+    return {
+        "nodes": [
+            {"id": str(r["id"]), "name": r["name"], "degree": degree[str(r["id"])]} for r in rows
+        ],
+        "edges": [{"source": a, "target": b} for a, b in sorted(edges)],
+    }
+
+
 async def _assert_not_memory(folder_id: UUID, owner_user_id: UUID) -> None:
     pool = get_pool()
     row = await pool.fetchrow(

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -385,3 +385,35 @@ async def test_recompute_metered_like_the_scheduler(client: AsyncClient, _db_poo
     run_curator_now.delay = lambda agent_id: None
     r = await client.post("/api/v1/me/memory/recompute", headers=_auth(key))
     assert r.status_code == 202
+
+
+# --- Memory wiki graph (GET /me/memory-graph) ---
+
+
+@pytest.mark.asyncio
+async def test_memory_graph_nodes_edges_and_scope(client: AsyncClient):
+    key, uid = await _register(client)
+    mem = (await client.get("/api/v1/me/memory-folder", headers=_auth(key))).json()
+
+    async def add_page(name: str, content: str, folder_id: str | None) -> str:
+        r = await client.post(
+            "/api/v1/me/pages/new",
+            json={"name": name, "content": content, "folder_id": folder_id},
+            headers=_auth(key),
+        )
+        assert r.status_code == 201
+        return r.json()["id"]
+
+    alpha = await add_page("Alpha", "seed page", mem["id"])
+    beta = await add_page("Beta", f"see [Alpha](/p/{alpha})", mem["id"])
+    # A Files page linking into the wiki is not a wiki node and adds no edge.
+    await add_page("Outside", f"see [Alpha](/p/{alpha})", None)
+
+    r = await client.get("/api/v1/me/memory-graph", headers=_auth(key))
+    assert r.status_code == 200
+    graph = r.json()
+    assert {n["name"] for n in graph["nodes"]} == {"Alpha", "Beta"}
+    a, b = sorted([alpha, beta])
+    assert graph["edges"] == [{"source": a, "target": b}]
+    # The link is one undirected edge — both ends count it in their degree.
+    assert {n["name"]: n["degree"] for n in graph["nodes"]} == {"Alpha": 1, "Beta": 1}

--- a/frontend/src/app/(app)/memory/page.tsx
+++ b/frontend/src/app/(app)/memory/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-// Memory is a workspace section — the shell renders the explorer + workbench;
-// this route just needs to exist so /memory resolves.
+import BrainDashboard from "@/components/memory/BrainDashboard";
+
+// Memory is a workspace section — the shell renders the explorer beside this
+// route's content: the brain dashboard as the section's landing view.
 export default function MemoryRoute() {
-  return null;
+  return <BrainDashboard />;
 }

--- a/frontend/src/app/activity/loading.tsx
+++ b/frontend/src/app/activity/loading.tsx
@@ -1,5 +1,0 @@
-import { ActivitySkeleton } from "../../components/SkeletonStates";
-
-export default function Loading() {
-  return <ActivitySkeleton />;
-}

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -164,7 +164,7 @@ export default function BrainDashboard() {
 
   return (
     <div className="h-full min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
+      <div className="mx-auto max-w-[1360px] px-8 pb-10 pt-7">
         {/* Header — what this brain holds and how fresh it is. */}
         <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
           Your brain
@@ -173,89 +173,101 @@ export default function BrainDashboard() {
           {`${knowledgePoints.toLocaleString()} things learned across your own and shared knowledge · ${recent24h} new in the last 24 hours.`}
         </p>
 
-        {/* Wiki graph — the curated context graph of linked pages, obsidian
-            style. The centerpiece: click a node to open its page. */}
-        <VizCard
-          label={
-            graph
-              ? `Memory wiki · ${graph.nodes.length} pages · ${graph.edges.length} links`
-              : "Memory wiki"
-          }
-          className="mt-6"
-        >
-          {!insightsLoaded ? (
-            <SkeletonBlock className="h-64 w-full" />
-          ) : graph && graph.nodes.length > 0 ? (
-            <WikiGraph data={graph} />
-          ) : (
-            <div className="px-2 py-12 text-center text-[12.5px] text-muted-foreground">
-              No wiki pages yet. Hit &quot;Curate wiki&quot; in the explorer and the
-              agent will compile your history into a context graph of linked pages.
-            </div>
-          )}
-        </VizCard>
+        {/* Dashboard grid: wiki graph + map/vitals/timeline on the left,
+            learnings feed as its own scrolling panel on the right. */}
+        <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="flex min-w-0 flex-col gap-4 lg:col-span-2">
+            {/* Wiki graph — the curated context graph of linked pages, obsidian
+                style. The centerpiece: click a node to open its page. */}
+            <VizCard
+              label={
+                graph
+                  ? `Memory wiki · ${graph.nodes.length} pages · ${graph.edges.length} links`
+                  : "Memory wiki"
+              }
+            >
+              {!insightsLoaded ? (
+                <SkeletonBlock className="h-[360px] w-full" />
+              ) : graph && graph.nodes.length > 0 ? (
+                <WikiGraph data={graph} />
+              ) : (
+                <div className="flex h-[360px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
+                  No wiki pages yet. Hit &quot;Curate wiki&quot; in the explorer and the
+                  agent will compile your history into a context graph of linked pages.
+                </div>
+              )}
+            </VizCard>
 
-        {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
-        <VizCard label="Knowledge map" className="mt-5">
-          {!insightsLoaded ? (
-            <SkeletonBlock className="h-64 w-full" />
-          ) : projection && projection.points.length > 0 ? (
-            <EmbeddingSpaceExplorer data={projection} />
-          ) : (
-            <div className="px-2 py-12 text-center text-[12.5px] text-muted-foreground">
-              No embeddings indexed yet. Pages, table rows, and session events get
-              embedded as they&apos;re added.
+            {/* Vitals — the brain's current size and pulse. */}
+            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-5">
+              <VitalCard label="Knowledge points" value={knowledgePoints} tint="var(--color-brand-600)" />
+              <VitalCard label="Pages" value={overview?.pages ?? 0} tint="var(--color-human)" />
+              <VitalCard label="Files" value={overview?.files ?? 0} tint="#16A34A" />
+              <VitalCard label="Sessions" value={overview?.sessions ?? 0} tint="var(--color-agent)" />
+              <VitalCard label="Learned today" value={recent24h} tint="var(--text-muted)" />
             </div>
-          )}
-        </VizCard>
 
-        {/* Vitals — the brain's current size and pulse. */}
-        <div className="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-4 lg:grid-cols-5">
-          <VitalCard label="Knowledge points" value={knowledgePoints} tint="var(--color-brand-600)" />
-          <VitalCard label="Pages" value={overview?.pages ?? 0} tint="var(--color-human)" />
-          <VitalCard label="Files" value={overview?.files ?? 0} tint="#16A34A" />
-          <VitalCard label="Sessions" value={overview?.sessions ?? 0} tint="var(--color-agent)" />
-          <VitalCard label="Learned today" value={recent24h} tint="var(--text-muted)" />
-        </div>
+            {/* Human / agent commits over time. (Decorative.) */}
+            <VizCard label="Human / agent commits — last 30 days" scroll>
+              {!insightsLoaded ? (
+                <SkeletonBlock className="h-40 w-full" />
+              ) : timeline && timeline.contributors.length > 0 ? (
+                <ContributorActivityTimeline data={timeline} />
+              ) : (
+                <div className="px-2 py-6 text-center text-[12.5px] text-muted-foreground">
+                  No agent session commits yet. Push a transcript to populate this view.
+                </div>
+              )}
+            </VizCard>
+          </div>
 
-        {/* Human / agent commits over time. (Decorative.) */}
-        <VizCard label="Human / agent commits — last 30 days" className="mt-5" scroll>
-          {!insightsLoaded ? (
-            <SkeletonBlock className="h-40 w-full" />
-          ) : timeline && timeline.contributors.length > 0 ? (
-            <ContributorActivityTimeline data={timeline} />
-          ) : (
-            <div className="px-2 py-6 text-center text-[12.5px] text-muted-foreground">
-              No agent session commits yet. Push a transcript to populate this view.
-            </div>
-          )}
-        </VizCard>
+          <div className="flex min-h-0 min-w-0 flex-col gap-4">
+            {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
+            <VizCard label="Knowledge map">
+              {!insightsLoaded ? (
+                <SkeletonBlock className="h-[240px] w-full" />
+              ) : projection && projection.points.length > 0 ? (
+                <div className="h-[240px]">
+                  <EmbeddingSpaceExplorer data={projection} />
+                </div>
+              ) : (
+                <div className="flex h-[240px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
+                  No embeddings indexed yet. Pages, table rows, and session events
+                  get embedded as they&apos;re added.
+                </div>
+              )}
+            </VizCard>
 
-        {/* Newsfeed — what the brain has been learning lately. */}
-        <div className="mt-8 border-b border-border pb-2">
-          <span className="sys-label">Recent learnings</span>
-        </div>
-
-        <div className="mt-3.5 flex flex-col gap-2.5">
-          {events.length === 0 ? (
-            <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted-foreground">
-              Nothing learned yet. Push a transcript, edit a page, or upload a
-              file.
-            </div>
-          ) : (
-            events.map((event, i) => (
-              <FeedCard
-                key={`${event.kind}-${event.target_id}-${i}`}
-                event={event}
-              />
-            ))
-          )}
-          {loadingMore && (
-            <div className="py-2 text-center text-[12.5px] text-muted-foreground">
-              Loading more…
-            </div>
-          )}
-          {hasMore && <div ref={sentinelRef} />}
+            {/* Newsfeed — what the brain has been learning lately. Scrolls in
+                place (hard cap — inside a grid, flex-1 can't bound it) so the
+                panel row stays a dashboard, not a page. */}
+            <section className="flex flex-col">
+              <div className="sys-label mb-1.5">Recent learnings</div>
+              <div className="card-soft max-h-[480px] overflow-y-auto p-3">
+                <div className="flex flex-col gap-2.5">
+                  {events.length === 0 ? (
+                    <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted-foreground">
+                      Nothing learned yet. Push a transcript, edit a page, or
+                      upload a file.
+                    </div>
+                  ) : (
+                    events.map((event, i) => (
+                      <FeedCard
+                        key={`${event.kind}-${event.target_id}-${i}`}
+                        event={event}
+                      />
+                    ))
+                  )}
+                  {loadingMore && (
+                    <div className="py-2 text-center text-[12.5px] text-muted-foreground">
+                      Loading more…
+                    </div>
+                  )}
+                  {hasMore && <div ref={sentinelRef} />}
+                </div>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -10,21 +9,15 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import WorkspaceShell from "@/components/workspace/workspace-shell";
-import {
-  ActivitySkeleton,
-  BasicPageSkeleton,
-  SkeletonBlock,
-} from "../../components/SkeletonStates";
+import { ActivitySkeleton, SkeletonBlock } from "@/components/SkeletonStates";
 import {
   FileIcon,
   PageIcon,
   SessionsIcon,
   SkillIcon,
-} from "../../components/SkillIcons";
-import ContributorActivityTimeline from "../../components/viz/ContributorActivityTimeline";
-import EmbeddingSpaceExplorer from "../../components/viz/EmbeddingSpaceExplorer";
-import { useAuth } from "../../hooks/useAuth";
+} from "@/components/SkillIcons";
+import ContributorActivityTimeline from "@/components/viz/ContributorActivityTimeline";
+import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
 import {
   getActivityTimeline,
   getEmbeddingProjection,
@@ -32,8 +25,8 @@ import {
   listActivity,
   type ActivityEvent,
   type MeOverview,
-} from "../../lib/api";
-import type { ActivityTimeline, EmbeddingProjection } from "../../lib/types";
+} from "@/lib/api";
+import type { ActivityTimeline, EmbeddingProjection } from "@/lib/types";
 
 const PAGE_SIZE = 50;
 
@@ -65,9 +58,10 @@ function relativeTime(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
 
-export default function ActivityPage() {
-  const router = useRouter();
-  const { user, loading, logout } = useAuth();
+/** The brain dashboard — knowledge map, vitals, commit timeline, and the
+ *  recent-learnings feed. Renders as the Memory section's landing content;
+ *  the shell guarantees a signed-in user. Scrolls itself (h-full). */
+export default function BrainDashboard() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [fetching, setFetching] = useState(true);
   const [hasMore, setHasMore] = useState(false);
@@ -81,7 +75,6 @@ export default function ActivityPage() {
   const [nowMs] = useState(() => Date.now());
 
   useEffect(() => {
-    if (!user) return;
     let cancelled = false;
     listActivity({ limit: PAGE_SIZE })
       .then((feed) => {
@@ -96,7 +89,7 @@ export default function ActivityPage() {
     return () => {
       cancelled = true;
     };
-  }, [user]);
+  }, []);
 
   const loadMore = useCallback(async () => {
     if (loadingMore || !hasMore || events.length === 0) return;
@@ -129,7 +122,6 @@ export default function ActivityPage() {
   // everything shared with them (the /me/* aggregates, called without a
   // scope, include readable shared rows).
   useEffect(() => {
-    if (!user) return;
     let cancelled = false;
     setInsightsLoaded(false);
     Promise.allSettled([
@@ -147,11 +139,7 @@ export default function ActivityPage() {
     return () => {
       cancelled = true;
     };
-  }, [user]);
-
-  useEffect(() => {
-    if (!loading && !user) router.push("/login");
-  }, [user, loading, router]);
+  }, []);
 
   const recent24h = useMemo(() => {
     const since = nowMs - 24 * 60 * 60 * 1000;
@@ -160,18 +148,16 @@ export default function ActivityPage() {
 
   const knowledgePoints = projection?.stats.total_embeddings ?? 0;
 
-  if (loading) return <BasicPageSkeleton />;
-  if (!user) return null;
   if (fetching) {
     return (
-      <WorkspaceShell user={user} onLogout={logout}>
+      <div className="h-full min-h-0 overflow-y-auto">
         <ActivitySkeleton />
-      </WorkspaceShell>
+      </div>
     );
   }
 
   return (
-    <WorkspaceShell user={user} onLogout={logout}>
+    <div className="h-full min-h-0 overflow-y-auto">
       <div className="mx-auto max-w-[920px] px-12 pb-20 pt-9">
         {/* Header — what this brain holds and how fresh it is. */}
         <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
@@ -245,7 +231,7 @@ export default function ActivityPage() {
           {hasMore && <div ref={sentinelRef} />}
         </div>
       </div>
-    </WorkspaceShell>
+    </div>
   );
 }
 

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -18,13 +18,16 @@ import {
 } from "@/components/SkillIcons";
 import ContributorActivityTimeline from "@/components/viz/ContributorActivityTimeline";
 import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
+import WikiGraph from "@/components/memory/WikiGraph";
 import {
   getActivityTimeline,
   getEmbeddingProjection,
+  getMemoryGraph,
   getMeOverview,
   listActivity,
   type ActivityEvent,
   type MeOverview,
+  type WikiGraph as WikiGraphData,
 } from "@/lib/api";
 import type { ActivityTimeline, EmbeddingProjection } from "@/lib/types";
 
@@ -70,6 +73,7 @@ export default function BrainDashboard() {
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
   const [overview, setOverview] = useState<MeOverview | null>(null);
+  const [graph, setGraph] = useState<WikiGraphData | null>(null);
   const [insightsLoaded, setInsightsLoaded] = useState(false);
   // Captured once so the "last 24h" window doesn't drift across re-renders.
   const [nowMs] = useState(() => Date.now());
@@ -128,12 +132,14 @@ export default function BrainDashboard() {
       getActivityTimeline(30, "day"),
       getEmbeddingProjection(500),
       getMeOverview(),
+      getMemoryGraph(),
     ])
-      .then(([t, p, o]) => {
+      .then(([t, p, o, g]) => {
         if (cancelled) return;
         if (t.status === "fulfilled") setTimeline(t.value);
         if (p.status === "fulfilled") setProjection(p.value);
         if (o.status === "fulfilled") setOverview(o.value);
+        if (g.status === "fulfilled") setGraph(g.value);
         setInsightsLoaded(true);
       });
     return () => {
@@ -167,9 +173,30 @@ export default function BrainDashboard() {
           {`${knowledgePoints.toLocaleString()} things learned across your own and shared knowledge · ${recent24h} new in the last 24 hours.`}
         </p>
 
-        {/* Brain map — the knowledge the brain holds, laid out in space. The
-            centerpiece visual. (Decorative.) */}
-        <VizCard label="Knowledge map" className="mt-6">
+        {/* Wiki graph — the curated context graph of linked pages, obsidian
+            style. The centerpiece: click a node to open its page. */}
+        <VizCard
+          label={
+            graph
+              ? `Memory wiki · ${graph.nodes.length} pages · ${graph.edges.length} links`
+              : "Memory wiki"
+          }
+          className="mt-6"
+        >
+          {!insightsLoaded ? (
+            <SkeletonBlock className="h-64 w-full" />
+          ) : graph && graph.nodes.length > 0 ? (
+            <WikiGraph data={graph} />
+          ) : (
+            <div className="px-2 py-12 text-center text-[12.5px] text-muted-foreground">
+              No wiki pages yet. Hit &quot;Curate wiki&quot; in the explorer and the
+              agent will compile your history into a context graph of linked pages.
+            </div>
+          )}
+        </VizCard>
+
+        {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
+        <VizCard label="Knowledge map" className="mt-5">
           {!insightsLoaded ? (
             <SkeletonBlock className="h-64 w-full" />
           ) : projection && projection.points.length > 0 ? (

--- a/frontend/src/components/memory/WikiGraph.tsx
+++ b/frontend/src/components/memory/WikiGraph.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { WikiGraph as WikiGraphData, WikiGraphNode } from "@/lib/api";
+
+const HEIGHT = 360;
+
+// Landing-page "Wiki" card palette: orange hubs, warm-gray leaves.
+function nodeColor(degree: number): string {
+  if (degree >= 5) return "#F97316";
+  if (degree >= 3) return "#EA7C1F";
+  if (degree === 0) return "#F97316";
+  return "#6B655B";
+}
+
+function nodeRadius(degree: number): number {
+  return Math.min(6 + degree * 1.2, 15);
+}
+
+interface Sim {
+  nodes: WikiGraphNode[];
+  x: Float64Array;
+  y: Float64Array;
+  vx: Float64Array;
+  vy: Float64Array;
+  edges: [number, number][];
+  alpha: number;
+}
+
+function buildSim(data: WikiGraphData, w: number, h: number): Sim {
+  const n = data.nodes.length;
+  const x = new Float64Array(n);
+  const y = new Float64Array(n);
+  // Seed on a golden-angle spiral so the simulation starts untangled and
+  // deterministic (same graph → same layout).
+  for (let i = 0; i < n; i++) {
+    const angle = i * 2.399963;
+    const r = 24 + 13 * Math.sqrt(i);
+    x[i] = w / 2 + r * Math.cos(angle);
+    y[i] = h / 2 + r * Math.sin(angle);
+  }
+  const index = new Map(data.nodes.map((node, i) => [node.id, i]));
+  const edges = data.edges.map(
+    (e) => [index.get(e.source)!, index.get(e.target)!] as [number, number],
+  );
+  return { nodes: data.nodes, x, y, vx: new Float64Array(n), vy: new Float64Array(n), edges, alpha: 1 };
+}
+
+/** One force-layout step: node-pair repulsion, edge springs, center gravity. */
+function tick(sim: Sim, w: number, h: number) {
+  const { x, y, vx, vy, edges, alpha } = sim;
+  const n = x.length;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = x[i] - x[j];
+      const dy = y[i] - y[j];
+      const d2 = Math.max(dx * dx + dy * dy, 400);
+      const f = (15000 * alpha) / d2;
+      const d = Math.sqrt(d2);
+      vx[i] += (dx / d) * f;
+      vy[i] += (dy / d) * f;
+      vx[j] -= (dx / d) * f;
+      vy[j] -= (dy / d) * f;
+    }
+  }
+
+  for (const [a, b] of edges) {
+    const dx = x[b] - x[a];
+    const dy = y[b] - y[a];
+    const d = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+    const f = (d - 110) * 0.05 * alpha;
+    vx[a] += (dx / d) * f;
+    vy[a] += (dy / d) * f;
+    vx[b] -= (dx / d) * f;
+    vy[b] -= (dy / d) * f;
+  }
+
+  for (let i = 0; i < n; i++) {
+    vx[i] += (w / 2 - x[i]) * 0.006 * alpha;
+    vy[i] += (h / 2 - y[i]) * 0.006 * alpha;
+    vx[i] *= 0.82;
+    vy[i] *= 0.82;
+    x[i] += vx[i];
+    y[i] += vy[i];
+  }
+
+  sim.alpha *= 0.985;
+}
+
+/** Obsidian-style force graph of the Memory wiki — pages as nodes sized and
+ *  colored by link count, page-to-page links as edges. Click a node to open
+ *  that page; the layout settles live on load. */
+export default function WikiGraph({ data }: { data: WikiGraphData }) {
+  const router = useRouter();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const simRef = useRef<Sim | null>(null);
+  const hoverRef = useRef<number>(-1);
+  const [hovered, setHovered] = useState<number>(-1);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const sim = simRef.current;
+    if (!canvas || !sim) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const w = canvas.parentElement?.clientWidth || 600;
+    const dpr = window.devicePixelRatio || 2;
+    canvas.width = w * dpr;
+    canvas.height = HEIGHT * dpr;
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${HEIGHT}px`;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, w, HEIGHT);
+
+    // Faint 40px grid, matching the landing card's backdrop.
+    ctx.strokeStyle = "rgba(26,23,20,0.04)";
+    ctx.lineWidth = 1;
+    for (let gx = 0; gx <= w; gx += 40) {
+      ctx.beginPath();
+      ctx.moveTo(gx, 0);
+      ctx.lineTo(gx, HEIGHT);
+      ctx.stroke();
+    }
+    for (let gy = 0; gy <= HEIGHT; gy += 40) {
+      ctx.beginPath();
+      ctx.moveTo(0, gy);
+      ctx.lineTo(w, gy);
+      ctx.stroke();
+    }
+
+    const { nodes, x, y, edges } = sim;
+    const hover = hoverRef.current;
+    const neighbors = new Set<number>();
+    if (hover >= 0) {
+      for (const [a, b] of edges) {
+        if (a === hover) neighbors.add(b);
+        if (b === hover) neighbors.add(a);
+      }
+    }
+
+    for (const [a, b] of edges) {
+      const active = hover >= 0 && (a === hover || b === hover);
+      ctx.beginPath();
+      ctx.moveTo(x[a], y[a]);
+      ctx.lineTo(x[b], y[b]);
+      ctx.strokeStyle = active ? "rgba(249,115,22,0.55)" : "rgba(26,23,20,0.22)";
+      ctx.lineWidth = active ? 1.5 : 1;
+      ctx.stroke();
+    }
+
+    // Label everything on small wikis; only hubs + the hovered node on big ones.
+    const labelAll = nodes.length <= 40;
+    ctx.font = "11px ui-monospace, Menlo, monospace";
+    ctx.textBaseline = "middle";
+    for (let i = 0; i < nodes.length; i++) {
+      const r = nodeRadius(nodes[i].degree);
+      ctx.beginPath();
+      ctx.arc(x[i], y[i], r, 0, Math.PI * 2);
+      ctx.fillStyle = nodeColor(nodes[i].degree);
+      ctx.globalAlpha = hover >= 0 && i !== hover && !neighbors.has(i) ? 0.35 : 1;
+      ctx.fill();
+      ctx.strokeStyle = "white";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+
+      if (labelAll || nodes[i].degree >= 3 || i === hover) {
+        const label =
+          nodes[i].name.length > 26 ? `${nodes[i].name.slice(0, 25)}…` : nodes[i].name;
+        const left = x[i] > w - 130;
+        ctx.fillStyle = i === hover ? "rgba(26,23,20,0.92)" : "rgba(26,23,20,0.62)";
+        ctx.textAlign = left ? "right" : "left";
+        ctx.fillText(label, left ? x[i] - r - 5 : x[i] + r + 5, y[i]);
+      }
+      ctx.globalAlpha = 1;
+    }
+  }, []);
+
+  useEffect(() => {
+    const w = canvasRef.current?.parentElement?.clientWidth || 600;
+    const sim = buildSim(data, w, HEIGHT);
+    simRef.current = sim;
+    let raf = 0;
+    const step = () => {
+      if (sim.alpha > 0.02) tick(sim, w, HEIGHT);
+      draw();
+      raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [data, draw]);
+
+  const findNode = useCallback((mx: number, my: number): number => {
+    const sim = simRef.current;
+    if (!sim) return -1;
+    for (let i = 0; i < sim.nodes.length; i++) {
+      const dx = mx - sim.x[i];
+      const dy = my - sim.y[i];
+      const r = nodeRadius(sim.nodes[i].degree) + 4;
+      if (dx * dx + dy * dy <= r * r) return i;
+    }
+    return -1;
+  }, []);
+
+  return (
+    <div className="relative">
+      <canvas
+        ref={canvasRef}
+        className="w-full"
+        style={{ height: HEIGHT, cursor: hovered >= 0 ? "pointer" : "default" }}
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          const i = findNode(e.clientX - rect.left, e.clientY - rect.top);
+          hoverRef.current = i;
+          setHovered(i);
+        }}
+        onMouseLeave={() => {
+          hoverRef.current = -1;
+          setHovered(-1);
+        }}
+        onClick={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          const i = findNode(e.clientX - rect.left, e.clientY - rect.top);
+          const sim = simRef.current;
+          if (i >= 0 && sim) router.push(`/p/${sim.nodes[i].id}?section=memory`);
+        }}
+      />
+      <div className="absolute bottom-2 right-2 flex flex-col gap-1 rounded-md border border-border bg-base/85 px-2.5 py-2 backdrop-blur">
+        {[
+          { dot: "#F97316", label: "hub" },
+          { dot: "#6B655B", label: "leaf" },
+        ].map((row) => (
+          <div key={row.label} className="flex items-center gap-2 font-mono text-[10.5px] text-muted-foreground">
+            <span className="h-[7px] w-[7px] rounded-full" style={{ background: row.dot }} />
+            {row.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
+++ b/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
@@ -86,7 +86,7 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
     if (!ctx) return;
 
     const containerWidth = canvas.parentElement?.clientWidth || 400;
-    const containerHeight = 320;
+    const containerHeight = canvas.parentElement?.clientHeight || 320;
     const dpr = window.devicePixelRatio || 2;
 
     canvas.width = containerWidth * dpr;
@@ -284,11 +284,10 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
   );
 
   return (
-    <div className="relative">
+    <div className="relative h-full">
       <canvas
         ref={canvasRef}
-        className="w-full cursor-grab active:cursor-grabbing"
-        style={{ height: 320 }}
+        className="block w-full cursor-grab active:cursor-grabbing"
         onMouseMove={handleMouseMove}
         onMouseLeave={() => {
           setTooltip(null);

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -101,6 +101,13 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
   const requestedSection = searchParams.get("section");
 
   function selectSection(section: RailSection) {
+    // Memory's landing is the brain dashboard, so it navigates; other sections
+    // just swap the explorer beside whatever's open.
+    if (section === "memory") {
+      setRailSection(section);
+      router.replace("/memory");
+      return;
+    }
     const params = new URLSearchParams(searchParams);
     params.set("section", section);
     setRailSection(section);

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -93,7 +93,10 @@ export default function WorkspaceShell({
   const requestedSection = searchParams.get("section");
   const selectedSection = EXPLORER_SECTIONS.find((s) => s === requestedSection) ?? null;
   const section = selectedSection ?? routeSection;
-  const renderRouteContent = pathname === "/sessions" && !selectedSection && searchParams.get("workspace") !== "1";
+  const renderRouteContent =
+    (pathname === "/sessions" && !selectedSection && searchParams.get("workspace") !== "1") ||
+    // Memory lands on the brain dashboard; opening an item switches to the workbench.
+    (pathname === "/memory" && !selectedSection);
 
   return (
     // Chrome surface — the content panel floats on top of it.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -450,6 +450,22 @@ export async function getMemoryFolder(): Promise<Folder> {
   return apiFetch(`${ME}/memory-folder`);
 }
 
+export interface WikiGraphNode {
+  id: string;
+  name: string;
+  degree: number;
+}
+
+export interface WikiGraph {
+  nodes: WikiGraphNode[];
+  edges: { source: string; target: string }[];
+}
+
+// The Memory wiki as a graph: pages in the Memory subtree + links between them.
+export async function getMemoryGraph(): Promise<WikiGraph> {
+  return apiFetch(`${ME}/memory-graph`);
+}
+
 export async function createFolder(
   name: string,
   parentFolderId?: string | null


### PR DESCRIPTION
## What & why

Two related changes that give the Memory section a real home:

1. **Memory lands on the brain dashboard.** The "Your brain" dashboard (3D knowledge map, vitals, human/agent commit timeline, recent-learnings feed) had been orphaned on `/activity` since the icon-rail rework dropped its nav link. Clicking Memory in the rail now shows the full dashboard beside the wiki explorer; opening any item switches to the workbench.
2. **Obsidian-style wiki graph, real data.** The landing page's "Wiki" card shows a mocked context graph — the dashboard's new top card renders the actual Memory wiki in the same visual language: pages as nodes (orange hubs sized by link count, warm-gray leaves, mono labels), page-to-page links as edges. Hovering a node highlights its links and dims the rest; clicking opens that page.

## Changes

**Dashboard move (commit 1)**
- `/activity` page moves wholesale to `components/memory/BrainDashboard.tsx` (shell-free; the workspace shell owns auth/chrome); `/activity` is deleted.
- `workspace-shell` renders `/memory` as route content (the `/sessions` pattern); the rail's Memory button navigates to `/memory` instead of only swapping the explorer panel.

**Wiki graph (commit 2)**
- Backend: `GET /me/memory-graph` (`files_tree.py` + `memory_wiki_graph` in `files_tree_service.py`) — every live page in the Memory subtree is a node; a page-body `/p/<id>` reference to another wiki page (the curator's markdown/HTML link format) is an undirected edge. Degree rides along for node sizing.
- Frontend: `WikiGraph.tsx`, a canvas force-graph (repulsion + edge springs + center gravity, seeded on a golden-angle spiral so the same graph always settles the same way — no layout library added). Labels all nodes on small wikis, hubs + hovered node on big ones. Click → `/p/<id>?section=memory` so the wiki explorer stays open.
- `BrainDashboard` fetches the graph alongside the other insights and shows it as the top card ("Memory wiki · N pages · M links"), with an empty state pointing at "Curate wiki".

**Multi-panel layout (commit 3)**
- The dashboard is a grid, not a column: wiki graph + vitals + commit timeline on the left (2/3), knowledge map + recent-learnings feed stacked on the right, with the feed scrolling in place (capped — inside a grid, flex-1 can't bound it). `EmbeddingSpaceExplorer` sizes to its container so the map fits its panel; the dashboard is its only consumer.

## Screenshots

- Dashboard grid: wiki graph + knowledge map + feed above the fold → https://app.joinstash.ai/f/f34c5a65-1939-48d9-aa8b-2cb34140731b
- Lower half: vitals row, commit timeline, feed scrolling in place → https://app.joinstash.ai/f/c759afe9-e036-4749-a563-2bf55aee9b3c
- Wiki graph hover: the hub's links highlight orange, unrelated nodes dim → https://app.joinstash.ai/f/9c1094a5-932e-4d4a-a518-9b63cfcfcc25

## Verified locally (real backend + Postgres, agent-browser)

Seeded a 13-page wiki with markdown links shaped like a real one (index hub, mid nodes, leaves): the card reads "13 pages · 26 links", the layout settles live and legibly, hover highlights work, clicking the hub opened its page in the workbench with the Memory explorer still open. Dashboard flows from the previous revision re-verified (feed "Open →", rail Memory returning to the dashboard).

## Tests

- Backend: new `test_memory_graph_nodes_edges_and_scope` (wiki pages nodes + link edge + degree; Files pages excluded even when they link in). Full suite: **758 passed**, coverage 76.5%. `ruff check` + `ruff format` clean.
- Frontend: 189 passed, lint clean (3 pre-existing warnings), `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
