### PR TITLE
X saves: tweet-text previews + inline expansion in the browse list

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -224,22 +224,18 @@ async def _hydrate_one(
 
 
 def _render(tweet: dict, root: dict | None) -> str:
-    parts: list[str] = []
-    if root is not None:
-        parts.append(f"# In reply to @{root['author']}")
-        parts.append(_quote(root["text"]))
-        parts.append("\n---\n")
-    parts.append(f"# @{tweet['author']}")
+    # Tweet text first so the listing's preview (first paragraph of content) is
+    # the tweet itself, not metadata. Everything after the blank line is the
+    # byline, reply context, and link.
+    parts: list[str] = [tweet["text"] or "", ""]
+    byline = f"— @{tweet['author']}"
     if tweet["created_at"]:
-        parts.append(f"Posted: {tweet['created_at'].isoformat()}")
-    parts.append(f"URL: {tweet_url(tweet['id'])}")
-    parts.append("")
-    parts.append(_quote(tweet["text"]))
+        byline += f" · {tweet['created_at'].date().isoformat()}"
+    parts.append(byline)
+    if root is not None:
+        parts.append(f"In reply to @{root['author']}: {root['text']}")
+    parts.append(tweet_url(tweet["id"]))
     return "\n".join(parts)
-
-
-def _quote(text: str) -> str:
-    return "\n".join(f"> {line}" for line in (text or "").splitlines())
 
 
 async def _fetch_tweet(client: httpx.AsyncClient, tweet_id: str) -> dict:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -836,10 +836,21 @@ async def list_documents(
         )
         return [_entry_row(r) for r in rows]
 
-    size_column = "length(coalesce(content, ''))" if table in CONTENT_TABLES else "NULL::bigint"
+    is_content = table in CONTENT_TABLES
+    size_column = "length(coalesce(content, ''))" if is_content else "NULL::bigint"
+    # First paragraph of the copied content, whitespace-collapsed — a one-line
+    # preview for the browse list (e.g. the tweet text for an X save).
+    # E'\n\n' is a real double-newline; '\s+' must be a *standard* string literal
+    # so the backslash reaches the regex engine (in an E-string \s isn't an
+    # escape and silently collapses to 's').
+    snippet_column = (
+        "left(regexp_replace(split_part(coalesce(content, ''), E'\\n\\n', 1), '\\s+', ' ', 'g'), 200)"
+        if is_content
+        else "NULL::text"
+    )
     rows = await get_pool().fetch(
         f"SELECT path, name, kind, external_ref, external_updated_at, "
-        f"{size_column} AS size FROM {table} "
+        f"{size_column} AS size, {snippet_column} AS snippet FROM {table} "
         f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
         f"ORDER BY path LIMIT $3",
         UUID(source["id"]),
@@ -859,6 +870,7 @@ def _entry_row(r) -> dict:
         "external_ref": r["external_ref"],
         "external_updated_at": (external_updated_at.isoformat() if external_updated_at else None),
         "size": r["size"],
+        "snippet": r["snippet"] if "snippet" in r.keys() else None,
     }
 
 

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -193,6 +193,11 @@ async def test_hydrates_content_thread_root_and_media(client, pool, fake_sync) -
         {"url": "https://blob.example/store/x-1001-0.jpg", "content_type": "image/jpeg"}
     ]
 
