### PR TITLE
Skip GitHub source re-sync when the repo's HEAD hasn't moved

### DIFF
--- a/backend/integrations/github/indexer.py
+++ b/backend/integrations/github/indexer.py
@@ -17,10 +17,13 @@ import tempfile
 import zipfile
 from collections.abc import Awaitable, Callable
 from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
 
 from ...services import source_service
 from ..storage import get_valid_token
-from .archive import UnsupportedHostError, resolve_archive_url
+from .archive import UnsupportedHostError, _parse_owner_repo, resolve_archive_url
 from .importers.repo import (
     MAX_FILES,
     MAX_PER_FILE_BYTES,
@@ -30,6 +33,20 @@ from .importers.repo import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _github_head_sha(url: str, headers: dict) -> str:
+    """Latest commit SHA on the default branch — one cheap API call, used to
+    skip the full zipball download when nothing changed since the last sync."""
+    owner, repo = _parse_owner_repo(urlparse(url).path)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}/commits",
+            params={"per_page": 1},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()[0]["sha"]
 
 
 async def _crawl_archive(
@@ -90,6 +107,14 @@ async def index_github_repo(source: dict) -> str | None:
     except UnsupportedHostError as e:
         raise RuntimeError(str(e))
 
+    # Change detection is GitHub-only; other hosts always crawl.
+    head_sha = None
+    if resolved.host_kind == "github":
+        head_sha = await _github_head_sha(url, resolved.headers)
+        if head_sha == source["sync_cursor"]:
+            logger.info("github source %s: HEAD unchanged, skipping crawl", source_id)
+            return head_sha
+
     async def _on_text_file(rel: str, text: str) -> None:
         await source_service.upsert_content_document(
             table="github_documents",
@@ -104,4 +129,4 @@ async def index_github_repo(source: dict) -> str | None:
     present = await _crawl_archive(resolved.archive_url, resolved.headers, _on_text_file)
     await source_service.remove_missing_documents("github_documents", source_id, present)
     logger.info("github source %s: indexed %d file(s)", source_id, len(present))
-    return None
+    return head_sha

--- a/backend/tests/test_integration_indexer_log_security.py
+++ b/backend/tests/test_integration_indexer_log_security.py
@@ -45,6 +45,7 @@ def _source(external_ref: str) -> dict:
         "id": str(uuid4()),
         "owner_user_id": str(uuid4()),
         "external_ref": external_ref,
+        "sync_cursor": None,
     }
 
 
@@ -97,12 +98,18 @@ async def test_github_index_success_logs_internal_source_id_only(monkeypatch):
         await on_text_file("webflow/secret.md", "customer transcript")
         return ["webflow/secret.md"]
 
+    async def head_sha(url, headers):
+        return "a" * 40
+
     monkeypatch.setattr(github_indexer, "get_valid_token", _token)
     monkeypatch.setattr(
         github_indexer,
         "resolve_archive_url",
-        lambda *args, **kwargs: SimpleNamespace(archive_url="archive-url", headers={}),
+        lambda *args, **kwargs: SimpleNamespace(
+            archive_url="archive-url", headers={}, host_kind="github"
+        ),
     )
+    monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
     monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
     monkeypatch.setattr(github_indexer.source_service, "upsert_content_document", _noop)
     monkeypatch.setattr(github_indexer.source_service, "remove_missing_documents", _noop)

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -536,3 +536,90 @@ def test_granola_parses_xml_meeting_blob():
     assert "sam@x.com" in meetings[0]["participants"]  # email preserved
     text = _render_meeting(meetings[0], "we shipped the thing")
     assert "# Standup" in text and "we shipped the thing" in text
+
+
+@pytest.mark.asyncio
+async def test_github_sync_skips_crawl_when_head_unchanged(monkeypatch):
+    # The whole point of the sync cursor: an unchanged repo must not be
+    # re-downloaded (the zipball crawls were OOM-killing the celery worker).
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from backend.integrations.github import indexer as github_indexer
+
+    sha = "b" * 40
+    source = {
+        "id": str(uuid4()),
+        "owner_user_id": str(uuid4()),
+        "external_ref": "octocat/hello-world",
+        "sync_cursor": sha,
+    }
+
+    async def token(user_id, provider=None):
+        return "tok"
+
+    async def head_sha(url, headers):
+        return sha
+
+    async def crawl_archive(*args, **kwargs):
+        raise AssertionError("unchanged repo must not be crawled")
+
+    monkeypatch.setattr(github_indexer, "get_valid_token", token)
+    monkeypatch.setattr(
+        github_indexer,
+        "resolve_archive_url",
+        lambda *args, **kwargs: SimpleNamespace(
+            archive_url="archive-url", headers={}, host_kind="github"
+        ),
+    )
+    monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
+    monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
+
+    assert await github_indexer.index_github_repo(source) == sha
+
+
+@pytest.mark.asyncio
+async def test_github_sync_crawls_and_returns_new_head_sha(monkeypatch):
+    # A moved HEAD must crawl and hand the new SHA back as the sync cursor,
+    # so the next cycle's unchanged-check compares against it.
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from backend.integrations.github import indexer as github_indexer
+
+    new_sha = "c" * 40
+    source = {
+        "id": str(uuid4()),
+        "owner_user_id": str(uuid4()),
+        "external_ref": "octocat/hello-world",
+        "sync_cursor": "b" * 40,
+    }
+    crawled = []
+
+    async def token(user_id, provider=None):
+        return "tok"
+
+    async def head_sha(url, headers):
+        return new_sha
+
+    async def crawl_archive(archive_url, headers, on_text_file):
+        crawled.append(archive_url)
+        return []
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(github_indexer, "get_valid_token", token)
+    monkeypatch.setattr(
+        github_indexer,
+        "resolve_archive_url",
+        lambda *args, **kwargs: SimpleNamespace(
+            archive_url="archive-url", headers={}, host_kind="github"
+        ),
+    )
+    monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
+    monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
+    monkeypatch.setattr(github_indexer.source_service, "remove_missing_documents", noop)
+
+    assert await github_indexer.index_github_repo(source) == new_sha
+    assert crawled == ["archive-url"]

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -872,6 +872,13 @@ async def test_github_indexer_crawls_text_files_and_resyncs(client, monkeypatch)
         Path(dest).write_bytes(zip_v1)
         return len(zip_v1)
 
+    # HEAD moves between the two syncs, so both crawl.
+    shas = iter(["a" * 40, "b" * 40])
+
+    async def fake_head_sha(url, headers):
+        return next(shas)
+
+    monkeypatch.setattr(indexer, "_github_head_sha", fake_head_sha)
     monkeypatch.setattr(indexer, "_download_archive", fake_download)
 
     result = await sources_task._sync_source(UUID(src["id"]))


### PR DESCRIPTION
## Why

The celery worker has been OOM-killed by Render every 15–45 minutes (the "exceeded its memory limit" email flood). Root cause: every scheduled sync re-downloaded and re-indexed every connected GitHub repo's full zipball, because `index_github_repo` always returned a `None` cursor — there was no "unchanged since last sync" short-circuit. With dozens of connected repos, the constant archive churn ratcheted worker RSS past the 2GB limit.

## What

- `index_github_repo` now fetches the repo's HEAD commit SHA first (one small API call: `GET /repos/{owner}/{repo}/commits?per_page=1`).
- If it matches the stored `sync_cursor`, the sync returns immediately — no zipball download, no re-index.
- Otherwise it crawls as before and returns the new SHA as the cursor. `mark_sync_done` already persisted the indexer's returned cursor, so no schema or plumbing changes.
- Change detection is GitHub-only; GitLab/Bitbucket/generic-zip sources always crawl, same as today.

Existing sources need no migration: their cursor is NULL, so each crawls once more after deploy, stores its SHA, and goes quiet.

## Tests

- New: an unchanged repo must not be crawled (asserts `_crawl_archive` is never called); a moved HEAD must crawl and store the new SHA as the cursor.
- Updated the indexer e2e test (`test_github_indexer_crawls_text_files_and_resyncs`) and the log-security test to stub the new SHA call.
- Full backend suite passes: 855 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)