### PR TITLE
X: faster hydration, clearer loading state, single-source page

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -30,7 +30,7 @@ X_BOOKMARKS_URL = "https://api.x.com/2/users/{user_id}/bookmarks"
 TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
 MAX_MEDIA_PER_TWEET = 4
-HYDRATION_BATCH = 25
+HYDRATION_BATCH = 200
 MAX_HYDRATION_ATTEMPTS = 3
 # Pages of the user's own timeline pulled per sync (20 tweets/page). Bounded so
 # one sync doesn't run away; older tweets keep arriving over subsequent syncs.

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -27,6 +27,14 @@ const DEFAULT_API_BASE = 'https://api.joinstash.ai';
 initClipper();
 initChatPoll(syncConversation);
 initInstagram();
+
+// The X bookmark harvest was removed (X syncs server-side over OAuth now); clear
+// any stale harvest error it left behind so the popup doesn't keep showing it.
+void chrome.storage.local.get('lastError').then(({ lastError }) => {
+  if (typeof lastError === 'string' && lastError.includes('X bookmarks')) {
+    void chrome.storage.local.set({ lastError: null });
+  }
+});
 // Auth sessions live 15 min server-side. The poll loop covers most of that,
 // and checkPendingConnect() collects an approval that lands after the loop
 // gave up (e.g. MV3 suspended the worker mid-wait).

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -106,6 +106,14 @@ export function IntegrationDetail({ provider }: { provider: string }) {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
+  useEffect(() => {
+    // X auto-creates one source; open it straight into browse so the page
+    // reads as "connected + your saves", not a source picker.
+    if (connector?.singleSource && sources.length === 1 && !openSourceId) {
+      setOpenSourceId(sources[0].source);
+    }
+  }, [connector, sources, openSourceId]);
+
   if (loading) return null;
   if (!user) return null;
 
@@ -129,6 +137,7 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   // Extension-fed connectors (X, Instagram) have no OAuth integration — they're
   // "connected" once the browser extension has pushed at least one source.
   const isExtension = connector.kind === "extension";
+  const singleSource = !!connector.singleSource;
   const connected = isExtension ? sources.length > 0 : !!status?.connected;
   const account = connectedAccountLabel(status);
   const canConnectAnother = connected && connector.provider === "gmail" && status?.auth_kind !== "api_key";
@@ -321,9 +330,9 @@ export function IntegrationDetail({ provider }: { provider: string }) {
         {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
 
         {/* Add a <thing> (for GitHub: the all-vs-select repository access chooser).
-            Extension-fed connectors have nothing to add by hand — the extension
-            pushes their sources. */}
-        {connected && !isExtension && (
+            Extension-fed and single-source connectors (X) have nothing to add by
+            hand — their one source is created on connect. */}
+        {connected && !isExtension && !singleSource && (
           <section className="mt-6">
             <SectionLabel>
               {connector.kind === "github" ? "Repository access" : `Add a ${itemNoun}`}
@@ -338,9 +347,12 @@ export function IntegrationDetail({ provider }: { provider: string }) {
           </section>
         )}
 
-        {/* <Things> */}
+        {/* <Things>. Single-source connectors (X) skip the "Sources" heading —
+            there's just the one, shown as the connection's sync status. */}
         <section className="mt-7">
-          <SectionLabel>{itemNoun === "source" ? "Sources" : `${capitalize(itemNoun)}s`}</SectionLabel>
+          {!singleSource && (
+            <SectionLabel>{itemNoun === "source" ? "Sources" : `${capitalize(itemNoun)}s`}</SectionLabel>
+          )}
           {sources.length === 0 ? (
             <div className="py-3 text-[12.5px] text-muted-foreground">
               {isExtension
@@ -902,7 +914,10 @@ function HitRow({
   snippet?: string;
   onOpen: () => void;
 }) {
-  const showKey = !!label && label !== hitKey && !label.startsWith(hitKey);
+  // An X save that hasn't hydrated yet has no title — its name is still the raw
+  // numeric tweet id. Show "Loading…" instead of a wall of numbers.
+  const pending = !!label && /^\d+$/.test(label);
+  const showKey = !pending && !!label && label !== hitKey && !label.startsWith(hitKey);
   return (
     <button
       type="button"
@@ -911,7 +926,11 @@ function HitRow({
     >
       <div className="flex items-baseline gap-2.5">
         {showKey && <span className="font-mono text-[12px] text-muted-foreground">{hitKey}</span>}
-        <span className="min-w-0 truncate text-[13px] text-foreground">{label || hitKey}</span>
+        {pending ? (
+          <span className="min-w-0 truncate text-[13px] italic text-muted-foreground">Loading…</span>
+        ) : (
+          <span className="min-w-0 truncate text-[13px] text-foreground">{label || hitKey}</span>
+        )}
       </div>
       {snippet && <div className="mt-0.5 truncate text-[11.5px] text-muted-foreground">{snippet}</div>}
     </button>

--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -33,6 +33,9 @@ export type Connector = {
   sourceType: string;
   kind: ConnectorKind;
   blurb: string;
+  // Connecting auto-creates exactly one source (X) — there's nothing to "add",
+  // so the page hides the add-source UI and browses that source directly.
+  singleSource?: boolean;
 };
 
 export const CONNECTORS: Connector[] = [
@@ -118,6 +121,7 @@ export const CONNECTORS: Connector[] = [
     label: "X",
     sourceType: "x_saves",
     kind: "auto",
+    singleSource: true,
     blurb: "Connect X to sync your bookmarks, posts, and replies.",
   },
   {


### PR DESCRIPTION
Follow-ups from testing the X OAuth integration:

- **Faster hydration** — 200 tweets/sync (was 25), so a freshly-connected account fills in in a sync or two instead of trickling over hours.
- **Clearer loading state** — un-hydrated saves showed the raw numeric tweet id ("just numbers"); now render **"Loading…"** until hydrated (a display fix, so it applies to existing rows too).
- **Single-source page** — X auto-creates one source on connect, so the page drops the "Add a source" control + "Sources" heading and opens that source's browse directly: reads as "connected + your saves", not a source picker.
- **Extension** — clear the stale "X bookmarks harvest timed out" error left by the now-removed X harvest.

Backend ruff + x_saves tests, frontend typecheck + connector vitest, extension typecheck/build all pass.