### PR TITLE
Extension: shared chat-API clients + manifest for the clipper scope

### DIFF
--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -64,6 +64,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "gong_calls": "gong-source",
         "twitter": "111",
         "twitter_bookmarks": "111",
+        "instagram_saves": "saves",
     }
     return refs[source_type]
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -63,6 +63,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "linear": "me",
         "gong_calls": "gong-source",
         "twitter": "111",
+        "twitter_bookmarks": "111",
     }
     return refs[source_type]
 
@@ -718,10 +719,12 @@ async def test_twitter_source_stores_account_id_and_handle(monkeypatch):
     monkeypatch.setattr(sources_router.integration_storage, "get_valid_token", fake_token)
     monkeypatch.setattr(twitter_indexer, "fetch_me", fake_me)
 
-    external_ref, display_name = await sources_router._resolve_twitter_source(uuid4())
+    # The resolver returns the raw handle; each source type composes its own
+    # display name from it ("Twitter / X (@…)" vs "X bookmarks (@…)").
+    external_ref, username = await sources_router._resolve_twitter_source(uuid4())
 
     assert external_ref == "111"
-    assert display_name == "Twitter / X (@henry_dowling)"
+    assert username == "henry_dowling"
 
 
 @pytest.mark.asyncio

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,12 +1,23 @@
 {
   "manifest_version": 3,
-  "name": "Stash Chat Sync",
-  "version": "0.2.0",
-  "description": "Automatically saves your ChatGPT and Claude conversations to Stash as agent sessions.",
-  "permissions": ["storage"],
+  "name": "Stash Sync",
+  "version": "0.3.0",
+  "description": "Saves webpages, PDFs, and your ChatGPT/Claude conversations to Stash.",
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting",
+    "contextMenus",
+    "alarms",
+    "notifications",
+    "tabs"
+  ],
   "host_permissions": [
     "https://api.joinstash.ai/*",
-    "http://localhost:3456/*"
+    "http://localhost:3456/*",
+    "https://chatgpt.com/*",
+    "https://chat.openai.com/*",
+    "https://claude.ai/*"
   ],
   "background": {
     "service_worker": "dist/background.js"
@@ -25,7 +36,7 @@
   ],
   "action": {
     "default_popup": "popup.html",
-    "default_title": "Stash Chat Sync",
+    "default_title": "Stash Sync",
     "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",

--- a/chrome_extension/package.json
+++ b/chrome_extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "stash-chat-sync",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
-  "description": "Chrome extension that syncs ChatGPT and Claude.ai conversations into Stash agent sessions",
+  "description": "Chrome extension that clips webpages/PDFs and syncs ChatGPT and Claude.ai conversations into Stash",
   "scripts": {
     "build": "node esbuild.config.js",
     "watch": "node esbuild.config.js --watch",

--- a/chrome_extension/src/content/chatgpt.ts
+++ b/chrome_extension/src/content/chatgpt.ts
@@ -1,92 +1,17 @@
-// ChatGPT extractor: reads the full conversation from ChatGPT's own
-// backend API (cookie-authed, same-origin) instead of scraping the DOM,
-// which drops virtualized messages and mangles code blocks.
+// ChatGPT content script: same-origin extraction (cookie-authed via the
+// site's own backend API — not DOM scraping, which drops virtualized
+// messages and mangles code blocks). The shared client lives in
+// lib/chat_apis so the background worker's daily poll uses the same code.
 
-import { ConversationSnapshot, TranscriptLine, watchConversation } from './sync';
+import { chatgptAccessToken, chatgptExtract } from '../lib/chat_apis';
+import { watchConversation } from './sync';
 
-let cachedToken: { value: string; fetchedAt: number } | null = null;
+const ctx = { origin: '' };
 
-async function accessToken(): Promise<string | null> {
-  if (cachedToken && Date.now() - cachedToken.fetchedAt < 5 * 60_000) {
-    return cachedToken.value;
-  }
-  const res = await fetch('/api/auth/session');
-  if (!res.ok) return null;
-  const data = await res.json();
-  if (!data?.accessToken) return null;
-  cachedToken = { value: data.accessToken, fetchedAt: Date.now() };
-  return cachedToken.value;
-}
-
-function textFromMessage(message: any): string {
-  const content = message?.content;
-  if (!content) return '';
-  if (content.content_type === 'text') {
-    return (content.parts || []).filter((p: any) => typeof p === 'string').join('\n\n');
-  }
-  if (content.content_type === 'code') {
-    const lang = content.language && content.language !== 'unknown' ? content.language : '';
-    return '```' + lang + '\n' + (content.text || '') + '\n```';
-  }
-  if (content.content_type === 'multimodal_text') {
-    return (content.parts || [])
-      .map((p: any) => (typeof p === 'string' ? p : '[image]'))
-      .join('\n\n');
-  }
-  return '';
-}
-
-function isHidden(message: any): boolean {
-  return Boolean(
-    message?.metadata?.is_visually_hidden_from_conversation ||
-      message?.content?.content_type === 'user_editable_context'
-  );
-}
-
-async function extract(): Promise<ConversationSnapshot | null> {
+watchConversation(async () => {
   const convId = location.pathname.match(/\/c\/([0-9a-f-]{36})/)?.[1];
   if (!convId) return null;
-  const token = await accessToken();
+  const token = await chatgptAccessToken(ctx);
   if (!token) return null;
-
-  const res = await fetch(`/backend-api/conversation/${convId}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) return null;
-  const data = await res.json();
-
-  // `mapping` is a tree of message nodes; the chain from current_node up to
-  // the root is the branch the user currently sees.
-  const lines: TranscriptLine[] = [];
-  let nodeId: string | undefined = data.current_node;
-  while (nodeId) {
-    const node = data.mapping?.[nodeId];
-    if (!node) break;
-    const message = node.message;
-    const role = message?.author?.role;
-    if ((role === 'user' || role === 'assistant') && !isHidden(message)) {
-      const text = textFromMessage(message).trim();
-      if (text) {
-        lines.push({
-          type: role,
-          message: { content: text },
-          timestamp: message.create_time
-            ? new Date(message.create_time * 1000).toISOString()
-            : undefined,
-        });
-      }
-    }
-    nodeId = node.parent;
-  }
-  lines.reverse();
-  if (lines.length === 0) return null;
-
-  return {
-    platform: 'chatgpt',
-    conversationId: convId,
-    title: data.title || 'ChatGPT conversation',
-    lines,
-  };
-}
-
-watchConversation(extract);
+  return chatgptExtract(ctx, token, convId);
+});

--- a/chrome_extension/src/content/claude.ts
+++ b/chrome_extension/src/content/claude.ts
@@ -1,78 +1,20 @@
-// Claude.ai extractor: reads the full conversation from claude.ai's own
-// JSON API (cookie-authed, same-origin). The conversation belongs to one
-// org; we try the active org from the cookie first, then the rest.
+// Claude.ai content script: same-origin extraction via claude.ai's own
+// JSON API. The active org from the cookie is tried first (only content
+// scripts can read document.cookie; the worker's daily poll just
+// enumerates orgs).
 
-import { ConversationSnapshot, TranscriptLine, watchConversation } from './sync';
+import { claudeExtract } from '../lib/chat_apis';
+import { watchConversation } from './sync';
 
-let cachedOrgId: string | null = null;
+const ctx = { origin: '' };
 
 function orgFromCookie(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)lastActiveOrg=([0-9a-f-]{36})/);
   return match ? match[1] : null;
 }
 
-async function candidateOrgIds(): Promise<string[]> {
-  const ids: string[] = [];
-  const known = cachedOrgId || orgFromCookie();
-  if (known) ids.push(known);
-  const res = await fetch('/api/organizations');
-  if (res.ok) {
-    const orgs = await res.json();
-    for (const org of Array.isArray(orgs) ? orgs : []) {
-      if (org?.uuid && !ids.includes(org.uuid)) ids.push(org.uuid);
-    }
-  }
-  return ids;
-}
-
-async function fetchConversation(convId: string): Promise<any | null> {
-  for (const orgId of await candidateOrgIds()) {
-    const res = await fetch(
-      `/api/organizations/${orgId}/chat_conversations/${convId}?tree=True&rendering_mode=messages&render_all_tools=true`
-    );
-    if (res.ok) {
-      cachedOrgId = orgId;
-      return res.json();
-    }
-  }
-  return null;
-}
-
-function textFromMessage(msg: any): string {
-  const blocks = Array.isArray(msg?.content) ? msg.content : [];
-  const parts = blocks
-    .filter((b: any) => b?.type === 'text' && typeof b.text === 'string' && b.text.trim())
-    .map((b: any) => b.text);
-  if (parts.length > 0) return parts.join('\n\n');
-  return typeof msg?.text === 'string' ? msg.text : '';
-}
-
-async function extract(): Promise<ConversationSnapshot | null> {
+watchConversation(async () => {
   const convId = location.pathname.match(/\/chat\/([0-9a-f-]{36})/)?.[1];
   if (!convId) return null;
-  const data = await fetchConversation(convId);
-  if (!data) return null;
-
-  const lines: TranscriptLine[] = [];
-  for (const msg of data.chat_messages || []) {
-    const role = msg.sender === 'human' ? 'user' : msg.sender === 'assistant' ? 'assistant' : null;
-    if (!role) continue;
-    const text = textFromMessage(msg).trim();
-    if (!text) continue;
-    lines.push({
-      type: role,
-      message: { content: text },
-      timestamp: msg.created_at || undefined,
-    });
-  }
-  if (lines.length === 0) return null;
-
-  return {
-    platform: 'claude-web',
-    conversationId: convId,
-    title: data.name || 'Claude conversation',
-    lines,
-  };
-}
-
-watchConversation(extract);
+  return claudeExtract(ctx, convId, orgFromCookie());
+});

--- a/chrome_extension/src/lib/chat_apis.ts
+++ b/chrome_extension/src/lib/chat_apis.ts
@@ -1,0 +1,174 @@
+// Chat-platform API clients shared by the content scripts and the
+// background service worker. Content scripts fetch same-origin (cookies
+// attach automatically); the worker passes an absolute origin plus
+// credentials: 'include' (cookie-attached because the origins are in
+// host_permissions).
+
+import type { ConversationSnapshot, TranscriptLine } from '../content/sync';
+
+export interface FetchCtx {
+  origin: string; // '' in content scripts; 'https://chatgpt.com' etc. in the worker
+  init?: RequestInit;
+}
+
+function get(ctx: FetchCtx, path: string, headers?: Record<string, string>): Promise<Response> {
+  return fetch(`${ctx.origin}${path}`, { ...ctx.init, headers });
+}
+
+// ---------------------------------------------------------------------------
+// ChatGPT
+// ---------------------------------------------------------------------------
+
+let cachedToken: { value: string; fetchedAt: number } | null = null;
+
+export async function chatgptAccessToken(ctx: FetchCtx): Promise<string | null> {
+  if (cachedToken && Date.now() - cachedToken.fetchedAt < 5 * 60_000) {
+    return cachedToken.value;
+  }
+  const res = await get(ctx, '/api/auth/session');
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data?.accessToken) return null;
+  cachedToken = { value: data.accessToken, fetchedAt: Date.now() };
+  return cachedToken.value;
+}
+
+function chatgptTextFromMessage(message: any): string {
+  const content = message?.content;
+  if (!content) return '';
+  if (content.content_type === 'text') {
+    return (content.parts || []).filter((p: any) => typeof p === 'string').join('\n\n');
+  }
+  if (content.content_type === 'code') {
+    const lang = content.language && content.language !== 'unknown' ? content.language : '';
+    return '```' + lang + '\n' + (content.text || '') + '\n```';
+  }
+  if (content.content_type === 'multimodal_text') {
+    return (content.parts || [])
+      .map((p: any) => (typeof p === 'string' ? p : '[image]'))
+      .join('\n\n');
+  }
+  return '';
+}
+
+function chatgptIsHidden(message: any): boolean {
+  return Boolean(
+    message?.metadata?.is_visually_hidden_from_conversation ||
+      message?.content?.content_type === 'user_editable_context'
+  );
+}
+
+export async function chatgptExtract(
+  ctx: FetchCtx,
+  token: string,
+  convId: string
+): Promise<ConversationSnapshot | null> {
+  const res = await get(ctx, `/backend-api/conversation/${convId}`, {
+    Authorization: `Bearer ${token}`,
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+
+  // `mapping` is a tree of message nodes; the chain from current_node up to
+  // the root is the branch the user currently sees.
+  const lines: TranscriptLine[] = [];
+  let nodeId: string | undefined = data.current_node;
+  while (nodeId) {
+    const node = data.mapping?.[nodeId];
+    if (!node) break;
+    const message = node.message;
+    const role = message?.author?.role;
+    if ((role === 'user' || role === 'assistant') && !chatgptIsHidden(message)) {
+      const text = chatgptTextFromMessage(message).trim();
+      if (text) {
+        lines.push({
+          type: role,
+          message: { content: text },
+          timestamp: message.create_time
+            ? new Date(message.create_time * 1000).toISOString()
+            : undefined,
+        });
+      }
+    }
+    nodeId = node.parent;
+  }
+  lines.reverse();
+  if (lines.length === 0) return null;
+
+  return {
+    platform: 'chatgpt',
+    conversationId: convId,
+    title: data.title || 'ChatGPT conversation',
+    lines,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Claude
+// ---------------------------------------------------------------------------
+
+let cachedOrgId: string | null = null;
+
+export async function claudeOrgIds(ctx: FetchCtx, knownOrgId?: string | null): Promise<string[]> {
+  const ids: string[] = [];
+  const known = cachedOrgId || knownOrgId;
+  if (known) ids.push(known);
+  const res = await get(ctx, '/api/organizations');
+  if (res.ok) {
+    const orgs = await res.json();
+    for (const org of Array.isArray(orgs) ? orgs : []) {
+      if (org?.uuid && !ids.includes(org.uuid)) ids.push(org.uuid);
+    }
+  }
+  return ids;
+}
+
+function claudeTextFromMessage(msg: any): string {
+  const blocks = Array.isArray(msg?.content) ? msg.content : [];
+  const parts = blocks
+    .filter((b: any) => b?.type === 'text' && typeof b.text === 'string' && b.text.trim())
+    .map((b: any) => b.text);
+  if (parts.length > 0) return parts.join('\n\n');
+  return typeof msg?.text === 'string' ? msg.text : '';
+}
+
+export async function claudeExtract(
+  ctx: FetchCtx,
+  convId: string,
+  knownOrgId?: string | null
+): Promise<ConversationSnapshot | null> {
+  let data: any = null;
+  for (const orgId of await claudeOrgIds(ctx, knownOrgId)) {
+    const res = await get(
+      ctx,
+      `/api/organizations/${orgId}/chat_conversations/${convId}?tree=True&rendering_mode=messages&render_all_tools=true`
+    );
+    if (res.ok) {
+      cachedOrgId = orgId;
+      data = await res.json();
+      break;
+    }
+  }
+  if (!data) return null;
+
+  const lines: TranscriptLine[] = [];
+  for (const msg of data.chat_messages || []) {
+    const role = msg.sender === 'human' ? 'user' : msg.sender === 'assistant' ? 'assistant' : null;
+    if (!role) continue;
+    const text = claudeTextFromMessage(msg).trim();
+    if (!text) continue;
+    lines.push({
+      type: role,
+      message: { content: text },
+      timestamp: msg.created_at || undefined,
+    });
+  }
+  if (lines.length === 0) return null;
+
+  return {
+    platform: 'claude-web',
+    conversationId: convId,
+    title: data.name || 'Claude conversation',
+    lines,
+  };
+}


### PR DESCRIPTION
Stacked on #799. Extension foundation for the clipper/poll PRs (net diff vs base is the one extension commit).

## What
- `src/lib/chat_apis.ts`: the ChatGPT/Claude fetch+parse logic extracted from the content scripts, parameterized by `{origin, init}` — content scripts keep same-origin fetches, and the background worker's upcoming tab-less daily poll will run the exact same client with absolute origins + `credentials: 'include'`. Content scripts shrink to URL-match + call.
- Manifest v0.3.0, renamed **"Stash Sync"**: adds `activeTab, scripting, contextMenus, alarms, notifications, tabs` permissions and `chatgpt.com` / `chat.openai.com` / `claude.ai` host_permissions (no new install-warning surface — the content-script matches already warn for those origins). Deliberately NOT added: `cookies`, `<all_urls>`.

## Verified
`npm run typecheck` + `npm run build` clean. No behavior change to the existing 15s visible-tab sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)