### PR TITLE
Clip API: save webpages and PDFs from the browser extension

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from .routers import (
     batch,
     billing,
     bulk_export,
+    clips,
     collab,
     demo,
     discover,
@@ -124,6 +125,7 @@ app.include_router(tables.me_router)
 app.include_router(tables.router)
 app.include_router(files.me_router)
 app.include_router(files.canonical_router)
+app.include_router(clips.router)
 app.include_router(batch.router)
 app.include_router(transcripts.router)
 app.include_router(aggregate.router)

--- a/backend/migrations/versions/0144_clip_source_url.py
+++ b/backend/migrations/versions/0144_clip_source_url.py
@@ -1,0 +1,24 @@
+"""Record where a clipped file came from.
+
+Web clips are ordinary pages/files in the Clips folder. Pages carry the
+source URL in their metadata jsonb, but files have no metadata column, so
+clipped binaries (PDFs) get a dedicated column.
+
+Revision ID: 0144
+Revises: 0143
+"""
+
+from alembic import op
+
+revision = "0144"
+down_revision = "0143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE files ADD COLUMN source_url text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE files DROP COLUMN IF EXISTS source_url")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,4 @@ pillow-heif>=0.19
 stripe>=12.0
 websockets>=13.0
 croniter>=2.0
+trafilatura>=2.0

