### PR TITLE
Extension: web clipper, clip-all-tabs, and bookmarks import

### DIFF
--- a/chrome_extension/esbuild.config.js
+++ b/chrome_extension/esbuild.config.js
@@ -5,6 +5,7 @@ const options = {
     background: 'src/background.ts',
     chatgpt: 'src/content/chatgpt.ts',
     claude: 'src/content/claude.ts',
+    clipper: 'src/content/clipper.ts',
     popup: 'src/popup/popup.ts',
   },
   bundle: true,

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -4,9 +4,19 @@
 // rest as replace-mode transcripts so a growing chat keeps updating the
 // same Stash session.
 
+import {
+  clipActiveTab,
+  clipAllTabs,
+  importBookmarks,
+  importProgress,
+  initClipper,
+  uploadPageClip,
+} from './background/clip';
 import type { ConversationSnapshot } from './content/sync';
 
 const DEFAULT_API_BASE = 'https://api.joinstash.ai';
+
+initClipper();
 // Auth sessions live 15 min server-side. The poll loop covers most of that,
 // and checkPendingConnect() collects an approval that lands after the loop
 // gave up (e.g. MV3 suspended the worker mid-wait).
@@ -23,10 +33,20 @@ async function handle(message: any): Promise<any> {
   switch (message.type) {
     case 'SYNC_CONVERSATION':
       return syncConversation(message.snapshot);
+    case 'CLIP_TAB':
+      return clipActiveTab();
+    case 'CLIP_PAGE':
+      return uploadPageClip(message.clip);
+    case 'CLIP_ALL_TABS':
+      return clipAllTabs();
+    case 'IMPORT_BOOKMARKS':
+      return importBookmarks(message.name, message.content);
+    case 'IMPORT_PROGRESS':
+      return importProgress(message.id);
     case 'CONNECT':
       return connect();
     case 'DISCONNECT':
-      await chrome.storage.local.remove(['apiKey', 'username', 'folderId', 'folderName', 'folders', 'lastSync', 'lastError']);
+      await chrome.storage.local.remove(['apiKey', 'username', 'folderId', 'folderName', 'folders', 'lastSync', 'lastClip', 'lastImport', 'lastError']);
       return { ok: true };
     case 'GET_STATUS':
       return getStatus();
@@ -238,6 +258,8 @@ async function getStatus(): Promise<any> {
     'folderName',
     'folders',
     'lastSync',
+    'lastClip',
+    'lastImport',
     'lastError',
   ]);
   return {
@@ -248,6 +270,8 @@ async function getStatus(): Promise<any> {
     folderId: cfg.folderId || null,
     folders: cfg.folders || [],
     lastSync: cfg.lastSync || null,
+    lastClip: cfg.lastClip || null,
+    lastImport: cfg.lastImport || null,
     lastError: cfg.lastError || null,
   };
 }

--- a/chrome_extension/src/background/clip.ts
+++ b/chrome_extension/src/background/clip.ts
@@ -1,0 +1,202 @@
+// Web clipper: context menu / popup button → inject clipper.ts into the
+// tab (activeTab grant) → CLIP_PAGE lands here and uploads. Pages Chrome
+// won't inject into (its PDF viewer, chrome:// pages) take the direct
+// byte-fetch path instead. Bulk imports (clip-all-tabs, bookmarks.html)
+// also run here so credentials stay in the worker.
+
+import { flashOkBadge, setBadge, stashConfig } from '../lib/stash';
+
+export interface PageClip {
+  url: string;
+  title: string;
+  html: string;
+  capturedAt: string;
+}
+
+export function initClipper(): void {
+  chrome.runtime.onInstalled.addListener(createMenu);
+  chrome.runtime.onStartup.addListener(createMenu);
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === 'stash-clip' && tab?.id != null) void clipTab(tab);
+  });
+}
+
+function createMenu(): void {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: 'stash-clip',
+      title: 'Save page to Stash',
+      contexts: ['page'],
+    });
+  });
+}
+
+export async function clipActiveTab(): Promise<any> {
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (!tab) return clipFailed('unknown', 'No active tab');
+  return clipTab(tab);
+}
+
+async function clipTab(tab: chrome.tabs.Tab): Promise<any> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id! },
+      files: ['dist/clipper.js'],
+    });
+    // The injected script reports back via CLIP_PAGE.
+    return { ok: true, started: true };
+  } catch {
+    // Injection is impossible in Chrome's PDF viewer — this is the PDF
+    // dispatch, not a fallback: fetch the bytes directly (activeTab covers
+    // the origin, credentials included for auth-gated PDFs).
+    return clipPdf(tab);
+  }
+}
+
+async function clipPdf(tab: chrome.tabs.Tab): Promise<any> {
+  const url = tab.url || '';
+  const response = await fetch(url, { credentials: 'include' });
+  const contentType = response.headers.get('content-type') || '';
+  if (!response.ok || !contentType.includes('application/pdf')) {
+    return clipFailed(
+      url,
+      `Not a clippable page (status ${response.status}, ${contentType || 'unknown type'})`
+    );
+  }
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return notConnected();
+
+  let filename = new URL(url).pathname.split('/').pop() || 'clip';
+  if (!filename.toLowerCase().endsWith('.pdf')) filename = `${filename}.pdf`;
+  const form = new FormData();
+  form.append('file', await response.blob(), filename);
+  form.append('url', url);
+
+  const upload = await fetch(`${cfg.apiBase}/api/v1/me/clips/file`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}` },
+    body: form,
+  });
+  if (!upload.ok) {
+    return clipFailed(url, `Upload failed (${upload.status}): ${(await upload.text()).slice(0, 180)}`);
+  }
+  const data = await upload.json();
+  return clipSucceeded({ title: data.name, appUrl: data.app_url });
+}
+
+export async function uploadPageClip(clip: PageClip): Promise<any> {
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return notConnected();
+
+  const response = await fetch(`${cfg.apiBase}/api/v1/me/clips/page`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: clip.url, html: clip.html, title: clip.title }),
+  });
+  if (response.status === 202) {
+    // YouTube/arXiv: the server fetches out-of-band (transcript, paper PDF).
+    const { import_id } = await response.json();
+    return clipSucceeded({ title: clip.title, importId: import_id });
+  }
+  if (!response.ok) {
+    let detail = (await response.text()).slice(0, 180);
+    try {
+      detail = JSON.parse(detail).detail ?? detail;
+    } catch {
+      // not JSON — keep the raw body
+    }
+    return clipFailed(clip.url, `(${response.status}) ${detail}`);
+  }
+  const data = await response.json();
+  return clipSucceeded({ title: data.name, appUrl: data.app_url });
+}
+
+async function clipSucceeded(clip: {
+  title: string;
+  appUrl?: string;
+  importId?: string;
+}): Promise<any> {
+  await chrome.storage.local.set({
+    lastClip: { ...clip, at: Date.now() },
+    lastError: null,
+  });
+  await flashOkBadge(`Saved "${clip.title}" to Stash`);
+  return { ok: true, clip };
+}
+
+async function clipFailed(url: string, error: string): Promise<any> {
+  await chrome.storage.local.set({ lastError: `Clip failed: ${error}` });
+  await setBadge('!', 'Stash clip failed — click for details');
+  chrome.notifications.create({
+    type: 'basic',
+    iconUrl: 'icons/icon128.png',
+    title: 'Stash clip failed',
+    message: error.slice(0, 180),
+  });
+  return { ok: false, error };
+}
+
+async function notConnected(): Promise<any> {
+  await setBadge('!', 'Not connected to Stash — click to sign in');
+  return { ok: false, error: 'not_connected' };
+}
+
+// ---------------------------------------------------------------------------
+// Bulk imports (clip-all-tabs, bookmarks.html)
+// ---------------------------------------------------------------------------
+
+export async function clipAllTabs(): Promise<any> {
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return notConnected();
+
+  const tabs = await chrome.tabs.query({ lastFocusedWindow: true });
+  const urls = tabs.map((t) => t.url).filter((u): u is string => Boolean(u && /^https?:/.test(u)));
+  if (urls.length === 0) return { ok: false, error: 'No clippable tabs' };
+
+  const response = await fetch(`${cfg.apiBase}/api/v1/me/imports/tabs`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ urls }),
+  });
+  if (!response.ok) {
+    return clipFailed('tabs', `(${response.status}) ${(await response.text()).slice(0, 180)}`);
+  }
+  const data = await response.json();
+  await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'tabs' } });
+  return { ok: true, importId: data.import_id, total: data.total };
+}
+
+export async function importBookmarks(name: string, content: string): Promise<any> {
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return notConnected();
+
+  const form = new FormData();
+  form.append('file', new Blob([content], { type: 'text/html' }), name || 'bookmarks.html');
+  const response = await fetch(`${cfg.apiBase}/api/v1/me/imports/bookmarks`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}` },
+    body: form,
+  });
+  if (!response.ok) {
+    let detail = (await response.text()).slice(0, 180);
+    try {
+      detail = JSON.parse(detail).detail ?? detail;
+    } catch {
+      // not JSON — keep the raw body
+    }
+    return { ok: false, error: `Import failed (${response.status}): ${detail}` };
+  }
+  const data = await response.json();
+  await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'bookmarks' } });
+  return { ok: true, importId: data.import_id, total: data.total };
+}
+
+export async function importProgress(importId: string): Promise<any> {
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return notConnected();
+  const response = await fetch(`${cfg.apiBase}/api/v1/me/imports/${importId}`, {
+    headers: { Authorization: `Bearer ${cfg.apiKey}` },
+  });
+  if (!response.ok) return { ok: false, error: `Progress check failed (${response.status})` };
+  return { ok: true, progress: await response.json() };
+}

