### PR TITLE
Mint API keys with st_ prefix (goodbye moltchat's mc_)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -45,7 +45,7 @@ _last_seen_written = _LastSeenCache(_LAST_SEEN_CACHE_SIZE)
 
 
 def generate_api_key() -> str:
-    return "mc_" + secrets.token_urlsafe(32)
+    return "st_" + secrets.token_urlsafe(32)
 
 
 def hash_api_key(key: str) -> str:
@@ -139,13 +139,16 @@ async def _get_user_from_jwt(token: str) -> dict:
 
 
 async def authenticate_token(token: str) -> dict:
-    """Resolve a raw bearer token (mc_ API key or Auth0 JWT) to a user.
+    """Resolve a raw bearer token (st_ API key or Auth0 JWT) to a user.
 
     For surfaces that can't carry an Authorization header, e.g. browser
     WebSockets passing the token as a query parameter."""
     from .config import settings
 
-    if token.startswith("mc_"):
+    # mc_ is the pre-rename (moltchat) prefix. Keys are stored hashed and the
+    # raw values live with users, so issued mc_ keys can never be rewritten —
+    # both prefixes stay valid for as long as those keys exist.
+    if token.startswith(("st_", "mc_")):
         return await _get_user_from_api_key(token, managed_auth_enabled=settings.AUTH0_ENABLED)
 
     if settings.AUTH0_ENABLED:

--- a/backend/static/SKILL.md
+++ b/backend/static/SKILL.md
@@ -56,7 +56,7 @@ Design boundary:
 ## Authentication
 All endpoints (except registration and a few public lookups) require an API key:
 ```
-Authorization: Bearer mc_xxxxxxxxxxxxx
+Authorization: Bearer st_xxxxxxxxxxxxx
 ```
 
 Your account is the scope. `GET /api/v1/users/me` returns the authenticated

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -23,7 +23,7 @@ async def test_register_success(client: AsyncClient):
     assert resp.status_code == 201
     body = resp.json()
     assert body["name"] == name
-    assert body["api_key"].startswith("mc_")
+    assert body["api_key"].startswith("st_")
 
 
 @pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_login_success(client: AsyncClient):
 
     login = await client.post("/api/v1/users/login", json={"name": name, "password": password})
     assert login.status_code == 200
-    assert login.json()["api_key"].startswith("mc_")
+    assert login.json()["api_key"].startswith("st_")
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_cli_auth_approve_then_poll_returns_usable_device_key(client: Asyn
     assert polled.status_code == 200
     body = polled.json()
     assert body["status"] == "complete"
-    assert body["api_key"].startswith("mc_")
+    assert body["api_key"].startswith("st_")
 
     assert (
         await pool.fetchval(
@@ -248,7 +248,7 @@ async def test_expired_cli_auth_approval_revokes_unclaimed_device_key(
         "SELECT api_key FROM cli_auth_sessions WHERE session_id = $1",
         session_id,
     )
-    assert unclaimed_key.startswith("mc_")
+    assert unclaimed_key.startswith("st_")
 
     await pool.execute(
         "UPDATE cli_auth_sessions "
@@ -328,9 +328,39 @@ async def test_scheduled_cleanup_revokes_expired_unclaimed_cli_keys(client: Asyn
 
 
 @pytest.mark.asyncio
-async def test_invalid_api_key_rejected(client: AsyncClient):
-    resp = await client.get("/api/v1/users/me", headers={"Authorization": "Bearer mc_fakekeyxxxx"})
+@pytest.mark.parametrize("prefix", ["st_", "mc_"])
+async def test_invalid_api_key_rejected(client: AsyncClient, prefix: str):
+    """Both prefixes route to API-key auth: st_ is current, mc_ is the
+    pre-rename prefix that issued keys still carry."""
+    resp = await client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {prefix}fakekeyxxxx"}
+    )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_issued_mc_key_still_authenticates(client: AsyncClient, pool):
+    """Keys minted before the st_ rename are hashed server-side and held raw
+    by users (including customer prod deployments) — they must keep working."""
+    from backend.auth import hash_api_key
+
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("legacy_key"), "password": "securepassword1"},
+    )
+    user_id = reg.json()["id"]
+    legacy_key = "mc_legacy_key_from_before_the_rename"
+    await pool.execute(
+        "INSERT INTO user_api_keys (user_id, key_hash, name, key_type) VALUES ($1, $2, $3, $4)",
+        UUID(user_id),
+        hash_api_key(legacy_key),
+        "legacy",
+        "manual",
+    )
+
+    me = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {legacy_key}"})
+    assert me.status_code == 200
+    assert me.json()["id"] == user_id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -169,7 +169,7 @@ async def test_managed_auth0_allows_manual_api_key_creation(client, monkeypatch)
 
     assert created.status_code == 201
     api_key = created.json()["api_key"]
-    assert api_key.startswith("mc_")
+    assert api_key.startswith("st_")
 
     me = await client.get(
         "/api/v1/users/me",
@@ -226,7 +226,7 @@ async def test_managed_auth0_allows_approved_cli_device_keys(client, monkeypatch
     assert polled.status_code == 200
     body = polled.json()
     assert body["status"] == "complete"
-    assert body["api_key"].startswith("mc_")
+    assert body["api_key"].startswith("st_")
 
     me = await client.get(
         "/api/v1/users/me",

--- a/chrome_extension/README.md
+++ b/chrome_extension/README.md
@@ -16,7 +16,7 @@ the same conversation. Each conversation becomes one Stash session
   transcript as JSONL to `POST /api/v1/workspaces/{id}/transcripts` with
   `replace=true`, so re-syncs update the session instead of duplicating it.
 - Auth reuses the CLI device flow: the extension opens `/connect-token`,
-  you sign in once, and it receives its own revocable `mc_` API key.
+  you sign in once, and it receives its own revocable `st_` API key.
 
 ## Development
 

--- a/sdk/src/stash_sdk/client.py
+++ b/sdk/src/stash_sdk/client.py
@@ -22,7 +22,7 @@ class Stash:
     """Client for the Stash API.
 
     Args:
-        api_key: Stash API key (``mc_...``). Falls back to ``STASH_API_KEY`` env var.
+        api_key: Stash API key (``st_...``). Falls back to ``STASH_API_KEY`` env var.
         base_url: API base URL. Falls back to ``STASH_URL`` env var, then production.
         timeout: Default request timeout in seconds.
     """


### PR DESCRIPTION
New API keys are minted as `st_...` instead of the pre-rename moltchat `mc_...`.

**Why both prefixes stay valid in auth:** keys are stored as SHA-256 hashes and the raw values live with users — including `STASH_API_KEY` in customer prod deployments (Heavi) and every engineer's `~/.stash/config.json`. They cannot be rewritten server-side, so `authenticate_token` accepts `st_` and `mc_` for as long as issued keys exist. This is recorded as a code comment at the check, not a silent fallback.

Changes:
- `generate_api_key()` mints `st_`
- `authenticate_token` routes both prefixes to API-key auth (JWTs unchanged)
- Tests updated; adds `test_issued_mc_key_still_authenticates` (positive legacy-key auth) and parametrizes the invalid-key 401 over both prefixes
- Docs/examples (`SKILL.md`, SDK docstring, chrome extension README) now show `st_`

Test plan: `pytest backend/tests/test_auth.py backend/tests/test_auth0_provision.py` — 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)