### PR TITLE
Connect PostHog with OAuth

### DIFF
--- a/backend/integrations/granola/provider.py
+++ b/backend/integrations/granola/provider.py
@@ -39,6 +39,9 @@ class GranolaIntegration:
         # Granola tokens are revoked by signing out in Granola; we drop our copy.
         return None
 
+    async def get_valid_access_token(self, user_id: UUID) -> str:
+        return await oauth.get_valid_access_token(user_id)
+
     # --- Unused generic OAuth surface (the mcp_oauth branch bypasses these) ---
 
     def authorize_url(self, state: str) -> str:

--- a/backend/integrations/posthog/client.py
+++ b/backend/integrations/posthog/client.py
@@ -1,0 +1,37 @@
+"""Authenticated client for PostHog's hosted MCP server."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+MCP_URL = (
+    "https://mcp.posthog.com/mcp"
+    "?features=dashboards,product_analytics,flags,experiments&readonly=true"
+)
+
+
+@asynccontextmanager
+async def posthog_session(access_token: str) -> AsyncIterator[ClientSession]:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with streamablehttp_client(MCP_URL, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def call_tool(session: ClientSession, name: str, arguments: dict[str, Any] | None = None):
+    result = await session.call_tool(name, arguments or {})
+    if result.isError:
+        raise RuntimeError(f"PostHog tool failed: {name}")
+    if result.structuredContent is not None:
+        return result.structuredContent
+    for block in result.content:
+        if getattr(block, "type", None) == "text":
+            return json.loads(block.text)
+    return None

--- a/backend/integrations/posthog/indexer.py
+++ b/backend/integrations/posthog/indexer.py
@@ -1,9 +1,4 @@
-"""PostHog project object index.
-
-The source indexes bounded product configuration rather than high-volume event
-or person data. Object bodies are fetched live on read so analytics results and
-experiment state do not go stale between syncs.
-"""
+"""Index bounded PostHog project objects through its read-only MCP server."""
 
 from __future__ import annotations
 
@@ -12,11 +7,9 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-import httpx
-
 from ...services import source_service
 from ..storage import get_valid_token
-from .provider import decode_credentials
+from .client import call_tool, posthog_session
 
 logger = logging.getLogger(__name__)
 
@@ -24,15 +17,19 @@ PAGE_SIZE = 100
 MAX_OBJECTS_PER_KIND = 1000
 SEARCH_LIMIT = 25
 KINDS = {
-    "dashboards": "dashboard",
-    "insights": "insight",
-    "feature_flags": "feature flag",
-    "experiments": "experiment",
+    "dashboards": {"label": "dashboard", "list": "dashboards-get-all", "get": "dashboard-get"},
+    "insights": {"label": "insight", "list": "insights-list", "get": "insight-get"},
+    "feature_flags": {
+        "label": "feature flag",
+        "list": "feature-flag-get-all",
+        "get": "feature-flag-get-definition",
+    },
+    "experiments": {"label": "experiment", "list": "experiment-list", "get": "experiment-get"},
 }
 
 
 def _parse_time(value: str | None) -> datetime | None:
-    if not value:
+    if value is None:
         return None
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
@@ -44,41 +41,33 @@ def _path_segment(value: str) -> str:
 def _object_name(kind: str, item: dict) -> str:
     if kind == "feature_flags":
         return item.get("key") or item.get("name") or str(item["id"])
-    return item.get("name") or f"Untitled {KINDS[kind]}"
+    return item.get("name") or f"Untitled {KINDS[kind]['label']}"
 
 
 def _object_path(kind: str, item: dict) -> str:
     return f"{kind}/{_path_segment(_object_name(kind, item))} ({item['id']})"
 
 
-async def _client(owner_user_id: UUID) -> tuple[httpx.AsyncClient, dict[str, str]]:
-    credentials = decode_credentials(await get_valid_token(owner_user_id, "posthog"))
-    client = httpx.AsyncClient(
-        timeout=60.0,
-        headers={"Authorization": f"Bearer {credentials['personal_api_key']}"},
-        base_url=credentials["instance_url"],
-    )
-    return client, credentials
+def _results(payload: dict) -> list[dict]:
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise ValueError("PostHog list tool returned no results array")
+    return results
 
 
 async def index_posthog(source: dict) -> str | None:
     source_id = UUID(source["id"])
     owner_user_id = UUID(source["owner_user_id"])
-    client, credentials = await _client(owner_user_id)
+    token = await get_valid_token(owner_user_id, "posthog")
     present: list[str] = []
-    async with client:
-        for kind, item_kind in KINDS.items():
+    async with posthog_session(token) as session:
+        for kind, config in KINDS.items():
             offset = 0
             while offset < MAX_OBJECTS_PER_KIND:
-                response = await client.get(
-                    f"/api/projects/{credentials['project_id']}/{kind}/",
-                    params={"limit": PAGE_SIZE, "offset": offset},
+                items = _results(
+                    await call_tool(session, config["list"], {"limit": PAGE_SIZE, "offset": offset})
                 )
-                response.raise_for_status()
-                items = response.json().get("results", [])
                 for item in items:
-                    if item.get("deleted"):
-                        continue
                     path = _object_path(kind, item)
                     await source_service.upsert_index_row(
                         table="posthog_index",
@@ -86,7 +75,7 @@ async def index_posthog(source: dict) -> str | None:
                         owner_user_id=owner_user_id,
                         path=path,
                         name=_object_name(kind, item),
-                        kind=item_kind,
+                        kind=config["label"],
                         external_ref=f"{kind}:{item['id']}",
                         external_updated_at=_parse_time(
                             item.get("updated_at") or item.get("created_at")
@@ -96,7 +85,6 @@ async def index_posthog(source: dict) -> str | None:
                 if len(items) < PAGE_SIZE:
                     break
                 offset += PAGE_SIZE
-
     await source_service.remove_missing_documents("posthog_index", source_id, present)
     logger.info("posthog source %s: indexed %d object(s)", source_id, len(present))
     return None
@@ -106,18 +94,12 @@ async def fetch_posthog_content(owner_user_id: UUID, external_ref: str) -> str:
     kind, separator, object_id = external_ref.partition(":")
     if not separator or kind not in KINDS or not object_id:
         raise ValueError("invalid PostHog object reference")
-
-    client, credentials = await _client(owner_user_id)
-    async with client:
-        response = await client.get(
-            f"/api/projects/{credentials['project_id']}/{kind}/{object_id}/"
-        )
-        response.raise_for_status()
-        item = response.json()
-
+    token = await get_valid_token(owner_user_id, "posthog")
+    async with posthog_session(token) as session:
+        item = await call_tool(session, KINDS[kind]["get"], {"id": object_id})
     name = _object_name(kind, item)
     description = item.get("description") or item.get("name") or ""
-    parts = [f"# {name}", f"Type: {KINDS[kind]}"]
+    parts = [f"# {name}", f"Type: {KINDS[kind]['label']}"]
     if description and description != name:
         parts.append(f"\n{description}")
     parts.append("\n## Details\n```json\n" + json.dumps(item, indent=2, sort_keys=True) + "\n```")
@@ -125,26 +107,19 @@ async def fetch_posthog_content(owner_user_id: UUID, external_ref: str) -> str:
 
 
 async def search_posthog(source: dict, query: str, limit: int = SEARCH_LIMIT) -> list[dict]:
-    """Search the four bounded object collections and resolve hits to index paths."""
     owner_user_id = UUID(source["owner_user_id"])
-    client, credentials = await _client(owner_user_id)
+    token = await get_valid_token(owner_user_id, "posthog")
     items: list[tuple[str, dict]] = []
-    async with client:
-        for kind in KINDS:
-            response = await client.get(
-                f"/api/projects/{credentials['project_id']}/{kind}/",
-                params={"search": query, "limit": limit},
-            )
-            response.raise_for_status()
-            items.extend((kind, item) for item in response.json().get("results", []))
-
+    async with posthog_session(token) as session:
+        for kind, config in KINDS.items():
+            payload = await call_tool(session, config["list"], {"search": query, "limit": limit})
+            items.extend((kind, item) for item in _results(payload))
     refs = [f"{kind}:{item['id']}" for kind, item in items]
     paths = await source_service.index_paths_for_refs("posthog_index", UUID(source["id"]), refs)
     hits = []
     for kind, item in items:
-        ref = f"{kind}:{item['id']}"
-        indexed = paths.get(ref)
-        if not indexed:
+        indexed = paths.get(f"{kind}:{item['id']}")
+        if indexed is None:
             continue
         path, name = indexed
         hits.append(
@@ -154,6 +129,6 @@ async def search_posthog(source: dict, query: str, limit: int = SEARCH_LIMIT) ->
                 "snippet": item.get("description") or item.get("name") or "",
             }
         )
-        if len(hits) >= limit:
+        if len(hits) == limit:
             break
     return hits

--- a/backend/integrations/posthog/oauth.py
+++ b/backend/integrations/posthog/oauth.py
@@ -1,0 +1,226 @@
+"""Stateless OAuth 2.0 flow for PostHog's hosted MCP server."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+from cryptography.fernet import InvalidToken
+from fastapi import HTTPException
+
+from ...config import settings
+from ...database import get_pool
+from ...services import security_audit_service
+from ..crypto import integration_fernet
+
+RESOURCE = "https://mcp.posthog.com"
+SCOPES = "openid profile email account:read project:read dashboard:read insight:read feature_flag:read experiment:read query:read"
+STATE_TTL = timedelta(minutes=10)
+PROTECTED_RESOURCE_METADATA = "https://mcp.posthog.com/.well-known/oauth-protected-resource"
+_metadata: dict | None = None
+
+
+def _redirect_uri() -> str:
+    return f"{settings.PUBLIC_URL.rstrip('/')}/api/v1/integrations/posthog/callback"
+
+
+async def _discover() -> dict:
+    global _metadata
+    if _metadata is not None:
+        return _metadata
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+        resource = (await client.get(PROTECTED_RESOURCE_METADATA)).raise_for_status().json()
+        issuer = resource["authorization_servers"][0].rstrip("/")
+        server = (
+            (await client.get(f"{issuer}/.well-known/oauth-authorization-server"))
+            .raise_for_status()
+            .json()
+        )
+    _metadata = {
+        "authorization_endpoint": server["authorization_endpoint"],
+        "token_endpoint": server["token_endpoint"],
+        "registration_endpoint": server["registration_endpoint"],
+        "revocation_endpoint": server["revocation_endpoint"],
+        "userinfo_endpoint": server["userinfo_endpoint"],
+    }
+    return _metadata
+
+
+async def _register_client() -> dict:
+    meta = await _discover()
+    body = {
+        "client_name": "Stash",
+        "redirect_uris": [_redirect_uri()],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": SCOPES,
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        return (
+            (await client.post(meta["registration_endpoint"], json=body)).raise_for_status().json()
+        )
+
+
+def _encode_state(user_id: UUID, return_to: str | None, verifier: str, client: dict) -> str:
+    payload = {
+        "u": str(user_id),
+        "r": return_to,
+        "v": verifier,
+        "c": client,
+        "t": datetime.now(UTC).isoformat(),
+    }
+    return integration_fernet().encrypt(json.dumps(payload).encode()).decode()
+
+
+def _decode_state(state: str) -> dict:
+    try:
+        raw = integration_fernet().decrypt(state.encode(), ttl=int(STATE_TTL.total_seconds()))
+    except InvalidToken:
+        raise HTTPException(status_code=400, detail="invalid or expired state")
+    return json.loads(raw)
+
+
+async def _post_token(data: dict) -> dict:
+    meta = await _discover()
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        return (await client.post(meta["token_endpoint"], data=data)).raise_for_status().json()
+
+
+def _expires_at(token: dict) -> datetime | None:
+    if "expires_in" not in token:
+        return None
+    return datetime.now(UTC) + timedelta(seconds=int(token["expires_in"]))
+
+
+async def start_authorization(user_id: UUID, return_to: str | None) -> str:
+    meta = await _discover()
+    client = await _register_client()
+    verifier = secrets.token_urlsafe(64)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+    state = _encode_state(user_id, return_to, verifier, client)
+    params = {
+        "response_type": "code",
+        "client_id": client["client_id"],
+        "redirect_uri": _redirect_uri(),
+        "scope": SCOPES,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "resource": RESOURCE,
+    }
+    return f"{meta['authorization_endpoint']}?{httpx.QueryParams(params)}"
+
+
+async def finish_authorization(code: str, state: str) -> str | None:
+    payload = _decode_state(state)
+    client = payload["c"]
+    token = await _post_token(
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": _redirect_uri(),
+            "client_id": client["client_id"],
+            "code_verifier": payload["v"],
+            "resource": RESOURCE,
+        }
+    )
+    account = await _fetch_account(token["access_token"])
+    user_id = UUID(payload["u"])
+    await _store_connection(user_id, token, client, account)
+    await security_audit_service.record_user_event(
+        action="integration.connected",
+        actor_user_id=user_id,
+        target_type="integration",
+        target_id="posthog",
+        provider="posthog",
+        metadata={"auth_kind": "mcp_oauth"},
+    )
+    return payload["r"]
+
+
+async def _fetch_account(access_token: str) -> dict:
+    meta = await _discover()
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+        info = (await client.get(meta["userinfo_endpoint"])).raise_for_status().json()
+    email = info.get("email")
+    return {"email": email, "display_name": info.get("name") or email or "PostHog"}
+
+
+async def _store_connection(user_id: UUID, token: dict, client: dict, account: dict) -> None:
+    f = integration_fernet()
+    await get_pool().execute(
+        """
+        INSERT INTO user_integrations (
+            user_id, provider, account_key, access_token_encrypted, refresh_token_encrypted,
+            scopes, expires_at, account_email, account_display_name, client_info, updated_at
+        ) VALUES ($1, 'posthog', 'default', $2, $3, $4, $5, $6, $7, $8, now())
+        ON CONFLICT (user_id, provider, account_key) DO UPDATE SET
+            access_token_encrypted = EXCLUDED.access_token_encrypted,
+            refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
+            scopes = EXCLUDED.scopes, expires_at = EXCLUDED.expires_at,
+            account_email = EXCLUDED.account_email,
+            account_display_name = EXCLUDED.account_display_name,
+            client_info = EXCLUDED.client_info, updated_at = now()
+        """,
+        user_id,
+        f.encrypt(token["access_token"].encode()),
+        f.encrypt(token["refresh_token"].encode()) if token.get("refresh_token") else None,
+        (token.get("scope") or SCOPES).split(),
+        _expires_at(token),
+        account["email"],
+        account["display_name"],
+        json.dumps(client),
+    )
+
+
+async def get_valid_access_token(user_id: UUID) -> str:
+    row = await get_pool().fetchrow(
+        """SELECT access_token_encrypted, refresh_token_encrypted, expires_at, client_info
+           FROM user_integrations
+           WHERE user_id = $1 AND provider = 'posthog' AND account_key = 'default'""",
+        user_id,
+    )
+    if row is None:
+        raise HTTPException(status_code=401, detail="not connected to posthog")
+    f = integration_fernet()
+    if row["expires_at"] is None or row["expires_at"] > datetime.now(UTC) + timedelta(seconds=60):
+        return f.decrypt(bytes(row["access_token_encrypted"])).decode()
+    if row["refresh_token_encrypted"] is None:
+        raise HTTPException(status_code=401, detail="posthog token expired; reconnect required")
+    refresh_token = f.decrypt(bytes(row["refresh_token_encrypted"])).decode()
+    client = json.loads(row["client_info"])
+    token = await _post_token(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client["client_id"],
+            "resource": RESOURCE,
+        }
+    )
+    await get_pool().execute(
+        """UPDATE user_integrations SET access_token_encrypted = $2,
+           refresh_token_encrypted = COALESCE($3, refresh_token_encrypted), expires_at = $4,
+           updated_at = now() WHERE user_id = $1 AND provider = 'posthog' AND account_key = 'default'""",
+        user_id,
+        f.encrypt(token["access_token"].encode()),
+        f.encrypt(token["refresh_token"].encode()) if token.get("refresh_token") else None,
+        _expires_at(token),
+    )
+    return token["access_token"]
+
+
+async def revoke(access_token: str) -> None:
+    meta = await _discover()
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        (
+            await client.post(meta["revocation_endpoint"], data={"token": access_token})
+        ).raise_for_status()