+    # The browse list previews the tweet text (not the raw id).
+    entries = await source_service.source_entries(UUID(owner_id), UUID(owner_id), str(source["id"]))
+    entry = next(e for e in entries if e["path"] == "1001")
+    assert entry["snippet"] == "totally agree with this"
+
 
 @pytest.mark.asyncio
 async def test_hydration_failure_lands_on_the_row(client, pool, fake_sync, monkeypatch) -> None:

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -847,15 +847,29 @@ function SearchablePanel({
             {realHits.length === 0 ? (
               <div className="px-1.5 py-1 text-[12.5px] text-muted-foreground">No matches.</div>
             ) : (
-              realHits.map((hit) => (
-                <HitRow
-                  key={hit.ref}
-                  hitKey={hit.ref!}
-                  label={hit.name}
-                  snippet={hit.snippet}
-                  onOpen={() => setOpenDoc({ ref: hit.ref!, name: hit.name })}
-                />
-              ))
+              realHits.map((hit) => {
+                const isOpen = openDoc?.ref === hit.ref;
+                return (
+                  <div key={hit.ref}>
+                    <HitRow
+                      hitKey={hit.ref!}
+                      label={hit.name}
+                      snippet={hit.snippet}
+                      open={isOpen}
+                      onOpen={() => setOpenDoc(isOpen ? null : { ref: hit.ref!, name: hit.name })}
+                    />
+                    {isOpen && (
+                      <DocViewer
+                        source={source.source}
+                        providerLabel={providerLabel}
+                        refValue={hit.ref!}
+                        name={hit.name}
+                        onClose={() => setOpenDoc(null)}
+                      />
+                    )}
+                  </div>
+                );
+              })
             )}
             {truncation && (
               <div className="px-1.5 py-1 text-[12px] text-muted-foreground">
@@ -872,26 +886,29 @@ function SearchablePanel({
         <div className="mb-2">
           {recent.map((entry) => {
             const ref = entry.id ?? entry.path ?? entry.name;
+            const isOpen = openDoc?.ref === ref;
             return (
-              <HitRow
-                key={ref}
-                hitKey={ref}
-                label={entry.name}
-                onOpen={() => setOpenDoc({ ref, name: entry.name })}
-              />
+              <div key={ref}>
+                <HitRow
+                  hitKey={ref}
+                  label={entry.name}
+                  snippet={entry.snippet ?? undefined}
+                  open={isOpen}
+                  onOpen={() => setOpenDoc(isOpen ? null : { ref, name: entry.name })}
+                />
+                {isOpen && (
+                  <DocViewer
+                    source={source.source}
+                    providerLabel={providerLabel}
+                    refValue={ref}
+                    name={entry.name}
+                    onClose={() => setOpenDoc(null)}
+                  />
+                )}
+              </div>
             );
           })}
         </div>
-      )}
-
-      {openDoc && (
-        <DocViewer
-          source={source.source}
-          providerLabel={providerLabel}
-          refValue={openDoc.ref}
-          name={openDoc.name}
-          onClose={() => setOpenDoc(null)}
-        />
       )}
 
       {showHistory && (
@@ -907,11 +924,13 @@ function HitRow({
   hitKey,
   label,
   snippet,
+  open,
   onOpen,
 }: {
   hitKey: string;
   label?: string;
   snippet?: string;
+  open?: boolean;
   onOpen: () => void;
 }) {
   // An X save that hasn't hydrated yet has no title — its name is still the raw
@@ -922,7 +941,10 @@ function HitRow({
     <button
       type="button"
       onClick={onOpen}
-      className="block w-full cursor-pointer rounded-md px-1.5 py-1.5 text-left hover:bg-raised"
+      className={
+        "block w-full cursor-pointer rounded-md px-1.5 py-1.5 text-left hover:bg-raised " +
+        (open ? "bg-raised" : "")
+      }
     >
       <div className="flex items-baseline gap-2.5">
         {showKey && <span className="font-mono text-[12px] text-muted-foreground">{hitKey}</span>}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -321,6 +321,8 @@ export interface SourceEntry {
   name: string;
   kind: string;
   external_ref?: string | null;
+  // One-line preview of the copied content (e.g. the tweet text).
+  snippet?: string | null;
 }
 
 const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);


### PR DESCRIPTION
Two browse-list fixes from testing X:

- **Preview** — rows showed only the title (or "Loading…"); now each carries a one-line **preview of the tweet text**. `list_documents` returns a `snippet` (first paragraph of content, whitespace-collapsed) for content-table sources, and the X render puts the tweet text first so that paragraph *is* the tweet. (Postgres gotcha fixed: the whitespace regex must be a standard `'\\s+'` literal — `E'\\s+'` silently collapses `\\s` to `s` and ate the trailing letter.)
- **Inline expand** — clicking a row opened the reader at the bottom of the whole list; it now expands **accordion-style right under the clicked row**.

Backend x_saves + sources/vfs tests (112) green, frontend typecheck + 209 vitest green.