### PR TITLE
URL-import worker: async clips for YouTube, arXiv, PDFs, and links

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -24,6 +24,7 @@ celery = Celery(
     backend=settings.REDIS_URL,
     include=[
         "backend.tasks.extraction",
+        "backend.tasks.clips",
         "backend.tasks.drive_extraction",
         "backend.tasks.embeddings",
         "backend.tasks.linear_tickets",
@@ -64,6 +65,10 @@ celery.conf.update(
         "extraction-enqueue-pending": {
             "task": "backend.tasks.extraction.enqueue_pending",
             "schedule": 60.0,
+        },
+        "clips-enqueue-pending-url-imports": {
+            "task": "backend.tasks.clips.enqueue_pending_url_imports",
+            "schedule": 300.0,
         },
         "drive-extraction-enqueue-pending": {
             "task": "backend.tasks.drive_extraction.enqueue_pending",

--- a/backend/migrations/versions/0145_url_imports.py
+++ b/backend/migrations/versions/0145_url_imports.py
@@ -1,0 +1,63 @@
+"""URL imports: out-of-band fetch jobs for URL-only clips.
+
+A url_imports row is job state (like files.extraction_status), not a
+product entity — the result is an ordinary page or file in the Clips tree.
+import_batches groups the rows of one bookmarks.html or clip-all-tabs
+import so progress can be reported per batch.
+
+Revision ID: 0145
+Revises: 0144
+"""
+
+from alembic import op
+
+revision = "0145"
+down_revision = "0144"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE import_batches (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            kind text NOT NULL,
+            filename text,
+            total integer NOT NULL,
+            created_at timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE url_imports (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_by uuid NOT NULL REFERENCES users(id),
+            batch_id uuid REFERENCES import_batches(id) ON DELETE CASCADE,
+            url text NOT NULL,
+            title text,
+            folder_id uuid REFERENCES folders(id) ON DELETE SET NULL,
+            status text NOT NULL DEFAULT 'pending',
+            error text,
+            attempts integer NOT NULL DEFAULT 0,
+            locked_at timestamptz,
+            result_page_id uuid REFERENCES pages(id) ON DELETE SET NULL,
+            result_file_id uuid REFERENCES files(id) ON DELETE SET NULL,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX url_imports_active_idx ON url_imports (created_at) "
+        "WHERE status IN ('pending', 'processing')"
+    )
+    op.execute("CREATE INDEX url_imports_batch_idx ON url_imports (batch_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS url_imports")
+    op.execute("DROP TABLE IF EXISTS import_batches")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,4 @@ stripe>=12.0
 websockets>=13.0
 croniter>=2.0
 trafilatura>=2.0
+yt-dlp>=2025.6.30

--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -1,11 +1,14 @@
 """Clips router: save webpages and files from the browser extension."""
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, HttpUrl
 
 from ..auth import get_current_user
 from ..models import UploadResponse
-from ..services import clip_service
+from ..services import clip_router, clip_service, url_import_service
 from ..services.article_extraction import ArticleExtractionError
 from .files import MAX_FILE_SIZE, _page_app_url
 
@@ -18,11 +21,25 @@ class ClipPageRequest(BaseModel):
     title: str | None = None
 
 
-@router.post("/page", response_model=UploadResponse, status_code=201)
+@router.post("/page", response_model=None, status_code=201)
 async def clip_page(
     body: ClipPageRequest,
     current_user: dict = Depends(get_current_user),
 ):
+    """Save a clipped page. Returns 201 + the created page, except for URLs
+    whose content isn't in the posted DOM (YouTube, arXiv abstracts) — those
+    become async import jobs and return 202 + the import id."""
+    url = str(body.url)
+    if clip_router.is_async_url(url):
+        from ..tasks.clips import dispatch_url_imports
+
+        ids = await url_import_service.create_url_imports(
+            owner_user_id=current_user["id"],
+            created_by=current_user["id"],
+            items=[{"url": url, "title": body.title}],
+        )
+        dispatch_url_imports(ids)
+        return JSONResponse(status_code=202, content={"import_id": str(ids[0])})
     try:
         page = await clip_service.save_page_clip(
             owner_user_id=current_user["id"],
@@ -67,3 +84,21 @@ async def clip_file(
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get("/{import_id}")
+async def get_clip_import(
+    import_id: UUID,
+    current_user: dict = Depends(get_current_user),
+):
+    row = await url_import_service.get_url_import(import_id, current_user["id"])
+    if row is None:
+        raise HTTPException(status_code=404, detail="Import not found")
+    return {
+        "id": str(row["id"]),
+        "url": row["url"],
+        "status": row["status"],
+        "error": row["error"],
+        "result_page_id": str(row["result_page_id"]) if row["result_page_id"] else None,
+        "result_file_id": str(row["result_file_id"]) if row["result_file_id"] else None,
+    }

--- a/backend/services/clip_router.py
+++ b/backend/services/clip_router.py
@@ -1,0 +1,128 @@
+"""Route a URL-only clip to its handler.
+
+All URL special-casing lives here — the extension and importers just send
+URLs. YouTube watch pages have no extractable article (the transcript is
+the content) and arXiv abstract pages are landing pages for the actual
+paper, so both get dedicated handling before the generic fetch. Everything
+else is fetched and routed by content: PDF → file clip, HTML → article
+page, anything else fails loud.
+"""
+
+import asyncio
+import re
+from urllib.parse import urlparse
+
+import httpx
+
+from . import clip_service, youtube_transcript
+
+MAX_FETCH_BYTES = 20 * 1024 * 1024
+FETCH_TIMEOUT = 30
+USER_AGENT = "Stash/1.0 (+https://joinstash.ai)"
+
+_YOUTUBE_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}
+_ARXIV_ABS = re.compile(r"^https?://(?:www\.)?arxiv\.org/abs/(?P<paper>[^?#]+)")
+
+
+class UnsupportedUrlContent(Exception):
+    """The URL resolved to content we can't clip."""
+
+
+def is_youtube(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.hostname not in _YOUTUBE_HOSTS:
+        return False
+    if parsed.hostname == "youtu.be":
+        return bool(parsed.path.strip("/"))
+    return parsed.path.startswith(("/watch", "/shorts"))
+
+
+def normalize_arxiv(url: str) -> str:
+    """arXiv abstract pages are landing pages — clip the paper PDF instead."""
+    match = _ARXIV_ABS.match(url)
+    if match:
+        return f"https://arxiv.org/pdf/{match.group('paper')}"
+    return url
+
+
+def is_async_url(url: str) -> bool:
+    """URLs the clip endpoint must hand to the worker instead of extracting
+    the posted DOM: the useful content isn't in the page HTML."""
+    return is_youtube(url) or bool(_ARXIV_ABS.match(url))
+
+
+async def process_url_import(row: dict) -> dict:
+    """Fetch one url_imports row's content and create its page/file.
+
+    Returns {"page_id": ...} or {"file_id": ...}; raises on any failure —
+    the caller records the error on the row.
+    """
+    owner_user_id = row["owner_user_id"]
+    user_id = row["created_by"]
+    url = row["url"]
+
+    if is_youtube(url):
+        video = await asyncio.to_thread(youtube_transcript.fetch_transcript, url)
+        folder_id = row["folder_id"] or await clip_service.clips_subfolder_id(
+            owner_user_id, user_id, "YouTube"
+        )
+        markdown = f"**{video['channel']}**\n\n{video['transcript']}"
+        page = await clip_service.create_clip_page(
+            owner_user_id=owner_user_id,
+            user_id=user_id,
+            url=url,
+            name=video["title"],
+            markdown=markdown,
+            folder_id=folder_id,
+        )
+        return {"page_id": page["id"]}
+
+    fetch_url = normalize_arxiv(url)
+    content, content_type = await _fetch(fetch_url)
+
+    if "application/pdf" in content_type or content[:5] == b"%PDF-":
+        filename = urlparse(fetch_url).path.rsplit("/", 1)[-1] or "clip"
+        if not filename.lower().endswith(".pdf"):
+            filename = f"{filename}.pdf"
+        response = await clip_service.save_file_clip(
+            owner_user_id=owner_user_id,
+            user_id=user_id,
+            url=url,
+            filename=filename,
+            content=content,
+            content_type="application/pdf",
+            folder_id=row["folder_id"],
+        )
+        return {"file_id": response.id}
+
+    if "text/html" in content_type or content.lstrip()[:1] == b"<":
+        page = await clip_service.save_page_clip(
+            owner_user_id=owner_user_id,
+            user_id=user_id,
+            url=url,
+            html=content.decode("utf-8", errors="replace"),
+            title=row.get("title"),
+            folder_id=row["folder_id"],
+        )
+        return {"page_id": page["id"]}
+
+    raise UnsupportedUrlContent(f"Unsupported content type: {content_type or 'unknown'}")
+
+
+async def _fetch(url: str) -> tuple[bytes, str]:
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=FETCH_TIMEOUT,
+        headers={"User-Agent": USER_AGENT},
+    ) as client:
+        async with client.stream("GET", url) as response:
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > MAX_FETCH_BYTES:
+                    raise UnsupportedUrlContent("Response larger than 20 MB")
+                chunks.append(chunk)
+            return b"".join(chunks), content_type

--- a/backend/services/clip_service.py
+++ b/backend/services/clip_service.py
@@ -23,25 +23,40 @@ async def clips_folder_id(owner_user_id: UUID, user_id: UUID) -> UUID:
     return folder["id"]
 
 
-async def save_page_clip(
+async def clips_subfolder_id(owner_user_id: UUID, user_id: UUID, name: str) -> UUID:
+    """Idempotent Clips/<name> folder (e.g. Clips/YouTube)."""
+    root_id = await clips_folder_id(owner_user_id, user_id)
+    existing = await get_pool().fetchval(
+        "SELECT id FROM folders WHERE owner_user_id = $1 AND parent_folder_id = $2 AND name = $3",
+        owner_user_id,
+        root_id,
+        name,
+    )
+    if existing:
+        return existing
+    folder = await files_tree_service.create_folder(
+        owner_user_id, name, user_id, parent_folder_id=root_id
+    )
+    return folder["id"]
+
+
+async def create_clip_page(
     *,
     owner_user_id: UUID,
     user_id: UUID,
     url: str,
-    html: str,
-    title: str | None,
+    name: str,
+    markdown: str,
+    folder_id: UUID | None,
 ) -> dict:
-    article = extract_article(html, url)
-    # The extractor's title beats the tab title (which carries "| Site" junk),
-    # but non-article metadata sometimes lacks one.
-    name = article["title"] or title
-    if not name:
-        raise ArticleExtractionError("The page has no usable title")
+    """Create the page every clip path ends in: source header + metadata,
+    unique name, default folder Clips/."""
     clipped_at = datetime.now(UTC)
     # The source header keeps the URL inside the page body — full-text search
     # and the curator index page content, not metadata.
-    content = f"> Clipped from <{url}> on {clipped_at.date().isoformat()}\n\n{article['markdown']}"
-    folder_id = await clips_folder_id(owner_user_id, user_id)
+    content = f"> Clipped from <{url}> on {clipped_at.date().isoformat()}\n\n{markdown}"
+    if folder_id is None:
+        folder_id = await clips_folder_id(owner_user_id, user_id)
     return await files_tree_service.create_page_unique(
         owner_user_id,
         name,
@@ -49,6 +64,31 @@ async def save_page_clip(
         folder_id,
         content=content,
         metadata={"source_url": url, "clipped_at": clipped_at.isoformat()},
+    )
+
+
+async def save_page_clip(
+    *,
+    owner_user_id: UUID,
+    user_id: UUID,
+    url: str,
+    html: str,
+    title: str | None,
+    folder_id: UUID | None = None,
+) -> dict:
+    article = extract_article(html, url)
+    # The extractor's title beats the tab title (which carries "| Site" junk),
+    # but non-article metadata sometimes lacks one.
+    name = article["title"] or title
+    if not name:
+        raise ArticleExtractionError("The page has no usable title")
+    return await create_clip_page(
+        owner_user_id=owner_user_id,
+        user_id=user_id,
+        url=url,
+        name=name,
+        markdown=article["markdown"],
+        folder_id=folder_id,
     )
 
 
@@ -60,13 +100,15 @@ async def save_file_clip(
     filename: str,
     content: bytes,
     content_type: str,
+    folder_id: UUID | None = None,
 ):
     """Store a binary clip (PDF etc.) in Clips and stamp its source URL."""
     from ..routers.files import ingest_bytes
 
     if files_tree_service.detect_page_kind(filename, content_type) is not None:
         raise ValueError("Markdown/HTML clips must go through the page path")
-    folder_id = await clips_folder_id(owner_user_id, user_id)
+    if folder_id is None:
+        folder_id = await clips_folder_id(owner_user_id, user_id)
     response = await ingest_bytes(
         owner_user_id=owner_user_id,
         user_id=user_id,

--- a/backend/services/url_import_service.py
+++ b/backend/services/url_import_service.py
@@ -1,0 +1,128 @@
+"""url_imports job rows: create, claim, resolve.
+
+Mirrors the files.extraction_status lifecycle: rows are claimed with an
+attempts guard so the Beat sweep and creation-time dispatch can both fire
+without double work, and failures are recorded loudly per row.
+"""
+
+from uuid import UUID
+
+from ..database import get_pool
+
+MAX_ATTEMPTS = 3
+
+
+async def create_url_imports(
+    *,
+    owner_user_id: UUID,
+    created_by: UUID,
+    items: list[dict],
+    batch_id: UUID | None = None,
+) -> list[UUID]:
+    """Bulk-insert import rows. Each item: {url, title?, folder_id?}."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        INSERT INTO url_imports (owner_user_id, created_by, batch_id, url, title, folder_id)
+        SELECT $1, $2, $3, i.url, i.title, i.folder_id
+        FROM unnest($4::text[], $5::text[], $6::uuid[]) AS i(url, title, folder_id)
+        RETURNING id
+        """,
+        owner_user_id,
+        created_by,
+        batch_id,
+        [i["url"] for i in items],
+        [i.get("title") for i in items],
+        [i.get("folder_id") for i in items],
+    )
+    return [r["id"] for r in rows]
+
+
+async def get_url_import(import_id: UUID, owner_user_id: UUID) -> dict | None:
+    row = await get_pool().fetchrow(
+        "SELECT * FROM url_imports WHERE id = $1 AND owner_user_id = $2",
+        import_id,
+        owner_user_id,
+    )
+    return dict(row) if row else None
+
+
+async def claim(import_id: UUID) -> dict | None:
+    """Move a row to processing if it's still pending/retryable."""
+    row = await get_pool().fetchrow(
+        f"""
+        UPDATE url_imports
+        SET status = 'processing', locked_at = now(), attempts = attempts + 1,
+            updated_at = now()
+        WHERE id = $1
+          AND (
+                status = 'pending'
+             OR (status = 'failed' AND attempts < {MAX_ATTEMPTS})
+             OR (status = 'processing' AND locked_at < now() - INTERVAL '10 minutes')
+          )
+        RETURNING *
+        """,
+        import_id,
+    )
+    return dict(row) if row else None
+
+
+async def mark_done(
+    import_id: UUID,
+    *,
+    page_id: UUID | None = None,
+    file_id: UUID | None = None,
+) -> None:
+    await get_pool().execute(
+        "UPDATE url_imports SET status = 'done', error = NULL, locked_at = NULL, "
+        "result_page_id = $2, result_file_id = $3, updated_at = now() WHERE id = $1",
+        import_id,
+        page_id,
+        file_id,
+    )
+
+
+async def mark_failed(import_id: UUID, error: str) -> None:
+    await get_pool().execute(
+        "UPDATE url_imports SET status = 'failed', error = $2, locked_at = NULL, "
+        "updated_at = now() WHERE id = $1",
+        import_id,
+        error[:2000],
+    )
+
+
+async def batch_progress(batch_id: UUID, owner_user_id: UUID) -> dict | None:
+    pool = get_pool()
+    batch = await pool.fetchrow(
+        "SELECT id, kind, filename, total, created_at FROM import_batches "
+        "WHERE id = $1 AND owner_user_id = $2",
+        batch_id,
+        owner_user_id,
+    )
+    if batch is None:
+        return None
+    counts = await pool.fetchrow(
+        """
+        SELECT
+            count(*) FILTER (WHERE status = 'done') AS done,
+            count(*) FILTER (WHERE status = 'failed' AND attempts >= 3) AS failed,
+            count(*) FILTER (
+                WHERE status IN ('pending', 'processing')
+                   OR (status = 'failed' AND attempts < 3)
+            ) AS pending
+        FROM url_imports WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    failures = await pool.fetch(
+        "SELECT url, error FROM url_imports "
+        "WHERE batch_id = $1 AND status = 'failed' ORDER BY updated_at DESC LIMIT 50",
+        batch_id,
+    )
+    return {
+        **dict(batch),
+        "done": counts["done"],
+        "failed": counts["failed"],
+        "pending": counts["pending"],
+        "failures": [dict(f) for f in failures],
+    }

--- a/backend/services/youtube_transcript.py
+++ b/backend/services/youtube_transcript.py
@@ -1,0 +1,74 @@
+"""Fetch a YouTube video's transcript without downloading the video.
+
+yt-dlp resolves metadata and caption tracks; the chosen track's json3
+payload is fetched directly. Track choice is one deterministic rule —
+manual captions beat auto-generated ones, English beats the video's
+original language — with no cascade beyond that: a video with neither is
+a loud TranscriptUnavailable.
+
+Everything here is synchronous (yt-dlp is blocking); callers run it in a
+worker thread.
+"""
+
+import httpx
+import yt_dlp
+
+
+class TranscriptUnavailable(Exception):
+    """The video has no usable caption track."""
+
+
+_FETCH_TIMEOUT = 30
+
+
+def fetch_transcript(url: str) -> dict:
+    """Return {"title", "channel", "transcript"} for a YouTube URL."""
+    options = {"skip_download": True, "quiet": True, "no_warnings": True}
+    with yt_dlp.YoutubeDL(options) as ydl:
+        info = ydl.extract_info(url, download=False)
+
+    track = _pick_track(
+        info.get("subtitles") or {},
+        info.get("automatic_captions") or {},
+        info.get("language"),
+    )
+    if track is None:
+        raise TranscriptUnavailable("No transcript available for this video")
+
+    json3_url = next((f["url"] for f in track if f.get("ext") == "json3"), None)
+    if json3_url is None:
+        raise TranscriptUnavailable("Caption track has no json3 format")
+    response = httpx.get(json3_url, timeout=_FETCH_TIMEOUT)
+    response.raise_for_status()
+
+    return {
+        "title": info.get("title") or url,
+        "channel": info.get("channel") or info.get("uploader") or "",
+        "transcript": _parse_json3(response.json()),
+    }
+
+
+def _pick_track(subtitles: dict, automatic: dict, original_language: str | None) -> list | None:
+    """Manual captions beat auto-generated; English beats the original language."""
+    for tracks in (subtitles, automatic):
+        for prefix in ("en", original_language):
+            if not prefix:
+                continue
+            for lang, formats in tracks.items():
+                if lang.startswith(prefix):
+                    return formats
+    return None
+
+
+def _parse_json3(payload: dict) -> str:
+    """Flatten YouTube's json3 caption events to plain text."""
+    lines: list[str] = []
+    for event in payload.get("events", []):
+        text = "".join(seg.get("utf8", "") for seg in event.get("segs", []))
+        text = text.strip()
+        if text:
+            lines.append(text)
+    transcript = " ".join(lines)
+    if not transcript:
+        raise TranscriptUnavailable("Caption track is empty")
+    return transcript

--- a/backend/tasks/clips.py
+++ b/backend/tasks/clips.py
@@ -1,0 +1,96 @@
+"""URL-import worker: fetch URL-only clips out-of-band.
+
+Work arrives in batches of ids rather than one task per URL so a 10k
+bookmark import becomes ~100 queue entries — other periodic work
+interleaves between batches instead of starving behind a flooded queue.
+Rows are claimed with an attempts guard (see url_import_service), so
+creation-time dispatch and the Beat sweep can overlap safely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from ..celery_app import celery
+from ..database import get_pool
+from ..services import clip_router, url_import_service
+from ._celery_helpers import run_async
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 100
+CONCURRENCY = 8
+
+
+async def _process_one(import_id: UUID) -> None:
+    row = await url_import_service.claim(import_id)
+    if row is None:
+        return
+    try:
+        result = await clip_router.process_url_import(row)
+    except Exception as exc:
+        logger.warning(
+            "url import failed id=%s exception_type=%s",
+            import_id,
+            type(exc).__name__,
+        )
+        await url_import_service.mark_failed(import_id, f"{type(exc).__name__}: {exc}")
+        return
+    await url_import_service.mark_done(
+        import_id,
+        page_id=result.get("page_id"),
+        file_id=result.get("file_id"),
+    )
+
+
+async def _process_batch(ids: list[UUID]) -> str:
+    semaphore = asyncio.Semaphore(CONCURRENCY)
+
+    async def bounded(import_id: UUID) -> None:
+        async with semaphore:
+            await _process_one(import_id)
+
+    await asyncio.gather(*(bounded(i) for i in ids))
+    return f"processed {len(ids)}"
+
+
+@celery.task(name="backend.tasks.clips.process_url_imports")
+def process_url_imports(ids: list[str]) -> str:
+    return run_async(_process_batch([UUID(i) for i in ids]))
+
+
+def dispatch_url_imports(ids: list[UUID]) -> None:
+    """Fan a set of import rows out to the worker in batch-sized tasks."""
+    for start in range(0, len(ids), BATCH_SIZE):
+        chunk = ids[start : start + BATCH_SIZE]
+        process_url_imports.delay([str(i) for i in chunk])
+
+
+async def _enqueue_pending() -> int:
+    """Sweep for rows that lost their dispatch (Redis blip, worker death).
+
+    The age filter keeps the sweep from re-queueing rows whose
+    creation-time dispatch is simply still in the queue.
+    """
+    pool = get_pool()
+    rows = await pool.fetch(
+        f"""
+        SELECT id FROM url_imports
+        WHERE (
+                (status = 'pending' AND created_at < now() - INTERVAL '2 minutes')
+             OR (status = 'failed' AND attempts < {url_import_service.MAX_ATTEMPTS})
+             OR (status = 'processing' AND locked_at < now() - INTERVAL '10 minutes')
+        )
+        ORDER BY created_at
+        LIMIT 1000
+        """,
+    )
+    dispatch_url_imports([r["id"] for r in rows])
+    return len(rows)
+
+
+@celery.task(name="backend.tasks.clips.enqueue_pending_url_imports")
+def enqueue_pending_url_imports() -> int:
+    return run_async(_enqueue_pending())

--- a/backend/tests/test_url_imports.py
+++ b/backend/tests/test_url_imports.py
@@ -1,0 +1,268 @@
+"""URL imports: async fetch jobs behind the clip API.
+
+The router must classify URLs in one place (YouTube → transcript, arXiv
+abs → paper PDF, PDFs → file clips, HTML → article pages) and every
+failure must land on the row as a loud per-item error — a dead link in a
+bookmark import can never block the batch.
+"""
+
+from uuid import UUID
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from backend.services import clip_router, storage_service, url_import_service
+from backend.services.youtube_transcript import TranscriptUnavailable, _parse_json3, _pick_track
+from backend.tasks import clips as clips_tasks
+from backend.tasks import extraction
+
+from .conftest import unique_name
+from .test_clips import ARTICLE_HTML
+
+
+async def _register(client: AsyncClient) -> tuple[dict, str]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['api_key']}"}, body["id"]
+
+
+# --- URL classification ---
+
+
+def test_is_youtube_matches_watch_shorts_and_short_links() -> None:
+    assert clip_router.is_youtube("https://www.youtube.com/watch?v=abc123")
+    assert clip_router.is_youtube("https://youtube.com/shorts/abc123")
+    assert clip_router.is_youtube("https://youtu.be/abc123")
+    assert not clip_router.is_youtube("https://youtu.be/")
+    assert not clip_router.is_youtube("https://www.youtube.com/@somechannel")
+    assert not clip_router.is_youtube("https://example.com/watch?v=abc123")
+
+
+def test_normalize_arxiv_rewrites_abs_to_pdf() -> None:
+    assert (
+        clip_router.normalize_arxiv("https://arxiv.org/abs/2401.00001")
+        == "https://arxiv.org/pdf/2401.00001"
+    )
+    assert (
+        clip_router.normalize_arxiv("https://www.arxiv.org/abs/2401.00001v2")
+        == "https://arxiv.org/pdf/2401.00001v2"
+    )
+    assert clip_router.normalize_arxiv("https://example.com/abs/x") == "https://example.com/abs/x"
+
+
+def test_is_async_url_covers_youtube_and_arxiv() -> None:
+    assert clip_router.is_async_url("https://www.youtube.com/watch?v=abc")
+    assert clip_router.is_async_url("https://arxiv.org/abs/2401.00001")
+    assert not clip_router.is_async_url("https://example.com/post")
+
+
+# --- YouTube caption parsing ---
+
+
+def test_pick_track_prefers_manual_then_english() -> None:
+    manual = {"de": [{"ext": "json3", "url": "manual-de"}]}
+    auto = {"en": [{"ext": "json3", "url": "auto-en"}]}
+    assert _pick_track(manual, auto, "de")[0]["url"] == "manual-de"
+    assert _pick_track({}, auto, "de")[0]["url"] == "auto-en"
+    assert _pick_track({}, {}, "de") is None
+
+
+def test_parse_json3_flattens_events() -> None:
+    payload = {
+        "events": [
+            {"segs": [{"utf8": "hello "}, {"utf8": "world"}]},
+            {"segs": [{"utf8": "\n"}]},
+            {"segs": [{"utf8": "again"}]},
+        ]
+    }
+    assert _parse_json3(payload) == "hello world again"
+    with pytest.raises(TranscriptUnavailable):
+        _parse_json3({"events": []})
+
+
+# --- Endpoint behaviour ---
+
+
+@pytest.mark.asyncio
+async def test_clip_page_defers_youtube_to_worker(client: AsyncClient, pool, monkeypatch) -> None:
+    dispatched: list[list[str]] = []
+    monkeypatch.setattr(
+        clips_tasks.process_url_imports, "delay", lambda ids: dispatched.append(ids)
+    )
+    headers, _ = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://www.youtube.com/watch?v=abc123", "html": "<html></html>"},
+        headers=headers,
+    )
+    assert resp.status_code == 202
+    import_id = resp.json()["import_id"]
+    assert dispatched == [[import_id]]
+
+    status = await client.get(f"/api/v1/me/clips/{import_id}", headers=headers)
+    assert status.status_code == 200
+    assert status.json()["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_clip_import_status_is_owner_scoped(client: AsyncClient, monkeypatch) -> None:
+    monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda ids: None)
+    headers, _ = await _register(client)
+    other_headers, _ = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/me/clips/page",
+        json={"url": "https://youtu.be/abc123", "html": "<html></html>"},
+        headers=headers,
+    )
+    import_id = resp.json()["import_id"]
+
+    other = await client.get(f"/api/v1/me/clips/{import_id}", headers=other_headers)
+    assert other.status_code == 404
+
+
+# --- Worker processing ---
+
+
+async def _make_import(owner_id: str, url: str, title: str | None = None) -> UUID:
+    ids = await url_import_service.create_url_imports(
+        owner_user_id=UUID(owner_id),
+        created_by=UUID(owner_id),
+        items=[{"url": url, "title": title}],
+    )
+    return ids[0]
+
+
+@pytest.mark.asyncio
+async def test_worker_turns_html_url_into_clip_page(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/post")
+
+    async def fake_fetch(url: str):
+        return ARTICLE_HTML.encode(), "text/html; charset=utf-8"
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    page = await pool.fetchrow(
+        "SELECT p.name, f.name AS folder_name FROM pages p "
+        "JOIN folders f ON f.id = p.folder_id WHERE p.id = $1",
+        row["result_page_id"],
+    )
+    assert page["name"] == "Why Simplicity Wins"
+    assert page["folder_name"] == "Clips"
+
+
+@pytest.mark.asyncio
+async def test_worker_turns_pdf_url_into_file_clip(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://arxiv.org/abs/2401.00001")
+
+    fetched: list[str] = []
+
+    async def fake_fetch(url: str):
+        fetched.append(url)
+        return b"%PDF-1.4 fake body", "application/pdf"
+
+    async def _upload(*args, **kwargs):
+        return "test/key"
+
+    async def _url(key):
+        return f"https://blob.example/{key}"
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_file", _upload)
+    monkeypatch.setattr(storage_service, "get_file_url", _url)
+    monkeypatch.setattr(extraction.extract_file_text, "delay", lambda *a, **k: None)
+
+    await clips_tasks._process_batch([import_id])
+
+    assert fetched == ["https://arxiv.org/pdf/2401.00001"]
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    file_row = await pool.fetchrow(
+        "SELECT name, source_url FROM files WHERE id = $1", row["result_file_id"]
+    )
+    assert file_row["source_url"] == "https://arxiv.org/abs/2401.00001"
+    assert file_row["name"].endswith(".pdf")
+
+
+@pytest.mark.asyncio
+async def test_worker_turns_youtube_url_into_transcript_page(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://www.youtube.com/watch?v=abc123")
+
+    monkeypatch.setattr(
+        clip_router.youtube_transcript,
+        "fetch_transcript",
+        lambda url: {"title": "A Great Talk", "channel": "Chan", "transcript": "words words"},
+    )
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    page = await pool.fetchrow(
+        "SELECT p.name, p.content_markdown, f.name AS folder_name FROM pages p "
+        "JOIN folders f ON f.id = p.folder_id WHERE p.id = $1",
+        row["result_page_id"],
+    )
+    assert page["name"] == "A Great Talk"
+    assert page["folder_name"] == "YouTube"
+    assert "words words" in page["content_markdown"]
+
+
+@pytest.mark.asyncio
+async def test_worker_records_fetch_failure_on_row(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/dead-link")
+
+    async def fake_fetch(url: str):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "failed"
+    assert "ConnectError" in row["error"]
+    assert row["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_done_rows_are_not_reclaimed(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/post")
+
+    async def fake_fetch(url: str):
+        return ARTICLE_HTML.encode(), "text/html"
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+    assert await url_import_service.claim(import_id) is None
+
+
+@pytest.mark.asyncio
+async def test_unsupported_content_type_fails_loud(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/video.mp4")
+
+    async def fake_fetch(url: str):
+        return b"\x00\x01binary", "video/mp4"
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "failed"
+    assert "video/mp4" in row["error"]


### PR DESCRIPTION
Stacked on #795. Second slice of the commonplace-book feature.

## What
- `url_imports` + `import_batches` tables (migration 0145): job state for URL-only clips, mirroring the `files.extraction_status` lifecycle (claim guard, attempts, Beat sweep for stragglers).
- One server-side URL router (`clip_router.py`): YouTube → transcript page via **yt-dlp** (manual captions beat auto, English beats original language — no cascade, loud `TranscriptUnavailable`); arXiv `/abs/` → the paper PDF; any PDF → file clip; HTML → article page; anything else fails loud per row.
- `POST /clips/page` now returns **202 + import_id** for URLs whose content isn't in the posted DOM (YouTube/arXiv); `GET /clips/{import_id}` reports status/error/result.
- Batched worker tasks (100 URLs per Celery task, concurrency 8 inside) so a big import can't starve other queue work — sized for the 10k-bookmark imports in the next PR.

## Verified
- 13 new tests in `test_url_imports.py` (classification, caption parsing, worker flows, fail-loud rows, claim idempotency).
- Real-world smoke test: `fetch_transcript("…jNQXAC9IVRw")` returns the actual "Me at the zoo" transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)