### PR TITLE
Hydrate X saves via twitterapi.io instead of ScrapeCreators

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -317,6 +317,10 @@ class Settings:
     # hydrates Instagram saves server-side; users never bring their own).
     SCRAPECREATORS_API_KEY: str | None = os.getenv("SCRAPECREATORS_API_KEY")
 
+    # twitterapi.io (public X/Twitter read API, product-level key — hydrates X
+    # saves server-side from the tweet links the extension pushes).
+    TWITTERAPI_IO_KEY: str | None = os.getenv("TWITTERAPI_IO_KEY")
+
     # --- LLM (Anthropic) ---
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")

--- a/backend/integrations/x_saves/__init__.py
+++ b/backend/integrations/x_saves/__init__.py
@@ -2,6 +2,6 @@
 
 There is no OAuth — the browser extension (logged into x.com) captures the
 links of the user's bookmarks / posts / replies / articles and pushes them;
-the public content is hydrated server-side via ScrapeCreators with a
+the public content is hydrated server-side via twitterapi.io with a
 product-level API key. Only the indexer lives here.
 """

--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -1,9 +1,9 @@
-"""Hydrate X (Twitter) saves via ScrapeCreators.
+"""Hydrate X (Twitter) saves via twitterapi.io.
 
 Skeleton rows arrive from the extension push (routers/sources.py
-x_items_router) as tweet URLs + a kind (Bookmark/Post/Reply/Article). Each
+x_items_router) as tweet ids + a kind (Bookmark/Post/Reply/Article). Each
 sync pass fills a bounded batch: the full tweet text + author from
-ScrapeCreators, the conversation root for reply context, and the tweet's
+twitterapi.io, the conversation root for reply context, and the tweet's
 images/video archived into object storage — so the save survives the tweet
 being deleted or the account going private. Per-item failures land on the
 row, loudly; rows are never deleted by sync (archive semantics).
@@ -23,8 +23,8 @@ from ...services import source_service, storage_service
 
 logger = logging.getLogger(__name__)
 
-SC_TWEET_URL = "https://api.scrapecreators.com/v1/twitter/tweet"
-SC_TIMEOUT = 60
+TAPI_TWEETS_URL = "https://api.twitterapi.io/twitter/tweets"
+TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
 MAX_MEDIA_PER_TWEET = 4
 HYDRATION_BATCH = 25
@@ -36,8 +36,8 @@ def tweet_url(tweet_id: str) -> str:
 
 
 async def index_x_saves(source: dict) -> str | None:
-    if not settings.SCRAPECREATORS_API_KEY:
-        raise RuntimeError("SCRAPECREATORS_API_KEY is not set")
+    if not settings.TWITTERAPI_IO_KEY:
+        raise RuntimeError("TWITTERAPI_IO_KEY is not set")
     if not storage_service.is_configured():
         raise RuntimeError("File storage is not configured; cannot archive save media")
 
@@ -58,7 +58,7 @@ async def index_x_saves(source: dict) -> str | None:
     )
 
     async with httpx.AsyncClient(
-        timeout=SC_TIMEOUT, headers={"x-api-key": settings.SCRAPECREATORS_API_KEY}
+        timeout=TAPI_TIMEOUT, headers={"X-API-Key": settings.TWITTERAPI_IO_KEY}
     ) as client:
         for row in rows:
             try:
@@ -88,7 +88,7 @@ async def _hydrate_one(
     tweet_id: str,
     kind: str,
 ) -> None:
-    tweet = await _fetch_tweet(client, tweet_url(tweet_id))
+    tweet = await _fetch_tweet(client, tweet_id)
 
     # A reply shows only its own text out of context, so pull the root of the
     # conversation and keep it as "In reply to:" above the reply.
@@ -96,7 +96,7 @@ async def _hydrate_one(
     root_id = tweet.get("conversation_id")
     if root_id and root_id != tweet_id:
         try:
-            root = await _fetch_tweet(client, tweet_url(root_id))
+            root = await _fetch_tweet(client, root_id)
         except Exception:
             root = None  # thread context is best-effort; the reply itself matters
 
@@ -145,33 +145,27 @@ def _quote(text: str) -> str:
     return "\n".join(f"> {line}" for line in (text or "").splitlines())
 
 
-async def _fetch_tweet(client: httpx.AsyncClient, url: str) -> dict:
-    response = await client.get(SC_TWEET_URL, params={"url": url})
+async def _fetch_tweet(client: httpx.AsyncClient, tweet_id: str) -> dict:
+    response = await client.get(TAPI_TWEETS_URL, params={"tweet_ids": tweet_id})
     response.raise_for_status()
-    return _normalize(response.json())
+    tweets = response.json().get("tweets") or []
+    # twitterapi.io returns an object with empty fields (rather than 404) for a
+    # deleted / suspended / protected tweet — treat that as unavailable so it
+    # fails loud onto the row instead of archiving a blank save.
+    if not tweets or not tweets[0].get("id"):
+        raise RuntimeError(f"tweet {tweet_id} is unavailable (deleted, private, or suspended)")
+    return _normalize(tweets[0])
 
 
-def _normalize(payload: dict) -> dict:
-    """Pull the fields we need out of ScrapeCreators' tweet response, tolerant
-    of the exact envelope (data/tweet wrapper, legacy shape)."""
-    t = payload.get("data") or payload.get("tweet") or payload
-    t = t.get("tweet") or t
-    legacy = t.get("legacy") or t
-    tweet_id = t.get("rest_id") or legacy.get("id_str") or str(legacy.get("id") or "")
-    user = (
-        (t.get("core") or {}).get("user_results", {}).get("result", {}).get("legacy")
-        or t.get("user")
-        or legacy.get("user")
-        or {}
-    )
-    created = legacy.get("created_at")
+def _normalize(t: dict) -> dict:
+    """Pull the fields we need out of a twitterapi.io tweet object."""
     return {
-        "id": tweet_id,
-        "text": legacy.get("full_text") or legacy.get("text") or "",
-        "author": user.get("screen_name") or user.get("username") or "unknown",
-        "created_at": _parse_time(created),
-        "conversation_id": legacy.get("conversation_id_str") or legacy.get("conversation_id"),
-        "media": _media_urls(legacy),
+        "id": t.get("id") or "",
+        "text": t.get("text") or "",
+        "author": (t.get("author") or {}).get("userName") or "unknown",
+        "created_at": _parse_time(t.get("createdAt")),
+        "conversation_id": t.get("conversationId"),
+        "media": _media_urls(t),
     }
 
 
@@ -189,9 +183,10 @@ def _parse_time(value) -> datetime | None:
         return None
 
 
-def _media_urls(legacy: dict) -> list[dict]:
-    """[{url, is_video}] for each image/video on the tweet (best variant)."""
-    entities = legacy.get("extended_entities") or legacy.get("entities") or {}
+def _media_urls(tweet: dict) -> list[dict]:
+    """[{url, is_video}] for each image/video on the tweet (best variant).
+    twitterapi.io carries the native Twitter media shape under extendedEntities."""
+    entities = tweet.get("extendedEntities") or tweet.get("entities") or {}
     out: list[dict] = []
     for m in (entities.get("media") or [])[:MAX_MEDIA_PER_TWEET]:
         if m.get("type") in ("video", "animated_gif"):

--- a/backend/migrations/versions/0153_x_saves.py
+++ b/backend/migrations/versions/0153_x_saves.py
@@ -1,8 +1,8 @@
-"""X (Twitter) saves: extension-captured links, hydrated via ScrapeCreators.
+"""X (Twitter) saves: extension-captured links, hydrated via twitterapi.io.
 
 Replaces the OAuth/bring-your-own-app X integration. The browser extension
 captures the links of your bookmarks / posts / replies / articles on x.com;
-the indexer hydrates each via ScrapeCreators — storing the full tweet text,
+the indexer hydrates each via twitterapi.io — storing the full tweet text,
 the conversation root for reply context, and archiving the images/video into
 object storage so the save survives the tweet being deleted.
 

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -516,14 +516,14 @@ async def push_x_items(
     """The extension (logged into x.com) pushes the links of the user's
     bookmarks / posts / replies / articles. Get-or-creates the x_saves source,
     inserts pending skeleton rows keyed by tweet id, and kicks a sync so
