### PR TITLE
Make silent plugin-upload failures loud

### DIFF
--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -68,10 +68,15 @@ PY_EOF
 )"
 fi
 
-# pip --user (stashai on system site-packages) or any case the venv-python
-# heuristic missed — fall through to whatever python3 is on PATH.
+# No interpreter that can import stashai means nothing can upload. Exec'ing a
+# bare python3 here would "work" whenever some stale site-packages copy is
+# importable — old client code against a new API, failing silently on every
+# hook (that exact path cost a machine a month of session uploads in June '26).
+# Refuse loudly instead.
 if [ -z "$PY" ]; then
-  PY="python3"
+  echo "stash plugin: no stashai install found — session activity is NOT uploading to Stash." \
+    "Fix: uv tool install stashai (or run install.sh from the stash repo)." >&2
+  exit 1
 fi
 
 exec "$PY" "$TARGET" "$@"

--- a/plugins/claude-plugin/scripts/_run.sh
+++ b/plugins/claude-plugin/scripts/_run.sh
@@ -75,7 +75,7 @@ fi
 # Refuse loudly instead.
 if [ -z "$PY" ]; then
   echo "stash plugin: no stashai install found — session activity is NOT uploading to Stash." \
-    "Fix: uv tool install stashai (or run install.sh from the stash repo)." >&2
+    "Fix: uv tool install stashai" >&2
   exit 1
 fi
 

