### PR TITLE
SMB landing page: LLM interview chat, skill lead magnet, snapshot report

### DIFF
--- a/backend/routers/marketing.py
+++ b/backend/routers/marketing.py
@@ -6,17 +6,24 @@ be scored from our own data (views and signups per variant) instead of
 relying on X's dashboards. Rows land in analytics_events.
 """
 
-from fastapi import APIRouter, Request
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ..database import get_pool
 from ..middleware import limiter
 from ..services import analytics_events_service
+from ..services.llm import ModelTier, complete_chat
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/marketing", tags=["marketing"])
 
 _POST_LIMIT = "60/minute"
 _GET_LIMIT = "30/minute"
+_CHAT_LIMIT = "30/minute"
 
 _KINDS = {"view", "signup"}
 _VARIANTS = {"drive", "wiki", "connect", "assistant"}
@@ -46,6 +53,87 @@ async def record_marketing_event(request: Request, event: MarketingEvent) -> Non
             "referrer": event.referrer,
         },
     )
+
+
+# The /smb landing page's interview chat. Public and anonymous by design —
+# the model produces the lead-qualifying snapshot report; contact capture and
+# lead email stay in the www app. Strict JSON replies let the page render
+# quick-reply chips and the final report.
+_SMB_CHAT_SYSTEM = """You are running a free "AI Opportunity Snapshot" interview with a small-business owner on the Stash website (joinstash.ai). Stash organizes a business's scattered knowledge into one system any AI can use. The interview qualifies them and produces a one-page report. A human from Stash follows up afterward.
+
+VOICE — non-negotiable:
+- Plain spoken, short sentences, zero jargon. Never say: leverage, streamline, cutting-edge, revolutionize, AI-powered, LLM.
+- Warm, direct, curious — like a helpful local person, not a marketing funnel.
+- Talk in hours and dollars, using THEIR numbers. Never invent a number they didn't give you.
+- One question per turn. Brief acknowledgment of their previous answer first when natural.
+- If they ask something off-topic, answer briefly and steer back to the interview.
+- Never ask for sensitive data (client names, financials, health data). If they volunteer specifics, generalize them.
+
+INTERVIEW — cover these, in roughly this order, adapting wording to what they've said and skipping anything already answered:
+1. What kind of business (offer options: professional services, agency/creative, home services/trades, healthcare/wellness, retail/e-commerce, other)
+2. Team size (Just me / 2-5 / 6-20 / 21+)
+3. Where business knowledge lives today (one organized system / Google Drive + spreadsheets / scattered across 3+ tools / email threads and my head)
+4. What eats the most hours weekly (writing / scheduling & follow-ups / invoicing & admin / answering repeat customer questions / finding information they already have)
+5. Roughly how many hours a week that costs (<3 / 3-5 / 5-10 / 10+)
+6. Whether they could find WHY a big decision was made 3 months ago (written down / buried in email / in my head / honestly no)
+7. How much is in flight tracked only in their head (almost nothing / a few things / more than I'd like to admit)
+8. Their #1 business goal this year — THE SPINE. Free text. Everything in the report must ladder to it.
+9. What an hour of their time is worth (<$50 / $50-100 / $100-250 / $250+)
+10. When they'd want to act if the numbers made sense (this month / this quarter / just exploring)
+
+OUTPUT FORMAT — every reply must be PURE JSON, no markdown, no text outside the JSON object:
+{"message": "<what you say>", "options": ["<chip>", ...], "done": false}
+- "options": include ONLY when multiple-choice chips genuinely help (use the option sets above). Omit for free-text questions.
+- Keep "message" under 60 words.
+
+FINAL TURN — after question 10, reply with:
+{"message": "<one-line wrap-up asking for their name, email, and business name for the report>", "done": true, "report": {
+  "business_type": "...", "goal": "<their exact goal>",
+  "score": <0-100: start 40; +15 knowledge in one organized system; +15 they already use AI (ChatGPT or an agent); +15 clear single time sink; +15 the sink costs 5+ hrs/week>,
+  "tier": "<QUALIFIED if (team 2+ AND 5+ hrs lost AND acting this month/quarter AND hourly value $100+), NURTURE if some of those, EARLY otherwise>",
+  "hours_week": <conservative reclaimable hours: at most half their stated weekly hours, +1 if knowledge is scattered>,
+  "value_month": <hours_week x their hourly-value midpoint (35/75/175/300) x 4.3, rounded down>,
+  "findings": [
+    {"title": "<their #1 time sink>", "before": "<'You said...' with their hours>", "after": "<the fix in plain words>", "hours": "<e.g. ~3 hrs/week back>"},
+    {"title": "...", "before": "...", "after": "...", "hours": "..."},
+    {"title": "...", "before": "...", "after": "...", "hours": "..."}
+  ],
+  "tool": {"name": "...", "why": "<one sentence, for THEIR case>", "cost": "...", "setup": "..."}
+}}
+- Finding 1 = their time sink. Include a decisions/open-loops finding if those live in their head. Include a scattered-knowledge finding if knowledge is scattered. Every finding's "after" should visibly serve their goal.
+- "tool": pick exactly ONE from this list (real current pricing): Claude ($20/mo, ~1 hour setup) for writing; Calendly ($12/mo, ~30 min) for scheduling; FreshBooks ($21/mo, ~2 hours) for invoicing/admin; Chatbase ($40/mo, ~2 hours) for repeat customer questions; Stash (free to start, ~30 min) for finding information they already have."""
+
+
+class SmbChatMessage(BaseModel):
+    role: str = Field(..., pattern=r"^(user|assistant)$")
+    content: str = Field(..., min_length=1, max_length=600)
+
+
+class SmbChatRequest(BaseModel):
+    messages: list[SmbChatMessage] = Field(..., min_length=1, max_length=40)
+
+
+@router.post("/smb-chat")
+@limiter.limit(_CHAT_LIMIT)
+async def smb_chat(request: Request, body: SmbChatRequest) -> dict:
+    text = await complete_chat(
+        messages=[m.model_dump() for m in body.messages],
+        system=_SMB_CHAT_SYSTEM,
+        tier=ModelTier.FAST,
+        max_tokens=1200,
+    )
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        logger.error("smb-chat model reply was not JSON: %s", text[:200])
+        raise HTTPException(status_code=502, detail="Chat is having trouble.")
+    raw = text[start : end + 1]
+    try:
+        reply = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error("smb-chat model reply failed to parse: %s", text[:200])
+        raise HTTPException(status_code=502, detail="Chat is having trouble.") from None
+    return {"reply": reply, "raw": raw}
 
 
 @router.get("/summary")

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -75,6 +75,29 @@ async def complete_text(
     return "".join(getattr(b, "text", "") for b in msg.content)
 
 
+async def complete_chat(
+    *,
+    messages: list[dict],
+    system: str | None = None,
+    tier: ModelTier = ModelTier.FAST,
+    max_tokens: int = 1024,
+) -> str:
+    """Multi-turn Claude completion over a full message transcript.
+
+    Same contract as complete_text but the caller supplies the whole
+    conversation ([{"role": "user"|"assistant", "content": str}, ...])."""
+    client = _get_client()
+    kwargs: dict = {
+        "model": _model_for(tier),
+        "max_tokens": max_tokens,
+        "messages": messages,
+    }
+    if system:
+        kwargs["system"] = system
+    msg = await client.messages.create(**kwargs)
+    return "".join(getattr(b, "text", "") for b in msg.content)
+
+
 _JSON_FENCE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
 
 

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -69,6 +69,7 @@ const USE_CASES = [
   ["Agent Drive", "/agent-drive", "An agent-native VFS for files and Skills"],
   ["Token Monitoring", "/token-monitoring", "See every agent session, like Gong"],
   ["Memory", "/memory", "Three-way retrieval that doesn't miss"],
+  ["For SMBs", "/smb", "Find the hours AI can give back"],
 ];
 
 // CSS-only dropdown (no client JS): opens on hover and on keyboard focus of

--- a/www/app/api/smb-chat/route.ts
+++ b/www/app/api/smb-chat/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.joinstash.ai";
+
+// Same-origin proxy for the /smb interview chat. The LLM call (and the
+// Anthropic key) live in the backend's public marketing router; this just
+// forwards so the browser never makes a cross-origin call.
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const res = await fetch(`${API_URL}/api/v1/marketing/smb-chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  return new NextResponse(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/www/app/smb/AssessmentChat.tsx
+++ b/www/app/smb/AssessmentChat.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { submitSnapshotLead } from "./actions";
+
+// The assessment interview as a real chat. One deterministic routing question
+// (what AI do you use today?) — agent users get the interview skill as a
+// friendly install card; everyone else talks to the model, which runs the
+// interview from /api/smb-chat and ends by producing the snapshot report.
+
+const AGENT_TOOLS = ["Claude Code", "Codex", "Cowork"];
+const AI_OPTIONS = [...AGENT_TOOLS, "ChatGPT", "None yet"];
+
+type Report = {
+  business_type: string;
+  goal: string;
+  score: number;
+  tier: string;
+  hours_week: number;
+  value_month: number;
+  findings: { title: string; before: string; after: string; hours: string }[];
+  tool: { name: string; why: string; cost: string; setup: string };
+};
+
+type ApiReply = {
+  message: string;
+  options?: string[];
+  done?: boolean;
+  report?: Report;
+};
+
+type Bubble =
+  | { kind: "text"; from: "agent" | "you"; text: string }
+  | { kind: "skill"; tool: string };
+
+type ApiMessage = { role: "user" | "assistant"; content: string };
+
+const INTRO =
+  "Hey — I'll ask a few quick questions, about three minutes, then hand you a one-page snapshot.";
+const FIRST_QUESTION = "First one: what AI do you use today?";
+
+function sanitizeReport(r: Report): Report {
+  return {
+    ...r,
+    score: Math.max(0, Math.min(100, Math.round(r.score))),
+    hours_week: Math.max(1, Math.min(20, Math.round(r.hours_week))),
+    value_month: Math.max(0, Math.floor(r.value_month)),
+    findings: r.findings.slice(0, 3),
+  };
+}
+
+export default function AssessmentChat() {
+  const [bubbles, setBubbles] = useState<Bubble[]>([]);
+  const [typing, setTyping] = useState(false);
+  const [mode, setMode] = useState<"routing" | "chat" | "skill" | "contact">("routing");
+  const [apiMessages, setApiMessages] = useState<ApiMessage[]>([]);
+  const [options, setOptions] = useState<string[]>(AI_OPTIONS);
+  const [draft, setDraft] = useState("");
+  const [chatError, setChatError] = useState(false);
+  const [contact, setContact] = useState({ name: "", email: "", business: "" });
+  const [pendingReport, setPendingReport] = useState<Report | null>(null);
+  const [report, setReport] = useState<Report | null>(null);
+  const [sendState, setSendState] = useState<"idle" | "sending">("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const opened = useRef(false);
+
+  useEffect(() => {
+    if (opened.current) return;
+    opened.current = true;
+    const t = timers.current;
+    setTyping(true);
+    t.push(
+      setTimeout(() => setBubbles([{ kind: "text", from: "agent", text: INTRO }]), 550),
+      setTimeout(() => {
+        setBubbles((b) => [...b, { kind: "text", from: "agent", text: FIRST_QUESTION }]);
+        setTyping(false);
+      }, 1100),
+    );
+    return () => t.forEach(clearTimeout);
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [bubbles, typing, report, mode]);
+
+  async function callChat(messages: ApiMessage[]) {
+    setTyping(true);
+    setChatError(false);
+    const res = await fetch("/api/smb-chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages }),
+    });
+    if (!res.ok) {
+      setTyping(false);
+      setChatError(true);
+      return;
+    }
+    const { reply, raw } = (await res.json()) as { reply: ApiReply; raw: string };
+    setApiMessages([...messages, { role: "assistant", content: raw }]);
+    setBubbles((b) => [...b, { kind: "text", from: "agent", text: reply.message }]);
+    setOptions(reply.options ?? []);
+    setTyping(false);
+    if (reply.done && reply.report) {
+      setPendingReport(sanitizeReport(reply.report));
+      setMode("contact");
+    }
+  }
+
+  function sendToChat(text: string) {
+    setBubbles((b) => [...b, { kind: "text", from: "you", text }]);
+    setDraft("");
+    setOptions([]);
+    const messages: ApiMessage[] = [...apiMessages, { role: "user", content: text }];
+    setApiMessages(messages);
+    void callChat(messages);
+  }
+
+  function answerRouting(value: string) {
+    setBubbles((b) => [...b, { kind: "text", from: "you", text: value }]);
+    setOptions([]);
+    if (AGENT_TOOLS.includes(value)) {
+      setMode("skill");
+      setTyping(true);
+      timers.current.push(
+        setTimeout(() => {
+          setBubbles((b) => [
+            ...b,
+            {
+              kind: "text",
+              from: "agent",
+              text: `You're ahead of most businesses. Since you already use ${value}, you can skip the questions — take the interview itself and run it at home. It works on your own files and history, and nothing leaves your computer.`,
+            },
+            { kind: "skill", tool: value },
+          ]);
+          setTyping(false);
+        }, 700),
+      );
+      return;
+    }
+    setMode("chat");
+    const seed: ApiMessage[] = [
+      {
+        role: "user",
+        content: `The AI I use today: ${value}. I'm ready — ask me your first question.`,
+      },
+    ];
+    setApiMessages(seed);
+    void callChat(seed);
+  }
+
+  function retryChat() {
+    void callChat(apiMessages);
+  }
+
+  async function generate() {
+    if (!contact.name.trim() || !contact.email.includes("@")) {
+      setErrorMessage("Add your name and a valid email to get the report.");
+      return;
+    }
+    if (!pendingReport) return;
+    setErrorMessage("");
+    setSendState("sending");
+    const transcript: [string, string][] = bubbles
+      .filter((b): b is Extract<Bubble, { kind: "text" }> => b.kind === "text")
+      .map((b) => [b.from === "you" ? "Visitor" : "Stash", b.text]);
+    const result = await submitSnapshotLead({
+      name: contact.name,
+      email: contact.email,
+      business: contact.business,
+      score: pendingReport.score,
+      tier: pendingReport.tier,
+      transcript,
+    });
+    setSendState("idle");
+    if (result.status === "error") {
+      setErrorMessage(result.message ?? "Something went wrong.");
+      return;
+    }
+    setReport(pendingReport);
+  }
+
+  if (report) {
+    return <SnapshotReport report={report} contact={contact} />;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-[14px] border border-border bg-background shadow-[var(--shadow-card)]">
+      <div className="flex items-center gap-2 border-b border-border-subtle bg-surface px-5 py-3">
+        <span className="live-pulse inline-block h-2 w-2 rounded-full bg-brand" />
+        <span className="text-[13px] font-medium text-ink">Free snapshot</span>
+        <span className="ml-auto text-[12px] text-muted">~3 min</span>
+      </div>
+
+      <div ref={scrollRef} className="max-h-[460px] space-y-3 overflow-y-auto p-5">
+        {bubbles.map((b, i) =>
+          b.kind === "skill" ? (
+            <SkillDrop key={i} tool={b.tool} />
+          ) : (
+            <div key={i} className={b.from === "you" ? "flex justify-end" : "flex"}>
+              <div
+                className={
+                  b.from === "you"
+                    ? "max-w-[80%] rounded-[12px] rounded-br-[3px] bg-brand px-4 py-2.5 text-[14px] leading-[1.5] text-white"
+                    : "max-w-[80%] rounded-[12px] rounded-bl-[3px] bg-raised px-4 py-2.5 text-[14px] leading-[1.5] text-ink"
+                }
+              >
+                {b.text}
+              </div>
+            </div>
+          ),
+        )}
+        {typing && (
+          <div className="flex">
+            <div className="rounded-[12px] rounded-bl-[3px] bg-raised px-4 py-3">
+              <span className="typing-dots inline-flex gap-1">
+                <i className="h-1.5 w-1.5 rounded-full bg-dim" />
+                <i className="h-1.5 w-1.5 rounded-full bg-dim" />
+                <i className="h-1.5 w-1.5 rounded-full bg-dim" />
+              </span>
+            </div>
+          </div>
+        )}
+        {chatError && (
+          <div className="flex">
+            <div className="rounded-[12px] rounded-bl-[3px] border border-border bg-surface px-4 py-2.5 text-[13.5px] text-dim">
+              Hit a snag on my end.{" "}
+              <button onClick={retryChat} className="font-medium text-brand hover:underline">
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {mode === "routing" && !typing && (
+        <div className="border-t border-border-subtle p-5">
+          <div className="flex flex-wrap gap-2">
+            {options.map((o) => (
+              <button
+                key={o}
+                onClick={() => answerRouting(o)}
+                className="rounded-full border border-border bg-background px-4 py-2 text-[13.5px] text-ink transition hover:border-brand hover:text-brand"
+              >
+                {o}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {mode === "chat" && (
+        <div className="space-y-2.5 border-t border-border-subtle p-5">
+          {options.length > 0 && !typing && (
+            <div className="flex flex-wrap gap-2">
+              {options.map((o) => (
+                <button
+                  key={o}
+                  onClick={() => sendToChat(o)}
+                  className="rounded-full border border-border bg-background px-4 py-2 text-[13.5px] text-ink transition hover:border-brand hover:text-brand"
+                >
+                  {o}
+                </button>
+              ))}
+            </div>
+          )}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (draft.trim() && !typing) sendToChat(draft.trim());
+            }}
+            className="flex gap-2"
+          >
+            <input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="Type your answer…"
+              maxLength={500}
+              className="h-11 flex-1 rounded-lg border border-border bg-background px-4 text-[14px] text-ink outline-none focus:border-brand"
+            />
+            <button
+              type="submit"
+              disabled={typing || !draft.trim()}
+              className="h-11 rounded-lg bg-brand px-5 text-[14px] font-medium text-white transition hover:bg-brand-hover disabled:opacity-50"
+            >
+              Send
+            </button>
+          </form>
+        </div>
+      )}
+
+      {mode === "contact" && !typing && (
+        <div className="space-y-2.5 border-t border-border-subtle p-5">
+          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3">
+            <input
+              value={contact.name}
+              onChange={(e) => setContact((c) => ({ ...c, name: e.target.value }))}
+              placeholder="Your name"
+              className="h-11 rounded-lg border border-border bg-background px-4 text-[14px] text-ink outline-none focus:border-brand"
+            />
+            <input
+              value={contact.email}
+              onChange={(e) => setContact((c) => ({ ...c, email: e.target.value }))}
+              placeholder="Email"
+              type="email"
+              className="h-11 rounded-lg border border-border bg-background px-4 text-[14px] text-ink outline-none focus:border-brand"
+            />
+            <input
+              value={contact.business}
+              onChange={(e) => setContact((c) => ({ ...c, business: e.target.value }))}
+              placeholder="Business name"
+              className="h-11 rounded-lg border border-border bg-background px-4 text-[14px] text-ink outline-none focus:border-brand"
+            />
+          </div>
+          <button
+            onClick={generate}
+            disabled={sendState === "sending"}
+            className="h-11 w-full rounded-lg bg-brand px-5 text-[14px] font-medium text-white transition hover:bg-brand-hover disabled:opacity-60"
+          >
+            {sendState === "sending" ? "Building your snapshot…" : "Show my snapshot →"}
+          </button>
+          {errorMessage && <p className="text-[13px] text-red-600">{errorMessage}</p>}
+          <p className="text-[12px] text-muted">
+            Your report renders right here. We&apos;ll also reach out about the full assessment
+            — no spam, unsubscribe with one reply.
+          </p>
+        </div>
+      )}
+
+      <style>{`
+        .typing-dots i { animation: typing-bounce 1.2s infinite; }
+        .typing-dots i:nth-child(2) { animation-delay: 0.15s; }
+        .typing-dots i:nth-child(3) { animation-delay: 0.3s; }
+        @keyframes typing-bounce {
+          0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+          30% { transform: translateY(-3px); opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+const INSTALL_COMMAND = `curl -fsSL https://joinstash.ai/smb/SKILL.md --create-dirs -o ~/.claude/skills/ai-assessment-interview/SKILL.md && curl -fsSL https://joinstash.ai/smb/report-template.html -o ~/.claude/skills/ai-assessment-interview/report-template.html`;
+
+// The lead magnet for people already running an agent: a friendly three-step
+// card — no terminal styling, one copy button hides the command.
+function SkillDrop({ tool }: { tool: string }) {
+  const [copied, setCopied] = useState(false);
+  const isCowork = tool === "Cowork";
+
+  function copy() {
+    void navigator.clipboard.writeText(INSTALL_COMMAND);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="max-w-[94%] rounded-[12px] border border-border bg-surface p-5">
+      <p className="font-display text-[15.5px] font-bold text-ink">
+        The interview, as a file your AI can run
+      </p>
+      <ol className="mt-3 space-y-2.5">
+        <StepItem n={1}>
+          {isCowork ? (
+            <>
+              <a href="/smb/SKILL.md" download className="font-medium text-brand hover:underline">
+                Download the skill file
+              </a>{" "}
+              and drag it into your Cowork session.
+            </>
+          ) : (
+            <>
+              Copy the setup line below and paste it into your terminal — or{" "}
+              <a href="/smb/SKILL.md" download className="font-medium text-brand hover:underline">
+                download the file
+              </a>{" "}
+              instead.
+            </>
+          )}
+        </StepItem>
+        <StepItem n={2}>
+          Say: <span className="font-medium text-ink">&ldquo;run the assessment interview&rdquo;</span>
+        </StepItem>
+        <StepItem n={3}>
+          Answer its questions like you would here — it writes the same one-page report, using
+          your real files and history. Nothing leaves your computer.
+        </StepItem>
+      </ol>
+      <div className="mt-4 flex flex-wrap items-center gap-2.5">
+        {!isCowork && (
+          <button
+            onClick={copy}
+            className="inline-flex h-10 items-center rounded-lg border border-border bg-background px-4 text-[13.5px] font-medium text-ink transition hover:border-ink"
+          >
+            {copied ? "Copied ✓" : "Copy setup line"}
+          </button>
+        )}
+        <a
+          href="/contact-sales"
+          className="inline-flex h-10 items-center rounded-lg bg-brand px-4 text-[13.5px] font-medium text-white transition hover:bg-brand-hover"
+        >
+          Or just book a call →
+        </a>
+      </div>
+      <p className="mt-3 text-[12px] leading-[1.5] text-muted">
+        Free — use it, share it, keep it. When the report finds real hours, we&apos;ll help you
+        get them back.
+      </p>
+    </div>
+  );
+}
+
+function StepItem({ n, children }: { n: number; children: React.ReactNode }) {
+  return (
+    <li className="flex gap-3 text-[14px] leading-[1.55] text-dim">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-raised font-display text-[12.5px] font-bold text-ink">
+        {n}
+      </span>
+      <span className="pt-0.5">{children}</span>
+    </li>
+  );
+}
+
+function SnapshotReport({
+  report,
+  contact,
+}: {
+  report: Report;
+  contact: { name: string; email: string; business: string };
+}) {
+  const today = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  return (
+    <div>
+      <style>{`@media print {
+        body * { visibility: hidden; }
+        #snapshot-report, #snapshot-report * { visibility: visible; }
+        #snapshot-report { position: absolute; inset: 0; margin: 0; border: none; box-shadow: none; }
+      }`}</style>
+
+      <div
+        id="snapshot-report"
+        className="rounded-[14px] border border-border bg-background p-7 shadow-[var(--shadow-card)] sm:p-9"
+      >
+        <h3 className="font-display text-[28px] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+          Where {contact.business || contact.name} is leaving hours on the table
+        </h3>
+        <p className="mt-1.5 text-[12.5px] text-muted">
+          Prepared for {contact.name} · {today} · {report.business_type}
+        </p>
+
+        <div className="mt-7 flex items-center gap-5">
+          <div className="font-display text-[52px] font-bold leading-none text-brand">
+            {report.score}
+            <span className="text-[18px] text-muted">/100</span>
+          </div>
+          <div className="flex-1">
+            <div className="h-2.5 overflow-hidden rounded-full bg-raised">
+              <div className="h-full bg-brand" style={{ width: `${report.score}%` }} />
+            </div>
+            <p className="mt-2 text-[13px] leading-[1.5] text-dim">
+              Your AI-readiness score. Everything below ladders to the goal you gave us:{" "}
+              <span className="text-ink">&ldquo;{report.goal}&rdquo;</span>
+            </p>
+          </div>
+        </div>
+
+        <h4 className="mt-9 font-display text-[17px] font-bold text-ink">
+          Three places your hours are going
+        </h4>
+        <div className="mt-3 space-y-3">
+          {report.findings.map((f, i) => (
+            <div key={i} className="rounded-[12px] border border-border bg-surface p-5">
+              <div className="flex items-baseline gap-3">
+                <span className="font-display text-[15px] font-bold text-brand">0{i + 1}</span>
+                <span className="font-display text-[15.5px] font-bold text-ink">{f.title}</span>
+                <span className="ml-auto shrink-0 text-[12.5px] font-medium text-brand">
+                  {f.hours}
+                </span>
+              </div>
+              <p className="mt-2 text-[14px] leading-[1.55] text-dim">{f.before}</p>
+              <p className="mt-1 text-[14px] leading-[1.55] text-ink">→ {f.after}</p>
+            </div>
+          ))}
+        </div>
+
+        <h4 className="mt-9 font-display text-[17px] font-bold text-ink">
+          Start here: one tool, this week
+        </h4>
+        <div className="mt-3 flex flex-wrap items-center gap-x-8 gap-y-3 rounded-[12px] border border-border bg-surface p-5">
+          <div className="min-w-[220px] flex-1">
+            <div className="font-display text-[16px] font-bold text-ink">{report.tool.name}</div>
+            <p className="mt-1 text-[13.5px] leading-[1.5] text-dim">{report.tool.why}</p>
+          </div>
+          <Stat label="Cost" value={report.tool.cost} />
+          <Stat label="Setup" value={report.tool.setup} />
+        </div>
+
+        <div className="mt-9 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="rounded-[12px] border border-border bg-surface p-6 text-center">
+            <div className="font-display text-[34px] font-bold text-brand">
+              {report.hours_week} hrs
+            </div>
+            <p className="mt-1 text-[13px] text-dim">
+              reclaimable every week — from your own numbers
+            </p>
+          </div>
+          <div className="rounded-[12px] border border-border bg-surface p-6 text-center">
+            <div className="font-display text-[34px] font-bold text-brand">
+              ${report.value_month.toLocaleString()}
+            </div>
+            <p className="mt-1 text-[13px] text-dim">
+              per month, at the hourly value you gave us
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-7 text-[12.5px] leading-[1.6] text-muted">
+          This snapshot was built from a 3-minute conversation. The full assessment goes nine
+          sections deep: an impact–effort matrix, six quick wins, a full tool stack with ROI
+          math, and a 4-day rollout plan.
+        </p>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3 print:hidden">
+        <a
+          href="/contact-sales"
+          className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white transition hover:bg-brand-hover"
+        >
+          Book the full assessment →
+        </a>
+        <button
+          onClick={() => window.print()}
+          className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+        >
+          Download as PDF
+        </button>
+        <p className="w-full text-[12.5px] text-muted sm:w-auto">
+          If the full assessment doesn&apos;t find you $999/month in recoverable time, you
+          don&apos;t pay.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[10.5px] font-medium uppercase tracking-[0.12em] text-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 text-[14px] font-medium text-ink">{value}</div>
+    </div>
+  );
+}

--- a/www/app/smb/actions.ts
+++ b/www/app/smb/actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { escapeHtml, sendPostmark } from "../_lib/postmark";
+
+const SALES_EMAIL = "sam@joinstash.ai";
+const FROM_ADDRESS = "Stash <notifications@joinstash.ai>";
+
+export type SnapshotLeadState = {
+  status: "idle" | "ok" | "error";
+  message?: string;
+};
+
+// Receives the completed assessment interview: contact info, the full chat
+// transcript, and the model-produced qualification. Delivers the lead to
+// sales; the visitor gets their report rendered client-side.
+export async function submitSnapshotLead(payload: {
+  name: string;
+  email: string;
+  business: string;
+  score: number;
+  tier: string;
+  transcript: [string, string][];
+}): Promise<SnapshotLeadState> {
+  const { name, email, business, score, tier, transcript } = payload;
+
+  if (!name.trim() || !email.includes("@")) {
+    return { status: "error", message: "Name and a valid email are required." };
+  }
+
+  const token = process.env.POSTMARK_SERVER_TOKEN;
+  if (!token) {
+    console.error("POSTMARK_SERVER_TOKEN is not set; cannot deliver snapshot lead", {
+      name,
+      email,
+      business,
+    });
+    return {
+      status: "error",
+      message: "We couldn't save your snapshot. Email sam@joinstash.ai directly.",
+    };
+  }
+
+  const transcriptRows = transcript
+    .map(
+      ([speaker, text]) =>
+        `<tr><td style="padding:4px 12px 4px 0;color:#6B655B;vertical-align:top">${escapeHtml(speaker)}</td><td style="padding:4px 0">${escapeHtml(text)}</td></tr>`,
+    )
+    .join("");
+
+  const leadHtml = `
+    <h2>New SMB snapshot lead</h2>
+    <p><strong>Name:</strong> ${escapeHtml(name)}</p>
+    <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+    <p><strong>Business:</strong> ${escapeHtml(business) || "—"}</p>
+    <p><strong>Qualification:</strong> ${escapeHtml(tier)} (score ${score})</p>
+    <h3>Interview transcript</h3>
+    <table>${transcriptRows}</table>
+  `;
+
+  const res = await sendPostmark(token, {
+    From: FROM_ADDRESS,
+    To: SALES_EMAIL,
+    ReplyTo: email,
+    Subject: `SMB snapshot lead — ${name}${business ? ` (${business})` : ""} · ${tier}`,
+    HtmlBody: leadHtml,
+    MessageStream: "outbound",
+  });
+
+  if (!res.ok) {
+    console.error("Postmark snapshot lead send failed", res.status, await res.text());
+    return {
+      status: "error",
+      message: "We couldn't save your snapshot. Email sam@joinstash.ai directly.",
+    };
+  }
+
+  return { status: "ok" };
+}

--- a/www/app/smb/page.tsx
+++ b/www/app/smb/page.tsx
@@ -1,0 +1,187 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import ScrollLink from "../_components/ScrollLink";
+import SiteHeader from "../_components/SiteHeader";
+import Texture from "../_components/Texture";
+import AssessmentChat from "./AssessmentChat";
+
+export const metadata: Metadata = {
+  title: "Stash for SMBs · Free AI Snapshot",
+  description:
+    "Three minutes of questions, one page of answers: where your hours are going, the one tool to start with, and what those hours are worth — from your own numbers.",
+};
+
+// Drop the explainer video's YouTube ID here when it's published.
+const YOUTUBE_VIDEO_ID = "";
+
+const PAINS = [
+  {
+    title: "Knowledge is everywhere",
+    body: "Client info in Google Drive, pricing in a spreadsheet, history in email threads — and the rest in your head.",
+  },
+  {
+    title: "You keep re-explaining",
+    body: "Every new tool, contractor, and hire gets the same walkthrough of how your business works. Again.",
+  },
+  {
+    title: "ChatGPT doesn't know you",
+    body: "You've tried AI, but it writes like a stranger — because it's never seen your clients, your voice, or your work.",
+  },
+  {
+    title: "Follow-ups slip",
+    body: "Proposals, promises, and open loops live in your head. Some of them don't make it out.",
+  },
+  {
+    title: "Decisions get forgotten",
+    body: "Why did we pick that vendor? Nobody remembers. So it gets debated, decided, and forgotten all over again.",
+  },
+  {
+    title: "You don't know where to start",
+    body: "You know AI could help. The 400 tools screaming for attention don't make it any clearer.",
+  },
+];
+
+export default function SmbPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <SiteHeader ctaHref="#snapshot" />
+
+      <section className="relative overflow-hidden border-b border-border-subtle py-24 md:py-32">
+        <Texture className="h-[560px]" fade="top" />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[520px]"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 18% 8%, rgba(249,115,22,0.10), transparent 60%)",
+          }}
+        />
+        <div className="relative z-10 mx-auto max-w-[1200px] px-7">
+          <h1 className="max-w-[920px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-bold leading-[1.02] tracking-[-0.035em] text-ink">
+            Find out where your business is{" "}
+            <span className="text-brand">leaving hours on the table.</span>
+          </h1>
+          <p className="mt-7 max-w-[560px] text-[18px] leading-[1.55] text-foreground">
+            A few questions, one page: where your hours go, what they&apos;re
+            worth, and the one tool to start with.
+          </p>
+          <div className="mt-9 flex flex-wrap items-center gap-3">
+            <ScrollLink
+              to="#snapshot"
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Get my free snapshot →
+            </ScrollLink>
+            <Link
+              href="/contact-sales"
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
+            >
+              Book a call
+            </Link>
+          </div>
+          <p className="mt-4 text-[13px] text-muted">
+            3 minutes · no signup · the report is yours either way
+          </p>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="max-w-[720px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Sound familiar?
+          </h2>
+          <p className="mt-4 max-w-[560px] text-[16px] leading-[1.6] text-dim">
+            If two or more of these hit home, the snapshot will find you hours.
+          </p>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {PAINS.map((p) => (
+              <div
+                key={p.title}
+                className="rounded-[12px] border border-border bg-background p-6 transition-colors hover:border-brand"
+              >
+                <h3 className="font-display text-[17px] font-bold tracking-[-0.01em] text-ink">
+                  {p.title}
+                </h3>
+                <p className="mt-2 text-[14.5px] leading-[1.55] text-dim">{p.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8 text-center">
+            <ScrollLink
+              to="#snapshot"
+              className="text-[15px] font-medium text-brand transition hover:text-brand-hover"
+            >
+              That&apos;s us — show me the snapshot →
+            </ScrollLink>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="max-w-[720px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            What we do, in two minutes.
+          </h2>
+          <div className="mt-10 aspect-video max-w-[860px] overflow-hidden rounded-[14px] border border-border shadow-[var(--shadow-terminal)]">
+            {YOUTUBE_VIDEO_ID ? (
+              <iframe
+                className="h-full w-full"
+                src={`https://www.youtube-nocookie.com/embed/${YOUTUBE_VIDEO_ID}`}
+                title="What we do, in two minutes"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-inverted">
+                <p className="text-[14px] text-on-inverted-dim">
+                  Explainer video coming soon
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section id="snapshot" className="border-b border-border-subtle bg-surface py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <h2 className="max-w-[760px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Answer a few questions. Walk away with{" "}
+            <span className="text-brand">the report.</span>
+          </h2>
+          <p className="mt-5 max-w-[620px] text-[16px] leading-[1.6] text-dim">
+            The same interview we run on paid engagements, self-serve. Already
+            using an AI agent like Claude Code? Say so — we&apos;ll hand you the
+            interview itself to run at home.
+          </p>
+          <div className="mt-10 max-w-[760px]">
+            <AssessmentChat />
+          </div>
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden py-28 text-center">
+        <Texture className="opacity-70" fade="center" />
+        <div className="relative z-10 mx-auto max-w-[1200px] px-7">
+          <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-bold leading-[1.0] tracking-[-0.035em] text-ink">
+            We find the hours.{" "}
+            <span className="text-brand">Then we build the system that keeps them.</span>
+          </h2>
+          <p className="mx-auto mt-5 max-w-[520px] text-[16px] leading-[1.6] text-dim">
+            The snapshot shows where your business is leaving hours on the
+            table. The full engagement goes further: a complete audit, then one
+            organized system for everything your business knows — that you own.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <ScrollLink
+              to="#snapshot"
+              className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover"
+            >
+              Get my free snapshot →
+            </ScrollLink>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/www/public/smb/SKILL.md
+++ b/www/public/smb/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: ai-assessment-interview
+description: >
+  Run a guided AI-readiness interview with a business owner, qualify them as a lead,
+  and generate a one-page "AI Opportunity Snapshot" report (HTML) in the assessment
+  brand style. Use when asked to "interview a prospect", "qualify this lead",
+  "run the assessment interview", or "generate a snapshot report". Works two ways:
+  operator-led (you on a call with the prospect) or self-serve (the prospect runs
+  this prompt themselves and sends back the result).
+---
+
+# AI Assessment Interview & Snapshot Report
+
+You are conducting a short, friendly AI-readiness interview for a small business,
+then generating a one-page report. The report is the free sample of a paid
+$999 AI Tools Assessment — it must look premium and every number in it must come
+from the interviewee's own answers. NEVER invent hours, costs, or savings.
+
+## Voice & style (non-negotiable)
+
+This offer sells organization, not AI hype — lead with where their time and knowledge
+go, not with technology. Rules for everything customer-facing (questions AND report):
+
+- Plain spoken, short sentences, zero jargon. "A tool that drafts your quotes," never
+  "an LLM-powered generation pipeline." Never say: leverage, streamline, cutting-edge,
+  revolutionize, AI-powered.
+- Talk in **hours and dollars**, their numbers, with attribution: "you said invoicing
+  takes about 3 hours a week." If they didn't say it, it doesn't go in the report.
+- Sound like a helpful local person, not a marketing funnel. Warm, direct, curious.
+- One CTA per touchpoint. The paid assessment is mentioned exactly once, in the CTA.
+- Sensitive info: this interview needs categories and hour estimates ONLY. Never ask
+  for financials, client names, patient/customer data, or account details — if they
+  volunteer specifics, generalize them in the report ("a key client" not the name).
+
+## Phase 1 — Interview (use AskUserQuestion, 3 rounds max)
+
+Keep it under 5 minutes. Batch questions; don't ask one at a time beyond these rounds.
+
+**Round 1 — Context (multiSelect where noted):**
+1. "What kind of business is it?" — options: Professional services (law/accounting/consulting),
+   Agency/creative, Home services/trades, Healthcare/wellness, Retail/e-commerce, Other
+2. "How many people, including you?" — Just me / 2–5 / 6–20 / 21+
+3. "Where does business knowledge live today?" (multiSelect) — Google Drive/Docs,
+   Spreadsheets, Notion/Asana/CRM, Email threads, Paper/my head
+
+**Round 2 — Pain (the report is built from these answers; probes adapted from the
+discovery method in the source video — they map to knowledge-base note types):**
+4. "What eats the most hours every week?" — options: Writing (emails/proposals/content),
+   Scheduling & follow-ups, Invoicing/quotes/admin, Answering the same customer questions,
+   Finding information we already have
+5. "Roughly how many hours a week does that cost you (or the team)?" — <3 / 3–5 / 5–10 / 10+
+6. "If you made a big decision three months ago — could you find *why* you made it today?" —
+   Yes, it's written down / It's in email/meeting notes somewhere / It's in my head /
+   Honestly, no  *(maps to: decisions & rationale)*
+7. "How much is currently in flight that's only tracked in your head — proposals, follow-ups,
+   promises to clients?" — Almost nothing / A few things / More than I'd like to admit
+   *(maps to: open loops)*
+8. "What have you already tried with AI?" — Nothing yet / ChatGPT sometimes /
+   A few tools, didn't stick / We use AI daily
+
+**Round 3 — The spine + qualification (the video anchors everything to the client's
+goals — "I can draw a line from every other thing in my business to a goal"):**
+9. Free text: "What's the #1 goal for the business this year?" *(this is the SPINE —
+   every finding in the report must visibly ladder to it)*
+10. "If you could reliably buy back those hours, what's an hour of your time worth?" —
+    <$50 / $50–100 / $100–250 / $250+
+11. "If the numbers made sense, when would you want to act?" — This month / This quarter /
+    Just exploring
+12. Free text: "What's the one thing you'd automate tomorrow if you could?"
+
+**Round 4 — Optional usage audit (consent required):**
+13. "Do you (or anyone on the team) already use an AI agent like Claude Code, Codex, or
+    Claude Cowork on this machine?" — Yes, Claude Code / Yes, Codex / Yes, Cowork /
+    More than one / No
+14. If yes: "Want me to analyze your local session history to ground this assessment in
+    your REAL usage? It's read-only, stays on this machine, nothing is uploaded, and the
+    report only includes aggregate numbers — never your actual prompts." — Yes, analyze it /
+    No thanks
+
+## Phase 1.5 — Local usage audit (ONLY if they said yes to Q14)
+
+Never run this without the explicit yes. If consented:
+
+1. Glob for session history (parse defensively; schemas vary):
+   - Claude Code: `~/.claude/projects/**/*.jsonl` and `~/.config/claude/projects/**/*.jsonl`
+   - Codex CLI: `~/.codex/sessions/**/*.jsonl` and `~/.codex/history.jsonl`
+   - Cowork: check `~/Library/Application Support/Cowork` / ask where their sessions live
+2. Extract aggregates only: session count, active days, total tokens, top tools used,
+   files re-read across 2+ sessions (repeated context), and recurring prompt themes.
+   A full analyzer exists in the `ai-usage-report` skill (`content/audit/ai-usage-report/`)
+   — reuse its `scripts/analyze.py` if available rather than rewriting.
+3. Use findings to sharpen the snapshot: real re-explained context becomes Finding 1
+   evidence ("your own history shows you re-briefed the agent on the same project N times"),
+   and fill the report's optional `{{USAGE_SECTION}}` with 2–3 aggregate stats.
+4. Guardrails: read-only, local, aggregates only in the report, never quote raw prompts,
+   never headline a number you didn't verify. If no history is found, say which paths you
+   checked and skip the section.
+
+If they said no — skip entirely, leave `{{USAGE_SECTION}}` empty, and don't mention it again.
+
+Adapt wording to what they've already said; skip anything already answered. If the
+interviewee is the operator role-playing with notes from a call, accept a pasted
+transcript instead and extract answers from it.
+
+## Phase 2 — Qualify (do this silently; do not show scoring to a prospect)
+
+Score: team size (2–5: +2, 6–20: +3, 21+: +2, solo: +1) · hours lost (10+: +3, 5–10: +2,
+3–5: +1) · hourly value ($100–250: +2, $250+: +3, $50–100: +1) · urgency (this month: +3,
+this quarter: +2) · tried AI but didn't stick: +1 (they've felt the gap) · decisions or
+open loops live "in my head" (Q6/Q7): +1 (the knowledge-scatter pain is live) · already
+uses an agent (Claude Code/Codex/Cowork): +2 (AI-forward buyer, shorter sales cycle).
+
+- **7+ = QUALIFIED** — full snapshot + strong CTA to book the paid assessment
+- **4–6 = NURTURE** — full snapshot, softer CTA ("keep this; here's my calendar when ready")
+- **<4 = DISQUALIFIED** — still generate the snapshot (goodwill + referrals), CTA becomes
+  "pass this to a business owner who needs it"
+
+In operator mode, append a private qualification note (score, reasoning, recommended
+follow-up) AFTER the report is delivered — never inside the report file.
+
+## Phase 3 — Generate the Snapshot report
+
+1. Read `report-template.html` in this skill's directory.
+2. Fill every `{{PLACEHOLDER}}`:
+   - `{{BUSINESS_NAME}}`, `{{DATE}}`, `{{BUSINESS_TYPE}}`
+   - `{{SCORE}}` (0–100 AI-readiness: base 40; +15 knowledge centralized; +15 tried tools;
+     +15 clear single time sink; +15 hours already quantified; show as meter)
+   - `{{FINDING_1..3}}`: pain → specific fix → hours back. Finding 1 must target their
+     answer to Q4/Q12. Use their own hour numbers with "you said" language. Each finding
+     must visibly ladder to the SPINE (their Q9 goal): "…which puts those hours back into
+     [their goal]." If they said decisions/open loops live in their head (Q6/Q7), one
+     finding should address it — that's the thread that later sells the knowledge-base
+     build ("a simple system that captures decisions and follow-ups automatically").
+   - `{{TOOL_NAME}}, {{TOOL_COST}}, {{TOOL_SETUP}}, {{TOOL_SAVES}}`: ONE real tool with
+     current real pricing for the biggest quick win. Verify pricing if uncertain — never
+     guess a price.
+   - `{{HOURS_WEEK}}`: conservative total reclaimable hours (never exceed what they reported)
+   - `{{VALUE_MONTH}}`: hours × their stated hourly value × 4.3, rounded down, shown as
+     "at the hourly value you gave me"
+   - `{{CTA_BLOCK}}`: per qualification tier above. For QUALIFIED, always include the
+     guarantee, verbatim in spirit: "If the full assessment doesn't find you at least
+     $999/month in recoverable time, you don't pay." Frame the paid product as the rest
+     of this same report: "This page came from [N] minutes. The full assessment is nine
+     pages from one hour — with the ROI math and a 4-day rollout plan."
+3. Save as `snapshot-{{business-slug}}.html`. Offer a PDF export if tools allow.
+
+Rules: one page only; short sentences; no jargon ("a tool that drafts your quotes" not
+"an LLM-powered generation pipeline"); every number traceable to an answer; the full
+9-section assessment is referenced ONCE, in the CTA, at $999.
+
+## Phase 4 — Close
+
+- Qualified prospect (self-serve mode): end with "Email this page back to {{OPERATOR_EMAIL}}
+  and we'll schedule your full assessment."
+- Operator mode: deliver the report file, then the private qualification note with a
+  suggested next touch (book review call / 2-week follow-up / park).

--- a/www/public/smb/report-template.html
+++ b/www/public/smb/report-template.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AI Opportunity Snapshot — {{BUSINESS_NAME}}</title>
+<style>
+/* Design tokens matched to the AI Tools Assessment deck (swap for your brand) */
+:root{
+  --orange:#F06000;--orange-bright:#FF7A1A;--slate:#8090A0;
+  --black:#000;--charcoal:#1A1A1A;--charcoal-2:#242424;
+  --white:#FFF;--cream:#F0E0D0;--cream-dim:rgba(240,224,208,.65);
+  --border-subtle:rgba(240,224,208,.10);--border-strong:rgba(240,224,208,.25);
+  --font-display:'Montserrat',system-ui,-apple-system,sans-serif;
+  --font-body:'Inter',system-ui,-apple-system,sans-serif;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--black);color:var(--cream);font:15px/1.6 var(--font-body)}
+.page{max-width:820px;margin:0 auto;padding:48px 32px 64px}
+.eyebrow{font-family:var(--font-body);text-transform:uppercase;letter-spacing:.14em;
+  font-size:11px;color:var(--slate);margin:0 0 8px}
+h1{font-family:var(--font-display);font-weight:800;color:var(--white);
+  font-size:40px;line-height:1.05;letter-spacing:.01em;margin:0}
+h1 .accent{color:var(--orange)}
+h2{font-family:var(--font-display);font-weight:800;color:var(--white);font-size:20px;margin:0 0 12px}
+.meta{display:flex;gap:32px;margin-top:20px;padding-top:20px;border-top:1px solid var(--border-subtle)}
+.meta div span{display:block}
+.meta .l{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:var(--slate)}
+.meta .v{color:var(--white);font-weight:600;margin-top:2px}
+.section{margin-top:40px}
+.card{background:var(--charcoal);border:1px solid var(--border-subtle);padding:20px 22px;margin:10px 0}
+.score-row{display:flex;align-items:center;gap:20px}
+.score-num{font-family:var(--font-display);font-weight:800;font-size:56px;color:var(--orange);line-height:1}
+.score-num small{font-size:18px;color:var(--slate);font-weight:400}
+.meter{flex:1;height:10px;background:var(--charcoal-2);position:relative}
+.meter .fill{position:absolute;inset:0 auto 0 0;width:{{SCORE}}%;background:linear-gradient(90deg,var(--orange),var(--orange-bright))}
+.finding{display:grid;grid-template-columns:34px 1fr;gap:14px}
+.finding .n{font-family:var(--font-display);font-weight:800;color:var(--orange);font-size:20px}
+.finding h3{margin:0 0 6px;color:var(--white);font-size:15.5px;font-family:var(--font-display);font-weight:800}
+.ba{margin:6px 0 0;padding-left:12px;border-left:2px solid var(--border-strong)}
+.ba .before{color:var(--cream-dim)}
+.ba .after{color:var(--white)}
+.ba .after b{color:var(--orange-bright)}
+.tool{display:grid;grid-template-columns:1fr auto auto auto;gap:18px;align-items:center}
+.tool .stat span{display:block}
+.tool .stat .l{font-size:10px;text-transform:uppercase;letter-spacing:.12em;color:var(--slate)}
+.tool .stat .v{color:var(--white);font-weight:600}
+.bignums{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.bignum{background:var(--charcoal);border:1px solid var(--border-subtle);padding:22px;text-align:center}
+.bignum .v{font-family:var(--font-display);font-weight:800;font-size:34px;color:var(--orange)}
+.bignum .l{color:var(--cream-dim);font-size:12.5px;margin-top:4px}
+.cta{margin-top:48px;background:var(--charcoal);border:1px solid var(--orange);padding:28px;text-align:center}
+.cta h2{font-size:24px}
+.cta p{color:var(--cream-dim);max-width:52ch;margin:8px auto 0}
+.cta .btn{display:inline-block;margin-top:18px;background:var(--orange);color:var(--white);
+  padding:13px 30px;text-decoration:none;font-family:var(--font-display);font-weight:800;letter-spacing:.02em}
+.foot{margin-top:28px;color:var(--slate);font-size:12px;text-align:center}
+.pagenum{margin-top:40px;color:var(--slate);font-size:11px;letter-spacing:.14em;text-align:right}
+@media print{body{background:#000}.page{padding:24px}}
+@media(max-width:640px){.tool{grid-template-columns:1fr 1fr}.meta{flex-wrap:wrap;gap:16px}.bignums{grid-template-columns:1fr}}
+</style></head><body><div class="page">
+
+<p class="eyebrow">AI Opportunity Snapshot · Free Preview</p>
+<h1>Where <span class="accent">{{BUSINESS_NAME}}</span> is leaving hours on the table</h1>
+<div class="meta">
+  <div><span class="l">Prepared for</span><span class="v">{{OWNER_NAME}}</span></div>
+  <div><span class="l">Date</span><span class="v">{{DATE}}</span></div>
+  <div><span class="l">Business type</span><span class="v">{{BUSINESS_TYPE}}</span></div>
+</div>
+
+<div class="section">
+  <h2>Your AI-readiness score</h2>
+  <div class="card score-row">
+    <div class="score-num">{{SCORE}}<small>/100</small></div>
+    <div style="flex:1">
+      <div class="meter"><div class="fill"></div></div>
+      <p style="margin:10px 0 0;color:var(--cream-dim);font-size:13.5px">{{SCORE_NOTE}}</p>
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <h2>Three places your hours are going</h2>
+  <div class="card finding">
+    <div class="n">01</div>
+    <div><h3>{{FINDING_1_TITLE}}</h3>
+      <div class="ba"><div class="before">{{FINDING_1_BEFORE}}</div>
+      <div class="after">→ {{FINDING_1_AFTER}} <b>{{FINDING_1_HOURS}}</b></div></div></div>
+  </div>
+  <div class="card finding">
+    <div class="n">02</div>
+    <div><h3>{{FINDING_2_TITLE}}</h3>
+      <div class="ba"><div class="before">{{FINDING_2_BEFORE}}</div>
+      <div class="after">→ {{FINDING_2_AFTER}} <b>{{FINDING_2_HOURS}}</b></div></div></div>
+  </div>
+  <div class="card finding">
+    <div class="n">03</div>
+    <div><h3>{{FINDING_3_TITLE}}</h3>
+      <div class="ba"><div class="before">{{FINDING_3_BEFORE}}</div>
+      <div class="after">→ {{FINDING_3_AFTER}} <b>{{FINDING_3_HOURS}}</b></div></div></div>
+  </div>
+</div>
+
+<div class="section">
+  <h2>Start here: one tool, this week</h2>
+  <div class="card tool">
+    <div><h3 style="margin:0;color:var(--white);font-family:var(--font-display)">{{TOOL_NAME}}</h3>
+      <p style="margin:4px 0 0;color:var(--cream-dim);font-size:13.5px">{{TOOL_WHY}}</p></div>
+    <div class="stat"><span class="l">Cost</span><span class="v">{{TOOL_COST}}</span></div>
+    <div class="stat"><span class="l">Setup</span><span class="v">{{TOOL_SETUP}}</span></div>
+    <div class="stat"><span class="l">Saves</span><span class="v">{{TOOL_SAVES}}</span></div>
+  </div>
+</div>
+
+{{USAGE_SECTION}}
+<!-- If the local usage audit was consented to and ran, replace the marker above with:
+<div class="section">
+  <h2>What your own AI history shows</h2>
+  <div class="card">
+    <p style="margin:0 0 12px;color:var(--cream-dim)">With your permission, we analyzed your
+    local agent sessions (read-only, nothing uploaded — aggregate numbers only).</p>
+    <div class="bignums" style="grid-template-columns:1fr 1fr 1fr">
+      <div class="bignum"><div class="v">{{AU_SESSIONS}}</div><div class="l">agent sessions</div></div>
+      <div class="bignum"><div class="v">{{AU_REREADS}}</div><div class="l">times context was re-explained</div></div>
+      <div class="bignum"><div class="v">{{AU_STAT3_V}}</div><div class="l">{{AU_STAT3_L}}</div></div>
+    </div>
+    <p style="margin:12px 0 0;color:var(--cream)">{{AU_INSIGHT}}</p>
+  </div>
+</div>
+Otherwise delete the marker entirely. -->
+
+<div class="section">
+  <h2>The bottom line</h2>
+  <div class="bignums">
+    <div class="bignum"><div class="v">{{HOURS_WEEK}} hrs</div><div class="l">reclaimable every week — from your own numbers</div></div>
+    <div class="bignum"><div class="v">{{VALUE_MONTH}}</div><div class="l">per month, at the hourly value you gave me</div></div>
+  </div>
+</div>
+
+<div class="cta">
+  <h2>{{CTA_HEAD}}</h2>
+  <p>{{CTA_BODY}}</p>
+  <a class="btn" href="{{CTA_LINK}}">{{CTA_BUTTON}} →</a>
+</div>
+
+<p class="foot">This snapshot was built from a {{INTERVIEW_MINUTES}}-minute conversation.
+Every number above came from your answers — nothing was invented.</p>
+<p class="pagenum">1 / 1 · PREVIEW</p>
+
+</div></body></html>


### PR DESCRIPTION
## What

New `/smb` use-case page on the www landing site, targeting small & medium businesses ("For SMBs" in the Use-cases dropdown):

- **Hero + pains**: "Find out where your business is leaving hours on the table" with six qualifying pain cards (scattered knowledge, re-explaining, ChatGPT-doesn't-know-you, slipping follow-ups, forgotten decisions, where-to-start).
- **Inline interview chat**: first question ("what AI do you use today?") routes — Claude Code / Codex / Cowork users get the free interview skill as a friendly 3-step install card; ChatGPT/none continues into an LLM-run interview.
- **LLM interview**: `POST /api/v1/marketing/smb-chat` (public, `30/minute` rate limit, Haiku via `services/llm.py`'s new `complete_chat`). Strict-JSON replies drive quick-reply chips; the final turn emits a one-page "AI Opportunity Snapshot" report (score, 3 findings, one tool, hours/$ reclaimable).
- **Lead capture**: contact form gates the report; the lead email (Postmark) carries the full chat transcript + model-assigned qualification tier.
- **Video slot**: placeholder until the explainer's YouTube ID is dropped in.

## Why backend

The Anthropic key stays server-side in the backend (www holds no LLM secret). The www `/api/smb-chat` route is a same-origin proxy following the existing `/api/track` pattern.

## Testing

- www build + lint green; ruff clean on backend files.
- Headless-browser QA of both chat branches locally (skill card renders; interview flow verified up to the LLM call, which 401s locally because the local backend key is rotated — prod key is valid per owner).
- Post-merge: verify live at joinstash.ai/smb (owner-approved prod test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9HiDrsxXHYPUxVkaijsEX