### PR TITLE
Show X + Instagram as extension-fed connectors; Save-all-tabs button

### DIFF
--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -28,7 +28,13 @@
       font-weight: 600;
       cursor: pointer;
     }
-    button:not(.secondary):hover { background: #EA580C; }
+    button:not(.secondary):not(.outline):hover { background: #EA580C; }
+    button.outline {
+      background: none;
+      color: #EA580C;
+      border: 1px solid #F97316;
+    }
+    button.outline:hover { background: #fff7ed; }
     button.secondary {
       background: none;
       color: #6b7280;

--- a/chrome_extension/src/popup/popup.ts
+++ b/chrome_extension/src/popup/popup.ts
@@ -77,7 +77,7 @@ async function render(): Promise<void> {
     ]),
     el('div', { className: 'row' }, [
       el('button', {
-        className: 'secondary',
+        className: 'outline',
         textContent: 'Save all open tabs',
         onclick: async () => {
           const result = await send({ type: 'CLIP_ALL_TABS' });

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -126,7 +126,10 @@ export function IntegrationDetail({ provider }: { provider: string }) {
     );
   }
 
-  const connected = !!status?.connected;
+  // Extension-fed connectors (X, Instagram) have no OAuth integration — they're
+  // "connected" once the browser extension has pushed at least one source.
+  const isExtension = connector.kind === "extension";
+  const connected = isExtension ? sources.length > 0 : !!status?.connected;
   const account = connectedAccountLabel(status);
   const canConnectAnother = connected && connector.provider === "gmail" && status?.auth_kind !== "api_key";
   const staleAccounts = status?.accounts.filter((a) => a.needs_reconnect) ?? [];
@@ -239,7 +242,11 @@ export function IntegrationDetail({ provider }: { provider: string }) {
                 {account}
               </span>
             )}
-            {connected ? (
+            {isExtension ? (
+              <span className="text-[12.5px] text-muted-foreground">
+                {connected ? "Synced from the browser extension" : "Save items with the browser extension"}
+              </span>
+            ) : connected ? (
               <>
                 {canConnectAnother && (
                   <button type="button" onClick={() => void connect()} disabled={busy === "connect"} className={secondaryButton()}>
@@ -313,8 +320,10 @@ export function IntegrationDetail({ provider }: { provider: string }) {
 
         {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
 
-        {/* Add a <thing> (for GitHub: the all-vs-select repository access chooser) */}
-        {connected && (
+        {/* Add a <thing> (for GitHub: the all-vs-select repository access chooser).
+            Extension-fed connectors have nothing to add by hand — the extension
+            pushes their sources. */}
+        {connected && !isExtension && (
           <section className="mt-6">
             <SectionLabel>
               {connector.kind === "github" ? "Repository access" : `Add a ${itemNoun}`}
@@ -334,7 +343,11 @@ export function IntegrationDetail({ provider }: { provider: string }) {
           <SectionLabel>{itemNoun === "source" ? "Sources" : `${capitalize(itemNoun)}s`}</SectionLabel>
           {sources.length === 0 ? (
             <div className="py-3 text-[12.5px] text-muted-foreground">
-              {connected ? "Nothing added yet." : "Connect to add sources."}
+              {isExtension
+                ? `Install the Stash browser extension and save on ${connector.label} — your items will appear here.`
+                : connected
+                  ? "Nothing added yet."
+                  : "Connect to add sources."}
             </div>
           ) : (
             <div>

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -206,3 +206,39 @@ export function SlackIcon({ className, size = defaultSize }: Props) {
     </svg>
   );
 }
+
+export function XIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M13.9 10.47 22.04 1h-1.93l-7.07 8.23L7.4 1H.9l8.53 12.44L.9 23.37h1.93l7.46-8.68 5.96 8.68h6.5zm-2.64 3.07-.86-1.24L3.52 2.45h2.95l5.55 7.94.86 1.24 7.23 10.35h-2.95z" />
+    </svg>
+  );
+}
+
+export function InstagramIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="2" y="2" width="20" height="20" rx="5" />
+      <circle cx="12" cy="12" r="4" />
+      <circle cx="17.5" cy="6.5" r="0.6" fill="currentColor" />
+    </svg>
+  );
+}

--- a/frontend/src/components/integrations/SourceConnectorList.test.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.test.tsx
@@ -1,11 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IntegrationStatus } from "../../lib/integrations";
 import { ConfirmDialogProvider } from "../ConfirmDialog";
 import SourceConnectorList from "./SourceConnectorList";
 
 const listIntegrations = vi.fn();
 const disconnectIntegration = vi.fn();
+const listSources = vi.fn();
 
 vi.mock("@/lib/integrations", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/integrations")>();
@@ -13,6 +14,16 @@ vi.mock("@/lib/integrations", async (importOriginal) => {
     ...actual,
     listIntegrations: () => listIntegrations(),
     disconnectIntegration: (...args: unknown[]) => disconnectIntegration(...args),
+  };
+});
+
+// The connector list also fetches sources to mark extension-fed connectors
+// (X / Instagram) connected; default to none so OAuth connectors render.
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/api")>();
+  return {
+    ...actual,
+    listSources: () => listSources(),
   };
 });
 
@@ -33,6 +44,10 @@ function connectedGithub(connected: boolean): IntegrationStatus {
     credential_fields: null,
   };
 }
+
+beforeEach(() => {
+  listSources.mockResolvedValue([]);
+});
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { ApiError } from "@/lib/api";
+import { ApiError, listSources, type Source } from "@/lib/api";
 import {
   disconnectIntegration,
   listIntegrations,
@@ -15,7 +15,7 @@ import {
 
 import { useConfirm } from "../ConfirmDialog";
 import { ObsidianIcon } from "./BrandIcons";
-import { CONNECTORS, connectorIcon, type Connector } from "./connectors";
+import { CONNECTORS, connectorIcon, providerForSourceType, type Connector } from "./connectors";
 import { CredentialForm, primaryButton, secondaryButton } from "./pickers";
 import ObsidianVaultDropZone from "./ObsidianVaultDropZone";
 import PaywallModal from "../PaywallModal";
@@ -35,6 +35,10 @@ export default function SourceConnectorList({
   onObsidianUploaded,
 }: Props) {
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus>>({});
+  // Extension-fed connectors (X, Instagram) have no OAuth integration — they're
+  // "connected" once the browser extension has pushed a source. Keyed by
+  // provider ("x"/"instagram").
+  const [extensionSources, setExtensionSources] = useState<Record<string, Source>>({});
   const [expanded, setExpanded] = useState<IntegrationProvider | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -43,12 +47,18 @@ export default function SourceConnectorList({
 
   const refresh = useCallback(async () => {
     setError(null);
-    const integrations = await listIntegrations();
+    const [integrations, sources] = await Promise.all([listIntegrations(), listSources()]);
     const nextStatuses: Record<string, IntegrationStatus> = {};
     for (const provider of integrations.providers) {
       nextStatuses[provider.provider] = provider;
     }
     setStatuses(nextStatuses);
+    const extension: Record<string, Source> = {};
+    for (const source of sources) {
+      const provider = providerForSourceType[source.type];
+      if (provider === "x" || provider === "instagram") extension[provider] = source;
+    }
+    setExtensionSources(extension);
   }, []);
 
   useEffect(() => {
@@ -129,9 +139,19 @@ export default function SourceConnectorList({
       )}
 
       {CONNECTORS.map((connector) => {
+        const isExtension = connector.kind === "extension";
         const status = statuses[connector.provider];
-        const connected = !!status?.connected;
+        const connected = isExtension
+          ? !!extensionSources[connector.provider]
+          : !!status?.connected;
         const enabled = status?.enabled ?? true;
+        const subtitle = isExtension
+          ? connected
+            ? "Connected via the browser extension"
+            : connector.blurb
+          : connected
+            ? connectedLabel(status)
+            : connector.blurb;
         return (
           <div key={connector.provider} className="rounded-lg border border-border bg-surface px-3 py-2.5">
             <div className="flex items-center gap-3">
@@ -140,25 +160,32 @@ export default function SourceConnectorList({
               </span>
               <div className="min-w-0 flex-1">
                 <div className="text-[13.5px] font-medium text-foreground">{connector.label}</div>
-                <div className="truncate text-[11.5px] text-muted-foreground">
-                  {connected ? connectedLabel(status) : connector.blurb}
-                </div>
+                <div className="truncate text-[11.5px] text-muted-foreground">{subtitle}</div>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                <ConnectorAction
-                  connected={connected}
-                  enabled={enabled}
-                  authKind={status?.auth_kind ?? "oauth"}
-                  disabledReason={status?.disabled_reason ?? null}
-                  provider={connector.provider}
-                  busy={busy === connector.provider}
-                  expanded={expanded === connector.provider}
-                  onConnect={() => void connect(connector)}
-                  onDisconnect={() => void disconnect(connector)}
-                  onExpand={() =>
-                    setExpanded((value) => (value === connector.provider ? null : connector.provider))
-                  }
-                />
+                {isExtension ? (
+                  // No OAuth to start — the extension pushes the saves. Always
+                  // offer "Open" so the page can show the saves or, when empty,
+                  // how to start.
+                  <Link href={`/integrations/${connector.provider}`} className={secondaryButton()}>
+                    Open
+                  </Link>
+                ) : (
+                  <ConnectorAction
+                    connected={connected}
+                    enabled={enabled}
+                    authKind={status?.auth_kind ?? "oauth"}
+                    disabledReason={status?.disabled_reason ?? null}
+                    provider={connector.provider}
+                    busy={busy === connector.provider}
+                    expanded={expanded === connector.provider}
+                    onConnect={() => void connect(connector)}
+                    onDisconnect={() => void disconnect(connector)}
+                    onExpand={() =>
+                      setExpanded((value) => (value === connector.provider ? null : connector.provider))
+                    }
+                  />
+                )}
               </div>
             </div>
 

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -11,12 +11,21 @@ import {
   GranolaIcon,
   JiraIcon,
   LinearIcon,
+  InstagramIcon,
   NotionIcon,
   PostHogIcon,
   SlackIcon,
+  XIcon,
 } from "./BrandIcons";
 
-export type ConnectorKind = "github" | "drive" | "notion" | "jira" | "asana" | "auto";
+export type ConnectorKind =
+  | "github"
+  | "drive"
+  | "notion"
+  | "jira"
+  | "asana"
+  | "auto"
+  | "extension";
 
 export type Connector = {
   provider: IntegrationProvider;
@@ -104,6 +113,20 @@ export const CONNECTORS: Connector[] = [
     kind: "auto",
     blurb: "Browse dashboards, insights, feature flags, and experiments.",
   },
+  {
+    provider: "x",
+    label: "X",
+    sourceType: "x_saves",
+    kind: "extension",
+    blurb: "Your X bookmarks, saved automatically by the Stash browser extension.",
+  },
+  {
+    provider: "instagram",
+    label: "Instagram",
+    sourceType: "instagram_saves",
+    kind: "extension",
+    blurb: "Your Instagram saves, captured by the Stash browser extension.",
+  },
 ];
 
 // Maps a connected-source row's `type` back to the integration provider that
@@ -121,6 +144,8 @@ export const providerForSourceType: Record<string, string> = {
   granola: "granola",
   gong_calls: "gong",
   posthog_project: "posthog",
+  x_saves: "x",
+  instagram_saves: "instagram",
 };
 
 export function connectorForProvider(provider: string): Connector | undefined {
@@ -155,6 +180,10 @@ export function connectorIcon(provider: string): ReactNode {
       return <GongIcon />;
     case "posthog":
       return <PostHogIcon />;
+    case "x":
+      return <XIcon />;
+    case "instagram":
+      return <InstagramIcon />;
     default:
       return null;
   }

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -19,7 +19,11 @@ export type IntegrationProvider =
   | "linear"
   | "asana"
   | "gong"
-  | "posthog";
+  | "posthog"
+  // Extension-fed connectors — no OAuth integration, "connected" once the
+  // browser extension has pushed a source.
+  | "x"
+  | "instagram";
 
 export type CredentialField = {
   name: string;


### PR DESCRIPTION
Addresses two bits of save-UX feedback.

**1. X / Instagram invisible in the integrations UI.** They're provider-less (extension-fed) sources, but the integrations page only rendered OAuth connector cards — so a synced X source had nowhere to appear. This adds X + Instagram as `kind: "extension"` connectors:
- They show **"Connected via the browser extension"** once a source exists (driven by `listSources`, not an OAuth status), with an **Open** link to browse their saves.
- The per-provider page hides the OAuth connect/add controls for them and just lists + browses the pushed sources (empty state points at the extension).
- Adds X / Instagram brand icons + the `x_saves`/`instagram_saves` → provider mapping.

**2. "Save all open tabs" looked like a link.** It was a `.secondary` (underlined) button in the popup; now an outlined button under "Save this tab".

App-code typecheck + ESLint clean; extension typecheck + build clean.