--- a/plugins/claude-plugin/scripts/cache_drift.py
+++ b/plugins/claude-plugin/scripts/cache_drift.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Warn when the cached plugin scripts drift from the marketplace clone.
+
+Claude Code copies a plugin into ~/.claude/plugins/cache/<marketplace>/<name>/…
+and refreshes that copy only when the marketplace registers a version bump. If
+that refresh breaks, the cache runs ever-staler scripts and nothing says so:
+hooks keep exiting 0 while the scripts drift incompatible with the library
+they pin (a machine spent Jun 12–Jul 10 '26 uploading nothing this way). The
+marketplace clone lives on the same disk, so the cheapest honest check is
+comparing the two manifests at session start.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+MANIFEST = Path(".claude-plugin") / "plugin.json"
+# Where this plugin lives inside the marketplace repo (the stash monorepo).
+# The module ships with that plugin, so the path is a fact about itself.
+SOURCE_SUBDIR = Path("plugins") / "claude-plugin"
+
+
+def _version(manifest: Path) -> str | None:
+    try:
+        data = json.loads(manifest.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = data.get("version")
+    return version if isinstance(version, str) and version else None
+
+
+def plugin_cache_drift_warning() -> str | None:
+    """Warning text when the cache and marketplace manifests disagree, else None."""
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not root:
+        return None
+    cache_root = Path(root).resolve()
+    parts = cache_root.parts
+    # A local dev checkout doesn't run from a marketplace cache; nothing to compare.
+    if "cache" not in parts:
+        return None
+    idx = parts.index("cache")
+    if len(parts) <= idx + 1:
+        return None
+    marketplace = parts[idx + 1]
+    plugins_dir = Path(*parts[:idx])
+    cached = _version(cache_root / MANIFEST)
+    source = _version(plugins_dir / "marketplaces" / marketplace / SOURCE_SUBDIR / MANIFEST)
+    if not cached or not source or cached == source:
+        return None
+    return (
+        f"Stash plugin scripts are stale: this session runs cached v{cached} but "
+        f"the '{marketplace}' marketplace has v{source}. Hooks may be running old "
+        "code — update the stash plugin from /plugin in Claude Code."
+    )

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from adapt import adapt_session_start
+from cache_drift import plugin_cache_drift_warning
 from config import DATA_DIR, get_config, get_stdin_data
 
 try:
@@ -16,6 +17,17 @@ except ImportError:
     # auto-updates; skip the check until the package catches up.
     def shadow_install_warning() -> None:
         return None
+
+
+try:
+    from stashai.plugin.hooks import color_upload_health_warning, upload_health_warning
+except ImportError:
+    # Same version-skew window as above.
+    def upload_health_warning(*_args) -> None:
+        return None
+
+    def color_upload_health_warning(text: str) -> str:
+        return text
 
 
 from stashai.plugin.hooks import (
@@ -81,7 +93,9 @@ def main():
     state = load_state(DATA_DIR)
     if not uploads_enabled(cfg):
         warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
-        messages = [m for m in (warning, shadow_install_warning()) if m]
+        messages = [
+            m for m in (warning, shadow_install_warning(), plugin_cache_drift_warning()) if m
+        ]
         if messages:
             json.dump({"systemMessage": "\n\n".join(messages)}, sys.stdout)
         return
@@ -122,9 +136,22 @@ def main():
             "additionalContext": CONTEXT + session_context,
         }
     }
-    shadow_warning = shadow_install_warning()
-    if shadow_warning:
-        output["systemMessage"] = shadow_warning
+    # Surface upload failures at session START, not only at first Stop: warned
+    # before any work happens, the user can fix streaming while it still covers
+    # the whole session. The once-per-session gate inside upload_health_warning
+    # keeps on_stop from repeating this.
+    health_warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    messages = [
+        m
+        for m in (
+            shadow_install_warning(),
+            plugin_cache_drift_warning(),
+            color_upload_health_warning(health_warning) if health_warning else None,
+        )
+        if m
+    ]
+    if messages:
+        output["systemMessage"] = "\n\n".join(messages)
     json.dump(output, sys.stdout)
 
 

--- a/plugins/tests/test_cache_drift.py
+++ b/plugins/tests/test_cache_drift.py
@@ -1,0 +1,71 @@
+"""The session-start drift check: cached plugin scripts vs the marketplace clone.
+
+A cache that silently stops refreshing runs ever-staler hook scripts (the
+Jun–Jul '26 upload outage). The check must speak up on a version mismatch and
+stay silent when it cannot know or there is nothing to say.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "claude-plugin" / "scripts"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("cache_drift", SCRIPTS / "cache_drift.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(plugin_dir: Path, version: str) -> None:
+    manifest_dir = plugin_dir / ".claude-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(json.dumps({"name": "stash", "version": version}))
+
+
+def _layout(tmp_path: Path, cached: str, source: str | None) -> Path:
+    """Build the ~/.claude/plugins/{cache,marketplaces} shape and return the
+    cache root (what CLAUDE_PLUGIN_ROOT points at)."""
+    cache_root = tmp_path / "plugins" / "cache" / "stash-plugins" / "stash" / cached
+    _write_manifest(cache_root, cached)
+    if source is not None:
+        _write_manifest(
+            tmp_path / "plugins" / "marketplaces" / "stash-plugins" / "plugins" / "claude-plugin",
+            source,
+        )
+    return cache_root
+
+
+def test_a_stale_cache_is_reported_with_both_versions(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_layout(tmp_path, "0.1.85", "0.1.279")))
+    warning = _load().plugin_cache_drift_warning()
+    assert warning is not None
+    assert "0.1.85" in warning
+    assert "0.1.279" in warning
+
+
+def test_matching_versions_stay_silent(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_layout(tmp_path, "0.1.279", "0.1.279")))
+    assert _load().plugin_cache_drift_warning() is None
+
+
+def test_no_marketplace_clone_stays_silent(tmp_path, monkeypatch):
+    # Installed without a marketplace checkout: there is nothing to compare against.
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_layout(tmp_path, "0.1.279", None)))
+    assert _load().plugin_cache_drift_warning() is None
+
+
+def test_a_dev_checkout_outside_the_cache_stays_silent(tmp_path, monkeypatch):
+    plugin_dir = tmp_path / "repo" / "plugins" / "claude-plugin"
+    _write_manifest(plugin_dir, "0.1.279")
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_dir))
+    assert _load().plugin_cache_drift_warning() is None
+
+
+def test_unset_plugin_root_stays_silent(monkeypatch):
+    monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    assert _load().plugin_cache_drift_warning() is None

--- a/plugins/tests/test_run_launcher.py
+++ b/plugins/tests/test_run_launcher.py
@@ -1,0 +1,29 @@
+"""The hook launcher must refuse loudly when no stashai interpreter exists.
+
+Exec'ing a fallback python3 in that case is how a stale pip-installed client
+ran (and 404'd) for a month without anyone seeing an error: whatever python
+happened to resolve could import old code and fail silently forever.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parent.parent / "claude-plugin" / "scripts" / "_run.sh"
+
+
+def test_missing_stashai_is_a_loud_error_not_a_fallback_python(tmp_path):
+    # A PATH with core utilities but no `stash` and no `uv`: resolution finds
+    # nothing, and the launcher must exit nonzero with a human-readable reason
+    # instead of exec'ing whatever python3 is lying around.
+    proc = subprocess.run(
+        ["bash", str(RUN_SH), "on_prompt"],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+        timeout=30,
+    )
+    assert proc.returncode == 1
+    assert "NOT uploading" in proc.stderr


### PR DESCRIPTION
## Context

Post-mortem hardening from the Jun 12 → Jul 10 outage where a machine uploaded **zero session activity for four weeks** with no visible error. Root causes and the quiet paths that hid them:

1. A stale pip-installed `stashai 0.1.99` (pyenv) shadowed the current uv install; the launcher's `python3` fallback happily ran it, and it POSTed to the removed `/api/v1/workspaces/...` endpoints — 404, spooled, swallowed, exit 0, forever.
2. The plugin cache's scripts were frozen at June 12 (its then-`git pull` self-update never worked: the cache isn't a git repo), so the fixes that already shipped for #1 never arrived.
3. `upload_status.json` recorded `"[404] Not Found", consecutive_failures: N` the whole time — machine-readable, surfaced nowhere at the start of a session.

Current main already fixes the *resolution* logic and has `upload_health_warning`; this PR closes the three remaining silence gaps.

## Changes (all in `plugins/claude-plugin` + tests)

- **`_run.sh`**: no interpreter that can import `stashai` → print the reason and `exit 1` instead of falling through to bare `python3`. The fallback is exactly the codepath that ran stale code silently; a loud one-time failure beats a silent month.
- **`on_session_start.py`**: call `upload_health_warning` at session **start** (was Stop-only in the claude plugin; codex already does both), so a broken pipeline is flagged before work begins. Once-per-session gate prevents duplicate warnings from `on_stop`.
- **`cache_drift.py`** (new): at session start, compare the cached plugin manifest version against the marketplace clone's and warn when the scripts are stale — the check that would have caught #2 on day one.

## Tests

- `test_run_launcher.py`: launcher with no `stash`/`uv` on PATH exits 1 with a human-readable "NOT uploading" message (locks out the fallback regression).
- `test_cache_drift.py`: drift reported with both versions; silent when versions match, when no marketplace clone exists, in dev checkouts outside the cache, and when `CLAUDE_PLUGIN_ROOT` is unset.
- Full `plugins/tests` suite: 102 passed. `ruff` clean on the changed files (the 4 pre-existing format offenders in `plugins/` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)