### PR TITLE
Slack sync: tighter safety-backfill + stale-source warner

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -102,6 +102,10 @@ celery.conf.update(
             "task": "backend.tasks.sources.reconcile_github_sync_all",
             "schedule": 3600.0,
         },
+        "sources-warn-stale": {
+            "task": "backend.tasks.sources.warn_stale_sources",
+            "schedule": 3600.0,
+        },
         "cli-auth-cleanup-expired": {
             "task": "backend.tasks.cli_auth.cleanup_expired_sessions",
             "schedule": 300.0,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -58,7 +58,10 @@ DEFAULT_SYNC_INTERVAL_S = {
     "google_drive": 1800,
     "google_drive_folder": 1800,
     "notion": 1800,
-    "slack": 21600,
+    # The Events-API webhook is Slack's live path; this backfill is the safety
+    # net for when it stops delivering, so it stays tight enough to bound
+    # staleness to minutes rather than the 6h it was.
+    "slack": 1800,
     "granola": 21600,
     "jira_project": 1800,
     "asana_project": 1800,
@@ -443,6 +446,35 @@ async def due_sources(limit: int = 50) -> list[dict]:
             "external_ref": r["external_ref"],
             "sync_cursor": r["sync_cursor"],
             "settings": r["settings"] or {},
+        }
+        for r in rows
+    ]
+
+
+async def stale_sources(overdue_factor: int = 3) -> list[dict]:
+    """Enabled sources whose sync has silently stopped keeping up: currently
+    failing, never completed, or last succeeded more than `overdue_factor` sync
+    intervals ago. A dead token or a wedged reconciler surfaces here instead of
+    rotting unnoticed (the way one Slack source sat failing for a month)."""
+    rows = await get_pool().fetch(
+        "SELECT id, owner_user_id, source_type, display_name, "
+        "last_synced_at, sync_error "
+        "FROM user_sources "
+        "WHERE sync_enabled AND ("
+        "  sync_error IS NOT NULL "
+        "  OR last_synced_at IS NULL "
+        "  OR last_synced_at < now() - ($1 * sync_interval_s || ' seconds')::interval"
+        ") ORDER BY last_synced_at NULLS FIRST",
+        overdue_factor,
+    )
+    return [
+        {
+            "id": str(r["id"]),
+            "owner_user_id": str(r["owner_user_id"]),
+            "source_type": r["source_type"],
+            "display_name": r["display_name"],
+            "last_synced_at": r["last_synced_at"],
+            "sync_error": r["sync_error"],
         }
         for r in rows
     ]

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -129,6 +129,28 @@ def reconcile_github_sync_all() -> int:
     return run_async(_reconcile_github_sync_all())
 
 
+async def _warn_stale_sources() -> int:
+    """Log a warning for every source whose sync has silently fallen behind, so a
+    dead token or a webhook that stopped delivering surfaces in the logs instead
+    of going unnoticed for weeks."""
+    stale = await source_service.stale_sources()
+    for s in stale:
+        logger.warning(
+            "stale source: id=%s type=%s owner=%s last_synced_at=%s sync_error=%s",
+            s["id"],
+            s["source_type"],
+            s["owner_user_id"],
+            s["last_synced_at"],
+            s["sync_error"],
+        )
+    return len(stale)
+
+
+@celery.task(name="backend.tasks.sources.warn_stale_sources")
+def warn_stale_sources() -> int:
+    return run_async(_warn_stale_sources())
+
+
 @celery.task(name="backend.tasks.sources.ingest_slack_event")
 def ingest_slack_event(team_id: str, event: dict) -> int:
     """Upsert a single Slack Events-API message (enqueued by the webhook)."""

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -285,6 +285,35 @@ async def test_source_sync_resolves_via_owner(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_stale_sources_flags_failing_and_overdue(client: AsyncClient):
+    """A source that is currently failing or hasn't succeeded in many intervals
+    surfaces to the stale-source warner; a freshly-synced one does not."""
+    _, owner_id = await _register(client, "src_stale")
+    from backend.database import get_pool
+
+    async def _mk(external_ref: str, last_synced_sql: str, sync_error: str | None) -> str:
+        row = await get_pool().fetchrow(
+            "INSERT INTO user_sources (owner_user_id, source_type, external_ref, "
+            "display_name, capability, sync_interval_s, sync_enabled, settings, "
+            f"last_synced_at, sync_error) VALUES ($1, 'slack', $2, 'Slack', "
+            f"'searchable', 1800, true, '{{}}'::jsonb, {last_synced_sql}, $3) RETURNING id",
+            owner_id,
+            external_ref,
+            sync_error,
+        )
+        return str(row["id"])
+
+    fresh_id = await _mk("TFRESH", "now()", None)
+    overdue_id = await _mk("TOVERDUE", "now() - interval '3 hours'", None)
+    failing_id = await _mk("TFAIL", "now()", "boom")
+
+    stale_ids = {s["id"] for s in await source_service.stale_sources()}
+    assert overdue_id in stale_ids
+    assert failing_id in stale_ids
+    assert fresh_id not in stale_ids
+
+
+@pytest.mark.asyncio
 async def test_unknown_source_type_rejected(client: AsyncClient):
     api_key, _ = await _register(client)
     resp = await client.post(


### PR DESCRIPTION
## Why

Our Slack integration went stale and I traced it in prod (Neon `stash-prod` + Render logs). Freshness has two paths: the **live Events-API webhook** (`/api/v1/integrations/slack/events` → `ingest_slack_event`) and a periodic **safety backfill** (`index_slack`). Today the webhook delivered **zero** events (Slack isn't POSTing us — a separate config fix in the Slack app console), so the only thing keeping data fresh was a **6-hour** backfill. A message posted at 17:47 UTC didn't land until the next backfill window — it was invisible for hours.

Separately, a duplicate Slack source (owner sam@) had been failing on **every** run since **June 12** (`RuntimeError: no allowed channels configured`) with no signal anywhere.

This PR doesn't fix the webhook (that's Slack-app config), but it makes the fallback tight and makes silent staleness visible.

## Changes

- **Tighten the Slack safety-backfill interval** `DEFAULT_SYNC_INTERVAL_S["slack"]` **21600s (6h) → 1800s (30m)**. When the webhook is down, worst-case staleness is minutes, not a quarter-day. Cost is ~1 `conversations.history` call per allowlisted channel per 30m — comfortably within Slack limits.
- **`source_service.stale_sources()` + hourly `warn_stale_sources` beat task.** Logs a WARNING for any `sync_enabled` source that is currently failing (`sync_error` set), never completed (`last_synced_at IS NULL`), or last succeeded more than 3 intervals ago. The month-dead Slack source would have surfaced on day one.

## Scope / limitations (deliberate)

- This does **not** detect the specific "webhook silent, backfill still succeeding" case (last_synced_at stays fresh). The mitigation for that is the tighter interval above + fixing the Events subscription in the Slack console; a per-source expected-cadence check would be over-engineering here.
- Does **not** touch the misconfigured sam@ duplicate source — that's a data cleanup (configure its channel allowlist or delete it), handled separately, not a code change. The new warner will now flag it every hour until it's resolved.

## Test

`pytest backend/tests/test_sources.py` → 89 passed. New `test_stale_sources_flags_failing_and_overdue` covers failing/overdue/fresh. One failure (`test_provider_cleanup_removes_source_and_retained_rows[posthog-posthog_project]`) is **pre-existing and unrelated** — it fails identically on the base commit with my changes stashed. `ruff check` / `ruff format --check` clean.

Backend-only; no GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)