### PR TITLE
Hide /computer unless a cloud computer actually exists

### DIFF
--- a/backend/routers/machine.py
+++ b/backend/routers/machine.py
@@ -33,11 +33,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/me/machine", tags=["machine"])
 
 
+async def _existing_sprite(user_id) -> sprite_service.Sprite:
+    """The user's provisioned computer, or 404. Browsing must never provision
+    a VM — only agent turns and the terminal do."""
+    sprite = await sprite_service.existing(user_id)
+    if sprite is None:
+        raise HTTPException(status_code=404, detail="No cloud computer provisioned")
+    return sprite
+
+
 @router.get("/fs")
 async def list_machine_dir(path: str = "", current_user: dict = Depends(get_current_user)):
     """Directory listing on the user's computer, path relative to the agent's
     working folder."""
-    sprite = await sprite_service.acquire(current_user["id"])
+    sprite = await _existing_sprite(current_user["id"])
     try:
         entries = await sprite_service.fs_list(sprite, path)
     except sprite_service.FsPathError as e:
@@ -50,7 +59,7 @@ async def list_machine_dir(path: str = "", current_user: dict = Depends(get_curr
 @router.get("/fs/file")
 async def read_machine_file(path: str, current_user: dict = Depends(get_current_user)):
     """A file's content from the user's computer (capped; read-only)."""
-    sprite = await sprite_service.acquire(current_user["id"])
+    sprite = await _existing_sprite(current_user["id"])
     try:
         content = await sprite_service.fs_read(sprite, path)
     except sprite_service.FsPathError as e:
@@ -78,7 +87,7 @@ async def save_machine_file_to_stash(
     req: SaveToStashRequest, current_user: dict = Depends(get_current_user)
 ):
     """Copy-on-share: the only way bytes leave the machine for the DB."""
-    sprite = await sprite_service.acquire(current_user["id"])
+    sprite = await _existing_sprite(current_user["id"])
     try:
         content = await sprite_service.fs_read(sprite, req.path)
     except sprite_service.FsPathError as e:

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -21,6 +21,7 @@ from ..services import (
     permission_service,
     session_title_service,
     skill_service,
+    sprite_service,
     user_scope_service,
     workspace_service,
 )
@@ -318,12 +319,20 @@ async def get_scope_overview(
     owner_user_id = scope_user_id
     await _check_overview_access(owner_user_id, current_user["id"])
 
-    sessions, files, skills = await asyncio.gather(
+    sessions, files, skills, sprite = await asyncio.gather(
         _list_sessions(owner_user_id, current_user["id"]),
         _files_tree(owner_user_id, current_user["id"]),
         _list_sidebar_skills(owner_user_id, current_user["id"]),
+        sprite_service.existing(owner_user_id),
     )
-    return {"sessions": sessions, "files": files, "skills": skills}
+    # The VFS mounts /computer only when a machine exists — checking must not
+    # provision one, so this is a row lookup, never a sprites API call.
+    return {
+        "sessions": sessions,
+        "files": files,
+        "skills": skills,
+        "machine": {"provisioned": sprite is not None},
+    }
 
 
 @router.get("/sidebar")

--- a/backend/services/sprite_service.py
+++ b/backend/services/sprite_service.py
@@ -83,6 +83,20 @@ def _sprite_name(user_id: UUID) -> str:
 # ---------------------------------------------------------------------------
 
 
+async def existing(user_id: UUID) -> Sprite | None:
+    """The user's sprite if one has been provisioned, else None — never
+    provisions. Read-only surfaces (fs browsing, the VFS /computer mount) use
+    this so that *looking* for a computer can't conjure one; only real usage
+    (agent turns, the terminal) goes through acquire."""
+    if settings.AGENT_EXEC_MODE == "local":
+        return Sprite(name="local") if _local_workdir().exists() else None
+
+    row = await get_pool().fetchrow(
+        "SELECT sprite_name FROM user_sprites WHERE user_id = $1 AND status = 'ready'", user_id
+    )
+    return Sprite(name=row["sprite_name"]) if row else None
+
+
 async def acquire(user_id: UUID) -> Sprite:
     """The user's sprite, provisioning it on first use.
 

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -168,3 +168,36 @@ async def test_document_read_budget_aborts_the_command(client: AsyncClient, monk
     resp = await _vfs(client, api_key, "grep -ri 'alpha' /files")
 
     assert resp.status_code == 413
+
+
+async def test_machine_fs_404s_without_provisioned_computer(client: AsyncClient, monkeypatch):
+    """Browsing must never conjure a VM: a user who never ran a cloud agent
+    gets a 404 from the machine fs, not a freshly provisioned sprite."""
+    from backend.config import settings
+
+    monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
+    api_key, _ = await _register(client)
+
+    resp = await client.get("/api/v1/me/machine/fs", headers=_auth(api_key))
+
+    assert resp.status_code == 404
+
+
+async def test_overview_reports_machine_provisioned_state(client: AsyncClient, monkeypatch, pool):
+    """The CLI VFS decides whether to mount /computer from this flag alone, so
+    it must flip exactly when a ready sprite row exists — no machine API call."""
+    from backend.config import settings
+
+    monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
+    api_key, owner_id = await _register(client)
+
+    before = await client.get("/api/v1/me/overview", headers=_auth(api_key))
+    assert before.json()["machine"] == {"provisioned": False}
+
+    await pool.execute(
+        "INSERT INTO user_sprites (user_id, sprite_name, status) VALUES ($1, $2, 'ready')",
+        owner_id,
+        "sprite-test",
+    )
+    after = await client.get("/api/v1/me/overview", headers=_auth(api_key))
+    assert after.json()["machine"] == {"provisioned": True}

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -67,6 +67,7 @@ class FakeClient:
                     "updated_at": "2026-05-03T08:15:00Z",
                 }
             ],
+            "machine": {"provisioned": True},
         }
 
     def get_page(self, page_id):
@@ -182,6 +183,22 @@ def test_vfs_exposes_user_sections():
     assert "Welcome email" in model.list_dir(gmail)
     assert model.read_file(f"{gmail}/Welcome email") == b"BODY of msg-1"
     assert model.read_file(f"{gmail}/threads/Nested note") == b"BODY of threads/msg-2"
+
+
+class UnprovisionedMachineClient(FakeClient):
+    def get_overview(self):
+        return {**super().get_overview(), "machine": {"provisioned": False}}
+
+
+def test_vfs_hides_computer_without_a_provisioned_machine():
+    """A user who never ran a cloud agent has no machine — /computer must not
+    appear, and deciding that must not touch the machine API (the overview
+    flag alone drives it)."""
+    model = StashVfsModel(UnprovisionedMachineClient(), include_computer=True)
+    model.refresh()
+
+    assert "computer" not in model.list_dir("/")
+    assert b"computer" not in model.read_file("/README.md")
 
 
 def test_vfs_loads_source_entries_lazily():

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { nanoid } from "nanoid";
 import { Bot, ChevronRight, File, Folder, Loader2, MessagesSquare, GraduationCap, Monitor, Plus, Settings, FolderTree, Brain, Plug, Sparkles, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
-import { listMySessions, listSessionFolders, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
+import { ApiError, listMySessions, listSessionFolders, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
 import { useMemoryFolderId } from "@/lib/memory-folder";
 import { SKILL_MD, skillMdTemplate } from "@/lib/localSkill";
 import { requestAgentConfigView, requestCuratorRun } from "@/lib/agent-tab-view";
@@ -91,6 +91,7 @@ function ComputerSection() {
   const [path, setPath] = useState("");
   const [entries, setEntries] = useState<MachineEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [noMachine, setNoMachine] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -98,9 +99,22 @@ function ComputerSection() {
     setError(null);
     machineFsList(path)
       .then((rows) => { if (!cancelled) setEntries(rows); })
-      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); });
+      .catch((e) => {
+        if (cancelled) return;
+        // 404 = no computer provisioned yet; browsing never creates one.
+        if (e instanceof ApiError && e.status === 404) setNoMachine(true);
+        else setError(e instanceof Error ? e.message : String(e));
+      });
     return () => { cancelled = true; };
   }, [path]);
+
+  if (noMachine) {
+    return (
+      <div className="px-3 py-2 text-[12px] text-muted-foreground">
+        No cloud computer yet — it&apos;s created the first time a cloud agent runs.
+      </div>
+    );
+  }
 
   const crumbs = path ? path.split("/") : [];
   return (

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -91,7 +91,7 @@ class StashVfsModel:
                 "- `computer` is a live, read-only view of the agent's "
                 "working folder on your cloud computer (browsing may wake it).",
             ]
-            if self.include_computer
+            if "/computer" in self.nodes
             else []
         )
         self._add_static_file(
@@ -216,7 +216,10 @@ class StashVfsModel:
         self._add_sessions(overview.get("sessions", []))
         self._add_tables()
         self._add_sources()
-        if self.include_computer:
+        # /computer appears only for users whose cloud computer actually
+        # exists — the overview flag is a DB lookup, so deciding this never
+        # provisions or wakes a machine.
+        if self.include_computer and overview["machine"]["provisioned"]:
             self._add_computer()
 
     def _add_computer(self) -> None:


### PR DESCRIPTION
## Problem

Two compounding issues made `/computer` feel like bloat:

1. **Browsing provisioned VMs.** The machine fs endpoints called `sprite_service.acquire()`, which creates a sprite on first use — so merely listing `/computer` in the VFS (or clicking the Computer rail) conjured a cloud computer for users who never ran a cloud agent.
2. **Everyone saw `/computer`.** The CLI mounted it unconditionally, so every user carried a mount that, for most of them, contained at most the seeded workspace `CLAUDE.md`.

## Fix

- **`sprite_service.existing()`** — returns the sprite only if a ready row exists; never provisions. All read surfaces (fs list/read, save-to-stash) use it and 404 when there is no machine. Only real usage — agent turns and the terminal — still goes through `acquire()`.
- **Overview carries `machine: {provisioned}`** — a `user_sprites` row lookup, never a sprites API call, so deciding visibility can't wake (or create) a machine.
- **The CLI VFS mounts `/computer` only when provisioned**, and the VFS README mentions it only when mounted.
- **Computer rail** shows "No cloud computer yet — it's created the first time a cloud agent runs." on the 404 instead of the misleading "Waking your VM…" spinner.

No screenshot of the rail empty state: reproducing it locally requires an unprovisioned machine, and the local sprite sim dir (`~/.stash-dev-sprite`) is shared with dev servers running in sibling worktrees on this machine right now. The change is the one muted text line quoted above.

Note: users who already have a browse-provisioned sprite (from the old behavior) still see `/computer` — the flag is "machine exists", not "machine was ever used". Cleaning up never-used sprites is a separate decision.

## Testing

- `test_machine_fs_404s_without_provisioned_computer` — browsing can't conjure a VM
- `test_overview_reports_machine_provisioned_state` — flag flips exactly on a ready sprite row
- `test_vfs_hides_computer_without_a_provisioned_machine` — no `/computer` node, no README mention
- Full `test_vfs.py` + `test_sprite_agent_mapping.py` + `cli/tests/`: 151 passed; frontend vitest 209 passed; ruff + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)