### PR TITLE
Curator feed: events carry their session's folder

### DIFF
--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -69,6 +69,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "event_type": e.get("event_type"),
             "content": (e.get("content") or "")[:_SNIPPET],
             "created_at": _iso(e.get("created_at")),
+            "folder": e.get("folder"),
         }
         for e in events
     ]
@@ -156,20 +157,29 @@ async def _feed_events(
     The curator's own run transcripts (`agent-curate-%` sessions) are excluded
     in SQL — feeding them back would echo-loop the daily gate and pollute the
     wiki, and filtering after the query would let them consume feed slots that
-    belong to real activity."""
+    belong to real activity.
+
+    Each event carries its session's folder name: folder placement is the
+    owner's curation signal (e.g. one folder per customer org, or a designated
+    folder of expert-sanctioned traces), so the curator must see it."""
     pool = get_pool()
     args: list = [owner_user_id]
-    where = "owner_user_id = $1 AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%')"
+    where = "he.owner_user_id = $1 AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
     if since is not None:
         args.append(since)
-        where += f" AND created_at > ${len(args)}"
+        where += f" AND he.created_at > ${len(args)}"
     if until is not None:
         args.append(until)
-        where += f" AND created_at <= ${len(args)}"
+        where += f" AND he.created_at <= ${len(args)}"
     rows = await pool.fetch(
-        f"SELECT session_id, agent_name, event_type, content, created_at "
-        f"FROM history_events WHERE {where} "
-        f"ORDER BY created_at, id LIMIT {limit + 1}",
+        f"SELECT he.session_id, he.agent_name, he.event_type, he.content, he.created_at, "
+        f"sf.name AS folder "
+        f"FROM history_events he "
+        f"LEFT JOIN sessions s ON s.owner_user_id = he.owner_user_id "
+        f"  AND s.session_id = he.session_id "
+        f"LEFT JOIN session_folders sf ON sf.id = s.session_folder_id "
+        f"WHERE {where} "
+        f"ORDER BY he.created_at, he.id LIMIT {limit + 1}",
         *args,
     )
     has_more = len(rows) > limit

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -137,6 +137,13 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - `history_has_more: true` means the history overflowed this run's cap. The
   remainder is already queued for your next run (the watermark only advances
   through what you were shown) — curate what's present, don't try to page.
+- Each history event carries its session's `folder`. Folder placement is the
+  owner's deliberate curation signal: sessions filed into a named folder share
+  a context (a customer, an org, a project) — attribute what you learn to that
+  context rather than generalizing it. A folder whose name marks it as
+  global/approved (e.g. "Global — approved for learning") holds traces an
+  expert has sanctioned: treat those as trustworthy, general knowledge and
+  weight them above unsorted activity.
 - `stash memory --json` — confirms the Memory folder id (`{memory_folder_id}`).
 - `stash ls /memory --json` and `stash read <page_id>` to inspect existing
   wiki pages. `stash search "<topic>" --json` to pull related source/file

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -177,6 +177,38 @@ async def test_curate_sessions_do_not_consume_feed_slots(
 
 
 @pytest.mark.asyncio
+async def test_feed_events_carry_session_folder(client: AsyncClient, _db_pool):
+    """Folder placement is the owner's curation signal — 'mark this trace as
+    sanctioned' is a move into a designated folder, so the feed must show each
+    event's folder for the curator to honor the mark."""
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+
+    folder = await client.post(
+        "/api/v1/me/session-folders/get-or-create",
+        json={"name": "Global — approved for learning", "external_key": "global"},
+        headers=_auth(key),
+    )
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message",
+                "content": "sanctioned trace",
+                "session_id": "conv-global",
+                "session_folder_id": folder.json()["id"],
+            }
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, old)
+    marked = next(h for h in feed["history"] if h["content"] == "sanctioned trace")
+    assert marked["folder"] == "Global — approved for learning"
+
+
+@pytest.mark.asyncio
 async def test_has_changes_false_after_watermark(client: AsyncClient, _db_pool):
     key, uid = await _register(client)
     await client.post(


### PR DESCRIPTION
Ships the learning half of "mark a trace as global / sanctioned" using primitives that already exist — no schema changes, works today, composes with Workspaces (#785) later instead of blocking on it.

**The design:** marking a trace is a folder move (the sessions page already has multi-select move + drag-to-folder). What was missing is that the curator couldn't *see* the mark: delta events didn't carry their session's folder.

- `_feed_events` now LEFT JOINs each event to its session's folder name; `changes_since` history items gain a `folder` field.
- The curator prompt explains what placement means: sessions in a named folder share a context (a customer org, a project) — attribute learnings to that context; a folder named as global/approved holds expert-sanctioned traces — treat as trustworthy general knowledge, weighted above unsorted activity.

With the per-org upload folders from #783/#784, this gives Heavi the full loop today: production traces land per-org, an expert drags the good ones into "Global — approved for learning", and the nightly rebuild treats them as sanctioned.

**Test:** create a keyed "Global — approved for learning" folder → push an event into it → the feed shows `folder` on that event. 21 pass in `test_curator.py`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)