### PR TITLE
Session folders: optional external_key so names are display-only

### DIFF
--- a/backend/migrations/versions/0143_session_folder_external_key.py
+++ b/backend/migrations/versions/0143_session_folder_external_key.py
@@ -1,0 +1,32 @@
+"""Give session folders an optional caller-owned external key.
+
+get-or-create matched folders by exact name, which made renaming a folder in
+the UI break the caller's mapping (the next call recreated the folder under
+the old name). An external key — unique per owner, chosen by the caller, e.g.
+a customer app's org id — separates identity from display: get-or-create
+matches on the key and the name becomes freely renamable.
+
+Revision ID: 0143
+Revises: 0142
+"""
+
+from alembic import op
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE session_folders ADD COLUMN external_key varchar(128)")
+    op.execute(
+        "CREATE UNIQUE INDEX session_folders_owner_external_key "
+        "ON session_folders (owner_user_id, external_key) "
+        "WHERE external_key IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS session_folders_owner_external_key")
+    op.execute("ALTER TABLE session_folders DROP COLUMN IF EXISTS external_key")

--- a/backend/routers/session_folders.py
+++ b/backend/routers/session_folders.py
@@ -84,23 +84,34 @@ async def create_folder(body: CreateFolderRequest, current_user: dict = Depends(
 
 class GetOrCreateFolderRequest(BaseModel):
     name: str
+    external_key: str | None = None
 
 
 @me_router.post("/get-or-create")
 async def get_or_create_folder(
     body: GetOrCreateFolderRequest, current_user: dict = Depends(get_current_user)
 ):
-    """Idempotent folder-by-name for machine callers (e.g. one folder per
-    customer org, resolved on every uploaded turn). Concurrent calls with the
-    same name return the same folder — no list-then-create race. Always
-    creates private folders; publishing stays on the explicit routes."""
+    """Idempotent folder resolution for machine callers (e.g. one folder per
+    customer org, resolved on every uploaded turn). With external_key (the
+    caller's stable id) the folder matches on the key and the name is
+    display-only — renamable in the UI without breaking the mapping. Without
+    one, matching falls to exact name. Concurrent calls return the same
+    folder — no list-then-create race. Always creates private folders;
+    publishing stays on the explicit routes."""
     owner_user_id = current_user["id"]
     await _require_member(owner_user_id, current_user["id"])
     await _require_write(owner_user_id, current_user["id"])
     name = body.name.strip()
     if not name:
         raise HTTPException(status_code=422, detail="Folder name is required")
-    return await session_folder_service.get_or_create_folder(owner_user_id, name)
+    external_key = body.external_key.strip() if body.external_key is not None else None
+    if external_key == "":
+        raise HTTPException(status_code=422, detail="external_key must not be blank")
+    if external_key is not None and len(external_key) > 128:
+        raise HTTPException(status_code=422, detail="external_key too long (max 128)")
+    return await session_folder_service.get_or_create_folder(
+        owner_user_id, name, external_key=external_key
+    )
 
 
 @me_router.get("")

--- a/backend/services/session_folder_service.py
+++ b/backend/services/session_folder_service.py
@@ -23,7 +23,7 @@ _GENERAL_PERMISSION_VALUES = {"none", "read", "write"}
 DEFAULT_FOLDER_NAME = "Default"
 
 _FOLDER_COLS = (
-    "sf.id, sf.owner_user_id, sf.slug, sf.name, "
+    "sf.id, sf.owner_user_id, sf.slug, sf.name, sf.external_key, "
     "owner_user.name AS owner_name, owner_user.display_name AS owner_display_name, "
     "CASE WHEN sf.public_permission != 'none' THEN 'public' ELSE 'private' END AS access, "
     "sf.public_permission, "
@@ -62,6 +62,7 @@ def _row(r) -> dict:
         "owner_user_id": str(r["owner_user_id"]),
         "slug": r["slug"],
         "name": r["name"],
+        "external_key": r["external_key"],
         "owner_name": r["owner_name"],
         "owner_display_name": r["owner_display_name"],
         "access": r["access"],
@@ -81,8 +82,8 @@ _INSERT_FOLDER_SQL = (
     "WITH inserted AS ("
     "  INSERT INTO session_folders "
     "    (owner_user_id, name, slug, "
-    "     public_permission, discoverable, is_default) "
-    "  VALUES ($1, $2, $3, $4, $5, $6) "
+    "     public_permission, discoverable, is_default, external_key) "
+    "  VALUES ($1, $2, $3, $4, $5, $6, $7) "
     "  RETURNING *"
     f") {_FOLDER_SELECT.replace('session_folders sf', 'inserted sf')}"
 )
@@ -105,35 +106,49 @@ async def create_folder(
         public_permission,
         discoverable,
         is_default,
+        None,
     )
     return _row(r)
 
 
-async def get_or_create_folder(owner_user_id: UUID, name: str) -> dict:
-    """Atomic get-or-create by exact name.
+async def get_or_create_folder(
+    owner_user_id: UUID, name: str, *, external_key: str | None = None
+) -> dict:
+    """Atomic get-or-create for machine callers that map an external grouping
+    onto folders — e.g. a customer's app creating one folder per org on the
+    first uploaded turn.
 
-    For machine callers that map an external grouping onto folders — e.g. a
-    customer's app creating one folder per org on the first uploaded turn.
+    With an external_key (the caller's stable id, e.g. an org id), matching is
+    by key and the name is display-only: set at creation, freely renamable in
+    the UI afterwards. Without one, matching is by exact name — renaming the
+    folder then breaks the mapping, so keyed lookup is the right call for
+    anything long-lived.
+
     Folder names are not unique, so a bare list-then-create race would mint
     duplicates; concurrent callers serialize on a transaction-scoped advisory
-    lock instead, and the oldest name match wins thereafter.
-
-    Matching is by exact name: renaming the folder breaks the mapping and the
-    next call recreates it under the original name.
+    lock (the keyed path is additionally backstopped by a unique index on
+    (owner_user_id, external_key)).
     """
     pool = get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            if external_key is not None:
+                lock_token = f"session_folder:key:{owner_user_id}:{external_key}"
+                match_sql = (
+                    f"{_FOLDER_SELECT} WHERE sf.owner_user_id = $1 AND sf.external_key = $2"
+                )
+                match_arg = external_key
+            else:
+                lock_token = f"session_folder:name:{owner_user_id}:{name}"
+                match_sql = (
+                    f"{_FOLDER_SELECT} WHERE sf.owner_user_id = $1 AND sf.name = $2 "
+                    "ORDER BY sf.created_at, sf.id LIMIT 1"
+                )
+                match_arg = name
             await conn.execute(
-                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                f"session_folder:{owner_user_id}:{name}",
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", lock_token
             )
-            row = await conn.fetchrow(
-                f"{_FOLDER_SELECT} WHERE sf.owner_user_id = $1 AND sf.name = $2 "
-                "ORDER BY sf.created_at, sf.id LIMIT 1",
-                owner_user_id,
-                name,
-            )
+            row = await conn.fetchrow(match_sql, owner_user_id, match_arg)
             if row is None:
                 row = await conn.fetchrow(
                     _INSERT_FOLDER_SQL,
@@ -143,6 +158,7 @@ async def get_or_create_folder(owner_user_id: UUID, name: str) -> dict:
                     "none",
                     False,
                     False,
+                    external_key,
                 )
     return _row(row)
 

--- a/backend/tests/test_session_folder_get_or_create.py
+++ b/backend/tests/test_session_folder_get_or_create.py
@@ -80,6 +80,94 @@ async def test_concurrent_calls_create_exactly_one_folder(client: AsyncClient, p
 
 
 @pytest.mark.asyncio
+async def test_external_key_matches_regardless_of_name(client: AsyncClient, _db_pool):
+    """With a key, identity is the key — the name is display-only, so a later
+    call with a different display name still resolves to the same folder."""
+    key = await _register(client, "goc-key")
+
+    first = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Riverside Truck Parts", "external_key": "org_riverside"},
+        headers=_auth(key),
+    )
+    assert first.status_code == 200
+    assert first.json()["external_key"] == "org_riverside"
+
+    renamed_upstream = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Riverside Truck & Trailer", "external_key": "org_riverside"},
+        headers=_auth(key),
+    )
+    assert renamed_upstream.json()["id"] == first.json()["id"]
+    # Found by key: the existing display name is left alone.
+    assert renamed_upstream.json()["name"] == "Riverside Truck Parts"
+
+
+@pytest.mark.asyncio
+async def test_renaming_folder_in_ui_keeps_keyed_mapping(client: AsyncClient, _db_pool):
+    """The gotcha this feature kills: a UI rename must not orphan the mapping
+    and mint a second folder on the next turn."""
+    key = await _register(client, "goc-rename")
+
+    created = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Riverside Truck Parts", "external_key": "org_riverside"},
+        headers=_auth(key),
+    )
+    folder_id = created.json()["id"]
+
+    rename = await client.patch(
+        f"/api/v1/me/session-folders/{folder_id}",
+        json={"name": "Riverside (VIP customer)"},
+        headers=_auth(key),
+    )
+    assert rename.status_code == 200
+
+    next_turn = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Riverside Truck Parts", "external_key": "org_riverside"},
+        headers=_auth(key),
+    )
+    assert next_turn.json()["id"] == folder_id
+    assert next_turn.json()["name"] == "Riverside (VIP customer)"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_keyed_calls_create_exactly_one_folder(client: AsyncClient, pool):
+    key = await _register(client, "goc-keyrace")
+
+    responses = await asyncio.gather(
+        *(
+            client.post(
+                "/api/v1/me/session-folders/get-or-create",
+                json={"name": "Same Org", "external_key": "org_same"},
+                headers=_auth(key),
+            )
+            for _ in range(5)
+        )
+    )
+    ids = {r.json()["id"] for r in responses}
+    assert all(r.status_code == 200 for r in responses)
+    assert len(ids) == 1
+
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM session_folders WHERE external_key = 'org_same'"
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_blank_external_key_rejected(client: AsyncClient, _db_pool):
+    key = await _register(client, "goc-blankkey")
+    resp = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Some Org", "external_key": "  "},
+        headers=_auth(key),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_blank_name_rejected(client: AsyncClient, _db_pool):
     key = await _register(client, "goc-blank")
     resp = await client.post(


### PR DESCRIPTION
Follow-up to #783, which resolved folders by exact name — leaving a footgun: renaming a folder in the UI broke the caller's mapping, and the next get-or-create recreated the folder under the old name. The most natural UI action (making an org folder's name prettier) was the one the docs had to warn against.

## What this does

- **Migration 0143**: adds nullable `external_key varchar(128)` to `session_folders`, with a partial unique index on `(owner_user_id, external_key)`.
- **`get-or-create` accepts `external_key`** (the caller's stable id, e.g. a customer app's org id). When present, matching is by key — the name is set once at creation and freely renamable in the UI afterwards; a later call with a different name still resolves to the same folder and leaves the display name alone. Name-only matching is unchanged for callers without a stable id.
- Keyed path is race-safe twice over: the same advisory lock as #783, backstopped by the unique index.
- `external_key` is returned in folder payloads.

## Tests (8 total in the file, 4 new)

- Key matches regardless of display name drift.
- **Rename immunity**: create by key → rename via PATCH → next get-or-create returns the same folder with the renamed title intact.
- 5-way concurrent keyed calls → exactly one folder row.
- Blank `external_key` → 422.

`pytest` green on affected files (83 passed), `ruff` clean.

Heavi's PR ([Heavi-Inc/heavi#687](https://github.com/Heavi-Inc/heavi/pull/687)) will switch to `{name: <org display name>, external_key: <org id>}` — prettier folder names and no rename gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)