### PR TITLE
Pin pgvector==0.4.2 — 0.5.0 breaks the embedding projection

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,10 @@ asyncpg==0.30.0
 pydantic==2.13.4
 httpx>=0.27.0
 bcrypt>=4.0.0
-pgvector>=0.3.0
+# ==0.4.2: pgvector 0.5.0 changed asyncpg decoding to return Vector objects
+# instead of numpy arrays, which 500s /me/embedding-projection (UMAP gets an
+# object-dtype matrix). Re-test the projection endpoint before bumping.
+pgvector==0.4.2
 slowapi>=0.1.9
 alembic>=1.14.0
 sqlalchemy[asyncio]>=2.0.0


### PR DESCRIPTION
## What

Prod hotfix: `/me/embedding-projection` has been 500ing on prod since **Jul 11 00:26 UTC** (first 500 in Render request logs), which blanks the knowledge map and pins the brain dashboard's "N things learned" count at 0.

## Why

`requirements.txt` pinned `pgvector>=0.3.0`. The Jul 10–11 image build picked up **pgvector 0.5.0**, which changed asyncpg decoding to return `Vector` objects instead of numpy arrays. `np.stack` over those builds an object-dtype matrix and UMAP fails immediately:

```
TypeError: float() argument must be a string or a real number, not 'Vector'
```

Reproduced locally on a fresh install (0.5.0 fails, 0.4.2 works); prod fails for every `source` value in ~250ms, consistent with the type error rather than a compute timeout.

## Testing

- Local backend on 0.4.2: `/me/embedding-projection` returns 200 with projected points (22/22 on seeded data).
- On 0.5.0 the same endpoint 500s with the traceback above.

Deploying this restores the projection without touching the projection code. A comment on the pin explains what to re-test before bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)