### PR TITLE
Curator reads documents via reader subagents, RLM-style

### DIFF
--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -112,7 +112,15 @@ def render_curator_prompt(memory_folder_id: str, since: str | None) -> str:
     Structured on Karpathy's LLM-wiki pattern: raw sources (the user's stash
     activity) are immutable inputs, the wiki under the Memory folder is the
     compiled, compounding artifact, and this prompt is the schema — page
-    types, linking rules, and the ingest + lint workflows."""
+    types, linking rules, and the ingest + lint workflows.
+
+    Reading is recursive, RLM-style (arXiv:2512.24601): the corpus can exceed
+    one context window, so the root agent handles sources symbolically (paths
+    and metadata only) and each artifact is fully read inside a disposable
+    reader subagent that writes the page and returns a constant-size digest.
+    A bootstrap run once skimmed transcripts with `head -20` and published
+    confident-looking pages whose "facts" were inferred from byte sizes —
+    this structure exists so that can't recur."""
     window = (
         f"the changes since {since}"
         if since
@@ -148,6 +156,39 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - `stash ls /memory --json` and `stash read <page_id>` to inspect existing
   wiki pages. `stash search "<topic>" --json` to pull related source/file
   context on demand.
+- You may list files and sources and read their metadata (paths, names,
+  sizes), but never print a document's *content* into your own context — no
+  `cat`/`head`/`grep` over file bodies, source docs, or transcripts.
+  Documents are read only inside reader subagents (next section).
+
+## Reading documents (one reader subagent per artifact)
+Your context window cannot hold the corpus, and a page written from a
+partial read looks complete while containing nothing — worse than no page.
+Documents stay outside your context; you touch them through subagents:
+
+- Dispatch one Task subagent per document in the delta, a few in parallel.
+  Give each: the document's path, the target category folder id, whether a
+  page for it already exists (and its page id), and the contract below.
+- The subagent reads the ENTIRE document in its own context — in chunks
+  (`sed -n '1,400p'`, `sed -n '401,800p'`, …) when it is large — before
+  writing a single fact. Then it creates or updates the wiki page itself
+  and returns ONLY a digest: `page_id | one-line summary | topic tags`.
+  Never page bodies, never document excerpts — the digest is all that
+  enters your context.
+- Every fact on a page must come from text the subagent actually read.
+  Facts guessed from a filename, byte size, or a different document are
+  forbidden. If the document cannot be fully read this run, the subagent
+  writes a stub page saying exactly that and returns INCOMPLETE; log every
+  INCOMPLETE in `Log` as next-run work — it is not done.
+- You never write a document-derived page yourself. Your job is inventory →
+  dispatch → weave: categories, cross-page links, the index, and `Log`,
+  built from the digests — the global view only you have. (Chat history
+  arrives inline via `stash changes` and you curate it directly; the
+  subagent rule is for documents.)
+
+Example — a bootstrap delta with 40 documents: inventory the 40 paths;
+dispatch reader subagents in batches of 5; collect 40 digests; write the
+categories, cross-links, index, and `Log`; log any INCOMPLETEs.
 
 ## Wiki anatomy (under the Memory folder)
 - **`Memory Wiki`** — the root index page: a catalog of every page with a
@@ -206,6 +247,8 @@ pages themselves.
 - Every page: a one-sentence summary; a markdown link up to its category;
   sideways links to related pages; confidence tags; date new content
   `<!-- added YYYY-MM-DD -->`.
+- Reader subagents write their pages with these same commands — include the
+  commands and the category folder id in the dispatch prompt.
 
 ## Lint (end of every run)
 Check the pages you touched plus the index for: contradictions between pages,

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -115,9 +115,10 @@ def render_curator_prompt(memory_folder_id: str, since: str | None) -> str:
     types, linking rules, and the ingest + lint workflows.
 
     Reading is recursive, RLM-style (arXiv:2512.24601): the corpus can exceed
-    one context window, so the root agent handles sources symbolically (paths
-    and metadata only) and each artifact is fully read inside a disposable
-    reader subagent that writes the page and returns a constant-size digest.
+    one context window, so the root agent peeks at documents to triage but
+    never accumulates their bodies — each artifact is fully read inside a
+    disposable reader subagent that writes the page and returns a
+    constant-size digest.
     A bootstrap run once skimmed transcripts with `head -20` and published
     confident-looking pages whose "facts" were inferred from byte sizes —
     this structure exists so that can't recur."""
@@ -156,15 +157,16 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - `stash ls /memory --json` and `stash read <page_id>` to inspect existing
   wiki pages. `stash search "<topic>" --json` to pull related source/file
   context on demand.
-- You may list files and sources and read their metadata (paths, names,
-  sizes), but never print a document's *content* into your own context — no
-  `cat`/`head`/`grep` over file bodies, source docs, or transcripts.
-  Documents are read only inside reader subagents (next section).
+- Peeking at document content is fine — a bounded `head`, a targeted
+  `grep` — to triage: pick a category, spot a duplicate, judge whether a
+  document matters. What you must not do is accumulate document bodies in
+  your context: full reads happen inside reader subagents (next section),
+  and your window stays free for orchestration.
 
 ## Reading documents (one reader subagent per artifact)
 Your context window cannot hold the corpus, and a page written from a
 partial read looks complete while containing nothing — worse than no page.
-Documents stay outside your context; you touch them through subagents:
+Peek at documents to triage; ingest them through subagents:
 
 - Dispatch one Task subagent per document in the delta, a few in parallel.
   Give each: the document's path, the target category folder id, whether a
@@ -180,11 +182,13 @@ Documents stay outside your context; you touch them through subagents:
   forbidden. If the document cannot be fully read this run, the subagent
   writes a stub page saying exactly that and returns INCOMPLETE; log every
   INCOMPLETE in `Log` as next-run work — it is not done.
-- You never write a document-derived page yourself. Your job is inventory →
-  dispatch → weave: categories, cross-page links, the index, and `Log`,
-  built from the digests — the global view only you have. (Chat history
-  arrives inline via `stash changes` and you curate it directly; the
-  subagent rule is for documents.)
+- A small document you have already read in full during triage is the
+  exception: write its page yourself. Everything you only peeked at gets
+  dispatched. Your job is inventory → dispatch → weave: categories,
+  cross-page links, the index, and `Log`, built from the digests — the
+  global view only you have. (Chat history arrives inline via
+  `stash changes` and you curate it directly; the subagent rule is for
+  documents.)
 
 Example — a bootstrap delta with 40 documents: inventory the 40 paths;
 dispatch reader subagents in batches of 5; collect 40 digests; write the

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -246,6 +246,21 @@ def test_curator_prompt_embeds_folder_and_window():
     assert "[[" not in boot
 
 
+def test_curator_prompt_reads_documents_via_subagents():
+    """Documents must be ingested RLM-style: the corpus can exceed one context
+    window, and a Heavi bootstrap run that read transcripts with `head -20`
+    published pages whose "facts" were inferred from byte sizes. The prompt
+    must keep document bodies out of the root's context, force whole-document
+    reads inside reader subagents, and make unfinished reads loud."""
+    boot = prompts.render_curator_prompt("folder-123", None)
+    assert "reader subagent" in boot
+    assert "ENTIRE document" in boot
+    assert "INCOMPLETE" in boot
+    # The root handles documents symbolically — content reads at the root are
+    # banned by name so the rule survives paraphrase-y prompt edits.
+    assert "never print a document's *content*" in boot
+
+
 async def _make_due(pool, agent_id: str, watermark: datetime) -> None:
     """Every-minute cron with a consumed-tick baseline in the past (due now),
     and the delta watermark set independently."""

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -256,9 +256,9 @@ def test_curator_prompt_reads_documents_via_subagents():
     assert "reader subagent" in boot
     assert "ENTIRE document" in boot
     assert "INCOMPLETE" in boot
-    # The root handles documents symbolically — content reads at the root are
-    # banned by name so the rule survives paraphrase-y prompt edits.
-    assert "never print a document's *content*" in boot
+    # The root may peek at document content to triage, but must not fill its
+    # window with document bodies — that pressure is what caused the skim.
+    assert "accumulate document bodies" in boot
 
 
 async def _make_due(pool, agent_id: str, watermark: datetime) -> None:


### PR DESCRIPTION
## Problem

The Memory curator runs as a single headless agent session, but a customer corpus can exceed its context window. Heavi's bootstrap run (2026-07-10, 40+ artifacts, ~1.4MB extracted text vs a ~200K-token window) showed exactly what happens then — the event log for that run shows the curator read:

| Transcript | Actual read |
|---|---|
| Brandon Walz #2 (69KB) | `head -20` |
| Brandon Walz #3, Dan Larlee #2 | `head -10` each |

…then wrote complete-looking annotation pages whose "key facts" were literally *"File size (69KB) suggests substantial domain discussion. (inferred)"*, marked its read-the-sources todo completed, and the next run's changelog declared all artifacts annotated. The hollow pages are permanently laundered as done.

This is the "Algorithm 2" anti-scaffold from [Recursive Language Models](https://arxiv.org/abs/2512.24601) (Zhang, Kraska, Khattab): corpus content pulled into the root's history until window pressure forces lossy heuristics.

## Change

Restructure `render_curator_prompt` around the RLM discipline. No plumbing changes — scheduled curator runs already execute headless Claude Code with no tool restrictions, so the Task tool is available; the prompt just never imposed the discipline.

- **Peek, don't accumulate:** the root may print bounded document snippets to triage (category choice, duplicate spotting), but must not fill its window with document bodies — full ingestion happens in subagents.
- **One reader subagent per document:** reads the ENTIRE document in its own disposable context (chunked `sed -n` for large files), writes/updates the wiki page itself, and returns only `page_id | one-line summary | topic tags`. A small document the root fully read during triage is the exception — it may write that page directly.
- **No facts from partial reads:** a document that can't be fully read this run becomes an explicit stub page plus an `INCOMPLETE` entry in `Log` — next-run work, never a confident shell.
- **Root's job = inventory → dispatch → weave:** categories, cross-links, index, and `Log` from digests. Chat history still curated inline (it arrives via `stash changes` and is small).
- Worked bootstrap example in the prompt, since the paper finds in-context decomposition examples strongly improve the first decomposition attempt.

Root context now scales with the number of documents (~300 chars each), not the corpus.

## Testing

- `pytest backend/tests/test_curator.py` — 20 passed, including new `test_curator_prompt_reads_documents_via_subagents` pinning the accumulate ban, whole-document rule, and INCOMPLETE protocol.
- `ruff check` / `ruff format --check` clean.
- Existing accounts pick the new prompt up on their next scheduled run; suggest validating with a fresh bootstrap on the heavi-test account and diffing transcript-page depth against prod's hollow pages before any backfill on Heavi's real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)