### PR TITLE
stash connect: enable Claude Code auto-update for the stash marketplace

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -3920,6 +3920,63 @@ def _install_claude_plugin() -> bool:
         last = (result.stdout or "").strip().splitlines()
         if last:
             console.print(f"  [green]✓[/green] {last[-1]}")
+
+    if _enable_marketplace_autoupdate(Path.home() / ".claude" / "settings.json"):
+        console.print("  [green]✓[/green] auto-update enabled for the stash-plugins marketplace")
+    else:
+        console.print(
+            "  [yellow]Could not update ~/.claude/settings.json — enable auto-update "
+            "manually: /plugin → Marketplaces → stash-plugins → Enable auto-update. "
+            "Without it the plugin never updates itself.[/yellow]"
+        )
+
+    # Freshen right now regardless: until this run set autoUpdate (or on Claude
+    # Code versions that ignore the key at user scope), the marketplace clone
+    # and plugin may be weeks stale. Best-effort — a failure here still leaves
+    # a working install, and the plugin's session-start drift warning names any
+    # remaining staleness.
+    for cmd in (
+        ["claude", "plugin", "marketplace", "update", "stash-plugins"],
+        ["claude", "plugin", "update", "stash@stash-plugins"],
+    ):
+        try:
+            _sp.run(cmd, check=True, capture_output=True, text=True, timeout=120)
+        except (_sp.CalledProcessError, FileNotFoundError, _sp.TimeoutExpired) as e:
+            console.print(f"  [yellow]`{' '.join(cmd)}` failed: {e}[/yellow]")
+            break
+    else:
+        console.print("  [green]✓[/green] marketplace and plugin updated to latest")
+    return True
+
+
+def _enable_marketplace_autoupdate(settings_path: Path) -> bool:
+    """Set `autoUpdate: true` on the stash-plugins marketplace in Claude Code's
+    user settings.
+
+    Claude Code auto-updates plugins from the official marketplace only;
+    third-party marketplaces like ours default to auto-update OFF, which
+    fossilizes the installed plugin (a machine ran June's hook scripts for a
+    month this way). `extraKnownMarketplaces.<name>.autoUpdate` is the settings
+    key documented for enabling it without the /plugin menu.
+
+    Returns False without writing when the settings file is unparseable —
+    clobbering a user's hand-edited settings.json is worse than a manual toggle.
+    """
+    try:
+        data = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    marketplaces = data.setdefault("extraKnownMarketplaces", {})
+    entry = marketplaces.setdefault(
+        "stash-plugins", {"source": {"source": "github", "repo": "Fergana-Labs/stash"}}
+    )
+    if entry.get("autoUpdate") is True:
+        return True
+    entry["autoUpdate"] = True
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(data, indent=2) + "\n")
     return True
 
 

--- a/cli/tests/test_marketplace_autoupdate.py
+++ b/cli/tests/test_marketplace_autoupdate.py
@@ -1,0 +1,83 @@
+"""`_enable_marketplace_autoupdate` — the settings write that keeps the Claude
+Code plugin from fossilizing.
+
+Third-party marketplaces default to auto-update OFF, so without this flag an
+installed plugin stays at its install-day version forever (a machine ran
+June's hook scripts for a month this way). The write must be additive — a
+user's existing settings survive untouched — and must refuse to touch a file
+it cannot parse.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cli.main import _enable_marketplace_autoupdate
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_flag_is_added_to_the_existing_marketplace_entry(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "model": "opus",
+                "extraKnownMarketplaces": {
+                    "stash-plugins": {"source": {"source": "github", "repo": "Fergana-Labs/stash"}}
+                },
+            }
+        )
+    )
+
+    assert _enable_marketplace_autoupdate(settings) is True
+
+    data = _read(settings)
+    assert data["extraKnownMarketplaces"]["stash-plugins"]["autoUpdate"] is True
+    # Everything the user already had survives.
+    assert data["model"] == "opus"
+    assert data["extraKnownMarketplaces"]["stash-plugins"]["source"]["repo"] == (
+        "Fergana-Labs/stash"
+    )
+
+
+def test_missing_settings_file_is_created_with_the_entry(tmp_path):
+    settings = tmp_path / "nested" / "settings.json"
+
+    assert _enable_marketplace_autoupdate(settings) is True
+
+    entry = _read(settings)["extraKnownMarketplaces"]["stash-plugins"]
+    assert entry["autoUpdate"] is True
+    assert entry["source"] == {"source": "github", "repo": "Fergana-Labs/stash"}
+
+
+def test_already_enabled_is_a_no_op(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "stash-plugins": {
+                        "source": {"source": "github", "repo": "Fergana-Labs/stash"},
+                        "autoUpdate": True,
+                    }
+                }
+            }
+        )
+    )
+    before = settings.read_text()
+
+    assert _enable_marketplace_autoupdate(settings) is True
+    assert settings.read_text() == before
+
+
+def test_unparseable_settings_are_left_alone(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text("{not json")
+
+    assert _enable_marketplace_autoupdate(settings) is False
+    # The broken file is preserved for the user to fix, not clobbered.
+    assert settings.read_text() == "{not json"


### PR DESCRIPTION
## Why

The final root cause behind the four-week silent-upload outage, confirmed against Claude Code's docs: **plugins from third-party marketplaces do not auto-update by default** — only the official Anthropic marketplace does. So every `stash connect` install to date leaves the customer with a plugin frozen at its install-day version, forever, unless they discover the `/plugin` → Marketplaces → Enable auto-update toggle on their own. That's how a machine ran June 12 hook scripts until July 10, and why the fixes we shipped in between never arrived.

## What

`_install_claude_plugin()` (used by `stash connect` / `stash signin`) now does two more things after the install:

1. **Sets `extraKnownMarketplaces.stash-plugins.autoUpdate: true`** in the user's `~/.claude/settings.json` — the key documented for enabling marketplace auto-update without the menu. The write is additive (existing settings preserved byte-for-byte semantically), idempotent, and refuses to touch an unparseable settings file — in that case it prints the manual toggle instructions loudly instead of clobbering.
2. **Freshens immediately**: `claude plugin marketplace update stash-plugins` + `claude plugin update stash@stash-plugins`, so an already-stale install catches up on the spot instead of waiting for the next Claude Code startup (or on Claude Code versions that ignore the settings key at user scope). Best-effort with visible warnings; the session-start drift check from #764 remains the backstop.

## Verified

- 4 new tests (`test_marketplace_autoupdate.py`): flag added to existing entry with user settings preserved, missing file created, already-enabled no-op, unparseable file left alone.
- Full CLI suite: 117 passed. Ruff clean.
- **Live end-to-end**: ran the real flow on the machine from the outage — plugin cache went from frozen `0.1.85` (June 12) to current `0.1.286`, `settings.json` gained the flag, `claude plugin marketplace list` parses it fine.

Note: the `autoUpdate` key is explicitly documented for managed settings; docs don't specify user-scope behavior. Hence change #2 and the #764 drift alarm as guarantees that don't depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)