-    ScrapeCreators hydration (full text + thread root + archived media) starts
+    twitterapi.io hydration (full text + thread root + archived media) starts
     immediately. Mirrors the Instagram saved-items flow."""
     from ..config import settings as app_settings
 
-    if not app_settings.SCRAPECREATORS_API_KEY:
+    if not app_settings.TWITTERAPI_IO_KEY:
         raise HTTPException(
             status_code=503,
-            detail="X saves are not enabled on this server (SCRAPECREATORS_API_KEY is not set)",
+            detail="X saves are not enabled on this server (TWITTERAPI_IO_KEY is not set)",
         )
     owner_user_id = current_user["id"]
     if not body.items:

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -1,4 +1,4 @@
-"""X (Twitter) saves: extension push + ScrapeCreators hydration.
+"""X (Twitter) saves: extension push + twitterapi.io hydration.
 
 The push endpoint get-or-creates the source, parses tweet ids from links
 loudly, and dedupes. The indexer hydrates the full text from the link, pulls
@@ -19,27 +19,23 @@ from backend.services import source_service, storage_service
 
 from .conftest import unique_name
 
+# twitterapi.io returns tweets in the native Twitter media shape under
+# extendedEntities; a reply carries conversationId = the thread root's id.
 _REPLY = {
-    "rest_id": "1001",
-    "core": {"user_results": {"result": {"legacy": {"screen_name": "alice", "name": "Alice"}}}},
-    "legacy": {
-        "full_text": "totally agree with this",
-        "created_at": "Wed Jul 01 12:00:00 +0000 2025",
-        "conversation_id_str": "1000",
-        "extended_entities": {
-            "media": [{"type": "photo", "media_url_https": "https://cdn.x/img.jpg"}]
-        },
-    },
+    "id": "1001",
+    "text": "totally agree with this",
+    "author": {"userName": "alice", "name": "Alice"},
+    "createdAt": "Wed Jul 01 12:00:00 +0000 2025",
+    "conversationId": "1000",
+    "extendedEntities": {"media": [{"type": "photo", "media_url_https": "https://cdn.x/img.jpg"}]},
 }
 
 _ROOT = {
-    "rest_id": "1000",
-    "core": {"user_results": {"result": {"legacy": {"screen_name": "bob", "name": "Bob"}}}},
-    "legacy": {
-        "full_text": "here is a hot take",
-        "created_at": "Wed Jul 01 11:00:00 +0000 2025",
-        "conversation_id_str": "1000",
-    },
+    "id": "1000",
+    "text": "here is a hot take",
+    "author": {"userName": "bob", "name": "Bob"},
+    "createdAt": "Wed Jul 01 11:00:00 +0000 2025",
+    "conversationId": "1000",
 }
 
 
@@ -56,9 +52,9 @@ class _FakeResponse:
         return self._payload
 
 
-class _FakeScrapeCreators:
-    """Answers the SC tweet endpoint (keyed by the ?url= param) and the CDN
-    media URL for _archive_media's separate client."""
+class _FakeTwitterApi:
+    """Answers the twitterapi.io tweets endpoint (keyed by ?tweet_ids=) and the
+    CDN media URL for _archive_media's separate client."""
 
     media_bytes = b"fake image bytes"
 
