### PR TITLE
Render X media + deep link in the doc viewer; raise free connection limit to 5

### DIFF
--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -23,7 +23,7 @@ from ..database import get_pool
 # Stripe statuses that grant Pro. Everything else (past_due, canceled,
 # unpaid, incomplete) means free-tier enforcement.
 ACTIVE_STATUSES = {"active", "trialing"}
-FREE_CONNECTION_LIMIT = 1
+FREE_CONNECTION_LIMIT = 5
 
 # Internal team accounts get Pro without a subscription — no card, no Stripe row.
 INTERNAL_EMAIL_DOMAINS = {"ferganalabs.com", "joinstash.ai"}
@@ -76,9 +76,10 @@ async def connection_count(user_id: UUID) -> int:
 
 
 async def ensure_can_connect(user_id: UUID) -> None:
-    """Connect-time pay gate. The free plan includes one connected account; a
-    second account — another provider or another mailbox on the same one —
-    requires Pro. Sources added under a connection are unlimited."""
+    """Connect-time pay gate. The free plan includes a handful of connected
+    accounts (FREE_CONNECTION_LIMIT); beyond that requires Pro. Sources added
+    under a connection are unlimited, and extension-fed sources (X, Instagram)
+    aren't accounts so they never count against this."""
     if not billing_enabled():
         return
     if await is_pro(user_id):
@@ -86,7 +87,10 @@ async def ensure_can_connect(user_id: UUID) -> None:
     if await connection_count(user_id) >= FREE_CONNECTION_LIMIT:
         raise HTTPException(
             status_code=402,
-            detail="The free plan includes 1 connected account. Upgrade to Pro to connect more.",
+            detail=(
+                f"The free plan includes {FREE_CONNECTION_LIMIT} connected accounts. "
+                "Upgrade to Pro to connect more."
+            ),
         )
 
 

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -23,7 +23,7 @@ from ..database import get_pool
 # Stripe statuses that grant Pro. Everything else (past_due, canceled,
 # unpaid, incomplete) means free-tier enforcement.
 ACTIVE_STATUSES = {"active", "trialing"}
-FREE_CONNECTION_LIMIT = 5
+FREE_CONNECTION_LIMIT = 2
 
 # Internal team accounts get Pro without a subscription — no card, no Stripe row.
 INTERNAL_EMAIL_DOMAINS = {"ferganalabs.com", "joinstash.ai"}

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1164,6 +1164,7 @@ async def _read_x_save(source_id: UUID, path: str) -> dict | None:
         "kind": row["kind"],
         "content": row["content"],
         "external_ref": row["external_ref"],
+        "url": f"https://x.com/i/status/{row['path']}",
     }
     media = row["media"] or []
     if media:

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -50,6 +50,13 @@ async def _connect_account(pool, user_id: UUID, provider: str, account_key: str 
     )
 
 
+async def _fill_to_free_limit(pool, user_id: UUID):
+    """Connect exactly FREE_CONNECTION_LIMIT accounts, so the next connect gates.
+    Each row is a distinct account, which is what the counter keys on."""
+    for i in range(billing_service.FREE_CONNECTION_LIMIT):
+        await _connect_account(pool, user_id, "gmail", account_key=f"acct{i}@x.com")
+
+
 def _stripe_signature(payload: bytes, secret: str) -> str:
     ts = int(time.time())
     sig = hmac.new(secret.encode(), f"{ts}.".encode() + payload, hashlib.sha256).hexdigest()
@@ -73,13 +80,13 @@ def github_enabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_free_user_gated_at_second_connection(client, pool, billing_on):
+async def test_free_user_gated_past_the_free_limit(client, pool, billing_on):
     _, user_id = await _register(client)
 
-    # No connections yet — the first one is free.
+    # Nothing connected yet — connecting is allowed.
     await billing_service.ensure_can_connect(user_id)
 
-    await _connect_account(pool, user_id, "github")
+    await _fill_to_free_limit(pool, user_id)
     with pytest.raises(HTTPException) as exc:
         await billing_service.ensure_can_connect(user_id)
     assert exc.value.status_code == 402
@@ -96,12 +103,12 @@ async def test_free_user_gated_at_second_connection(client, pool, billing_on):
 
 @pytest.mark.asyncio
 async def test_each_account_counts(client, pool, billing_on):
