### PR TITLE
Bound PDF OCR memory: lazy slices, capped concurrency, realistic timeout

### DIFF
--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -10,11 +10,15 @@ the text layer; a scanned PDF simply has no layer to attach and the
 same call degrades to pure OCR.
 
 Pages go up in chunks of PAGES_PER_REQUEST to the configured fast-tier
-model (`ANTHROPIC_FAST_MODEL`), all chunks in parallel, with vision
-capped at MAX_VISION_PAGES so one giant catalog can't burn unbounded
-API spend. Pages past the cap contribute their raw text layer under an
-explicit marker — the cap bounds spend, it must not discard text that
-pypdf reads for free.
+model (`ANTHROPIC_FAST_MODEL`), at most OCR_CONCURRENCY chunks in
+flight at once, with vision capped at MAX_VISION_PAGES so one giant
+catalog can't burn unbounded API spend. Pages past the cap contribute
+their raw text layer under an explicit marker — the cap bounds spend,
+it must not discard text that pypdf reads for free.
+
+Chunk slices are built lazily, one per in-flight request: the whole
+document held simultaneously as slices plus their base64 copies is what
+used to breach the extraction child's RLIMIT_AS on scanned catalogs.
 
 Unlike `file_extraction.extract_text`, this module raises on failure
 (missing API key, API errors) so the extraction pipeline's retry
@@ -36,8 +40,12 @@ from .file_extraction import extract_text
 
 MAX_VISION_PAGES = 100
 PAGES_PER_REQUEST = 10
+OCR_CONCURRENCY = 3
 MAX_OUTPUT_TOKENS = 16000
-REQUEST_TIMEOUT_SECONDS = 120.0
+# A dense 10-page catalog chunk emitting toward the 16K output cap routinely
+# needs more than two minutes; at 120s the timeout burned all three extraction
+# attempts on real customer catalogs.
+REQUEST_TIMEOUT_SECONDS = 300.0
 
 _PROMPT = (
     "Transcribe all text in this document exactly as it appears, in reading order. "
@@ -95,6 +103,19 @@ async def _transcribe_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
     return text
 
 
+def _text_layer_tail(reader: pypdf.PdfReader, start: int) -> str:
+    """Text layer of pages[start:], read straight off the open reader —
+    building a sliced copy of a several-hundred-page tail is itself enough
+    to breach the extraction child's memory cap."""
+    parts: list[str] = []
+    for page in reader.pages[start:]:
+        try:
+            parts.append(page.extract_text() or "")
+        except Exception:
+            continue
+    return "\n\n".join(p for p in parts if p).strip()
+
+
 async def transcribe_pdf(content: bytes) -> str:
     if not settings.ANTHROPIC_API_KEY:
         raise RuntimeError("ANTHROPIC_API_KEY is required to transcribe PDFs")
@@ -102,20 +123,28 @@ async def transcribe_pdf(content: bytes) -> str:
     reader = pypdf.PdfReader(io.BytesIO(content))
     total_pages = len(reader.pages)
     vision_pages = min(total_pages, MAX_VISION_PAGES)
-    chunks = [
-        _slice_pdf(reader, start, min(start + PAGES_PER_REQUEST, vision_pages))
-        for start in range(0, vision_pages, PAGES_PER_REQUEST)
-    ]
+
+    sem = asyncio.Semaphore(OCR_CONCURRENCY)
+
+    async def transcribe_from(start: int) -> str:
+        # The slice is built inside the semaphore and freed when this frame
+        # ends, so peak memory is the document plus OCR_CONCURRENCY slices —
+        # not the document plus every slice at once.
+        async with sem:
+            chunk = _slice_pdf(reader, start, min(start + PAGES_PER_REQUEST, vision_pages))
+            return await _transcribe_chunk(client, chunk)
 
     client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY, timeout=REQUEST_TIMEOUT_SECONDS)
     try:
-        texts = await asyncio.gather(*(_transcribe_chunk(client, chunk) for chunk in chunks))
+        texts = await asyncio.gather(
+            *(transcribe_from(start) for start in range(0, vision_pages, PAGES_PER_REQUEST))
+        )
     finally:
         await client.close()
 
     parts = [t for t in texts if t]
     if total_pages > vision_pages:
-        tail = extract_text(_slice_pdf(reader, vision_pages, total_pages), "application/pdf")
+        tail = _text_layer_tail(reader, vision_pages)
         if tail:
             parts.append(
                 f"[vision transcription stopped at page {vision_pages} of {total_pages}; "

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -128,7 +128,7 @@ async def test_pages_past_the_vision_cap_keep_their_text_layer(monkeypatch):
         return "chunk"
 
     monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
-    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: "tail layer text")
+    monkeypatch.setattr(pdf_ocr, "_text_layer_tail", lambda reader, start: "tail layer text")
 
     result = await pdf_ocr.transcribe_pdf(_blank_pdf(6))
 
