### PR TITLE
Memory wiki as a browsable file system + unhijack graph scroll

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -164,6 +164,16 @@ async def get_memory_folder(
     return FolderResponse(**folder)
 
 
+@router.get("/memory-tree", response_model=ScopeTreeResponse)
+async def get_memory_tree(
+    current_user: dict = Depends(get_current_user),
+):
+    """The Memory wiki as a nested file-system tree (folders + pages), rooted
+    at the caller's Memory folder. Drives the wiki browser page."""
+    tree = await files_tree_service.memory_tree(current_user["id"], current_user["id"])
+    return ScopeTreeResponse(**tree)
+
+
 @router.get("/memory-graph")
 async def get_memory_graph(
     current_user: dict = Depends(get_current_user),

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -379,6 +379,44 @@ async def memory_wiki_graph(owner_user_id: UUID) -> dict:
     }
 
 
+async def memory_tree(owner_user_id: UUID, created_by: UUID) -> dict:
+    """The Memory wiki as a nested file-system tree — folders with pages
+    attached at each level, rooted at the Memory folder (the folder itself is
+    implicit; the response is its contents). Owner-only, like the graph."""
+    memory = await get_or_create_memory_folder(owner_user_id, created_by)
+    pool = get_pool()
+    folder_rows = await pool.fetch(
+        "WITH RECURSIVE mtree AS ("
+        "  SELECT f.* FROM folders f WHERE f.id = $1"
+        "  UNION ALL"
+        "  SELECT f.* FROM folders f JOIN mtree m ON f.parent_folder_id = m.id"
+        ") SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+        "FROM mtree ORDER BY name",
+        memory["id"],
+    )
+    folder_by_id: dict[UUID, dict] = {}
+    for row in folder_rows:
+        node = dict(row)
+        node["folders"] = []
+        node["pages"] = []
+        folder_by_id[node["id"]] = node
+
+    page_rows = await pool.fetch(
+        "SELECT id, owner_user_id, folder_id, name, content_type, created_at, updated_at "
+        "FROM pages WHERE folder_id = ANY($1::uuid[]) AND deleted_at IS NULL ORDER BY name",
+        list(folder_by_id.keys()),
+    )
+
+    for node in folder_by_id.values():
+        if node["id"] != memory["id"]:
+            folder_by_id[node["parent_folder_id"]]["folders"].append(node)
+    for row in page_rows:
+        folder_by_id[row["folder_id"]]["pages"].append(dict(row))
+
+    root = folder_by_id[memory["id"]]
+    return {"folders": root["folders"], "pages": root["pages"]}
+
+
 async def _assert_not_memory(folder_id: UUID, owner_user_id: UUID) -> None:
     pool = get_pool()
     row = await pool.fetchrow(

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -417,3 +417,46 @@ async def test_memory_graph_nodes_edges_and_scope(client: AsyncClient):
     assert graph["edges"] == [{"source": a, "target": b}]
     # The link is one undirected edge — both ends count it in their degree.
     assert {n["name"]: n["degree"] for n in graph["nodes"]} == {"Alpha": 1, "Beta": 1}
+
+
+# --- Memory wiki file-system tree (GET /me/memory-tree) ---
+
+
+@pytest.mark.asyncio
+async def test_memory_tree_nests_folders_and_scopes_to_memory(client: AsyncClient):
+    key, uid = await _register(client)
+    mem = (await client.get("/api/v1/me/memory-folder", headers=_auth(key))).json()
+
+    sub = (
+        await client.post(
+            "/api/v1/me/folders",
+            json={"name": "Research", "parent_folder_id": mem["id"]},
+            headers=_auth(key),
+        )
+    ).json()
+
+    async def add_page(name: str, folder_id: str | None) -> str:
+        r = await client.post(
+            "/api/v1/me/pages/new",
+            json={"name": name, "content": "x", "folder_id": folder_id},
+            headers=_auth(key),
+        )
+        assert r.status_code == 201
+        return r.json()["id"]
+
+    root_page = await add_page("Index", mem["id"])
+    nested_page = await add_page("Deep Dive", sub["id"])
+    # A Files page is not part of the wiki tree.
+    await add_page("Outside", None)
+
+    r = await client.get("/api/v1/me/memory-tree", headers=_auth(key))
+    assert r.status_code == 200
+    tree = r.json()
+    assert [p["id"] for p in tree["pages"]] == [root_page]
+    assert [f["name"] for f in tree["folders"]] == ["Research"]
+    assert [p["id"] for p in tree["folders"][0]["pages"]] == [nested_page]
+
+    # The Files tree keeps hiding the Memory subtree — the two stay MECE.
+    files_tree = (await client.get("/api/v1/me/tree", headers=_auth(key))).json()
+    assert [p["name"] for p in files_tree["pages"]] == ["Outside"]
+    assert all(f["id"] != mem["id"] for f in files_tree["folders"])

--- a/frontend/src/app/(app)/memory/wiki/page.tsx
+++ b/frontend/src/app/(app)/memory/wiki/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import { SkeletonBlock } from "@/components/SkeletonStates";
+import WikiFileTree, {
+  wikiFolderCount,
+  wikiPageCount,
+} from "@/components/memory/WikiFileTree";
+import { getMemoryTree } from "@/lib/api";
+import type { Tree } from "@/lib/types";
+
+/** The whole Memory wiki laid out as a file system — every folder and page,
+ *  browsable in place. The graph on /memory shows how pages connect; this
+ *  page shows where they live. */
+export default function MemoryWikiRoute() {
+  const [tree, setTree] = useState<Tree | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMemoryTree()
+      .then((t) => {
+        if (!cancelled) setTree(t);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const pages = tree
+    ? tree.pages.length + tree.folders.reduce((n, f) => n + wikiPageCount(f), 0)
+    : 0;
+  const folders = tree ? wikiFolderCount(tree.folders) : 0;
+  const empty = !!tree && tree.folders.length === 0 && tree.pages.length === 0;
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto max-w-[860px] px-8 pb-10 pt-7">
+        <Link
+          href="/memory"
+          className="inline-flex items-center gap-1 text-[12.5px] text-dim hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Your brain
+        </Link>
+        <h1 className="mt-2 font-display text-[22px] font-semibold tracking-tight text-foreground">
+          Wiki file system
+        </h1>
+        <p className="mt-1 text-[13.5px] text-muted-foreground">
+          {loading
+            ? "Loading the Memory wiki…"
+            : `${pages} ${pages === 1 ? "page" : "pages"} across ${folders} ${folders === 1 ? "folder" : "folders"} — the whole wiki, laid out as a file system. Click a page to open it.`}
+        </p>
+
+        <div className="mt-5">
+          <div className="sys-label mb-1.5">Memory</div>
+          <div className="card-soft p-3">
+            {loading ? (
+              <SkeletonBlock className="h-[320px] w-full" />
+            ) : empty ? (
+              <div className="flex h-[200px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
+                No wiki pages yet. Hit &quot;Curate wiki&quot; in the explorer and the
+                agent will compile your history into linked pages.
+              </div>
+            ) : (
+              tree && <WikiFileTree tree={tree} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -18,14 +18,16 @@ import {
 } from "@/components/SkillIcons";
 import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
 import WikiGraph from "@/components/memory/WikiGraph";
+import WikiFileTree from "@/components/memory/WikiFileTree";
 import {
   getEmbeddingProjection,
   getMemoryGraph,
+  getMemoryTree,
   listActivity,
   type ActivityEvent,
   type WikiGraph as WikiGraphData,
 } from "@/lib/api";
-import type { EmbeddingProjection } from "@/lib/types";
+import type { EmbeddingProjection, Tree } from "@/lib/types";
 
 const PAGE_SIZE = 50;
 
@@ -52,6 +54,7 @@ export default function BrainDashboard() {
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
   const [graph, setGraph] = useState<WikiGraphData | null>(null);
+  const [wikiTree, setWikiTree] = useState<Tree | null>(null);
   const [insightsLoaded, setInsightsLoaded] = useState(false);
   // Captured once so the "last 24h" window doesn't drift across re-renders.
   const [nowMs] = useState(() => Date.now());
@@ -106,13 +109,17 @@ export default function BrainDashboard() {
   useEffect(() => {
     let cancelled = false;
     setInsightsLoaded(false);
-    Promise.allSettled([getEmbeddingProjection(2000), getMemoryGraph()])
-      .then(([p, g]) => {
-        if (cancelled) return;
-        if (p.status === "fulfilled") setProjection(p.value);
-        if (g.status === "fulfilled") setGraph(g.value);
-        setInsightsLoaded(true);
-      });
+    Promise.allSettled([
+      getEmbeddingProjection(2000),
+      getMemoryGraph(),
+      getMemoryTree(),
+    ]).then(([p, g, t]) => {
+      if (cancelled) return;
+      if (p.status === "fulfilled") setProjection(p.value);
+      if (g.status === "fulfilled") setGraph(g.value);
+      if (t.status === "fulfilled") setWikiTree(t.value);
+      setInsightsLoaded(true);
+    });
     return () => {
       cancelled = true;
     };
@@ -168,6 +175,33 @@ export default function BrainDashboard() {
                 </div>
               )}
             </VizCard>
+
+            {/* Wiki file system — the same pages, laid out as browsable
+                folders. Links to the full-page view at /memory/wiki. */}
+            <section>
+              <div className="mb-1.5 flex items-baseline justify-between">
+                <span className="sys-label">Wiki file system</span>
+                <Link
+                  href="/memory/wiki"
+                  className="text-[12px] text-dim hover:text-foreground"
+                >
+                  Open full view →
+                </Link>
+              </div>
+              <div className="card-soft max-h-[420px] overflow-y-auto p-3">
+                {!insightsLoaded ? (
+                  <SkeletonBlock className="h-[180px] w-full" />
+                ) : wikiTree &&
+                  (wikiTree.folders.length > 0 || wikiTree.pages.length > 0) ? (
+                  <WikiFileTree tree={wikiTree} />
+                ) : (
+                  <div className="flex h-[180px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
+                    Nothing filed yet. Wiki pages show up here as folders and
+                    pages once the curator runs.
+                  </div>
+                )}
+              </div>
+            </section>
           </div>
 
           <div className="flex min-h-0 min-w-0 flex-col gap-4">

--- a/frontend/src/components/memory/WikiFileTree.tsx
+++ b/frontend/src/components/memory/WikiFileTree.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { FolderIcon, PageIcon } from "@/components/SkillIcons";
+import type { FolderTreeNode, PageSummary, Tree } from "@/lib/types";
+
+/** Total pages in a folder's subtree — the count shown next to each folder. */
+export function wikiPageCount(folder: FolderTreeNode): number {
+  return (
+    folder.pages.length +
+    folder.folders.reduce((n, child) => n + wikiPageCount(child), 0)
+  );
+}
+
+/** Total folders in a tree, all depths. */
+export function wikiFolderCount(folders: FolderTreeNode[]): number {
+  return folders.reduce((n, f) => n + 1 + wikiFolderCount(f.folders), 0);
+}
+
+const INDENT_PX = 18;
+
+/** The Memory wiki rendered as a browsable file system: nested folders with
+ *  their pages, every page a link to /p/[pageId]. Folders start expanded so
+ *  the whole wiki reads at a glance; click a folder row to collapse it. */
+export default function WikiFileTree({ tree }: { tree: Tree }) {
+  return (
+    <div className="flex flex-col gap-px">
+      {tree.folders.map((folder) => (
+        <FolderNode key={folder.id} folder={folder} depth={0} />
+      ))}
+      {tree.pages.map((page) => (
+        <PageRow key={page.id} page={page} depth={0} />
+      ))}
+    </div>
+  );
+}
+
+function FolderNode({ folder, depth }: { folder: FolderTreeNode; depth: number }) {
+  const [open, setOpen] = useState(true);
+  const count = wikiPageCount(folder);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-raised"
+        style={{ paddingLeft: depth * INDENT_PX + 8 }}
+        aria-expanded={open}
+      >
+        <ChevronRight
+          className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform${open ? " rotate-90" : ""}`}
+        />
+        <span className="shrink-0 text-muted-foreground">
+          <FolderIcon />
+        </span>
+        <span className="truncate font-medium text-foreground">{folder.name}</span>
+        <span className="shrink-0 text-[11.5px] text-dim">
+          {count === 1 ? "1 page" : `${count} pages`}
+        </span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-px">
+          {folder.folders.map((child) => (
+            <FolderNode key={child.id} folder={child} depth={depth + 1} />
+          ))}
+          {folder.pages.map((page) => (
+            <PageRow key={page.id} page={page} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PageRow({ page, depth }: { page: PageSummary; depth: number }) {
+  return (
+    <Link
+      href={`/p/${page.id}?section=memory`}
+      className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] text-foreground hover:bg-raised"
+      style={{ paddingLeft: depth * INDENT_PX + 8 }}
+    >
+      {/* Spacer where the folder chevron sits, so page names align with folder names. */}
+      <span className="w-3.5 shrink-0" />
+      <span className="shrink-0 text-muted-foreground">
+        <PageIcon />
+      </span>
+      <span className="truncate">{page.name}</span>
+    </Link>
+  );
+}

--- a/frontend/src/components/memory/WikiGraph.tsx
+++ b/frontend/src/components/memory/WikiGraph.tsx
@@ -275,10 +275,14 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
 
   // React registers onWheel passively, so preventDefault (needed to stop the
   // page scrolling while zooming) requires a native non-passive listener.
+  // Plain wheel scrolls the page — the graph sits mid-page, so swallowing
+  // every wheel event traps scrolling whenever the cursor crosses it. Zoom
+  // needs ⌘/ctrl held; trackpad pinch arrives as ctrl+wheel, so it zooms too.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const onWheel = (e: WheelEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return;
       e.preventDefault();
       userAdjustedRef.current = true;
       const rect = canvas.getBoundingClientRect();
@@ -376,7 +380,7 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
         }}
       />
       <div className="absolute bottom-2 left-2 rounded-md border border-border bg-base/85 px-2.5 py-1.5 font-mono text-[10.5px] text-muted-foreground backdrop-blur">
-        scroll to zoom · drag to pan · double-click to fit
+        ⌘ scroll to zoom · drag to pan · double-click to fit
       </div>
     </div>
   );

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -67,7 +67,7 @@ function sectionForPath(pathname: string): ExplorerSection | null {
   if (pathname === "/sessions" || pathname.startsWith("/sessions/") || pathname.startsWith("/session-folders")) return "sessions";
   if (pathname === "/skills" || pathname.startsWith("/skills/folder")) return "skills";
   if (pathname === "/agents") return "agents";
-  if (pathname === "/memory") return "memory";
+  if (pathname === "/memory" || pathname.startsWith("/memory/")) return "memory";
   if (pathname === "/tools") return "tools";
   return null;
 }
@@ -95,8 +95,9 @@ export default function WorkspaceShell({
   const section = selectedSection ?? routeSection;
   const renderRouteContent =
     (pathname === "/sessions" && !selectedSection && searchParams.get("workspace") !== "1") ||
-    // Memory lands on the brain dashboard; opening an item switches to the workbench.
-    (pathname === "/memory" && !selectedSection);
+    // Memory routes (brain dashboard, wiki file system) render as pages
+    // beside the explorer; opening an item switches to the workbench.
+    (pathname.startsWith("/memory") && !selectedSection);
 
   return (
     // Chrome surface — the content panel floats on top of it.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -471,6 +471,11 @@ export async function getMemoryGraph(): Promise<WikiGraph> {
   return apiFetch(`${ME}/memory-graph`);
 }
 
+// The Memory wiki as a nested file-system tree, rooted at the Memory folder.
+export async function getMemoryTree(): Promise<Tree> {
+  return apiFetch(`${ME}/memory-tree`);
+}
+
 export async function createFolder(
   name: string,
   parentFolderId?: string | null


### PR DESCRIPTION
## What

The brain dashboard's graph shows how wiki pages **connect**, but nothing showed **where they live** except the one-level explorer sidebar. This makes the wiki browsable as a file system:

- **`GET /me/memory-tree`** — the Memory subtree as a nested folders+pages tree. Needs its own endpoint because `/me/tree` deliberately hides the Memory subtree (Files and Memory are MECE).
- **`WikiFileTree`** — recursive expand/collapse tree. Folders start expanded with subtree page counts; pages open in the workbench via `/p/<id>?section=memory` so the Memory explorer stays put.
- **`/memory/wiki`** — full-page "Wiki file system" view. The workspace shell now treats any `/memory/*` route as the Memory section.
- **Brain dashboard** — new "Wiki file system" section under the graph, with an "Open full view →" link.

## Also: graph no longer hijacks page scroll

The wiki graph swallowed every wheel event, so scrolling the dashboard trapped you whenever the cursor crossed it. Zoom now requires **⌘/ctrl + scroll** (plain wheel scrolls the page; trackpad pinch still zooms since browsers deliver it as ctrl+wheel). Hint badge updated to match.

## Screenshots

- [Brain dashboard with the new Wiki file system section](https://app.joinstash.ai/f/e7b9f859-8ae3-44b7-9009-a89230000f77)
- [Full-page /memory/wiki browser](https://app.joinstash.ai/f/d150c0f7-5c67-4714-b704-7b60c239e1bc)

## Testing

- New backend test: `test_memory_tree_nests_folders_and_scopes_to_memory` (nesting, wiki/Files stay MECE). Curator + folder suites pass.
- 191 frontend vitest tests pass; lint + `next build` clean.
- Browser QA on a seeded local stack: tree renders on both screens, collapse/expand works, page rows navigate to the workbench with the Memory explorer open, plain wheel scrolls past the graph while ⌘-wheel zooms (verified via dispatched events' `defaultPrevented`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)