### PR TITLE
Refuse over-cap GitHub repos via the tree API before downloading anything

### DIFF
--- a/backend/integrations/github/indexer.py
+++ b/backend/integrations/github/indexer.py
@@ -40,6 +40,15 @@ logger = logging.getLogger(__name__)
 # under the limit.
 MAX_INDEXED_TEXT_BYTES = 512 * 1024
 
+# Cap on a snapshot's total content size, enforced against the git tree
+# BEFORE the zipball download. Repos over this cap (or over MAX_FILES) used
+# to download up to 100MB just to fail on the in-crawl caps — every cycle,
+# forever, because a failed sync stores no cursor. That hourly re-download
+# churn is what kept OOM-ing the celery worker; now an over-cap repo costs
+# two API calls per cycle and heals on its own if the repo shrinks. The
+# in-crawl caps stay as the enforcement for non-GitHub hosts.
+MAX_SNAPSHOT_BYTES = 100 * 1024 * 1024
+
 
 async def _github_head_sha(url: str, headers: dict) -> str:
     """Latest commit SHA on the default branch — one cheap API call, used to
@@ -53,6 +62,40 @@ async def _github_head_sha(url: str, headers: dict) -> str:
         )
         resp.raise_for_status()
         return resp.json()[0]["sha"]
+
+
+async def _github_snapshot_tree(url: str, headers: dict, head_sha: str) -> dict:
+    """The repo's full file listing at `head_sha` — one API call, no download."""
+    owner, repo = _parse_owner_repo(urlparse(url).path)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}/git/trees/{head_sha}",
+            params={"recursive": "1"},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _check_tree_indexable(tree: dict) -> None:
+    """Refuse a snapshot the crawler would give up on anyway, before paying
+    for the download. Messages are owner-facing (SourceSyncUserError)."""
+    if tree["truncated"]:
+        # GitHub truncates the listing past ~100k entries — far over MAX_FILES.
+        raise source_service.SourceSyncUserError(
+            "Repo is too large to index: GitHub truncated its file listing"
+        )
+    blobs = [e for e in tree["tree"] if e["type"] == "blob"]
+    if len(blobs) > MAX_FILES:
+        raise source_service.SourceSyncUserError(
+            f"Repo has {len(blobs)} files; the indexing cap is {MAX_FILES}"
+        )
+    total_bytes = sum(e["size"] for e in blobs)
+    if total_bytes > MAX_SNAPSHOT_BYTES:
+        raise source_service.SourceSyncUserError(
+            f"Repo content is {total_bytes // (1024 * 1024)}MB; "
+            f"the indexing cap is {MAX_SNAPSHOT_BYTES // (1024 * 1024)}MB"
+        )
 
 
 async def _crawl_archive(
@@ -113,13 +156,15 @@ async def index_github_repo(source: dict) -> str | None:
     except UnsupportedHostError as e:
         raise RuntimeError(str(e))
 
-    # Change detection is GitHub-only; other hosts always crawl.
+    # Change detection + size pre-check are GitHub-only; other hosts always
+    # crawl and rely on the in-crawl caps.
     head_sha = None
     if resolved.host_kind == "github":
         head_sha = await _github_head_sha(url, resolved.headers)
         if head_sha == source["sync_cursor"]:
             logger.info("github source %s: HEAD unchanged, skipping crawl", source_id)
             return head_sha
+        _check_tree_indexable(await _github_snapshot_tree(url, resolved.headers, head_sha))
 
     async def _on_text_file(rel: str, text: str) -> None:
         await source_service.upsert_content_document(

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -606,6 +606,9 @@ async def test_github_sync_crawls_and_returns_new_head_sha(monkeypatch):
         crawled.append(archive_url)
         return []
 
+    async def snapshot_tree(url, headers, sha):
+        return {"truncated": False, "tree": [{"type": "blob", "size": 10}]}
+
     async def noop(*args, **kwargs):
         return None
 
@@ -618,8 +621,88 @@ async def test_github_sync_crawls_and_returns_new_head_sha(monkeypatch):
         ),
     )
     monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
+    monkeypatch.setattr(github_indexer, "_github_snapshot_tree", snapshot_tree)
     monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
     monkeypatch.setattr(github_indexer.source_service, "remove_missing_documents", noop)
 
     assert await github_indexer.index_github_repo(source) == new_sha
     assert crawled == ["archive-url"]