@@ -72,10 +68,9 @@ class _FakeScrapeCreators:
         return False
 
     async def get(self, url, params=None):
-        if url == x_indexer.SC_TWEET_URL:
-            tweet_url = params["url"]
-            payload = _REPLY if tweet_url.endswith("/1001") else _ROOT
-            return _FakeResponse(payload=payload)
+        if url == x_indexer.TAPI_TWEETS_URL:
+            tweet = _REPLY if params["tweet_ids"] == "1001" else _ROOT
+            return _FakeResponse(payload={"tweets": [tweet], "status": "success"})
         if url == "https://cdn.x/img.jpg":
             return _FakeResponse(content=type(self).media_bytes)
         raise AssertionError(f"unexpected URL {url}")
@@ -92,11 +87,11 @@ def fake_hydration(monkeypatch):
     async def _url(key):
         return f"https://blob.example/{key}"
 
-    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
+    monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", "tapi-key")
     monkeypatch.setattr(storage_service, "is_configured", lambda: True)
     monkeypatch.setattr(storage_service, "upload_file", _upload)
     monkeypatch.setattr(storage_service, "get_file_url", _url)
-    monkeypatch.setattr(x_indexer, "httpx", SimpleNamespace(AsyncClient=_FakeScrapeCreators))
+    monkeypatch.setattr(x_indexer, "httpx", SimpleNamespace(AsyncClient=_FakeTwitterApi))
     return uploads
 
 
