### PR TITLE
Drop flat-path X save orphans left by the folders rollout

### DIFF
--- a/backend/migrations/versions/0157_drop_flat_x_save_orphans.py
+++ b/backend/migrations/versions/0157_drop_flat_x_save_orphans.py
@@ -1,0 +1,28 @@
+"""Drop flat-path X save orphans left by the folders rollout.
+
+During the 0156 deploy, the pre-folders worker finished an in-flight sync on
+warm shutdown and inserted a batch of X posts with the old flat path (just the
+tweet id, no kind folder). The new worker then re-backfilled the same tweets
+under Posts/<id>, so every flat row is a content-less pending duplicate of a
+foldered twin — it only shows up as a stray "Loading…" row at the source root.
+Delete the flat rows; the foldered copies carry the real data.
+
+Revision ID: 0157
+Revises: 0156
+"""
+
+from alembic import op
+
+revision = "0157"
+down_revision = "0156"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM x_save_docs WHERE path NOT LIKE '%/%'")
+
+
+def downgrade() -> None:
+    # The deleted rows were content-less duplicates; there is nothing to restore.
+    pass


### PR DESCRIPTION
## What

After #846 deployed, the X source showed a flat list of stray **Loading…** rows at its root instead of the kind folders.

**Root cause:** a Render rolling-deploy warm-shutdown race. Migration 0156 correctly folded the existing ~600 rows into `Bookmarks/ Posts/ Replies/ Articles/`, but the *pre-folders* worker finished an in-flight sync on SIGTERM and inserted ~100 of the user's posts with the old **flat** path (bare tweet id). The new worker then re-backfilled those same tweets under `Posts/<id>`, so every flat row is a **content-less, pending duplicate** of a foldered twin — it just renders as a `Loading…` row hanging off the root.

Verified against prod before writing this: all 100 flat rows are `pending` with `NULL` content, and all 100 already have a `Posts/<id>` twin.

## Fix

Migration **0157** deletes the flat orphans (`DELETE FROM x_save_docs WHERE path NOT LIKE '%/%'`). Nothing is lost — the foldered copies carry the data. This can't recur: `main` no longer contains any flat-path insert code, so future deploys write foldered paths on both sides of a rollover.

## Testing

- `alembic upgrade head` applies cleanly; single head `0157`.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)