@@ -149,11 +149,57 @@ async def test_the_vision_cap_is_marked_not_silent(monkeypatch):
         return "chunk"
 
     monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
-    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+    monkeypatch.setattr(pdf_ocr, "_text_layer_tail", lambda reader, start: "")
 
     result = await pdf_ocr.transcribe_pdf(_blank_pdf(6))
 
     assert result == "chunk\n\nchunk\n\n[transcription stopped at page 4 of 6]"
+
+
+@pytest.mark.asyncio
+async def test_ocr_holds_at_most_the_concurrency_limit_in_memory(monkeypatch):
+    """A scanned catalog sliced into N chunks, all built and sent at once, is
+    what used to blow the extraction child's 1GB RLIMIT_AS (Heavi's Timken and
+    supplier catalogs: MemoryError after 3 attempts). Peak memory must be the
+    document plus OCR_CONCURRENCY slices, so both slice construction and the
+    API call have to sit behind the semaphore."""
+    import asyncio
+
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 12)
+    monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 1)
+
+    in_flight = 0
+    peak = 0
+
+    async def fake_chunk(client, chunk):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0.005)
+        in_flight -= 1
+        return "chunk"
+
+    slice_calls = []
+    real_slice = pdf_ocr._slice_pdf
+
+    def counting_slice(reader, start, end):
+        # Slices must be created lazily (inside the semaphore), never
+        # all up front — laziness IS the memory fix.
+        slice_calls.append(in_flight)
+        return real_slice(reader, start, end)
+
+    monkeypatch.setattr(pdf_ocr, "_transcribe_chunk", fake_chunk)
+    monkeypatch.setattr(pdf_ocr, "_slice_pdf", counting_slice)
+
+    result = await pdf_ocr.transcribe_pdf(_blank_pdf(12))
+
+    assert result == "\n\n".join(["chunk"] * 12)
+    assert peak <= pdf_ocr.OCR_CONCURRENCY
+    # If slices were pre-built, every _slice_pdf call would happen before any
+    # request is in flight; lazy construction interleaves them.
+    assert len(slice_calls) == 12
+    assert any(n > 0 for n in slice_calls)
 
 
 class _FakeConnection:


### PR DESCRIPTION
## Problem

16 of Heavi's Drive documents are stuck at `extraction_status='failed'` after 3 attempts each — a third of their catalog corpus, which their memory wiki then honestly-but-wrongly described as "0-byte placeholders". The errors in prod:

| Error | Docs | Cause |
|---|---|---|
| `Extraction failed: MemoryError` | 8 | child hit its 1GB `RLIMIT_AS` |
| `extraction exited 1` | 7 | same, but died too hard to record its own error |
| `APITimeoutError` | 1 | one OCR chunk exceeded the 120s per-request timeout |

The memory blowup is structural in `pdf_ocr.transcribe_pdf`: it built **every** 10-page slice up front (`pypdf.PdfWriter` copies drag full-resolution scan images along), then sent **all** chunks in parallel — so a big scanned catalog was held in memory three ways at once: original bytes + every slice + every base64 copy (+33%). A ~700-page Timken book cannot fit in the child's 1GB cap that way. The failures are deterministic, so the 3-attempt retry machinery just re-ran the same death.

Two secondary hits:
- The past-the-vision-cap tail path built a slice copy of *all remaining pages* (600+ pages for the big books) just to read its text layer.
- 120s per request is genuinely too short for a dense 10-page chunk emitting toward the 16K output-token cap, and one timed-out chunk fails the whole document's attempt.

## Change (`backend/services/pdf_ocr.py`)

- **Lazy slices behind a semaphore (`OCR_CONCURRENCY = 3`):** each slice is built inside the semaphore and freed when its request completes. Peak memory: document + 3 slices, independent of page count.
- **Tail text layer read straight off the open reader** (`_text_layer_tail`) instead of a giant `PdfWriter` copy.
- **Per-request timeout 120s → 300s.** SDK-level retries for transient failures are unchanged; a chunk that ultimately fails still fails the document loudly (no silent degradation), per house rules.

## Testing

- New `test_ocr_holds_at_most_the_concurrency_limit_in_memory` pins both halves of the fix: ≤3 chunks in flight, and slices constructed lazily (interleaved with requests) rather than pre-built.
- Existing cap-marker tests updated to the new `_text_layer_tail` seam; contract unchanged.
- `pytest backend/tests/test_pdf_ocr.py` (11 passed), `test_drive_extraction_pipeline.py` + `test_extraction_security.py` (22 passed), ruff clean.

## Deploy note

The 16 failed docs have `extraction_attempts = 3`, so the dispatcher will **not** retry them on its own after this merges. They need a one-time reset (`extraction_status='pending', extraction_attempts=0` for the failed rows on Heavi's account) — that's a prod write we'll do separately with explicit approval. Once re-extracted, the memory curator re-annotates them automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)