### PR TITLE
Plugin: make the session-record link opt-in, separate from uploads

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -160,3 +160,20 @@ def start_streaming() -> None:
 
 def stop_streaming() -> None:
     _write_to(USER_CONFIG_FILE, {"stopped_streaming": True})
+
+
+# --- Session-link toggle ---
+#
+# When on, the Claude plugin instructs the agent to append the session record
+# link to every response. Independent of upload streaming, and off unless the
+# user turns it on.
+
+
+def session_link_enabled() -> bool:
+    if USER_CONFIG_FILE.exists():
+        return bool(_read_json(USER_CONFIG_FILE).get("session_link"))
+    return False
+
+
+def set_session_link(enabled: bool) -> None:
+    _write_to(USER_CONFIG_FILE, {"session_link": enabled})

--- a/cli/main.py
+++ b/cli/main.py
@@ -33,6 +33,8 @@ from .config import (
     load_manifest,
     save_config,
     save_enabled_agents,
+    session_link_enabled,
+    set_session_link,
     start_streaming,
     stop_streaming,
     stored_base_url,
@@ -4186,6 +4188,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             {
                 "config": display_cfg,
                 "enabled_agents": load_enabled_agents(),
+                "session_link": session_link_enabled(),
                 "plugins_installed": [name for name, d in PLUGIN_DATA_DIRS.items() if d.exists()],
                 "upload_health": _upload_health_snapshot(),
             }
@@ -4203,6 +4206,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
 
         rows = [
             ("Streaming", enabled_label, "enabled_agents"),
+            ("Session link", "on" if session_link_enabled() else "off", "session_link"),
             ("Endpoint", base_url, "base_url"),
         ]
         label_w = max(len(label) for label, _, _ in rows)
@@ -4237,6 +4241,13 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             if selected is not None:
                 save_enabled_agents(selected)
                 _install_all_hooks(selected)
+        elif picked == "session_link":
+            answer = questionary.confirm(
+                "Append the session record link to every Claude response?",
+                default=session_link_enabled(),
+            ).ask()
+            if answer is not None:
+                set_session_link(answer)
         elif picked == "base_url":
             new_url = questionary.text("Endpoint base URL", default=base_url).ask()
             if new_url:

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -57,6 +57,7 @@ def get_config() -> dict:
             "agent_name": cli.get("username", ""),
             "session_folder_id": cli.get("session_folder_id", ""),
             "stopped_streaming": bool(cli.get("stopped_streaming")),
+            "session_link": bool(cli.get("session_link")),
             "client": "claude_code",
         }
 
@@ -66,12 +67,9 @@ def get_config() -> dict:
         ),
         "api_key": api_key,
         "agent_name": agent_name,
-        "session_folder_id": os.environ.get(
-            "CLAUDE_PLUGIN_USER_CONFIG_session_folder_id", ""
-        ),
-        "stopped_streaming": bool(
-            os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_stopped_streaming")
-        ),
+        "session_folder_id": os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_session_folder_id", ""),
+        "stopped_streaming": bool(os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_stopped_streaming")),
+        "session_link": bool(os.environ.get("CLAUDE_PLUGIN_USER_CONFIG_session_link")),
         "client": "claude_code",
     }
 

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -104,7 +104,10 @@ def main():
     spawn_skills_sync(cfg)
 
     if session_url:
