### PR TITLE
fix(plugin): unreadable PATH entries crash SessionStart on WSL

### DIFF
--- a/plugins/tests/test_shadow_installs.py
+++ b/plugins/tests/test_shadow_installs.py
@@ -6,6 +6,8 @@ install that caused it. These tests pin the triggering conditions."""
 import os
 from pathlib import Path
 
+import pytest
+
 from stashai.plugin.doctor import find_stash_installs, shadow_install_warning
 
 
@@ -46,6 +48,26 @@ def test_two_distinct_installs_warn_with_both_paths(tmp_path, monkeypatch):
     assert warning is not None
     assert str(first) in warning
     assert str(stale) in warning
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory permissions")
+def test_unreadable_path_entry_is_skipped(tmp_path, monkeypatch):
+    # WSL appends the Windows PATH to $PATH, and some of those directories
+    # (e.g. /mnt/c/WINDOWS/system32/config/systemprofile/.../WindowsApps)
+    # raise PermissionError on stat(). That escaped find_stash_installs() and
+    # crashed every SessionStart hook before it could emit its context — a
+    # silent failure, since the session record is created earlier.
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    denied.chmod(0o000)
+    real = _make_stash(tmp_path / "bin")
+    monkeypatch.setenv("PATH", f"{denied}{os.pathsep}{real.parent}")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    try:
+        assert find_stash_installs() == [real]
+        assert shadow_install_warning() is None
+    finally:
+        denied.chmod(0o755)  # let tmp_path cleanup remove it
 
 
 def test_activated_dev_venv_suppresses_warning(tmp_path, monkeypatch):

--- a/plugins/tests/test_shadow_installs.py
+++ b/plugins/tests/test_shadow_installs.py
@@ -50,7 +50,7 @@ def test_two_distinct_installs_warn_with_both_paths(tmp_path, monkeypatch):
     assert str(stale) in warning
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory permissions")
+@pytest.mark.skipif(not hasattr(os, "geteuid") or os.geteuid() == 0, reason="requires POSIX permissions and non-root user")
 def test_unreadable_path_entry_is_skipped(tmp_path, monkeypatch):
     # WSL appends the Windows PATH to $PATH, and some of those directories
     # (e.g. /mnt/c/WINDOWS/system32/config/systemprofile/.../WindowsApps)

--- a/stashai/plugin/doctor.py
+++ b/stashai/plugin/doctor.py
@@ -22,9 +22,16 @@ def find_stash_installs() -> list[Path]:
         if not entry:
             continue
         candidate = Path(entry) / "stash"
-        if not (candidate.is_file() and os.access(candidate, os.X_OK)):
+        try:
+            if not (candidate.is_file() and os.access(candidate, os.X_OK)):
+                continue
+            real = candidate.resolve()
+        except OSError:
+            # An unreadable PATH entry is not a stash install; skip it rather
+            # than let stat() abort the scan. WSL puts the Windows PATH on
+            # $PATH, and some of those dirs raise PermissionError — that
+            # crashed every SessionStart hook before the context was emitted.
             continue
-        real = candidate.resolve()
         if real in seen:
             continue
         seen.add(real)


### PR DESCRIPTION
## The bug

On WSL, `$PATH` includes the Windows PATH. Some of those directories raise `PermissionError` on `stat()` — reliably:

```
/mnt/c/WINDOWS/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps
```

`find_stash_installs()` calls `candidate.is_file()` on every `$PATH` entry with no guard, so the `PermissionError` propagates out of `shadow_install_warning()` and takes down `on_session_start` with it:

```
Traceback (most recent call last):
  File ".../scripts/on_session_start.py", line 162, in <module>
    main()
  File ".../scripts/on_session_start.py", line 150, in main
    shadow_install_warning(),
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../stashai/plugin/doctor.py", line 44, in shadow_install_warning
    installs = find_stash_installs()
               ^^^^^^^^^^^^^^^^^^^^^
  File ".../stashai/plugin/doctor.py", line 25, in find_stash_installs
    if not (candidate.is_file() and os.access(candidate, os.X_OK)):
            ^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/mnt/c/WINDOWS/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps/stash'
```

The hook dies at line 150, **before** it returns its `additionalContext` — so the agent is never told the `stash` CLI exists, and never browses the Stash.

## Why it took a while to spot

The failure is silent. `create_session_record()` runs earlier in the hook (line 114), so on WSL:

- sessions still upload and are searchable,
- `stash status` stays green (`Health: ok`),
- only the context injection is lost.

Nothing surfaces the crash. I found it only by running the hook by hand while asking why the agent never mentioned Stash on its own.

## Repro

Any WSL2 install (mine: Ubuntu 24.04, WSL2 on Windows 11, `stashai` 0.1.269 via `uv tool install`, self-hosted backend). `bash -lc 'echo $PATH'` shows 31 `/mnt/c/...` entries.

```bash
echo '{"session_id":"t","cwd":"'$HOME'","hook_event_name":"SessionStart"}' \
  | bash ~/.claude/plugins/cache/stash-plugins/stash/<version>/scripts/_run.sh on_session_start
```

Before: traceback above. After: the expected `{"hookSpecificOutput": {...}}`.

## The fix

An unreadable `$PATH` entry cannot be a stash install, so skip it rather than let `stat()` abort the scan.

Added a regression test to `plugins/tests/test_shadow_installs.py`, in the style of the existing cases. It fails on `main` with the exact `PermissionError` and passes with the fix. Skipped when running as root, since root bypasses directory permissions.

```
plugins/tests/test_shadow_installs.py  →  5 passed
plugins/tests/                         →  107 passed
```

## Note

`os.access()` is already non-raising, so `is_file()`/`resolve()` were the only exposure here. Happy to broaden the guard or reshape the test if you'd rather it patch `Path.is_file` than use a `chmod 000` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
