### PR TITLE
Fix the two tests broken on main by the PostHog and Auth0 merges

### DIFF
--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -409,7 +409,9 @@ async def test_returning_login_grants_membership_once_verified(pool):
     from backend.services import permission_service, workspace_service
 
     domain = f"{unique_name('corp')}.com".lower()
-    sub = f"google-oauth2|{unique_name()}"
+    # A database-connection sub: google-oauth2 subs are force-verified on
+    # every login, so only a non-Google user can exist unverified.
+    sub = f"auth0|{unique_name()}"
     email = f"late@{domain}"
 
     user, _ = await get_or_create_user_row_from_auth0(

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -65,6 +65,7 @@ def _external_ref_for_source_type(source_type: str) -> str:
         "twitter": "111",
         "twitter_bookmarks": "111",
         "instagram_saves": "saves",
+        "posthog_project": "project",
     }
     return refs[source_type]
 


### PR DESCRIPTION
Backend pytest has been red on main since #811 (Auth0 trust-Google) and #814/#815 (PostHog) landed — every PR since shows the same two failures:

- `test_sources.py::test_provider_cleanup_removes_source_and_retained_rows[posthog-posthog_project]` — `KeyError: 'posthog_project'`: the provider was added to the provider map but not to the test helper's external-ref fixture. Added `"posthog_project": "project"` (the ref `source_service.py` requires).
- `test_auth0_provision.py::test_returning_login_grants_membership_once_verified` — `assert not True`: #811 force-verifies `google-oauth2|` subs on every login, so the test's unverified-Google-user premise is now unconstructible by design. Switched to an `auth0|` database-connection sub, preserving the test's intent (the UPDATE path must persist `email_verified`).

Test-only diff; no runtime code touched. Both tests pass locally against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9HiDrsxXHYPUxVkaijsEX