--- a/backend/integrations/posthog/provider.py
+++ b/backend/integrations/posthog/provider.py
@@ -1,98 +1,44 @@
-"""Credential-based PostHog provider."""
+"""PostHog integration via OAuth 2.0 and the official MCP server."""
 
 from __future__ import annotations
 
-import json
-from urllib.parse import urlparse
+from uuid import UUID
 
-import httpx
+from fastapi import HTTPException
 
-from ..base import AccountInfo, CredentialField, TokenSet
+from ..base import AccountInfo, TokenSet
+from . import oauth
 
-POSTHOG_CLOUD_HOSTS = {"us.posthog.com", "eu.posthog.com"}
-
-
-def normalize_host(value: str) -> str:
-    host = value.strip().rstrip("/")
-    parsed = urlparse(host)
-    if parsed.scheme != "https" or not parsed.netloc or parsed.path:
-        raise ValueError("instance_url must be an HTTPS origin")
-    if parsed.username or parsed.password or parsed.query or parsed.fragment:
-        raise ValueError("instance_url must not contain credentials, a query, or a fragment")
-    if parsed.hostname not in POSTHOG_CLOUD_HOSTS or parsed.port not in (None, 443):
-        raise ValueError("instance_url must be a PostHog Cloud origin")
-    return host
-
-
-def decode_credentials(token: str) -> dict[str, str]:
-    values = json.loads(token)
-    return {
-        "instance_url": values["instance_url"],
-        "project_id": values["project_id"],
-        "personal_api_key": values["personal_api_key"],
-    }
+_GENERIC = "PostHog uses the MCP OAuth flow."
 
 
 class PostHogIntegration:
     name = "posthog"
     display_name = "PostHog"
