### PR TITLE
Add PostHog as a connected source

### DIFF
--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -24,6 +24,7 @@ from . import (
     jira,  # noqa: F401
     linear,  # noqa: F401
     notion,  # noqa: F401
+    posthog,  # noqa: F401
     slack,  # noqa: F401
     twitter,  # noqa: F401
 )

--- a/backend/integrations/posthog/__init__.py
+++ b/backend/integrations/posthog/__init__.py
@@ -1,0 +1,6 @@
+"""PostHog integration for project analytics configuration."""
+
+from ..registry import register_provider
+from .provider import PostHogIntegration
+
+register_provider(PostHogIntegration())

--- a/backend/integrations/posthog/indexer.py
+++ b/backend/integrations/posthog/indexer.py
@@ -1,0 +1,159 @@
+"""PostHog project object index.
+
+The source indexes bounded product configuration rather than high-volume event
+or person data. Object bodies are fetched live on read so analytics results and
+experiment state do not go stale between syncs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from ...services import source_service
+from ..storage import get_valid_token
+from .provider import decode_credentials
+
+logger = logging.getLogger(__name__)
+
+PAGE_SIZE = 100
+MAX_OBJECTS_PER_KIND = 1000
+SEARCH_LIMIT = 25
+KINDS = {
+    "dashboards": "dashboard",
+    "insights": "insight",
+    "feature_flags": "feature flag",
+    "experiments": "experiment",
+}
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _path_segment(value: str) -> str:
+    return " ".join(value.replace("/", "-").split())[:100].strip()
+
+
+def _object_name(kind: str, item: dict) -> str:
+    if kind == "feature_flags":
+        return item.get("key") or item.get("name") or str(item["id"])
+    return item.get("name") or f"Untitled {KINDS[kind]}"
+
+
+def _object_path(kind: str, item: dict) -> str:
+    return f"{kind}/{_path_segment(_object_name(kind, item))} ({item['id']})"
+
+
+async def _client(owner_user_id: UUID) -> tuple[httpx.AsyncClient, dict[str, str]]:
+    credentials = decode_credentials(await get_valid_token(owner_user_id, "posthog"))
+    client = httpx.AsyncClient(
+        timeout=60.0,
+        headers={"Authorization": f"Bearer {credentials['personal_api_key']}"},
+        base_url=credentials["instance_url"],
+    )
+    return client, credentials
+
+
+async def index_posthog(source: dict) -> str | None:
+    source_id = UUID(source["id"])
+    owner_user_id = UUID(source["owner_user_id"])
+    client, credentials = await _client(owner_user_id)
+    present: list[str] = []
+    async with client:
+        for kind, item_kind in KINDS.items():
+            offset = 0
+            while offset < MAX_OBJECTS_PER_KIND:
+                response = await client.get(
+                    f"/api/projects/{credentials['project_id']}/{kind}/",
+                    params={"limit": PAGE_SIZE, "offset": offset},
+                )
+                response.raise_for_status()
+                items = response.json().get("results", [])
+                for item in items:
+                    if item.get("deleted"):
+                        continue
+                    path = _object_path(kind, item)
+                    await source_service.upsert_index_row(
+                        table="posthog_index",
+                        source_id=source_id,
+                        owner_user_id=owner_user_id,
+                        path=path,
+                        name=_object_name(kind, item),
+                        kind=item_kind,
+                        external_ref=f"{kind}:{item['id']}",
+                        external_updated_at=_parse_time(
+                            item.get("updated_at") or item.get("created_at")
+                        ),
+                    )
+                    present.append(path)
+                if len(items) < PAGE_SIZE:
+                    break
+                offset += PAGE_SIZE
+
+    await source_service.remove_missing_documents("posthog_index", source_id, present)
+    logger.info("posthog source %s: indexed %d object(s)", source_id, len(present))
+    return None
+
+
+async def fetch_posthog_content(owner_user_id: UUID, external_ref: str) -> str:
+    kind, separator, object_id = external_ref.partition(":")
+    if not separator or kind not in KINDS or not object_id:
+        raise ValueError("invalid PostHog object reference")
+
+    client, credentials = await _client(owner_user_id)
+    async with client:
+        response = await client.get(
+            f"/api/projects/{credentials['project_id']}/{kind}/{object_id}/"
+        )
+        response.raise_for_status()
+        item = response.json()
+
+    name = _object_name(kind, item)
+    description = item.get("description") or item.get("name") or ""
+    parts = [f"# {name}", f"Type: {KINDS[kind]}"]
+    if description and description != name:
+        parts.append(f"\n{description}")
+    parts.append("\n## Details\n```json\n" + json.dumps(item, indent=2, sort_keys=True) + "\n```")
+    return "\n".join(parts)
+
+
+async def search_posthog(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
+    """Search the four bounded object collections and resolve hits to index paths."""
+    owner_user_id = UUID(source["owner_user_id"])
+    client, credentials = await _client(owner_user_id)
+    items: list[tuple[str, dict]] = []
+    async with client:
+        for kind in KINDS:
+            response = await client.get(
+                f"/api/projects/{credentials['project_id']}/{kind}/",
+                params={"search": query, "limit": limit},
+            )
+            response.raise_for_status()
+            items.extend((kind, item) for item in response.json().get("results", []))
+
+    refs = [f"{kind}:{item['id']}" for kind, item in items]
+    paths = await source_service.index_paths_for_refs("posthog_index", UUID(source["id"]), refs)
+    hits = []
+    for kind, item in items:
+        ref = f"{kind}:{item['id']}"
+        indexed = paths.get(ref)
+        if not indexed:
+            continue
+        path, name = indexed
+        hits.append(
+            {
+                "ref": path,
+                "name": name,
+                "snippet": item.get("description") or item.get("name") or "",
+            }
+        )
+        if len(hits) >= limit:
+            break
+    return hits

--- a/backend/integrations/posthog/provider.py
+++ b/backend/integrations/posthog/provider.py
@@ -1,0 +1,98 @@
+"""Credential-based PostHog provider."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+import httpx
+
+from ..base import AccountInfo, CredentialField, TokenSet
+
+POSTHOG_CLOUD_HOSTS = {"us.posthog.com", "eu.posthog.com"}
+
+
+def normalize_host(value: str) -> str:
+    host = value.strip().rstrip("/")
+    parsed = urlparse(host)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.path:
+        raise ValueError("instance_url must be an HTTPS origin")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("instance_url must not contain credentials, a query, or a fragment")
+    if parsed.hostname not in POSTHOG_CLOUD_HOSTS or parsed.port not in (None, 443):
+        raise ValueError("instance_url must be a PostHog Cloud origin")
+    return host
+
+
+def decode_credentials(token: str) -> dict[str, str]:
+    values = json.loads(token)
+    return {
+        "instance_url": values["instance_url"],
+        "project_id": values["project_id"],
+        "personal_api_key": values["personal_api_key"],
+    }
+
+
+class PostHogIntegration:
+    name = "posthog"
+    display_name = "PostHog"
+    auth_kind = "api_key"
+    scopes = ["project:read"]
+    supports_refresh = False
+    credential_fields = [
+        CredentialField(
+            "instance_url",
+            "PostHog instance URL",
+            placeholder="https://us.posthog.com",
+            help="Use https://eu.posthog.com for EU Cloud.",
+        ),
+        CredentialField("project_id", "Project ID", placeholder="12345"),
+        CredentialField(
+            "personal_api_key",
+            "Personal API key",
+            secret=True,
+            placeholder="phx_…",
+            help="Create a key with project read access in PostHog settings.",
+        ),
+    ]
+
+    async def connect_with_credentials(
+        self, values: dict[str, str]
+    ) -> tuple[TokenSet, AccountInfo]:
+        required = ("instance_url", "project_id", "personal_api_key")
+        if any(not values.get(field, "").strip() for field in required):
+            raise ValueError("all PostHog credentials are required")
+
+        instance_url = normalize_host(values["instance_url"])
+        project_id = values["project_id"].strip()
+        if not project_id.isascii() or not project_id.isdigit():
+            raise ValueError("project_id must be numeric")
+        personal_api_key = values["personal_api_key"].strip()
+        headers = {"Authorization": f"Bearer {personal_api_key}"}
+        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+            response = await client.get(f"{instance_url}/api/projects/{project_id}/")
+            response.raise_for_status()
+            project = response.json()
+
+        if str(project.get("id")) != project_id:
+            raise ValueError("PostHog returned a different project")
+        token = json.dumps(
+            {
+                "instance_url": instance_url,
+                "project_id": project_id,
+                "personal_api_key": personal_api_key,
+            }
+        )
+        project_name = project.get("name") or f"Project {project_id}"
+        return (
+            TokenSet(
+                access_token=token,
+                refresh_token=None,
+                expires_at=None,
+                scopes=list(self.scopes),
+            ),
+            AccountInfo(email=None, display_name=project_name),
+        )
+
+    async def revoke(self, access_token: str) -> None:
+        return None

