### PR TITLE
Curator feed: session digests + reader subagent per session, RLM-style

### DIFF
--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -1,11 +1,13 @@
 """The change feed the daily Memory curator reads.
 
 `changes_since` is the incremental delta since the curator's watermark: new
-history events (excluding the curator's own run sessions), changed pages
-(excluding the Memory subtree), new files, and the user's connected sources as
-pointers (the agent pulls source specifics with `stash search`) — the curator
-never sees its own output. `has_changes_since` is the cheap EXISTS the beat
-task uses to skip idle users without waking a sprite.
+session activity as one digest line per session (the curator dispatches a
+reader subagent per session; transcripts never ride the feed, and the
+curator's own run sessions are excluded), changed pages (excluding the Memory
+subtree), new files, and the user's connected sources as pointers (the agent
+pulls source specifics with `stash search`) — the curator never sees its own
+output. `has_changes_since` is the cheap EXISTS the beat task uses to skip
+idle users without waking a sprite.
 """
 
 from __future__ import annotations
@@ -17,10 +19,12 @@ from ..database import get_pool
 from . import files_tree_service, source_service
 
 # Caps so a single delta stays bounded (a long-idle account's first delta, a
-# high-volume account's busy day). Overflowing _MAX_EVENTS never loses events:
+# high-volume account's busy day). The session cap is the inventory guard: a
+# digest is ~200 chars regardless of the session's size, so root context
+# scales with sessions/day, not events/day. Overflowing never loses anything:
 # the watermark only advances through what fit (see complete_through), so the
 # remainder is re-presented on the next run.
-_MAX_EVENTS = 500
+_MAX_SESSIONS = 500
 _MAX_PAGES = 100
 _MAX_FILES = 100
 _SNIPPET = 280
