### PR TITLE
Stream X media downloads under the size cap instead of buffering whole videos

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -319,17 +319,32 @@ async def _archive_media(owner_user_id: UUID, tweet_id: str, media: list[dict]) 
     stored: list[dict] = []
     async with httpx.AsyncClient(timeout=60, follow_redirects=True) as client:
         for i, item in enumerate(media):
-            response = await client.get(item["url"])
-            response.raise_for_status()
-            content = response.content
-            if len(content) > MAX_MEDIA_BYTES:
-                continue  # skip an oversized blob rather than fail the whole save
-            content_type = response.headers.get(
-                "content-type", "video/mp4" if item["is_video"] else "image/jpeg"
-            )
-            ext = "mp4" if item["is_video"] else "jpg"
-            key = await storage_service.upload_file(
-                str(owner_user_id), f"x-{tweet_id}-{i}.{ext}", content, content_type
-            )
-            stored.append({"storage_key": key, "content_type": content_type})
+            async with client.stream("GET", item["url"]) as response:
+                response.raise_for_status()
+                # The cap must hold WHILE downloading. The old code buffered
+                # the whole highest-bitrate video into memory just to measure
+                # it — a long 1080p MP4 is hundreds of MB, which spiked the
+                # celery worker past its 2GB limit in seconds and OOM-killed
+                # the box mid-hydration.
+                declared = response.headers.get("content-length")
+                if declared is not None and int(declared) > MAX_MEDIA_BYTES:
+                    continue  # skip an oversized blob rather than fail the whole save
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes(64 * 1024):
+                    total += len(chunk)
+                    if total > MAX_MEDIA_BYTES:
+                        break
+                    chunks.append(chunk)
+                if total > MAX_MEDIA_BYTES:
+                    continue  # skip an oversized blob rather than fail the whole save
+                content = b"".join(chunks)
+                content_type = response.headers.get(
+                    "content-type", "video/mp4" if item["is_video"] else "image/jpeg"
+                )
+                ext = "mp4" if item["is_video"] else "jpg"
+                key = await storage_service.upload_file(
+                    str(owner_user_id), f"x-{tweet_id}-{i}.{ext}", content, content_type
+                )
+                stored.append({"storage_key": key, "content_type": content_type})
     return stored

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -74,9 +74,37 @@ def _generic_tweet(tweet_id: str) -> dict:
     }
 
 
+class _FakeStreamResponse:
+    """Streaming media response: the indexer must read it chunk-wise under a
+    running byte cap, never `.content`-style all at once."""
+
+    def __init__(self, content: bytes, headers: dict):
+        self._content = content
+        self.headers = headers
+        self.reads = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self, chunk_size):
+        for i in range(0, len(self._content), chunk_size):
+            self.reads += 1
+            yield self._content[i : i + chunk_size]
+
+
 class _FakeApi:
     """One fake for every HTTP the indexer makes: twitterapi.io tweet-by-id +
     user-timeline, the X API bookmarks endpoint, and the CDN media URL."""
+
+    media_bytes = b"fake image bytes"
+    media_headers = {"content-type": "image/jpeg"}
+    media_streams: list = []
 
     bookmarks_status = 200
 
@@ -100,9 +128,13 @@ class _FakeApi:
             if type(self).bookmarks_status != 200:
                 return _FakeResponse(payload={}, status_code=type(self).bookmarks_status)
             return _FakeResponse(payload=_BOOKMARKS)
-        if url == "https://cdn.x/img.jpg":
-            return _FakeResponse(content=b"fake image bytes")
         raise AssertionError(f"unexpected URL {url}")
+
+    def stream(self, method, url):
+        assert url == "https://cdn.x/img.jpg", f"unexpected media URL {url}"
+        response = _FakeStreamResponse(type(self).media_bytes, dict(type(self).media_headers))
+        type(self).media_streams.append(response)
+        return response
 
 
 @pytest.fixture
@@ -120,6 +152,9 @@ def fake_sync(monkeypatch):
         return "oauth-token"
 
     _FakeApi.bookmarks_status = 200
+    _FakeApi.media_bytes = b"fake image bytes"
+    _FakeApi.media_headers = {"content-type": "image/jpeg"}
+    _FakeApi.media_streams = []
     monkeypatch.setattr(settings, "TWITTERAPI_IO_KEY", "tapi-key")
     monkeypatch.setattr(storage_service, "is_configured", lambda: True)
     monkeypatch.setattr(storage_service, "upload_file", _upload)
