### PR TITLE
Knowledge map computes in the worker; prod 500s become diagnosable

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -166,11 +167,19 @@ async def add_security_headers(request: Request, call_next):
     try:
         response = await call_next(request)
     except Exception as exc:
+        # Frame locations only — no exception message and no source lines,
+        # either of which can carry user content. Type + file:line stack is
+        # what makes a prod 500 diagnosable at all.
+        frames = "".join(
+            f"  {f.filename}:{f.lineno} in {f.name}\n"
+            for f in traceback.extract_tb(exc.__traceback__)
+        )
         logger.error(
-            "Unhandled request failed method=%s path=%s exception_type=%s",
+            "Unhandled request failed method=%s path=%s exception_type=%s\n%s",
             request.method,
             request.url.path,
             type(exc).__name__,
+            frames,
         )
         response = JSONResponse(status_code=500, content={"detail": "Internal server error"})
     for key, value in SECURITY_HEADERS.items():

--- a/backend/migrations/versions/0143_projection_cache_scope_ids.py
+++ b/backend/migrations/versions/0143_projection_cache_scope_ids.py
@@ -1,0 +1,29 @@
+"""Record the scope set an embedding projection was computed over.
+
+The knowledge-map projection now computes in the Celery worker and the
+endpoint serves from this cache. A user-wide cache row mixes content from
+every scope the user could read at compute time, so serving it after an
+access change would leak points from revoked scopes. The read path compares
+the stored scope set against the caller's current one and treats any
+mismatch as a cache miss.
+
+Revision ID: 0143
+Revises: 0142
+"""
+
+from alembic import op
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE embedding_projections ADD COLUMN scope_ids UUID[] NOT NULL DEFAULT '{}'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE embedding_projections DROP COLUMN scope_ids")

--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -1,6 +1,5 @@
 """Analytics service: aggregated views for dashboard visualizations."""
 
-import asyncio
 import logging
 import math
 import re
@@ -12,15 +11,11 @@ import numpy as np
 from ..database import get_pool
 from . import memory_service, permission_service
 
-# Numba's default threading layer aborts the whole process on concurrent
-# entry, so UMAP runs strictly one-at-a-time per process.
-_UMAP_LOCK = asyncio.Lock()
-
 
 def _umap_3d(embeddings: np.ndarray) -> np.ndarray:
     """3D UMAP of an embedding matrix, whitened per axis and clamped to
-    [-1, 1] at 2.5σ. CPU-heavy (seconds) — call via asyncio.to_thread,
-    holding _UMAP_LOCK."""
+    [-1, 1] at 2.5σ. CPU-heavy (numba JIT + fit) — worker-only; Celery's
+    prefork processes keep numba's non-threadsafe layer isolated."""
     # Deferred import: umap-learn's numba JIT makes module import slow, and
     # only this path needs it.
     import umap
