### PR TITLE
Brain dashboard: render each insight card as its own fetch settles

### DIFF
--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -55,7 +55,9 @@ export default function BrainDashboard() {
   const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
   const [graph, setGraph] = useState<WikiGraphData | null>(null);
   const [wikiTree, setWikiTree] = useState<Tree | null>(null);
-  const [insightsLoaded, setInsightsLoaded] = useState(false);
+  const [projectionLoaded, setProjectionLoaded] = useState(false);
+  const [graphLoaded, setGraphLoaded] = useState(false);
+  const [treeLoaded, setTreeLoaded] = useState(false);
   // Captured once so the "last 24h" window doesn't drift across re-renders.
   const [nowMs] = useState(() => Date.now());
 
@@ -105,21 +107,35 @@ export default function BrainDashboard() {
 
   // The brain's vitals + visualizations. All span the user's own content plus
   // everything shared with them (the /me/* aggregates, called without a
-  // scope, include readable shared rows).
+  // scope, include readable shared rows). Each card renders as soon as its
+  // own fetch settles — gating them together let one slow or failing
+  // endpoint hold the whole dashboard in skeletons.
   useEffect(() => {
     let cancelled = false;
-    setInsightsLoaded(false);
-    Promise.allSettled([
-      getEmbeddingProjection(2000),
-      getMemoryGraph(),
-      getMemoryTree(),
-    ]).then(([p, g, t]) => {
-      if (cancelled) return;
-      if (p.status === "fulfilled") setProjection(p.value);
-      if (g.status === "fulfilled") setGraph(g.value);
-      if (t.status === "fulfilled") setWikiTree(t.value);
-      setInsightsLoaded(true);
-    });
+    getEmbeddingProjection(2000)
+      .then((p) => {
+        if (!cancelled) setProjection(p);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setProjectionLoaded(true);
+      });
+    getMemoryGraph()
+      .then((g) => {
+        if (!cancelled) setGraph(g);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setGraphLoaded(true);
+      });
+    getMemoryTree()
+      .then((t) => {
+        if (!cancelled) setWikiTree(t);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setTreeLoaded(true);
+      });
     return () => {
       cancelled = true;
     };
@@ -164,7 +180,7 @@ export default function BrainDashboard() {
                   : "Memory wiki"
               }
             >
-              {!insightsLoaded ? (
+              {!graphLoaded ? (
                 <SkeletonBlock className="h-[560px] w-full" />
               ) : graph && graph.nodes.length > 0 ? (
                 <WikiGraph data={graph} />
@@ -189,7 +205,7 @@ export default function BrainDashboard() {
                 </Link>
               </div>
               <div className="card-soft max-h-[420px] overflow-y-auto p-3">
-                {!insightsLoaded ? (
+                {!treeLoaded ? (
                   <SkeletonBlock className="h-[180px] w-full" />
                 ) : wikiTree &&
                   (wikiTree.folders.length > 0 || wikiTree.pages.length > 0) ? (
@@ -207,7 +223,7 @@ export default function BrainDashboard() {
           <div className="flex min-h-0 min-w-0 flex-col gap-4">
             {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
             <VizCard label="Knowledge map">
-              {!insightsLoaded ? (
+              {!projectionLoaded ? (
                 <SkeletonBlock className="h-[240px] w-full" />
               ) : projection && projection.points.length > 0 ? (
                 <div className="h-[240px]">


### PR DESCRIPTION
## What

The brain dashboard gated the wiki graph, knowledge map, and wiki file system behind a single `Promise.allSettled`, so one slow or failing request held **all** cards in gray skeletons. Each card now tracks its own loaded flag and renders the moment its own fetch settles.

## Why

On prod, `/me/embedding-projection` has been 500ing since Jul 11 (fix: #791), and through the `app.joinstash.ai` proxy that failure takes **~23 seconds** to come back. For those 23 seconds the whole dashboard looked empty — even though `/me/memory-graph` and `/me/memory-tree` return in ~200ms. Independent of that specific bug, one endpoint shouldn't be able to blank the page.

## Screenshot

[Dashboard with the projection request artificially hung forever](https://app.joinstash.ai/f/3d07b894-689e-43ea-bebc-8b2523e084f1) — graph, wiki file system, and recent edits all render; only the knowledge map stays a skeleton. (No visual change in the healthy case.)

## Testing

- Playwright repro of the prod failure: routed `**/embedding-projection*` to never settle, loaded `/memory`, asserted the graph label ("Memory wiki · 17 pages"), the file-system tree, and that the map alone stays in skeleton. Passes.
- 191 frontend vitest tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)