### PR TITLE
VFS endpoint: cap concurrent scripts and add a wall-clock budget

### DIFF
--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -11,7 +11,7 @@ from stashvfs import MountError
 
 from ..auth import get_current_user
 from ..services import vfs_service
-from ..services.vfs_service import VfsBudgetExceeded
+from ..services.vfs_service import VfsBudgetExceeded, VfsBusy
 
 router = APIRouter(prefix="/api/v1/me/vfs", tags=["vfs"])
 
@@ -47,3 +47,5 @@ async def run_vfs(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except VfsBudgetExceeded as e:
         raise HTTPException(status_code=413, detail=str(e)) from e
+    except VfsBusy as e:
+        raise HTTPException(status_code=429, detail=str(e), headers={"Retry-After": "2"}) from e

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import threading
+import time
 
 import anyio
 import anyio.to_thread
@@ -29,13 +30,30 @@ from stashvfs import SkillAppVfsShell, StashVfsModel, VfsClientError
 # on an open connection until the client's own timeout fires.
 MAX_DOCUMENT_READS = 400
 
+# Every concurrent shell holds a full filesystem model plus every document its
+# command read, and one process serves the whole API — a burst of ~20 heavy
+# scripts from one customer's agent OOM'd prod on 2026-07-09. Past this many,
+# tell the caller to retry instead of letting the pile-up kill the process.
+MAX_CONCURRENT_SCRIPTS = 4
+
+# A long command is what turns "a few concurrent scripts" into a pile-up: slow
+# scans hold their slot (and their memory) while new requests stack behind
+# them. Checked on every nested read, so a runaway scan dies at the next read
+# after the deadline.
+MAX_SCRIPT_SECONDS = 60
+
 SOURCE_ENTRIES_PAGE = 1000
 
 
 class VfsBudgetExceeded(Exception):
-    """More document reads than one shell invocation is allowed. Deliberately not
-    a VfsClientError: the shell downgrades those to per-file warnings, and this
-    must abort the whole command."""
+    """More document reads or wall-clock time than one shell invocation is
+    allowed. Deliberately not a VfsClientError: the shell downgrades those to
+    per-file warnings, and this must abort the whole command."""
+
+
+class VfsBusy(Exception):
+    """More concurrent scripts than one instance safely runs. The caller should
+    retry; nothing is queued server-side."""
 
 
 class InProcessVfsClient:
@@ -50,8 +68,14 @@ class InProcessVfsClient:
         self._loop = loop
         self._document_reads = 0
         self._reads_lock = threading.Lock()
+        self._started = time.monotonic()
 
     def _request(self, method: str, endpoint: str, **params) -> httpx.Response:
+        if time.monotonic() - self._started > MAX_SCRIPT_SECONDS:
+            raise VfsBudgetExceeded(
+                f"command ran longer than {MAX_SCRIPT_SECONDS}s; "
+                "scope it to a smaller subtree or use search"
+            )
         # Dispatched onto the app's event loop from whichever thread we are on.
         # `StashVfsModel.prefetch` calls loaders from a pool, so this must work
         # from an arbitrary thread — not just anyio's worker, which is all
@@ -165,20 +189,34 @@ def _run_script(
     }
 
 
+# Scripts currently executing in this process. Checked and bumped on the event
+# loop with no await in between, so no lock is needed.
+_scripts_running = 0
+
+
 async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict:
     """Execute one read-only shell script against the caller's Stash.
 
     `authorization` is forwarded verbatim onto every nested request, so the VFS
     sees precisely what that credential sees anywhere else in the API.
     """
-    loop = asyncio.get_running_loop()
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport,
-        base_url="http://vfs.internal",
-        headers={"Authorization": authorization},
-        timeout=None,
-    ) as http:
-        return await anyio.to_thread.run_sync(
-            functools.partial(_run_script, http, loop, script, cwd)
+    global _scripts_running
+    if _scripts_running >= MAX_CONCURRENT_SCRIPTS:
+        raise VfsBusy(
+            f"{MAX_CONCURRENT_SCRIPTS} VFS commands are already running; retry in a moment"
         )
+    _scripts_running += 1
+    try:
+        loop = asyncio.get_running_loop()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://vfs.internal",
+            headers={"Authorization": authorization},
+            timeout=None,
+        ) as http:
+            return await anyio.to_thread.run_sync(
+                functools.partial(_run_script, http, loop, script, cwd)
+            )
+    finally:
+        _scripts_running -= 1

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -168,3 +168,42 @@ async def test_document_read_budget_aborts_the_command(client: AsyncClient, monk
     resp = await _vfs(client, api_key, "grep -ri 'alpha' /files")
 
     assert resp.status_code == 413
+
+
+async def test_concurrency_cap_rejects_immediately_with_429(client: AsyncClient, monkeypatch):
+    """Concurrent shells each hold a full filesystem model in memory; a burst
+    of them OOM'd prod on 2026-07-09. Over the cap, the caller must get an
+    immediate retry signal — never a server-side queue that holds the memory."""
+    monkeypatch.setattr("backend.services.vfs_service.MAX_CONCURRENT_SCRIPTS", 0)
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "ls /")
+
+    assert resp.status_code == 429
+    assert resp.headers["retry-after"]
+
+
+async def test_concurrency_slot_is_released_after_a_run(client: AsyncClient, monkeypatch):
+    """The slot must free on completion (success or failure), or the cap
+    ratchets down to a permanently bricked endpoint."""
+    monkeypatch.setattr("backend.services.vfs_service.MAX_CONCURRENT_SCRIPTS", 1)
+    api_key, _ = await _register(client)
+
+    first = await _vfs(client, api_key, "ls /")
+    second = await _vfs(client, api_key, "ls /")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+async def test_wall_clock_budget_aborts_the_command(client: AsyncClient, monkeypatch):
+    """Long-running scans are what turn a few concurrent scripts into a
+    pile-up: they hold their slot and their memory while requests stack behind
+    them. Past the deadline the command must die, not run to completion."""
+    monkeypatch.setattr("backend.services.vfs_service.MAX_SCRIPT_SECONDS", 0)
+    api_key, _ = await _register(client)
+
+    resp = await _vfs(client, api_key, "ls /")
+
+    assert resp.status_code == 413
+    assert "longer than" in resp.json()["detail"]