-    auth_kind = "api_key"
-    scopes = ["project:read"]
-    supports_refresh = False
-    credential_fields = [
-        CredentialField(
-            "instance_url",
-            "PostHog instance URL",
-            placeholder="https://us.posthog.com",
-            help="Use https://eu.posthog.com for EU Cloud.",
-        ),
-        CredentialField("project_id", "Project ID", placeholder="12345"),
-        CredentialField(
-            "personal_api_key",
-            "Personal API key",
-            secret=True,
-            placeholder="phx_…",
-            help="Create a key with project read access in PostHog settings.",
-        ),
-    ]
+    auth_kind = "mcp_oauth"
+    scopes = oauth.SCOPES.split()
+    supports_refresh = True
 
-    async def connect_with_credentials(
-        self, values: dict[str, str]
-    ) -> tuple[TokenSet, AccountInfo]:
-        required = ("instance_url", "project_id", "personal_api_key")
-        if any(not values.get(field, "").strip() for field in required):
-            raise ValueError("all PostHog credentials are required")
+    async def start_authorization(self, user_id: UUID, return_to: str | None) -> str:
+        return await oauth.start_authorization(user_id, return_to)
 
-        instance_url = normalize_host(values["instance_url"])
-        project_id = values["project_id"].strip()
-        if not project_id.isascii() or not project_id.isdigit():
-            raise ValueError("project_id must be numeric")
-        personal_api_key = values["personal_api_key"].strip()
-        headers = {"Authorization": f"Bearer {personal_api_key}"}
-        async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
-            response = await client.get(f"{instance_url}/api/projects/{project_id}/")
-            response.raise_for_status()
-            project = response.json()
-
-        if str(project.get("id")) != project_id:
-            raise ValueError("PostHog returned a different project")
-        token = json.dumps(
-            {
-                "instance_url": instance_url,
-                "project_id": project_id,
-                "personal_api_key": personal_api_key,
-            }
-        )
-        project_name = project.get("name") or f"Project {project_id}"
-        return (
-            TokenSet(
-                access_token=token,
-                refresh_token=None,
-                expires_at=None,
-                scopes=list(self.scopes),
-            ),
-            AccountInfo(email=None, display_name=project_name),
-        )
+    async def finish_authorization(self, code: str, state: str) -> str | None:
+        return await oauth.finish_authorization(code, state)
 
     async def revoke(self, access_token: str) -> None:
