### PR TITLE
Curator: drain the full event backlog within one nightly beat (10x daily budget)

### DIFF
--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -18,6 +18,14 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
+# One curator pass consumes at most one event-cap's worth of the change feed
+# (curation_service._MAX_EVENTS, 500). Per-turn transcript streams (e.g. a
+# customer app uploading every chat turn) can exceed that in a single day, so
+# a due curator keeps running until its feed drains, bounded by this many
+# passes per beat — a ~5,000-event daily budget without ever giving one run an
+# unbounded delta.
+CURATOR_DRAIN_PASSES = 10
+
 
 def _is_due(cron: str, last_run: datetime | None, now: datetime) -> bool:
     """True if a cron tick falls in (last_run, now]. Never fires on the very
@@ -102,18 +110,48 @@ async def _run_due() -> int:
         ):
             continue
         try:
-            await sprite_agent_service.run_scheduled(agent, stamp)
             if agent["is_curator"]:
-                # `now` predates the run, so changes made during it stay ahead
-                # of the watermark and are picked up next time. If the delta
-                # overflowed the event cap, the watermark stops at the last
-                # event that fit — the overflow drains on subsequent runs.
-                through = await curation_service.complete_through(
-                    user_id, agent["curated_through"], now
-                )
-                await agent_service.mark_curated(agent["id"], through)
+                await _drain_curator(agent, user_id, stamp, now)
+            else:
+                await sprite_agent_service.run_scheduled(agent, stamp)
             ran += 1
         except Exception as e:
             logger.exception("agent schedule: run failed for agent %s", agent["id"])
             await agent_service.mark_run_failed(agent["id"], str(e))
     return ran
+
+
+async def _drain_curator(agent: dict, user_id: UUID, stamp: str, now: datetime) -> None:
+    """Run the curator, repeating while the delta overflowed the per-run event
+    cap, so a busy day drains within one beat instead of lagging one cap per
+    day. `now` predates the first run, so changes made during a pass stay
+    ahead of the watermark and are picked up next beat. The watermark advances
+    after every successful pass, so a failure mid-drain loses nothing already
+    curated. Extra passes stay metered against the free-tier monthly
+    allowance; enterprise is unlimited."""
+    from ..config import settings
+    from ..database import get_pool
+    from ..services import agent_service, curation_service, sprite_agent_service
+
+    for run_pass in range(CURATOR_DRAIN_PASSES):
+        if run_pass:
+            month_runs = await agent_service.mark_run(agent["id"])
+            if month_runs > settings.FREE_CURATOR_RUNS_PER_MONTH:
+                plan = await get_pool().fetchval("SELECT plan FROM users WHERE id = $1", user_id)
+                if plan != "enterprise":
+                    logger.info(
+                        "agent schedule: curator credits exhausted mid-drain for user %s",
+                        user_id,
+                    )
+                    return
+        await sprite_agent_service.run_scheduled(agent, f"{stamp}-{run_pass}")
+        through = await curation_service.complete_through(user_id, agent["curated_through"], now)
+        await agent_service.mark_curated(agent["id"], through)
+        if through >= now:
+            return
+        agent = {**agent, "curated_through": through}
+    logger.warning(
+        "agent schedule: curator feed still overflowing after %s passes for user %s",
+        CURATOR_DRAIN_PASSES,
+        user_id,
+    )

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -586,3 +586,47 @@ async def test_memory_tree_nests_folders_and_scopes_to_memory(client: AsyncClien
     files_tree = (await client.get("/api/v1/me/tree", headers=_auth(key))).json()
     assert [p["name"] for p in files_tree["pages"]] == ["Outside"]
     assert all(f["id"] != mem["id"] for f in files_tree["folders"])
+
+
+@pytest.mark.asyncio
+async def test_busy_day_drains_within_one_beat(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
+    """A day's events can exceed one delta cap (Heavi's per-turn transcript
+    uploads produced ~one cap on day one). The beat must not advance one cap
+    per DAY — it re-runs the curator until the feed drains, so the wiki learns
+    from yesterday's conversations tomorrow, not next week."""
+    from backend.services import curation_service
+    from backend.tasks.agent_schedules import _run_due
+
+    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+    base = datetime.now(UTC) - timedelta(hours=2)
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message",
+                "content": f"turn {i}",
+                "session_id": f"conv-{i}",
+                "created_at": (base + timedelta(minutes=i)).isoformat(),
+            }
+            for i in range(8)
+        ],
+    )
+    await _make_due(_db_pool, curator["id"], base - timedelta(minutes=1))
+
+    ran = await _run_due()
+    assert ran == 1
+
+    after = await _db_pool.fetchval(
+        "SELECT curated_through FROM agents WHERE id = $1", UUID(curator["id"])
+    )
+    # The whole backlog was consumed in this single beat...
+    assert await curation_service.has_changes_since(uid, uid, after) is False
+    # ...which took multiple curator passes, each bounded by the event cap.
+    passes = [a for a in sprite_exec.calls if "Memory Wiki Curation" in " ".join(a)]
+    assert len(passes) >= 3


### PR DESCRIPTION
## Problem

The curator consumes at most `_MAX_EVENTS` (500) feed events per run and runs once a day. Heavi's per-turn transcript uploads produced **429 events on day one** with a handful of orgs — one busy day ≈ the whole daily budget. Past ~500 events/day, the watermark falls further behind every day and never recovers; the wiki learns from increasingly stale conversations (safely — #786 means nothing is dropped — but late, and unboundedly so).

## Fix

When a due curator's delta overflowed the cap, the beat re-runs it immediately — up to `CURATOR_DRAIN_PASSES = 10` passes — until `complete_through` reaches the beat's `now`. Effective daily budget: ~5,000 events (10× headroom over Heavi's day-one volume), while each individual run keeps its bounded delta.

- Watermark advances after every successful pass, so a mid-drain failure loses nothing already curated.
- Extra passes are metered against the free-tier monthly allowance (mirroring the existing gate); enterprise is unlimited.
- Each pass gets its own run stamp → own `agent-curate-*` session, keeping the echo-loop exclusion intact.
- Still-overflowing after 10 passes logs a warning instead of looping forever.

## Tests

`backend/tests/test_curator.py::test_busy_day_drains_within_one_beat`: with the cap monkeypatched to 3 and 8 pending events, one beat runs multiple curator passes and finishes with `has_changes_since(watermark) == False`. Full curator suite: 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)