### PR TITLE
Capture your own X posts + replies via twitterapi.io timeline

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -24,11 +24,15 @@ from ...services import source_service, storage_service
 logger = logging.getLogger(__name__)
 
 TAPI_TWEETS_URL = "https://api.twitterapi.io/twitter/tweets"
+TAPI_USER_TWEETS_URL = "https://api.twitterapi.io/twitter/user/last_tweets"
 TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
 MAX_MEDIA_PER_TWEET = 4
 HYDRATION_BATCH = 25
 MAX_HYDRATION_ATTEMPTS = 3
+# Pages of the user's own timeline pulled per sync (20 tweets/page). Bounded so
+# one sync doesn't run away; older tweets keep arriving over subsequent syncs.
+MAX_USER_TWEET_PAGES = 5
 
 
 def tweet_url(tweet_id: str) -> str:
@@ -44,22 +48,28 @@ async def index_x_saves(source: dict) -> str | None:
     source_id = UUID(source["id"])
     owner_user_id = UUID(source["owner_user_id"])
     pool = get_pool()
-    rows = await pool.fetch(
-        f"""
-        SELECT id, path, kind FROM x_save_docs
-        WHERE source_id = $1 AND (
-              hydration_status = 'pending'
-           OR (hydration_status = 'failed' AND hydration_attempts < {MAX_HYDRATION_ATTEMPTS})
-        )
-        ORDER BY created_at
-        LIMIT {HYDRATION_BATCH}
-        """,
-        source_id,
-    )
+    x_user_id = (source.get("settings") or {}).get("x_user_id")
 
     async with httpx.AsyncClient(
         timeout=TAPI_TIMEOUT, headers={"X-API-Key": settings.TWITTERAPI_IO_KEY}
     ) as client:
+        # The extension pushes bookmark links directly; the user's own
+        # posts/replies come from their timeline once we know their id.
+        if x_user_id:
+            await _backfill_user_tweets(client, source_id, owner_user_id, str(x_user_id))
+
+        rows = await pool.fetch(
+            f"""
+            SELECT id, path, kind FROM x_save_docs
+            WHERE source_id = $1 AND (
+                  hydration_status = 'pending'
+               OR (hydration_status = 'failed' AND hydration_attempts < {MAX_HYDRATION_ATTEMPTS})
+            )
+            ORDER BY created_at
+            LIMIT {HYDRATION_BATCH}
+            """,
+            source_id,
+        )
         for row in rows:
             try:
                 await _hydrate_one(client, source_id, owner_user_id, row["path"], row["kind"])
@@ -79,6 +89,44 @@ async def index_x_saves(source: dict) -> str | None:
                     f"{type(exc).__name__}: {exc}"[:2000],
                 )
     return None
