### PR TITLE
Recover sources stuck in 'syncing'; shrink X hydration batch

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -30,7 +30,10 @@ X_BOOKMARKS_URL = "https://api.x.com/2/users/{user_id}/bookmarks"
 TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
 MAX_MEDIA_PER_TWEET = 4
-HYDRATION_BATCH = 200
+# Hydration is per-tweet (each commits on its own), and a sync can be killed
+# mid-run by a worker redeploy — so keep the batch small enough that a sync
+# usually finishes before that happens; the reconciler re-runs for the rest.
+HYDRATION_BATCH = 50
 MAX_HYDRATION_ATTEMPTS = 3
 # Pages of the user's own timeline pulled per sync (20 tweets/page). Bounded so
 # one sync doesn't run away; older tweets keep arriving over subsequent syncs.

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -431,11 +431,17 @@ async def get_source_for_sync(source_id: UUID) -> dict | None:
 
 
 async def due_sources(limit: int = 50) -> list[dict]:
-    """Pull sources whose scheduled sync is due (for the Beat reconciler)."""
+    """Pull sources whose scheduled sync is due (for the Beat reconciler). Also
+    reclaims sources stuck in 'syncing' for over 10 minutes: a sync killed
+    mid-run (e.g. a worker redeploy) never reaches mark_sync_done, so without
+    this the source would sit 'syncing' forever and never re-sync."""
     rows = await get_pool().fetch(
         "SELECT id, owner_user_id, source_type, external_ref, sync_cursor, settings "
         "FROM user_sources "
-        "WHERE sync_enabled AND next_sync_at <= now() "
+        "WHERE sync_enabled AND ("
+        "  next_sync_at <= now() "
+        "  OR (sync_status = 'syncing' AND updated_at < now() - interval '10 minutes')"
+        ") "
         "ORDER BY next_sync_at LIMIT $1",
         limit,
     )

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -285,6 +285,37 @@ async def test_source_sync_resolves_via_owner(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_due_sources_reclaims_stuck_syncing(client: AsyncClient, _db_pool):
+    """A sync killed mid-run leaves the source 'syncing'; due_sources reclaims it
+    once it's been stuck past the threshold, but leaves a fresh one alone."""
+    _, owner_id = await _register(client, "src_stuck")
+    source = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="slack",
+        external_ref="TSTUCK",
+        display_name="Stuck",
+        settings={"allowed_channel_ids": ["CSTUCK"]},
+    )
+    sid = UUID(source["id"])
+
+    # Currently syncing and not due by schedule, freshly started -> left alone.
+    await _db_pool.execute(
+        "UPDATE user_sources SET sync_status = 'syncing', "
+        "next_sync_at = now() + interval '1 hour', updated_at = now() WHERE id = $1",
+        sid,
+    )
+    due = {UUID(s["id"]) for s in await source_service.due_sources(limit=50)}
+    assert sid not in due
+
+    # Stuck syncing past the threshold -> reclaimed even though not schedule-due.
+    await _db_pool.execute(
+        "UPDATE user_sources SET updated_at = now() - interval '15 minutes' WHERE id = $1", sid
+    )
+    due = {UUID(s["id"]) for s in await source_service.due_sources(limit=50)}
+    assert sid in due
+
+
+@pytest.mark.asyncio
 async def test_unknown_source_type_rejected(client: AsyncClient):
     api_key, _ = await _register(client)
     resp = await client.post(


### PR DESCRIPTION
**Root cause of "still loading for most tweets."** A sync killed mid-run (a worker redeploy — every merge triggers a release-bump redeploy) never reaches `mark_sync_done`, so the source sat `syncing` forever and the reconciler never re-dispatched it. X hydration froze at 82/600 (per-tweet commits meant the 82 survived, but the source couldn't recover). Verified on prod: source pinned `syncing` since 05:31, worker idle.

- `due_sources` now also reclaims sources stuck `syncing` for **>10 min**, so a killed sync self-heals on the next reconcile (a fresh sync is left alone).
- X hydration batch **200 → 50**: hydration commits per-tweet, so a smaller batch usually finishes before a redeploy interrupts it; the reconciler handles the rest. Reaches a consistent state faster than one long batch that keeps dying.

Once deployed, the stuck source reclaims itself and drains the remaining ~518 pending over the next reconcile cycles (or immediately on Sync). Backend x_saves + due-sources-recovery tests pass.