### PR TITLE
Recent edits: name the editor; knowledge map: drop meta pages, fill panel

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -113,6 +113,10 @@ async def list_activity(
                    ARRAY_AGG(he.agent_name ORDER BY he.created_at DESC)
                    FILTER (WHERE he.agent_name IS NOT NULL)
                  )[1] || ': ' || he.session_id AS target_label,
+                 (
+                   ARRAY_AGG(he.agent_name ORDER BY he.created_at DESC)
+                   FILTER (WHERE he.agent_name IS NOT NULL)
+                 )[1] AS agent_name,
                  aw.id AS owner_user_id,
                  aw.name AS owner_name
           FROM history_events he
@@ -130,6 +134,7 @@ async def list_activity(
                  COALESCE(p.updated_by, p.created_by) AS actor_id,
                  p.id::text AS target_id,
                  p.name AS target_label,
+                 p.last_edit_agent_name AS agent_name,
                  aw.id AS owner_user_id,
                  aw.name AS owner_name
           FROM pages p
@@ -146,6 +151,7 @@ async def list_activity(
                  f.uploaded_by AS actor_id,
                  f.id::text AS target_id,
                  f.name AS target_label,
+                 NULL::text AS agent_name,
                  aw.id AS owner_user_id,
                  aw.name AS owner_name
           FROM files f
@@ -184,6 +190,7 @@ async def list_activity(
                 "actor": users[r["actor_id"]],
                 "target_id": r["target_id"],
                 "target_label": r["target_label"],
+                "agent_name": r["agent_name"],
                 "owner_user_id": r["owner_user_id"],
                 "owner_name": r["owner_name"],
             }

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -791,6 +791,10 @@ async def get_embedding_projection(
             SELECT COUNT(*) FROM pages np
             WHERE np.id IN (SELECT page_id FROM accessible_pages)
               AND np.embedding IS NOT NULL
+              -- The wiki's _system folder holds meta pages (schema, usage
+              -- notes) — instructions about the knowledge, not knowledge.
+              AND (np.folder_id IS NULL OR np.folder_id NOT IN
+                   (SELECT id FROM folders WHERE name = '_system'))
             """,
             *content_count_args,
         )
@@ -870,6 +874,8 @@ async def get_embedding_projection(
             FROM pages np
             WHERE np.id IN (SELECT page_id FROM accessible_pages)
               AND np.embedding IS NOT NULL
+              AND (np.folder_id IS NULL OR np.folder_id NOT IN
+                   (SELECT id FROM folders WHERE name = '_system'))
             ORDER BY np.updated_at DESC
             LIMIT $2
             """,

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -191,7 +191,7 @@ export default function BrainDashboard() {
                 place (hard cap — inside a grid, flex-1 can't bound it) so the
                 panel row stays a dashboard, not a page. */}
             <section className="flex flex-col">
-              <div className="sys-label mb-1.5">Recent learnings</div>
+              <div className="sys-label mb-1.5">Recent edits</div>
               <div className="card-soft max-h-[480px] overflow-y-auto p-3">
                 <div className="flex flex-col gap-2.5">
                   {events.length === 0 ? (
@@ -251,7 +251,12 @@ function FeedCard({ event }: { event: ActivityEvent }) {
   return (
     <article className="card px-4 py-3.5">
       <div className="flex flex-wrap items-baseline gap-2 text-[12.5px] text-dim">
-        <span>{verb}</span>
+        <span>
+          <strong className="font-medium text-foreground">
+            {event.agent_name ?? "human"}
+          </strong>{" "}
+          {verb}
+        </span>
         <span className="sys-label" style={{ fontSize: 10.5 }}>
           {relativeTime(event.ts)}
         </span>

--- a/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
+++ b/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
@@ -62,11 +62,11 @@ interface Prep {
  *  Deterministic: centroids seed from evenly-strided points. */
 function prepare(points: EmbeddingProjectionPoint[]): Prep {
   const n = points.length;
-  let maxR = 0;
-  for (const p of points) {
-    maxR = Math.max(maxR, Math.hypot(p.x, p.y, p.z));
-  }
-  const s = maxR > 0 ? 1 / maxR : 1;
+  // Fill the view from the 90th-percentile radius, not the max — otherwise
+  // one far outlier shrinks the whole cloud (it just renders past the edge).
+  const radii = points.map((p) => Math.hypot(p.x, p.y, p.z)).sort((a, b) => a - b);
+  const fitR = radii[Math.min(n - 1, Math.floor(n * 0.9))];
+  const s = fitR > 0 ? 1 / fitR : 1;
   const coords = points.map((p) => [p.x * s, p.y * s, p.z * s] as [number, number, number]);
 
   const k = Math.max(1, Math.min(CLUSTER_COLORS.length, Math.round(Math.sqrt(n / 2))));
@@ -148,7 +148,7 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
 
       const fov = 3;
       const viewDist = fov + rz;
-      const scale = Math.min(w, h) * 0.46 * (fov / Math.max(viewDist, 0.5));
+      const scale = Math.min(w, h) * 0.52 * (fov / Math.max(viewDist, 0.5));
 
       return {
         sx: w / 2 + rx * scale,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1569,6 +1569,8 @@ export interface ActivityEvent {
   actor: { name: string; display_name: string };
   target_id: string;
   target_label: string;
+  /** Agent that made the edit (e.g. the Memory curator); null = a human did. */
+  agent_name: string | null;
 }
 
 export interface ActivityFeed {


### PR DESCRIPTION
## What & why

Three dashboard refinements from real-data review:

1. **"Recent learnings" → "Recent edits", with honest attribution.** Each card now leads with who made the edit: the agent name from `pages.last_edit_agent_name` (e.g. the Memory curator) or **human** when a person edited. The old UI guessed from event kind (page edit = human), which is exactly backwards for a curator-maintained wiki. Session cards carry their agent name; file uploads read as human.
2. **Meta pages excluded from the knowledge map.** The wiki's `_system` folder (schema, "How to use") is instructions about the knowledge, not knowledge — those pages no longer appear in the embedding projection (both the count and the fetch filter on it). Verified on a real curator-built wiki: 50 → 48 points, the two `_system` pages gone.
3. **The map fills its panel.** Normalizing the cloud by max radius let a single far outlier shrink everything (the same disease the wiki-graph fit had); it now normalizes to the 90th-percentile radius — outliers render past the fit boundary instead of dictating it — plus a small projection-scale bump.

## Screenshot (demo data)

"Recent edits" with attribution + the filled map → https://app.joinstash.ai/f/74520f98-6380-4ac0-a468-04eacdbf9304

## Tests

Backend: `test_activity.py` + `test_analytics.py` pass (20); ruff clean. Frontend: 191 passed, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)