--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -1,0 +1,69 @@
+"""Clips router: save webpages and files from the browser extension."""
+
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
+from pydantic import BaseModel, HttpUrl
+
+from ..auth import get_current_user
+from ..models import UploadResponse
+from ..services import clip_service
+from ..services.article_extraction import ArticleExtractionError
+from .files import MAX_FILE_SIZE, _page_app_url
+
+router = APIRouter(prefix="/api/v1/me/clips", tags=["clips"])
+
+
+class ClipPageRequest(BaseModel):
+    url: HttpUrl
+    html: str
+    title: str | None = None
+
+
+@router.post("/page", response_model=UploadResponse, status_code=201)
+async def clip_page(
+    body: ClipPageRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    try:
+        page = await clip_service.save_page_clip(
+            owner_user_id=current_user["id"],
+            user_id=current_user["id"],
+            url=str(body.url),
+            html=body.html,
+            title=body.title,
+        )
+    except ArticleExtractionError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    return UploadResponse(
+        kind="page",
+        id=page["id"],
+        owner_user_id=page["owner_user_id"],
+        folder_id=page.get("folder_id"),
+        name=page["name"],
+        content_type=page["content_type"],
+        app_url=_page_app_url(page["id"]),
+        created_at=page["created_at"],
+        content_markdown=page.get("content_markdown") or None,
+        created_by=page["created_by"],
+    )
+
+
+@router.post("/file", response_model=UploadResponse, status_code=201)
+async def clip_file(
+    file: UploadFile,
+    url: str = Form(...),
+    current_user: dict = Depends(get_current_user),
+):
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File too large (max 100 MB)")
+    try:
+        return await clip_service.save_file_clip(
+            owner_user_id=current_user["id"],
+            user_id=current_user["id"],
+            url=url,
+            filename=file.filename or "clip",
+            content=content,
+            content_type=file.content_type or "application/octet-stream",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/services/article_extraction.py
+++ b/backend/services/article_extraction.py
@@ -1,0 +1,33 @@
+"""Extract the readable article from raw page HTML.
+
+One extractor for every clip path: the browser extension sends the DOM it
+captured, the URL-import worker sends fetched HTML — both land here. A page
+that yields no article is a loud, typed error; there is deliberately no
+fallback extractor.
+"""
+
+import trafilatura
+
+
+class ArticleExtractionError(Exception):
+    """The HTML has no extractable article content."""
+
+
+def extract_article(html: str, url: str) -> dict:
+    """Return {"title": str | None, "markdown": str}.
+
+    Raises ArticleExtractionError when the page has no article body
+    (navigation pages, empty shells, login walls).
+    """
+    markdown = trafilatura.extract(
+        html,
+        url=url,
+        output_format="markdown",
+        include_links=True,
+        include_images=True,
+    )
+    if not markdown or not markdown.strip():
+        raise ArticleExtractionError("Could not extract an article from this page")
+    meta = trafilatura.extract_metadata(html, default_url=url)
+    title = meta.title if meta else None
+    return {"title": title, "markdown": markdown}

--- a/backend/services/clip_service.py
+++ b/backend/services/clip_service.py
@@ -1,0 +1,79 @@
+"""Clips: user-initiated saves from the browser extension.
+
+A clip is an ordinary page or file in the "Clips" root folder — the
+extension is just another upload client. Web pages go through the shared
+article extractor and become markdown pages; PDFs and other binaries become
+S3-backed file rows with their source URL recorded.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from ..database import get_pool
+from . import files_tree_service
+from .article_extraction import ArticleExtractionError, extract_article
+
+CLIPS_FOLDER = "Clips"
+
+
+async def clips_folder_id(owner_user_id: UUID, user_id: UUID) -> UUID:
+    folder = await files_tree_service.find_or_create_root_folder(
+        owner_user_id, CLIPS_FOLDER, user_id
+    )
+    return folder["id"]
+
+
+async def save_page_clip(
+    *,
+    owner_user_id: UUID,
+    user_id: UUID,
+    url: str,
+    html: str,
+    title: str | None,
+) -> dict:
+    article = extract_article(html, url)
+    # The extractor's title beats the tab title (which carries "| Site" junk),
+    # but non-article metadata sometimes lacks one.
+    name = article["title"] or title
+    if not name:
+        raise ArticleExtractionError("The page has no usable title")
+    clipped_at = datetime.now(UTC)
+    # The source header keeps the URL inside the page body — full-text search
+    # and the curator index page content, not metadata.
+    content = f"> Clipped from <{url}> on {clipped_at.date().isoformat()}\n\n{article['markdown']}"
+    folder_id = await clips_folder_id(owner_user_id, user_id)
+    return await files_tree_service.create_page_unique(
+        owner_user_id,
+        name,
+        user_id,
+        folder_id,
+        content=content,
+        metadata={"source_url": url, "clipped_at": clipped_at.isoformat()},
+    )
+
+
+async def save_file_clip(
+    *,
+    owner_user_id: UUID,
+    user_id: UUID,
+    url: str,
+    filename: str,
+    content: bytes,
+    content_type: str,
+):
+    """Store a binary clip (PDF etc.) in Clips and stamp its source URL."""
+    from ..routers.files import ingest_bytes
+
+    if files_tree_service.detect_page_kind(filename, content_type) is not None:
+        raise ValueError("Markdown/HTML clips must go through the page path")
+    folder_id = await clips_folder_id(owner_user_id, user_id)
+    response = await ingest_bytes(
+        owner_user_id=owner_user_id,
+        user_id=user_id,
+        filename=filename,
+        content=content,
+        content_type=content_type,
+        folder_id=folder_id,
+    )
+    await get_pool().execute("UPDATE files SET source_url = $1 WHERE id = $2", url, response.id)
+    return response

--- a/backend/tests/test_clips.py
+++ b/backend/tests/test_clips.py
@@ -1,0 +1,156 @@
+"""Clips: webpages and binaries saved by the browser extension.
+
+Web clips must land as markdown pages in the Clips root folder with their
+source URL both in metadata (structured) and in the body (so FTS and the
+curator see it). Binary clips must record source_url on the file row.
+"""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import storage_service
+from backend.services.article_extraction import ArticleExtractionError, extract_article
+from backend.tasks import extraction
+
+from .conftest import unique_name
+
+_PARAGRAPH = (
+    "Simplicity is the most important property a codebase can have, because "
+    "every additional moving part multiplies the number of states the team "
+    "has to reason about when something goes wrong in production. "
+)
+
+ARTICLE_HTML = f"""<html>
+<head><title>Why Simplicity Wins | Some Blog</title></head>
+<body>
+<article>
+<h1>Why Simplicity Wins</h1>
+<p>{_PARAGRAPH * 3}</p>
+<p>{_PARAGRAPH * 3}</p>
+<p>{_PARAGRAPH * 3}</p>
+</article>
+</body>
+</html>"""
+
+
+async def _register(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return {"Authorization": f"Bearer {resp.json()['api_key']}"}
+
+
+def test_extract_article_returns_title_and_markdown() -> None:
+    article = extract_article(ARTICLE_HTML, "https://example.com/post")
+    assert article["title"] == "Why Simplicity Wins"
+    assert "moving part" in article["markdown"]
+
+
+def test_extract_article_rejects_empty_page() -> None:
+    with pytest.raises(ArticleExtractionError):
+        extract_article("<html><head></head><body></body></html>", "https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_clip_page_lands_in_clips_folder(client: AsyncClient, pool) -> None:
+    headers = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://example.com/post", "html": ARTICLE_HTML},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["kind"] == "page"
+    assert data["name"] == "Why Simplicity Wins"
+
+    row = await pool.fetchrow(
+        "SELECT p.content_markdown, p.metadata, f.name AS folder_name, f.parent_folder_id "
+        "FROM pages p JOIN folders f ON f.id = p.folder_id WHERE p.id = $1",
+        UUID(data["id"]),
+    )
+    assert row["folder_name"] == "Clips"
+    assert row["parent_folder_id"] is None
+    assert row["metadata"]["source_url"] == "https://example.com/post"
+    assert "Clipped from <https://example.com/post>" in row["content_markdown"]
+
+
+@pytest.mark.asyncio
+async def test_clip_page_fails_loud_on_unextractable_html(client: AsyncClient) -> None:
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://example.com/empty", "html": "<html><body></body></html>"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "article" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reclip_same_title_creates_new_page(client: AsyncClient) -> None:
+    headers = await _register(client)
+    first = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://example.com/post", "html": ARTICLE_HTML},
+        headers=headers,
+    )
+    second = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://example.com/post", "html": ARTICLE_HTML},
+        headers=headers,
+    )
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["name"] == "Why Simplicity Wins (2)"
+
+
+@pytest.mark.asyncio
+async def test_clip_file_records_source_url(client: AsyncClient, pool, monkeypatch) -> None:
+    headers = await _register(client)
+
+    async def _upload(*args, **kwargs):
+        return "test/storage-key"
+
+    async def _url(key):
+        return f"https://blob.example/{key}"
+
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_file", _upload)
+    monkeypatch.setattr(storage_service, "get_file_url", _url)
+    monkeypatch.setattr(extraction.extract_file_text, "delay", lambda *a, **k: None)
+
+    resp = await client.post(
+        "/api/v1/me/clips/file",
+        files={"file": ("paper.pdf", b"%PDF-1.4 fake body", "application/pdf")},
+        data={"url": "https://arxiv.org/pdf/2401.00001"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["kind"] == "file"
+
+    row = await pool.fetchrow(
+        "SELECT fi.source_url, fo.name AS folder_name "
+        "FROM files fi JOIN folders fo ON fo.id = fi.folder_id WHERE fi.id = $1",
+        UUID(data["id"]),
+    )
+    assert row["source_url"] == "https://arxiv.org/pdf/2401.00001"
+    assert row["folder_name"] == "Clips"
+
+
+@pytest.mark.asyncio
+async def test_clip_file_rejects_markdown(client: AsyncClient) -> None:
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/clips/file",
+        files={"file": ("note.md", b"# hi", "text/markdown")},
+        data={"url": "https://example.com/note"},
+        headers=headers,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
First slice of the commonplace-book feature (plan: clipper → URL imports → bookmark/tabs imports → X bookmarks → Instagram saves → extension).

## What
- `POST /api/v1/me/clips/page` `{url, html, title?}` — the extension sends the captured, logged-in DOM; one server-side extractor (**trafilatura**) turns it into a markdown page in a **Clips** root folder, with `source_url`/`clipped_at` in page metadata plus a `> Clipped from <url>` header in the body so FTS and the curator see the URL.
- `POST /api/v1/me/clips/file` — binary clips (PDFs) ride the existing `ingest_bytes` path into Clips; new `files.source_url` column (migration 0144) records provenance.
- Extraction failure = loud 422; no fallback extractor. Re-clips get " (2)" names — user edits are never clobbered.

## Why
Clips are uploads, not a new entity: the extension is just another upload client, so existing FTS, embeddings, and the nightly curator pick clips up with zero extra machinery.

## Tests
`backend/tests/test_clips.py` — extractor unit tests, Clips-folder landing + metadata, 422 fail-loud, duplicate-name suffix, file source_url. Full suite green locally (pre-existing local-env failures fixed separately: Postgres timezone + S3 env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)