@@ -38,7 +42,7 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
         SELECT
           EXISTS (SELECT 1 FROM history_events
                   WHERE owner_user_id = $1 AND created_at > $2
-                    AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%'))
+                    AND session_id NOT LIKE 'agent-curate-%')
           OR EXISTS (SELECT 1 FROM pages
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND ($3::uuid[] IS NULL OR folder_id IS NULL
@@ -55,23 +59,26 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
 
 
 async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> dict:
-    """The delta the curator reads: history events, changed pages (excl. Memory),
-    new files, and connected-source pointers."""
+    """The delta the curator reads: session digests, changed pages (excl.
+    Memory), new files, and connected-source pointers."""
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
     exclude = list(memory_ids) or None
 
-    events, history_has_more = await _feed_events(owner_user_id, since, None, _MAX_EVENTS)
-    history = [
+    digests, sessions_has_more = await _feed_session_digests(
+        owner_user_id, since, None, _MAX_SESSIONS
+    )
+    session_digests = [
         {
-            "session_id": e.get("session_id"),
-            "agent_name": e.get("agent_name"),
-            "event_type": e.get("event_type"),
-            "content": (e.get("content") or "")[:_SNIPPET],
-            "created_at": _iso(e.get("created_at")),
-            "folder": e.get("folder"),
+            "session_id": d["session_id"],
+            "agent_name": d["agent_name"],
+            "folder": d["folder"],
+            "event_count": d["event_count"],
+            "first_at": _iso(d["first_at"]),
+            "last_at": _iso(d["last_at"]),
+            "opening": d["opening"],
         }
-        for e in events
+        for d in digests
     ]
 
     page_rows = await pool.fetch(
@@ -133,57 +140,102 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
     return {
         "since": _iso(since),
         "counts": {
-            "history": len(history),
+            "sessions": len(session_digests),
             "pages": len(pages),
             "files": len(files),
             "sources": len(sources),
         },
-        "history": history,
-        "history_has_more": history_has_more,
+        "session_digests": session_digests,
+        "sessions_has_more": sessions_has_more,
         "pages": pages,
         "files": files,
         "sources": sources,
     }
 
 
-async def _feed_events(
+def _window(args: list, since: datetime | None, until: datetime | None) -> str:
+    clause = ""
+    if since is not None:
+        args.append(since)
+        clause += f" AND he.created_at > ${len(args)}"
+    if until is not None:
+        args.append(until)
+        clause += f" AND he.created_at <= ${len(args)}"
+    return clause
+
+
+async def _feed_session_digests(
     owner_user_id: UUID,
     since: datetime | None,
     until: datetime | None,
     limit: int,
 ) -> tuple[list[dict], bool]:
-    """The curator's event feed, oldest first. Returns (events, has_more).
+    """The curator's session inventory: one row per session with events in the
+    window, ordered by each session's last event. Returns (digests, has_more).
+
+    The order matters for the watermark: complete_through advances through the
+    last session that fit, so an excluded session's last event is always after
+    the watermark and the whole session re-presents next run.
 
     The curator's own run transcripts (`agent-curate-%` sessions) are excluded
     in SQL — feeding them back would echo-loop the daily gate and pollute the
     wiki, and filtering after the query would let them consume feed slots that
     belong to real activity.
 
-    Each event carries its session's folder name: folder placement is the
+    Each digest carries its session's folder name: folder placement is the
     owner's curation signal (e.g. one folder per customer org, or a designated
     folder of expert-sanctioned traces), so the curator must see it."""
     pool = get_pool()
     args: list = [owner_user_id]
-    where = "he.owner_user_id = $1 AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
-    if since is not None:
-        args.append(since)
-        where += f" AND he.created_at > ${len(args)}"
-    if until is not None:
-        args.append(until)
-        where += f" AND he.created_at <= ${len(args)}"
+    where = "he.owner_user_id = $1 AND he.session_id NOT LIKE 'agent-curate-%'" + _window(
+        args, since, until
+    )
     rows = await pool.fetch(
-        f"SELECT he.session_id, he.agent_name, he.event_type, he.content, he.created_at, "
-        f"sf.name AS folder "
+        f"SELECT he.session_id, count(*) AS event_count, "
+        f"min(he.created_at) AS first_at, max(he.created_at) AS last_at, "
+        f"max(he.agent_name) AS agent_name, max(sf.name) AS folder "
         f"FROM history_events he "
         f"LEFT JOIN sessions s ON s.owner_user_id = he.owner_user_id "
         f"  AND s.session_id = he.session_id "
         f"LEFT JOIN session_folders sf ON sf.id = s.session_folder_id "
         f"WHERE {where} "
-        f"ORDER BY he.created_at, he.id LIMIT {limit + 1}",
+        f"GROUP BY he.session_id "
+        f"ORDER BY max(he.created_at), he.session_id LIMIT {limit + 1}",
         *args,
     )
     has_more = len(rows) > limit
-    return [dict(r) for r in rows[:limit]], has_more
+    digests = [dict(r) for r in rows[:limit]]
+    openings = await _session_openings(
+        owner_user_id, [d["session_id"] for d in digests], since, until
+    )
+    for d in digests:
+        d["opening"] = openings.get(d["session_id"])
+    return digests, has_more
+
+
+async def _session_openings(
+    owner_user_id: UUID,
+    session_ids: list[str],
+    since: datetime | None,
+    until: datetime | None,
+) -> dict[str, str]:
+    """Each session's first user message in the window, truncated — the one
+    content peek a digest carries, so triage can judge substance cheaply."""
+    if not session_ids:
+        return {}
+    pool = get_pool()
+    args: list = [owner_user_id, session_ids]
+    where = (
+        "he.owner_user_id = $1 AND he.session_id = ANY($2) AND he.event_type = 'user_message'"
+    ) + _window(args, since, until)
+    rows = await pool.fetch(
+        f"SELECT DISTINCT ON (he.session_id) he.session_id, "
+        f"left(coalesce(he.content, ''), {_SNIPPET}) AS opening "
+        f"FROM history_events he WHERE {where} "
+        f"ORDER BY he.session_id, he.created_at, he.id",
+        *args,
+    )
+    return {r["session_id"]: r["opening"] for r in rows}
 
 
 async def complete_through(
@@ -191,15 +243,16 @@ async def complete_through(
 ) -> datetime:
     """How far the curator's watermark may advance after a successful run.
 
-    The feed is complete through `until` unless it overflowed _MAX_EVENTS, in
-    which case it is only complete through the last event that fit — minus a
-    microsecond, so events sharing that exact timestamp are re-presented next
-    run rather than skipped. Overflow therefore drains run by run and no event
-    is ever silently dropped from curation."""
-    events, has_more = await _feed_events(owner_user_id, since, until, _MAX_EVENTS)
+    The feed is complete through `until` unless the inventory overflowed
+    _MAX_SESSIONS, in which case it is only complete through the last session
+    that fit — its last event's timestamp, minus a microsecond, so sessions
+    sharing that exact timestamp are re-presented next run rather than
+    skipped. Overflow therefore drains run by run and no session is ever
+    silently dropped from curation."""
+    digests, has_more = await _feed_session_digests(owner_user_id, since, until, _MAX_SESSIONS)
     if not has_more:
         return until
-    return events[-1]["created_at"] - timedelta(microseconds=1)
+    return digests[-1]["last_at"] - timedelta(microseconds=1)
 
 
 def _iso(dt) -> str | None:

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -116,9 +116,9 @@ def render_curator_prompt(memory_folder_id: str, since: str | None) -> str:
 
     Reading is recursive, RLM-style (arXiv:2512.24601): the corpus can exceed
     one context window, so the root agent peeks at documents to triage but
-    never accumulates their bodies — each artifact is fully read inside a
-    disposable reader subagent that writes the page and returns a
-    constant-size digest.
+    never accumulates their bodies — each artifact (document or session
+    transcript) is fully read inside a disposable reader subagent that writes
+    the page and returns a constant-size digest.
     A bootstrap run once skimmed transcripts with `head -20` and published
     confident-looking pages whose "facts" were inferred from byte sizes —
     this structure exists so that can't recur."""
@@ -141,12 +141,16 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Read the inputs
 - `{changes_cmd}` — the delta to curate: recent
-  history/chats, changed pages, new files, and connected sources. This IS your
-  work set; do not re-scan the whole corpus.
-- `history_has_more: true` means the history overflowed this run's cap. The
-  remainder is already queued for your next run (the watermark only advances
-  through what you were shown) — curate what's present, don't try to page.
-- Each history event carries its session's `folder`. Folder placement is the
+  session activity, changed pages, new files, and connected sources. This IS
+  your work set; do not re-scan the whole corpus.
+- `session_digests` is the chat inventory: one line per conversation
+  (`session_id`, `agent_name`, `folder`, `event_count`, `first_at`, `last_at`,
+  `opening`) — never the transcript itself.
+- `sessions_has_more: true` means the inventory overflowed this run's cap.
+  The remainder is already queued for your next run (the watermark only
+  advances through what you were shown) — curate what's present, don't try
+  to page.
+- Each session digest carries its session's `folder`. Folder placement is the
   owner's deliberate curation signal: sessions filed into a named folder share
   a context (a customer, an org, a project) — attribute what you learn to that
   context rather than generalizing it. A folder whose name marks it as
@@ -186,13 +190,41 @@ Peek at documents to triage; ingest them through subagents:
   exception: write its page yourself. Everything you only peeked at gets
   dispatched. Your job is inventory → dispatch → weave: categories,
   cross-page links, the index, and `Log`, built from the digests — the
-  global view only you have. (Chat history arrives inline via
-  `stash changes` and you curate it directly; the subagent rule is for
-  documents.)
+  global view only you have.
 
 Example — a bootstrap delta with 40 documents: inventory the 40 paths;
 dispatch reader subagents in batches of 5; collect 40 digests; write the
 categories, cross-links, index, and `Log`; log any INCOMPLETEs.
+
+## Reading sessions (one reader subagent per session)
+Conversations get the same treatment as documents. `session_digests` is your
+inventory — you never see transcripts inline, and you never fetch one into
+your own context. Triage each digest, then dispatch:
+
+- **Triage from the digest alone**: `folder` tells you whose context it is,
+  `event_count` and `opening` tell you whether it's substantive. A trivial
+  session (a two-turn "thanks!" exchange) is a `skipped` line in `Log` with a
+  one-line reason, not a dispatch. Rank the rest and dispatch a reader
+  subagent per session worth curating, a few in parallel — at most ~50
+  dispatches per run; anything you triage out for budget gets a `skipped`
+  Log line naming the budget, so nothing is silently dropped.
+- The reader finds its transcript by session id and reads the ENTIRE
+  transcript in its own context before writing a single fact:
+  `stash vfs "grep '<session_id>' /sessions/_index.jsonl"` names the session
+  directory, then `stash vfs "cat '/sessions/<dir>/transcript.md'"` — in
+  chunks (`sed -n '1,400p'`, …) when it is long. It updates or creates the
+  wiki pages for the session's folder/org itself and returns ONLY
+  `page_id | one-line digest | topic tags`.
+- No facts from partial reads. A page must never say what a conversation was
+  "likely about" from `event_count` or `opening` — those exist for triage
+  only. A session the reader couldn't fully ingest is an INCOMPLETE line in
+  `Log`, re-presented as next-run work — never a confident summary.
+
+Example — a maintenance delta with 14 session digests: triage from the
+inventory (3 trivial → `skipped` lines); dispatch 11 readers in batches of 5,
+each with its session id, its folder's category folder id, and any existing
+page id for that org; collect 11 digests; weave cross-links, the org pages,
+the index, and `Log`.
 
 ## Wiki anatomy (under the Memory folder)
 - **`Memory Wiki`** — the root index page: a catalog of every page with a
@@ -219,7 +251,7 @@ pages themselves.
 
 ## Ingest principles
 - **Bootstrap vs. maintain — know which mode you're in.** If the Memory folder
-  has no pages, you are bootstrapping: cluster the history into 3-7 coherent
+  has no pages, you are bootstrapping: cluster the delta into 3-7 coherent
   categories and seed the index, the Log, and the first pages in one pass. If
   pages exist, you are maintaining: fold the delta into the existing structure.
 - **Maintain, don't regenerate.** Once the wiki exists, fold in new information;
@@ -227,8 +259,8 @@ pages themselves.
 - **Scope by diff, not by corpus.** Only touch pages whose topic appears in this
   delta. Leave untouched pages alone.
 - **Category-first, pages-second.** A concept from chat history gets its own
-  page only when it appears in >=2 distinct events; one-shot mentions stay as
-  bullets on the category index page.
+  page only when it appears in >=2 distinct sessions; one-shot mentions stay
+  as bullets on the category index page.
 - **Uploaded documents are content, not context.** The changed pages and new
   files in the delta are material the user deliberately added — represent every
   distinct document or document set in the wiki: a topic page, or bullets under
@@ -269,9 +301,10 @@ in `Log` so a future run picks it up.
 
 ## Report
 One line per action: created / updated / merged / skipped, with page titles —
-and append the same lines to the `Log` page. Account for every changed page
-and new file in the delta — anything you chose not to represent in the wiki
-gets a `skipped` line with a one-line reason, never a silent drop.
+and append the same lines to the `Log` page. Account for every session
+digest, changed page, and new file in the delta — anything you chose not
+to represent in the wiki gets a `skipped` line with a one-line reason,
+never a silent drop.
 
 Begin now.
 """

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -90,12 +90,47 @@ async def _push_events(client: AsyncClient, key: str, events: list[dict]) -> Non
 
 
 @pytest.mark.asyncio
-async def test_feed_overflow_never_drops_events(client: AsyncClient, _db_pool, monkeypatch):
-    """A busy account can produce more events than one delta holds. The feed
-    truncates, but the watermark bound stops at the last event that fit — so
-    the next run picks up exactly where this one left off, and every event is
-    eventually curated."""
-    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+async def test_feed_groups_session_events_into_digests(client: AsyncClient, _db_pool):
+    """The session is the event feed's document: a busy conversation is one
+    inventory line (count, window, opening), never per-event snippets — root
+    context scales with sessions/day, not events/day. Reader subagents pull
+    the transcript; the feed never carries it."""
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message" if i % 2 == 0 else "assistant_message",
+                "content": f"turn {i}",
+                "session_id": "conv-busy",
+                "created_at": (base + timedelta(minutes=i)).isoformat(),
+            }
+            for i in range(6)
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, old)
+    (digest,) = feed["session_digests"]
+    assert digest["session_id"] == "conv-busy"
+    assert digest["agent_name"] == "heavi-chat"
+    assert digest["event_count"] == 6
+    assert digest["first_at"] == base.isoformat()
+    assert digest["last_at"] == (base + timedelta(minutes=5)).isoformat()
+    assert digest["opening"] == "turn 0"  # first user message, not first event
+
+
+@pytest.mark.asyncio
+async def test_feed_overflow_never_drops_sessions(client: AsyncClient, _db_pool, monkeypatch):
+    """A busy account can produce more sessions than one inventory holds. The
+    feed truncates, but the watermark stops at the last session that fit — so
+    the next run picks up exactly where this one left off, and every session
+    is eventually curated."""
+    monkeypatch.setattr(curation_service, "_MAX_SESSIONS", 3)
     key, uid = await _register(client)
     old = datetime(2020, 1, 1, tzinfo=UTC)
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -116,21 +151,25 @@ async def test_feed_overflow_never_drops_events(client: AsyncClient, _db_pool, m
     )
 
     feed = await curation_service.changes_since(uid, uid, old)
-    assert feed["history_has_more"] is True
-    assert [h["content"] for h in feed["history"]] == ["turn 0", "turn 1", "turn 2"]
+    assert feed["sessions_has_more"] is True
+    assert [d["session_id"] for d in feed["session_digests"]] == ["conv-0", "conv-1", "conv-2"]
 
     until = base + timedelta(hours=1)
     through = await curation_service.complete_through(uid, old, until)
-    # Complete only through the last event that fit, not through `until`.
+    # Complete only through the last session that fit, not through `until`.
     assert through < base + timedelta(minutes=3)
 
     # The next run's feed starts where this one stopped: nothing was lost.
-    # The boundary event re-appears by design — the watermark backs off a
-    # microsecond so events sharing its timestamp can never be skipped; a
-    # duplicated boundary event is the cheap side of that trade.
+    # The boundary session re-appears by design — the watermark backs off a
+    # microsecond so sessions sharing its timestamp can never be skipped; a
+    # duplicated boundary session is the cheap side of that trade.
     next_feed = await curation_service.changes_since(uid, uid, through)
-    assert [h["content"] for h in next_feed["history"]] == ["turn 2", "turn 3", "turn 4"]
-    assert next_feed["history_has_more"] is False
+    assert [d["session_id"] for d in next_feed["session_digests"]] == [
+        "conv-2",
+        "conv-3",
+        "conv-4",
+    ]
+    assert next_feed["sessions_has_more"] is False
     assert await curation_service.complete_through(uid, through, until) == until
 
 
@@ -139,9 +178,9 @@ async def test_curate_sessions_do_not_consume_feed_slots(
     client: AsyncClient, _db_pool, monkeypatch
 ):
     """The curator's own run transcripts are excluded in SQL. If they were
-    filtered after the query they would eat delta slots and could crowd real
-    activity out of the feed entirely."""
-    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+    filtered after the query they would eat inventory slots and could crowd
+    real activity out of the feed entirely."""
+    monkeypatch.setattr(curation_service, "_MAX_SESSIONS", 2)
     key, uid = await _register(client)
     old = datetime(2020, 1, 1, tzinfo=UTC)
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -151,7 +190,7 @@ async def test_curate_sessions_do_not_consume_feed_slots(
             "agent_name": "curator",
             "event_type": "assistant_message",
             "content": f"curator step {i}",
-            "session_id": "agent-curate-abc-202601011200",
+            "session_id": f"agent-curate-abc-20260101120{i}",
             "created_at": (base + timedelta(seconds=i)).isoformat(),
         }
         for i in range(4)
@@ -169,18 +208,18 @@ async def test_curate_sessions_do_not_consume_feed_slots(
     await _push_events(client, key, curate_noise + real)
 
     feed = await curation_service.changes_since(uid, uid, old)
-    assert [h["content"] for h in feed["history"]] == ["real 0", "real 1"]
-    assert feed["history_has_more"] is False
+    assert [d["session_id"] for d in feed["session_digests"]] == ["conv-0", "conv-1"]
+    assert feed["sessions_has_more"] is False
     assert await curation_service.complete_through(
         uid, old, base + timedelta(hours=1)
     ) == base + timedelta(hours=1)
 
 
 @pytest.mark.asyncio
-async def test_feed_events_carry_session_folder(client: AsyncClient, _db_pool):
+async def test_session_digests_carry_folder(client: AsyncClient, _db_pool):
     """Folder placement is the owner's curation signal — 'mark this trace as
-    sanctioned' is a move into a designated folder, so the feed must show each
-    event's folder for the curator to honor the mark."""
+    sanctioned' is a move into a designated folder, so the digest must show
+    the session's folder for the curator to honor the mark."""
     key, uid = await _register(client)
     old = datetime(2020, 1, 1, tzinfo=UTC)
 
@@ -204,7 +243,7 @@ async def test_feed_events_carry_session_folder(client: AsyncClient, _db_pool):
     )
 
     feed = await curation_service.changes_since(uid, uid, old)
-    marked = next(h for h in feed["history"] if h["content"] == "sanctioned trace")
+    marked = next(d for d in feed["session_digests"] if d["session_id"] == "conv-global")
     assert marked["folder"] == "Global — approved for learning"
 
 
@@ -225,7 +264,7 @@ async def test_changes_endpoint(client: AsyncClient):
     r = await client.get("/api/v1/me/changes?since=2020-01-01T00:00:00", headers=_auth(key))
     assert r.status_code == 200
     body = r.json()
-    assert "counts" in body and "history" in body and "pages" in body
+    assert "counts" in body and "session_digests" in body and "pages" in body
 
 
 def test_curator_prompt_embeds_folder_and_window():
@@ -259,6 +298,23 @@ def test_curator_prompt_reads_documents_via_subagents():
     # The root may peek at document content to triage, but must not fill its
     # window with document bodies — that pressure is what caused the skim.
     assert "accumulate document bodies" in boot
+
+
+def test_curator_prompt_reads_sessions_via_subagents():
+    """Sessions get the same RLM discipline as documents: the feed hands the
+    root a per-session inventory, never transcripts, and per-turn uploads
+    (Heavi: 429 events on day one) would otherwise pressure the root into
+    skim-and-infer pages. The prompt must force whole-transcript reads inside
+    reader subagents, allow triage skips only as loud Log lines, and forbid
+    writing facts from digest metadata."""
+    boot = prompts.render_curator_prompt("folder-123", None)
+    flat = " ".join(boot.split())  # collapse hard-wrapped lines
+    assert "one reader subagent per session" in flat
+    assert "session_digests" in flat
+    assert "ENTIRE transcript" in flat
+    # Triage happens on the digest; the digest is never a source of facts.
+    assert "No facts from partial reads" in flat
+    assert "`skipped` line" in flat
 
 
 async def _make_due(pool, agent_id: str, watermark: datetime) -> None:
@@ -320,7 +376,7 @@ async def test_curator_run_does_not_echo_loop(client: AsyncClient, sprite_exec, 
     # doesn't re-trigger the gate or appear in the feed.
     assert await curation_service.has_changes_since(uid, uid, after) is False
     feed = await curation_service.changes_since(uid, uid, after)
-    assert all(not str(e["session_id"] or "").startswith("agent-curate-") for e in feed["history"])
+    assert all(not d["session_id"].startswith("agent-curate-") for d in feed["session_digests"])
 
 
 @pytest.mark.asyncio

--- a/cli/main.py
+++ b/cli/main.py
@@ -2631,7 +2631,7 @@ def changes(
     counts = data.get("counts", {})
     console.print(
         f"Changes since {data.get('since') or 'the beginning'}: "
-        f"{counts.get('history', 0)} events, {counts.get('pages', 0)} pages, "
+        f"{counts.get('sessions', 0)} sessions, {counts.get('pages', 0)} pages, "
         f"{counts.get('files', 0)} files, {counts.get('sources', 0)} sources"
     )
 


### PR DESCRIPTION
Implements the [curator-session-readers proposal](https://app.joinstash.ai/p/aded08b2-04a4-4814-b5fd-d1028232b822): extend #789's reader discipline to the event feed. **Stacked on #789** (based on `curator-rlm-reader-subagents`) — land that first, then retarget this to `main`.

## Problem

Heavi's per-turn transcript uploads made the event feed the fastest-growing corpus in the account (429 events on day one). `changes_since` inlined a ~280-char snippet per event under a 500-event cap — the same "Algorithm 2" failure #789 diagnosed for documents, in the carve-out #789 left for chat.

## Design

The session is the event feed's document:

- **Feed** — `changes_since` replaces per-event `history` snippets with `session_digests`: one ~200-char line per session (`agent_name`, `folder`, `event_count`, `first_at`/`last_at`, `opening` user message). A GROUP BY over the same `history_events` window; no new tables. Root context scales with sessions/day, not events/day.
- **Prompt** — new "Reading sessions (one reader subagent per session)" section mirroring the documents rule: triage from the digest alone, dispatch one reader per substantive session (~50/run, budget skips logged), reader reads the ENTIRE transcript via the sessions VFS before writing a fact, INCOMPLETE reads are loud `Log` lines, and facts inferred from `event_count`/`opening` are forbidden. Includes a worked dispatch example.
- **Watermark** — `complete_through` is session-granular: on overflow it stops at the last session that fit (its last event's timestamp minus the microsecond backoff), so unread sessions re-present in full. Same never-drop guarantee, pinned by `test_feed_overflow_never_drops_sessions`.

## Deviation from the proposal

The proposal keeps a "loose session-less events" inline list; those rows can't exist — `history_events.session_id` has been NOT NULL since #699. The inline `history` path is removed entirely rather than shipped dead.

## Not in this PR

- Fresh-bootstrap validation on the heavi-test account (proposal step 5).
- #808's fate (dormant backstop vs. close) once this proves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)