### PR TITLE
Auth0: trust Google connection for email_verified on every login

### DIFF
--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -42,6 +42,13 @@ async def get_or_create_user_row_from_auth0(
     """
     pool = get_pool()
 
+    # A Google login is Google itself vouching that the user controls this
+    # address, so trust the connection. The /userinfo email_verified claim is
+    # dropped on returning sessions, which would otherwise leave returning
+    # Google users permanently unverified.
+    if auth0_sub.startswith("google-oauth2|"):
+        email_verified = True
+
     row = await pool.fetchrow(
         "SELECT id, name, display_name, description, created_at, last_seen, "
         f"created_at >= now() - interval '{_NEW_USER_WINDOW_SQL}' AS is_new_user "
@@ -61,6 +68,14 @@ async def get_or_create_user_row_from_auth0(
             # An invite may have been addressed to this email after the account
             # existed (e.g. before its email was recorded) — convert on login.
             await share_service.convert_pending_invites(row["id"], email)
+        elif email_verified:
+            # Returning login with no email in the sparse /userinfo payload but
+            # a positive verification signal (Google) — persist it, never
+            # downgrade an already-verified account.
+            await pool.execute(
+                "UPDATE users SET last_seen = now(), email_verified = true WHERE id = $1",
+                row["id"],
+            )
         else:
             await pool.execute("UPDATE users SET last_seen = now() WHERE id = $1", row["id"])
         user = dict(row)

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -72,6 +72,59 @@ async def test_repeat_session_provision_reports_not_created(pool):
 
 
 @pytest.mark.asyncio
+async def test_google_login_is_trusted_as_verified(pool):
+    """A Google connection means Google vouched for the email, so the row must
+    be email_verified even when the /userinfo claim didn't come through."""
+    sub = f"google-oauth2|{unique_name()}"
+    user, _created = await get_or_create_user_row_from_auth0(
+        auth0_sub=sub,
+        email=f"{unique_name('g')}@example.com",
+        name="Google Person",
+        email_verified=False,
+    )
+    verified = await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"])
+    assert verified is True
+
+
+@pytest.mark.asyncio
+async def test_returning_google_login_reverifies_stuck_account(pool):
+    """An existing Google account left unverified (e.g. predating this fix)
+    must flip to verified on the next login even when the returning session's
+    /userinfo returns no email."""
+    sub = f"google-oauth2|{unique_name()}"
+    user, _created = await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=None, name="Stuck Google", email_verified=False
+    )
+    await pool.execute("UPDATE users SET email_verified = false WHERE id = $1", user["id"])
+
+    await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=None, name="Stuck Google", email_verified=False
+    )
+    verified = await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"])
+    assert verified is True
+
+
+@pytest.mark.asyncio
+async def test_returning_password_login_without_email_does_not_downgrade(pool):
+    """A non-Google account that is already verified must not be silently
+    downgraded when a later login arrives with no email in the profile."""
+    sub = f"auth0|{unique_name()}"
+    user, _created = await get_or_create_user_row_from_auth0(
+        auth0_sub=sub,
+        email=f"{unique_name('p')}@example.com",
+        name="Password Person",
+        email_verified=True,
+    )
+    assert await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"]) is True
+
+    await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=None, name="Password Person", email_verified=False
+    )
+    verified = await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"])
+    assert verified is True
+
+
+@pytest.mark.asyncio
 async def test_immediate_duplicate_session_provision_still_reports_created(pool):
     sub = f"google-oauth2|{unique_name()}"
     await get_or_create_user_row_from_auth0(auth0_sub=sub, email=None, name="Strict Mode Person")


### PR DESCRIPTION
automatically verify accounts that login through social oauth


## What & why

Domain workspace membership (from #785) gates on `users.email_verified`, but that flag was only ever set from a separate Auth0 `/userinfo` call — which comes back empty on **returning** sessions. Result: only brand-new signups got verified; every existing account (including the entire Heavi team and all internal users) stayed `email_verified = false` and could never auto-join a workspace by domain.

A `google-oauth2` login is Google itself vouching that the user controls the address, so we should trust the connection directly rather than the fragile `/userinfo` claim.

## Change

- `backend/managed/auth0/users.py`: if `auth0_sub` starts with `google-oauth2|`, set `email_verified = true` on every login (INSERT and UPDATE). Also persist it on returning logins whose profile has no email (the sparse-`/userinfo` case that was leaving Google users stuck), without downgrading an already-verified account.
- `backend/tests/test_auth0_provision.py`: adds the provisioning tests that were missing — new Google login is verified, a stuck returning Google account re-verifies on next login, and a verified password account is not downgraded.

## Notes

- **Safe to merge with password auth still enabled** — this only *adds* trust for Google logins; it does not touch the membership gate or password/database accounts.
- Existing accounts were already corrected via a one-time DB backfill (`email_verified = true` for `google-oauth2` + `@heaviai.com`); this PR makes it durable so new/returning logins stay correct without re-backfilling.
- Not run locally (no DB in the review worktree); `ruff check`/`format` pass. CI runs the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)