--- a/backend/migrations/versions/0150_posthog_source.py
+++ b/backend/migrations/versions/0150_posthog_source.py
@@ -1,0 +1,35 @@
+"""PostHog project source index.
+
+Revision ID: 0150
+Revises: 0149
+"""
+
+from alembic import op
+
+revision = "0150"
+down_revision = "0149"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE posthog_index (
+            id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            source_id           uuid NOT NULL REFERENCES user_sources(id) ON DELETE CASCADE,
+            path                text NOT NULL,
+            name                text NOT NULL,
+            kind                text NOT NULL,
+            external_ref        text NOT NULL,
+            external_updated_at timestamptz,
+            created_at          timestamptz NOT NULL DEFAULT now(),
+            updated_at          timestamptz NOT NULL DEFAULT now(),
+            deleted_at          timestamptz,
+            UNIQUE (source_id, path)
+        )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS posthog_index")

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -135,6 +135,16 @@ async def _resolve_linear_source(user_id) -> tuple[str, str]:
     return "me", "Linear"
 
 
+async def _resolve_posthog_source(user_id) -> tuple[str, str]:
+    """One connected PostHog credential bundle represents one project."""
+    await integration_storage.get_valid_token(user_id, "posthog")
+    status = await integration_storage.status(user_id, "posthog")
+    display_name = status.get("account_display_name")
+    if not display_name:
+        raise HTTPException(status_code=409, detail="Reconnect PostHog before adding it.")
+    return "project", f"PostHog ({display_name})"
+
+
 @router.get("")
 async def list_sources(
     current_user: dict = Depends(get_current_user),
@@ -314,6 +324,9 @@ async def add_source(
         display_name = f"X bookmarks (@{username})"
     elif body.source_type == "linear":
         external_ref, resolved_name = await _resolve_linear_source(current_user["id"])
+        display_name = display_name or resolved_name
+    elif body.source_type == "posthog_project":
+        external_ref, resolved_name = await _resolve_posthog_source(current_user["id"])
         display_name = display_name or resolved_name
 
     if not external_ref:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -63,6 +63,7 @@ DEFAULT_SYNC_INTERVAL_S = {
     "jira_project": 1800,
     "asana_project": 1800,
     "linear": 1800,
+    "posthog_project": 1800,
     "gong_calls": 21600,
     "twitter_bookmarks": 21600,
     # Freshness comes from extension pushes (which kick a sync); the interval
@@ -82,6 +83,7 @@ SOURCE_CAPABILITY = {
     "jira_project": "searchable",
     "asana_project": "navigable",
     "linear": "navigable",
+    "posthog_project": "navigable",
     "gong_calls": "searchable",
     "twitter": "searchable",
     "twitter_bookmarks": "searchable",
@@ -98,6 +100,7 @@ PROVIDER_SOURCE_TYPES = {
     "jira": ("jira_project",),
     "asana": ("asana_project",),
     "linear": ("linear",),
+    "posthog": ("posthog_project",),
     "gong": ("gong_calls",),
     "twitter": ("twitter", "twitter_bookmarks"),
     # Provider-less grouping: there is no Instagram OAuth integration — the
@@ -132,6 +135,8 @@ def validate_source_external_ref(source_type: str, external_ref: str) -> None:
     # there is one canonical ref; the router resolves it before we get here.
     if source_type == "linear" and external_ref != "me":
         raise ValueError("Linear external_ref must be 'me'")
+    if source_type == "posthog_project" and external_ref != "project":
+        raise ValueError("PostHog external_ref must be 'project'")
 
 
 def _clean_string_list(value, field_name: str) -> list[str]:
@@ -484,6 +489,7 @@ SOURCE_TABLE = {
     "jira_project": "jira_documents",
     "asana_project": "asana_documents",
     "linear": "linear_index",
+    "posthog_project": "posthog_index",
     "gong_calls": "gong_documents",
     "twitter": "twitter_posts",
     "twitter_bookmarks": "twitter_bookmark_docs",
@@ -521,6 +527,7 @@ FEDERATED_SEARCH_TYPES = {
     "jira_project",
     "asana_project",
     "linear",
+    "posthog_project",
     "twitter",
 }
 
@@ -1200,6 +1207,10 @@ async def _lazy_fetch(source: dict, external_ref: str | None) -> str:
         from ..integrations.linear.indexer import fetch_linear_content
 
         return await fetch_linear_content(owner_user_id, external_ref)
+    if source_type == "posthog_project":
+        from ..integrations.posthog.indexer import fetch_posthog_content
+
+        return await fetch_posthog_content(owner_user_id, external_ref)
     # twitter never reaches here: every cached path is a numeric post id, which
     # read_document already routes through the live-ref path.
     return ""
@@ -1272,6 +1283,8 @@ async def _federated_search(
             from ..integrations.asana.indexer import search_asana as fn
         elif source_type == "linear":
             from ..integrations.linear.indexer import search_linear as fn
+        elif source_type == "posthog_project":
+            from ..integrations.posthog.indexer import search_posthog as fn
         elif source_type == "twitter":
             from ..integrations.twitter.indexer import search_twitter as fn
         else:

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -26,6 +26,7 @@ from ..integrations.granola.indexer import index_granola
 from ..integrations.jira.indexer import index_jira
 from ..integrations.linear.indexer import index_linear
 from ..integrations.notion.indexer import index_notion
+from ..integrations.posthog.indexer import index_posthog
 from ..integrations.slack.indexer import index_slack, ingest_slack_message
 from ..integrations.social_saves.indexer import index_instagram_saves
 from ..integrations.twitter.indexer import index_twitter_bookmarks
@@ -43,6 +44,7 @@ INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {
     "google_drive": index_google_drive,
     "google_drive_folder": index_google_drive_folder,
     "notion": index_notion,
+    "posthog_project": index_posthog,
     "slack": index_slack,
     "granola": index_granola,
     "jira_project": index_jira,

--- a/backend/tests/test_posthog_integration.py
+++ b/backend/tests/test_posthog_integration.py
@@ -1,0 +1,127 @@
+from uuid import UUID
+
+import httpx
+import pytest
+
+from backend.integrations.posthog import indexer
+from backend.integrations.posthog.provider import normalize_host
+
+
+def test_posthog_host_requires_a_bare_https_origin():
+    assert normalize_host(" https://eu.posthog.com/ ") == "https://eu.posthog.com"
+    with pytest.raises(ValueError):
+        normalize_host("http://posthog.internal")
+    with pytest.raises(ValueError):
+        normalize_host("https://posthog.example.com/api")
+    with pytest.raises(ValueError):
+        normalize_host("https://127.0.0.1")
+
+
+def test_posthog_paths_group_objects_and_keep_duplicate_names_distinct():
+    first = indexer._object_path("insights", {"id": 12, "name": "Activation / weekly"})
+    second = indexer._object_path("insights", {"id": 13, "name": "Activation / weekly"})
+    assert first == "insights/Activation - weekly (12)"
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_posthog_indexer_indexes_each_product_collection(monkeypatch):
+    captured: list[dict] = []
+    removed: list[list[str]] = []
+    responses = {
+        "dashboards": {"id": 1, "name": "Company KPI", "created_at": "2026-07-01T00:00:00Z"},
+        "insights": {"id": 2, "name": "Activation", "updated_at": "2026-07-02T00:00:00Z"},
+        "feature_flags": {"id": 3, "key": "new-nav", "updated_at": "2026-07-03T00:00:00Z"},
+        "experiments": {"id": 4, "name": "Better onboarding", "updated_at": "2026-07-04T00:00:00Z"},
+    }
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, path, params=None):
+            kind = path.rstrip("/").rsplit("/", 1)[-1]
+            return FakeResponse({"results": [responses[kind]]})
+
+    async def fake_client(owner_user_id):
+        assert owner_user_id == UUID("00000000-0000-0000-0000-000000000002")
+        return FakeClient(), {"project_id": "42"}
+
+    async def capture_upsert(**kwargs):
+        captured.append(kwargs)
+
+    async def capture_remove(table, source_id, paths):
+        assert table == "posthog_index"
+        removed.append(paths)
+
+    monkeypatch.setattr(indexer, "_client", fake_client)
+    monkeypatch.setattr(indexer.source_service, "upsert_index_row", capture_upsert)
+    monkeypatch.setattr(indexer.source_service, "remove_missing_documents", capture_remove)
+
+    await indexer.index_posthog(
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "owner_user_id": "00000000-0000-0000-0000-000000000002",
+        }
+    )
+
+    assert [row["external_ref"] for row in captured] == [
+        "dashboards:1",
+        "insights:2",
+        "feature_flags:3",
+        "experiments:4",
+    ]
+    assert captured[2]["path"] == "feature_flags/new-nav (3)"
+    assert removed == [[row["path"] for row in captured]]
+
+
+@pytest.mark.asyncio
+async def test_posthog_provider_validates_project_before_storing_credentials(monkeypatch):
+    from backend.integrations.posthog import provider
+
+    request = httpx.Request("GET", "https://us.posthog.com/api/projects/42/")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id": 42, "name": "Acme Product"}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            assert kwargs["headers"] == {"Authorization": "Bearer phx_secret"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url):
+            assert url == str(request.url)
+            return FakeResponse()
+
+    monkeypatch.setattr(provider.httpx, "AsyncClient", FakeClient)
+    token, account = await provider.PostHogIntegration().connect_with_credentials(
+        {
+            "instance_url": "https://us.posthog.com",
+            "project_id": "42",
+            "personal_api_key": "phx_secret",
+        }
+    )
+    assert account.display_name == "Acme Product"
+    assert provider.decode_credentials(token.access_token)["project_id"] == "42"

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -394,6 +394,7 @@ const ITEM_NOUN: Record<string, string> = {
   notion: "page",
   jira_project: "project",
   asana_project: "project",
+  posthog_project: "project",
 };
 
 function relativeTime(iso: string | null | undefined): string {

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -118,6 +118,27 @@ export function GongIcon({ className, size = defaultSize }: Props) {
   );
 }
 
+export function PostHogIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+    >
+      <path
+        d="M3.2 14.6 5.6 10 4.7 5.4l4.6 1.4L12 3l2.7 3.8 4.6-1.4-.9 4.6 2.4 4.6-4.4 1.8L14.7 21 12 18.1 9.3 21l-1.7-4.6z"
+        fill="#F54E00"
+      />
+      <circle cx="9.3" cy="11.7" r="1.1" fill="white" />
+      <circle cx="14.7" cy="11.7" r="1.1" fill="white" />
+      <path d="M9.2 15.1c1.8 1.2 3.8 1.2 5.6 0" stroke="white" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function JiraIcon({ className, size = defaultSize }: Props) {
   // Official Jira mark — interlocking chevrons in Jira blue.
   return (

--- a/frontend/src/components/integrations/SourceConnectorList.test.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.test.tsx
@@ -79,3 +79,20 @@ describe("SourceConnectorList disconnect", () => {
     expect(disconnectIntegration).not.toHaveBeenCalled();
   });
 });
+
+describe("SourceConnectorList providers", () => {
+  it("offers PostHog as a product analytics source", async () => {
+    listIntegrations.mockResolvedValue({ providers: [] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(await screen.findByText("PostHog")).toBeInTheDocument();
+    expect(
+      screen.getByText("Browse dashboards, insights, feature flags, and experiments.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -12,6 +12,7 @@ import {
   JiraIcon,
   LinearIcon,
   NotionIcon,
+  PostHogIcon,
   SlackIcon,
   TwitterIcon,
 } from "./BrandIcons";
@@ -98,6 +99,13 @@ export const CONNECTORS: Connector[] = [
     blurb: "Call transcripts, kept in sync.",
   },
   {
+    provider: "posthog",
+    label: "PostHog",
+    sourceType: "posthog_project",
+    kind: "auto",
+    blurb: "Browse dashboards, insights, feature flags, and experiments.",
+  },
+  {
     provider: "twitter",
     label: "Twitter / X",
     sourceType: "twitter",
@@ -120,6 +128,7 @@ export const providerForSourceType: Record<string, string> = {
   slack: "slack",
   granola: "granola",
   gong_calls: "gong",
+  posthog_project: "posthog",
   twitter: "twitter",
   twitter_bookmarks: "twitter",
 };
@@ -154,6 +163,8 @@ export function connectorIcon(provider: string): ReactNode {
       return <GranolaIcon />;
     case "gong":
       return <GongIcon />;
+    case "posthog":
+      return <PostHogIcon />;
     case "twitter":
       return <TwitterIcon />;
     default:
@@ -173,6 +184,7 @@ export function labelForSourceType(type: string): string {
   if (type === "asana_project") return "Asana";
   if (type === "linear") return "Linear";
   if (type === "gong_calls") return "Gong";
+  if (type === "posthog_project") return "PostHog";
   if (type === "twitter") return "Twitter / X";
   if (type === "twitter_bookmarks") return "X bookmarks";
   if (type === "instagram_saves") return "Instagram saves";

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -19,6 +19,7 @@ export type IntegrationProvider =
   | "linear"
   | "asana"
   | "gong"
+  | "posthog"
   | "twitter";
 
 export type CredentialField = {

--- a/frontend/src/lib/onboarding/welcomeContent.ts
+++ b/frontend/src/lib/onboarding/welcomeContent.ts
@@ -20,7 +20,7 @@ export function generateWelcomeHtml(inputs: WelcomeInputs): string {
   parts.push(`<h2>What to try next</h2>`);
   parts.push(
     `<ul>
-      <li><strong><a href="/settings/integrations">Connect a data source</a></strong> — GitHub, Google Drive, Gmail, Notion, Slack, Granola, Twitter / X. Your agent reads across everything you connect.</li>
+      <li><strong><a href="/settings/integrations">Connect a data source</a></strong> — GitHub, Google Drive, Gmail, Notion, Slack, Granola, PostHog, Twitter / X. Your agent reads across everything you connect.</li>
       <li><strong>Share a folder or page</strong> — give a link or invite specific people, so teammates and their agents work from the same docs.</li>
       <li><strong>Install the CLI</strong> — let your coding agent use Stash directly: <code>bash -c "$(curl -fsSL https://joinstash.ai/install)"</code></li>
     </ul>`,


### PR DESCRIPTION
## Summary

- add credential-based PostHog Cloud authentication for US and EU projects
- index dashboards, insights, feature flags, and experiments into a navigable source
- fetch current object details on read and federate searches to PostHog
- add the PostHog settings card, credential form, source lifecycle, migration, and tests

Raw events and person data are deliberately excluded so this stays a bounded product-knowledge source.

## Security

- credentials are stored through the existing encrypted integration storage
- instance URLs are restricted to the official PostHog Cloud US/EU HTTPS origins
- connection failures do not echo credential values

## Verification

- `ruff check backend/ cli/`
- `ruff format --check backend/ cli/`
- 65 relevant backend tests
- 199 frontend tests
- frontend production build
- manual browser QA with no browser errors

## Screenshot

[PostHog connection form](https://app.joinstash.ai/f/6feab3e3-3a6e-48d8-b4c8-934265cb5eee)