### PR TITLE
Sync Slack thread replies

### DIFF
--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -1,8 +1,9 @@
 """Slack → slack_messages: one-time backfill + per-event ingest.
 
 `index_slack` backfills recent history for the source's explicit channel
-allowlist. Live updates arrive via the Events API webhook, which enqueues
-`ingest_slack_message` per message. Each message is a row at `{channel}/{ts}`
+allowlist, including thread replies (conversations.history omits them, so each
+threaded parent gets a conversations.replies fetch). Live updates arrive via
+the Events API webhook, which enqueues `ingest_slack_message` per message. Each message is a row at `{channel}/{ts}`
 (with native channel_id/channel_name/ts and author columns); the *document
 projection* over these rows is one transcript per channel per UTC day (see
 source_service.list_documents/read_document), so agents read coherent,
@@ -11,6 +12,7 @@ attributed conversations instead of one-line files.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from uuid import UUID
 
@@ -24,11 +26,13 @@ logger = logging.getLogger(__name__)
 
 CONVERSATIONS_LIST_URL = "https://slack.com/api/conversations.list"
 CONVERSATIONS_HISTORY_URL = "https://slack.com/api/conversations.history"
+CONVERSATIONS_REPLIES_URL = "https://slack.com/api/conversations.replies"
 USERS_INFO_URL = "https://slack.com/api/users.info"
 
 CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
 MAX_CHANNELS = 100
 MAX_MESSAGES_PER_CHANNEL = 200
+RATE_LIMIT_MAX_RETRIES = 5
 
 # Sorts before any real YYYY-MM-DD transcript, so the cap disclosure is the
 # first entry an agent sees when listing a capped channel.
@@ -36,12 +40,20 @@ CAP_MARKER_LEAF = "0000-history-cap"
 
 
 async def _slack_get(client: httpx.AsyncClient, url: str, params: dict) -> dict:
-    resp = await client.get(url, params=params)
-    resp.raise_for_status()
-    payload = resp.json()
-    if not payload.get("ok"):
-        raise RuntimeError("Slack API returned ok=false")
-    return payload
+    # conversations.replies is Tier 3 (~50 req/min), so a threaded backfill can
+    # legitimately hit 429s; honoring Retry-After keeps the sync alive instead
+    # of aborting the channel.
+    for _ in range(RATE_LIMIT_MAX_RETRIES):
+        resp = await client.get(url, params=params)
+        if resp.status_code == 429:
+            await asyncio.sleep(float(resp.headers["Retry-After"]))
+            continue
+        resp.raise_for_status()
+        payload = resp.json()
+        if not payload.get("ok"):
+            raise RuntimeError("Slack API returned ok=false")
+        return payload
+    raise RuntimeError("Slack API kept rate limiting after retries")
 
 
 async def _author_of(
@@ -130,7 +142,18 @@ async def index_slack(source: dict) -> str | None:
                     text=msg.get("text") or "",
                     author_id=author_id,
                     author=author,
+                    thread_ts=_thread_ts_of(msg),
                 )
+                if msg.get("reply_count"):
+                    await _index_thread_replies(
+                        client=client,
+                        source_id=source_id,
+                        owner_user_id=owner_user_id,
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                        parent_ts=msg["ts"],
+                        names=names,
+                    )
             await _sync_cap_marker(
                 source_id=source_id,
                 owner_user_id=owner_user_id,
@@ -202,10 +225,24 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
                     text=msg.get("text") or "",
                     author_id=author_id,
                     author=author,
+                    thread_ts=_thread_ts_of(msg),
                 )
                 refs.append(f"{channel_name}/{msg['ts']}")
                 if len(refs) >= limit:
                     break
+                if msg.get("reply_count"):
+                    reply_ts = await _index_thread_replies(
+                        client=client,
+                        source_id=source_id,
+                        owner_user_id=owner_user_id,
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                        parent_ts=msg["ts"],
+                        names=names,
+                    )
+                    refs.extend(f"{channel_name}/{ts}" for ts in reply_ts)
+                    if len(refs) >= limit:
+                        break
 
     return {
         "fetched": len(refs),
@@ -213,6 +250,72 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
         "until": until.isoformat() if until else None,
         "results": [{"ref": r} for r in refs[:25]],
     }
+
+
+def _thread_ts_of(msg: dict) -> str | None:
+    """The parent ts if `msg` is a thread reply, else None. Slack marks thread
+    parents with thread_ts == ts, and `thread_broadcast` copies in history
+    carry the real parent's thread_ts."""
+    thread_ts = msg.get("thread_ts")
+    if not thread_ts or thread_ts == msg.get("ts"):
+        return None
+    return thread_ts
+
+
+async def _index_thread_replies(
+    *,
+    client: httpx.AsyncClient,
+    source_id: UUID,
+    owner_user_id: UUID,
+    channel_id: str,
+    channel_name: str,
+    parent_ts: str,
+    names: dict[str, str],
+) -> list[str]:
+    """Page conversations.replies for one thread and upsert every reply with
+    its parent linkage. Replies beyond MAX_MESSAGES_PER_CHANNEL are dropped;
+    a capped thread gets a notice document, an uncapped one gets any stale
+    notice removed. Returns the upserted reply ts values."""
+    reply_ts: list[str] = []
+    capped = False
+    cursor = None
+    while True:
+        params = {"channel": channel_id, "ts": parent_ts, "limit": MAX_MESSAGES_PER_CHANNEL}
+        if cursor:
+            params["cursor"] = cursor
+        payload = await _slack_get(client, CONVERSATIONS_REPLIES_URL, params)
+        for msg in payload.get("messages", []):
+            # conversations.replies returns the parent as its first message.
+            if msg.get("type") != "message" or not msg.get("ts") or msg["ts"] == parent_ts:
+                continue
+            if len(reply_ts) >= MAX_MESSAGES_PER_CHANNEL:
+                capped = True
+                break
+            author_id, author = await _author_of(client, names, msg)
+            await _upsert_message(
+                source_id=source_id,
+                owner_user_id=owner_user_id,
+                channel_id=channel_id,
+                channel_name=channel_name,
+                ts=msg["ts"],
+                text=msg.get("text") or "",
+                author_id=author_id,
+                author=author,
+                thread_ts=parent_ts,
+            )
+            reply_ts.append(msg["ts"])
+        cursor = (payload.get("response_metadata") or {}).get("next_cursor")
+        if capped or not cursor:
+            break
+    await _sync_thread_cap_marker(
+        source_id=source_id,
+        owner_user_id=owner_user_id,
+        channel_id=channel_id,
+        channel_name=channel_name,
+        parent_ts=parent_ts,
+        capped=capped,
+    )
+    return reply_ts
 
 
 async def _upsert_message(
@@ -225,6 +328,7 @@ async def _upsert_message(
     text: str,
     author_id: str | None,
     author: str,
+    thread_ts: str | None,
 ) -> None:
     existing = await get_pool().fetchrow(
         "SELECT path, name FROM slack_messages "
@@ -248,6 +352,7 @@ async def _upsert_message(
             "channel_id": channel_id,
             "channel_name": channel_name,
             "ts": ts,
+            "thread_ts": thread_ts,
             "author_id": author_id,
             "author": author,
         },
@@ -292,6 +397,43 @@ async def _sync_cap_marker(
     )
 
 
+async def _sync_thread_cap_marker(
+    *,
+    source_id: UUID,
+    owner_user_id: UUID,
+    channel_id: str,
+    channel_name: str,
+    parent_ts: str,
+    capped: bool,
+) -> None:
+    """Per-thread analogue of _sync_cap_marker: a thread whose replies exceeded
+    the per-thread cap gets a notice document; one that fit gets any stale
+    notice removed."""
+    path = f"{channel_name}/{parent_ts}-thread-cap"
+    if not capped:
+        await get_pool().execute(
+            "DELETE FROM slack_messages WHERE source_id = $1 AND path = $2",
+            source_id,
+            path,
+        )
+        return
+    await source_service.upsert_content_document(
+        table="slack_messages",
+        source_id=source_id,
+        owner_user_id=owner_user_id,
+        path=path,
+        name=f"#{channel_name} thread {parent_ts} is NOT fully indexed",
+        kind="notice",
+        content=(
+            f"Only the {MAX_MESSAGES_PER_CHANNEL} oldest replies of the thread started at "
+            f"{parent_ts} in #{channel_name} are indexed. Later replies exist in Slack "
+            "but are not searchable here."
+        ),
+        external_ref=None,
+        extra={"channel_id": channel_id, "channel_name": channel_name, "ts": None},
+    )
+
+
 async def ingest_slack_message(team_id: str, event: dict) -> int:
     """Upsert one Events-API message into matching Slack sources for this team.
     Each source is user-scoped and channel-scoped, so the same message lands
@@ -322,12 +464,13 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
         message = event.get("message") or {}
         if message.get("type") != "message" or not message.get("ts"):
             return 0
-        # Edits of subtyped messages (bot_message, thread_broadcast, ...) carry
-        # the subtype inside the nested message; drop them like fresh ones.
-        if message.get("subtype"):
+        # Edits of subtyped messages (bot_message, ...) carry the subtype inside
+        # the nested message; drop them like fresh ones — except thread_broadcast,
+        # which is just a reply that was also sent to the channel.
+        if message.get("subtype") not in (None, "thread_broadcast"):
             return 0
         event = {**message, "channel": channel_id, "type": "message"}
-    elif subtype:
+    elif subtype not in (None, "thread_broadcast"):
         return 0
 
     if not event.get("ts"):
@@ -360,6 +503,7 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
             text=event.get("text") or "",
             author_id=author_id,
             author=author,
+            thread_ts=_thread_ts_of(event),
         )
         ingested += 1
     return ingested

--- a/backend/migrations/versions/0148_slack_thread_ts.py
+++ b/backend/migrations/versions/0148_slack_thread_ts.py
@@ -1,0 +1,28 @@
+"""Add thread linkage to slack_messages.
+
+Thread replies were either never fetched (backfill) or stored with their
+`thread_ts` discarded (live ingest), so replies rendered as free-floating
+top-level lines and most of them were simply missing. Rows now record the
+parent's ts; NULL means a top-level message.
+
+Existing rows get thread_ts on the next sync (the upsert's extra-column
+freshness check sees NULL != parent ts and rewrites the row).
+
+Revision ID: 0148
+Revises: 0147
+"""
+
+from alembic import op
+
+revision = "0148"
+down_revision = "0147"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE slack_messages ADD COLUMN thread_ts text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE slack_messages DROP COLUMN thread_ts")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -916,7 +916,7 @@ async def _render_slack_day(
 ) -> dict | None:
     rows = await get_pool().fetch(
         """
-        SELECT ts, author, content FROM slack_messages
+        SELECT ts, thread_ts, author, content FROM slack_messages
         WHERE source_id = $1 AND deleted_at IS NULL AND kind = 'message'
           AND channel_id = ANY($2::text[]) AND channel_name = $3
           AND to_char(to_timestamp(ts::float8) AT TIME ZONE 'UTC', 'YYYY-MM-DD') = $4
@@ -929,20 +929,100 @@ async def _render_slack_day(
     )
     if not rows:
         return None
+    groups = _group_slack_threads(rows)
+    cross_day_parents = await _slack_thread_parents(
+        source,
+        channel,
+        allowed_channel_ids,
+        [g["parent_ts"] for g in groups if g["parent"] is None],
+    )
     lines = [f"# #{channel} — {day} (UTC)", ""]
-    for row in rows:
-        clock = datetime.fromtimestamp(float(row["ts"]), UTC).strftime("%H:%M")
-        # Continuation lines are indented so a line-leading HH:MM always means
-        # a new message.
-        text = (row["content"] or "").replace("\n", "\n    ")
-        author = row["author"] or ""
-        lines.append(f"{clock} {author}: {text}" if author else f"{clock} {text}")
+    for group in groups:
+        if group["parent"] is not None:
+            lines.append(_slack_message_line(group["parent"]))
+        else:
+            lines.append(
+                _slack_thread_context_line(
+                    group["replies"][0]["ts"],
+                    group["parent_ts"],
+                    cross_day_parents.get(group["parent_ts"]),
+                )
+            )
+        for reply in group["replies"]:
+            lines.append("  ↳ " + _slack_message_line(reply))
     return {
         "path": f"{channel}/{day}",
         "name": f"#{channel} {day}",
         "kind": "transcript",
         "content": "\n".join(lines) + "\n",
     }
+
+
+def _group_slack_threads(rows) -> list[dict]:
+    """Group a day's message rows into render units, in chronological order:
+    one group per top-level message (carrying its same-day replies), plus one
+    group per cross-day thread — replies whose parent lives in an earlier
+    day's transcript — anchored where the day's first reply lands. Rows are ts
+    ordered, so a same-day parent is always seen before its replies."""
+    groups: list[dict] = []
+    by_parent_ts: dict[str, dict] = {}
+    for row in rows:
+        parent_ts = row["thread_ts"]
+        if parent_ts is None:
+            group = {"parent": row, "parent_ts": row["ts"], "replies": []}
+            groups.append(group)
+            by_parent_ts[row["ts"]] = group
+            continue
+        group = by_parent_ts.get(parent_ts)
+        if group is None:
+            group = {"parent": None, "parent_ts": parent_ts, "replies": []}
+            groups.append(group)
+            by_parent_ts[parent_ts] = group
+        group["replies"].append(row)
+    return groups
+
+
+async def _slack_thread_parents(
+    source: dict, channel: str, allowed_channel_ids: list[str], parent_ts: list[str]
+) -> dict[str, dict]:
+    """Rows of cross-day thread parents, keyed by ts, for context lines."""
+    if not parent_ts:
+        return {}
+    rows = await get_pool().fetch(
+        "SELECT ts, author, content FROM slack_messages "
+        "WHERE source_id = $1 AND deleted_at IS NULL AND kind = 'message' "
+        "AND channel_id = ANY($2::text[]) AND channel_name = $3 AND ts = ANY($4::text[])",
+        UUID(source["id"]),
+        allowed_channel_ids,
+        channel,
+        parent_ts,
+    )
+    return {r["ts"]: r for r in rows}
+
+
+def _slack_message_line(row) -> str:
+    clock = datetime.fromtimestamp(float(row["ts"]), UTC).strftime("%H:%M")
+    # Continuation lines are indented so a line-leading HH:MM always means
+    # a new message.
+    text = (row["content"] or "").replace("\n", "\n    ")
+    author = row["author"] or ""
+    return f"{clock} {author}: {text}" if author else f"{clock} {text}"
+
+
+def _slack_thread_context_line(first_reply_ts: str, parent_ts: str, parent_row) -> str:
+    """One line of context before a cross-day thread's first reply, quoting
+    the parent from its own day. The parent row can be absent (older than the
+    backfill window), in which case only its timestamp is known."""
+    clock = datetime.fromtimestamp(float(first_reply_ts), UTC).strftime("%H:%M")
+    stamp = datetime.fromtimestamp(float(parent_ts), UTC).strftime("%Y-%m-%d %H:%M")
+    if parent_row is None:
+        return f"{clock} (thread from {stamp})"
+    quote = " ".join((parent_row["content"] or "").split())
+    if len(quote) > 80:
+        quote = quote[:80] + "…"
+    author = parent_row["author"] or ""
+    attribution = f"{author}: " if author else ""
+    return f'{clock} (thread from {stamp} {attribution}"{quote}")'
 
 
 async def _read_twitter_live_ref(source: dict, ref: str) -> dict:

--- a/backend/tests/test_slack_security.py
+++ b/backend/tests/test_slack_security.py
@@ -7,6 +7,8 @@ from backend.integrations.slack import indexer
 
 
 class _SlackErrorResponse:
+    status_code = 200
+
     def raise_for_status(self):
         return None
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1794,6 +1794,322 @@ async def test_slack_projects_day_transcripts_with_authors(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_slack_day_transcript_groups_threads(client: AsyncClient):
+    """Coherent conversations are the point of thread sync: same-day replies
+    render indented under their parent (not shredded into channel chronology),
+    and a cross-day thread opens with one context line quoting the parent from
+    its own day, truncated to ~80 chars."""
+    from datetime import UTC, datetime
+
+    api_key, owner_id = await _register(client, "slack_threads")
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_THREADS",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+
+    def ts_of(*args) -> str:
+        return f"{datetime(*args, tzinfo=UTC).timestamp():.6f}"
+
+    parent_ts = ts_of(2026, 7, 13, 22, 53)
+    parent_text = (
+        "FYI — I put up a draft PR (#687) that syncs Slack thread replies into "
+        "Stash so incident timelines stay searchable"
+    )
+    messages = [
+        (parent_ts, None, "henry", parent_text),
+        (ts_of(2026, 7, 13, 23, 0), None, "sam", "unrelated message"),
+        (ts_of(2026, 7, 13, 23, 10), parent_ts, "michael", "taking a look tomorrow"),
+        (ts_of(2026, 7, 13, 23, 12), parent_ts, "henry", "no rush"),
+        (ts_of(2026, 7, 14, 9, 2), parent_ts, "michael", "merged already? let's talk"),
+    ]
+    for ts, thread_ts, author, text in messages:
+        await source_service.upsert_content_document(
+            table="slack_messages",
+            source_id=UUID(src["id"]),
+            owner_user_id=ws,
+            path=f"general/{ts}",
+            name="#general",
+            kind="message",
+            content=text,
+            external_ref=f"C1:{ts}",
+            extra={
+                "channel_id": "C1",
+                "channel_name": "general",
+                "ts": ts,
+                "thread_ts": thread_ts,
+                "author_id": f"U_{author}",
+                "author": author,
+            },
+        )
+
+    day_one = await source_service.read_document(src, "general/2026-07-13")
+    assert day_one["content"].splitlines()[2:] == [
+        f"22:53 henry: {parent_text}",
+        "  ↳ 23:10 michael: taking a look tomorrow",
+        "  ↳ 23:12 henry: no rush",
+        "23:00 sam: unrelated message",
+    ]
+
+    day_two = await source_service.read_document(src, "general/2026-07-14")
+    quote = parent_text[:80] + "…"
+    assert day_two["content"].splitlines()[2:] == [
+        f'09:02 (thread from 2026-07-13 22:53 henry: "{quote}")',
+        "  ↳ 09:02 michael: merged already? let's talk",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slack_backfill_fetches_thread_replies(client: AsyncClient, monkeypatch, pool):
+    """conversations.history omits thread replies, so a parent with
+    reply_count must trigger a paged conversations.replies fetch whose rows
+    land with thread_ts linkage. Re-running is idempotent."""
+    from backend.integrations.slack import indexer
+
+    api_key, owner_id = await _register(client, "slack_replies")
+    await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_REPLIES",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+    replies_calls: list[dict] = []
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.CONVERSATIONS_LIST_URL:
+            return {"channels": [{"id": "C1", "name": "general"}]}
+        if url == indexer.CONVERSATIONS_REPLIES_URL:
+            replies_calls.append(dict(params))
+            if "cursor" not in params:
+                return {
+                    "messages": [
+                        # Slack returns the parent as the thread's first message.
+                        {"type": "message", "ts": "1000.000100", "text": "parent"},
+                        {
+                            "type": "message",
+                            "ts": "1000.000200",
+                            "text": "first reply",
+                            "thread_ts": "1000.000100",
+                        },
+                    ],
+                    "response_metadata": {"next_cursor": "page2"},
+                }
+            return {
+                "messages": [
+                    {
+                        "type": "message",
+                        "ts": "1000.000300",
+                        "text": "second reply",
+                        "thread_ts": "1000.000100",
+                    }
+                ]
+            }
+        return {
+            "messages": [
+                {"type": "message", "ts": "1000.000100", "text": "parent", "reply_count": 2},
+                {"type": "message", "ts": "1000.000050", "text": "no thread"},
+            ]
+        }
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+    await indexer.index_slack(src)
+
+    assert [c.get("cursor") for c in replies_calls] == [None, "page2"]
+    assert all(c["channel"] == "C1" and c["ts"] == "1000.000100" for c in replies_calls)
+    rows = await pool.fetch(
+        "SELECT ts, thread_ts FROM slack_messages WHERE source_id = $1 ORDER BY ts",
+        UUID(src["id"]),
+    )
+    assert [(r["ts"], r["thread_ts"]) for r in rows] == [
+        ("1000.000050", None),
+        ("1000.000100", None),
+        ("1000.000200", "1000.000100"),
+        ("1000.000300", "1000.000100"),
+    ]
+
+    await indexer.index_slack(src)
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM slack_messages WHERE source_id = $1", UUID(src["id"])
+    )
+    assert count == 4
+
+
+@pytest.mark.asyncio
+async def test_slack_backfill_discloses_thread_cap(client: AsyncClient, monkeypatch, pool):
+    """A thread whose replies exceed the per-thread cap must say so in the
+    channel's listing, like the channel history cap does — and the notice
+    clears once the thread fits."""
+    from backend.integrations.slack import indexer
+
+    monkeypatch.setattr(indexer, "MAX_MESSAGES_PER_CHANNEL", 2)
+    api_key, owner_id = await _register(client, "slack_thread_cap")
+    await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_THREAD_CAP",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+    reply_count = 3
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.CONVERSATIONS_LIST_URL:
+            return {"channels": [{"id": "C1", "name": "general"}]}
+        if url == indexer.CONVERSATIONS_REPLIES_URL:
+            replies = [
+                {
+                    "type": "message",
+                    "ts": f"1000.00020{i}",
+                    "text": f"reply {i}",
+                    "thread_ts": "1000.000100",
+                }
+                for i in range(reply_count)
+            ]
+            return {"messages": replies}
+        return {
+            "messages": [
+                {
+                    "type": "message",
+                    "ts": "1000.000100",
+                    "text": "parent",
+                    "reply_count": reply_count,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+    await indexer.index_slack(src)
+    docs = await source_service.list_documents(src)
+    notices = [d["path"] for d in docs if d["kind"] == "notice"]
+    assert notices == ["general/1000.000100-thread-cap"]
+    notice = await source_service.read_document(src, notices[0])
+    assert "not searchable here" in notice["content"]
+    # The capped third reply was dropped, not silently stored.
+    stored = await pool.fetchval(
+        "SELECT COUNT(*) FROM slack_messages WHERE source_id = $1 AND thread_ts IS NOT NULL",
+        UUID(src["id"]),
+    )
+    assert stored == 2
+
+    # The thread now fits — the stale notice must disappear.
+    reply_count = 2
+    await indexer.index_slack(src)
+    docs = await source_service.list_documents(src)
+    assert [d["kind"] for d in docs] == ["transcript"]
+
+
+@pytest.mark.asyncio
+async def test_slack_event_ingest_keeps_thread_linkage(client: AsyncClient, pool):
+    """A live reply keeps its parent linkage, and thread_broadcast — a reply
+    also sent to the channel — is ingested rather than dropped. A thread
+    parent (thread_ts == ts) stays top-level."""
+    from backend.integrations.slack.indexer import ingest_slack_message
+
+    _, owner_id = await _register(client, "slack_thread_ingest")
+    source = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_THREAD_INGEST",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["C1"]},
+    )
+
+    events = [
+        {
+            "type": "message",
+            "channel": "C1",
+            "ts": "1717.0001",
+            "thread_ts": "1717.0001",
+            "text": "the parent",
+        },
+        {
+            "type": "message",
+            "channel": "C1",
+            "ts": "1717.0002",
+            "thread_ts": "1717.0001",
+            "text": "a plain reply",
+        },
+        {
+            "type": "message",
+            "subtype": "thread_broadcast",
+            "channel": "C1",
+            "ts": "1717.0003",
+            "thread_ts": "1717.0001",
+            "text": "broadcast reply",
+        },
+    ]
+    for event in events:
+        assert await ingest_slack_message("T_THREAD_INGEST", event) == 1
+
+    rows = await pool.fetch(
+        "SELECT ts, thread_ts FROM slack_messages WHERE source_id = $1 ORDER BY ts",
+        UUID(source["id"]),
+    )
+    assert [(r["ts"], r["thread_ts"]) for r in rows] == [
+        ("1717.0001", None),
+        ("1717.0002", "1717.0001"),
+        ("1717.0003", "1717.0001"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slack_get_honors_rate_limit_retry_after():
+    """A 429 must not abort the channel: _slack_get sleeps out Retry-After and
+    retries, and only a persistently rate-limited call fails loud."""
+    from backend.integrations.slack import indexer
+
+    class FakeResponse:
+        def __init__(self, status_code, payload=None, headers=None):
+            self.status_code = status_code
+            self._payload = payload
+            self.headers = headers or {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, responses):
+            self.responses = list(responses)
+            self.calls = 0
+
+        async def get(self, url, params):
+            self.calls += 1
+            return self.responses.pop(0)
+
+    limited = FakeResponse(429, headers={"Retry-After": "0"})
+    ok = FakeResponse(200, payload={"ok": True, "messages": []})
+    recovering = FakeClient([limited, ok])
+    payload = await indexer._slack_get(recovering, "https://slack.test/api", {})
+    assert payload["ok"] is True
+    assert recovering.calls == 2
+
+    exhausted = FakeClient(
+        [FakeResponse(429, headers={"Retry-After": "0"})] * indexer.RATE_LIMIT_MAX_RETRIES
+    )
+    with pytest.raises(RuntimeError, match="rate limit"):
+        await indexer._slack_get(exhausted, "https://slack.test/api", {})
+
+
+@pytest.mark.asyncio
 async def test_slack_backfill_resolves_authors_and_caches_lookups(
     client: AsyncClient, monkeypatch, pool
 ):
@@ -1895,8 +2211,9 @@ async def test_slack_event_ingest_drops_edits_of_subtyped_messages(
     client: AsyncClient,
     pool,
 ):
-    """Fresh subtyped messages (bot_message, thread_broadcast, ...) are never
-    ingested, so editing one must not sneak it in via message_changed either."""
+    """Fresh subtyped messages (bot_message, channel_join, ...) are never
+    ingested, so editing one must not sneak it in via message_changed either.
+    (thread_broadcast is the exception — it's a normal reply, tested above.)"""
     from backend.integrations.slack.indexer import ingest_slack_message
 
     api_key, owner_id = await _register(client, "slack_bot_edit")


### PR DESCRIPTION
## What

Stash's Slack source captured only top-level channel messages. Thread replies — where most substantive discussion happens — were invisible to search, ask-the-stash, the curator's nightly wiki, and any agent reading `/sources/slack`. This syncs thread replies end to end.

Implements the [slack-thread-sync-proposal](https://app.joinstash.ai/p/a83544d9-97b7-4e0b-a94c-d407926f1962).

## Changes

- **Migration `0148`** — nullable `thread_ts` on `slack_messages` (NULL = top-level message; else the parent's ts). Existing rows pick it up on the next sync via the upsert's freshness check.
- **Backfill + fetch-history** (`indexer.py`) — `conversations.history` omits thread replies, so every parent with `reply_count > 0` now triggers a paged `conversations.replies` fetch; each reply is upserted with its parent linkage. Replies past the 200-per-thread cap are dropped with a notice document (same mechanism as the channel history-cap marker), which clears when the thread fits.
- **Live ingest** — reply events keep their `thread_ts`, and `thread_broadcast` (a reply also posted to the channel) is ingested instead of dropped, both as fresh events and as `message_changed` edits.
- **Rate limits** — `_slack_get` honors `429 Retry-After` with bounded retries so a threaded backfill survives Tier 3 limits instead of aborting the channel.
- **Rendering** (`source_service.py`) — day transcripts group threads coherently instead of flat chronology.

## Rendered transcript: before → after

Before (flat, thread-blind):
```
22:53 henry: FYI — I put up a draft PR (#687)…
23:00 sam: unrelated message
23:10 michael: taking a look tomorrow
23:12 henry: no rush
```

After (same-day replies grouped under their parent):
```
22:53 henry: FYI — I put up a draft PR (#687)…
  ↳ 23:10 michael: taking a look tomorrow
  ↳ 23:12 henry: no rush
23:00 sam: unrelated message
```

A cross-day thread opens with one context line quoting the parent from its own day:
```
09:02 (thread from 2026-07-13 22:53 henry: "FYI — I put up a draft PR (#687)…")
  ↳ 09:02 michael: merged already? let's talk
```

_No GUI surface in this change — the user-facing artifact is the rendered transcript text shown above, so there are no product screenshots to attach._

## Rate-limit tier: verified

The proposal flagged one open question: Slack's 2025 changes drop `conversations.history`/`replies` to ~1 req/min for non-Marketplace apps created after May 2025, which would make backfill take hours. **Probed empirically** against the busiest synced channel — two back-to-back `conversations.history` calls at `limit=200` both returned the full 200 messages with no 429, so the app is on **legacy Tier 3 (~50 req/min)** and backfill runs in minutes. The 429 handling stays as a safety net regardless (Slack has said existing apps transition to the new limits eventually).

## Rollout

After deploy, each Slack source needs **one `index_slack` re-run** to pull historical replies (existing sync path; upserts make it safe). New replies flow in live from day one. Until a source is re-synced, its old threads stay missing.

## Testing

Full backend suite passes (839 tests); ruff clean. New coverage: same-day grouping, cross-day context line with truncation, interleaved threads, reply pagination, thread-cap appear/clear, live thread linkage incl. `thread_broadcast`, and 429 retry + idempotent re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