--- a/chrome_extension/src/content/clipper.ts
+++ b/chrome_extension/src/content/clipper.ts
@@ -1,0 +1,14 @@
+// Injected on demand by the background worker (never listed in the
+// manifest). Captures the live DOM — logged-in and JS-rendered, which
+// beats any server-side refetch — and hands it to the background; the
+// server's single article extractor does the rest.
+
+void chrome.runtime.sendMessage({
+  type: 'CLIP_PAGE',
+  clip: {
+    url: location.href,
+    title: document.title,
+    html: document.documentElement.outerHTML,
+    capturedAt: new Date().toISOString(),
+  },
+});

--- a/chrome_extension/src/lib/stash.ts
+++ b/chrome_extension/src/lib/stash.ts
@@ -1,0 +1,30 @@
+// Shared Stash-backend plumbing for the background worker's modules.
+
+export const DEFAULT_API_BASE = 'https://api.joinstash.ai';
+
+export interface StashConfig {
+  apiBase: string;
+  apiKey: string | null;
+  folderId: string | null;
+}
+
+export async function stashConfig(): Promise<StashConfig> {
+  const cfg = await chrome.storage.local.get(['apiBase', 'apiKey', 'folderId']);
+  return {
+    apiBase: cfg.apiBase || DEFAULT_API_BASE,
+    apiKey: cfg.apiKey || null,
+    folderId: cfg.folderId || null,
+  };
+}
+
+export async function setBadge(text: string, title: string): Promise<void> {
+  await chrome.action.setBadgeText({ text });
+  if (text === '!') await chrome.action.setBadgeBackgroundColor({ color: '#ef4444' });
+  if (text === '✓') await chrome.action.setBadgeBackgroundColor({ color: '#16a34a' });
+  await chrome.action.setTitle({ title });
+}
+
+export async function flashOkBadge(title: string): Promise<void> {
+  await setBadge('✓', title);
+  setTimeout(() => void setBadge('', 'Stash Sync'), 3000);
+}

