### PR TITLE
Name Slack DMs after their humans, not raw channel ids

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -34,6 +34,7 @@ from .base import AccountInfo
 from .crypto import integration_fernet, integration_keyring_error
 from .github import account_sync as github_account_sync
 from .registry import get_provider, list_providers
+from .slack import indexer as slack_indexer
 
 logger = logging.getLogger(__name__)
 
@@ -487,24 +488,31 @@ async def slack_list_channels(current_user: dict = Depends(get_current_user)):
         resp.raise_for_status()
         payload = resp.json()
 
-    if not payload.get("ok"):
-        raise HTTPException(
-            status_code=502,
-            detail=f"Slack API error: {payload.get('error') or 'unknown_error'}",
-        )
-
-    channels: list[SlackChannelSummary] = []
-    for channel in payload.get("channels", []):
-        channel_id = channel.get("id")
-        if not channel_id:
-            continue
-        channels.append(
-            SlackChannelSummary(
-                id=channel_id,
-                name=channel.get("name") or channel.get("user") or channel_id,
-                is_private=bool(channel.get("is_private")),
+        if not payload.get("ok"):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Slack API error: {payload.get('error') or 'unknown_error'}",
             )
-        )
+
+        # DMs carry no name in Slack's API — resolve them to the humans in the
+        # conversation, exactly as the indexer names them, so the picker shows
+        # what the source tree will show.
+        self_user_id = await slack_indexer.authed_user_id(client)
+        names: dict[str, str] = {}
+        channels: list[SlackChannelSummary] = []
+        for channel in payload.get("channels", []):
+            channel_id = channel.get("id")
+            if not channel_id:
+                continue
+            channels.append(
+                SlackChannelSummary(
+                    id=channel_id,
+                    name=await slack_indexer.channel_display_name(
+                        client, names, channel, self_user_id
+                    ),
+                    is_private=bool(channel.get("is_private")),
+                )
+            )
     return channels
 
 

--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -12,6 +12,7 @@ attributed conversations instead of one-line files.
 from __future__ import annotations
 
 import logging
+import re
 from uuid import UUID
 
 import httpx
@@ -24,7 +25,10 @@ logger = logging.getLogger(__name__)
 
 CONVERSATIONS_LIST_URL = "https://slack.com/api/conversations.list"
 CONVERSATIONS_HISTORY_URL = "https://slack.com/api/conversations.history"
+CONVERSATIONS_MEMBERS_URL = "https://slack.com/api/conversations.members"
+CONVERSATIONS_INFO_URL = "https://slack.com/api/conversations.info"
 USERS_INFO_URL = "https://slack.com/api/users.info"
+AUTH_TEST_URL = "https://slack.com/api/auth.test"
 
 CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
 MAX_CHANNELS = 100
