### PR TITLE
Pin opencode version in the sprite seed script

### DIFF
--- a/backend/services/sprite_service.py
+++ b/backend/services/sprite_service.py
@@ -47,7 +47,12 @@ SPRITE_PATH = (
 # Bump whenever _seed_script changes: boxes provisioned under an older
 # version re-run the (idempotent) seed on their next acquire, so additions
 # like a new harness CLI reach existing sprites, not just new ones.
-SEED_VERSION = 1
+SEED_VERSION = 2
+
+# Pinned because the installer's "latest" lookup hits the unauthenticated
+# GitHub API, whose per-IP rate limit the sprites' shared egress IP exhausts —
+# a pinned version downloads straight from the release CDN instead.
+OPENCODE_VERSION = "1.17.18"
 
 # A first-ever provision creates the VM and seeds it (~10-30s).
 PROVISION_TIMEOUT_S = 180
@@ -244,7 +249,7 @@ set -euo pipefail
 export PATH="{SPRITE_PATH}"
 command -v stash > /dev/null || python3 -m pip install --user --break-system-packages stashai
 mkdir -p ~/.local/bin
-command -v opencode > /dev/null || {{ curl -fsSL https://opencode.ai/install | bash; ln -sf ~/.opencode/bin/opencode ~/.local/bin/opencode; }}
+command -v opencode > /dev/null || {{ curl -fsSL https://opencode.ai/install | VERSION={OPENCODE_VERSION} bash; ln -sf ~/.opencode/bin/opencode ~/.local/bin/opencode; }}
 mkdir -p ~/.stash
 cat > ~/.stash/config.json << 'STASH_CONFIG'
 {config}


### PR DESCRIPTION
## Why

Every **fresh sprite provision in prod is failing right now**: the opencode installer's "latest" lookup calls the unauthenticated GitHub API (`api.github.com/repos/anomalyco/opencode/releases/latest`), and the sprites' shared egress IP has exhausted the 60-req/hr per-IP rate limit. The installer exits 1 with `Failed to fetch version information`, the seed script aborts, and the user's first managed agent run fails (observed at 08:50 and 08:51 UTC today; it blocked the heaviai.com curator onboarding).

## What

- Pin `VERSION=1.17.18` when piping the installer — a pinned version downloads straight from the release CDN (`github.com/.../releases/download/...`) and never touches the rate-limited API.
- Bump `SEED_VERSION` to 2 so boxes that half-seeded under the old script re-run the idempotent seed on next acquire.

## Testing

- `ruff check` + `ruff format --check` clean.
- `backend/tests/test_sprite_reseed.py` and `test_sprite_agent_mapping.py`: 17 passed.
- Verified against the live installer script that `VERSION=x.y.z` skips the `releases/latest` API call entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)