-        return None
+        await oauth.revoke(access_token)
+
+    async def get_valid_access_token(self, user_id: UUID) -> str:
+        return await oauth.get_valid_access_token(user_id)
+
+    def authorize_url(self, state: str) -> str:
+        raise HTTPException(status_code=400, detail=_GENERIC)
+
+    async def exchange_code(self, code: str) -> TokenSet:
+        raise HTTPException(status_code=400, detail=_GENERIC)
+
+    async def refresh(self, refresh_token: str) -> TokenSet:
+        raise HTTPException(status_code=400, detail=_GENERIC)
+
+    async def fetch_account(self, access_token: str) -> AccountInfo:
+        raise HTTPException(status_code=400, detail=_GENERIC)

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -113,6 +113,10 @@ async def get_valid_token(
     account_key: str = DEFAULT_ACCOUNT_KEY,
 ) -> str:
     """Return a usable access token, refreshing if expired."""
+    provider_impl = get_provider(provider)
+    if getattr(provider_impl, "auth_kind", "oauth") == "mcp_oauth":
+        return await provider_impl.get_valid_access_token(user_id)
+
     pool = get_pool()
     row = await pool.fetchrow(_TOKEN_QUERY, user_id, provider, account_key)
     if row is None:
@@ -150,7 +154,7 @@ async def get_valid_token(
                 detail=f"{provider} token expired; reconnect required",
             )
 
