### PR TITLE
Docs: uv is the only recommended install; drop pip install stashai

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Built for —
 ## Quick Start
 
 ```bash
-pip install stashai / uv tool install stashai
+uv tool install stashai
 stash signin
 ```
 
@@ -170,7 +170,7 @@ docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d
 Then install the CLI:
 
 ```bash
-pip install stashai   # or: uv tool install stashai
+uv tool install stashai
 cd /path/to/the/repo/you/want/to/connect
 stash signin   # choose "Self-host" and enter http://localhost:3456
 ```

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -5,7 +5,7 @@ plugin's event coverage.
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stashai && stash signin`)
+- `stash` CLI installed and logged in (`uv tool install stashai && stash signin`)
 - `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -28,14 +28,14 @@ openclaw-plugin/
 
 `index.ts` runs inside the Openclaw Node process. On each hook it
 normalizes the event to a flat JSON payload and pipes it into the matching
-Python script. The Python side imports from `stashai.plugin` (shipped via
-`pip install stashai`) just like every other agent's plugin.
+Python script. The Python side imports from `stashai.plugin` (shipped with the `stashai`
+package) just like every other agent's plugin.
 
 ## Install
 
 ```bash
 # Prereqs (one-time)
-pip install stashai httpx
+uv tool install stashai
 stash connect
 # Ensure .stash manifest exists in your repo
 

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -33,7 +33,7 @@ Restart opencode.
 
 ## How it works
 
-`plugin.ts` registers two keyed hooks (`chat.message`, `tool.execute.after`) plus a single `event` dispatcher for bus events. All real logic lives in the `stashai.plugin` Python package (shipped via `pip install stashai`) and is identical to the Claude/Cursor/Gemini/Codex plugins.
+`plugin.ts` registers two keyed hooks (`chat.message`, `tool.execute.after`) plus a single `event` dispatcher for bus events. All real logic lives in the `stashai.plugin` Python package (shipped with the `stashai` package) and is identical to the Claude/Cursor/Gemini/Codex plugins.
 
 | opencode signal | Stash event |
 |---|---|

--- a/plugins/opencode-plugin/plugin.ts
+++ b/plugins/opencode-plugin/plugin.ts
@@ -3,7 +3,7 @@
  *
  * Thin TS shim: each opencode event handler serializes its input and pipes it
  * into the matching Python hook script via stdin. All real work happens in
- * the `stashai.plugin` package (shipped via pip install stashai), reused
+ * the `stashai.plugin` package (shipped with the stashai package), reused
  * from every other agent's plugin.
  *
  * Bus events (session.*, message.*, file.*, etc.) are delivered through the

--- a/stashai/plugin/__init__.py
+++ b/stashai/plugin/__init__.py
@@ -1,6 +1,6 @@
 """Shared core for Stash plugins across all coding agents.
 
 Ships as part of the `stashai` PyPI package. Every per-agent plugin imports
-from `stashai.plugin.*`; `pip install stashai` puts this on PYTHONPATH so
+from `stashai.plugin.*`; installing the `stashai` package puts this on PYTHONPATH so
 the plugin dir can stay thin (only stdin adapter + manifest + hook scripts).
 """

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -5,7 +5,7 @@ plugin's event coverage.
 
 ## Prerequisites
 
-- `stash` CLI installed and logged in (`pip install stashai && stash signin`)
+- `stash` CLI installed and logged in (`uv tool install stashai && stash signin`)
 - `.stash` manifest present in repo (or ancestor)
 - Python 3.10+ on PATH
 - `httpx` installed (`pip install httpx`)

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -33,7 +33,7 @@ Restart opencode.
 
 ## How it works
 
-`plugin.ts` registers two keyed hooks (`chat.message`, `tool.execute.after`) plus a single `event` dispatcher for bus events. All real logic lives in the `stashai.plugin` Python package (shipped via `pip install stashai`) and is identical to the Claude/Cursor/Gemini/Codex plugins.
+`plugin.ts` registers two keyed hooks (`chat.message`, `tool.execute.after`) plus a single `event` dispatcher for bus events. All real logic lives in the `stashai.plugin` Python package (shipped with the `stashai` package) and is identical to the Claude/Cursor/Gemini/Codex plugins.
 
 | opencode signal | Stash event |
 |---|---|

--- a/stashai/plugin/assets/opencode/plugin.ts
+++ b/stashai/plugin/assets/opencode/plugin.ts
@@ -3,7 +3,7 @@
  *
  * Thin TS shim: each opencode event handler serializes its input and pipes it
  * into the matching Python hook script via stdin. All real work happens in
- * the `stashai.plugin` package (shipped via pip install stashai), reused
+ * the `stashai.plugin` package (shipped with the stashai package), reused
  * from every other agent's plugin.
  *
  * Bus events (session.*, message.*, file.*, etc.) are delivered through the

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -14,7 +14,7 @@ export default function CLIPage() {
       </Callout>
 
       <H2>Install</H2>
-      <CodeBlock>{`pip install stashai`}</CodeBlock>
+      <CodeBlock>{`uv tool install stashai`}</CodeBlock>
 
       <H2>First-time setup</H2>
       <P>

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -23,7 +23,7 @@ export default function QuickstartPage() {
       <P>
         <strong>Prefer the CLI?</strong> Instead of the web UI, run{" "}
         <code className="text-brand font-mono text-[13px]">stash connect</code> after installing{" "}
-        <code className="text-brand font-mono text-[13px]">pip install stashai</code>. The
+        <code className="text-brand font-mono text-[13px]">uv tool install stashai</code>. The
         interactive wizard covers account creation
         in one shot — then come back to step 2.
       </P>
@@ -34,7 +34,7 @@ export default function QuickstartPage() {
       </Callout>
 
       <H3>2. Install the CLI</H3>
-      <CodeBlock>{`pip install stashai
+      <CodeBlock>{`uv tool install stashai
 stash signin`}</CodeBlock>
 
       <H3>3. Try these commands</H3>

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -34,7 +34,7 @@ curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>
         Then install the CLI and connect a repo:
       </P>
