### PR TITLE
Label knowledge-map event points with their content, not the event-type enum

### DIFF
--- a/backend/services/analytics_service.py
+++ b/backend/services/analytics_service.py
@@ -921,7 +921,7 @@ async def get_embedding_projection(
         rows = await pool.fetch(
             _accessible_events_cte(scope_idx=event_fetch_scope_idx)
             + """
-            SELECT me.id, me.agent_name, me.event_type, me.embedding, me.created_at
+            SELECT me.id, me.content, me.embedding, me.created_at
             FROM history_events me
             JOIN accessible_events a ON a.event_id = me.id
             WHERE me.embedding IS NOT NULL
@@ -931,10 +931,13 @@ async def get_embedding_projection(
             *event_fetch_args,
         )
         for r in rows:
+            # Label with the content the embedding was computed from, not the
+            # event-type enum — every tool call labeled "user: tool_use" made
+            # the map unreadable.
             all_items.append(
                 {
                     "id": str(r["id"]),
-                    "label": f"{r['agent_name'] or 'agent'}: {r['event_type'] or 'event'}",
+                    "label": " ".join(r["content"].split())[:80],
                     "source": "history_events",
                     "created_at": r["created_at"].isoformat() if r["created_at"] else None,
                     "embedding": np.array(r["embedding"]),


### PR DESCRIPTION
## Problem

Every session-event point in the Knowledge Map (embedding space explorer) was labeled `agent_name: event_type` — so with a stash full of tool calls, nearly every cluster label rendered as `user: tool_use`. The dot's *position* comes from an embedding of the event's `content`, but the label threw that content away and showed the type enum instead.

## Fix

In `get_embedding_projection`, the `history_events` query now selects `content`, and each point is labeled with the content itself — whitespace-collapsed and truncated to 80 chars. The explorer already truncates cluster labels to 24 chars and shows the full label in the hover tooltip, so the snippet serves both.

## Screenshots

- Before — every cluster labeled `user: tool_use`: https://app.joinstash.ai/f/014abcbd-c368-47d5-88b6-68096f3b86b6
- After (local stack, real data) — clusters labeled by their content, e.g. "Chelsea PTO", "Truck Parts Cr…": https://app.joinstash.ai/f/e1dd85fb-2d15-425a-94b9-32bcb8bb8314

## Notes

- Cached rows in `embedding_projections` still hold old labels, but the cache is only trusted for one hour, so the map self-corrects shortly after deploy — no migration needed.
- Verified end-to-end on the local stack: the projection API returns content snippets for `history_events` points and the map renders them.
- Full backend suite passes (837 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)