### PR TITLE
/smb polish: free-text-only interview chat, tighter copy, Calendly booking

### DIFF
--- a/backend/routers/marketing.py
+++ b/backend/routers/marketing.py
@@ -70,7 +70,7 @@ VOICE — non-negotiable:
 - Never ask for sensitive data (client names, financials, health data). If they volunteer specifics, generalize them.
 
 INTERVIEW — cover these, in roughly this order, adapting wording to what they've said and skipping anything already answered:
-1. What kind of business (offer options: professional services, agency/creative, home services/trades, healthcare/wellness, retail/e-commerce, other)
+1. What kind of business (professional services, agency/creative, home services/trades, healthcare/wellness, retail/e-commerce, other)
 2. Team size (Just me / 2-5 / 6-20 / 21+)
 3. Where business knowledge lives today (one organized system / Google Drive + spreadsheets / scattered across 3+ tools / email threads and my head)
 4. What eats the most hours weekly (writing / scheduling & follow-ups / invoicing & admin / answering repeat customer questions / finding information they already have)
@@ -82,8 +82,8 @@ INTERVIEW — cover these, in roughly this order, adapting wording to what they'
 10. When they'd want to act if the numbers made sense (this month / this quarter / just exploring)
 
 OUTPUT FORMAT — every reply must be PURE JSON, no markdown, no text outside the JSON object:
-{"message": "<what you say>", "options": ["<chip>", ...], "done": false}
-- "options": include ONLY when multiple-choice chips genuinely help (use the option sets above). Omit for free-text questions.
+{"message": "<what you say>", "done": false}
+- Ask naturally, one question at a time. Never enumerate answer options like a form — the visitor types freely. Mentioning one or two examples inline is fine when it helps.
 - Keep "message" under 60 words.
 
 FINAL TURN — after question 10, reply with:

--- a/www/app/smb/AssessmentChat.tsx
+++ b/www/app/smb/AssessmentChat.tsx
@@ -25,7 +25,6 @@ type Report = {
 
 type ApiReply = {
   message: string;
-  options?: string[];
   done?: boolean;
   report?: Report;
 };
@@ -102,7 +101,6 @@ export default function AssessmentChat() {
     const { reply, raw } = (await res.json()) as { reply: ApiReply; raw: string };
     setApiMessages([...messages, { role: "assistant", content: raw }]);
     setBubbles((b) => [...b, { kind: "text", from: "agent", text: reply.message }]);
-    setOptions(reply.options ?? []);
     setTyping(false);
     if (reply.done && reply.report) {
       setPendingReport(sanitizeReport(reply.report));
@@ -113,7 +111,6 @@ export default function AssessmentChat() {
   function sendToChat(text: string) {
     setBubbles((b) => [...b, { kind: "text", from: "you", text }]);
     setDraft("");
-    setOptions([]);
     const messages: ApiMessage[] = [...apiMessages, { role: "user", content: text }];
     setApiMessages(messages);
     void callChat(messages);
@@ -189,12 +186,6 @@ export default function AssessmentChat() {
 
   return (
     <div className="overflow-hidden rounded-[14px] border border-border bg-background shadow-[var(--shadow-card)]">
-      <div className="flex items-center gap-2 border-b border-border-subtle bg-surface px-5 py-3">
-        <span className="live-pulse inline-block h-2 w-2 rounded-full bg-brand" />
-        <span className="text-[13px] font-medium text-ink">Free snapshot</span>
-        <span className="ml-auto text-[12px] text-muted">~3 min</span>
-      </div>
-
       <div ref={scrollRef} className="max-h-[460px] space-y-3 overflow-y-auto p-5">
         {bubbles.map((b, i) =>
           b.kind === "skill" ? (
@@ -254,19 +245,6 @@ export default function AssessmentChat() {
 
       {mode === "chat" && (
         <div className="space-y-2.5 border-t border-border-subtle p-5">
-          {options.length > 0 && !typing && (
-            <div className="flex flex-wrap gap-2">
-              {options.map((o) => (
-                <button
-                  key={o}
-                  onClick={() => sendToChat(o)}
-                  className="rounded-full border border-border bg-background px-4 py-2 text-[13.5px] text-ink transition hover:border-brand hover:text-brand"
-                >
-                  {o}
-                </button>
-              ))}
-            </div>
-          )}
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -345,6 +323,8 @@ export default function AssessmentChat() {
 
 const INSTALL_COMMAND = `curl -fsSL https://joinstash.ai/smb/SKILL.md --create-dirs -o ~/.claude/skills/ai-assessment-interview/SKILL.md && curl -fsSL https://joinstash.ai/smb/report-template.html -o ~/.claude/skills/ai-assessment-interview/report-template.html`;
 
+const BOOK_CALL_URL = "https://calendly.com/sam-ferganalabs/30min";
+
 // The lead magnet for people already running an agent: a friendly three-step
 // card — no terminal styling, one copy button hides the command.
 function SkillDrop({ tool }: { tool: string }) {
@@ -399,7 +379,7 @@ function SkillDrop({ tool }: { tool: string }) {
           </button>
         )}
         <a
-          href="/contact-sales"
+          href={BOOK_CALL_URL}
           className="inline-flex h-10 items-center rounded-lg bg-brand px-4 text-[13.5px] font-medium text-white transition hover:bg-brand-hover"
         >
           Or just book a call →
@@ -530,7 +510,7 @@ function SnapshotReport({
 
       <div className="mt-5 flex flex-wrap items-center gap-3 print:hidden">
         <a
-          href="/contact-sales"
+          href={BOOK_CALL_URL}
           className="inline-flex h-11 items-center rounded-lg bg-brand px-5 text-[14px] font-medium text-white transition hover:bg-brand-hover"
         >
           Book the full assessment →

--- a/www/app/smb/page.tsx
+++ b/www/app/smb/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import ScrollLink from "../_components/ScrollLink";
 import SiteHeader from "../_components/SiteHeader";
@@ -11,9 +10,6 @@ export const metadata: Metadata = {
   description:
     "Three minutes of questions, one page of answers: where your hours are going, the one tool to start with, and what those hours are worth — from your own numbers.",
 };
-
-// Drop the explainer video's YouTube ID here when it's published.
-const YOUTUBE_VIDEO_ID = "";
 
 const PAINS = [
   {
@@ -63,8 +59,9 @@ export default function SmbPage() {
             <span className="text-brand">leaving hours on the table.</span>
           </h1>
           <p className="mt-7 max-w-[560px] text-[18px] leading-[1.55] text-foreground">
-            A few questions, one page: where your hours go, what they&apos;re
-            worth, and the one tool to start with.
+            We can help you figure out the best way to organize all your
+            information so that you can automate the repetitive work and get
+            time back.
           </p>
           <div className="mt-9 flex flex-wrap items-center gap-3">
             <ScrollLink
@@ -73,23 +70,20 @@ export default function SmbPage() {
             >
               Get my free snapshot →
             </ScrollLink>
-            <Link
-              href="/contact-sales"
+            <a
+              href="https://calendly.com/sam-ferganalabs/30min"
               className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-[14px] font-medium text-ink transition hover:border-ink"
             >
               Book a call
-            </Link>
+            </a>
           </div>
-          <p className="mt-4 text-[13px] text-muted">
-            3 minutes · no signup · the report is yours either way
-          </p>
         </div>
       </section>
 
       <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
         <div className="mx-auto max-w-[1200px] px-7">
           <h2 className="max-w-[720px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
-            Sound familiar?
+            Common problems we see our customers facing
           </h2>
           <p className="mt-4 max-w-[560px] text-[16px] leading-[1.6] text-dim">
             If two or more of these hit home, the snapshot will find you hours.
@@ -118,42 +112,12 @@ export default function SmbPage() {
         </div>
       </section>
 
-      <section className="border-b border-border-subtle py-20 md:py-28">
-        <div className="mx-auto max-w-[1200px] px-7">
-          <h2 className="max-w-[720px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
-            What we do, in two minutes.
-          </h2>
-          <div className="mt-10 aspect-video max-w-[860px] overflow-hidden rounded-[14px] border border-border shadow-[var(--shadow-terminal)]">
-            {YOUTUBE_VIDEO_ID ? (
-              <iframe
-                className="h-full w-full"
-                src={`https://www.youtube-nocookie.com/embed/${YOUTUBE_VIDEO_ID}`}
-                title="What we do, in two minutes"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-              />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center bg-inverted">
-                <p className="text-[14px] text-on-inverted-dim">
-                  Explainer video coming soon
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-      </section>
-
-      <section id="snapshot" className="border-b border-border-subtle bg-surface py-20 md:py-28">
+      <section id="snapshot" className="border-b border-border-subtle py-20 md:py-28">
         <div className="mx-auto max-w-[1200px] px-7">
           <h2 className="max-w-[760px] font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
             Answer a few questions. Walk away with{" "}
             <span className="text-brand">the report.</span>
           </h2>
-          <p className="mt-5 max-w-[620px] text-[16px] leading-[1.6] text-dim">
-            The same interview we run on paid engagements, self-serve. Already
-            using an AI agent like Claude Code? Say so — we&apos;ll hand you the
-            interview itself to run at home.
-          </p>
           <div className="mt-10 max-w-[760px]">
             <AssessmentChat />
           </div>


### PR DESCRIPTION
Follow-up polish to #810, all owner-requested:

- **Interview is pure chat now** — after the "what AI do you use today?" routing question, the model asks questions conversationally and the visitor types freely; no more multiple-choice chips (backend system-prompt + frontend change).
- Removed the "Free snapshot / ~3 min" chat header bar.
- Removed the video placeholder section and the "same interview we run on paid engagements" subtitle.
- "Sound familiar?" → "Common problems we see our customers facing".
- Hero subtitle replaced with the organize-your-information value prop; removed the "3 minutes · no signup" footnote.
- Page-level "Book a call" buttons (hero, skill card, report) now link to Calendly (https://calendly.com/sam-ferganalabs/30min); the global site-header link is untouched.

Testing: www build + lint green, ruff green; headless-browser verification that all removed strings are gone, new copy renders, and the hero Book-a-call href is Calendly. Live chat re-test on prod after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9HiDrsxXHYPUxVkaijsEX