### PR TITLE
X bookmarks as a synced, archived source

### DIFF
--- a/backend/integrations/twitter/indexer.py
+++ b/backend/integrations/twitter/indexer.py
@@ -421,3 +421,43 @@ async def fetch_twitter_content(owner_user_id: UUID, account_id: str, ref: str) 
             return _render_users(f"People who reposted {tweet_id}", resp.json())
 
     raise ValueError(f"invalid twitter ref {ref!r}")
+
+
+BOOKMARKS_SYNC_PAGE_SIZE = 100
+
+
+async def index_twitter_bookmarks(source: dict) -> str | None:
+    """Archive the connected account's X bookmarks.
+
+    One API page per sync — the X free tier allows a single bookmarks call
+    per 15 minutes, so paging deeper would blow the owner's quota. Upsert
+    only, never delete: a bookmark stays archived after it's un-bookmarked
+    or ages past the first page (commonplace-book semantics)."""
+    from ...services import source_service as _source_service
+
+    source_id = UUID(source["id"])
+    owner_user_id = UUID(source["owner_user_id"])
+    token = await get_valid_token(owner_user_id, "twitter")
+
+    async with httpx.AsyncClient(timeout=30.0, headers=_headers(token)) as client:
+        resp = await client.get(
+            BOOKMARKS_URL.format(user_id=source["external_ref"]),
+            params={"max_results": BOOKMARKS_SYNC_PAGE_SIZE, **_TWEET_PARAMS},
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+
+    users = _users_by_id(payload)
+    for tweet in payload.get("data") or []:
+        await _source_service.upsert_content_document(
+            table="twitter_bookmark_docs",
+            source_id=source_id,
+            owner_user_id=owner_user_id,
+            path=tweet["id"],
+            name=_tweet_name(tweet, users),
+            kind="post",
+            content=_render_tweet(tweet, users.get(tweet.get("author_id") or "")),
+            external_ref=tweet["id"],
+            external_updated_at=_parse_time(tweet.get("created_at")),
+        )
+    return None

--- a/backend/migrations/versions/0146_twitter_bookmarks.py
+++ b/backend/migrations/versions/0146_twitter_bookmarks.py
@@ -1,0 +1,58 @@
+"""X bookmarks become a synced, copied-content source.
+
+Unlike the live `bookmarks` ref on a twitter source (one page, read on
+demand), a twitter_bookmarks source archives every bookmark it has ever
+seen: content is copied for FTS + embeddings and never deleted when a post
+is un-bookmarked or ages past the API's first page — a diary, not a mirror.
+
+Revision ID: 0146
+Revises: 0145
+"""
+
+from alembic import op
+
+revision = "0146"
+down_revision = "0145"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE twitter_bookmark_docs (
+            id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            source_id           uuid NOT NULL REFERENCES user_sources(id) ON DELETE CASCADE,
+            path                text NOT NULL,
+            name                text NOT NULL,
+            kind                text NOT NULL DEFAULT 'post',
+            external_ref        text,
+            external_updated_at timestamptz,
+            created_at          timestamptz NOT NULL DEFAULT now(),
+            updated_at          timestamptz NOT NULL DEFAULT now(),
+            deleted_at          timestamptz,
+
+            content       text,
+            content_hash  text,
+            embedding     vector(384),
+            embed_stale   boolean NOT NULL DEFAULT FALSE,
+
+            UNIQUE (source_id, path)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX twitter_bookmark_docs_source_idx ON twitter_bookmark_docs (source_id, path) "
+        "WHERE deleted_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX twitter_bookmark_docs_fts_idx ON twitter_bookmark_docs "
+        "USING gin (to_tsvector('english', coalesce(content, '')))"
+    )
+    op.execute(
+        "CREATE INDEX twitter_bookmark_docs_embed_stale_idx ON twitter_bookmark_docs (id) "
+        "WHERE embed_stale"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS twitter_bookmark_docs")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -116,7 +116,7 @@ async def _resolve_twitter_source(user_id) -> tuple[str, str]:
             status_code=400,
             detail="Reconnect Twitter / X before adding it as a source.",
         )
-    return me["id"], f"Twitter / X (@{username})"
+    return me["id"], username
 
 
 async def _resolve_linear_source(user_id) -> tuple[str, str]:
@@ -288,8 +288,11 @@ async def add_source(
         external_ref, resolved_name = await _resolve_gong_source(current_user["id"])
         display_name = display_name or resolved_name
     elif body.source_type == "twitter":
-        external_ref, resolved_name = await _resolve_twitter_source(current_user["id"])
-        display_name = resolved_name
+        external_ref, username = await _resolve_twitter_source(current_user["id"])
+        display_name = f"Twitter / X (@{username})"
+    elif body.source_type == "twitter_bookmarks":
+        external_ref, username = await _resolve_twitter_source(current_user["id"])
+        display_name = f"X bookmarks (@{username})"
     elif body.source_type == "linear":
         external_ref, resolved_name = await _resolve_linear_source(current_user["id"])
         display_name = display_name or resolved_name

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -64,6 +64,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "asana_project": 1800,
     "linear": 1800,
     "gong_calls": 21600,
+    "twitter_bookmarks": 21600,
 }
 
 # Which capability each connected source type exposes.
@@ -80,6 +81,7 @@ SOURCE_CAPABILITY = {
     "linear": "navigable",
     "gong_calls": "searchable",
     "twitter": "searchable",
+    "twitter_bookmarks": "searchable",
 }
 
 PROVIDER_SOURCE_TYPES = {
@@ -93,7 +95,7 @@ PROVIDER_SOURCE_TYPES = {
     "asana": ("asana_project",),
     "linear": ("linear",),
     "gong": ("gong_calls",),
-    "twitter": ("twitter",),
+    "twitter": ("twitter", "twitter_bookmarks"),
 }
 
 SOURCE_TYPE_PROVIDER = {
@@ -477,6 +479,7 @@ SOURCE_TABLE = {
     "linear": "linear_index",
     "gong_calls": "gong_documents",
     "twitter": "twitter_posts",
+    "twitter_bookmarks": "twitter_bookmark_docs",
 }
 
 # Tables that COPY content (FTS + embeddings live in them). The rest are
@@ -495,6 +498,8 @@ CONTENT_TABLES = {
     # A picked Drive folder is bounded, so its bodies are extracted once at sync
     # (OCR included) and stored. A whole-Drive source is not, and stays index-only.
     "drive_documents",
+    # Bookmarks are an archive: posts vanish from X but never from here.
+    "twitter_bookmark_docs",
 }
 
 # Index-only source types whose `search` is federated live to the provider's

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -27,6 +27,7 @@ from ..integrations.jira.indexer import index_jira
 from ..integrations.linear.indexer import index_linear
 from ..integrations.notion.indexer import index_notion
 from ..integrations.slack.indexer import index_slack, ingest_slack_message
+from ..integrations.twitter.indexer import index_twitter_bookmarks
 from ..services import source_service
 from ._celery_helpers import run_async
 
@@ -47,6 +48,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "asana_project": index_asana,
     "linear": index_linear,
     "gong_calls": index_gong,
+    "twitter_bookmarks": index_twitter_bookmarks,
 }
 
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -63,6 +63,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "linear": "me",
         "gong_calls": "gong-source",
         "twitter": "111",
+        "twitter_bookmarks": "111",
     }
     return refs[source_type]
 
@@ -718,10 +719,12 @@ async def test_twitter_source_stores_account_id_and_handle(monkeypatch):
     monkeypatch.setattr(sources_router.integration_storage, "get_valid_token", fake_token)
     monkeypatch.setattr(twitter_indexer, "fetch_me", fake_me)
 
-    external_ref, display_name = await sources_router._resolve_twitter_source(uuid4())
+    # The resolver returns the raw handle; each source type composes its own
+    # display name from it ("Twitter / X (@…)" vs "X bookmarks (@…)").
+    external_ref, username = await sources_router._resolve_twitter_source(uuid4())
 
     assert external_ref == "111"
-    assert display_name == "Twitter / X (@henry_dowling)"
+    assert username == "henry_dowling"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_twitter_bookmarks.py
+++ b/backend/tests/test_twitter_bookmarks.py
@@ -1,0 +1,174 @@
+"""X bookmarks synced source.
+
+The indexer must archive bookmarks (upsert-only — a post un-bookmarked or
+aged past the API's first page stays stored) and copy rendered content so
+FTS/embeddings work without further X API calls.
+"""
+
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.integrations.twitter import indexer as twitter_indexer
+from backend.services import source_service
+
+from .conftest import unique_name
+
+_PAYLOAD_TWO = {
+    "data": [
+        {
+            "id": "111",
+            "author_id": "u1",
+            "created_at": "2026-07-01T12:00:00.000Z",
+            "text": "the first bookmarked post",
+            "public_metrics": {"like_count": 5, "retweet_count": 1, "reply_count": 0},
+        },
+        {
+            "id": "222",
+            "author_id": "u2",
+            "created_at": "2026-07-02T12:00:00.000Z",
+            "text": "the second bookmarked post",
+        },
+    ],
+    "includes": {
+        "users": [
+            {"id": "u1", "username": "alice", "name": "Alice"},
+            {"id": "u2", "username": "bob", "name": "Bob"},
+        ]
+    },
+}
+
+_PAYLOAD_ONE = {
+    "data": [_PAYLOAD_TWO["data"][1]],
+    "includes": {"users": [_PAYLOAD_TWO["includes"]["users"][1]]},
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    payload: dict = {}
+    requests: list = []
+
+    def __init__(self, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, params=None):
+        type(self).requests.append((url, params))
+        return _FakeResponse(type(self).payload)
+
+
+@pytest.fixture
+def fake_x_api(monkeypatch):
+    _FakeAsyncClient.requests = []
+
+    async def fake_token(owner_user_id, provider):
+        assert provider == "twitter"
+        return "token"
+
+    monkeypatch.setattr(twitter_indexer, "get_valid_token", fake_token)
+    monkeypatch.setattr(twitter_indexer, "httpx", SimpleNamespace(AsyncClient=_FakeAsyncClient))
+    return _FakeAsyncClient
+
+
+async def _make_source(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    owner_id = UUID(resp.json()["id"])
+    created = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="twitter_bookmarks",
+        external_ref="9999",
+        display_name="X bookmarks (@alice)",
+        settings={},
+    )
+    return await source_service.get_source_for_sync(UUID(created["id"]))
+
+
+@pytest.mark.asyncio
+async def test_indexer_archives_bookmarks_with_content(
+    client: AsyncClient, pool, fake_x_api
+) -> None:
+    source = await _make_source(client)
+    fake_x_api.payload = _PAYLOAD_TWO
+
+    await twitter_indexer.index_twitter_bookmarks(source)
+
+    url, params = fake_x_api.requests[0]
+    assert url.endswith("/2/users/9999/bookmarks")
+    assert params["max_results"] == twitter_indexer.BOOKMARKS_SYNC_PAGE_SIZE
+
+    rows = await pool.fetch(
+        "SELECT path, name, content, embed_stale FROM twitter_bookmark_docs "
+        "WHERE source_id = $1 ORDER BY path",
+        UUID(source["id"]),
+    )
+    assert [r["path"] for r in rows] == ["111", "222"]
+    assert rows[0]["name"] == "@alice - 2026-07-01"
+    assert "the first bookmarked post" in rows[0]["content"]
+    assert rows[0]["embed_stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_unbookmarked_posts_stay_archived(client: AsyncClient, pool, fake_x_api) -> None:
+    source = await _make_source(client)
+    fake_x_api.payload = _PAYLOAD_TWO
+    await twitter_indexer.index_twitter_bookmarks(source)
+
+    # The user un-bookmarks post 111; the next sync only returns 222.
+    fake_x_api.payload = _PAYLOAD_ONE
+    await twitter_indexer.index_twitter_bookmarks(source)
+
+    rows = await pool.fetch(
+        "SELECT path FROM twitter_bookmark_docs "
+        "WHERE source_id = $1 AND deleted_at IS NULL ORDER BY path",
+        UUID(source["id"]),
+    )
+    assert [r["path"] for r in rows] == ["111", "222"]
+
+
+@pytest.mark.asyncio
+async def test_add_source_resolves_account_and_names_bookmarks(
+    client: AsyncClient, monkeypatch
+) -> None:
+    async def fake_resolve(user_id):
+        return "9999", "alice"
+
+    from backend.routers import sources as sources_router
+
+    monkeypatch.setattr(sources_router, "_resolve_twitter_source", fake_resolve)
+
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['api_key']}"}
+
+    created = await client.post(
+        "/api/v1/me/sources",
+        json={"source_type": "twitter_bookmarks"},
+        headers=headers,
+    )
+    assert created.status_code == 200, created.text
+    listed = await client.get("/api/v1/me/sources", headers=headers)
+    source = next(s for s in listed.json()["sources"] if s["type"] == "twitter_bookmarks")
+    assert source["display_name"] == "X bookmarks (@alice)"

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -16,7 +16,7 @@ import {
   TwitterIcon,
 } from "./BrandIcons";
 
-export type ConnectorKind = "github" | "drive" | "notion" | "jira" | "asana" | "auto";
+export type ConnectorKind = "github" | "drive" | "notion" | "jira" | "asana" | "twitter" | "auto";
 
 export type Connector = {
   provider: IntegrationProvider;
@@ -101,7 +101,7 @@ export const CONNECTORS: Connector[] = [
     provider: "twitter",
     label: "Twitter / X",
     sourceType: "twitter",
-    kind: "auto",
+    kind: "twitter",
     blurb: "OAuth access to X search, posts, bookmarks, likes, timelines, and DMs.",
   },
 ];
@@ -121,6 +121,7 @@ export const providerForSourceType: Record<string, string> = {
   granola: "granola",
   gong_calls: "gong",
   twitter: "twitter",
+  twitter_bookmarks: "twitter",
 };
 
 export function connectorForProvider(provider: string): Connector | undefined {
@@ -173,5 +174,6 @@ export function labelForSourceType(type: string): string {
   if (type === "linear") return "Linear";
   if (type === "gong_calls") return "Gong";
   if (type === "twitter") return "Twitter / X";
+  if (type === "twitter_bookmarks") return "X bookmarks";
   return type;
 }

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -240,6 +240,39 @@ export function AddSourceControls({
     );
   }
 
+  if (connector.kind === "twitter") {
+    // Two source flavors off one connection: live search/feeds ("auto"-style)
+    // and the synced bookmarks archive. The backend resolves both refs.
+    return (
+      <div className="space-y-2">
+        {!connected && (
+          <div className="text-[11.5px] text-muted-foreground">
+            Connect {connector.label} first to add it.
+          </div>
+        )}
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void add()}
+            disabled={busy || !connected}
+            className={secondaryButton()}
+          >
+            {busy ? "Adding..." : "Add account"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void add({ source_type: "twitter_bookmarks" })}
+            disabled={busy || !connected}
+            className={secondaryButton()}
+          >
+            {busy ? "Adding..." : "Sync bookmarks"}
+          </button>
+        </div>
+        {errorRow}
+      </div>
+    );
+  }
+
   // kind "auto" — granola/gong. The backend resolves the ref.
   return (
     <div className="space-y-2">


### PR DESCRIPTION
Stacked on #797 (for migration numbering only — no code dependency). Fourth slice of the commonplace-book feature.

## What
- New `twitter_bookmarks` source type on the existing Twitter OAuth provider (`bookmark.read` scope + `BOOKMARKS_URL` already existed): `index_twitter_bookmarks` pulls one page of 100 per 6-hour sync (X free tier allows 1 bookmarks call/15 min) and upserts rendered posts into a new `twitter_bookmark_docs` content table (migration 0146, `drive_documents` shape).
- **Archive semantics**: upsert-only, no `remove_missing_documents` — a bookmark stays in Stash after it's un-bookmarked or ages past the API's first page.
- Content table is in `CONTENT_TABLES`, so FTS via `search_documents` and embedding reconciliation come for free; docs appear under `/sources`.
- Frontend: the X connector card gains a "Sync bookmarks" action (new `twitter` connector kind with two add buttons); source rows label as "X bookmarks (@handle)".

## Tests
`test_twitter_bookmarks.py` — indexer archives with rendered content + embed_stale, un-bookmarked posts stay archived, add-source resolves the account id and names the source. Map-consistency suite (`test_integration_sources.py`) passes unmodified. Frontend integration component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)