@@ -120,7 +115,7 @@ async def test_push_creates_source_and_skeleton_rows(
     sent: list = []
     from backend.routers import sources as sources_router
 
-    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
+    monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", "tapi-key")
     monkeypatch.setattr(
         sources_router.celery, "send_task", lambda name, args: sent.append((name, args))
     )
@@ -162,7 +157,7 @@ async def test_push_creates_source_and_skeleton_rows(
 
 @pytest.mark.asyncio
 async def test_push_rejects_non_x_urls(client: AsyncClient, monkeypatch) -> None:
-    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
+    monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", "tapi-key")
     headers, _ = await _register(client)
     resp = await client.post(
         "/api/v1/me/x-items",
@@ -174,10 +169,10 @@ async def test_push_rejects_non_x_urls(client: AsyncClient, monkeypatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_push_refused_until_scrapecreators_key_is_configured(
+async def test_push_refused_until_twitterapi_key_is_configured(
     client: AsyncClient, pool, monkeypatch
 ) -> None:
-    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", None)
+    monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", None)
     headers, owner_id = await _register(client)
 
     resp = await client.post(
@@ -186,7 +181,7 @@ async def test_push_refused_until_scrapecreators_key_is_configured(
         headers=headers,
     )
     assert resp.status_code == 503
-    assert "SCRAPECREATORS_API_KEY" in resp.json()["detail"]
+    assert "TWITTERAPI_IO_KEY" in resp.json()["detail"]
 
     count = await pool.fetchval(
         "SELECT count(*) FROM user_sources WHERE owner_user_id = $1", UUID(owner_id)


### PR DESCRIPTION
Swaps X-saves hydration from ScrapeCreators to **twitterapi.io**, per direction. Instagram stays on ScrapeCreators — only X moves.

## Why it's a clean swap
twitterapi.io's `GET /twitter/tweets?tweet_ids=<id>` (auth via `X-API-Key`) returns tweet objects in the **native Twitter shape**:
- media under `extendedEntities.media[]` (`type`, `media_url_https`, `video_info.variants`) — the exact shape the existing media/variant parser already handles;
- `conversationId` + `inReplyToId` for thread context;
- `createdAt` in the same classic format.

So only `_fetch_tweet` / `_normalize` / `_media_urls` change; `_render`, `_archive_media`, and the reply-root logic are untouched.

## Verified against the live API
- Photo tweet → image URL extracted.
- Video tweet → highest-bitrate mp4 variant selected.
- Reply → `conversationId` differs from the tweet id, so the thread-root fetch triggers.
- Deleted/private/suspended tweet returns **empty fields, not a 404** — handled: an empty id now **fails loud onto the row** instead of archiving a blank save.

## Config
New `TWITTERAPI_IO_KEY` gates the `/me/x-items` push (503 without it) and the indexer. Must be set on **web + worker** in prod (env-group parity). `SCRAPECREATORS_API_KEY` is still needed for Instagram.

## Tests
`test_x_saves.py` updated to the twitterapi.io response shape; 5 X tests + config-security pass, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