@@ -739,23 +734,102 @@ async def get_knowledge_density(
     return {"clusters": clusters[:max_clusters]}
 
 
+_PROJECTION_TTL = timedelta(hours=1)
+_PROJECTION_COUNT_DRIFT = 0.1
+# Below this a 3D projection is meaningless — and UMAP's spectral init
+# crashes outright for n <= n_components + 1.
+_PROJECTION_MIN_POINTS = 10
+
+
+async def _accessible_scope_ids(user_id: UUID) -> list[UUID]:
+    """Every scope whose content can appear in this user's projection."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT u.id FROM users u WHERE u.id IN " + permission_service.accessible_scope_ids_sql(1),
+        user_id,
+    )
+    return sorted(r["id"] for r in rows)
+
+
+def _enqueue_projection_refresh(
+    user_id: UUID, source: str | None, owner_user_id: UUID | None
+) -> None:
+    from ..tasks.viz import refresh_projection
+
+    refresh_projection.delay(str(user_id), source, str(owner_user_id) if owner_user_id else None)
+
+
 async def get_embedding_projection(
     user_id: UUID,
     max_points: int = 500,
     source: str | None = None,
     owner_user_id: UUID | None = None,
 ) -> dict:
-    """3D UMAP projection of embeddings for the space explorer.
+    """Serve the cached 3D UMAP projection for the space explorer.
 
-    Pass ``owner_user_id`` to scope to one user.
+    Computing runs in the Celery worker (`tasks.viz.refresh_projection`) —
+    UMAP + numba JIT need far more memory and time than a web request
+    should spend; running it in-request OOM-crashlooped prod.
 
-    Only explicit scope-scoped requests use the embedding_projections cache.
-    User-wide results depend on current scope access."""
+    A cache row is served only to the scope set it was computed over — an
+    access change reads as a cache miss, so points from a revoked scope
+    never leak. Miss → empty payload with pending=True and a refresh
+    enqueued; time- or count-stale but scope-valid → served as-is with a
+    refresh enqueued (layout lags briefly, membership never does).
+    """
     pool = get_pool()
     max_points = min(max_points, 2000)
-
     source_key = source or "_all"
 
+    total_count = await _count_projectable(user_id, source, owner_user_id)
+    if total_count == 0:
+        return {
+            "points": [],
+            "stats": {"total_embeddings": 0, "projected": 0},
+            "cached": False,
+            "pending": False,
+        }
+
+    scope_ids = (
+        [owner_user_id] if owner_user_id is not None else await _accessible_scope_ids(user_id)
+    )
+    cache = await pool.fetchrow(
+        "SELECT points, embedding_count, computed_at, scope_ids FROM embedding_projections "
+        "WHERE user_id = $1 AND source_type = $2 "
+        "AND owner_user_id IS NOT DISTINCT FROM $3",
+        user_id,
+        source_key,
+        owner_user_id,
+    )
+
+    if cache is None or set(cache["scope_ids"]) != set(scope_ids):
+        _enqueue_projection_refresh(user_id, source, owner_user_id)
+        return {
+            "points": [],
+            "stats": {"total_embeddings": total_count, "projected": 0},
+            "cached": False,
+            "pending": True,
+        }
+
+    drift = abs(total_count - cache["embedding_count"]) / max(cache["embedding_count"], 1)
+    if (
+        datetime.now(UTC) - cache["computed_at"] > _PROJECTION_TTL
+        or drift >= _PROJECTION_COUNT_DRIFT
+    ):
+        _enqueue_projection_refresh(user_id, source, owner_user_id)
+
+    points = cache["points"][:max_points]
+    return {
+        "points": points,
+        "stats": {"total_embeddings": total_count, "projected": len(points)},
+        "cached": True,
+        "pending": False,
+    }
+
+
+async def _count_projectable(user_id: UUID, source: str | None, owner_user_id: UUID | None) -> int:
+    """Current number of embedded items the user can see for this source."""
+    pool = get_pool()
     content_count_args = [user_id]
     content_count_scope_idx = None
     if owner_user_id is not None:
@@ -767,22 +841,6 @@ async def get_embedding_projection(
         event_count_args.append(owner_user_id)
         event_scope_idx = 2
 
-    # Cache row keyed by (user_id, source_type, owner_user_id), explicit
-    # scopes only: user-wide results depend on the user's current scope access
-    # and must be recomputed when access changes.
-    cache = None
-    use_cache = owner_user_id is not None
-    if use_cache:
-        cache = await pool.fetchrow(
-            "SELECT points, embedding_count, computed_at FROM embedding_projections "
-            "WHERE user_id = $1 AND source_type = $2 "
-            "AND owner_user_id IS NOT DISTINCT FROM $3",
-            user_id,
-            source_key,
-            owner_user_id,
-        )
-
-    # Count current embeddings
     total_count = 0
     if source is None or source == "pages":
         row = await pool.fetchval(
@@ -836,19 +894,24 @@ async def get_embedding_projection(
         )
         total_count += row or 0
 
-    # Check if cache is still valid
-    one_hour_ago = datetime.now(UTC) - timedelta(hours=1)
-    if cache and cache["computed_at"] > one_hour_ago:
-        count_diff = abs(total_count - cache["embedding_count"])
-        if count_diff / max(cache["embedding_count"], 1) < 0.1:
-            return {
-                "points": cache["points"],
-                "stats": {"total_embeddings": total_count, "projected": len(cache["points"])},
-                "cached": True,
-            }
+    return total_count
 
-    if total_count == 0:
-        return {"points": [], "stats": {"total_embeddings": 0, "projected": 0}, "cached": False}
+
+async def compute_embedding_projection(
+    user_id: UUID,
+    source: str | None = None,
+    owner_user_id: UUID | None = None,
+    max_points: int = 2000,
+) -> int:
+    """Compute the 3D UMAP projection and upsert the cache row the endpoint
+    serves. Worker-only (see get_embedding_projection). Returns the number
+    of projected points."""
+    pool = get_pool()
+    source_key = source or "_all"
+    total_count = await _count_projectable(user_id, source, owner_user_id)
+    scope_ids = (
+        [owner_user_id] if owner_user_id is not None else await _accessible_scope_ids(user_id)
+    )
 
     # Fetch up to the full budget from each source — splitting it evenly
     # starved accounts that live in one source. The union is downsampled to
@@ -965,13 +1028,6 @@ async def get_embedding_projection(
                 }
             )
 
-    if not all_items:
-        return {
-            "points": [],
-            "stats": {"total_embeddings": total_count, "projected": 0},
-            "cached": False,
-        }
-
     # Downsample the union evenly (each source list is recency-ordered, so a
     # stride keeps the mix representative).
     if len(all_items) > max_points:
@@ -981,46 +1037,39 @@ async def get_embedding_projection(
     # 3D UMAP — neighbor-preserving, so related content clumps into visible
     # islands (PCA collapsed everything into one centered blob). Whiten each
     # axis and clamp outliers so a single far point can't compress the rest.
-    embeddings_matrix = np.stack([item["embedding"] for item in all_items])
-    if embeddings_matrix.shape[0] > 3:
-        async with _UMAP_LOCK:
-            coords = await asyncio.to_thread(_umap_3d, embeddings_matrix)
-    else:
-        coords = np.zeros((len(all_items), 3))
+    # Under the floor, cache an empty projection: too few points to mean
+    # anything in 3D, and UMAP's spectral init can't even run.
+    points: list[dict] = []
+    if len(all_items) >= _PROJECTION_MIN_POINTS:
+        embeddings_matrix = np.stack([item["embedding"] for item in all_items])
+        coords = _umap_3d(embeddings_matrix)
+        for i, item in enumerate(all_items):
+            points.append(
+                {
+                    "id": item["id"],
+                    "x": round(float(coords[i, 0]), 4),
+                    "y": round(float(coords[i, 1]), 4),
+                    "z": round(float(coords[i, 2]), 4),
+                    "source": item["source"],
+                    "label": item["label"],
+                    "created_at": item["created_at"],
+                }
+            )
 
-    # Build points
-    points = []
-    for i, item in enumerate(all_items):
-        points.append(
-            {
-                "id": item["id"],
-                "x": round(float(coords[i, 0]), 4),
-                "y": round(float(coords[i, 1]), 4),
-                "z": round(float(coords[i, 2]), 4),
-                "source": item["source"],
-                "label": item["label"],
-                "created_at": item["created_at"],
-            }
-        )
-
-    if use_cache:
-        await pool.execute(
-            "INSERT INTO embedding_projections "
-            "(user_id, source_type, owner_user_id, points, embedding_count, computed_at) "
-            "VALUES ($1, $2, $3, $4, $5, NOW()) "
-            "ON CONFLICT (user_id, source_type, owner_user_id) "
-            "DO UPDATE SET points = EXCLUDED.points, "
-            "              embedding_count = EXCLUDED.embedding_count, "
-            "              computed_at = NOW()",
-            user_id,
-            source_key,
-            owner_user_id,
-            points,
-            total_count,
-        )
-
-    return {
-        "points": points,
-        "stats": {"total_embeddings": total_count, "projected": len(points)},
-        "cached": False,
-    }
+    await pool.execute(
+        "INSERT INTO embedding_projections "
+        "(user_id, source_type, owner_user_id, points, embedding_count, computed_at, scope_ids) "
+        "VALUES ($1, $2, $3, $4, $5, NOW(), $6) "
+        "ON CONFLICT (user_id, source_type, owner_user_id) "
+        "DO UPDATE SET points = EXCLUDED.points, "
+        "              embedding_count = EXCLUDED.embedding_count, "
+        "              computed_at = NOW(), "
+        "              scope_ids = EXCLUDED.scope_ids",
+        user_id,
+        source_key,
+        owner_user_id,
+        points,
+        total_count,
+        scope_ids,
+    )
+    return len(points)

--- a/backend/tasks/viz.py
+++ b/backend/tasks/viz.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 from ..celery_app import celery
 from ..database import get_pool
@@ -84,3 +85,19 @@ async def _precompute() -> int:
 @celery.task(name="backend.tasks.viz.precompute")
 def precompute() -> int:
     return run_async(_precompute())
+
+
+@celery.task(name="backend.tasks.viz.refresh_projection")
+def refresh_projection(
+    user_id: str, source: str | None = None, owner_user_id: str | None = None
+) -> int:
+    """Recompute one embedding projection, enqueued by the projection
+    endpoint on cache miss or staleness. UMAP + numba live here because the
+    web instances can't afford them (memory + latency)."""
+    return run_async(
+        analytics_service.compute_embedding_projection(
+            UUID(user_id),
+            source=source,
+            owner_user_id=UUID(owner_user_id) if owner_user_id else None,
+        )
+    )

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -185,7 +185,105 @@ async def test_user_wide_embedding_projection_ignores_stale_cache_without_curren
         "points": [],
         "stats": {"total_embeddings": 0, "projected": 0},
         "cached": False,
+        "pending": False,
     }