-        session_context = "\n" + SESSION_CONTEXT.format(url=session_url)
+        # The link instruction is its own toggle (`stash settings` → Session
+        # link), independent of uploads — the record and watcher always run.
+        if cfg.get("session_link"):
+            session_context = "\n" + SESSION_CONTEXT.format(url=session_url)
         spawn_session_watcher(
             agent_pid=os.getppid(),
             session_id=event.session_id,

--- a/plugins/tests/test_session_link.py
+++ b/plugins/tests/test_session_link.py
@@ -1,0 +1,96 @@
+"""The session-record-link instruction is opt-in and independent of uploads.
+
+`stash settings` writes `session_link` to ~/.stash/config.json, the Claude
+plugin reads it, and SessionStart injects the "always include this link"
+instruction only when it is on. Uploads (session record + watcher) must run
+either way — turning the link off must not turn streaming off.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from cli import config as cli_config
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "plugins/claude-plugin/scripts"
+
+_SCRIPT_MODULES = ("adapt", "config", "on_session_start")
+
+
+@pytest.fixture
+def plugin_home(tmp_path, monkeypatch):
+    """A fake HOME whose ~/.stash/config.json both the CLI and plugin read."""
+    home = tmp_path / "home"
+    (home / ".stash").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+    monkeypatch.delenv("CLAUDE_PLUGIN_USER_CONFIG_api_key", raising=False)
+    monkeypatch.setattr(cli_config, "USER_CONFIG_FILE", home / ".stash" / "config.json")
+    return home
+
+
+@pytest.fixture
+def session_start(plugin_home, monkeypatch):
+    """Import the hook script fresh under the fake HOME."""
+    monkeypatch.syspath_prepend(str(SCRIPTS))
+    for name in _SCRIPT_MODULES:
+        sys.modules.pop(name, None)
+    yield importlib.import_module("on_session_start")
+    for name in _SCRIPT_MODULES:
+        sys.modules.pop(name, None)
+
+
+def _run_hook(mod, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "get_stdin_data", lambda: {"session_id": "s1", "cwd": "/repo"})
+    monkeypatch.setattr(mod, "uploads_enabled", lambda cfg: True)
+    monkeypatch.setattr(
+        mod, "create_session_record", lambda *a, **k: "https://app.example/sessions/s1"
+    )
+    monkeypatch.setattr(mod, "shadow_install_warning", lambda: None)
+    watchers = []
+    monkeypatch.setattr(mod, "spawn_session_watcher", lambda **kw: watchers.append(kw))
+    monkeypatch.setattr(mod, "spawn_skills_sync", lambda cfg: None)
+    mod.main()
+    output = json.loads(capsys.readouterr().out)
+    return output["hookSpecificOutput"]["additionalContext"], watchers
+
+
+def test_link_instruction_off_by_default(plugin_home, session_start, monkeypatch, capsys):
+    cli_config.save_config(api_key="k", username="alice")
+
+    context, watchers = _run_hook(session_start, monkeypatch, capsys)
+
+    assert "Session record" not in context
+    # The toggle only silences the link — the session still streams.
+    assert len(watchers) == 1
+
+
+def test_link_instruction_injected_when_enabled(plugin_home, session_start, monkeypatch, capsys):
+    cli_config.save_config(api_key="k", username="alice")
+    cli_config.set_session_link(True)
+
+    context, watchers = _run_hook(session_start, monkeypatch, capsys)
+
+    assert "Session record: https://app.example/sessions/s1" in context
+    assert len(watchers) == 1
+
+
+def test_cli_toggle_and_plugin_config_agree(plugin_home, session_start):
+    """CLI writer and plugin reader live in separate packages; pin the contract."""
+    plugin_config = sys.modules["config"]
+
+    assert cli_config.session_link_enabled() is False
+    assert plugin_config.get_config()["session_link"] is False
+
+    cli_config.set_session_link(True)
+    assert cli_config.session_link_enabled() is True
+    assert plugin_config.get_config()["session_link"] is True
+
+    cli_config.set_session_link(False)
+    assert plugin_config.get_config()["session_link"] is False


### PR DESCRIPTION
The Claude plugin told the agent to append `Session: <url>` to **every response**, with no way to turn that off short of disabling uploads entirely. This makes the link instruction its own toggle, independent of streaming, and **off by default**.

## What changed

- `on_session_start.py` only injects the "always include this session record link" instruction when the new `session_link` config is on. The session record is still created and the upload watcher still spawns either way — turning the link off does not touch streaming.
- New `session_link` boolean in `~/.stash/config.json` (`session_link_enabled()` / `set_session_link()` in `cli/config.py`, same pattern as `stopped_streaming`). A missing key reads as off, so fresh installs — and existing installs that never set it — default to off.
- `stash settings` gains a **Session link** row (`on`/`off`) with a confirm prompt; `stash settings --json` reports the value.
- The plugin config threads `session_link` through both config paths (CLI config file and `CLAUDE_PLUGIN_USER_CONFIG_session_link`).

## Behavior change

Since the default is off, the `Session: https://app.joinstash.ai/sessions/...` footer stops appearing for everyone until they opt in via `stash settings`.

## Testing

- New `plugins/tests/test_session_link.py`: hook injects nothing by default but still spawns the watcher; injects the instruction when enabled; CLI-writes/plugin-reads contract test pinning the on-disk format (modeled on `test_streaming_toggle.py`).
- All 212 plugin + CLI tests pass; `ruff check` and `ruff format --check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)