### PR TITLE
Attribute non-agent edits to "Stash admin", not "human"

### DIFF
--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -253,7 +253,7 @@ function FeedCard({ event }: { event: ActivityEvent }) {
       <div className="flex flex-wrap items-baseline gap-2 text-[12.5px] text-dim">
         <span>
           <strong className="font-medium text-foreground">
-            {event.agent_name ?? "human"}
+            {event.agent_name ?? "Stash admin"}
           </strong>{" "}
           {verb}
         </span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1569,7 +1569,8 @@ export interface ActivityEvent {
   actor: { name: string; display_name: string };
   target_id: string;
   target_label: string;
-  /** Agent that made the edit (e.g. the Memory curator); null = a human did. */
+  /** Agent that made the edit (e.g. the Memory curator); null = the edit
+   *  didn't come through an agent session (a person, or setup/API writes). */
   agent_name: string | null;
 }
 


### PR DESCRIPTION
## What & why

Follow-up to #777. A null `agent_name` only means the edit didn't come through an agent session — that's a person in the UI *or* setup/API writes (e.g. seeding a wiki). Labeling those "human" claimed more than the data knows and read wrong on curator-built wikis whose pages were loaded during setup. They now read "**Stash admin** edited a page"; agent edits keep their real agent name.

## Tests

191 passed, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)