+
+
+@pytest.mark.asyncio
+async def test_embedding_projection_serves_from_worker_cache(
+    client: AsyncClient, pool, monkeypatch
+):
+    from backend.services import analytics_service
+    from backend.tasks import viz as viz_tasks
+
+    api_key = await _register(client, "proj_cache")
+    me = await _scope(client, api_key)
+    user_id = UUID(me["id"])
+
+    enqueued = []
+    monkeypatch.setattr(viz_tasks.refresh_projection, "delay", lambda *args: enqueued.append(args))
+
+    # Three embedded pages: enough to count, below the projection floor.
+    emb = [0.1] * 384
+    for i in range(3):
+        await pool.execute(
+            "INSERT INTO pages (name, created_by, owner_user_id, embedding, embed_stale) "
+            "VALUES ($1, $2, $2, $3, false)",
+            f"P{i}",
+            user_id,
+            emb,
+        )
+
+    # Cache miss: nothing served, refresh enqueued, caller told to wait.
+    r = await client.get("/api/v1/me/embedding-projection", headers=_auth(api_key))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pending"] is True
+    assert body["points"] == []
+    assert body["stats"]["total_embeddings"] == 3
+    assert len(enqueued) == 1
+
+    # The worker computes; under the floor it caches an empty projection.
+    projected = await analytics_service.compute_embedding_projection(user_id)
+    assert projected == 0
+
+    r = await client.get("/api/v1/me/embedding-projection", headers=_auth(api_key))
+    assert r.json() == {
+        "points": [],
+        "stats": {"total_embeddings": 3, "projected": 0},
+        "cached": True,
+        "pending": False,
+    }
+    # Fresh, scope-valid cache: no second refresh enqueued.
+    assert len(enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_projection_scope_change_reads_as_cache_miss(
+    client: AsyncClient, pool, monkeypatch
+):
+    from backend.tasks import viz as viz_tasks
+
+    api_key = await _register(client, "proj_scope")
+    me = await _scope(client, api_key)
+    user_id = UUID(me["id"])
+
+    monkeypatch.setattr(viz_tasks.refresh_projection, "delay", lambda *args: None)
+
+    emb = [0.1] * 384
+    await pool.execute(
+        "INSERT INTO pages (name, created_by, owner_user_id, embedding, embed_stale) "
+        "VALUES ('P', $1, $1, $2, false)",
+        user_id,
+        emb,
+    )
+    # A cache row computed over a different scope set (here: empty) must not
+    # be served — its points may belong to scopes the user can no longer read.
+    await pool.execute(
+        "INSERT INTO embedding_projections "
+        "(user_id, source_type, owner_user_id, points, embedding_count, computed_at, scope_ids) "
+        "VALUES ($1, '_all', NULL, $2::jsonb, 1, now(), '{}')",
+        user_id,
+        json.dumps(
+            [
+                {
+                    "id": "left-over",
+                    "x": 0,
+                    "y": 0,
+                    "z": 0,
+                    "source": "pages",
+                    "label": "revoked-scope page",
+                    "created_at": None,
+                }
+            ]
+        ),
+    )
+
+    r = await client.get("/api/v1/me/embedding-projection", headers=_auth(api_key))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pending"] is True
+    assert body["points"] == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -38,11 +38,13 @@ async def test_unhandled_errors_are_redacted_and_keep_security_headers(
     assert resp.headers["X-Content-Type-Options"] == "nosniff"
     assert "secret-token" not in resp.text
     assert "customer transcript" not in resp.text
-    assert captured_logs == [
-        (
-            "Unhandled request failed method=%s path=%s exception_type=%s",
-            ("GET", "/__test_unhandled_error_redaction", "RuntimeError"),
-        )
-    ]
+    assert len(captured_logs) == 1
+    message, args = captured_logs[0]
+    assert message == "Unhandled request failed method=%s path=%s exception_type=%s\n%s"
+    assert args[:3] == ("GET", "/__test_unhandled_error_redaction", "RuntimeError")
+    # The stack is frame locations only — enough to diagnose the 500...
+    assert "in _raise_secret_error" in args[3]
+    # ...but never exception messages or source lines, which can carry user
+    # content.
     assert "secret-token" not in str(captured_logs)
     assert "customer transcript" not in str(captured_logs)

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -118,6 +118,27 @@ export default function BrainDashboard() {
     };
   }, []);
 
