### PR TITLE
Events: never 500 on payload content; stash status reads the real dir

### DIFF
--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -33,6 +33,23 @@ def _normalize_ts(ts: datetime) -> datetime:
     return ts
 
 
+def _strip_nuls(value):
+    """Postgres text/jsonb cannot store \\u0000, so scrub it from every string.
+
+    Agent payloads carry NUL bytes in practice (e.g. a tool-output preview of
+    grepping a binary). Without this, one such event 500s forever and wedges
+    the plugin's retry queue behind it — a 500 must mean "transient", never
+    "this payload".
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {_strip_nuls(k): _strip_nuls(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_nuls(v) for v in value]
+    return value
+
+
 # Dedup map for in-flight event embeds, keyed by event_id.
 _embed_tasks: dict[UUID, asyncio.Task] = {}
 
@@ -105,7 +122,13 @@ async def push_event(
 ) -> dict:
     """Push a single event."""
     pool = get_pool()
-    meta = metadata or {}
+    agent_name = _strip_nuls(agent_name)
+    event_type = _strip_nuls(event_type)
+    content = _strip_nuls(content)
+    session_id = _strip_nuls(session_id)
+    tool_name = _strip_nuls(tool_name)
+    attachments = _strip_nuls(attachments)
+    meta = _strip_nuls(metadata or {})
     if created_at is None:
         ts = datetime.now(UTC)
     else:
@@ -165,6 +188,7 @@ async def push_events_batch(
         return []
     pool = get_pool()
     now = datetime.now(UTC)
+    events = [_strip_nuls(e) for e in events]
 
     agent_names = [e["agent_name"] for e in events]
     event_types = [e["event_type"] for e in events]

--- a/backend/tests/test_event_nul_sanitization.py
+++ b/backend/tests/test_event_nul_sanitization.py
@@ -1,0 +1,75 @@
+"""NUL bytes in event payloads must never cause a 500.
+
+Postgres cannot store NUL (0x00) in text/jsonb. Agents send it in practice
+(e.g. a tool-output preview of grepping a binary), and a payload that
+500s deterministically wedges the plugin's retry queue behind it: the
+client treats 5xx as "transient, retry later", so the contract is that
+the backend never returns a payload-dependent 500.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("nul"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return {"Authorization": f"Bearer {resp.json()['api_key']}"}
+
+
+@pytest.mark.asyncio
+async def test_event_with_nul_bytes_is_accepted_and_stripped(client: AsyncClient):
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "tester",
+            "event_type": "tool_use",
+            "content": "Ran: grep binary\x00output",
+            "session_id": "nul-session",
+            "tool_name": "bash\x00",
+            "metadata": {"response_preview": "junk\x00\x00bytes", "nested": {"k\x00ey": ["v\x00"]}},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    event = resp.json()
+    assert event["content"] == "Ran: grep binaryoutput"
+    assert event["tool_name"] == "bash"
+    assert event["metadata"]["response_preview"] == "junkbytes"
+    assert event["metadata"]["nested"] == {"key": ["v"]}
+
+
+@pytest.mark.asyncio
+async def test_batch_event_with_nul_bytes_is_accepted_and_stripped(client: AsyncClient):
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "tester",
+                    "event_type": "tool_use",
+                    "content": "clean event",
+                    "session_id": "nul-batch-session",
+                },
+                {
+                    "agent_name": "tester",
+                    "event_type": "tool_use",
+                    "content": "dirty\x00event",
+                    "session_id": "nul-batch-session",
+                    "metadata": {"preview": "\x00\x00"},
+                },
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    events = resp.json()
+    assert [e["content"] for e in events] == ["clean event", "dirtyevent"]
+    assert events[1]["metadata"] == {"preview": ""}