### PR DESCRIPTION
## Why

**Incident, 2026-07-09 20:57 UTC:** a customer's production agent fired ~20 concurrent `POST /api/v1/me/vfs` scripts. Each request builds a full `StashVfsModel` (every listing walked) and holds every document its command reads in memory. Usage raced from the 272MB baseline toward the 512MB instance limit; the kernel killed the API process (Render: "Instance restarted"), and since one instance serves the whole product, **every customer got 502s for ~8 seconds and all in-flight requests were dropped**. The 502 bodies were Render's error page answering for the dead upstream.

The endpoint had a per-request read-count budget (`MAX_DOCUMENT_READS`) but nothing bounded concurrency or wall-clock time — and long scans (we logged an 81s request) are exactly what stack requests into a pile-up.

## What

Two guards in `vfs_service`, both following the existing budget pattern:

- **`MAX_CONCURRENT_SCRIPTS = 4`** — past the cap, the request fails immediately with **429 + `Retry-After`**. Deliberately no server-side queue: a queue would hold the memory the cap exists to not hold. Agent callers retry naturally.
- **`MAX_SCRIPT_SECONDS = 60`** — a monotonic deadline checked on every nested read, raising the existing `VfsBudgetExceeded` (**413**). A runaway scan dies at its next read past the deadline instead of holding a slot (and its memory) indefinitely.

The counter is checked and bumped on the event loop with no await in between, so no lock; the `finally` guarantees slot release on success, budget abort, or crash.

After this, the failure mode for a burst is "one agent sees 429/413" instead of "the API dies for everyone." Instance count ≥2 and per-key rate limiting are follow-ups from the same incident review.

## Testing

- New tests in `backend/tests/test_vfs.py`: over-cap request → immediate 429 with `Retry-After`; slot released after a run (cap=1, two sequential requests both succeed); past-deadline command aborts with 413 naming the time limit.
- `pytest backend/tests/test_vfs.py` — 12 passed (9 pre-existing + 3 new).
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)