### PR TITLE
Fix duplicate context-menu id error in the extension

### DIFF
--- a/chrome_extension/src/background/clip.ts
+++ b/chrome_extension/src/background/clip.ts
@@ -14,8 +14,11 @@ export interface PageClip {
 }
 
 export function initClipper(): void {
+  // Context menus persist across browser sessions and service-worker restarts,
+  // so onInstalled is the only place to (re)create them. Registering on
+  // onStartup too made two removeAll→create calls race, and the loser hit an
+  // already-created id ("Cannot create item with duplicate id stash-clip").
   chrome.runtime.onInstalled.addListener(createMenu);
-  chrome.runtime.onStartup.addListener(createMenu);
   chrome.contextMenus.onClicked.addListener((info, tab) => {
     if (info.menuItemId === 'stash-clip' && tab?.id != null) void clipTab(tab);
   });


### PR DESCRIPTION
The clipper registered `createMenu` on both `onInstalled` and `onStartup`, so two `removeAll`→`create` calls could race and the loser hit an already-created menu id — the `Unchecked runtime.lastError: Cannot create item with duplicate id stash-clip` you saw. Context menus persist across browser sessions and service-worker restarts, so `onInstalled` alone is correct; this drops the redundant `onStartup` registration. Extension typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)