--- a/chrome_extension/src/popup/popup.ts
+++ b/chrome_extension/src/popup/popup.ts
@@ -68,8 +68,38 @@ async function render(): Promise<void> {
 
     app.append(
       el('p', {}, ['Connected as ', el('strong', { textContent: status.username || '?' })]),
+      el('div', { className: 'row' }, [
+        el('button', {
+          textContent: 'Save this page to Stash',
+          onclick: async () => {
+            const result = await send({ type: 'CLIP_TAB' });
+            if (result?.ok) {
+              // Give the injected clipper a beat to report back, then re-render
+              // so lastClip / lastError shows.
+              setTimeout(() => void render(), 1200);
+            } else {
+              await render();
+            }
+          },
+        }),
+      ]),
       el('div', { className: 'row' }, [el('label', { textContent: 'Session folder' }), folderSelect])
     );
+
+    if (status.lastClip) {
+      const clipChildren: (HTMLElement | string)[] = [
+        `Clipped “${status.lastClip.title}” ${timeAgo(status.lastClip.at)}`,
+      ];
+      if (status.lastClip.appUrl) {
+        clipChildren.push(
+          ' — ',
+          el('a', { href: status.lastClip.appUrl, target: '_blank', textContent: 'view clip' })
+        );
+      } else if (status.lastClip.importId) {
+        clipChildren.push(' — processing on the server');
+      }
+      app.append(el('p', { className: 'row muted' }, clipChildren));
+    }
 
     if (status.lastSync) {
       app.append(
@@ -87,6 +117,8 @@ async function render(): Promise<void> {
     if (status.lastError) {
       app.append(el('div', { className: 'error', textContent: status.lastError }));
     }
+
+    app.append(renderImports(status));
 
     app.append(
       el('div', { className: 'row' }, [
@@ -121,6 +153,67 @@ async function render(): Promise<void> {
       ]),
     ])
   );
+}
+
+// Bulk imports: clip every open tab, or upload a browser bookmarks.html
+// export. Both run in the background worker; this section just triggers
+// them and polls batch progress.
+function renderImports(status: any): HTMLElement {
+  const section = el('details', {}, [el('summary', { textContent: 'Import' })]);
+  const progressRow = el('div', { className: 'row muted' });
+
+  async function showProgress(importId: string): Promise<void> {
+    const result = await send({ type: 'IMPORT_PROGRESS', id: importId });
+    if (!result?.ok) {
+      progressRow.textContent = result?.error || 'Progress check failed';
+      return;
+    }
+    const p = result.progress;
+    progressRow.textContent = `${p.kind} import: ${p.done}/${p.total} done, ${p.failed} failed, ${p.pending} pending`;
+    if (p.pending > 0) setTimeout(() => void showProgress(importId), 2000);
+  }
+
+  const fileInput = el('input', { type: 'file', accept: '.html' });
+  fileInput.addEventListener('change', async () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    progressRow.textContent = 'Uploading bookmarks…';
+    const result = await send({
+      type: 'IMPORT_BOOKMARKS',
+      name: file.name,
+      content: await file.text(),
+    });
+    if (!result?.ok) {
+      progressRow.textContent = result?.error || 'Import failed';
+      return;
+    }
+    void showProgress(result.importId);
+  });
+
+  section.append(
+    el('div', { className: 'row' }, [
+      el('button', {
+        textContent: 'Clip all open tabs',
+        onclick: async () => {
+          progressRow.textContent = 'Starting…';
+          const result = await send({ type: 'CLIP_ALL_TABS' });
+          if (!result?.ok) {
+            progressRow.textContent = result?.error || 'Clip-all-tabs failed';
+            return;
+          }
+          void showProgress(result.importId);
+        },
+      }),
+    ]),
+    el('div', { className: 'row' }, [
+      el('label', { textContent: 'Import a bookmarks.html export' }),
+      fileInput,
+    ]),
+    progressRow
+  );
+
+  if (status.lastImport?.id) void showProgress(status.lastImport.id);
+  return section;
 }
 
 void render();


### PR DESCRIPTION
Stacked on #800; talks to the backend endpoints from #795–#797.

## What
- **Clip this page**: context menu "Save page to Stash" + popup button → `clipper.ts` injected on demand (activeTab grant only — no `<all_urls>`) captures the live, logged-in DOM → `POST /me/clips/page`. YouTube/arXiv URLs return 202 and finish server-side (transcript / paper PDF).
- **PDF dispatch**: Chrome's PDF viewer refuses script injection, so those tabs take the byte-fetch path (`credentials: 'include'`, works on auth-gated PDFs) → `POST /me/clips/file`.
- **Clip all open tabs**: popup button sends every http(s) tab URL to `POST /me/imports/tabs`; popup polls batch progress.
- **Bookmarks import**: popup file picker uploads a bookmarks.html export to `POST /me/imports/bookmarks`, same progress view — no web-app UI needed.
- Fail-loud UX: clip failure → red `!` badge + Chrome notification with the real server error + `lastError` in the popup; success → transient green `✓` badge + "view clip" link.

## Verified
`npm run typecheck` + `npm run build` clean; `dist/clipper.js` is injected via `chrome.scripting.executeScript` (no `web_accessible_resources` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)