### PR TITLE
Agents can no longer list skills on Discover

### DIFF
--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -386,7 +386,6 @@ async def _create_skill(args: dict) -> dict:
         "type": "object",
         "properties": {
             "folder_id": {"type": "string"},
-            "discoverable": {"type": "boolean", "default": False},
         },
         "required": ["folder_id"],
     },
@@ -399,7 +398,6 @@ async def _publish_skill(args: dict) -> dict:
             owner_user_id,
             user_id,
             UUID(args["folder_id"]),
-            discoverable=bool(args.get("discoverable", False)),
         )
     except (ValueError, PermissionError) as e:
         return _text_result(json.dumps({"error": str(e)}))
@@ -410,14 +408,13 @@ async def _publish_skill(args: dict) -> dict:
 
 @tool(
     "update_skill",
-    "Update a published skill's share settings (title, description, access, Discover listing).",
+    "Update a published skill's title or description.",
     {
         "type": "object",
         "properties": {
             "skill_id": {"type": "string"},
             "title": {"type": "string"},
             "description": {"type": "string"},
-            "discoverable": {"type": "boolean"},
         },
         "required": ["skill_id"],
     },
@@ -428,7 +425,9 @@ async def _update_skill(args: dict) -> dict:
     if not await shared_skill_service.user_can_manage(skill_id, user_id):
         return _text_result(json.dumps({"error": "not allowed"}))
 
-    updates = {key: args[key] for key in ("title", "description", "discoverable") if key in args}
+    # Discover listing is deliberately not agent-settable: putting content on
+    # the public Discover feed must be a human clicking the settings toggle.
+    updates = {key: args[key] for key in ("title", "description") if key in args}
     skill = await shared_skill_service.update_skill(skill_id, user_id, updates)
     if not skill:
         return _text_result(json.dumps({"error": "not found"}))

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -140,6 +140,52 @@ async def test_skill_tools_create_publish_update_and_unpublish(scope: UUID, _db_
     assert skill_md == 1
 
 
+@pytest.mark.asyncio
+async def test_agent_cannot_list_skill_on_discover(scope: UUID, _db_pool):
+    """Discover listing is human-only (the settings toggle). An agent that
+    passes discoverable=true anyway — schemas don't stop a determined model —
+    must be silently ignored, on publish and on update."""
+    user_id = scope  # the scope id is the user id
+
+    scope_token = agent_runtime._scope_ctx.set(scope)
+    user_token = agent_runtime._user_ctx.set(user_id)
+    try:
+        created = json.loads(
+            (
+                await agent_runtime._create_skill.handler(
+                    {
+                        "name": "Sneaky bundle",
+                        "skill_md": "---\nname: Sneaky bundle\ndescription: x\n---\n\n# S\n",
+                    }
+                )
+            )["content"][0]["text"]
+        )
+        published = json.loads(
+            (
+                await agent_runtime._publish_skill.handler(
+                    {"folder_id": created["folder_id"], "discoverable": True}
+                )
+            )["content"][0]["text"]
+        )
+        updated = json.loads(
+            (
+                await agent_runtime._update_skill.handler(
+                    {"skill_id": published["id"], "discoverable": True}
+                )
+            )["content"][0]["text"]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._scope_ctx.reset(scope_token)
+
+    assert published["discoverable"] is False
+    assert updated["discoverable"] is False
+    in_db = await _db_pool.fetchval(
+        "SELECT discoverable FROM skills WHERE id = $1", UUID(published["id"])
+    )
+    assert in_db is False
+
+
 def test_page_tools_withheld_from_ask_surface():
     """create_page/update_page are mutations: implemented in the tool library,
     but withheld from the read-only ask surface so a prompt-injected ask can't


### PR DESCRIPTION
So yea, an agent can never list a skill on the Discover page. It just doesn't have a button for this now. Risk/reward was not good.



## Problem

The "5.13.26 20 Questions about Stash Specs" incident: an internal doc sat on every user's Discover home page (and the unauthenticated `/api/v1/discover` feed). Discover only lists skills with `discoverable = true`, and every surface — DB default, publish API, CLI, share-modal toggle — defaults that to false. The one exception: the agent runtime's `publish_skill`/`update_skill` tools exposed a `discoverable` flag, so a server-side agent could opt content into the public feed on its own judgment, with no human ever clicking "Show in Discover".

## Fix

Discover listing is now human-only (the settings-page toggle). The flag is removed from both agent tool schemas, and the handlers ignore it even if a model passes it anyway — schemas don't stop a determined LLM. Agents keep `publish_skill`/`unpublish_skill` (public-URL sharing) unchanged.

No GUI changes — this only narrows the server-side agent tool surface.

## Testing

- New test `test_agent_cannot_list_skill_on_discover`: an agent passing `discoverable: true` on publish and on update still ends up `discoverable = false`, verified in the DB.
- Full backend suite: 853 passed, 1 failed (`test_bookmark_imports.py::test_import_progress_reports_failures_per_url` — order-dependent flake; passes in isolation both with and without this diff, which doesn't touch bookmark imports).
- `ruff check` and `ruff format --check` clean.

Note: this PR prevents recurrence; it does not delist the existing row. That's a one-line data fix handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)