+  // First projection for an account computes in the worker (~a minute);
+  // poll while the backend reports pending so the map appears when ready.
+  useEffect(() => {
+    if (!projection?.pending) return;
+    let attempts = 0;
+    const timer = setInterval(() => {
+      attempts += 1;
+      if (attempts > 15) {
+        clearInterval(timer);
+        return;
+      }
+      getEmbeddingProjection(2000)
+        .then((p) => {
+          setProjection(p);
+          if (!p.pending) clearInterval(timer);
+        })
+        .catch(() => {});
+    }, 8000);
+    return () => clearInterval(timer);
+  }, [projection?.pending]);
+
   const recent24h = useMemo(() => {
     const since = nowMs - 24 * 60 * 60 * 1000;
     return events.filter((e) => new Date(e.ts).getTime() >= since).length;
@@ -181,8 +202,11 @@ export default function BrainDashboard() {
                 </div>
               ) : (
                 <div className="flex h-[240px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
-                  No embeddings indexed yet. Pages, table rows, and session events
-                  get embedded as they&apos;re added.
+                  {projection?.pending
+                    ? "Mapping your knowledge — the first pass takes about a minute."
+                    : projection && projection.stats.total_embeddings > 0
+                      ? "Not enough embedded content to map yet."
+                      : "No embeddings indexed yet. Pages, table rows, and session events get embedded as they're added."}
                 </div>
               )}
             </VizCard>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -196,6 +196,8 @@ export interface EmbeddingProjection {
   points: EmbeddingProjectionPoint[];
   stats: { total_embeddings: number; projected: number };
   cached: boolean;
+  /** The worker hasn't computed this projection yet — poll until it lands. */
+  pending: boolean;
 }
 
 // --- Page comments ---


### PR DESCRIPTION
## What & why

Follow-up to last night's prod incident. The projection endpoint ran UMAP in-request, which (a) OOM-crashlooped the 512MB web instances until the plan bump, and (b) still 500s for every account because of a second, silent bug. This PR removes the whole class of problem and makes the next one visible.

## Changes

**Projection = worker + cache**
- `GET /me/embedding-projection` now only reads the `embedding_projections` cache. Computing runs in the Celery worker (`tasks.viz.refresh_projection`, enqueued on cache miss or staleness) — the worker is on the 2GB plan and numba's JIT happens off-request, once per worker process.
- **Access safety**: cache rows record the scope set they were computed over (migration 0143 adds `scope_ids`); a scope mismatch reads as a cache miss, so points from a revoked scope can never be served. This preserves the exact contract the old code enforced by refusing to cache user-wide results at all (the existing redaction test still passes, updated only for the new `pending` field).
- Responses carry **`pending`**: the dashboard shows "Mapping your knowledge — the first pass takes about a minute" and polls every 8s until the worker lands the projection. Stale-but-scope-valid caches serve immediately with a refresh enqueued (layout lags briefly; membership never does).

**Small-N floor** — the second prod bug, reproduced with a traceback: 3D UMAP's spectral init throws `TypeError: k >= N` in `scipy eigsh` for tiny point counts. Projections now require ≥ 10 points; below that the worker caches an empty projection and the panel honestly says there isn't enough content yet.

**Observability** — the unhandled-error middleware now logs the exception's frame locations (`file:line in function` — no exception messages, no source lines, so user content still can't leak into logs; the redaction test asserts both properties). Last night's residual bug was only undiagnosable because prod 500s were completely silent.

## Verified locally (real backend + Postgres + Redis + live Celery worker)

Full loop end-to-end: fresh cache → dashboard shows pending → task consumed from the queue by a real worker → projection cached → poll picks it up → map renders (24 points, `cached: true, pending: false` confirmed via API). Scope-mismatch and under-floor paths covered by tests.

## Tests

Backend: full suite **768 passed** (two initial failures: one flaky under the marathon run, passes solo; one was the redaction test, updated to assert the new frame-only log format plus the original no-user-content guarantees). New tests: cache-miss→pending→enqueue→serve cycle, scope-change-as-cache-miss. `ruff` clean. Frontend: 191 passed, lint clean.

## Deploy note

After merge, the first `/memory` load per account shows the pending state for ~30–60s (worker JIT + fit), then the map appears and stays cached. No web-instance memory pressure at any point — the starter plan would actually suffice again if you want to downgrade later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)