### PR TITLE
Curator feed: never drop events past the delta cap

### DIFF
--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -10,14 +10,17 @@ task uses to skip idle users without waking a sprite.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from ..database import get_pool
-from . import files_tree_service, memory_service, source_service
+from . import files_tree_service, source_service
 
-# Caps so a long-idle account's first delta stays bounded.
-_MAX_EVENTS = 200
+# Caps so a single delta stays bounded (a long-idle account's first delta, a
+# high-volume account's busy day). Overflowing _MAX_EVENTS never loses events:
+# the watermark only advances through what fit (see complete_through), so the
+# remainder is re-presented on the next run.
+_MAX_EVENTS = 500
 _MAX_PAGES = 100
 _MAX_FILES = 100
 _SNIPPET = 280
@@ -58,12 +61,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
     exclude = list(memory_ids) or None
 
-    events, _ = await memory_service.query_scope_events(
-        owner_user_id, user_id, after=since, limit=_MAX_EVENTS, order="asc"
-    )
-    # The curator's own run transcripts are not user activity — feeding them
-    # back would echo-loop the daily gate and pollute the wiki.
-    events = [e for e in events if not str(e.get("session_id") or "").startswith("agent-curate-")]
+    events, history_has_more = await _feed_events(owner_user_id, since, None, _MAX_EVENTS)
     history = [
         {
             "session_id": e.get("session_id"),
@@ -140,10 +138,58 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "sources": len(sources),
         },
         "history": history,
+        "history_has_more": history_has_more,
         "pages": pages,
         "files": files,
         "sources": sources,
     }
+
+
+async def _feed_events(
+    owner_user_id: UUID,
+    since: datetime | None,
+    until: datetime | None,
+    limit: int,
+) -> tuple[list[dict], bool]:
+    """The curator's event feed, oldest first. Returns (events, has_more).
+
+    The curator's own run transcripts (`agent-curate-%` sessions) are excluded
+    in SQL — feeding them back would echo-loop the daily gate and pollute the
+    wiki, and filtering after the query would let them consume feed slots that
+    belong to real activity."""
+    pool = get_pool()
+    args: list = [owner_user_id]
+    where = "owner_user_id = $1 AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%')"
+    if since is not None:
+        args.append(since)
+        where += f" AND created_at > ${len(args)}"
+    if until is not None:
+        args.append(until)
+        where += f" AND created_at <= ${len(args)}"
+    rows = await pool.fetch(
+        f"SELECT session_id, agent_name, event_type, content, created_at "
+        f"FROM history_events WHERE {where} "
+        f"ORDER BY created_at, id LIMIT {limit + 1}",
+        *args,
+    )
+    has_more = len(rows) > limit
+    return [dict(r) for r in rows[:limit]], has_more
+
+
+async def complete_through(
+    owner_user_id: UUID, since: datetime | None, until: datetime
+) -> datetime:
+    """How far the curator's watermark may advance after a successful run.
+
+    The feed is complete through `until` unless it overflowed _MAX_EVENTS, in
+    which case it is only complete through the last event that fit — minus a
+    microsecond, so events sharing that exact timestamp are re-presented next
+    run rather than skipped. Overflow therefore drains run by run and no event
+    is ever silently dropped from curation."""
+    events, has_more = await _feed_events(owner_user_id, since, until, _MAX_EVENTS)
+    if not has_more:
+        return until
+    return events[-1]["created_at"] - timedelta(microseconds=1)
 
 
 def _iso(dt) -> str | None:

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -134,6 +134,9 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - `{changes_cmd}` — the delta to curate: recent
   history/chats, changed pages, new files, and connected sources. This IS your
   work set; do not re-scan the whole corpus.
+- `history_has_more: true` means the history overflowed this run's cap. The
+  remainder is already queued for your next run (the watermark only advances
+  through what you were shown) — curate what's present, don't try to page.
 - `stash memory --json` — confirms the Memory folder id (`{memory_folder_id}`).
 - `stash ls /memory --json` and `stash read <page_id>` to inspect existing
   wiki pages. `stash search "<topic>" --json` to pull related source/file

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -45,7 +45,7 @@ async def _run_curator_now(agent_id: UUID) -> None:
     """A user-requested curator run: same execution as the daily tick, minus
     the due-check — the user is the trigger. The router already enforced the
     free-tier allowance and resolved credentials."""
-    from ..services import agent_service, sprite_agent_service
+    from ..services import agent_service, curation_service, sprite_agent_service
 
     agent = await agent_service.get_agent_by_id(agent_id)
     now = datetime.now(UTC)
@@ -57,7 +57,10 @@ async def _run_curator_now(agent_id: UUID) -> None:
     except Exception as e:
         await agent_service.mark_run_failed(agent_id, str(e))
         raise
-    await agent_service.mark_curated(agent_id, now)
+    through = await curation_service.complete_through(
+        UUID(str(agent["user_id"])), agent["curated_through"], now
+    )
+    await agent_service.mark_curated(agent_id, through)
 
 
 async def _run_due() -> int:
@@ -102,8 +105,13 @@ async def _run_due() -> int:
             await sprite_agent_service.run_scheduled(agent, stamp)
             if agent["is_curator"]:
                 # `now` predates the run, so changes made during it stay ahead
