### PR TITLE
Scope /computer to the agent workdir, not the VM home

### DIFF
--- a/backend/routers/machine.py
+++ b/backend/routers/machine.py
@@ -35,7 +35,8 @@ router = APIRouter(prefix="/api/v1/me/machine", tags=["machine"])
 
 @router.get("/fs")
 async def list_machine_dir(path: str = "", current_user: dict = Depends(get_current_user)):
-    """Directory listing on the user's computer, path relative to its home."""
+    """Directory listing on the user's computer, path relative to the agent's
+    working folder."""
     sprite = await sprite_service.acquire(current_user["id"])
     try:
         entries = await sprite_service.fs_list(sprite, path)

--- a/backend/services/sprite_service.py
+++ b/backend/services/sprite_service.py
@@ -436,17 +436,20 @@ _FS_LIST_PY = (
 
 
 class FsPathError(ValueError):
-    """A path escaped the box home or doesn't resolve."""
+    """A path escaped the agent workdir or doesn't resolve."""
 
 
 def _box_path(rel_path: str) -> str:
-    """Resolve a home-relative path to an absolute box path, refusing escapes."""
+    """Resolve a workdir-relative path to an absolute box path, refusing escapes.
+
+    The fs projection exposes only the agent's working folder — never the VM's
+    home or system internals."""
     import posixpath
 
-    home = SPRITE_HOME if settings.AGENT_EXEC_MODE == "sprites" else str(_local_workdir().parent)
-    joined = posixpath.normpath(posixpath.join(home, rel_path.lstrip("/")))
-    if joined != home and not joined.startswith(home + "/"):
-        raise FsPathError(f"path escapes the machine home: {rel_path}")
+    root = SPRITE_WORKDIR if settings.AGENT_EXEC_MODE == "sprites" else str(_local_workdir())
+    joined = posixpath.normpath(posixpath.join(root, rel_path.lstrip("/")))
+    if joined != root and not joined.startswith(root + "/"):
+        raise FsPathError(f"path escapes the agent workdir: {rel_path}")
     return joined
 
 
@@ -468,7 +471,7 @@ async def write_file(sprite: Sprite, abs_path: str, contents: str) -> None:
 
 
 async def fs_list(sprite: Sprite, rel_path: str) -> list[dict]:
-    """Directory entries at a home-relative path on the box."""
+    """Directory entries at a workdir-relative path on the box."""
     output, code = await exec_collect(
         sprite,
         ["python3", "-c", _FS_LIST_PY, _box_path(rel_path)],

--- a/backend/tests/test_sprite_agent_mapping.py
+++ b/backend/tests/test_sprite_agent_mapping.py
@@ -223,8 +223,8 @@ def test_box_path_rejects_escapes(monkeypatch):
     from backend.services import sprite_service
 
     monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
-    assert sprite_service._box_path("") == "/home/sprite"
-    assert sprite_service._box_path("work/notes.md") == "/home/sprite/work/notes.md"
-    for bad in ("../etc/passwd", "work/../../etc", "..", "a/../../.."):
+    assert sprite_service._box_path("") == "/home/sprite/work"
+    assert sprite_service._box_path("notes.md") == "/home/sprite/work/notes.md"
+    for bad in ("../etc/passwd", "../.ssh/id_rsa", "..", "a/../../.."):
         with pytest.raises(sprite_service.FsPathError):
             sprite_service._box_path(bad)

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -83,8 +83,8 @@ function ToolsSection() {
   );
 }
 
-// Computer = a read-through view of the user's cloud machine's filesystem
-// (relative to its home). Browsing wakes a sleeping machine; nothing here is
+// Computer = a read-through view of the agent's working folder on the user's
+// cloud machine. Browsing wakes a sleeping machine; nothing here is
 // synced — "Save to Stash" on an open file is the only copy path.
 function ComputerSection() {
   const open = useOpenTab();

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -88,8 +88,8 @@ class StashVfsModel:
         self._add_root()
         computer_lines = (
             [
-                "- `computer` is a live, read-only view of your cloud "
-                "computer's disk (browsing may wake it).",
+                "- `computer` is a live, read-only view of the agent's "
+                "working folder on your cloud computer (browsing may wake it).",
             ]
             if self.include_computer
             else []
@@ -220,7 +220,8 @@ class StashVfsModel:
             self._add_computer()
 
     def _add_computer(self) -> None:
-        """The user's cloud computer, projected read-through at /computer.
+        """The agent's working folder on the user's cloud computer, projected
+        read-through at /computer.
 
         Directories expand lazily one level at a time (a workspace can hold a
         cloned repo — materializing the whole tree would be pathological), and


### PR DESCRIPTION
## Problem

The machine fs projection (`/api/v1/me/machine/fs`) rooted at `/home/sprite`, so the Computer surfaces — the app's Computer rail and the VFS `/computer` mount — exposed the sprite VM's entire home directory: dotfiles, `.cache`, `.local`, installed agent tooling. Since the CLI mounts `/computer` for every user and `tree`/`find` recurse into it at one HTTP round-trip per directory, a bare `stash vfs tree` crawled the whole VM home and effectively hung (5+ minutes before being killed, still going).

## Fix

`_box_path` in `sprite_service.py` is the single resolver every fs endpoint goes through. Reroot it at `SPRITE_WORKDIR` (`/home/sprite/work`) so the projection exposes only the agent's working folder — never the VM internals. Escape rejection (`../.ssh/id_rsa`, …) is unchanged. Local exec mode (`AGENT_EXEC_MODE=local`) gets the matching reroot to `~/.stash-dev-sprite/work`.

All consumers (CLI VFS, frontend Computer rail, save-to-Stash) pass workdir-relative paths through this one seam, so no client changes are needed — only stale "relative to its home" comments and the VFS README text are updated.

## Testing

- `backend/tests/test_sprite_agent_mapping.py` — 15 passed, including the rewritten `_box_path` escape test
- `cli/tests/test_mount_vfs.py` + `backend/tests/test_permissions.py` — 60 passed
- `ruff check` / `ruff format --check` clean

No user-facing UI change beyond the Computer rail now listing the workdir contents instead of the VM home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)