### PR TITLE
docs: document how hosted prod deploys; allow data migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ Write extremely easy to consume code. Optimize for readability: skimmable, no cl
 
 ### Write simple code
 We are a startup. Therefore, code simplicity is our most important concern. Please NEVER
- - Add backwards compatibility support of any kind. This includes migrations, compatibility shims, aliases, legacy format support, and fallback code paths.
+ - Add backwards compatibility support of any kind. This includes compatibility shims, aliases, legacy format support, and fallback code paths.
  - Attempt to preserve backwards compatibility when making an edit.
  - Use fallbacks of ANY kind, ANYWHERE, under ANY circumstance. There are no exceptions. This includes UX-saving fallbacks when a primary path fails, default values papered over a missing input (`x or DEFAULT`, `x or stored_value()`), `try/except` that swallows an error and continues, and "if the real source is empty, use this other source" chains. When a required input is absent or a path fails, FAIL LOUD (raise/exit with a clear message) — never silently substitute. A single source of truth with one codepath, always.
  - Support old formats. If a format changes, change it everywhere in one shot.
+
+**Data migrations are allowed** (updated 2026-07: we have real users now). When a schema or format changes, you may — and should — write a one-time migration that carries existing user data forward to the new format, so nobody loses data. This is not a license for backwards compatibility: migrate the data forward in one shot, then delete the old path. The end state is still a single format and one codepath — the migration is just how you get there without stranding what users already have. Everything else above stands: no compatibility shims, no fallbacks, no dual code paths.
 
 Here are some common code patterns that we need you to avoid:
  - Excessive try/catch: only use try/catch when there's a reasonable expectation that the code within might fail during normal usage. Every try/catch that we add adds another codepath that we need to maintain (the catch) and balloons complexity. In general, we follow the concept of "parse, don't validate" from TDD whenever possible. That is, we validate inputs at module boundaries, and within a module, we don't randomly add try/catch everywhere.
@@ -107,6 +109,16 @@ By default `stash` is the released PyPI build (`uv tool` install, self-updating)
 ### Local stack
 - One-shot start (migrations + backend + frontend): `./start.sh`
 - Docker compose: `docker compose up`
+
+### Deployment (hosted prod — joinstash.ai)
+**Merging to `main` deploys to production. There is no separate release step for the hosted app.**
+
+- Hosted prod runs on **Render** (team `Stash`, region oregon), building directly from this repo's Dockerfiles. Every service has `autoDeploy: yes` on `branch: main`, so a commit to `main` triggers a build + deploy within a couple of minutes. Confirm/inspect via the Render MCP (`list_services`, `list_deploys`, `list_logs`) — do not infer deploy state from repo files.
+- Services (all `Fergana-Labs/stash`, branch `main`): `stash_backend` (slug `moltchat`, → api.joinstash.ai, `backend/Dockerfile`), `stash_app_frontend`, `stash_collab`, `stash-celery-worker`, `stash-celery-beat`. `aspose-pptx` is the one service defined in `render.yaml`; the rest are configured in the Render dashboard, so the repo holds no blueprint for them.
+- **Migrations run automatically at backend boot** (`backend/database.py` runs `alembic upgrade head`), so a merged migration applies to the prod DB on the next deploy — no manual `alembic` step.
+- Prod DB is **Neon** (`stash-prod`, id `little-scene-08473932`), not Render Postgres. Query read-only via the Neon MCP.
+- `docker-compose.prod.yml` and the **GHCR images are for self-hosters only** — they are NOT how joinstash.ai deploys. Editing them does not affect prod.
+- `publish.yml` (on push to `main`) publishes the **`stashai` CLI to PyPI** on a version bump and builds GHCR release images — this is CLI/self-host distribution, separate from the Render app deploy.
 
 # 12-rule template
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,9 @@
-# Stash — production / self-hosting deployment
+# Stash — SELF-HOSTING deployment (community / on-prem).
+#
+# This is NOT how joinstash.ai runs. Our hosted prod is on Render, building
+# from the repo Dockerfiles and auto-deploying on every commit to main (see
+# CLAUDE.md → Deployment). This compose file + the GHCR images below exist
+# only so third parties can self-host Stash. Editing it does not affect prod.
 #
 # Usage:
 #   cp .env.example .env        # fill in required values

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,14 @@
 # Render blueprint for the Aspose.Slides REST service that the native-export
 # sandbox (backend/exports/native/) talks to for per-element PPTX construction.
 #
-# This is the only Render-managed piece of the repo today — the rest of
-# moltchat still deploys via docker-compose.prod.yml. The sandbox CLI hits
-# the public URL of this service directly.
+# This is the only hosted service DEFINED as a render.yaml blueprint. It is
+# NOT the only Render-managed service: our whole hosted prod (backend →
+# api.joinstash.ai, frontend, collab, celery worker + beat) also runs on
+# Render, auto-deploying on every commit to main — those services are
+# configured in the Render dashboard, not in this file, so the repo has no
+# blueprint for them. docker-compose.prod.yml is for SELF-HOSTERS only and is
+# not how joinstash.ai deploys. The sandbox CLI hits this service's public URL
+# directly.
 services:
   - type: web
     name: aspose-pptx


### PR DESCRIPTION
Two documentation corrections that surfaced during the workspaces launch work.

## Deployment reality
Hosted prod (joinstash.ai) runs on **Render** and **auto-deploys on every commit to `main`** — there is no separate release step for the hosted app. The repo previously implied otherwise:
- `render.yaml`'s comment claimed it was "the only Render-managed piece … the rest still deploys via docker-compose.prod.yml" — false; the whole stack (backend, frontend, collab, celery worker/beat) is on Render, dashboard-configured.
- `docker-compose.prod.yml`'s header called itself "production / self-hosting," conflating the two.

This PR fixes both comments and adds an authoritative **Deployment (hosted prod)** section to `CLAUDE.md`, so future agents check the Render MCP instead of inferring deploy state from repo files. (An agent — me — got this wrong this week.)

## Migration rule
We have real users now, so a one-time forward **data migration** is allowed when a schema/format changes. Removes `migrations` from the banned backwards-compat list and adds a scoped carve-out. Everything else stands: no compatibility shims, no fallbacks, no dual code paths — migrate forward in one shot, delete the old path.

Docs only. `AGENTS.md` is a symlink to `CLAUDE.md`, so it inherits both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)