### PR TITLE
Parse Granola's timestamped date format so meetings are recency-sortable

### DIFF
--- a/backend/integrations/granola/indexer.py
+++ b/backend/integrations/granola/indexer.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from ...database import get_pool
@@ -109,17 +109,40 @@ def _extract_transcript(td) -> str | list:
     return ""
 
 
+# US timezone abbreviations in the list blob's date. strptime's %Z can't parse
+# these portably, so the zone is split off and applied as an explicit offset.
+_US_TZ_OFFSET_HOURS = {
+    "PST": -8,
+    "PDT": -7,
+    "MST": -7,
+    "MDT": -6,
+    "CST": -6,
+    "CDT": -5,
+    "EST": -5,
+    "EDT": -4,
+}
+
+
 def _meeting_time(meeting: dict) -> datetime | None:
-    """The meeting's timestamp. Granola's MCP tool returns dates in two shapes —
-    ISO-8601 and the list blob's "Jun 5, 2026" — so both parse; anything else
-    yields None (the document shows no timestamp) rather than failing the sync."""
+    """The meeting's timestamp. Granola's MCP tool returns dates in three
+    shapes — ISO-8601, "Jun 5, 2026", and "Jul 9, 2026 6:10 PM PDT" — so all
+    parse; anything else yields None (the document shows no timestamp) rather
+    than failing the sync."""
     when = meeting.get("date") or meeting.get("created_at") or meeting.get("start_time")
     if not when or not isinstance(when, str):
         return None
+    when = when.strip()
     try:
         return datetime.fromisoformat(when.replace("Z", "+00:00"))
     except ValueError:
         pass
+    date_part, _, zone = when.rpartition(" ")
+    if zone in _US_TZ_OFFSET_HOURS:
+        try:
+            naive = datetime.strptime(date_part, "%b %d, %Y %I:%M %p")
+        except ValueError:
+            return None
+        return naive.replace(tzinfo=timezone(timedelta(hours=_US_TZ_OFFSET_HOURS[zone])))
     try:
         return datetime.strptime(when, "%b %d, %Y")
     except ValueError:

--- a/backend/tests/test_source_paths.py
+++ b/backend/tests/test_source_paths.py
@@ -72,6 +72,23 @@ def test_granola_path_parses_the_list_blob_date_format():
     assert _meeting_path(meeting, meeting["id"]) == "2026-06/05 Standup (abc12345)"
 
 
+def test_granola_path_parses_the_list_blob_date_with_time_and_zone():
+    # Live accounts return "Jul 9, 2026 6:10 PM PDT" — with this unparsed,
+    # every meeting piled into undated/ and no document carried a timestamp,
+    # so `ls -lt`/`stat`/"my most recent call" were all unanswerable.
+    meeting = {"id": "abc12345-6789", "title": "Standup", "date": "Jul 9, 2026 6:10 PM PDT"}
+    assert _meeting_path(meeting, meeting["id"]) == "2026-07/09 Standup (abc12345)"
+
+
+def test_granola_meeting_time_carries_the_zone_offset():
+    # external_updated_at is timestamptz and becomes the VFS mtime — the PDT
+    # offset must survive so recency sorting is correct across zones.
+    meeting = {"id": "abc12345-6789", "title": "Standup", "date": "Jul 9, 2026 6:10 PM PDT"}
+    when = granola_indexer._meeting_time(meeting)
+    assert when is not None
+    assert when.astimezone(UTC) == datetime(2026, 7, 10, 1, 10, tzinfo=UTC)
+
+
 def test_granola_path_files_unparseable_dates_visibly():
     meeting = {"id": "abc12345-6789", "title": "Standup", "date": "last Tuesday"}
     assert _meeting_path(meeting, meeting["id"]) == "undated/Standup (abc12345)"


### PR DESCRIPTION
## Why

On live accounts, every Granola meeting files under `undated/` and carries no timestamp: `_meeting_time()` parses ISO-8601 and `"Jun 5, 2026"`, but the list blob actually returns `"Jul 9, 2026 6:10 PM PDT"`. Since `external_updated_at` is the VFS mtime, `ls -lt`, `stat`, and `find -mtime` show nothing for Granola docs — "find the conversation I just had" requires grepping the date line out of every doc body.

## What

- `_meeting_time()` now parses the timestamped form: the US zone abbreviation is split off and applied as an explicit UTC offset (strptime `%Z` can't parse `PDT`/`EDT` portably).
- On the next sync, the existing re-file branch moves stored docs from `undated/…` to their `YYYY-MM/DD …` month folders and stamps `external_updated_at` — no refetch, no migration.

## Testing

- New tests: the timestamped format lands in the right month/day path, and the parsed datetime carries the zone offset (PDT 6:10 PM → 01:10 UTC next day).
- `backend/tests/test_source_paths.py`: 15 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)