@@ -76,6 +80,77 @@ async def _user_display_name(client: httpx.AsyncClient, names: dict[str, str], u
     return name
 
 
+def _name_slug(value: str) -> str:
+    """A display name flattened for use in channel_name (which is a path
+    segment): lowercase, runs of anything unsafe collapsed to '-'."""
+    slug = re.sub(r"[^a-z0-9._-]+", "-", value.lower()).strip("-")
+    return slug or "unknown"
+
+
+async def authed_user_id(client: httpx.AsyncClient) -> str:
+    """The Slack user id behind this token — excluded from group-DM names so a
+    DM is named after the *other* people in it."""
+    return (await _slack_get(client, AUTH_TEST_URL, {}))["user_id"]
+
+
+async def channel_display_name(
+    client: httpx.AsyncClient, names: dict[str, str], channel: dict, self_user_id: str
+) -> str:
+    """A human channel_name. Slack gives channels a name but IMs none at all,
+    so a DM is named after its counterpart (dm-jane-doe) and a group DM after
+    every member except the token's own user (dm-jane-doe--sam-liu)."""
+    if channel.get("is_im"):
+        return f"dm-{_name_slug(await _user_display_name(client, names, channel['user']))}"
+    if channel.get("is_mpim"):
+        payload = await _slack_get(
+            client, CONVERSATIONS_MEMBERS_URL, {"channel": channel["id"], "limit": 100}
+        )
+        members = [m for m in payload.get("members", []) if m != self_user_id]
+        slugs = sorted([_name_slug(await _user_display_name(client, names, m)) for m in members])
+        return "dm-" + "--".join(slugs)
+    return channel["name"]
+
+
+def _dedupe_channel_names(named: list[tuple[dict, str]]) -> list[tuple[dict, str]]:
+    """Two DMs with identically-named counterparts must not share a
+    channel_name — the day-transcript projection groups by it, so a collision
+    would silently merge two conversations. Colliding names get the channel id
+    appended; unique names stay clean."""
+    counts: dict[str, int] = {}
+    for _, name in named:
+        counts[name] = counts.get(name, 0) + 1
+    return [
+        (channel, f"{name}--{channel['id'].lower()}" if counts[name] > 1 else name)
+        for channel, name in named
+    ]
+
+
+async def _rename_channel_rows(source_id: UUID, channel_id: str, channel_name: str) -> None:
+    """One-shot migration of rows ingested before this channel's name was
+    known (webhook rows stamped with the raw id, DMs indexed pre-name-
+    resolution) onto the resolved name. Runs at sync time because names live
+    behind per-user tokens — an offline migration can't resolve them. Stale
+    notices are deleted, not renamed; _sync_cap_marker recreates them."""
+    pool = get_pool()
+    await pool.execute(
+        "DELETE FROM slack_messages "
+        "WHERE source_id = $1 AND channel_id = $2 AND kind = 'notice' AND channel_name <> $3",
+        source_id,
+        channel_id,
+        channel_name,
+    )
+    await pool.execute(
+        "UPDATE slack_messages "
+        "SET channel_name = $3, "
+        "    path = $3 || substr(path, strpos(path, '/')), "
+        "    name = '#' || $3 "
+        "WHERE source_id = $1 AND channel_id = $2 AND channel_name <> $3",
+        source_id,
+        channel_id,
+        channel_name,
+    )
+
+
 async def index_slack(source: dict) -> str | None:
     source_id = UUID(source["id"])
     owner_user_id = UUID(source["owner_user_id"])
@@ -96,11 +171,17 @@ async def index_slack(source: dict) -> str | None:
             CONVERSATIONS_LIST_URL,
             {"types": CHANNEL_TYPES, "limit": MAX_CHANNELS},
         )
-        for channel in channels_payload.get("channels", []):
+        self_user_id = await authed_user_id(client)
+        named = _dedupe_channel_names(
+            [
+                (channel, await channel_display_name(client, names, channel, self_user_id))
+                for channel in channels_payload.get("channels", [])
+                if channel["id"] in allowed_channel_ids
+            ]
+        )
+        for channel, channel_name in named:
             channel_id = channel["id"]
-            if channel_id not in allowed_channel_ids:
-                continue
-            channel_name = channel.get("name") or channel_id
+            await _rename_channel_rows(source_id, channel_id, channel_name)
             # A channel we can't read (not a member, archived, …) must not abort
             # the whole backfill — skip it and continue. conversations.history
             # returns most-recent-first, so this bootstraps recent messages.
@@ -170,13 +251,18 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
                 client, CONVERSATIONS_LIST_URL, {"types": CHANNEL_TYPES, "limit": MAX_CHANNELS}
             )
         ).get("channels", [])
-        for channel in channels:
+        self_user_id = await authed_user_id(client)
+        named = _dedupe_channel_names(
+            [
+                (channel, await channel_display_name(client, names, channel, self_user_id))
+                for channel in channels
+                if channel["id"] in allowed_channel_ids
+            ]
+        )
+        for channel, channel_name in named:
             if len(refs) >= limit:
                 break
             channel_id = channel["id"]
-            if channel_id not in allowed_channel_ids:
-                continue
-            channel_name = channel.get("name") or channel_id
             params = {"channel": channel_id, "oldest": oldest, "limit": MAX_MESSAGES_PER_CHANNEL}
             if latest:
                 params["latest"] = latest
@@ -339,9 +425,9 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
         "AND ws.sync_enabled",
         team_id,
     )
-    # The webhook has no user token to resolve a display name with, so live
-    # messages carry the raw Slack id as their author. The next sync's
-    # freshness check sees the resolved name differs and rewrites the row.
+    # The webhook payload carries no display names, so live messages keep the
+    # raw Slack id as their author. The next sync's freshness check sees the
+    # resolved name differs and rewrites the row.
     author_id = event.get("user") or event.get("bot_id")
     author = event.get("username") or author_id or ""
 
@@ -355,7 +441,7 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
             source_id=row["id"],
             owner_user_id=row["owner_user_id"],
             channel_id=channel_id,