-        new_token = await get_provider(provider).refresh(refresh_token)
+        new_token = await provider_impl.refresh(refresh_token)
         await conn.execute(
             """
             UPDATE user_integrations SET

--- a/backend/migrations/versions/0151_posthog_oauth.py
+++ b/backend/migrations/versions/0151_posthog_oauth.py
@@ -1,0 +1,31 @@
+"""Replace legacy PostHog API-key connections with OAuth.
+
+Revision ID: 0151
+Revises: 0150
+"""
+
+from alembic import op
+
+revision = "0151"
+down_revision = "0150"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DELETE FROM user_sources
+        WHERE source_type = 'posthog'
+          AND owner_user_id IN (
+              SELECT user_id FROM user_integrations
+              WHERE provider = 'posthog' AND client_info IS NULL
+          )
+        """)
+    op.execute("""
+        DELETE FROM user_integrations
+        WHERE provider = 'posthog' AND client_info IS NULL
+        """)
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_posthog_integration.py
+++ b/backend/tests/test_posthog_integration.py
@@ -1,20 +1,19 @@
+from contextlib import asynccontextmanager
+from urllib.parse import parse_qs, urlparse
 from uuid import UUID
 
-import httpx
 import pytest
 
-from backend.integrations.posthog import indexer
-from backend.integrations.posthog.provider import normalize_host
+from backend.integrations.posthog import indexer, oauth
+
+TEST_FERNET_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 
-def test_posthog_host_requires_a_bare_https_origin():
-    assert normalize_host(" https://eu.posthog.com/ ") == "https://eu.posthog.com"
-    with pytest.raises(ValueError):
-        normalize_host("http://posthog.internal")
-    with pytest.raises(ValueError):
-        normalize_host("https://posthog.example.com/api")
-    with pytest.raises(ValueError):
-        normalize_host("https://127.0.0.1")
+def _async(value):
+    async def result(*args, **kwargs):
+        return value
+
+    return result
 
 
 def test_posthog_paths_group_objects_and_keep_duplicate_names_distinct():