-                # of the watermark and are picked up next time.
-                await agent_service.mark_curated(agent["id"], now)
+                # of the watermark and are picked up next time. If the delta
+                # overflowed the event cap, the watermark stops at the last
+                # event that fit — the overflow drains on subsequent runs.
+                through = await curation_service.complete_through(
+                    user_id, agent["curated_through"], now
+                )
+                await agent_service.mark_curated(agent["id"], through)
             ran += 1
         except Exception as e:
             logger.exception("agent schedule: run failed for agent %s", agent["id"])

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -82,6 +82,100 @@ async def test_has_changes_and_feed_exclude_memory(client: AsyncClient, _db_pool
     assert all(p["name"] != "Wiki Page" for p in feed2["pages"])
 
 
+async def _push_events(client: AsyncClient, key: str, events: list[dict]) -> None:
+    r = await client.post(
+        "/api/v1/me/sessions/events/batch", json={"events": events}, headers=_auth(key)
+    )
+    assert r.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_feed_overflow_never_drops_events(client: AsyncClient, _db_pool, monkeypatch):
+    """A busy account can produce more events than one delta holds. The feed
+    truncates, but the watermark bound stops at the last event that fit — so
+    the next run picks up exactly where this one left off, and every event is
+    eventually curated."""
+    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message",
+                "content": f"turn {i}",
+                "session_id": f"conv-{i}",
+                "created_at": (base + timedelta(minutes=i)).isoformat(),
+            }
+            for i in range(5)
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, old)
+    assert feed["history_has_more"] is True
+    assert [h["content"] for h in feed["history"]] == ["turn 0", "turn 1", "turn 2"]
+
+    until = base + timedelta(hours=1)
+    through = await curation_service.complete_through(uid, old, until)
+    # Complete only through the last event that fit, not through `until`.
+    assert through < base + timedelta(minutes=3)
+
+    # The next run's feed starts where this one stopped: nothing was lost.
+    # The boundary event re-appears by design — the watermark backs off a
+    # microsecond so events sharing its timestamp can never be skipped; a
+    # duplicated boundary event is the cheap side of that trade.
+    next_feed = await curation_service.changes_since(uid, uid, through)
+    assert [h["content"] for h in next_feed["history"]] == ["turn 2", "turn 3", "turn 4"]
+    assert next_feed["history_has_more"] is False
+    assert await curation_service.complete_through(uid, through, until) == until
+
+
+@pytest.mark.asyncio
+async def test_curate_sessions_do_not_consume_feed_slots(
+    client: AsyncClient, _db_pool, monkeypatch
+):
+    """The curator's own run transcripts are excluded in SQL. If they were
+    filtered after the query they would eat delta slots and could crowd real
+    activity out of the feed entirely."""
+    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    curate_noise = [
+        {
+            "agent_name": "curator",
+            "event_type": "assistant_message",
+            "content": f"curator step {i}",
+            "session_id": "agent-curate-abc-202601011200",
+            "created_at": (base + timedelta(seconds=i)).isoformat(),
+        }
+        for i in range(4)
+    ]
+    real = [
+        {
+            "agent_name": "heavi-chat",
+            "event_type": "user_message",
+            "content": f"real {i}",
+            "session_id": f"conv-{i}",
+            "created_at": (base + timedelta(minutes=1 + i)).isoformat(),
+        }
+        for i in range(2)
+    ]
+    await _push_events(client, key, curate_noise + real)
+
+    feed = await curation_service.changes_since(uid, uid, old)
+    assert [h["content"] for h in feed["history"]] == ["real 0", "real 1"]
+    assert feed["history_has_more"] is False
+    assert await curation_service.complete_through(
+        uid, old, base + timedelta(hours=1)
+    ) == base + timedelta(hours=1)
+
+
 @pytest.mark.asyncio
 async def test_has_changes_false_after_watermark(client: AsyncClient, _db_pool):
     key, uid = await _register(client)


### PR DESCRIPTION
Once a customer app streams production traces (Heavi-Inc/heavi#687), a day's events can exceed the change-feed cap. Before this PR that overflow was **silently lost forever**: `changes_since` capped history at 200 events while the curator's watermark jumped to run time regardless, so anything past the cap was never presented for curation again.

## What this does

- **The watermark only advances through what the feed actually delivered.** New `curation_service.complete_through(owner, since, until)`: returns `until` when the delta fit, else the last delivered event's timestamp minus 1µs (so events sharing the boundary timestamp re-present next run instead of being skipped — one duplicated boundary event is the cheap side of that trade). Both watermark call sites (`_run_due`, `_run_curator_now`) use it. Overflow drains run by run; nothing is ever dropped.
- **`agent-curate-%` exclusion moved into SQL.** The curator's own run transcripts were filtered *after* the query, so they consumed feed slots — a chatty curator run could crowd real activity out of its own next delta. The new `_feed_events` query excludes them up front.
- **Cap raised 200 → 500** (~35k tokens of snippets at the 280-char clip), and the delta now carries `history_has_more` so a partial run is visible rather than indistinguishable from a complete one.
- **Prompt updated**: the curator is told a truncated delta's remainder is queued for its next run automatically — curate what's present, don't page.

## Tests

- Overflow: 5 events with cap forced to 3 → first feed truncates with `history_has_more`, watermark bound stops at event 3, next feed picks up from the boundary — every event eventually presented, boundary re-presentation asserted as intentional.
- Curate-session noise: 4 `agent-curate-%` events + 2 real events with cap 3 → feed contains exactly the 2 real events, no truncation.

22 passed across `test_curator.py` + pagination tests; `ruff` clean. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)