-      <CodeBlock>{`pip install stashai   # or: uv tool install stashai
+      <CodeBlock>{`uv tool install stashai
 cd /path/to/your/repo
 stash signin   # choose "Self-host" and enter http://localhost:3456`}</CodeBlock>
       <P>


### PR DESCRIPTION
## Why

Follow-up to #764 / the four-week silent-upload outage. Its root install was a bare `pip install stashai` into a pyenv interpreter: frozen forever, invisible to uv, and shadowing the real client from inside the plugin's interpreter resolution. `install.sh` has been uv-only for a while — but our own docs still recommended `pip install stashai`, and listed it **before** uv, in the README Quick Start, the www docs (quickstart, CLI, self-hosting pages), and three plugin READMEs. Per the repo's single-codepath rule, there should be exactly one blessed install path.

## What

- README Quick Start + self-host: `uv tool install stashai` only.
- www docs pages (`quickstart`, `cli`, `self-hosting`): same.
- cursor/openclaw/opencode plugin READMEs (+ their byte-identical mirrors under `stashai/plugin/assets/`, kept in sync for `test_assets_in_sync`): pip references removed; openclaw's `pip install stashai httpx` becomes `uv tool install stashai` (httpx is already a stashai dependency).
- Descriptive comments ("shipped via pip install stashai") reworded to not normalize pip.
- `doctor.py` deliberately keeps its pip mention — its docstring documents the stray-install pattern it exists to detect.

`pip install stashai` remains *possible* (PyPI is how uv installs too); it's just no longer recommended anywhere, and `stash doctor`/session-start warnings flag it when it shadows.

## Verified

`test_assets_in_sync` passes (2/2); www lint 0 errors and `next build` passes. Docs/comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)