### PR TITLE
Regenerate legacy garbage session titles

### DIFF
--- a/backend/migrations/versions/0154_regen_legacy_session_titles.py
+++ b/backend/migrations/versions/0154_regen_legacy_session_titles.py
@@ -1,0 +1,40 @@
+"""Drop legacy garbage session titles so the current pipeline regenerates them.
+
+The 2026-05-21 bulk title backfill stored titles that are markdown-wrapped,
+truncated mid-sentence at the 80-char cap, or just an assistant reply echoed
+back ("You're right—I apologize for the confusion"). Their source_hash still
+matches, so the staleness check never refreshes them. Deleting the rows makes
+them "missing": the reconcile_missing beat task and lazy enqueue on listing
+regenerate them with the current prompt + cleaning.
+
+A false positive is harmless — the row just regenerates through the same
+good pipeline. user_set titles are never touched.
+
+Revision ID: 0154
+Revises: 0153
+Create Date: 2026-07-16
+"""
+
+from alembic import op
+
+revision = "0154"
+down_revision = "0153"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DELETE FROM session_titles
+        WHERE user_set = FALSE
+          AND (
+            title LIKE '**%'
+            OR title LIKE '#%'
+            OR length(title) >= 78
+            OR title ~ $re$^(You're |You are |I'll |I've |I ap|I don't |I need |I appreciate |Yes[,— .]|Your |Good |Great |Perfect|Looking |pong$)$re$
+          )
+        """)
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Why

Session lists are full of titles like **"You're right—I apologize for the confusion"**, `**Bold Title**`, `# Header Title`, 80-char truncated prose, and Haiku refusals stored verbatim ("I need more context to generate a title").

These all come from the 2026-05-21 bulk title backfill (right after #372 shipped). The rows are cached in `session_titles` with a `source_hash` derived from event count + last event time — old sessions never change, so the staleness check considers the garbage "fresh" forever.

Verified against prod (read-only): **1,423 bad rows across 21 users**, clustered at 2026-05-21 00:00–01:00 UTC.

## What

One-shot migration that deletes non-`user_set` `session_titles` rows matching the legacy garbage patterns:
- starts with `**` or `#` (markdown never stripped)
- length ≥ 78 (truncated-at-80 prose blobs)
- assistant-reply/refusal openers (`You're `, `I'll `, `I need `, `Yes—`, `pong`, …)

Deleted rows count as "missing", so the `reconcile_missing` beat task (60s cadence, 25/run) plus the lazy enqueue on listing regenerate them through the current pipeline — all ~1,400 within the hour after deploy. User-renamed titles are untouched. A false positive (e.g. "Looking Up Active User Definition", the one legit match found) just regenerates through the same good pipeline — harmless.

The exact `WHERE` clause was validated against prod read-only: matches exactly the 1,423 bad rows, samples eyeballed for false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)