--- a/cli/main.py
+++ b/cli/main.py
@@ -4102,7 +4102,8 @@ def welcome_cmd():
 # ===========================================================================
 
 PLUGIN_DATA_DIRS = {
-    "claude": Path.home() / ".claude/plugins/data/stash",
+    # Claude Code names the data dir <plugin>-<marketplace>.
+    "claude": Path.home() / ".claude/plugins/data/stash-stash-plugins",
     "codex": Path.home() / ".stash/plugins/codex",
     "cursor": Path.home() / ".stash/plugins/cursor",
     "gemini": Path.home() / ".stash/plugins/gemini",

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -13,12 +13,10 @@ from pathlib import Path
 
 from stashai.plugin.stash_client import StashClient
 
-DATA_DIR = Path(
-    os.environ.get(
-        "CLAUDE_PLUGIN_DATA",
-        Path.home() / ".claude/plugins/data/stash",
-    )
-)
+# Claude Code sets this for every hook invocation. No fallback: a guessed
+# path splits plugin state across two dirs and `stash status` reads the
+# wrong one (which is how upload failures went invisible once already).
+DATA_DIR = Path(os.environ["CLAUDE_PLUGIN_DATA"])
 
 PRODUCTION_BASE_URL = "https://api.joinstash.ai"
 

--- a/plugins/tests/test_plugin_config.py
+++ b/plugins/tests/test_plugin_config.py
@@ -31,13 +31,14 @@ def _load_config(path: Path):
 
 
 @pytest.fixture(autouse=True)
-def _clear_claude_env(monkeypatch):
+def _clear_claude_env(monkeypatch, tmp_path):
     for key in (
         "CLAUDE_PLUGIN_USER_CONFIG_api_key",
         "CLAUDE_PLUGIN_USER_CONFIG_agent_name",
         "CLAUDE_PLUGIN_USER_CONFIG_api_endpoint",
     ):
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin-data"))
 
 
 @pytest.mark.parametrize("config_path", CONFIG_PATHS, ids=lambda p: str(p.relative_to(ROOT)))

--- a/plugins/tests/test_session_link.py
+++ b/plugins/tests/test_session_link.py
@@ -29,7 +29,7 @@ def plugin_home(tmp_path, monkeypatch):
     home = tmp_path / "home"
     (home / ".stash").mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(home / "plugin-data"))
     monkeypatch.delenv("CLAUDE_PLUGIN_USER_CONFIG_api_key", raising=False)
     monkeypatch.setattr(cli_config, "USER_CONFIG_FILE", home / ".stash" / "config.json")
     return home


### PR DESCRIPTION
## The bug

A Claude Code session grepped the Claude binary; the plugin captured the output into an event's `metadata.response_preview` — including NUL (0x00) bytes. Postgres cannot store NUL in text/jsonb, so `POST /api/v1/me/sessions/events` 500'd on that payload, deterministically, forever.

The plugin treats 5xx as "transient, retry later" (correct for real outages), so the poisoned event wedged the local queue: 4 later events (including two `session_end`s) sat stuck behind it, health stayed `failing`, and prod ate a retry 500 **every ~10 seconds** for days.

#747 and #748 covered the 4xx side (permanent rejections are dropped, never queued). This closes the 5xx side by fixing the contract at the source: **the backend must never return a payload-dependent 500.** With that guarantee, "5xx = transient, retry" is safe again, and no client-side poison-pill logic is needed.

## Changes

- **`memory_service`**: strip NUL from event strings (content, tool_name, metadata, attachments, identifiers) before insert. Done in the service, not the Pydantic model, because it is the one choke point shared by the events route, `/events/batch`, transcript import, and demo seeding — the latter two call the service directly with raw dicts.
- **`stash status` read the wrong dir and reported "ok" while uploads failed.** `PLUGIN_DATA_DIRS["claude"]` pointed at `~/.claude/plugins/data/stash`, but Claude Code names the plugin data dir `<plugin>-<marketplace>` → `stash-stash-plugins`. Fixed.
- **Removed the plugin's `DATA_DIR` env-var fallback.** The `CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/stash` fallback is what created the phantom second dir (it still received stray writes as recently as Jul 10). Claude Code sets the var on every hook invocation; anything env-less now fails loud instead of silently splitting plugin state across two dirs.

## Testing

- New `backend/tests/test_event_nul_sanitization.py`: NUL-laden single + batch event posts return 201 and are stored stripped (exercises the real Postgres insert).
- Neighboring suites pass: 35 event/transcript backend tests, 106 plugin tests, 117 CLI tests.
- Verified live: after stripping NULs from the wedged queue entry on my machine, all 5 stuck events drained and delivered (confirmed server-side), and Render logs show the 500s stopped at 09:55:10 UTC — the moment of the strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
