### PR TITLE
Support tree -d (directories only) in the VFS shell

### DIFF
--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -105,6 +105,18 @@ def test_app_vfs_supports_common_agent_listing_patterns():
     assert client.lazy_loads == 0
 
 
+def test_tree_dirs_only_hides_files():
+    shell, _client = _shell()
+
+    page_path = _page_path(shell)
+    folder_path, page_name = page_path.rsplit("/", 1)
+
+    output = shell.run("tree /files -d").stdout
+
+    assert folder_path.rsplit("/", 1)[1] in output
+    assert page_name not in output
+
+
 def test_app_vfs_surfaces_backend_timestamps_and_marks_unknown():
     """A node's modified time comes from the backend payload and flows through
     to `ls -l` and `stat`. A node the backend gave no timestamp for shows `-`,

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -298,6 +298,7 @@ class SkillAppVfsShell:
 
     def _tree(self, args: list[str]) -> str:
         max_depth: int | None = None
+        dirs_only = False
         path = "."
         index = 0
         while index < len(args):
@@ -310,6 +311,8 @@ class SkillAppVfsShell:
                     max_depth = int(args[index])
                 except ValueError as e:
                     raise VfsShellError("-L value must be an integer", exit_code=2) from e
+            elif arg == "-d":
+                dirs_only = True
             elif arg.startswith("-"):
                 if arg != "-a":
                     raise VfsShellError(f"unsupported tree option: {arg}", exit_code=2)
@@ -320,7 +323,9 @@ class SkillAppVfsShell:
         root = self._resolve_path(path)
         self.model._get_node(root)
         lines = [root]
-        lines.extend(self._tree_lines(root, prefix="", depth=1, max_depth=max_depth))
+        lines.extend(
+            self._tree_lines(root, prefix="", depth=1, max_depth=max_depth, dirs_only=dirs_only)
+        )
         for source_root, shown in self.model.truncated_roots_under(root):
             self._warn(
                 f"tree: '{source_root}' has more than {shown} entries; only the first "
@@ -335,6 +340,7 @@ class SkillAppVfsShell:
         prefix: str,
         depth: int,
         max_depth: int | None,
+        dirs_only: bool = False,
     ) -> list[str]:
         if max_depth is not None and depth > max_depth:
             return []
@@ -343,6 +349,10 @@ class SkillAppVfsShell:
             return []
 
         names = self.model.list_dir(path)
+        if dirs_only:
+            names = [
+                name for name in names if self.model._get_node(posixpath.join(path, name)).is_dir
+            ]
         rows = []
         for index, name in enumerate(names):
             child_path = posixpath.join(path, name)
@@ -356,6 +366,7 @@ class SkillAppVfsShell:
                     prefix=child_prefix,
                     depth=depth + 1,
                     max_depth=max_depth,
+                    dirs_only=dirs_only,
                 )
             )
         return rows


### PR DESCRIPTION
just adding a useful -d option to make our vfs more like a real fs

## Summary
- `stash vfs "tree -L 2 -d"` previously failed with `tree: unsupported tree option: -d`. The VFS shell's `tree` now accepts `-d` and lists only directories, matching real `tree -d`. Composes with `-L` and `-a`, flag order doesn't matter.

## Testing
- New test `test_tree_dirs_only_hides_files` asserts folders show and pages (files) are hidden.
- `pytest cli/tests/test_app_vfs.py`: 37 passed. `ruff check` + `ruff format --check` clean.
- Verified live: `stash vfs "tree /files -L 2 -d"` against a real account renders the directory-only tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)