### PR TITLE
Sync all X bookmarks by scrolling the whole list

### DIFF
--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -19,7 +19,7 @@ import {
   savedItemsFailed,
   shouldFetchSaves,
 } from './background/instagram';
-import { initTwitter, receiveBookmarks } from './background/twitter';
+import { finishHarvest, initTwitter, isHarvestTab, receiveBookmarks } from './background/twitter';
 import { platformStatus, syncNow } from './background/status';
 import type { ConversationSnapshot } from './content/sync';
 
@@ -63,6 +63,10 @@ async function handle(message: any, sender: chrome.runtime.MessageSender): Promi
       return savedItemsFailed(message.error, sender);
     case 'X_BOOKMARKS':
       return receiveBookmarks(message.ids, sender);
+    case 'IS_HARVEST_TAB':
+      return isHarvestTab(sender);
+    case 'X_HARVEST_DONE':
+      return finishHarvest(sender);
     case 'CLIP_FAILED':
       await chrome.storage.local.set({ lastError: `Save failed: ${message.error}` });
       await setBadge('!', 'Save failed — click for details');

--- a/chrome_extension/src/background/twitter.ts
+++ b/chrome_extension/src/background/twitter.ts
@@ -1,11 +1,13 @@
 // X bookmarks: capture bookmark links, push to Stash, daily auto-visit.
 //
-// The content scripts on x.com read the user's Bookmarks response whenever
+// The content scripts on x.com read the user's Bookmarks responses whenever
 // they visit the bookmarks page; a daily alarm also opens a background
 // (non-active) tab to x.com/i/bookmarks so capture happens without a manual
-// visit. We push only the tweet LINKS to POST /me/x-items — the server
-// hydrates the full content, thread, and media from each link via
-// ScrapeCreators, and get-or-creates the x_saves source on first push.
+// visit. On a harvest tab the content script scrolls the whole list so every
+// cursor page loads (x.com only returns ~20 bookmarks per page), and we push
+// each page's tweet LINKS to POST /me/x-items — the server hydrates the full
+// content, thread, and media, and get-or-creates the x_saves source. The tab
+// stays open until the content script signals the list is exhausted.
 
 import { setBadge, stashConfig } from '../lib/stash';
 