-    """A second mailbox on an already-connected provider is a second account,
-    so it gates just like a brand-new provider would."""
+    """Each account row counts on its own — two mailboxes on one provider are
+    two connections — so filling the free limit with mailboxes gates the next."""
     _, user_id = await _register(client)
-    await _connect_account(pool, user_id, "gmail", account_key="a@x.com")
+    await _fill_to_free_limit(pool, user_id)
 
-    assert await billing_service.connection_count(user_id) == 1
+    assert await billing_service.connection_count(user_id) == billing_service.FREE_CONNECTION_LIMIT
     with pytest.raises(HTTPException) as exc:
         await billing_service.ensure_can_connect(user_id)
     assert exc.value.status_code == 402
@@ -112,7 +119,7 @@ async def test_internal_email_gets_pro_without_subscription(client, pool, billin
     """Team accounts on an internal domain bypass the pay gate with no Stripe row."""
     api_key, user_id = await _register(client)
     await pool.execute("UPDATE users SET email = 'dev@joinstash.ai' WHERE id = $1", user_id)
-    await _connect_account(pool, user_id, "github")
+    await _fill_to_free_limit(pool, user_id)
 
     # A free user would be gated here; the internal account is not.
     await billing_service.ensure_can_connect(user_id)
@@ -129,7 +136,7 @@ async def test_internal_bypass_can_be_disabled(client, pool, billing_on, monkeyp
     monkeypatch.setattr(settings, "INTERNAL_DOMAINS_FREE_PRO", False)
     _, user_id = await _register(client)
     await pool.execute("UPDATE users SET email = 'dev@joinstash.ai' WHERE id = $1", user_id)
-    await _connect_account(pool, user_id, "github")
+    await _fill_to_free_limit(pool, user_id)
 
     with pytest.raises(HTTPException) as exc:
         await billing_service.ensure_can_connect(user_id)
@@ -147,14 +154,14 @@ async def test_gate_off_when_billing_disabled(client, pool, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_connect_endpoint_gates_second_connection(client, pool, billing_on, github_enabled):
+async def test_connect_endpoint_gates_past_the_free_limit(client, pool, billing_on, github_enabled):
     api_key, user_id = await _register(client)
 
     first = await client.get("/api/v1/integrations/github/connect", headers=_auth(api_key))
     assert first.status_code == 200
     assert "github.com/login/oauth/authorize" in first.json()["authorize_url"]
 
-    await _connect_account(pool, user_id, "github")
+    await _fill_to_free_limit(pool, user_id)
 
     blocked = await client.get("/api/v1/integrations/github/connect", headers=_auth(api_key))
     assert blocked.status_code == 402
@@ -172,7 +179,7 @@ async def test_billing_me_reflects_plan(client, pool, billing_on):
         "plan": "free",
         "status": None,
         "connection_count": 1,
-        "connection_limit": 1,
+        "connection_limit": billing_service.FREE_CONNECTION_LIMIT,
     }
 
     await pool.execute(

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -676,22 +676,25 @@ function DocViewer({
   const [content, setContent] = useState<string | null>(null);
   const [title, setTitle] = useState(name ?? "");
   const [url, setUrl] = useState<string | null>(null);
-  const [media, setMedia] = useState<{ url: string; contentType: string } | null>(null);
+  const [media, setMedia] = useState<{ url: string; contentType: string }[]>([]);
   const [error, setError] = useState("");
 
   useEffect(() => {
     let cancelled = false;
     setContent(null);
     setUrl(null);
-    setMedia(null);
+    setMedia([]);
     setError("");
     readSourceDoc(source, refValue)
       .then((doc) => {
         if (cancelled) return;
         setContent(doc.content ?? "");
         setUrl(doc.url ?? null);
-        if (doc.media_url) {
-          setMedia({ url: doc.media_url, contentType: doc.media_content_type ?? "" });
+        // X carries up to 4 media items (media[]); Instagram a single blob.
+        if (doc.media?.length) {
+          setMedia(doc.media.map((m) => ({ url: m.url, contentType: m.content_type ?? "" })));
+        } else if (doc.media_url) {
+          setMedia([{ url: doc.media_url, contentType: doc.media_content_type ?? "" }]);
         }
         if (doc.name) setTitle(doc.name);
       })
@@ -731,16 +734,17 @@ function DocViewer({
         <div className="bg-base px-3 py-3 text-[12px] text-muted-foreground">Loading…</div>
       ) : (
         <>
-          {media &&
-            (media.contentType.startsWith("video/") ? (
+          {media.map((m, i) =>
+            m.contentType.startsWith("video/") ? (
               // eslint-disable-next-line jsx-a11y/media-has-caption -- archived
               // social video; the transcript is in the document body below.
-              <video src={media.url} controls className="max-h-72 w-full bg-black" />
+              <video key={i} src={m.url} controls className="max-h-72 w-full bg-black" />
             ) : (
               // eslint-disable-next-line @next/next/no-img-element -- presigned
               // blob URL, not an optimizable static asset.
-              <img src={media.url} alt={title} className="max-h-72 w-full bg-black object-contain" />
-            ))}
+              <img key={i} src={m.url} alt={title} className="max-h-72 w-full bg-black object-contain" />
+            ),
+          )}
           <pre className="scroll-thin max-h-96 overflow-auto whitespace-pre-wrap break-words bg-base px-3 py-3 font-mono text-[12px] text-foreground">
             {content}
           </pre>

--- a/frontend/src/components/PaywallModal.tsx
+++ b/frontend/src/components/PaywallModal.tsx
@@ -40,7 +40,7 @@ export default function PaywallModal({ onClose }: { onClose: () => void }) {
           Upgrade to Pro
         </div>
         <div className="mt-1.5 text-[12.5px] leading-[1.55] text-muted-foreground">
-          The free plan includes 1 connected account. Pro unlocks unlimited
+          The free plan includes a few connected accounts. Pro unlocks unlimited
           integrations — GitHub, Slack, Gmail, Drive, Notion, and more —
           for $20/month.
         </div>

--- a/frontend/src/components/settings/SubscriptionSection.tsx
+++ b/frontend/src/components/settings/SubscriptionSection.tsx
@@ -41,7 +41,8 @@ export default function SubscriptionSection() {
       <div>
         <h2 className="text-base font-semibold text-foreground">Subscription</h2>
         <p className="text-xs text-muted-foreground mt-0.5">
-          The free plan includes 1 connected account. Pro is $20/month for unlimited integrations.
+          The free plan includes {billing.connection_limit} connected accounts. Pro is $20/month
+          for unlimited integrations.
         </p>
       </div>
 
@@ -53,7 +54,7 @@ export default function SubscriptionSection() {
           <div className="text-xs text-muted-foreground mt-0.5">
             {isPro
               ? `Subscription ${billing.status}.`
-              : `${billing.connection_count} of ${billing.connection_limit} connected account used.`}
+              : `${billing.connection_count} of ${billing.connection_limit} connected accounts used.`}
           </div>
         </div>
         {isPro ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -385,9 +385,11 @@ export async function readSourceDoc(
   name?: string;
   content?: string;
   url?: string | null;
-  // Archived save media (Instagram) served via a fresh presigned URL.
+  // Archived save media served via fresh presigned URLs. Instagram carries a
+  // single blob (media_url); X can carry up to 4 (media[]).
   media_url?: string | null;
   media_content_type?: string | null;
+  media?: { url: string; content_type?: string | null }[] | null;
 }> {
   return apiFetch(`${ME}/sources/${source}/doc?ref=${encodeURIComponent(ref)}`);
 }


### PR DESCRIPTION
**Click-to-open X saves.** Opening a saved tweet showed text only — the doc viewer renders Instagram's single `media_url`, but X docs carry a `media[]` list and had no deep link. This adds the tweet `url` to the X doc read and teaches `DocViewer` to render a media list (up to 4 images / a video), keeping Instagram's single-blob path. Saved tweets now open with images/video + an "Open in X ↗" link.

**Free connection limit 1 → 5.** The pay gate tripped on the *second* connected account; raised to 5. Extension-fed sources (X, Instagram) still never count (they don't create `user_integrations` rows). Paywall copy reads the limit dynamically; billing tests rewritten to gate at `FREE_CONNECTION_LIMIT` instead of hardcoding "second connection".

Backend billing + x_saves tests pass; app-code typecheck + ruff clean.