-            channel_name=channel_id,
+            channel_name=await _ingest_channel_name(row, channel_id),
             ts=event["ts"],
             text=event.get("text") or "",
             author_id=author_id,
@@ -363,3 +449,26 @@ async def ingest_slack_message(team_id: str, event: dict) -> int:
         )
         ingested += 1
     return ingested
+
+
+async def _ingest_channel_name(source_row: dict, channel_id: str) -> str:
+    """The channel_name for a live event. Sync already resolved it for any
+    channel with indexed rows; a channel with none yet (first message of a new
+    DM) is resolved against Slack with the owner's token, so no row is ever
+    written with a raw id as its name."""
+    known = await get_pool().fetchval(
+        "SELECT channel_name FROM slack_messages "
+        "WHERE source_id = $1 AND channel_id = $2 AND channel_name <> channel_id "
+        "LIMIT 1",
+        source_row["id"],
+        channel_id,
+    )
+    if known:
+        return known
+    token = await get_valid_token(source_row["owner_user_id"], "slack")
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        channel = (await _slack_get(client, CONVERSATIONS_INFO_URL, {"channel": channel_id}))[
+            "channel"
+        ]
+        return await channel_display_name(client, {}, channel, await authed_user_id(client))

--- a/backend/tests/test_slack_security.py
+++ b/backend/tests/test_slack_security.py
@@ -53,6 +53,8 @@ async def _noop_purge(source):
 async def _fake_slack_get_with_sensitive_channel(client, url, params):
     if url == indexer.CONVERSATIONS_LIST_URL:
         return {"channels": [{"id": "C_SECRET", "name": "webflow-acquisition"}]}
+    if url == indexer.AUTH_TEST_URL:
+        return {"user_id": "U_SELF"}
     raise RuntimeError("token=secret-token customer transcript")
 
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -359,6 +359,7 @@ async def test_add_slack_source_stores_channel_allowlist(client: AsyncClient, mo
 @pytest.mark.asyncio
 async def test_slack_channel_picker_lists_conversations(client: AsyncClient, monkeypatch):
     from backend.integrations import router as integrations_router
+    from backend.integrations.slack import indexer
 
     api_key, _ = await _register(client)
 
@@ -367,18 +368,14 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
         return "slack-token"
 
     class FakeSlackResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
         def raise_for_status(self):
             return None
 
         def json(self):
-            return {
-                "ok": True,
-                "channels": [
-                    {"id": "C1", "name": "general", "is_private": False},
-                    {"id": "G1", "name": "leadership", "is_private": True},
-                    {"id": "D1", "user": "U1"},
-                ],
-            }
+            return self._payload
 
     class FakeSlackClient:
         def __init__(self, *, timeout, headers):
@@ -392,12 +389,27 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
             return None
 
         async def get(self, url, params):
-            assert url == integrations_router.SLACK_CONVERSATIONS_LIST_URL
-            assert params == {
-                "types": integrations_router.SLACK_CHANNEL_TYPES,
-                "limit": integrations_router.SLACK_CHANNEL_LIMIT,
-            }
-            return FakeSlackResponse()
+            if url == integrations_router.SLACK_CONVERSATIONS_LIST_URL:
+                assert params == {
+                    "types": integrations_router.SLACK_CHANNEL_TYPES,
+                    "limit": integrations_router.SLACK_CHANNEL_LIMIT,
+                }
+                return FakeSlackResponse(
+                    {
+                        "ok": True,
+                        "channels": [
+                            {"id": "C1", "name": "general", "is_private": False},
+                            {"id": "G1", "name": "leadership", "is_private": True},
+                            {"id": "D1", "is_im": True, "user": "U1"},
+                        ],
+                    }
+                )
+            if url == indexer.AUTH_TEST_URL:
+                return FakeSlackResponse({"ok": True, "user_id": "U_SELF"})
+            assert url == indexer.USERS_INFO_URL and params == {"user": "U1"}
+            return FakeSlackResponse(
+                {"ok": True, "user": {"name": "sam", "profile": {"display_name": "Sam Liu"}}}
+            )
 
     monkeypatch.setattr(integrations_router.storage, "get_valid_token", fake_get_valid_token)
     monkeypatch.setattr(integrations_router.httpx, "AsyncClient", FakeSlackClient)
@@ -405,10 +417,11 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
     resp = await client.get("/api/v1/integrations/slack/channels", headers=_auth(api_key))
 
     assert resp.status_code == 200
+    # The DM surfaces as the human it's with — never the raw D…/U… id.
     assert resp.json() == [
         {"id": "C1", "name": "general", "is_private": False},
         {"id": "G1", "name": "leadership", "is_private": True},
-        {"id": "D1", "name": "U1", "is_private": False},
+        {"id": "D1", "name": "dm-sam-liu", "is_private": False},
     ]
 
 
@@ -1263,6 +1276,8 @@ async def test_slack_indexer_backfills_only_allowed_channels(
                     {"id": "C_BLOCKED", "name": "exec"},
                 ]
             }
