### PR TITLE
Extension: Instagram saves capture with daily auto-visit

### DIFF
--- a/chrome_extension/esbuild.config.js
+++ b/chrome_extension/esbuild.config.js
@@ -6,6 +6,7 @@ const options = {
     chatgpt: 'src/content/chatgpt.ts',
     claude: 'src/content/claude.ts',
     clipper: 'src/content/clipper.ts',
+    instagram: 'src/content/instagram.ts',
     popup: 'src/popup/popup.ts',
   },
   bundle: true,

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -17,7 +17,8 @@
     "http://localhost:3456/*",
     "https://chatgpt.com/*",
     "https://chat.openai.com/*",
-    "https://claude.ai/*"
+    "https://claude.ai/*",
+    "https://www.instagram.com/*"
   ],
   "background": {
     "service_worker": "dist/background.js"
@@ -31,6 +32,11 @@
     {
       "matches": ["https://claude.ai/*"],
       "js": ["dist/claude.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://www.instagram.com/*"],
+      "js": ["dist/instagram.js"],
       "run_at": "document_idle"
     }
   ],

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -13,25 +13,32 @@ import {
   initClipper,
   uploadPageClip,
 } from './background/clip';
+import {
+  initInstagram,
+  receiveSavedItems,
+  savedItemsFailed,
+  shouldFetchSaves,
+} from './background/instagram';
 import type { ConversationSnapshot } from './content/sync';
 
 const DEFAULT_API_BASE = 'https://api.joinstash.ai';
 
 initClipper();
 initChatPoll(syncConversation);
+initInstagram();
 // Auth sessions live 15 min server-side. The poll loop covers most of that,
 // and checkPendingConnect() collects an approval that lands after the loop
 // gave up (e.g. MV3 suspended the worker mid-wait).
 const CONNECT_POLL_TIMEOUT_MS = 600_000;
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  handle(message)
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handle(message, sender)
     .then(sendResponse)
     .catch((e) => sendResponse({ ok: false, error: String(e?.message || e) }));
   return true;
 });
 
-async function handle(message: any): Promise<any> {
+async function handle(message: any, sender: chrome.runtime.MessageSender): Promise<any> {
   switch (message.type) {
     case 'SYNC_CONVERSATION':
       return syncConversation(message.snapshot);
@@ -45,6 +52,12 @@ async function handle(message: any): Promise<any> {
       return importBookmarks(message.name, message.content);
     case 'IMPORT_PROGRESS':
       return importProgress(message.id);
+    case 'SHOULD_FETCH_SAVES':
+      return shouldFetchSaves();
+    case 'SAVED_ITEMS':
+      return receiveSavedItems(message.items, sender);
+    case 'SAVED_ITEMS_FAILED':
+      return savedItemsFailed(message.error, sender);
     case 'CONNECT':
       return connect();
     case 'DISCONNECT':

--- a/chrome_extension/src/background/instagram.ts
+++ b/chrome_extension/src/background/instagram.ts
@@ -1,0 +1,101 @@
+// Instagram saves: throttle + upload + daily auto-visit.
+//
+// The content script harvests the saved-posts list whenever the user is on
+// instagram.com and the 24h throttle allows; a daily alarm additionally
+// opens a background (non-active) tab to instagram.com so capture happens
+// even when the user hasn't visited. The pushed URLs go to
+// POST /me/saved-items, which auto-creates the source and hydrates
+// server-side.
+
+import { setBadge, stashConfig } from '../lib/stash';
+
+const VISIT_ALARM = 'instagram-saves-visit';
+const VISIT_TIMEOUT_ALARM = 'instagram-saves-visit-timeout';
+const HARVEST_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export function initInstagram(): void {
+  chrome.runtime.onInstalled.addListener(schedule);
+  chrome.runtime.onStartup.addListener(schedule);
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === VISIT_ALARM) void autoVisit();
+    if (alarm.name === VISIT_TIMEOUT_ALARM) void visitTimedOut();
+  });
+}
+
+function schedule(): void {
+  chrome.alarms.create(VISIT_ALARM, { periodInMinutes: 24 * 60 });
+}
+
+export async function shouldFetchSaves(): Promise<any> {
+  const { apiKey } = await chrome.storage.local.get(['apiKey']);
+  if (!apiKey) return { fetch: false };
+  const { igFetchedAt } = await chrome.storage.local.get(['igFetchedAt']);
+  return { fetch: !igFetchedAt || Date.now() - igFetchedAt > HARVEST_INTERVAL_MS };
+}
+
+export async function receiveSavedItems(
+  items: { url: string }[],
+  sender: chrome.runtime.MessageSender
+): Promise<any> {
+  await chrome.storage.local.set({ igFetchedAt: Date.now() });
+  await closeVisitTab(sender.tab?.id);
+
+  if (items.length === 0) return { ok: true, new: 0 };
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return { ok: false, error: 'not_connected' };
+
+  const response = await fetch(`${cfg.apiBase}/api/v1/me/saved-items`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ platform: 'instagram', items }),
+  });
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 180);
+    await chrome.storage.local.set({
+      lastError: `Instagram saves push failed (${response.status}): ${detail}`,
+    });
+    await setBadge('!', 'Instagram saves push failed — click for details');
+    return { ok: false, error: `push_failed_${response.status}` };
+  }
+  const data = await response.json();
+  await chrome.storage.local.set({ lastError: null });
+  return { ok: true, ...data };
+}
+
+export async function savedItemsFailed(
+  error: string,
+  sender: chrome.runtime.MessageSender
+): Promise<any> {
+  await closeVisitTab(sender.tab?.id);
+  await chrome.storage.local.set({ lastError: `Instagram saves harvest failed: ${error}` });
+  await setBadge('!', 'Instagram saves harvest failed — click for details');
+  return { ok: false, error };
+}
+
+async function autoVisit(): Promise<void> {
+  const { fetch: due } = await shouldFetchSaves();
+  if (!due) return;
+  const tab = await chrome.tabs.create({ url: 'https://www.instagram.com/', active: false });
+  await chrome.storage.session.set({ igVisitTabId: tab.id });
+  chrome.alarms.create(VISIT_TIMEOUT_ALARM, { delayInMinutes: 2 });
+}
+
+async function visitTimedOut(): Promise<void> {
+  const { igVisitTabId } = await chrome.storage.session.get(['igVisitTabId']);
+  if (igVisitTabId == null) return;
+  await chrome.storage.session.remove(['igVisitTabId']);
+  await chrome.tabs.remove(igVisitTabId).catch(() => undefined);
+  await chrome.storage.local.set({
+    lastError: 'Instagram saves harvest timed out — are you signed in to instagram.com?',
+  });
+  await setBadge('!', 'Instagram saves harvest timed out — click for details');
+}
+
+async function closeVisitTab(senderTabId: number | undefined): Promise<void> {
+  if (senderTabId == null) return;
+  const { igVisitTabId } = await chrome.storage.session.get(['igVisitTabId']);
+  if (igVisitTabId !== senderTabId) return;
+  await chrome.storage.session.remove(['igVisitTabId']);
+  chrome.alarms.clear(VISIT_TIMEOUT_ALARM);
+  await chrome.tabs.remove(senderTabId).catch(() => undefined);
+}

