### PR TITLE
Scale wiki-graph repulsion with node count

### DIFF
--- a/frontend/src/components/memory/WikiGraph.tsx
+++ b/frontend/src/components/memory/WikiGraph.tsx
@@ -51,13 +51,15 @@ function buildSim(data: WikiGraphData, w: number, h: number): Sim {
 function tick(sim: Sim, w: number, h: number) {
   const { x, y, vx, vy, edges, alpha } = sim;
   const n = x.length;
+  // Bigger graphs need more shove to claim the same canvas.
+  const repulsion = 15000 * Math.max(1, n / 25);
 
   for (let i = 0; i < n; i++) {
     for (let j = i + 1; j < n; j++) {
       const dx = x[i] - x[j];
       const dy = y[i] - y[j];
       const d2 = Math.max(dx * dx + dy * dy, 400);
-      const f = (15000 * alpha) / d2;
+      const f = (repulsion * alpha) / d2;
       const d = Math.sqrt(d2);
       vx[i] += (dx / d) * f;
       vy[i] += (dy / d) * f;


### PR DESCRIPTION
## What & why

Follow-up to #760. The wiki-graph force layout used a fixed repulsion constant, tuned on a 13-page wiki. On a ~50-page wiki (a real curator-built knowledge base) the graph collapsed into a tangle at the center of the canvas — bigger graphs need more shove to claim the same area.

One-line fix: repulsion scales with node count (`15000 * max(1, n/25)`), so small wikis are unchanged and large ones spread out legibly.

Verified against a seeded 50-page / 97-link wiki mirroring a real curator output: hubs separate cleanly, labels stay readable, hover/click still work.

## Tests

`npm test`: 189 passed. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)