@@ -28,10 +30,11 @@ function schedule(): void {
 
 export async function receiveBookmarks(
   ids: unknown[],
-  sender: chrome.runtime.MessageSender
+  _sender: chrome.runtime.MessageSender
 ): Promise<any> {
+  // Set on every captured page — the harvest tab stays open until the content
+  // script reports the list is exhausted (finishHarvest), not on first push.
   await chrome.storage.local.set({ xBookmarksFetchedAt: Date.now() });
-  await closeVisitTab(sender.tab?.id);
 
   if (!Array.isArray(ids) || ids.length === 0) return { ok: true, new: 0 };
   const cfg = await stashConfig();
@@ -61,7 +64,25 @@ async function autoVisit(): Promise<void> {
   if (!apiKey) return;
   const tab = await chrome.tabs.create({ url: BOOKMARKS_URL, active: false });
   await chrome.storage.session.set({ xVisitTabId: tab.id });
-  chrome.alarms.create(VISIT_TIMEOUT_ALARM, { delayInMinutes: 2 });
+  // Scrolling the whole list can take a few minutes on large accounts; the
+  // content script closes the tab sooner when it hits the end.
+  chrome.alarms.create(VISIT_TIMEOUT_ALARM, { delayInMinutes: 5 });
+}
+
+/** Whether the asking content script is running in our background harvest tab
+ *  (vs. the user manually browsing their bookmarks — those we don't scroll). */
+export async function isHarvestTab(
+  sender: chrome.runtime.MessageSender
+): Promise<{ harvest: boolean }> {
+  const { xVisitTabId } = await chrome.storage.session.get(['xVisitTabId']);
+  return { harvest: sender.tab?.id != null && sender.tab.id === xVisitTabId };
+}
+
+/** The content script scrolled to the end of the bookmarks list — close the
+ *  harvest tab and stop the timeout. */
+export async function finishHarvest(sender: chrome.runtime.MessageSender): Promise<{ ok: boolean }> {
+  await closeVisitTab(sender.tab?.id);
+  return { ok: true };
 }
 
 /** "Sync now" for X: open the bookmarks page in the background and harvest. */

--- a/chrome_extension/src/content/twitter.ts
+++ b/chrome_extension/src/content/twitter.ts
@@ -1,11 +1,41 @@
 // Isolated-world companion on x.com. The main-world interceptor
-// (twitter_main.ts) can read x.com's Bookmarks responses but can't reach
-// chrome.runtime; this script bridges its window messages to the
-// background worker.
+// (twitter_main.ts) reads x.com's Bookmarks responses but can't reach
+// chrome.runtime; this script bridges its window messages to the background
+// worker. On a background harvest tab it also scrolls the bookmarks list so
+// every cursor page loads — x.com returns only ~20 bookmarks per page, so
+// without scrolling only the first page is ever captured.
+
+const MAX_SCROLLS = 80; // ~80 pages * ~20 = up to ~1600 bookmarks per run
+const SCROLL_INTERVAL_MS = 1200;
+
+let reachedEnd = false;
 
 window.addEventListener('message', (event) => {
   if (event.source !== window) return;
   const data = event.data;
-  if (data?.source !== 'stash-x-bookmarks' || !Array.isArray(data.ids)) return;
-  void chrome.runtime.sendMessage({ type: 'X_BOOKMARKS', ids: data.ids });
+  if (data?.source !== 'stash-x-bookmarks') return;
+  if (Array.isArray(data.ids) && data.ids.length) {
+    void chrome.runtime.sendMessage({ type: 'X_BOOKMARKS', ids: data.ids });
+  }
+  if (data.done) reachedEnd = true;
 });
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function harvestIfBackgroundTab(): Promise<void> {
+  if (!location.pathname.startsWith('/i/bookmarks')) return;
+  // A manual visit captures pages as the user scrolls on their own; only the
+  // background harvest tab should auto-scroll.
+  const res = await chrome.runtime.sendMessage({ type: 'IS_HARVEST_TAB' });
+  if (!res?.harvest) return;
+
+  for (let i = 0; i < MAX_SCROLLS && !reachedEnd; i++) {
+    window.scrollTo(0, document.documentElement.scrollHeight);
+    await sleep(SCROLL_INTERVAL_MS);
+  }
+  void chrome.runtime.sendMessage({ type: 'X_HARVEST_DONE' });
+}
+
+void harvestIfBackgroundTab();

--- a/chrome_extension/src/content/twitter_main.ts
+++ b/chrome_extension/src/content/twitter_main.ts
@@ -10,15 +10,17 @@ import { parseBookmarkIds } from '../lib/x_bookmarks';
 
 const BOOKMARKS_RE = /\/graphql\/[^/]+\/Bookmarks/;
 
-function post(ids: string[]): void {
-  if (ids.length === 0) return;
-  window.postMessage({ source: 'stash-x-bookmarks', ids }, window.location.origin);
+// `done` = this Bookmarks page carried no tweets, i.e. we've scrolled past the
+// end of the list — the companion uses it to stop auto-scrolling.
+function post(ids: string[], done: boolean): void {
+  window.postMessage({ source: 'stash-x-bookmarks', ids, done }, window.location.origin);
 }
 
 function handleBody(url: string, body: string): void {
   if (!BOOKMARKS_RE.test(url)) return;
   try {
-    post(parseBookmarkIds(JSON.parse(body)));
+    const ids = parseBookmarkIds(JSON.parse(body));
+    post(ids, ids.length === 0);
   } catch {
     // A non-JSON or shape-changed response is not fatal — the next page load
     // tries again. Staying silent avoids console noise on every x.com fetch.


### PR DESCRIPTION
**Fixes "it didn't sync all my bookmarks."** Not a twitterapi.io limit — the extension only grabbed the first page. x.com paginates bookmarks by cursor (~20/page), the harvest never scrolled, and `receiveBookmarks` closed the tab on the first page's push, so pages 2+ never loaded.

Now the background harvest tab's content script auto-scrolls to the bottom (loading every cursor page), the main-world interceptor captures each page and flags the empty page as the end, and the tab stays open (5-min timeout backstop) until the content script reports it reached the end. Each page's tweet links are pushed to `/me/x-items` and deduped server-side. Manual visits still capture as the user scrolls and are not auto-scrolled.

Extension typecheck + build clean.