+
+
+def test_check_tree_indexable_enforces_caps_before_download():
+    # The whole value of the pre-check is refusing BEFORE the zipball
+    # download: an over-cap repo used to download ~100MB every cycle just to
+    # fail on the same in-crawl caps, which is what kept OOM-ing the worker.
+    from backend.integrations.github.indexer import (
+        MAX_FILES,
+        MAX_SNAPSHOT_BYTES,
+        _check_tree_indexable,
+    )
+    from backend.services.source_service import SourceSyncUserError
+
+    def tree(blobs, truncated=False):
+        return {"truncated": truncated, "tree": blobs}
+
+    blob = {"type": "blob", "size": 100}
+
+    # Under every cap: passes. Non-blob entries (trees, submodules) don't count.
+    _check_tree_indexable(tree([blob] * 10 + [{"type": "tree"}, {"type": "commit"}]))
+
+    with pytest.raises(SourceSyncUserError, match="truncated"):
+        _check_tree_indexable(tree([blob], truncated=True))
+
+    with pytest.raises(SourceSyncUserError, match=f"cap is {MAX_FILES}"):
+        _check_tree_indexable(tree([blob] * (MAX_FILES + 1)))
+
+    over = {"type": "blob", "size": MAX_SNAPSHOT_BYTES + 1}
+    with pytest.raises(SourceSyncUserError, match="cap is 100MB"):
+        _check_tree_indexable(tree([over]))
+
+
+@pytest.mark.asyncio
+async def test_github_sync_refuses_oversized_repo_without_downloading(monkeypatch):
+    # An over-cap repo must be refused with the owner-facing reason and no
+    # download attempt. The refusal repeats each cycle at the cost of two API
+    # calls, and clears on its own if the repo shrinks under the caps.
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from backend.integrations.github import indexer as github_indexer
+    from backend.services.source_service import SourceSyncUserError
+
+    source = {
+        "id": str(uuid4()),
+        "owner_user_id": str(uuid4()),
+        "external_ref": "octocat/hello-world",
+        "sync_cursor": None,
+    }
+
+    async def token(user_id, provider=None):
+        return "tok"
+
+    async def head_sha(url, headers):
+        return "f" * 40
+
+    async def snapshot_tree(url, headers, sha):
+        return {
+            "truncated": False,
+            "tree": [{"type": "blob", "size": 1}] * (github_indexer.MAX_FILES + 1),
+        }
+
+    async def crawl_archive(*args, **kwargs):
+        raise AssertionError("an over-cap repo must not be downloaded")
+
+    monkeypatch.setattr(github_indexer, "get_valid_token", token)
+    monkeypatch.setattr(
+        github_indexer,
+        "resolve_archive_url",
+        lambda *args, **kwargs: SimpleNamespace(
+            archive_url="archive-url", headers={}, host_kind="github"
+        ),
+    )
+    monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
+    monkeypatch.setattr(github_indexer, "_github_snapshot_tree", snapshot_tree)
+    monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
+
+    with pytest.raises(SourceSyncUserError, match=f"cap is {github_indexer.MAX_FILES}"):
+        await github_indexer.index_github_repo(source)

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -878,7 +878,11 @@ async def test_github_indexer_crawls_text_files_and_resyncs(client, monkeypatch)
     async def fake_head_sha(url, headers):
         return next(shas)
 
+    async def fake_snapshot_tree(url, headers, sha):
+        return {"truncated": False, "tree": [{"type": "blob", "size": 10}]}
+
     monkeypatch.setattr(indexer, "_github_head_sha", fake_head_sha)
+    monkeypatch.setattr(indexer, "_github_snapshot_tree", fake_snapshot_tree)
     monkeypatch.setattr(indexer, "_download_archive", fake_download)
 
     result = await sources_task._sync_source(UUID(src["id"]))
@@ -935,7 +939,11 @@ async def test_github_indexer_skips_files_too_big_to_index(client, monkeypatch):
         Path(dest).write_bytes(repo_zip)
         return len(repo_zip)
 
+    async def fake_snapshot_tree(url, headers, sha):
+        return {"truncated": False, "tree": [{"type": "blob", "size": 10}]}
+
     monkeypatch.setattr(indexer, "_github_head_sha", fake_head_sha)
+    monkeypatch.setattr(indexer, "_github_snapshot_tree", fake_snapshot_tree)
     monkeypatch.setattr(indexer, "_download_archive", fake_download)
 
     result = await sources_task._sync_source(UUID(src["id"]))


### PR DESCRIPTION
## Why

The celery worker kept OOM-ing after #855/#856/#857. The remaining driver: **a failed sync stores no cursor, so #855's unchanged-HEAD skip never engages for failing repos.** 27 prod GitHub sources are over the indexing caps and re-downloaded up to 100MB every hour, forever — the file-count cap even fires only *after* the full zipball download. Every observed OOM (Render metrics + logs) correlated with these download bursts; the 4:46 AM instance restart hit mid-download of the `cadburylabs/*` cluster on fully-fixed code.

## What

One **git trees API call** at the already-fetched HEAD SHA gives the exact snapshot before any download: file count, per-blob sizes, and a `truncated` flag for repos too big to even list. The indexer refuses over-cap repos right there, with an owner-facing reason (`Repo has 12305 files; the indexing cap is 5000`) instead of the redacted generic error.

- An unsyncable repo now costs **two API calls per cycle** instead of a 100MB download — cheap enough that no retry-suppression state is needed, and it heals on its own once the repo shrinks under the caps.
- No schema changes, no new sync states, no cursor tricks. (First draft of this PR pinned the failed SHA into `sync_cursor` to suppress retries; this version deletes that in favor of making the failure too cheap to matter.)

## Tradeoff, stated plainly

The size cap is now defined on **uncompressed snapshot content** (100MB, same number as the zipball cap). A repo with >100MB of content that compressed under 100MB was previously indexable; it is now refused with a clear error. One rule, checked before paying for the download. In-crawl caps remain as enforcement for non-GitHub hosts (no tree API there).

## Tests

- `test_check_tree_indexable_enforces_caps_before_download` (pure: count / size / truncated / passing, non-blob entries excluded)
- `test_github_sync_refuses_oversized_repo_without_downloading` (refusal happens before any download)
- Full `test_integration_sources.py` + `test_sources.py`: 107 passed; ruff check + format clean.

## Expected effect in prod

The 27 failing sources flip from a 100MB/hr download loop to two API calls per hour, each with an actionable error in the UI. If OOM emails continue after deploy, the download-burst diagnosis is wrong and we instrument the worker (per-task peak RSS) before guessing further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)