@@ -197,6 +232,50 @@ async def test_hydrates_content_thread_root_and_media(client, pool, fake_sync) -
     entries = await source_service.source_entries(UUID(owner_id), UUID(owner_id), str(source["id"]))
     entry = next(e for e in entries if e["path"] == "1001")
     assert entry["snippet"] == "totally agree with this"
+
+
+@pytest.mark.asyncio
+async def test_media_over_cap_is_skipped_while_streaming(
+    client, pool, fake_sync, monkeypatch
+) -> None:
+    # The cap must abort the download mid-stream. The old code buffered the
+    # whole highest-bitrate video into memory before measuring it, which
+    # spiked the worker past its 2GB limit and OOM-killed the box.
+    monkeypatch.setattr(x_indexer, "MAX_MEDIA_BYTES", 100)
+    _FakeApi.media_bytes = b"x" * 100_000  # over the cap; no content-length header
+    _FakeApi.media_headers = {"content-type": "video/mp4"}
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_pending(pool, owner_id, source["id"], "1001", "Bookmark")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow("SELECT * FROM x_save_docs WHERE source_id = $1", UUID(source["id"]))
+    assert row["hydration_status"] == "done"  # the save survives, minus the blob
+    assert row["media"] == []
+    assert fake_sync == []  # nothing uploaded
+    # Aborted after the first over-cap chunk, not read to the end.
+    assert _FakeApi.media_streams[0].reads == 1
+
+
+@pytest.mark.asyncio
+async def test_media_with_oversized_content_length_is_never_read(
+    client, pool, fake_sync, monkeypatch
+) -> None:
+    # When the CDN declares the size up front, skip without reading any body.
+    monkeypatch.setattr(x_indexer, "MAX_MEDIA_BYTES", 100)
+    _FakeApi.media_headers = {"content-type": "video/mp4", "content-length": "500000000"}
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_pending(pool, owner_id, source["id"], "1001", "Bookmark")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow("SELECT * FROM x_save_docs WHERE source_id = $1", UUID(source["id"]))
+    assert row["hydration_status"] == "done"
+    assert row["media"] == []
+    assert fake_sync == []
+    assert _FakeApi.media_streams[0].reads == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The actual OOM killer, caught live

After #858 deployed, one more OOM email arrived (~5:17 AM PT). The logs and metrics for that minute show the real mechanism, red-handed:

1. Fresh worker instance boots at 12:16:31Z, celery ready at :32.
2. It receives the **redelivered `sync_source` task for the X-saves source** (`task_acks_late` re-queues whatever the killed instance had in flight) — and both pool children end up running a copy.
3. At 12:16:42Z **both children start downloading the same 1920×1080 `video.twimg.com` MP4**.
4. Memory sample at 12:17:00Z: **1.61GB** (baseline ~300MB). Instance restarted at 12:17:01Z. That's the email.

`_archive_media` did `response.content` — the entire video buffered into RAM — and only then compared against `MAX_MEDIA_BYTES` (100MB). It also deliberately picks the highest-bitrate MP4 variant, so a single long video can be several hundred MB. This also explains the overnight kill loop: the X source sits stuck in `syncing`, the 10-minute reclaimer re-dispatches it, the box dies mid-download, the unacked task redelivers to the replacement instance, which dies the same way (the paired restarts every 30–45 min, and the email minutes after every deploy).

The GitHub zipball churn (#855–#858) was real waste and worth fixing, but this was the primary killer.

## What

- Skip immediately when `Content-Length` already exceeds the cap — zero bytes read.
- Otherwise stream in 64KB chunks and abort the moment the running total crosses the cap.
- Behavior otherwise unchanged: oversized blob skipped, the save still hydrates; under-cap media stored exactly as before. Peak memory per media download is now bounded by the cap.

## Tests

- `test_media_over_cap_is_skipped_while_streaming` — aborts after the first over-cap chunk (read counter = 1), save still hydrates, nothing uploaded.
- `test_media_with_oversized_content_length_is_never_read` — declared-size skip reads zero body bytes.
- Full `test_x_saves.py`: 6 passed; ruff check + format clean.

## Follow-ups (separate, not urgent tonight)

- The stuck-`syncing` reclaimer can double-dispatch a source that's genuinely still running (both children on the same source) — needs a dispatch lock or ack-aware reclaim.
- Worker observability: per-task peak-RSS logging, so the next memory issue is diagnosed with data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)