--- a/chrome_extension/src/content/instagram.ts
+++ b/chrome_extension/src/content/instagram.ts
@@ -1,0 +1,63 @@
+// Instagram saved-posts capture: reads the user's saved list via
+// Instagram's own same-origin API (the pattern every saved-posts exporter
+// extension uses — cookies attach automatically, no signed params).
+// Only the list of post URLs leaves the page; content hydration happens
+// server-side via ScrapeCreators. The background worker owns the 24h
+// throttle and the upload.
+
+const SAVED_FEED_PATH = '/api/v1/feed/saved/posts/';
+// Instagram's public web-app id, required on internal API calls.
+const IG_APP_ID = '936619743392459';
+const MAX_ITEMS = 200;
+
+async function harvest(): Promise<void> {
+  const check = await chrome.runtime.sendMessage({
+    type: 'SHOULD_FETCH_SAVES',
+    platform: 'instagram',
+  });
+  if (!check?.fetch) return;
+
+  const csrf = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/)?.[1];
+  if (!csrf) {
+    void chrome.runtime.sendMessage({
+      type: 'SAVED_ITEMS_FAILED',
+      platform: 'instagram',
+      error: 'not signed in to instagram.com',
+    });
+    return;
+  }
+
+  const items: { url: string }[] = [];
+  let maxId = '';
+  while (items.length < MAX_ITEMS) {
+    const query = maxId ? `?max_id=${encodeURIComponent(maxId)}` : '';
+    const res = await fetch(`${SAVED_FEED_PATH}${query}`, {
+      headers: {
+        'x-ig-app-id': IG_APP_ID,
+        'x-csrftoken': csrf,
+        'x-requested-with': 'XMLHttpRequest',
+      },
+    });
+    if (!res.ok) {
+      void chrome.runtime.sendMessage({
+        type: 'SAVED_ITEMS_FAILED',
+        platform: 'instagram',
+        error: `saved-posts API returned ${res.status}`,
+      });
+      return;
+    }
+    const data = await res.json();
+    for (const wrapper of data.items || []) {
+      const media = wrapper?.media || wrapper;
+      if (media?.code) items.push({ url: `https://www.instagram.com/p/${media.code}/` });
+    }
+    if (!data.more_available || !data.next_max_id) break;
+    maxId = data.next_max_id;
+  }
+
+  // Empty is a valid harvest (no saves yet) — the background still records
+  // the pass so the throttle works.
+  void chrome.runtime.sendMessage({ type: 'SAVED_ITEMS', platform: 'instagram', items });
+}
+
+void harvest();


### PR DESCRIPTION
Stacked on #802; talks to `POST /me/saved-items` from #799. Completes the v1 commonplace-book stack.

## What
- `src/content/instagram.ts`: on instagram.com, reads the saved-posts list via Instagram's own same-origin API (`/api/v1/feed/saved/posts/`, `x-ig-app-id` + csrftoken from cookies — the proven pattern saved-posts exporter extensions use). Paginates up to 200 items; only **URLs** leave the page (ScrapeCreators hydrates content server-side).
- 24h throttle owned by the background (`SHOULD_FETCH_SAVES` → single writer of `igFetchedAt`); empty harvests still record the pass.
- **Daily auto-visit** (user-requested): an alarm opens a non-active tab to instagram.com when a harvest is due; the tab closes when `SAVED_ITEMS` arrives or after a 2-minute timeout, which surfaces loudly ("are you signed in to instagram.com?") on the badge.
- Failures (logged out, API drift) report through `SAVED_ITEMS_FAILED` → badge + popup error.
- Manifest: instagram.com content script + host permission.

## CWS note
Listing must disclose that the extension reads the user's own Instagram saves and sends them to the user's Stash account (Limited Use). Reading the saved list via the internal API is the same user-owned-data pattern as existing saved-posts exporters; accepted startup risk per plan.

## Verified
`npm run typecheck` + `npm run build` clean. Endpoint shape verified against a logged-in session should happen before store submission (internal APIs drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)