### PR TITLE
Delete a folder's subtree contents instead of orphaning them to root

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -487,7 +487,9 @@ async def delete_folder(
         require="write",
     )
     try:
-        deleted = await files_tree_service.delete_folder(folder_id, owner_user_id)
+        deleted = await files_tree_service.delete_folder(
+            folder_id, owner_user_id, current_user["id"]
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not deleted:

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -428,15 +428,63 @@ async def update_folder(
     return dict(row) if row else None
 
 
-async def delete_folder(folder_id: UUID, owner_user_id: UUID) -> bool:
-    pool = get_pool()
+async def delete_folder(folder_id: UUID, owner_user_id: UUID, deleted_by: UUID) -> bool:
+    """Delete a folder and everything in its subtree.
+
+    Contents get the same treatment their own delete endpoints give them:
+    pages and files are soft-deleted into trash, tables are hard-deleted,
+    and skill rows cascade with their folder. Without this pass, the
+    ON DELETE SET NULL foreign keys would silently strand every page, file,
+    and table of the subtree at the scope root instead of deleting them.
+    (Trashed pages/files still get their folder_id nulled by the FK, so a
+    later restore files them at the scope root — same as restoring any item
+    whose folder is gone.)
+    """
     await _assert_not_memory(folder_id, owner_user_id)
-    result = await pool.execute(
-        "DELETE FROM folders WHERE id = $1 AND owner_user_id = $2",
-        folder_id,
-        owner_user_id,
+    async with get_pool().acquire() as conn, conn.transaction():
+        subtree = await conn.fetch(
+            "WITH RECURSIVE tree AS ("
+            "  SELECT id FROM folders WHERE id = $1 AND owner_user_id = $2"
+            "  UNION ALL"
+            "  SELECT f.id FROM folders f JOIN tree t ON f.parent_folder_id = t.id"
+            ") SELECT id FROM tree",
+            folder_id,
+            owner_user_id,
+        )
+        if not subtree:
+            return False
+        folder_ids = [r["id"] for r in subtree]
+        pages_result = await conn.execute(
+            "UPDATE pages SET deleted_at = NOW(), deleted_by = $2 "
+            "WHERE folder_id = ANY($1) AND deleted_at IS NULL",
+            folder_ids,
+            deleted_by,
+        )
+        files_result = await conn.execute(
+            "UPDATE files SET deleted_at = NOW(), deleted_by = $2 "
+            "WHERE folder_id = ANY($1) AND deleted_at IS NULL",
+            folder_ids,
+            deleted_by,
+        )
+        tables_result = await conn.execute(
+            "DELETE FROM tables WHERE folder_id = ANY($1)", folder_ids
+        )
+        await conn.execute("DELETE FROM folders WHERE id = $1", folder_id)
+    # Audited here so every front door (REST, batch, agent tools) leaves a trail.
+    await security_audit_service.record_content_lifecycle_event(
+        operation="deleted",
+        actor_user_id=deleted_by,
+        owner_user_id=owner_user_id,
+        target_type="folder",
+        target_id=folder_id,
+        metadata={
+            "folders": len(folder_ids),
+            "pages_trashed": int(pages_result.split()[-1]),
+            "files_trashed": int(files_result.split()[-1]),
+            "tables_deleted": int(tables_result.split()[-1]),
+        },
     )
-    return result == "DELETE 1"
+    return True
 
 
 async def walk_ancestors(folder_id: UUID) -> list[dict]:

--- a/backend/tests/test_folder_delete.py
+++ b/backend/tests/test_folder_delete.py
@@ -1,0 +1,120 @@
+"""Deleting a folder must delete its subtree, not strand contents at the root.
+
+The FKs on pages/files/tables are ON DELETE SET NULL, so before the service
+swept the subtree, "delete folder" silently dumped every contained page, file,
+and table at the scope root as live orphans (found in prod on 2026-07-10).
+These tests pin the contract: contents get the same treatment their own delete
+endpoints give them — pages/files to trash, tables hard-deleted.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import files_tree_service, table_service
+
+
+@pytest_asyncio.fixture
+async def scope(_db_pool):
+    user_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    return user_id, user_id
+
+
+async def _make_file(pool, scope_id, user_id, folder_id):
+    fid = uuid4()
+    await pool.execute(
+        "INSERT INTO files (id, owner_user_id, name, content_type, size_bytes, storage_key, "
+        "uploaded_by, folder_id) VALUES ($1, $2, $3, 'text/plain', 1, $4, $5, $6)",
+        fid,
+        scope_id,
+        f"f_{fid.hex[:6]}",
+        f"key_{fid.hex[:6]}",
+        user_id,
+        folder_id,
+    )
+    return fid
+
+
+@pytest.mark.asyncio
+async def test_delete_folder_sweeps_subtree_instead_of_orphaning(scope, _db_pool):
+    scope_id, user_id = scope
+    root = await files_tree_service.create_folder(scope_id, "Project", user_id)
+    sub = await files_tree_service.create_folder(
+        scope_id, "Sub", user_id, parent_folder_id=root["id"]
+    )
+    top_page = await files_tree_service.create_page(
+        owner_user_id=scope_id, name="Top", created_by=user_id, folder_id=root["id"], content="t"
+    )
+    nested_page = await files_tree_service.create_page(
+        owner_user_id=scope_id, name="Nested", created_by=user_id, folder_id=sub["id"], content="n"
+    )
+    file_id = await _make_file(_db_pool, scope_id, user_id, sub["id"])
+    table = await table_service.create_table(
+        scope_id, "Data", "", [{"name": "Col", "type": "text"}], user_id, folder_id=root["id"]
+    )
+
+    assert await files_tree_service.delete_folder(root["id"], scope_id, user_id) is True
+
+    # Both folders are gone.
+    folders_left = await _db_pool.fetchval(
+        "SELECT count(*) FROM folders WHERE id = ANY($1::uuid[])", [root["id"], sub["id"]]
+    )
+    assert folders_left == 0
+
+    # Pages and the file are in trash, stamped with who deleted them — the
+    # pre-fix bug left them live (deleted_at NULL) at the scope root.
+    for page_id in (top_page["id"], nested_page["id"]):
+        row = await _db_pool.fetchrow(
+            "SELECT deleted_at, deleted_by FROM pages WHERE id = $1", page_id
+        )
+        assert row["deleted_at"] is not None
+        assert row["deleted_by"] == user_id
+    file_row = await _db_pool.fetchrow(
+        "SELECT deleted_at, deleted_by FROM files WHERE id = $1", file_id
+    )
+    assert file_row["deleted_at"] is not None
+    assert file_row["deleted_by"] == user_id
+
+    # Tables have no trash; the row is gone.
+    assert await _db_pool.fetchval("SELECT count(*) FROM tables WHERE id = $1", table["id"]) == 0
+
+    # Nothing from the subtree is sitting live at the scope root.
+    live_orphans = await _db_pool.fetchval(
+        "SELECT count(*) FROM pages WHERE owner_user_id = $1 "
+        "AND folder_id IS NULL AND deleted_at IS NULL",
+        scope_id,
+    )
+    assert live_orphans == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_folder_missing_or_foreign_returns_false(scope, _db_pool):
+    scope_id, user_id = scope
+    assert await files_tree_service.delete_folder(uuid4(), scope_id, user_id) is False
+
+    # Another scope's folder is invisible to this scope's delete.
+    other_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        other_id,
+        f"u_{other_id.hex[:6]}",
+    )
+    theirs = await files_tree_service.create_folder(other_id, "Theirs", other_id)
+    assert await files_tree_service.delete_folder(theirs["id"], scope_id, user_id) is False
+    assert await _db_pool.fetchval("SELECT count(*) FROM folders WHERE id = $1", theirs["id"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_folder_still_refuses_memory(scope, _db_pool):
+    scope_id, user_id = scope
+    memory = await files_tree_service.get_or_create_memory_folder(scope_id, user_id)
+    with pytest.raises(ValueError):
+        await files_tree_service.delete_folder(memory["id"], scope_id, user_id)


### PR DESCRIPTION
## Why

**Deleting a folder silently dumps its contents at the account root.** The `pages`/`files`/`tables` FKs to `folders` are `ON DELETE SET NULL`, and `delete_folder` only deleted the folder row — so every page, file, and table in the subtree survived as a live orphan with `folder_id = NULL`. Subfolders and skills cascade, so the containers vanished while the contents scattered.

Found in prod today (2026-07-10) while cleaning up the Heavi onboarding account: deleting two folders left their pages sitting loose at the account root, still visible in every tree/listing.

## What

`files_tree_service.delete_folder` now sweeps the subtree in one transaction, giving contents the same treatment their own delete endpoints give them:

- **pages** → soft-deleted to trash, stamped `deleted_by` (same as `DELETE /pages/{id}`)
- **files** → soft-deleted to trash, stamped `deleted_by` (same as `DELETE /files/{id}`)
- **tables** → hard-deleted (tables have no trash, same as `DELETE /tables/{id}`)
- **subfolders + skills** → cascade with the folder rows, as before

Trashed pages/files still get `folder_id` nulled by the FK when the folder row goes, so restoring one files it at the scope root — the normal behavior for restoring an item whose folder is gone. One security-audit event records the sweep with per-type counts.

The router passes the acting user through for the `deleted_by` stamp; no other callers of `delete_folder` exist.

## Testing

- New `backend/tests/test_folder_delete.py`: nested subtree (pages + file + table) is swept — pages/file land in trash with `deleted_by`, table row gone, no live orphans at root; missing/foreign-scope folders return False untouched; Memory folder still refuses deletion.
- `pytest backend/tests/test_copy.py test_folder_skills.py test_shared_folder_writes.py test_batch.py test_folder_delete.py` — 20 passed.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)