### PR TITLE
Raise upload extraction text cap to 4MB, matching the Drive worker

### DIFF
--- a/backend/tasks/extraction.py
+++ b/backend/tasks/extraction.py
@@ -27,7 +27,7 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
-# Scanned-PDF OCR calls the Anthropic API with a 120s per-request timeout
+# Scanned-PDF OCR calls the Anthropic API with a 300s per-request timeout
 # and SDK retries, so the child needs far more headroom than local parsing.
 CHILD_TIMEOUT_SECONDS = 600
 MAX_ATTEMPTS = 3

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -54,7 +54,11 @@ async def _run(file_id: UUID) -> int:
     from ..services.file_extraction import extract_text, is_pdf
     from ..services.pdf_ocr import transcribe_pdf
 
-    MAX_EXTRACTED_TEXT = 1 * 1024 * 1024
+    # A document that extracts to more than this is stored truncated rather
+    # than refused — the marker tells the reader the tail is missing. Matches
+    # the Drive worker's cap; 1MB clipped vision transcriptions of large
+    # scanned catalogs (~2-3MB for a few hundred pages) mid-document.
+    MAX_EXTRACTED_TEXT = 4 * 1024 * 1024
 
     conn = await asyncpg.connect(settings.DATABASE_URL)
     try:


### PR DESCRIPTION
## Problem

The upload worker's `MAX_EXTRACTED_TEXT` was still **1MB** — unchanged from the original April extraction commit (7678e13), when extracted text was a best-effort pypdf/tesseract nicety. Vision OCR (#725) now produces ~2–3MB transcriptions for large scanned catalogs, so the upload path clipped them mid-document with a `[truncated]` marker before any downstream reader (VFS `cat`, the Memory curator's reader subagents) ever saw the tail. The Drive worker was already raised to 4MB (#749); the upload worker got left behind.

## Change

- `backend/workers/extract_one.py`: raise `MAX_EXTRACTED_TEXT` 1MB → 4MB, with the Drive worker's comment explaining the truncate-don't-refuse contract.
- `backend/tasks/extraction.py`: fix the stale "120s per-request timeout" comment — the OCR request timeout has been 300s since #793.

No downstream consumer depends on the old cap: embeddings, the curation feed, and agent runtime context all take their own (much smaller) prefixes; Postgres TOASTs multi-MB TEXT without issue.

Not touched (deliberate, separate decisions): `MAX_VISION_PAGES = 100` (the API-spend bound) and `CHILD_TIMEOUT_SECONDS` — this PR only stops storage from discarding text the pipeline already paid to transcribe.

## Testing

- `pytest backend/tests/test_pdf_ocr.py backend/tests/test_extraction_security.py` — 18 passed.
- `ruff check` / `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)