@@ -25,51 +24,58 @@ def test_posthog_paths_group_objects_and_keep_duplicate_names_distinct():
 
 
 @pytest.mark.asyncio
-async def test_posthog_indexer_indexes_each_product_collection(monkeypatch):
+async def test_connect_builds_read_only_pkce_authorize_url(monkeypatch):
+    monkeypatch.setattr(oauth.settings, "INTEGRATIONS_ENCRYPTION_KEY", TEST_FERNET_KEY)
+    monkeypatch.setattr(oauth.settings, "PUBLIC_URL", "https://app.example.com")
+    monkeypatch.setattr(
+        oauth,
+        "_discover",
+        _async(
+            {
+                "authorization_endpoint": "https://oauth.posthog.com/oauth/authorize/",
+                "registration_endpoint": "https://oauth.posthog.com/oauth/register/",
+            }
+        ),
+    )
+    monkeypatch.setattr(oauth, "_register_client", _async({"client_id": "client_abc"}))
+
+    url = await oauth.start_authorization(UUID(int=1), "/onboarding")
+    params = {key: values[0] for key, values in parse_qs(urlparse(url).query).items()}
+
+    assert params["resource"] == "https://mcp.posthog.com"
+    assert params["code_challenge_method"] == "S256"
+    assert "dashboard:read" in params["scope"]
+    assert "dashboard:write" not in params["scope"]
+    assert oauth._decode_state(params["state"])["r"] == "/onboarding"
+
+
+@pytest.mark.asyncio
+async def test_posthog_indexer_uses_each_mcp_collection(monkeypatch):
     captured: list[dict] = []