+
+
+async def _backfill_user_tweets(
+    client: httpx.AsyncClient, source_id: UUID, owner_user_id: UUID, x_user_id: str
+) -> None:
+    """Insert pending rows for the user's own posts + replies (from their
+    timeline), which then hydrate through the same path as bookmarks. Retweets
+    are skipped — they aren't the user's own writing. Idempotent per tweet."""
+    pool = get_pool()
+    cursor: str | None = None
+    for _ in range(MAX_USER_TWEET_PAGES):
+        params = {"userId": x_user_id}
+        if cursor:
+            params["cursor"] = cursor
+        response = await client.get(TAPI_USER_TWEETS_URL, params=params)
+        response.raise_for_status()
+        payload = response.json()
+        tweets = (payload.get("data") or {}).get("tweets") or []
+        for tweet in tweets:
+            tweet_id = tweet.get("id")
+            if not tweet_id or tweet.get("isRetweet"):
+                continue
+            kind = "Reply" if tweet.get("isReply") else "Post"
+            await pool.execute(
+                "INSERT INTO x_save_docs "
+                "(owner_user_id, source_id, path, name, kind, external_ref) "
+                "VALUES ($1, $2, $3, $3, $4, $3) "
+                "ON CONFLICT (source_id, path) DO NOTHING",
+                owner_user_id,
+                source_id,
+                tweet_id,
+                kind,
+            )
+        if not payload.get("has_next_page"):
+            break
+        cursor = payload.get("next_cursor")
+        if not cursor:
+            break
 
 
 async def _hydrate_one(

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -570,3 +570,44 @@ async def push_x_items(
     if new:
         celery.send_task("backend.tasks.sources.sync_source", args=[str(source_id)])
     return {"accepted": len(parsed), "new": new, "existing": len(parsed) - new}
+
+
+class XAccount(BaseModel):
+    user_id: str
+
+
+@x_items_router.post("/account")
+async def set_x_account(
+    body: XAccount,
+    current_user: dict = Depends(get_current_user),
+):
+    """The extension reports the signed-in X account's numeric id (from the
+    twid cookie). We store it on the x_saves source so the indexer can pull the
+    user's own posts + replies from their timeline via twitterapi.io — bookmarks
+    stay extension-fed, everything else is scraped by handle."""
+    from ..config import settings as app_settings
+
+    if not app_settings.TWITTERAPI_IO_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail="X saves are not enabled on this server (TWITTERAPI_IO_KEY is not set)",
+        )
+    if not body.user_id.isdigit():
+        raise HTTPException(status_code=400, detail="user_id must be the numeric X account id")
+
+    source = await source_service.create_source(
+        owner_user_id=current_user["id"],
+        source_type="x_saves",
+        external_ref="saves",
+        display_name="X saves",
+        settings={},
+    )
+    source_id = UUID(source["id"])
+    await get_pool().execute(
+        "UPDATE user_sources SET settings = coalesce(settings, '{}'::jsonb) || $2::jsonb "
+        "WHERE id = $1",
+        source_id,
+        {"x_user_id": body.user_id},
+    )
+    celery.send_task("backend.tasks.sources.sync_source", args=[str(source_id)])
+    return {"ok": True}

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -266,3 +266,81 @@ async def test_hydration_failure_lands_on_the_row(
     )
     assert ok and doc["http_status"] == 422
     assert "scrapecreators exploded" in doc["error"]
+
+
+_USER_TIMELINE = {
+    "data": {
+        "tweets": [
+            {"id": "200", "isReply": False, "isRetweet": False},
+            {"id": "201", "isReply": True, "isRetweet": False},
+            {"id": "202", "isReply": False, "isRetweet": True},  # retweet — skipped
+        ]
+    },
+    "has_next_page": False,
+}
+
+
+class _FakeTimelineApi:
+    """Answers the user-timeline endpoint and, for hydration, the tweet-by-id
+    endpoint (a self-contained tweet, no thread root or media)."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, params=None):
+        if url == x_indexer.TAPI_USER_TWEETS_URL:
+            return _FakeResponse(payload=_USER_TIMELINE)
+        if url == x_indexer.TAPI_TWEETS_URL:
+            tid = params["tweet_ids"]
+            return _FakeResponse(
+                payload={
+                    "tweets": [
+                        {
+                            "id": tid,
+                            "text": f"my tweet {tid}",
+                            "author": {"userName": "me"},
+                            "createdAt": "Wed Jul 01 12:00:00 +0000 2025",
+                            "conversationId": tid,
+                        }
+                    ]
+                }
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+
+@pytest.mark.asyncio
+async def test_backfill_pulls_own_posts_and_replies(client, pool, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", "tapi-key")
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(x_indexer, "httpx", SimpleNamespace(AsyncClient=_FakeTimelineApi))
+    from backend.routers import sources as sources_router
+
+    monkeypatch.setattr(sources_router.celery, "send_task", lambda name, args: None)
+    headers, owner_id = await _register(client)
+
+    # The extension reports the signed-in account id; posts/replies come from
+    # the timeline (bookmarks would be pushed separately).
+    resp = await client.post("/api/v1/me/x-items/account", json={"user_id": "999"}, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    source = await pool.fetchrow(
+        "SELECT id FROM user_sources WHERE owner_user_id = $1 AND source_type = 'x_saves'",
+        UUID(owner_id),
+    )
+    await x_indexer.index_x_saves(await source_service.get_source_for_sync(source["id"]))
+
+    rows = await pool.fetch(
+        "SELECT path, kind, hydration_status FROM x_save_docs WHERE source_id = $1 ORDER BY path",
+        source["id"],
+    )
+    # The retweet (202) is skipped; the post + reply are captured and hydrated.
+    assert [(r["path"], r["kind"], r["hydration_status"]) for r in rows] == [
+        ("200", "Post", "done"),
+        ("201", "Reply", "done"),
+    ]

--- a/chrome_extension/src/background/twitter.ts
+++ b/chrome_extension/src/background/twitter.ts
@@ -62,11 +62,27 @@ export async function receiveBookmarks(
 async function autoVisit(): Promise<void> {
   const { apiKey } = await chrome.storage.local.get(['apiKey']);
   if (!apiKey) return;
+  await pushXAccount();
   const tab = await chrome.tabs.create({ url: BOOKMARKS_URL, active: false });
   await chrome.storage.session.set({ xVisitTabId: tab.id });
   // Scrolling the whole list can take a few minutes on large accounts; the
   // content script closes the tab sooner when it hits the end.
   chrome.alarms.create(VISIT_TIMEOUT_ALARM, { delayInMinutes: 5 });
+}
+
+/** Report the signed-in X account's numeric id (from the twid cookie) so the
+ *  server can pull the user's own posts + replies from their timeline. */
+async function pushXAccount(): Promise<void> {
+  const cfg = await stashConfig();
+  if (!cfg.apiKey) return;
+  const cookie = await chrome.cookies.get({ url: 'https://x.com', name: 'twid' });
+  const match = cookie?.value && decodeURIComponent(cookie.value).match(/u=(\d+)/);
+  if (!match) return;
+  await fetch(`${cfg.apiBase}/api/v1/me/x-items/account`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: match[1] }),
+  }).catch(() => undefined);
 }
 
 /** Whether the asking content script is running in our background harvest tab


### PR DESCRIPTION
**Adds capture of your own posts/replies/articles** — previously only bookmarks were captured.

- The extension reports the signed-in X account's **numeric id** (read from the `twid` cookie — no DOM scraping) to `POST /me/x-items/account`, stored on the `x_saves` source.
- Each sync, the indexer pulls that account's recent **timeline** from twitterapi.io's `user/last_tweets` (bounded to a few pages/run, older ones arrive over subsequent syncs), inserts pending **Post/Reply** rows (retweets skipped — not your writing), and they hydrate through the same path as bookmarks: full text, thread root for replies, archived media.
- New test covers the backfill (post + reply captured, retweet skipped, both hydrate).

⚠️ **Stacked on #834** (bookmarks pagination) — its commit shows here until #834 merges. Merge #834 first.

Extension typecheck+build, ruff, and x_saves tests (6) all pass.