### PR TITLE
Extension: daily tab-less ChatGPT/Claude poll

### DIFF
--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -4,6 +4,7 @@
 // rest as replace-mode transcripts so a growing chat keeps updating the
 // same Stash session.
 
+import { initChatPoll } from './background/chat_poll';
 import {
   clipActiveTab,
   clipAllTabs,
@@ -17,6 +18,7 @@ import type { ConversationSnapshot } from './content/sync';
 const DEFAULT_API_BASE = 'https://api.joinstash.ai';
 
 initClipper();
+initChatPoll(syncConversation);
 // Auth sessions live 15 min server-side. The poll loop covers most of that,
 // and checkPendingConnect() collects an approval that lands after the loop
 // gave up (e.g. MV3 suspended the worker mid-wait).

--- a/chrome_extension/src/background/chat_poll.ts
+++ b/chrome_extension/src/background/chat_poll.ts
@@ -1,0 +1,90 @@
+// Daily tab-less chat poll: the visible-tab content scripts only see
+// conversations the user has open, so once a day the worker lists recent
+// ChatGPT/Claude conversations directly (cookie-attached fetches — the
+// origins are in host_permissions) and syncs anything updated since the
+// last successful pass. The watermark only advances on a fully successful
+// pass; a failed platform surfaces on the badge and retries next alarm.
+
+import {
+  chatgptAccessToken,
+  chatgptExtract,
+  chatgptListConversations,
+  claudeExtract,
+  claudeListConversations,
+  claudeOrgIds,
+} from '../lib/chat_apis';
+import type { ConversationSnapshot } from '../content/sync';
+import { setBadge } from '../lib/stash';
+
+const ALARM_NAME = 'chat-poll';
+const POLL_PERIOD_MINUTES = 24 * 60;
+const MAX_CONVERSATIONS_PER_PLATFORM = 50;
+
+type SyncFn = (snapshot: ConversationSnapshot) => Promise<any>;
+
+export function initChatPoll(sync: SyncFn): void {
+  chrome.runtime.onInstalled.addListener(schedule);
+  chrome.runtime.onStartup.addListener(schedule);
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === ALARM_NAME) void pollAll(sync);
+  });
+}
+
+function schedule(): void {
+  chrome.alarms.create(ALARM_NAME, { periodInMinutes: POLL_PERIOD_MINUTES });
+}
+
+async function pollAll(sync: SyncFn): Promise<void> {
+  const { apiKey, lastChatPollAt } = await chrome.storage.local.get(['apiKey', 'lastChatPollAt']);
+  if (!apiKey) return;
+  const since = lastChatPollAt || 0;
+
+  const errors: string[] = [];
+  await pollChatgpt(sync, since).catch((e) => errors.push(`ChatGPT: ${e?.message || e}`));
+  await pollClaude(sync, since).catch((e) => errors.push(`Claude: ${e?.message || e}`));
+
+  if (errors.length > 0) {
+    // No notification — a logged-out site would nag daily. Badge + popup error.
+    await chrome.storage.local.set({ lastError: `Daily chat poll failed — ${errors.join('; ')}` });
+    await setBadge('!', 'Stash daily poll failed — click for details');
+    return;
+  }
+  await chrome.storage.local.set({ lastChatPollAt: Date.now(), lastError: null });
+}
+
+async function pollChatgpt(sync: SyncFn, since: number): Promise<void> {
+  const ctx = {
+    origin: 'https://chatgpt.com',
+    init: { credentials: 'include' as RequestCredentials },
+  };
+  const token = await chatgptAccessToken(ctx);
+  if (!token) throw new Error('not signed in to chatgpt.com');
+
+  const conversations = await chatgptListConversations(ctx, token, MAX_CONVERSATIONS_PER_PLATFORM);
+  for (const conv of conversations) {
+    if (new Date(conv.updatedAt).getTime() <= since) continue;
+    const snapshot = await chatgptExtract(ctx, token, conv.id);
+    if (snapshot) await sync(snapshot);
+  }
+}
+
+async function pollClaude(sync: SyncFn, since: number): Promise<void> {
+  const ctx = {
+    origin: 'https://claude.ai',
+    init: { credentials: 'include' as RequestCredentials },
+  };
+  const orgIds = await claudeOrgIds(ctx);
+  if (orgIds.length === 0) throw new Error('not signed in to claude.ai');
+
+  for (const orgId of orgIds) {
+    const conversations = (await claudeListConversations(ctx, orgId)).slice(
+      0,
+      MAX_CONVERSATIONS_PER_PLATFORM
+    );
+    for (const conv of conversations) {
+      if (new Date(conv.updatedAt).getTime() <= since) continue;
+      const snapshot = await claudeExtract(ctx, conv.id, orgId);
+      if (snapshot) await sync(snapshot);
+    }
+  }
+}

--- a/chrome_extension/src/lib/chat_apis.ts
+++ b/chrome_extension/src/lib/chat_apis.ts
@@ -33,6 +33,23 @@ export async function chatgptAccessToken(ctx: FetchCtx): Promise<string | null> 
   return cachedToken.value;
 }
 
+export async function chatgptListConversations(
+  ctx: FetchCtx,
+  token: string,
+  limit: number
+): Promise<{ id: string; title: string; updatedAt: string }[]> {
+  const res = await get(ctx, `/backend-api/conversations?offset=0&limit=${limit}&order=updated`, {
+    Authorization: `Bearer ${token}`,
+  });
+  if (!res.ok) throw new Error(`conversation list failed (${res.status})`);
+  const data = await res.json();
+  return (data.items || []).map((item: any) => ({
+    id: item.id,
+    title: item.title || 'ChatGPT conversation',
+    updatedAt: item.update_time,
+  }));
+}
+
 function chatgptTextFromMessage(message: any): string {
   const content = message?.content;
   if (!content) return '';
@@ -121,6 +138,20 @@ export async function claudeOrgIds(ctx: FetchCtx, knownOrgId?: string | null): P
     }
   }
   return ids;
+}
+
+export async function claudeListConversations(
+  ctx: FetchCtx,
+  orgId: string
+): Promise<{ id: string; title: string; updatedAt: string }[]> {
+  const res = await get(ctx, `/api/organizations/${orgId}/chat_conversations`);
+  if (!res.ok) throw new Error(`conversation list failed (${res.status})`);
+  const data = await res.json();
+  return (Array.isArray(data) ? data : []).map((conv: any) => ({
+    id: conv.uuid,
+    title: conv.name || 'Claude conversation',
+    updatedAt: conv.updated_at,
+  }));
 }
 
 function claudeTextFromMessage(msg: any): string {


### PR DESCRIPTION
Stacked on #801. No new backend surface — reuses the existing `syncConversation` upload path (hash dedupe makes re-uploads cheap).

## What
- `chrome.alarms` daily tick → list the 50 most recent conversations per platform (**ChatGPT**: `/api/auth/session` → `/backend-api/conversations?order=updated`; **Claude**: `/api/organizations` → `/chat_conversations`) as cookie-attached service-worker fetches, then extract + sync anything updated since the last successful pass — the exact same `chat_apis` client the content scripts use, just with an absolute origin and `credentials: 'include'`.
- Watermark (`lastChatPollAt`) advances only on a fully successful pass; failure of either platform sets the badge + popup error and retries at the next alarm. No notifications — a logged-out site would nag daily.

## Manual check
Fire the alarm from the SW console: `chrome.alarms.create('chat-poll', {when: Date.now()})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)