### PR TITLE
Render source Browse as a directory tree, with Load more / Load all

### DIFF
--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MoreHorizontal } from "lucide-react";
 
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
@@ -875,28 +875,94 @@ function NavigablePanel({
 }) {
   const [path, setPath] = useState("");
   const [entries, setEntries] = useState<SourceEntry[] | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [crumbs, setCrumbs] = useState<{ label: string; path: string }[]>([{ label: source.display_name, path: "" }]);
   const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
   const [error, setError] = useState("");
+  // Bumped whenever the listing target changes, so an in-flight Load more for
+  // the previous directory can't clobber the new one.
+  const listingSeq = useRef(0);
+
+  // The endpoint truncates at the requested limit; asking for one extra row is
+  // how callers detect that another page exists (see routers/sources.py).
+  const PAGE_SIZE = 200;
+
+  async function fetchPage(dir: string, after: string): Promise<{ page: SourceEntry[]; more: boolean }> {
+    const rows = await getSourceEntries(source.source, dir, { limit: PAGE_SIZE + 1, after });
+    const more = rows.length > PAGE_SIZE;
+    return { page: more ? rows.slice(0, PAGE_SIZE) : rows, more };
+  }
 
   useEffect(() => {
-    let cancelled = false;
+    const seq = ++listingSeq.current;
     setEntries(null);
+    setHasMore(false);
     setError("");
-    getSourceEntries(source.source, path)
-      .then((next) => {
-        if (!cancelled) setEntries(next);
+    fetchPage(path, "")
+      .then(({ page, more }) => {
+        if (listingSeq.current !== seq) return;
+        setEntries(page);
+        setHasMore(more);
       })
       .catch((e) => {
-        if (!cancelled) {
-          setEntries([]);
-          setError(e instanceof Error ? e.message : "Could not list entries");
-        }
+        if (listingSeq.current !== seq) return;
+        setEntries([]);
+        setError(e instanceof Error ? e.message : "Could not list entries");
       });
-    return () => {
-      cancelled = true;
-    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source.source, path]);
+
+  async function loadMore(all: boolean) {
+    if (!entries || loadingMore) return;
+    const seq = listingSeq.current;
+    setLoadingMore(true);
+    try {
+      let acc = entries;
+      let more = hasMore;
+      while (more) {
+        const cursor = acc[acc.length - 1]?.path;
+        if (!cursor) break; // the cursor is a path; a path-less listing can't page
+        const { page, more: nextMore } = await fetchPage(path, cursor);
+        if (listingSeq.current !== seq) return;
+        acc = [...acc, ...page];
+        more = nextMore;
+        if (!all) break;
+      }
+      setEntries(acc);
+      setHasMore(more);
+    } catch (e) {
+      if (listingSeq.current === seq) {
+        setError(e instanceof Error ? e.message : "Could not list entries");
+      }
+    } finally {
+      if (listingSeq.current === seq) setLoadingMore(false);
+    }
+  }
+
+  // The entries endpoint returns every descendant file as a flat, path-ordered
+  // list (the VFS builds its tree from the same shape). Fold that into one
+  // directory level: an entry nested below the current path becomes a folder
+  // row for its first path segment, emitted once, in path order.
+  const visibleEntries = useMemo(() => {
+    if (!entries) return null;
+    const dirPrefix = path ? `${path}/` : "";
+    const seenFolders = new Set<string>();
+    const rows: SourceEntry[] = [];
+    for (const entry of entries) {
+      const rel = entry.path?.startsWith(dirPrefix) ? entry.path.slice(dirPrefix.length) : null;
+      const slash = rel?.indexOf("/") ?? -1;
+      if (rel === null || slash === -1) {
+        rows.push(entry);
+        continue;
+      }
+      const segment = rel.slice(0, slash);
+      if (seenFolders.has(segment)) continue;
+      seenFolders.add(segment);
+      rows.push({ name: segment, kind: "dir", path: `${dirPrefix}${segment}` });
+    }
+    return rows;
+  }, [entries, path]);
 
   // Folder-like entries (have a `path` and are a container) drill in; leaves open a doc.
   function isFolder(entry: SourceEntry): boolean {
@@ -940,15 +1006,15 @@ function NavigablePanel({
 
       {error && <div className="mb-2 text-[12px] text-error">{error}</div>}
 
-      {entries === null ? (
+      {visibleEntries === null ? (
         <div className="text-[12px] text-muted-foreground">Loading…</div>
-      ) : entries.length === 0 ? (
+      ) : visibleEntries.length === 0 ? (
         <div className="text-[12px] text-muted-foreground">Empty.</div>
       ) : (
         <div className="space-y-0.5">
-          {entries.map((entry) => {
-            const key = entry.id ?? entry.path ?? entry.name;
+          {visibleEntries.map((entry) => {
             const folder = isFolder(entry);
+            const key = `${folder ? "dir" : "doc"}:${entry.id ?? entry.path ?? entry.name}`;
             return (
               <button
                 key={key}
@@ -963,6 +1029,30 @@ function NavigablePanel({
               </button>
             );
           })}
+          {hasMore && (
+            <div className="flex items-center gap-3 px-2 py-1.5 text-[12px] text-muted-foreground">
+              {loadingMore ? (
+                <span>Loading…</span>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => loadMore(false)}
+                    className="cursor-pointer hover:text-foreground hover:underline"
+                  >
+                    Load more
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => loadMore(true)}
+                    className="cursor-pointer hover:text-foreground hover:underline"
+                  >
+                    Load all
+                  </button>
+                </>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -343,8 +343,13 @@ export async function getSourceStatus(sourceId: string): Promise<SourceStatus> {
 export async function getSourceEntries(
   source: string,
   path = "",
+  opts: { limit?: number; after?: string } = {},
 ): Promise<SourceEntry[]> {
-  const q = path ? `?path=${encodeURIComponent(path)}` : "";
+  const params = new URLSearchParams();
+  if (path) params.set("path", path);
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.after) params.set("after", opts.after);
+  const q = params.size ? `?${params}` : "";
   const data = await apiFetch<{ entries: SourceEntry[] }>(
     `${ME}/sources/${source}/entries${q}`,
   );


### PR DESCRIPTION
## Problem

Two related Browse-panel gaps on the integrations page, both surfaced while testing #757:

1. **Nested folders rendered flat.** The `/entries` endpoint returns every descendant file as one flat, path-ordered list (the VFS builds its tree from the same shape). The Browse panel rendered that verbatim, so a synced Drive folder with subfolders showed as a heap of leaf filenames — this is the "nested folders get flattened" report; the *data* was always correctly nested (the VFS proves it), only this view was flat. Affected every navigable source (Drive, GitHub, Gmail, …).
2. **Silent truncation at 200.** The panel only ever fetched the first page (`ENTRIES_LIMIT = 200`), with no indication more existed and no way to get it.

## Fix (frontend only, no API change)

- `NavigablePanel` folds the flat listing into one directory level: an entry nested below the current path becomes a 📁 row for its first path segment, emitted once, in path order. Drilling in refetches with the segment as the server-side path prefix — which the endpoint already supports.
- Truncation now uses the endpoint's request-one-extra-row convention, and shows **Load more** / **Load all** driven by the existing keyset `after` cursor. An in-flight load is dropped if you navigate away mid-fetch.
- `getSourceEntries` gains optional `limit`/`after` params.

I deliberately did *not* move the tree logic server-side: the VFS (CLI mount and the server-side agent VFS) depends on the recursive flat listing, so changing the `/entries` contract would be a much wider blast radius for the same visual result.

## Verified in the browser (seeded dev stack)

Seeded a `google_drive_folder` source with a 3-level tree plus 210 files in one subfolder:

- Root shows folders + leaves correctly: https://app.joinstash.ai/f/75ceefe2-2a31-42a6-b967-2d0e1e66be79
- Three-level drill-down with breadcrumbs, doc viewer opens nested leaves: https://app.joinstash.ai/f/b1894e58-aa84-443f-8a1c-cb691dd00203
- 200-row first page with Load more / Load all: https://app.joinstash.ai/f/a195d7a6-a0ec-479f-906b-5dc81257034e
- "Load all" fetched all 210 rows and the control disappeared.

Lint clean (0 errors), 191 frontend tests pass, `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)