-    removed: list[list[str]] = []
     responses = {
-        "dashboards": {"id": 1, "name": "Company KPI", "created_at": "2026-07-01T00:00:00Z"},
-        "insights": {"id": 2, "name": "Activation", "updated_at": "2026-07-02T00:00:00Z"},
-        "feature_flags": {"id": 3, "key": "new-nav", "updated_at": "2026-07-03T00:00:00Z"},
-        "experiments": {"id": 4, "name": "Better onboarding", "updated_at": "2026-07-04T00:00:00Z"},
+        "dashboards-get-all": {"results": [{"id": 1, "name": "Company KPI"}]},
+        "insights-list": {"results": [{"id": 2, "name": "Activation"}]},
+        "feature-flag-get-all": {"results": [{"id": 3, "key": "new-nav"}]},
+        "experiment-list": {"results": [{"id": 4, "name": "Onboarding"}]},
     }
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self.payload = payload
+    @asynccontextmanager
+    async def fake_session(token):
+        assert token == "access_token"
+        yield object()
 
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self.payload
-
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, path, params=None):
-            kind = path.rstrip("/").rsplit("/", 1)[-1]
-            return FakeResponse({"results": [responses[kind]]})
-
-    async def fake_client(owner_user_id):
-        assert owner_user_id == UUID("00000000-0000-0000-0000-000000000002")
-        return FakeClient(), {"project_id": "42"}
+    async def fake_call_tool(session, name, arguments):
+        assert arguments == {"limit": 100, "offset": 0}
+        return responses[name]
 
     async def capture_upsert(**kwargs):
         captured.append(kwargs)
 
-    async def capture_remove(table, source_id, paths):
-        assert table == "posthog_index"
-        removed.append(paths)
-
-    monkeypatch.setattr(indexer, "_client", fake_client)
+    monkeypatch.setattr(indexer, "get_valid_token", _async("access_token"))
+    monkeypatch.setattr(indexer, "posthog_session", fake_session)
+    monkeypatch.setattr(indexer, "call_tool", fake_call_tool)
     monkeypatch.setattr(indexer.source_service, "upsert_index_row", capture_upsert)
-    monkeypatch.setattr(indexer.source_service, "remove_missing_documents", capture_remove)
+    monkeypatch.setattr(indexer.source_service, "remove_missing_documents", _async(None))
 
     await indexer.index_posthog(
         {
@@ -85,43 +91,3 @@ async def test_posthog_indexer_indexes_each_product_collection(monkeypatch):
         "experiments:4",
     ]
     assert captured[2]["path"] == "feature_flags/new-nav (3)"
-    assert removed == [[row["path"] for row in captured]]
-
-
-@pytest.mark.asyncio
-async def test_posthog_provider_validates_project_before_storing_credentials(monkeypatch):
-    from backend.integrations.posthog import provider
-
-    request = httpx.Request("GET", "https://us.posthog.com/api/projects/42/")
-
-    class FakeResponse:
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return {"id": 42, "name": "Acme Product"}
-
-    class FakeClient:
-        def __init__(self, **kwargs):
-            assert kwargs["headers"] == {"Authorization": "Bearer phx_secret"}
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, url):
-            assert url == str(request.url)
-            return FakeResponse()
-
-    monkeypatch.setattr(provider.httpx, "AsyncClient", FakeClient)
-    token, account = await provider.PostHogIntegration().connect_with_credentials(
-        {
-            "instance_url": "https://us.posthog.com",
-            "project_id": "42",
-            "personal_api_key": "phx_secret",
-        }
-    )
-    assert account.display_name == "Acme Product"
-    assert provider.decode_credentials(token.access_token)["project_id"] == "42"


### PR DESCRIPTION
## Summary
- replace the PostHog personal API key form with PostHog hosted OAuth (DCR + PKCE)
- request only read scopes and access PostHog through its read-only hosted MCP server
- refresh MCP OAuth tokens during health checks and background syncs
- remove non-migratable legacy API-key connections so users reconnect through OAuth

## Verification
- `ruff check backend/ cli/`
- `ruff format --check backend/ cli/`
- `pytest --no-cov -q backend/tests/test_posthog_integration.py backend/tests/test_integration_sources.py backend/tests/test_integration_token_refresh.py backend/tests/test_granola.py backend/tests/test_migrations.py` (46 passed)
- `npm test -- --run` (199 passed)
- `BACKEND_INTERNAL_URL=http://localhost:3456 npm run build`
- live PostHog dynamic client registration smoke test
- browser QA: Stash Connect opens PostHog OAuth region selection with no browser/server errors

## OAuth permissions
`openid profile email account:read project:read dashboard:read insight:read feature_flag:read experiment:read query:read`