+        if url == indexer.AUTH_TEST_URL:
+            return {"user_id": "U_SELF"}
         requested_history.append(params["channel"])
         return {"messages": [{"type": "message", "ts": "1", "text": "ship safely"}]}
 
@@ -1304,10 +1319,29 @@ async def test_slack_sync_without_channels_records_sync_error(client: AsyncClien
     assert slack["sync_error"] == sources_task.SYNC_FAILED_MESSAGE
 
 
+def _fake_webhook_channel_resolution(monkeypatch, channel_name="general"):
+    """A live event for a never-synced channel resolves its name against Slack
+    with the owner's token — fake that seam for webhook tests."""
+    from backend.integrations.slack import indexer
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.AUTH_TEST_URL:
+            return {"user_id": "U_SELF"}
+        assert url == indexer.CONVERSATIONS_INFO_URL
+        return {"channel": {"id": params["channel"], "name": channel_name}}
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+
 @pytest.mark.asyncio
-async def test_slack_event_ingest_fans_out_per_owner(client: AsyncClient):
+async def test_slack_event_ingest_fans_out_per_owner(client: AsyncClient, monkeypatch):
     from backend.integrations.slack.indexer import ingest_slack_message
 
+    _fake_webhook_channel_resolution(monkeypatch)
     # Two users each connect the same Slack team, but only the source that
     # explicitly allowed the event channel stores the message.
     owner_a_key, owner_a = await _register(client, "a")
@@ -1346,9 +1380,11 @@ async def test_slack_event_ingest_fans_out_per_owner(client: AsyncClient):
 async def test_slack_event_ingest_requires_enabled_source(
     client: AsyncClient,
     pool,
+    monkeypatch,
 ):
     from backend.integrations.slack.indexer import ingest_slack_message
 
+    _fake_webhook_channel_resolution(monkeypatch)
     _, active_owner = await _register(client, "active_slack")
     _, disabled_owner = await _register(client, "disabled_slack")
     active_source = await source_service.create_source(
@@ -1577,6 +1613,8 @@ async def test_slack_backfill_resolves_authors_and_caches_lookups(
     async def fake_slack_get(client_, url, params):
         if url == indexer.CONVERSATIONS_LIST_URL:
             return {"channels": [{"id": "C1", "name": "general"}]}
+        if url == indexer.AUTH_TEST_URL:
+            return {"user_id": "U_SELF"}
         if url == indexer.USERS_INFO_URL:
             users_info_calls.append(params["user"])
             return {"ok": True, "user": {"name": "hdowling", "profile": {"display_name": "henry"}}}
@@ -1627,6 +1665,8 @@ async def test_slack_backfill_discloses_history_cap(client: AsyncClient, monkeyp
     async def fake_slack_get(client_, url, params):
         if url == indexer.CONVERSATIONS_LIST_URL:
             return {"channels": [{"id": "C1", "name": "general"}]}
+        if url == indexer.AUTH_TEST_URL:
+            return {"user_id": "U_SELF"}
         return {
             "messages": [{"type": "message", "ts": "1783362000.1", "text": "hi"}],
             "has_more": has_more,
@@ -1647,6 +1687,80 @@ async def test_slack_backfill_discloses_history_cap(client: AsyncClient, monkeyp
     await indexer.index_slack(src)
     docs = await source_service.list_documents(src)
     assert [d["kind"] for d in docs] == ["transcript"]
+
+
+@pytest.mark.asyncio
+async def test_slack_dms_are_named_after_their_humans(client: AsyncClient, monkeypatch, pool):
+    """A DM carries no name in Slack's API — it must surface as the person
+    you're talking to (dm-sam-liu), and a group DM as everyone except
+    yourself. Rows ingested before the name was known (webhook rows stamped
+    with the raw channel id) must migrate onto the resolved name at sync."""
+    from backend.integrations.slack import indexer
+
+    api_key, owner_id = await _register(client, "slack_dms")
+    ws = await _user_scope(client, api_key)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="T_DMS",
+        display_name="Slack",
+        settings={"allowed_channel_ids": ["D1", "G1"]},
+    )
+    # A pre-fix webhook row, stamped with the raw channel id as its name.
+    await source_service.upsert_content_document(
+        table="slack_messages",
+        source_id=UUID(src["id"]),
+        owner_user_id=ws,
+        path="D1/1783362000.0",
+        name="#D1",
+        kind="message",
+        content="pre-fix webhook message",
+        external_ref="D1:1783362000.0",
+        extra={"channel_id": "D1", "channel_name": "D1", "ts": "1783362000.0"},
+    )
+
+    user_names = {"U_SAM": "Sam Liu", "U_JANE": "Jane Doe"}
+
+    async def fake_get_valid_token(user_id, provider):
+        return "slack-token"
+
+    async def fake_slack_get(client_, url, params):
+        if url == indexer.CONVERSATIONS_LIST_URL:
+            return {
+                "channels": [
+                    {"id": "D1", "is_im": True, "user": "U_SAM"},
+                    {"id": "G1", "is_mpim": True},
+                ]
+            }
+        if url == indexer.AUTH_TEST_URL:
+            return {"user_id": "U_SELF"}
+        if url == indexer.CONVERSATIONS_MEMBERS_URL:
+            assert params["channel"] == "G1"
+            return {"members": ["U_SELF", "U_SAM", "U_JANE"]}
+        if url == indexer.USERS_INFO_URL:
+            return {"user": {"name": "n", "profile": {"display_name": user_names[params["user"]]}}}
+        return {
+            "messages": [{"type": "message", "ts": "1783362001.0", "text": "hey", "user": "U_SAM"}]
+        }
+
+    monkeypatch.setattr(indexer, "get_valid_token", fake_get_valid_token)
+    monkeypatch.setattr(indexer, "_slack_get", fake_slack_get)
+
+    await indexer.index_slack(src)
+
+    docs = await source_service.list_documents(src)
+    assert sorted(d["path"] for d in docs) == [
+        "dm-jane-doe--sam-liu/2026-07-06",
+        "dm-sam-liu/2026-07-06",
+    ]
+    migrated = await pool.fetchrow(
+        "SELECT path, name, channel_name FROM slack_messages "
+        "WHERE source_id = $1 AND ts = '1783362000.0'",
+        UUID(src["id"]),
+    )
+    assert migrated["path"] == "dm-sam-liu/1783362000.0"
+    assert migrated["name"] == "#dm-sam-liu"
+    assert migrated["channel_name"] == "dm-sam-liu"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The Slack source tree rendered DM conversations as raw channel ids:

```
`-- slack
    |-- D096X4MT4PL
    |-- D09BFJAATFX
    |-- D09BZBSHS1K
    ...
```

Two causes:
- Slack's API carries no `name` for `is_im` channels, and the indexer's `channel.get("name") or channel_id` silently fell back to the raw id.
- The Events-API webhook ingest stamped `channel_name=channel_id` unconditionally — even for named public channels — and `_upsert_message` freezes `path`/`name` at first insert, so webhook-born rows kept id-prefixed paths forever.

## Fix

- **`channel_display_name`** (indexer): channels keep their Slack name; a DM resolves its counterpart via `users.info` → `dm-sam-liu`; a group DM resolves `conversations.members` minus the token's own user (`auth.test`) → `dm-jane-doe--sam-liu`. Used by backfill, on-demand history, and the settings channel picker (which previously showed `U…` ids for DMs).
- **Collision guard**: two DMs with identically-named counterparts get the channel id appended — the day-transcript projection groups by `channel_name`, so a collision would silently interleave two conversations.
- **Webhook**: reuses the channel name sync already resolved (DB lookup); a never-synced channel (first message of a new DM) resolves live with the owner's token. No row is ever written with a raw id as its name.
- **Migration**: a rename pass at the top of each channel's sync rewrites `channel_name`/`path`/`name` on rows ingested before the name was known, and drops stale cap-notices (recreated by `_sync_cap_marker`). It runs at sync time, not alembic, because names are only resolvable behind each user's Slack token. Existing `D…` folders collapse into `dm-…` names on each source's next sync.

## Testing

- New `test_slack_dms_are_named_after_their_humans`: end-to-end DM + group-DM naming and the id→name row migration.
- Updated picker test pins `dm-sam-liu` instead of `U1`.
- Full `test_sources.py` + `test_slack_security.py`: 82 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)