### PR TITLE
Session folders: atomic get-or-create; batch events honor session_folder_id

### DIFF
--- a/backend/routers/session_folders.py
+++ b/backend/routers/session_folders.py
@@ -82,6 +82,27 @@ async def create_folder(body: CreateFolderRequest, current_user: dict = Depends(
         raise HTTPException(status_code=422, detail=str(exc))
 
 
+class GetOrCreateFolderRequest(BaseModel):
+    name: str
+
+
+@me_router.post("/get-or-create")
+async def get_or_create_folder(
+    body: GetOrCreateFolderRequest, current_user: dict = Depends(get_current_user)
+):
+    """Idempotent folder-by-name for machine callers (e.g. one folder per
+    customer org, resolved on every uploaded turn). Concurrent calls with the
+    same name return the same folder — no list-then-create race. Always
+    creates private folders; publishing stays on the explicit routes."""
+    owner_user_id = current_user["id"]
+    await _require_member(owner_user_id, current_user["id"])
+    await _require_write(owner_user_id, current_user["id"])
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="Folder name is required")
+    return await session_folder_service.get_or_create_folder(owner_user_id, name)
+
+
 @me_router.get("")
 async def list_folders(current_user: dict = Depends(get_current_user)):
     owner_user_id = current_user["id"]

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -253,6 +253,9 @@ async def _upsert_sessions_for_events(
         sessions[session_id] = {
             "agent_name": event.get("agent_name") or "",
             "cwd": metadata.get("cwd") if isinstance(metadata.get("cwd"), str) else None,
+            # First event for a session wins, matching upsert_session's
+            # set-once folder semantics.
+            "session_folder_id": event.get("session_folder_id"),
         }
 
     for session_id, session in sessions.items():
@@ -262,6 +265,7 @@ async def _upsert_sessions_for_events(
             agent_name=session["agent_name"],
             cwd=session["cwd"],
             created_by=created_by,
+            session_folder_id=session["session_folder_id"],
         )
         contents = [
             event.get("content") or "" for event in events if event.get("session_id") == session_id

--- a/backend/services/session_folder_service.py
+++ b/backend/services/session_folder_service.py
@@ -77,6 +77,17 @@ def _row(r) -> dict:
     }
 
 
+_INSERT_FOLDER_SQL = (
+    "WITH inserted AS ("
+    "  INSERT INTO session_folders "
+    "    (owner_user_id, name, slug, "
+    "     public_permission, discoverable, is_default) "
+    "  VALUES ($1, $2, $3, $4, $5, $6) "
+    "  RETURNING *"
+    f") {_FOLDER_SELECT.replace('session_folders sf', 'inserted sf')}"
+)
+
+
 async def create_folder(
     owner_user_id: UUID,
     name: str,
@@ -87,13 +98,7 @@ async def create_folder(
 ) -> dict:
     _validate_permissions(public_permission, discoverable)
     r = await get_pool().fetchrow(
-        f"WITH inserted AS ("
-        "  INSERT INTO session_folders "
-        "    (owner_user_id, name, slug, "
-        "     public_permission, discoverable, is_default) "
-        "  VALUES ($1, $2, $3, $4, $5, $6) "
-        "  RETURNING *"
-        f") {_FOLDER_SELECT.replace('session_folders sf', 'inserted sf')}",
+        _INSERT_FOLDER_SQL,
         owner_user_id,
         name,
         _slugify(name),
@@ -102,6 +107,44 @@ async def create_folder(
         is_default,
     )
     return _row(r)
+
+
+async def get_or_create_folder(owner_user_id: UUID, name: str) -> dict:
+    """Atomic get-or-create by exact name.
+
+    For machine callers that map an external grouping onto folders — e.g. a
+    customer's app creating one folder per org on the first uploaded turn.
+    Folder names are not unique, so a bare list-then-create race would mint
+    duplicates; concurrent callers serialize on a transaction-scoped advisory
+    lock instead, and the oldest name match wins thereafter.
+
+    Matching is by exact name: renaming the folder breaks the mapping and the
+    next call recreates it under the original name.
+    """
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"session_folder:{owner_user_id}:{name}",
+            )
+            row = await conn.fetchrow(
+                f"{_FOLDER_SELECT} WHERE sf.owner_user_id = $1 AND sf.name = $2 "
+                "ORDER BY sf.created_at, sf.id LIMIT 1",
+                owner_user_id,
+                name,
+            )
+            if row is None:
+                row = await conn.fetchrow(
+                    _INSERT_FOLDER_SQL,
+                    owner_user_id,
+                    name,
+                    _slugify(name),
+                    "none",
+                    False,
+                    False,
+                )
+    return _row(row)
 
 
 async def ensure_default_folder(owner_user_id: UUID) -> dict:

--- a/backend/tests/test_session_folder_get_or_create.py
+++ b/backend/tests/test_session_folder_get_or_create.py
@@ -1,0 +1,126 @@
+"""get-or-create session folders: the folder-per-org path for machine callers.
+
+A customer app (e.g. Heavi) resolves one folder per org on every uploaded
+turn. The endpoint must be idempotent under concurrency — folder names are
+not unique, so a list-then-create client race would mint duplicate folders —
+and the batch events endpoint must honor the resolved folder id so sessions
+are born into it.
+"""
+
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient, prefix: str) -> str:
+    name = unique_name(prefix)
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1", "email": f"{name}@test.local"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_is_idempotent(client: AsyncClient, _db_pool):
+    key = await _register(client, "goc-idem")
+
+    first = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "riverside-truck-parts"},
+        headers=_auth(key),
+    )
+    assert first.status_code == 200
+    again = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "riverside-truck-parts"},
+        headers=_auth(key),
+    )
+    assert again.status_code == 200
+    assert again.json()["id"] == first.json()["id"]
+
+    other = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "acme-diesel"},
+        headers=_auth(key),
+    )
+    assert other.json()["id"] != first.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_create_exactly_one_folder(client: AsyncClient, pool):
+    """The whole point of the endpoint: two orgs' first turns arriving at the
+    same moment must not mint duplicate folders."""
+    key = await _register(client, "goc-race")
+
+    responses = await asyncio.gather(
+        *(
+            client.post(
+                "/api/v1/me/session-folders/get-or-create",
+                json={"name": "same-org"},
+                headers=_auth(key),
+            )
+            for _ in range(5)
+        )
+    )
+    ids = {r.json()["id"] for r in responses}
+    assert all(r.status_code == 200 for r in responses)
+    assert len(ids) == 1
+
+    count = await pool.fetchval("SELECT COUNT(*) FROM session_folders WHERE name = 'same-org'")
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_blank_name_rejected(client: AsyncClient, _db_pool):
+    key = await _register(client, "goc-blank")
+    resp = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "   "},
+        headers=_auth(key),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_batch_events_honor_session_folder_id(client: AsyncClient, pool):
+    """Regression: the batch path used to drop session_folder_id, so every
+    batch-pushed session landed in Default regardless of the request."""
+    key = await _register(client, "goc-batch")
+
+    folder = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "riverside-truck-parts"},
+        headers=_auth(key),
+    )
+    folder_id = folder.json()["id"]
+
+    resp = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "heavi-chat",
+                    "event_type": "user_message",
+                    "content": "Need a fan clutch",
+                    "session_id": "conv-folder-test",
+                    "session_folder_id": folder_id,
+                }
+            ]
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 201
+
+    stored = await pool.fetchval(
+        "SELECT session_folder_id FROM sessions WHERE session_id = 'conv-folder-test'"
+    )
+    assert str(stored) == folder_id


