### PR TITLE
Skip repo files too big to full-text index instead of failing the sync

### DIFF
--- a/backend/integrations/github/indexer.py
+++ b/backend/integrations/github/indexer.py
@@ -26,13 +26,19 @@ from ..storage import get_valid_token
 from .archive import UnsupportedHostError, _parse_owner_repo, resolve_archive_url
 from .importers.repo import (
     MAX_FILES,
-    MAX_PER_FILE_BYTES,
     _download_archive,
     _is_skipped_path,
     _strip_top_level_prefix,
 )
 
 logger = logging.getLogger(__name__)
+
+# Postgres caps a row's tsvector at 1MB, and github_documents carries a
+# full-text index on content — a bigger file aborts the whole repo's sync
+# at insert time. Text files over this cap (minified bundles, lockfiles,
+# data dumps) are skipped like binaries; 512KB keeps the vector safely
+# under the limit.
+MAX_INDEXED_TEXT_BYTES = 512 * 1024
 
 
 async def _github_head_sha(url: str, headers: dict) -> str:
@@ -74,7 +80,7 @@ async def _crawl_archive(
                 if not rel or _is_skipped_path(Path(rel)):
                     continue
                 info = zf.getinfo(member)
-                if info.file_size > MAX_PER_FILE_BYTES:
+                if info.file_size > MAX_INDEXED_TEXT_BYTES:
                     continue
                 with zf.open(info) as src:
                     raw = src.read()

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -905,6 +905,47 @@ async def test_github_indexer_crawls_text_files_and_resyncs(client, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_github_indexer_skips_files_too_big_to_index(client, monkeypatch):
+    # Postgres caps a row's tsvector at 1MB and github_documents is FTS-indexed
+    # on content, so an oversized text file (minified bundle, lockfile) must be
+    # skipped like a binary — not abort the whole repo's sync at insert time.
+    from backend.integrations.github import indexer
+    from backend.tasks import sources as sources_task
+
+    api_key, owner_id = await _register(client)
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref="acme/bundled",
+        display_name="acme/bundled",
+    )
+
+    bundle = b"var x=1;" * (indexer.MAX_INDEXED_TEXT_BYTES // 8 + 1)
+    repo_zip = _make_repo_zip(
+        {
+            "README.md": b"# Bundled",
+            "dist/bundle.min.js": bundle,
+        }
+    )
+
+    async def fake_head_sha(url, headers):
+        return "d" * 40
+
+    async def fake_download(url, headers, dest):
+        Path(dest).write_bytes(repo_zip)
+        return len(repo_zip)
+
+    monkeypatch.setattr(indexer, "_github_head_sha", fake_head_sha)
+    monkeypatch.setattr(indexer, "_download_archive", fake_download)
+
+    result = await sources_task._sync_source(UUID(src["id"]))
+    assert result["status"] == "done"
+
+    paths = {d["path"] for d in await source_service.list_documents(src)}
+    assert paths == {"README.md"}
+
+
+@pytest.mark.asyncio
 async def test_sync_source_unknown_type_is_noop(client: AsyncClient, monkeypatch):
     from backend.tasks import sources as sources_task
 


### PR DESCRIPTION
@ColemanDuPlessie - heads up, we had some github files that were so big that we couldn't fit them into a `tsvector`- when you get a chance, could you think of ways to work around this? seems like we're probably doing something dumb here. Like, maybe there's another way to index these files...

## Why

`github_documents` has a GIN full-text index on `content`, and Postgres hard-caps a single row's tsvector at **1MB** (non-configurable). The repo crawler skips binaries and files over 10MB, but a *text* file between ~1MB and 10MB sails through and blows up at insert time:

```
asyncpg.exceptions.ProgramLimitExceededError: string is too long for tsvector (1253392 bytes, max 1048575 bytes)
```

That exception aborts the **entire repo's sync** — none of the repo's files are searchable, not just the big one. And since failed syncs never store a cursor, the #855 HEAD-unchanged skip never engages: the repo re-downloads its full zipball every cycle just to fail again. Two prod repos are stuck in exactly this loop (`dopeboy/trycadbury.com`, `vadymkostucok/cadbury`).

## What

Text files over **512KB** are now skipped during the crawl, exactly like binaries and >10MB files — same skip rule, one codepath. Oversized text files are near-always minified bundles, lockfiles, or data dumps with little search value. Skipping (rather than truncating stored content) means the agent never reads a silently-chopped file when browsing a repo. The stuck repos will sync clean on their next cycle, no migration needed.

## Tests

New: a repo containing an oversized text file syncs successfully and indexes everything else. Ruff clean, sync-related suites pass (113 tests).
