### PR TITLE
Explorer: open files on single click

### DIFF
--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -37,11 +37,12 @@ function useOpenTab() {
   };
 }
 
-// `onOpen` fires on double-click (standardized across the explorer — like a file
-// manager). `onClick` (single) is for navigation rows (Home → section).
+// `onClick` (single) is for navigation rows (Home → section). Rows without one
+// open on single click (web convention); rows with both keep `onOpen` on
+// double-click so navigate and open don't collide.
 function LeafRow({ icon, label, onClick, onOpen, trailing }: { icon: React.ReactNode; label: string; onClick?: () => void; onOpen?: () => void; trailing?: React.ReactNode }) {
   return (
-    <button onClick={onClick} onDoubleClick={onOpen} className="group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[13px] text-sidebar-foreground hover:bg-sidebar-accent" title={label}>
+    <button onClick={onClick ?? onOpen} onDoubleClick={onClick ? onOpen : undefined} className="group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[13px] text-sidebar-foreground hover:bg-sidebar-accent" title={label}>
       <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">{icon}</span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {trailing}

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -151,16 +151,17 @@ export default function FilesExplorer({
     router.replace(urlForTab({ kind, refId: item.id }) + suffix);
   }
 
-  // Single-click a folder (or skill/session folder) → browse into it in the
-  // explorer; double-click → open it as a tab. A short timer lets the dblclick
-  // cancel the pending navigate.
+  // Single-click opens files/pages/tables as a tab (web convention). Folders
+  // (and skill/session folders) browse on single-click and open as a tab on
+  // double-click; a short timer lets the dblclick cancel the pending navigate.
   const isFolderLike = (item: Item) => item.kind === "folder" || item.kind === "skill" || item.kind === "session-folder";
   function onRowClick(item: Item) {
-    if (!isFolderLike(item)) return;
+    if (!isFolderLike(item)) { openAsTab(item); return; }
     if (clickTimer.current) clearTimeout(clickTimer.current);
     clickTimer.current = setTimeout(() => { clickTimer.current = null; setFolderId(item.id); }, 220);
   }
   function onRowDoubleClick(item: Item) {
+    if (!isFolderLike(item)) return; // files already opened on the first click
     if (clickTimer.current) { clearTimeout(clickTimer.current); clickTimer.current = null; }
     openAsTab(item);
   }


### PR DESCRIPTION
## What & why

Files in the left-side explorer only opened on **double-click**; a single click on a page/file/table row did nothing. That's a desktop-file-manager convention and unintuitive on the web — you'd click "How to use" in the Memory explorer and nothing would happen.

## Changes

**`files-explorer.tsx`** — `onRowClick` was a no-op for non-folder items; it now opens pages, files, tables, and sessions as a tab on the first click. Folders are unchanged: single-click browses into them, double-click opens them as a tab (the existing debounce timer still lets the double-click cancel the pending browse). `onRowDoubleClick` early-returns for non-folders since the first click already opened them.

**`explorer.tsx`** — `LeafRow` (Tools connectors, Terminal, Computer files, Recent chats) fired `onOpen` only on double-click. Rows without a navigation `onClick` now open on single click; rows with both handlers (e.g. the Sessions section row on Home) keep navigate-on-single / open-on-double so the two don't collide.

The main-pane file browser (`FolderItemGrid`/`ItemsColumns`) is deliberately untouched — there single-click is selection/preview, which is a different model.

## Screenshots

- Single click on a page opens it as a tab (the "Live editing" banner is a local-stack artifact — no collab websocket running): https://app.joinstash.ai/f/44876fe3-e16b-4c71-9ec3-d49db40fdc18
- Folder double-click still opens the folder tab; single click still browses in place: https://app.joinstash.ai/f/e156a255-cbfd-4300-97c6-b1cf4ce4ecee

## Verified locally (real backend + Postgres, agent-browser)

Single click opens a page/nested page as a tab with the URL synced; folder single-click browses without opening a tab; folder double-click opens the folder tab and cancels the pending browse; rapid double-click on a file refocuses the existing tab (no duplicates); the Sessions row on Home still navigates on single click; a Tools connector opens the integrations tab on first click.

## Tests

`npm test`: 191 passed. Lint clean (3 pre-existing warnings). Pre-existing unrelated `tsc` errors in `managedAuth0Config.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)