### PR DESCRIPTION
## What this does

**New endpoint: `POST /api/v1/me/session-folders/get-or-create`** — resolves a folder by exact name, creating it if missing. Folder names are not unique, so the list-then-create dance every machine caller would otherwise write mints duplicate folders under concurrency. Callers with the same (owner, name) now serialize on a Postgres transaction advisory lock (`pg_advisory_xact_lock`), so exactly one folder is ever created; the oldest name match wins thereafter. Always creates private folders — publishing stays on the explicit routes.

Built for the folder-per-org path: a customer's app (Heavi, [Heavi-Inc/heavi#687](https://github.com/Heavi-Inc/heavi/pull/687)) resolves one session folder per org on every uploaded turn, named by the org's unique slug.

**Bug fix: `push_events_batch` dropped `session_folder_id`.** The request model accepted the field, but `_upsert_sessions_for_events` never passed it to `upsert_session`, so batch-pushed sessions always landed in the Default folder regardless of the request. Now the first event of a session wins, matching `upsert_session`'s set-once folder semantics (manual moves still stick).

## Tests

- Idempotency: repeat calls return the same folder id; different names get different folders.
- Concurrency: 5 simultaneous get-or-create calls → one folder row, all responses agree.
- Blank name → 422.
- Regression: batch events with `session_folder_id` land the session in that folder.

`pytest` green on the affected files (81 passed), `ruff check` + `ruff format --check` clean.

## Deploy ordering

Heavi's PR fails closed until this is live on prod (a `[stash-upload]` log per turn, their chat unaffected) — merge and deploy this first.

## Follow-up (not in this PR)

The events endpoints (single and batch) don't validate that `session_folder_id` belongs to the caller — pre-existing on the single path; batch now matches it for consistency. Worth a separate ownership check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)