### PR TITLE
Hide the Gong connector card until an OAuth app exists

### DIFF
--- a/frontend/src/components/integrations/connectors.tsx
+++ b/frontend/src/components/integrations/connectors.tsx
@@ -102,13 +102,16 @@ export const CONNECTORS: Connector[] = [
     kind: "auto",
     blurb: "Meeting notes and transcripts.",
   },
-  {
-    provider: "gong",
-    label: "Gong",
-    sourceType: "gong_calls",
-    kind: "auto",
-    blurb: "Call transcripts, kept in sync.",
-  },
+  // Gong is hidden until an OAuth app exists: no GONG_OAUTH_* creds are
+  // registered anywhere (2026-07), so the card only ever showed users a
+  // "not configured" error. Re-enable once the creds land in Render + .env.
+  // {
+  //   provider: "gong",
+  //   label: "Gong",
+  //   sourceType: "gong_calls",
+  //   kind: "auto",
+  //   blurb: "Call transcripts, kept in sync.",
+  // },
   {
     provider: "posthog",
     label: "PostHog",


### PR DESCRIPTION
we should actually make gong work at some point! but not until someone asks us for it!

## Why

Reviewing prod's Render env today showed there are no `GONG_OAUTH_*` credentials anywhere — the Gong OAuth app was never created. So the Gong card on /integrations has only ever produced "Gong OAuth is not configured for this server" for every user who clicked Connect, locally and in prod.

## Change

Comment out (not delete) the Gong entry in the connector catalog (`connectors.tsx`) — the single spot that renders the card. The provider implementation stays intact and untouched; re-enabling is uncommenting one block once someone registers the OAuth app with Gong and lands the creds in Render + `.env`. A comment at the site says exactly that.

Everything else Gong-related (backend provider, icons, `gong_calls` render paths) is unreachable without the card and left alone — existing-source render paths would still work if any sources existed (none can, since connecting was never possible).

## Verified

- `npm run lint`: 0 errors (3 pre-existing warnings in unrelated files).
- `npm test`: 209/209 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)