### PR TITLE
Login page says "Welcome back" only to actually-returning visitors

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
 import { API_BASE, getToken, setToken } from "../../lib/api";
 import { consumeManualAuth0Logout } from "../../lib/authLogout";
+import { hasSignedInBefore } from "../../lib/returningUser";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
 
@@ -207,7 +208,7 @@ function LoginPageInner() {
 
   return (
     <AuthShell
-      title={mode === "login" ? "Welcome back" : "Create your stash"}
+      title={mode === "login" ? signInTitle() : "Create your stash"}
       subtitle={
         mode === "login"
           ? "Sign in to the stash you share with your agents."
@@ -220,6 +221,12 @@ function LoginPageInner() {
       </p>
     </AuthShell>
   );
+}
+
+// Safe to read localStorage here: every caller renders behind the useAuth
+// loading gate, so this only runs client-side after mount.
+function signInTitle(): string {
+  return hasSignedInBefore() ? "Welcome back" : "Welcome";
 }
 
 function localNextPath(value: string | null): string {
@@ -357,7 +364,7 @@ function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0Panel
 
   return (
     <AuthShell
-      title="Welcome back"
+      title={signInTitle()}
       subtitle="Sign in to the stash you share with your agents."
     >
       <FormCard>{body}</FormCard>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ApiError, clearToken, getMe, getToken, revokeStoredApiKey } from "../lib/api";
 import { auth0LogoutUrl, markManualAuth0Logout } from "../lib/authLogout";
+import { markSignedInBefore } from "../lib/returningUser";
 import { User } from "../lib/types";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
@@ -27,6 +28,7 @@ export function useAuth() {
     try {
       const me = await getMe();
       setUser(me);
+      markSignedInBefore();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
         clearToken();

--- a/frontend/src/lib/returningUser.test.ts
+++ b/frontend/src/lib/returningUser.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { hasSignedInBefore, markSignedInBefore } from "./returningUser";
+
+// The login page's "Welcome back" copy must never greet a visitor whose
+// browser has no record of a prior sign-in (incognito, new machine).
+describe("returning-user marker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is absent for a fresh browser", () => {
+    expect(hasSignedInBefore()).toBe(false);
+  });
+
+  it("persists once a sign-in marks it", () => {
+    markSignedInBefore();
+
+    expect(hasSignedInBefore()).toBe(true);
+  });
+});

--- a/frontend/src/lib/returningUser.ts
+++ b/frontend/src/lib/returningUser.ts
@@ -1,0 +1,15 @@
+const SIGNED_IN_BEFORE_KEY = "stash_signed_in_before";
+
+// The login page should only greet visitors with "Welcome back" if someone has
+// actually signed in on this browser before. The server can't know that for a
+// cookie-less visitor, so successful sign-ins leave this durable marker (it
+// intentionally survives logout — a logged-out user is still a returning one).
+export function markSignedInBefore() {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(SIGNED_IN_BEFORE_KEY, "1");
+}
+
+export function hasSignedInBefore(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(SIGNED_IN_BEFORE_KEY) === "1";
+}


### PR DESCRIPTION
## Problem

The login title was hardcoded "Welcome back" — brand-new visitors (and anyone in an incognito window) got greeted like returning users.

## Fix

The server can't tell a new visitor from a returning one with no cookies, so the browser remembers instead: every successful sign-in (password, Auth0, and CLI flows all funnel through `useAuth`'s `getMe()`) sets a `stash_signed_in_before` localStorage marker. Both login titles (the Auth0 panel prod renders and the self-hosted form) show "Welcome back" only when the marker exists, and a neutral "Welcome" otherwise. The marker survives logout on purpose — a logged-out user is still a returning one.

## Screenshots

Captured on the local self-hosted form (the Auth0 panel shares the same title logic):

- New visitor (no marker, e.g. incognito) — "Welcome": https://app.joinstash.ai/f/f285fc68-e222-4cb3-bf34-d0e0e7066b76
- Returning visitor — "Welcome back": https://app.joinstash.ai/f/8019f862-bca1-4e91-879e-ca35ece501c6

## Testing

- Unit test for the marker in `returningUser.test.ts`; full frontend suite passes (209 tests)
- Browser-verified both states via agent-browser: cleared localStorage → "Welcome"; marker set → "Welcome back"

🤖 Generated with [Claude Code](https://claude.com/claude-code)