### PR TITLE
stop trying to be fancy with port assignment for local dev w/ worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ By default `stash` is the released PyPI build (`uv tool` install, self-updating)
 - Lint: `cd www && npm run lint`
 
 ### Local stack
-- One-shot start (migrations + backend + frontend): `./start.sh`
+- One-shot start (db + redis + backend + celery + collab + frontend): `./start.sh`
+- App ports are fixed and exclusive per machine: backend 3456, frontend 3457, collab 3458. OAuth redirect URIs are registered against 3456, so there is no way to run the stack on other ports. If a port is taken, `start.sh` fails and prints the holding process: one local stack at a time — kill the holder only if it's yours or a zombie, otherwise wait. Tests, lint, and most dev work don't need the live stack.
 - Docker compose: `docker compose up`
 
 ### Deployment (hosted prod — joinstash.ai)

--- a/start.sh
+++ b/start.sh
@@ -13,10 +13,6 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
 PIDS=()
-# Keep local dev ports aligned with backend defaults and docker compose when free.
-DEFAULT_BACKEND_PORT=3456
-DEFAULT_FRONTEND_PORT=3457
-DEFAULT_COLLAB_PORT=3458
 DEV_DB_IMAGE="pgvector/pgvector:pg16"
 # Containers carry this label (set to the absolute worktree path) so databases
 # of deleted worktrees can be garbage-collected on every start.
@@ -170,9 +166,13 @@ ensure_node_deps() {
     done
 }
 
-BACKEND_PORT="${BACKEND_PORT:-$DEFAULT_BACKEND_PORT}"
-FRONTEND_PORT="${FRONTEND_PORT:-$DEFAULT_FRONTEND_PORT}"
-COLLAB_PORT="${COLLAB_PORT:-$DEFAULT_COLLAB_PORT}"
+# App ports are fixed, not configurable: OAuth redirect URIs registered with
+# providers (Google, Linear, GitHub, ...) point at the backend on 3456, so a
+# stack on any other port has silently broken integrations. One local stack
+# per machine; if a port is taken, we fail loud instead of shifting.
+BACKEND_PORT=3456
+FRONTEND_PORT=3457
+COLLAB_PORT=3458
 
 database_is_ready() {
     python - <<'PY' >/dev/null 2>&1
@@ -391,35 +391,29 @@ PY
 
 find_free_port() {
     local candidate="$1"
-    local avoid="${2:-}"
 
-    while [[ ",${avoid}," == *",${candidate},"* ]] || ! port_is_free "$candidate"; do
+    while ! port_is_free "$candidate"; do
         candidate=$((candidate + 1))
     done
 
     echo "$candidate"
 }
 
-choose_dev_ports() {
-    local requested_backend_port="$BACKEND_PORT"
-    local requested_frontend_port="$FRONTEND_PORT"
-    local requested_collab_port="$COLLAB_PORT"
+ensure_app_ports_free() {
+    local port
+    for port in "$BACKEND_PORT" "$FRONTEND_PORT" "$COLLAB_PORT"; do
+        if port_is_free "$port"; then
+            continue
+        fi
 
-    BACKEND_PORT="$(find_free_port "$requested_backend_port")"
-    FRONTEND_PORT="$(find_free_port "$requested_frontend_port" "$BACKEND_PORT")"
-    COLLAB_PORT="$(find_free_port "$requested_collab_port" "${BACKEND_PORT},${FRONTEND_PORT}")"
-
-    if [ "$BACKEND_PORT" != "$requested_backend_port" ]; then
-        echo "[ports]   Backend port ${requested_backend_port} is busy; using ${BACKEND_PORT}."
-    fi
-
-    if [ "$FRONTEND_PORT" != "$requested_frontend_port" ]; then
-        echo "[ports]   Frontend port ${requested_frontend_port} is busy; using ${FRONTEND_PORT}."
-    fi
-
-    if [ "$COLLAB_PORT" != "$requested_collab_port" ]; then
-        echo "[ports]   Collab port ${requested_collab_port} is busy; using ${COLLAB_PORT}."
-    fi
+        echo "[ports]   Port ${port} is already in use:"
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | sed 's/^/[ports]     /' || true
+        echo "[ports]   App ports are fixed (backend ${BACKEND_PORT}, frontend ${FRONTEND_PORT}, collab ${COLLAB_PORT}):"
+        echo "[ports]   OAuth redirect URIs are registered against them, so running elsewhere"
+        echo "[ports]   silently breaks integrations. One local stack at a time — stop the"
+        echo "[ports]   process above (kill <pid>) if it's yours or a zombie, or wait your turn."
+        exit 1
+    done
 }
 
 # Next.js allows one dev server per checkout: `next dev` holds an exclusive
@@ -512,6 +506,7 @@ echo "================================"
 
 # --- Preflight ---
 ensure_frontend_dev_server_not_running
+ensure_app_ports_free
 
 # --- Dependencies ---
 ensure_python_deps
@@ -522,9 +517,6 @@ ensure_local_database
 
 # --- Redis ---
 ensure_local_redis
-
-# --- Ports ---
-choose_dev_ports
 
 # --- Migrations ---
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
so previously we did this thing where we'd dynamically allocate ports for your servers in local development, just taking the next available ports. the intention was to enable several local worktrees running simultaneously. unfortunately, we forgot that OAuth asks you to hardcode in allowed redirect URIs. so then we run into a problem where all the additional servers besides the first one don't have functional oauth. I mean, we could just go into the oauth consoles for each integration and add a bunch of port numbers, but that seems like a slippery slope. This was supposed to make us work faster and it's slowing us down. So we're getting rid of it.

## Problem

`start.sh` treated the app ports as preferences: if 3456 was busy, it silently shifted the whole stack up (backend→3457, frontend→3458, ...). But OAuth redirect URIs are registered with providers against `localhost:3456`, so a shifted stack has silently broken integrations — Google/Linear redirect the callback to a port where the wrong thing (or nothing) is listening. This is exactly how Coleman's Gmail connect failed: his redirect_uri said 3456 while his backend ran on 3457, because a zombie process from an earlier crashed run was squatting on the default port.

## Change

Ports are now facts, not variables:

- **Hardcoded**: backend 3456, frontend 3457, collab 3458. The `BACKEND_PORT`/`FRONTEND_PORT`/`COLLAB_PORT` env overrides are deleted — a knob that can move the backend off 3456 is a knob that silently breaks OAuth.
- **Fail loud, never shift**: a preflight checks all three ports before any slow work and, if one is taken, prints the holding process via `lsof` and exits. The message distinguishes the two real cases at a glance: a zombie to `kill`, or another live stack — one stack at a time, wait your turn.
- **Per-worktree Postgres/Redis keep their dynamic ports.** Nothing external is registered against them, so worktree containers still coexist freely.
- `choose_dev_ports` and the port-bumping logic are deleted; `find_free_port` survives only for the DB/Redis container host ports.
- Policy documented in CLAUDE.md (Local stack).

## Verified

- Busy-port path: with a process on 3456, `./start.sh` exits 1 immediately with the holder's PID/command printed. (The preflight also caught a real 2-day-old zombie `stash-collab-1` compose container holding 3458 during testing.)
- Clean path: full stack boots on exactly 3456/3457/3458 — backend `/health` 200, celery worker ready, zero log errors — and shuts down cleanly in ~6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)