### PR TITLE
Recycle celery children above 800MB instead of OOM-ing the box

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -45,6 +45,11 @@ celery.conf.update(
     task_acks_late=True,
     task_reject_on_worker_lost=True,
     worker_prefetch_multiplier=1,
+    # CPython never returns freed heap to the OS, so a child's RSS only
+    # ratchets upward. Recycle any child above ~800MB after it finishes its
+    # current task, keeping 2 children + parent under Render's 2GB limit
+    # (the box was getting OOM-killed instead, losing in-flight tasks).
+    worker_max_memory_per_child=800_000,  # KB
     # Long-running tasks (Playwright renders, zip downloads) shouldn't be
     # cancelled by a soft timeout mid-render. Hard cap at 30 min.
     task_time_limit=1800,


### PR DESCRIPTION

let's set a max memory per child on celery so that it doesn't crash randomly

## Why

Follow-up to #855. CPython never returns freed heap to the OS, so a celery child's RSS only ratchets upward over its lifetime. When accumulated bloat crosses Render's 2GB instance limit, the whole box gets OOM-killed mid-task (the overnight email flood). #855 removed the main churn source; this is the general backstop against whatever memory-hungry task shows up next.

## What

One setting in `backend/celery_app.py`: `worker_max_memory_per_child=800_000` (KB, ~800MB). After a child finishes a task over the threshold, celery retires it and forks a fresh one — current task completes cleanly, nothing is lost, no Render kill. With `--concurrency=2`, two children at 800MB plus the parent stays comfortably under the 2GB box.

Verified the config loads (`celery.conf.worker_max_memory_per_child == 800000`); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)