### PR TITLE
Bulk import hardening: dispatch window, domain throttling, ScrapeCreators YouTube, extension-fed hydration, link-only saves

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -73,7 +73,9 @@ celery.conf.update(
         },
         "clips-enqueue-pending-url-imports": {
             "task": "backend.tasks.clips.enqueue_pending_url_imports",
-            "schedule": 300.0,
+            # The import dispatcher is windowed (see tasks/clips.py); a fast
+            # sweep is what keeps the window topped up during bulk imports.
+            "schedule": 60.0,
         },
         "drive-extraction-enqueue-pending": {
             "task": "backend.tasks.drive_extraction.enqueue_pending",

--- a/backend/migrations/versions/0158_url_import_hardening.py
+++ b/backend/migrations/versions/0158_url_import_hardening.py
@@ -1,0 +1,59 @@
+"""Bulk-import hardening: retry/dispatch bookkeeping and link-only saves.
+
+url_imports gains retry_at (rate-limited rows wait instead of burning an
+attempt) and dispatched_at (the dispatcher caps in-flight batches, so it
+must know what is already out). A new needs_client status marks rows the
+server cannot fetch (401/403, exhausted rate limits) that the extension
+retries from the user's browser; the partial index serves the extension's
+per-user polling endpoint.
+
+Existing Bookmarks tables also learn the "Link" type so imports that never
+yield readable content can still be indexed as a bare link row.
+
+Revision ID: 0158
+Revises: 0157
+"""
+
+from alembic import op
+
+revision = "0158"
+down_revision = "0157"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE url_imports ADD COLUMN retry_at timestamptz")
+    op.execute("ALTER TABLE url_imports ADD COLUMN dispatched_at timestamptz")
+    op.execute(
+        "CREATE INDEX url_imports_needs_client_idx "
+        "ON url_imports (owner_user_id, created_at) "
+        "WHERE status = 'needs_client'"
+    )
+    # One-shot data migration: existing Bookmarks tables were created before
+    # the "Link" type existed; row validation rejects values outside the
+    # stored options, so append it everywhere it's missing.
+    op.execute(
+        """
+        UPDATE tables
+        SET columns = (
+            SELECT jsonb_agg(
+                CASE
+                    WHEN col->>'name' = 'Type'
+                         AND NOT (col->'options' ? 'Link')
+                    THEN jsonb_set(col, '{options}', (col->'options') || '"Link"')
+                    ELSE col
+                END
+            )
+            FROM jsonb_array_elements(columns) AS col
+        )
+        WHERE name = 'Bookmarks'
+          AND columns @> '[{"name": "Type"}]'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS url_imports_needs_client_idx")
+    op.execute("ALTER TABLE url_imports DROP COLUMN IF EXISTS dispatched_at")
+    op.execute("ALTER TABLE url_imports DROP COLUMN IF EXISTS retry_at")

--- a/backend/migrations/versions/0159_url_import_hardening.py
+++ b/backend/migrations/versions/0159_url_import_hardening.py
@@ -10,14 +10,14 @@ per-user polling endpoint.
 Existing Bookmarks tables also learn the "Link" type so imports that never
 yield readable content can still be indexed as a bare link row.
 
-Revision ID: 0158
-Revises: 0157
+Revision ID: 0159
+Revises: 0158
 """
 
 from alembic import op
 
-revision = "0158"
-down_revision = "0157"
+revision = "0159"
+down_revision = "0158"
 branch_labels = None
 depends_on = None
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,4 +34,3 @@ stripe>=12.0
 websockets>=13.0
 croniter>=2.0
 trafilatura>=2.0
-yt-dlp>=2025.6.30

--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -16,7 +16,7 @@ from .files import MAX_FILE_SIZE, _page_app_url
 router = APIRouter(prefix="/api/v1/me/clips", tags=["clips"])
 imports_router = APIRouter(prefix="/api/v1/me/imports", tags=["clips"])
 
-MAX_IMPORT_URLS = 25_000
+MAX_IMPORT_URLS = 100_000
 MAX_TAB_URLS = 200
 
 
@@ -45,7 +45,7 @@ async def clip_page(
             created_by=current_user["id"],
             items=[{"url": url, "title": body.title}],
         )
-        dispatch_url_imports(ids)
+        await dispatch_url_imports(ids)
         return JSONResponse(status_code=202, content={"import_id": str(ids[0])})
     try:
         page = await clip_service.store_html_clip(
@@ -122,8 +122,8 @@ async def _create_import(
     items: list[dict],
 ) -> JSONResponse:
     """Shared tail of both import endpoints: batch row, url_imports rows,
-    worker dispatch."""
-    from ..tasks.clips import dispatch_url_imports
+    then top up the windowed dispatcher — the Beat sweep drains the rest."""
+    from ..tasks.clips import top_up_url_imports
 
     batch_id = await url_import_service.create_batch(
         owner_user_id=owner_user_id,
@@ -131,13 +131,13 @@ async def _create_import(
         filename=filename,
         total=len(items),
     )
-    ids = await url_import_service.create_url_imports(
+    await url_import_service.create_url_imports(
         owner_user_id=owner_user_id,
         created_by=owner_user_id,
         items=items,
         batch_id=batch_id,
     )
-    dispatch_url_imports(ids)
+    await top_up_url_imports()
     return JSONResponse(status_code=201, content={"import_id": str(batch_id), "total": len(items)})
 
 
@@ -204,6 +204,72 @@ async def import_tabs(
         filename=None,
         items=items,
     )
+
+
+# ===== Extension-fed hydration =====
+# URLs the server can't fetch (login walls, IP blocks) are marked
+# needs_client; the extension polls this queue, refetches them with the
+# user's own browser session, and posts the raw HTML back. Registered
+# before /{batch_id} so "client-queue" isn't parsed as a batch id.
+
+
+class ClientResultRequest(BaseModel):
+    # Exactly one of html (the client-fetched page) or error (why the
+    # client couldn't fetch it either) must be set.
+    html: str | None = None
+    title: str | None = None
+    error: str | None = None
+
+
+@imports_router.get("/client-queue")
+async def client_queue(
+    limit: int = 5,
+    current_user: dict = Depends(get_current_user),
+):
+    """Claim up to `limit` needs_client rows for this user's extension."""
+    rows = await url_import_service.claim_client_batch(current_user["id"], limit=min(limit, 20))
+    return {"items": [{"id": str(r["id"]), "url": r["url"]} for r in rows]}
+
+
+@imports_router.post("/{import_id}/client-result")
+async def client_result(
+    import_id: UUID,
+    body: ClientResultRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Resolve a needs_client row with the extension's fetch result. The
+    client is the last resort, so its failure is terminal: the bookmark is
+    saved link-only rather than bounced back to the server."""
+    from ..tasks.clips import _resolve_link_only
+
+    row = await url_import_service.get_url_import(import_id, current_user["id"])
+    if row is None:
+        raise HTTPException(status_code=404, detail="Import not found")
+    if row["status"] != "needs_client":
+        raise HTTPException(status_code=409, detail=f"Import is {row['status']}")
+    if (body.html is None) == (body.error is None):
+        raise HTTPException(status_code=422, detail="Send exactly one of html or error")
+
+    if body.error is not None:
+        await _resolve_link_only(row, f"{row['error']}; client fetch failed: {body.error}")
+        return {"status": "link_only"}
+
+    if len(body.html.encode()) > clip_router.MAX_FETCH_BYTES:
+        raise HTTPException(status_code=413, detail="HTML larger than 20 MB")
+    try:
+        page = await clip_service.save_page_clip(
+            owner_user_id=row["owner_user_id"],
+            user_id=row["created_by"],
+            url=row["url"],
+            html=body.html,
+            title=body.title or row.get("title"),
+            folder_id=row["folder_id"],
+        )
+    except ArticleExtractionError as e:
+        await _resolve_link_only(row, f"{row['error']}; client HTML unusable: {e}")
+        return {"status": "link_only"}
+    await url_import_service.mark_done(import_id, page_id=page["id"])
+    return {"status": "done"}
 
 
 @imports_router.get("/{batch_id}")

--- a/backend/services/clip_router.py
+++ b/backend/services/clip_router.py
@@ -8,7 +8,6 @@ else is fetched and routed by content: PDF → file clip, HTML → article
 page, anything else fails loud.
 """
 
-import asyncio
 import re
 from urllib.parse import urlparse
 
@@ -62,7 +61,7 @@ async def process_url_import(row: dict) -> dict:
     url = row["url"]
 
     if is_youtube(url):
-        video = await asyncio.to_thread(youtube_transcript.fetch_transcript, url)
+        video = await youtube_transcript.fetch_transcript(url)
         markdown = f"**{video['channel']}**\n\n{video['transcript']}"
         page = await clip_service.create_clip_page(
             owner_user_id=owner_user_id,

--- a/backend/services/clip_service.py
+++ b/backend/services/clip_service.py
@@ -10,6 +10,7 @@ So "Clips" reads like a bookmark manager (the table) with the full captured
 content one click away (the raw folder).
 """
 
+import asyncio
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 from uuid import UUID
@@ -27,11 +28,18 @@ BOOKMARKS_TABLE = "Bookmarks"
 KIND_PAGE = "Page"
 KIND_PDF = "PDF"
 KIND_VIDEO = "Video"
+# A bookmark whose content could not be captured (login wall, no captions,
+# unsupported content) — the link itself is still worth keeping.
+KIND_LINK = "Link"
 
 _BOOKMARK_COLUMNS = [
     {"name": "Title", "type": "text"},
     {"name": "URL", "type": "url"},
-    {"name": "Type", "type": "select", "options": ["Page", "PDF", "Video", "Tweet", "Instagram"]},
+    {
+        "name": "Type",
+        "type": "select",
+        "options": ["Page", "PDF", "Video", "Tweet", "Instagram", "Link"],
+    },
     {"name": "Saved", "type": "text"},
     {"name": "Site", "type": "text"},
     {"name": "Clip", "type": "url"},
@@ -56,9 +64,18 @@ async def clips_subfolder_id(owner_user_id: UUID, user_id: UUID, name: str) -> U
     )
     if existing:
         return existing
-    folder = await files_tree_service.create_folder(
-        owner_user_id, name, user_id, parent_folder_id=root_id
-    )
+    try:
+        folder = await files_tree_service.create_folder(
+            owner_user_id, name, user_id, parent_folder_id=root_id
+        )
+    except files_tree_service.DuplicateFolderName:
+        # Lost a get-or-create race (concurrent batch saves): fetch the winner.
+        return await get_pool().fetchval(
+            "SELECT id FROM folders WHERE owner_user_id = $1 AND parent_folder_id = $2 AND name = $3",
+            owner_user_id,
+            root_id,
+            name,
+        )
     return folder["id"]
 
 
@@ -70,27 +87,34 @@ async def raw_folder_id(owner_user_id: UUID, user_id: UUID) -> UUID:
 # --- Bookmarks table (the bookmark manager) -----------------------------------
 
 
+# tables has no unique (owner, folder, name) index, so a lost get-or-create
+# race would silently duplicate the Bookmarks table. This lock serializes
+# lookups within the process — batch imports save many bookmarks concurrently.
+_bookmarks_table_lock = asyncio.Lock()
+
+
 async def _bookmarks_table(owner_user_id: UUID, user_id: UUID) -> tuple[UUID, dict[str, str]]:
     """Get-or-create the Bookmarks table in the Clips folder. Returns
     (table_id, {column name -> column id}) so callers can build row data."""
     clips_id = await clips_folder_id(owner_user_id, user_id)
-    row = await get_pool().fetchrow(
-        "SELECT id, columns FROM tables WHERE owner_user_id = $1 AND folder_id = $2 AND name = $3",
-        owner_user_id,
-        clips_id,
-        BOOKMARKS_TABLE,
-    )
-    if row:
-        return row["id"], {c["name"]: c["id"] for c in row["columns"]}
-    table = await table_service.create_table(
-        owner_user_id,
-        BOOKMARKS_TABLE,
-        "Everything you've saved with the Stash browser extension.",
-        [dict(c) for c in _BOOKMARK_COLUMNS],
-        user_id,
-        folder_id=clips_id,
-    )
-    return table["id"], {c["name"]: c["id"] for c in table["columns"]}
+    async with _bookmarks_table_lock:
+        row = await get_pool().fetchrow(
+            "SELECT id, columns FROM tables WHERE owner_user_id = $1 AND folder_id = $2 AND name = $3",
+            owner_user_id,
+            clips_id,
+            BOOKMARKS_TABLE,
+        )
+        if row:
+            return row["id"], {c["name"]: c["id"] for c in row["columns"]}
+        table = await table_service.create_table(
+            owner_user_id,
+            BOOKMARKS_TABLE,
+            "Everything you've saved with the Stash browser extension.",
+            [dict(c) for c in _BOOKMARK_COLUMNS],
+            user_id,
+            folder_id=clips_id,
+        )
+        return table["id"], {c["name"]: c["id"] for c in table["columns"]}
 
 
 def _clip_app_url(*, page_id: UUID | None = None, file_id: UUID | None = None) -> str:
@@ -112,9 +136,11 @@ async def add_bookmark(
     title: str,
     url: str,
     kind: str,
-    clip_url: str,
+    clip_url: str | None,
 ) -> None:
-    """Append a row to the Bookmarks table for a saved clip."""
+    """Append a row to the Bookmarks table for a saved clip. clip_url is None
+    for link-only bookmarks (no captured content) — the url-typed Clip cell
+    rejects empty strings, so the cell is omitted entirely."""
     table_id, cols = await _bookmarks_table(owner_user_id, user_id)
     data = {
         cols["Title"]: title,
@@ -122,9 +148,30 @@ async def add_bookmark(
         cols["Type"]: kind,
         cols["Saved"]: datetime.now(UTC).date().isoformat(),
         cols["Site"]: _site(url),
-        cols["Clip"]: clip_url,
     }
+    if clip_url is not None:
+        data[cols["Clip"]] = clip_url
     await table_service.create_row(table_id, data, user_id)
+
+
+async def save_link_only(
+    owner_user_id: UUID,
+    user_id: UUID,
+    *,
+    url: str,
+    title: str | None,
+) -> None:
+    """Index a bookmark whose content hydration is done trying: no raw clip,
+    just the Bookmarks-table row. The URL doubles as the title when the
+    bookmark file didn't carry one."""
+    await add_bookmark(
+        owner_user_id,
+        user_id,
+        title=title or url,
+        url=url,
+        kind=KIND_LINK,
+        clip_url=None,
+    )
 
 
 # --- Saving clips -------------------------------------------------------------

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1536,7 +1536,18 @@ async def find_or_create_root_folder(owner_user_id: UUID, name: str, created_by:
     )
     if row:
         return dict(row)
-    return await create_folder(owner_user_id, name, created_by, parent_folder_id=None)
+    try:
+        return await create_folder(owner_user_id, name, created_by, parent_folder_id=None)
+    except DuplicateFolderName:
+        # Lost a get-or-create race (concurrent clip saves): the folder now
+        # exists, so return it.
+        row = await pool.fetchrow(
+            "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+            "FROM folders WHERE owner_user_id = $1 AND parent_folder_id IS NULL AND name = $2",
+            owner_user_id,
+            name,
+        )
+        return dict(row)
 
 
 # --- Bulk folder-content replacement (skill sync + GitHub import) ---

--- a/backend/services/url_import_service.py
+++ b/backend/services/url_import_service.py
@@ -77,6 +77,7 @@ async def claim(import_id: UUID) -> dict | None:
              OR (status = 'failed' AND attempts < {MAX_ATTEMPTS})
              OR (status = 'processing' AND locked_at < now() - INTERVAL '10 minutes')
           )
+          AND (retry_at IS NULL OR retry_at < now())
         RETURNING *
         """,
         import_id,
@@ -89,13 +90,17 @@ async def mark_done(
     *,
     page_id: UUID | None = None,
     file_id: UUID | None = None,
+    error: str | None = None,
 ) -> None:
+    """Resolve a row. A done row WITH an error is a link-only save: the
+    bookmark row exists but content hydration gave up (the error says why)."""
     await get_pool().execute(
-        "UPDATE url_imports SET status = 'done', error = NULL, locked_at = NULL, "
+        "UPDATE url_imports SET status = 'done', error = $4, locked_at = NULL, "
         "result_page_id = $2, result_file_id = $3, updated_at = now() WHERE id = $1",
         import_id,
         page_id,
         file_id,
+        error[:2000] if error else None,
     )
 
 
@@ -106,6 +111,56 @@ async def mark_failed(import_id: UUID, error: str) -> None:
         import_id,
         error[:2000],
     )
+
+
+async def mark_rate_limited(import_id: UUID, *, retry_minutes: int = 15) -> None:
+    """A 429 is the site pushing back, not a content failure: give the
+    attempt back and park the row until the retry window passes."""
+    await get_pool().execute(
+        f"""
+        UPDATE url_imports
+        SET status = 'pending', attempts = greatest(attempts - 1, 0),
+            retry_at = now() + INTERVAL '{retry_minutes} minutes',
+            dispatched_at = NULL, locked_at = NULL, updated_at = now()
+        WHERE id = $1
+        """,
+        import_id,
+    )
+
+
+async def mark_needs_client(import_id: UUID, error: str) -> None:
+    """The server can't fetch this URL (login wall, IP block); hand it to
+    the browser extension, which retries with the user's own session."""
+    await get_pool().execute(
+        "UPDATE url_imports SET status = 'needs_client', error = $2, locked_at = NULL, "
+        "updated_at = now() WHERE id = $1",
+        import_id,
+        error[:2000],
+    )
+
+
+async def claim_client_batch(owner_user_id: UUID, *, limit: int) -> list[dict]:
+    """Atomically claim needs_client rows for the extension to fetch.
+    locked_at is the claim marker; stale claims (extension died mid-fetch)
+    are reclaimable after 10 minutes."""
+    rows = await get_pool().fetch(
+        """
+        UPDATE url_imports
+        SET locked_at = now(), updated_at = now()
+        WHERE id IN (
+            SELECT id FROM url_imports
+            WHERE owner_user_id = $1 AND status = 'needs_client'
+              AND (locked_at IS NULL OR locked_at < now() - INTERVAL '10 minutes')
+            ORDER BY created_at
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING id, url
+        """,
+        owner_user_id,
+        limit,
+    )
+    return [dict(r) for r in rows]
 
 
 async def batch_progress(batch_id: UUID, owner_user_id: UUID) -> dict | None:
@@ -121,8 +176,9 @@ async def batch_progress(batch_id: UUID, owner_user_id: UUID) -> dict | None:
     counts = await pool.fetchrow(
         """
         SELECT
-            count(*) FILTER (WHERE status = 'done') AS done,
-            count(*) FILTER (WHERE status = 'failed' AND attempts >= 3) AS failed,
+            count(*) FILTER (WHERE status = 'done' AND error IS NULL) AS done,
+            count(*) FILTER (WHERE status = 'done' AND error IS NOT NULL) AS link_only,
+            count(*) FILTER (WHERE status = 'needs_client') AS needs_client,
             count(*) FILTER (
                 WHERE status IN ('pending', 'processing')
                    OR (status = 'failed' AND attempts < 3)
@@ -131,15 +187,17 @@ async def batch_progress(batch_id: UUID, owner_user_id: UUID) -> dict | None:
         """,
         batch_id,
     )
-    failures = await pool.fetch(
+    link_only_rows = await pool.fetch(
         "SELECT url, error FROM url_imports "
-        "WHERE batch_id = $1 AND status = 'failed' ORDER BY updated_at DESC LIMIT 50",
+        "WHERE batch_id = $1 AND status = 'done' AND error IS NOT NULL "
+        "ORDER BY updated_at DESC LIMIT 50",
         batch_id,
     )
     return {
         **dict(batch),
         "done": counts["done"],
-        "failed": counts["failed"],
+        "link_only": counts["link_only"],
+        "needs_client": counts["needs_client"],
         "pending": counts["pending"],
-        "failures": [dict(f) for f in failures],
+        "failures": [dict(f) for f in link_only_rows],
     }

--- a/backend/services/url_import_service.py
+++ b/backend/services/url_import_service.py
@@ -114,12 +114,14 @@ async def mark_failed(import_id: UUID, error: str) -> None:
 
 
 async def mark_rate_limited(import_id: UUID, *, retry_minutes: int = 15) -> None:
-    """A 429 is the site pushing back, not a content failure: give the
-    attempt back and park the row until the retry window passes."""
+    """A 429 parks the row until the retry window passes. The attempt is
+    kept — a site that 429s on every spaced-out retry is blocking us, and
+    after MAX_ATTEMPTS the caller escalates to needs_client instead of
+    cycling forever."""
     await get_pool().execute(
         f"""
         UPDATE url_imports
-        SET status = 'pending', attempts = greatest(attempts - 1, 0),
+        SET status = 'pending',
             retry_at = now() + INTERVAL '{retry_minutes} minutes',
             dispatched_at = NULL, locked_at = NULL, updated_at = now()
         WHERE id = $1

--- a/backend/services/youtube_transcript.py
+++ b/backend/services/youtube_transcript.py
@@ -1,74 +1,54 @@
-"""Fetch a YouTube video's transcript without downloading the video.
+"""Fetch a YouTube video's transcript via ScrapeCreators.
 
-yt-dlp resolves metadata and caption tracks; the chosen track's json3
-payload is fetched directly. Track choice is one deterministic rule —
-manual captions beat auto-generated ones, English beats the video's
-original language — with no cascade beyond that: a video with neither is
-a loud TranscriptUnavailable.
-
-Everything here is synchronous (yt-dlp is blocking); callers run it in a
-worker thread.
+Server-side yt-dlp was the old path; YouTube bot-detects datacenter IPs,
+which is fatal at bulk-import scale (a real bookmark export is a quarter
+YouTube). The transcript comes from ScrapeCreators — the same vendor,
+key, and header as Instagram saves — and the title/channel from YouTube's
+official oEmbed endpoint, which is key-free and not bot-gated. oEmbed is
+checked first: it failing means the video is private or deleted, so no
+transcript can exist and no ScrapeCreators credit should be spent.
 """
 
 import httpx
-import yt_dlp
+
+from ..config import settings
+
+SC_TRANSCRIPT_URL = "https://api.scrapecreators.com/v1/youtube/video/transcript"
+OEMBED_URL = "https://www.youtube.com/oembed"
+
+# ScrapeCreators may transcribe on demand; give it room.
+_TIMEOUT = 90
 
 
 class TranscriptUnavailable(Exception):
-    """The video has no usable caption track."""
+    """The video is private/deleted or has no usable caption track."""
 
 
-_FETCH_TIMEOUT = 30
-
-
-def fetch_transcript(url: str) -> dict:
+async def fetch_transcript(url: str) -> dict:
     """Return {"title", "channel", "transcript"} for a YouTube URL."""
-    options = {"skip_download": True, "quiet": True, "no_warnings": True}
-    with yt_dlp.YoutubeDL(options) as ydl:
-        info = ydl.extract_info(url, download=False)
+    if not settings.SCRAPECREATORS_API_KEY:
+        raise RuntimeError("SCRAPECREATORS_API_KEY is not set")
 
-    track = _pick_track(
-        info.get("subtitles") or {},
-        info.get("automatic_captions") or {},
-        info.get("language"),
-    )
-    if track is None:
-        raise TranscriptUnavailable("No transcript available for this video")
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        oembed = await client.get(OEMBED_URL, params={"url": url, "format": "json"})
+        if oembed.status_code != 200:
+            raise TranscriptUnavailable(
+                f"Video is private or deleted (oEmbed HTTP {oembed.status_code})"
+            )
+        meta = oembed.json()
 
-    json3_url = next((f["url"] for f in track if f.get("ext") == "json3"), None)
-    if json3_url is None:
-        raise TranscriptUnavailable("Caption track has no json3 format")
-    response = httpx.get(json3_url, timeout=_FETCH_TIMEOUT)
-    response.raise_for_status()
+        sc = await client.get(
+            SC_TRANSCRIPT_URL,
+            params={"url": url},
+            headers={"x-api-key": settings.SCRAPECREATORS_API_KEY},
+        )
+        sc.raise_for_status()
+        transcript = sc.json().get("transcript_only_text")
+        if not transcript:
+            raise TranscriptUnavailable("No transcript available for this video")
 
     return {
-        "title": info.get("title") or url,
-        "channel": info.get("channel") or info.get("uploader") or "",
-        "transcript": _parse_json3(response.json()),
+        "title": meta["title"],
+        "channel": meta["author_name"],
+        "transcript": transcript,
     }
-
-
-def _pick_track(subtitles: dict, automatic: dict, original_language: str | None) -> list | None:
-    """Manual captions beat auto-generated; English beats the original language."""
-    for tracks in (subtitles, automatic):
-        for prefix in ("en", original_language):
-            if not prefix:
-                continue
-            for lang, formats in tracks.items():
-                if lang.startswith(prefix):
-                    return formats
-    return None
-
-
-def _parse_json3(payload: dict) -> str:
-    """Flatten YouTube's json3 caption events to plain text."""
-    lines: list[str] = []
-    for event in payload.get("events", []):
-        text = "".join(seg.get("utf8", "") for seg in event.get("segs", []))
-        text = text.strip()
-        if text:
-            lines.append(text)
-    transcript = " ".join(lines)
-    if not transcript:
-        raise TranscriptUnavailable("Caption track is empty")
-    return transcript

--- a/backend/tasks/clips.py
+++ b/backend/tasks/clips.py
@@ -9,7 +9,8 @@ cluster heavily (a quarter of a real export is youtube.com) and hammering
 one site from a datacenter IP is how imports get rate-limited.
 
 Failure routing, in order of preference:
-  - 429                → park the row (retry_at) without burning an attempt
+  - 429                → park the row (retry_at); a site that 429s every
+                          spaced-out retry escalates to needs_client
   - 401/403 from the   → needs_client: the browser extension refetches with
     bookmark's own host   the user's session (import_fetch.ts)
   - no usable content  → link-only bookmark, immediately (retry can't help)

--- a/backend/tasks/clips.py
+++ b/backend/tasks/clips.py
@@ -1,27 +1,51 @@
 """URL-import worker: fetch URL-only clips out-of-band.
 
-Work arrives in batches of ids rather than one task per URL so a 10k
-bookmark import becomes ~100 queue entries — other periodic work
-interleaves between batches instead of starving behind a flooded queue.
-Rows are claimed with an attempts guard (see url_import_service), so
-creation-time dispatch and the Beat sweep can overlap safely.
+Work arrives in batches of ids rather than one task per URL, and the
+dispatcher only keeps WINDOW_URLS in flight at once — a 40k bookmark
+import trickles through 2 of the worker's 4 slots instead of starving
+embeddings and syncs behind a flooded queue. Batches are interleaved
+across domains and fetches are capped per domain, because bookmark files
+cluster heavily (a quarter of a real export is youtube.com) and hammering
+one site from a datacenter IP is how imports get rate-limited.
+
+Failure routing, in order of preference:
+  - 429                → park the row (retry_at) without burning an attempt
+  - 401/403 from the   → needs_client: the browser extension refetches with
+    bookmark's own host   the user's session (import_fetch.ts)
+  - no usable content  → link-only bookmark, immediately (retry can't help)
+  - anything else      → retry up to MAX_ATTEMPTS, then link-only bookmark
+
+Every row therefore ends as either a hydrated clip or a link-only bookmark
+— an imported bookmark is never silently lost, and the row's error says
+why content is missing.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections import defaultdict, deque
+from urllib.parse import urlparse
 from uuid import UUID
+
+import httpx
 
 from ..celery_app import celery
 from ..database import get_pool
-from ..services import clip_router, url_import_service
+from ..services import clip_router, clip_service, url_import_service
+from ..services.article_extraction import ArticleExtractionError
+from ..services.youtube_transcript import TranscriptUnavailable
 from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 100
 CONCURRENCY = 8
+PER_DOMAIN_CONCURRENCY = 2
+# 2 batches in flight leaves 2 of the worker's 4 slots free for other work.
+WINDOW_URLS = 2 * BATCH_SIZE
+NEEDS_CLIENT_EXPIRY_HOURS = 24
+EXPIRY_SWEEP_LIMIT = 200
 
 
 async def _process_one(import_id: UUID) -> None:
@@ -30,30 +54,77 @@ async def _process_one(import_id: UUID) -> None:
         return
     try:
         result = await clip_router.process_url_import(row)
+    except (
+        clip_router.UnsupportedUrlContent,
+        ArticleExtractionError,
+        TranscriptUnavailable,
+    ) as exc:
+        # Deterministic no-content outcomes: retrying can't produce content,
+        # but the link itself is still worth keeping.
+        await _resolve_link_only(row, f"{type(exc).__name__}: {exc}")
+    except httpx.HTTPStatusError as exc:
+        await _resolve_http_error(row, exc)
     except Exception as exc:
         logger.warning(
             "url import failed id=%s exception_type=%s",
             import_id,
             type(exc).__name__,
         )
-        await url_import_service.mark_failed(import_id, f"{type(exc).__name__}: {exc}")
-        return
-    await url_import_service.mark_done(
-        import_id,
-        page_id=result.get("page_id"),
-        file_id=result.get("file_id"),
+        await _resolve_failure(row, f"{type(exc).__name__}: {exc}")
+    else:
+        await url_import_service.mark_done(
+            row["id"],
+            page_id=result.get("page_id"),
+            file_id=result.get("file_id"),
+        )
+
+
+async def _resolve_http_error(row: dict, exc: httpx.HTTPStatusError) -> None:
+    code = exc.response.status_code
+    # 401/403 count as client-recoverable only when the bookmark's own site
+    # sent them (login wall, IP block) — the same status from a third-party
+    # API call (ScrapeCreators) means our config is broken, not the site.
+    from_bookmark_host = exc.request.url.host == urlparse(row["url"]).hostname
+    if code in (401, 403) and from_bookmark_host:
+        await url_import_service.mark_needs_client(row["id"], f"HTTP {code}")
+    elif code == 429 and row["attempts"] < url_import_service.MAX_ATTEMPTS:
+        await url_import_service.mark_rate_limited(row["id"])
+    elif code == 429 and from_bookmark_host:
+        await url_import_service.mark_needs_client(row["id"], "HTTP 429 (rate limited)")
+    else:
+        await _resolve_failure(row, f"HTTP {code} from {exc.request.url.host}")
+
+
+async def _resolve_failure(row: dict, error: str) -> None:
+    if row["attempts"] >= url_import_service.MAX_ATTEMPTS:
+        await _resolve_link_only(row, error)
+    else:
+        await url_import_service.mark_failed(row["id"], error)
+
+
+async def _resolve_link_only(row: dict, error: str) -> None:
+    await clip_service.save_link_only(
+        row["owner_user_id"],
+        row["created_by"],
+        url=row["url"],
+        title=row.get("title"),
     )
+    await url_import_service.mark_done(row["id"], error=error)
 
 
 async def _process_batch(ids: list[UUID]) -> str:
-    semaphore = asyncio.Semaphore(CONCURRENCY)
+    rows = await get_pool().fetch("SELECT id, url FROM url_imports WHERE id = ANY($1)", ids)
+    overall = asyncio.Semaphore(CONCURRENCY)
+    per_domain: dict[str, asyncio.Semaphore] = defaultdict(
+        lambda: asyncio.Semaphore(PER_DOMAIN_CONCURRENCY)
+    )
 
-    async def bounded(import_id: UUID) -> None:
-        async with semaphore:
+    async def bounded(import_id: UUID, url: str) -> None:
+        async with per_domain[urlparse(url).netloc], overall:
             await _process_one(import_id)
 
-    await asyncio.gather(*(bounded(i) for i in ids))
-    return f"processed {len(ids)}"
+    await asyncio.gather(*(bounded(r["id"], r["url"]) for r in rows))
+    return f"processed {len(rows)}"
 
 
 @celery.task(name="backend.tasks.clips.process_url_imports")
@@ -61,36 +132,102 @@ def process_url_imports(ids: list[str]) -> str:
     return run_async(_process_batch([UUID(i) for i in ids]))
 
 
-def dispatch_url_imports(ids: list[UUID]) -> None:
-    """Fan a set of import rows out to the worker in batch-sized tasks."""
+def _interleave_by_domain(rows: list[dict]) -> list[dict]:
+    """Round-robin rows across domains so no batch hammers a single site."""
+    queues: dict[str, deque] = defaultdict(deque)
+    for row in rows:
+        queues[urlparse(row["url"]).netloc].append(row)
+    order = deque(queues.values())
+    interleaved: list[dict] = []
+    while order:
+        queue = order.popleft()
+        interleaved.append(queue.popleft())
+        if queue:
+            order.append(queue)
+    return interleaved
+
+
+async def dispatch_url_imports(ids: list[UUID]) -> None:
+    """Interactive path (single async clip): dispatch immediately, bypassing
+    the bulk window so one YouTube clip never queues behind a 40k import."""
+    await get_pool().execute("UPDATE url_imports SET dispatched_at = now() WHERE id = ANY($1)", ids)
     for start in range(0, len(ids), BATCH_SIZE):
         chunk = ids[start : start + BATCH_SIZE]
         process_url_imports.delay([str(i) for i in chunk])
 
 
-async def _enqueue_pending() -> int:
-    """Sweep for rows that lost their dispatch (Redis blip, worker death).
-
-    The age filter keeps the sweep from re-queueing rows whose
-    creation-time dispatch is simply still in the queue.
-    """
+async def top_up_url_imports() -> int:
+    """Dispatch eligible rows up to the in-flight window. Called at import
+    creation and by the Beat sweep; the dispatched_at bookkeeping makes the
+    two safe to overlap, and re-dispatches rows whose task was lost (Redis
+    blip, worker death) once their dispatched_at goes stale."""
     pool = get_pool()
+    in_flight = await pool.fetchval(
+        """
+        SELECT count(*) FROM url_imports
+        WHERE status = 'processing'
+           OR (status = 'pending' AND dispatched_at > now() - INTERVAL '2 minutes')
+        """
+    )
+    capacity = WINDOW_URLS - in_flight
+    if capacity <= 0:
+        return 0
     rows = await pool.fetch(
         f"""
-        SELECT id FROM url_imports
+        SELECT id, url FROM url_imports
         WHERE (
-                (status = 'pending' AND created_at < now() - INTERVAL '2 minutes')
+                (status = 'pending'
+                 AND (dispatched_at IS NULL OR dispatched_at < now() - INTERVAL '2 minutes'))
              OR (status = 'failed' AND attempts < {url_import_service.MAX_ATTEMPTS})
              OR (status = 'processing' AND locked_at < now() - INTERVAL '10 minutes')
         )
+          AND (retry_at IS NULL OR retry_at < now())
         ORDER BY created_at
-        LIMIT 1000
+        LIMIT $1
         """,
+        capacity,
     )
-    dispatch_url_imports([r["id"] for r in rows])
+    if not rows:
+        return 0
+    ordered = _interleave_by_domain([dict(r) for r in rows])
+    ids = [r["id"] for r in ordered]
+    await pool.execute("UPDATE url_imports SET dispatched_at = now() WHERE id = ANY($1)", ids)
+    for start in range(0, len(ids), BATCH_SIZE):
+        chunk = ids[start : start + BATCH_SIZE]
+        process_url_imports.delay([str(i) for i in chunk])
+    return len(ids)
+
+
+async def _expire_needs_client() -> int:
+    """needs_client rows nobody's extension picked up resolve as link-only
+    bookmarks — a batch must never hang open waiting for a client that
+    doesn't exist."""
+    rows = await get_pool().fetch(
+        f"""
+        SELECT * FROM url_imports
+        WHERE status = 'needs_client'
+          AND updated_at < now() - INTERVAL '{NEEDS_CLIENT_EXPIRY_HOURS} hours'
+        ORDER BY created_at
+        LIMIT {EXPIRY_SWEEP_LIMIT}
+        """
+    )
+    for row in rows:
+        record = dict(row)
+        await _resolve_link_only(
+            record,
+            f"{record['error']}; no browser extension fetched it "
+            f"within {NEEDS_CLIENT_EXPIRY_HOURS}h",
+        )
     return len(rows)
+
+
+async def _sweep() -> int:
+    expired = await _expire_needs_client()
+    if expired:
+        logger.info("expired %d needs_client url imports to link-only", expired)
+    return await top_up_url_imports()
 
 
 @celery.task(name="backend.tasks.clips.enqueue_pending_url_imports")
 def enqueue_pending_url_imports() -> int:
-    return run_async(_enqueue_pending())
+    return run_async(_sweep())

--- a/backend/tests/test_bookmark_imports.py
+++ b/backend/tests/test_bookmark_imports.py
@@ -161,6 +161,11 @@ async def test_import_progress_reports_failures_per_url(
         return ARTICLE_HTML.encode(), "text/html"
 
     monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    # Put the dead link on its last attempt so its failure is terminal.
+    await pool.execute(
+        "UPDATE url_imports SET attempts = 2 WHERE owner_user_id = $1 AND url LIKE '%/two'",
+        UUID(owner_id),
+    )
     ids = [
         r["id"]
         for r in await pool.fetch(
@@ -174,8 +179,10 @@ async def test_import_progress_reports_failures_per_url(
     body = progress.json()
     assert body["total"] == 3
     assert body["done"] == 2
-    # attempts < 3, so the failed row still counts as retryable/pending.
-    assert body["pending"] == 1
+    # Terminal failures keep the bookmark as a link-only row and surface in
+    # the failures list — the batch drains to zero pending.
+    assert body["link_only"] == 1
+    assert body["pending"] == 0
     assert body["failures"][0]["url"] == "https://example.com/two"
     assert "dead link" in body["failures"][0]["error"]
 

--- a/backend/tests/test_integration_indexer_log_security.py
+++ b/backend/tests/test_integration_indexer_log_security.py
@@ -101,6 +101,12 @@ async def test_github_index_success_logs_internal_source_id_only(monkeypatch):
     async def head_sha(url, headers):
         return "a" * 40
 
+    async def snapshot_tree(url, headers, head_sha):
+        return {
+            "truncated": False,
+            "tree": [{"type": "blob", "path": "webflow/secret.md", "size": 10}],
+        }
+
     monkeypatch.setattr(github_indexer, "get_valid_token", _token)
     monkeypatch.setattr(
         github_indexer,
@@ -110,6 +116,7 @@ async def test_github_index_success_logs_internal_source_id_only(monkeypatch):
         ),
     )
     monkeypatch.setattr(github_indexer, "_github_head_sha", head_sha)
+    monkeypatch.setattr(github_indexer, "_github_snapshot_tree", snapshot_tree)
     monkeypatch.setattr(github_indexer, "_crawl_archive", crawl_archive)
     monkeypatch.setattr(github_indexer.source_service, "upsert_content_document", _noop)
     monkeypatch.setattr(github_indexer.source_service, "remove_missing_documents", _noop)

--- a/backend/tests/test_url_imports.py
+++ b/backend/tests/test_url_imports.py
@@ -1,9 +1,11 @@
 """URL imports: async fetch jobs behind the clip API.
 
 The router must classify URLs in one place (YouTube → transcript, arXiv
-abs → paper PDF, PDFs → file clips, HTML → article pages) and every
-failure must land on the row as a loud per-item error — a dead link in a
-bookmark import can never block the batch.
+abs → paper PDF, PDFs → file clips, HTML → article pages), and every row
+must end as either a hydrated clip or a link-only bookmark — a dead link
+in a bookmark import can never block the batch or silently vanish. Rate
+limits park rows instead of burning attempts, and login walls hand rows
+to the extension (needs_client) before giving up.
 """
 
 from uuid import UUID
@@ -12,8 +14,9 @@ import httpx
 import pytest
 from httpx import AsyncClient
 
-from backend.services import clip_router, storage_service, url_import_service
-from backend.services.youtube_transcript import TranscriptUnavailable, _parse_json3, _pick_track
+from backend.config import settings
+from backend.services import clip_router, storage_service, url_import_service, youtube_transcript
+from backend.services.youtube_transcript import TranscriptUnavailable
 from backend.tasks import clips as clips_tasks
 from backend.tasks import extraction
 
@@ -61,28 +64,92 @@ def test_is_async_url_covers_youtube_and_arxiv() -> None:
     assert not clip_router.is_async_url("https://example.com/post")
 
 
-# --- YouTube caption parsing ---
+# --- YouTube transcript fetching (ScrapeCreators + oEmbed) ---
 
 
-def test_pick_track_prefers_manual_then_english() -> None:
-    manual = {"de": [{"ext": "json3", "url": "manual-de"}]}
-    auto = {"en": [{"ext": "json3", "url": "auto-en"}]}
-    assert _pick_track(manual, auto, "de")[0]["url"] == "manual-de"
-    assert _pick_track({}, auto, "de")[0]["url"] == "auto-en"
-    assert _pick_track({}, {}, "de") is None
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("GET", youtube_transcript.SC_TRANSCRIPT_URL)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=request,
+                response=httpx.Response(self.status_code, request=request),
+            )
 
 
-def test_parse_json3_flattens_events() -> None:
-    payload = {
-        "events": [
-            {"segs": [{"utf8": "hello "}, {"utf8": "world"}]},
-            {"segs": [{"utf8": "\n"}]},
-            {"segs": [{"utf8": "again"}]},
-        ]
-    }
-    assert _parse_json3(payload) == "hello world again"
-    with pytest.raises(TranscriptUnavailable):
-        _parse_json3({"events": []})
+class _FakeAsyncClient:
+    """Feeds canned responses in call order (oEmbed first, then SC)."""
+
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = responses
+        self.calls: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url: str, **kwargs) -> _FakeResponse:
+        self.calls.append(url)
+        return self._responses.pop(0)
+
+
+def _fake_youtube_http(monkeypatch, responses: list[_FakeResponse]) -> _FakeAsyncClient:
+    fake = _FakeAsyncClient(responses)
+    monkeypatch.setattr(youtube_transcript.httpx, "AsyncClient", lambda **kw: fake)
+    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "test-key")
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_fetch_transcript_combines_oembed_and_scrapecreators(monkeypatch) -> None:
+    _fake_youtube_http(
+        monkeypatch,
+        [
+            _FakeResponse(200, {"title": "A Talk", "author_name": "Chan"}),
+            _FakeResponse(200, {"transcript_only_text": "words words"}),
+        ],
+    )
+    video = await youtube_transcript.fetch_transcript("https://www.youtube.com/watch?v=abc")
+    assert video == {"title": "A Talk", "channel": "Chan", "transcript": "words words"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_transcript_private_video_spends_no_credit(monkeypatch) -> None:
+    fake = _fake_youtube_http(monkeypatch, [_FakeResponse(401)])
+    with pytest.raises(TranscriptUnavailable, match="private or deleted"):
+        await youtube_transcript.fetch_transcript("https://www.youtube.com/watch?v=abc")
+    # oEmbed failing must short-circuit before the ScrapeCreators call.
+    assert fake.calls == [youtube_transcript.OEMBED_URL]
+
+
+@pytest.mark.asyncio
+async def test_fetch_transcript_null_transcript_is_unavailable(monkeypatch) -> None:
+    _fake_youtube_http(
+        monkeypatch,
+        [
+            _FakeResponse(200, {"title": "A Talk", "author_name": "Chan"}),
+            _FakeResponse(200, {"transcript_only_text": None}),
+        ],
+    )
+    with pytest.raises(TranscriptUnavailable, match="No transcript"):
+        await youtube_transcript.fetch_transcript("https://www.youtube.com/watch?v=abc")
+
+
+@pytest.mark.asyncio
+async def test_fetch_transcript_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "")
+    with pytest.raises(RuntimeError, match="SCRAPECREATORS_API_KEY"):
+        await youtube_transcript.fetch_transcript("https://www.youtube.com/watch?v=abc")
 
 
 # --- Endpoint behaviour ---
@@ -203,11 +270,10 @@ async def test_worker_turns_youtube_url_into_transcript_page(
     _, owner_id = await _register(client)
     import_id = await _make_import(owner_id, "https://www.youtube.com/watch?v=abc123")
 
-    monkeypatch.setattr(
-        clip_router.youtube_transcript,
-        "fetch_transcript",
-        lambda url: {"title": "A Great Talk", "channel": "Chan", "transcript": "words words"},
-    )
+    async def fake_transcript(url: str) -> dict:
+        return {"title": "A Great Talk", "channel": "Chan", "transcript": "words words"}
+
+    monkeypatch.setattr(clip_router.youtube_transcript, "fetch_transcript", fake_transcript)
     await clips_tasks._process_batch([import_id])
 
     row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
@@ -252,10 +318,23 @@ async def test_done_rows_are_not_reclaimed(client: AsyncClient, pool, monkeypatc
     assert await url_import_service.claim(import_id) is None
 
 
+async def _bookmark_rows(pool, owner_id: str) -> list[dict]:
+    rows = await pool.fetch(
+        "SELECT r.data FROM table_rows r JOIN tables t ON t.id = r.table_id "
+        "WHERE t.name = 'Bookmarks' AND t.owner_user_id = $1",
+        UUID(owner_id),
+    )
+    return [r["data"] for r in rows]
+
+
 @pytest.mark.asyncio
-async def test_unsupported_content_type_fails_loud(client: AsyncClient, pool, monkeypatch) -> None:
+async def test_unsupported_content_becomes_link_only(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """Content we can't capture is deterministic — the bookmark must still be
+    saved as a link row instead of retrying or vanishing."""
     _, owner_id = await _register(client)
-    import_id = await _make_import(owner_id, "https://example.com/video.mp4")
+    import_id = await _make_import(owner_id, "https://example.com/video.mp4", title="A Video")
 
     async def fake_fetch(url: str):
         return b"\x00\x01binary", "video/mp4"
@@ -264,5 +343,261 @@ async def test_unsupported_content_type_fails_loud(client: AsyncClient, pool, mo
     await clips_tasks._process_batch([import_id])
 
     row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
-    assert row["status"] == "failed"
+    assert row["status"] == "done"
     assert "video/mp4" in row["error"]
+    assert row["result_page_id"] is None
+
+    bookmarks = await _bookmark_rows(pool, owner_id)
+    assert len(bookmarks) == 1
+    assert "A Video" in bookmarks[0].values()
+    assert "Link" in bookmarks[0].values()
+
+
+# --- Failure routing: rate limits, login walls, exhausted retries ---
+
+
+def _status_error(code: int, url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", url)
+    return httpx.HTTPStatusError(
+        f"HTTP {code}", request=request, response=httpx.Response(code, request=request)
+    )
+
+
+@pytest.mark.asyncio
+async def test_429_parks_row_without_burning_an_attempt(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/busy")
+
+    async def fake_fetch(url: str):
+        raise _status_error(429, url)
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "pending"
+    assert row["attempts"] == 0
+    assert row["retry_at"] is not None
+    # Parked rows are not claimable until the retry window passes.
+    assert await url_import_service.claim(import_id) is None
+
+
+@pytest.mark.asyncio
+async def test_403_from_bookmark_host_goes_to_client_queue(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://www.reddit.com/r/WhatIsMyCQS/")
+
+    async def fake_fetch(url: str):
+        raise _status_error(403, url)
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "needs_client"
+    assert "403" in row["error"]
+
+
+@pytest.mark.asyncio
+async def test_403_from_third_party_api_is_a_plain_failure(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """A 403 from ScrapeCreators means our key/config is broken — sending the
+    row to the user's browser can't fix that."""
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://www.youtube.com/watch?v=abc")
+
+    async def fake_transcript(url: str) -> dict:
+        raise _status_error(403, "https://api.scrapecreators.com/v1/youtube/video/transcript")
+
+    monkeypatch.setattr(clip_router.youtube_transcript, "fetch_transcript", fake_transcript)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "failed"
+    assert "api.scrapecreators.com" in row["error"]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_attempts_resolve_link_only(client: AsyncClient, pool, monkeypatch) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://example.com/flaky", title="Flaky")
+    await pool.execute(
+        "UPDATE url_imports SET status = 'failed', attempts = 2 WHERE id = $1", import_id
+    )
+
+    async def fake_fetch(url: str):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert "ConnectError" in row["error"]
+    bookmarks = await _bookmark_rows(pool, owner_id)
+    assert len(bookmarks) == 1
+    assert "Flaky" in bookmarks[0].values()
+
+
+# --- Windowed dispatch ---
+
+
+@pytest.mark.asyncio
+async def test_top_up_caps_in_flight_urls(client: AsyncClient, pool, monkeypatch) -> None:
+    dispatched: list[list[str]] = []
+    monkeypatch.setattr(
+        clips_tasks.process_url_imports, "delay", lambda ids: dispatched.append(ids)
+    )
+    _, owner_id = await _register(client)
+    await url_import_service.create_url_imports(
+        owner_user_id=UUID(owner_id),
+        created_by=UUID(owner_id),
+        items=[{"url": f"https://example.com/{i}"} for i in range(clips_tasks.WINDOW_URLS + 50)],
+    )
+
+    first = await clips_tasks.top_up_url_imports()
+    assert first == clips_tasks.WINDOW_URLS
+    assert sum(len(chunk) for chunk in dispatched) == clips_tasks.WINDOW_URLS
+
+    # The window is full (dispatched rows count as in flight) — a second
+    # sweep must not dispatch the remainder yet.
+    assert await clips_tasks.top_up_url_imports() == 0
+
+
+def test_interleave_by_domain_round_robins() -> None:
+    rows = [
+        {"url": "https://a.example/1"},
+        {"url": "https://a.example/2"},
+        {"url": "https://a.example/3"},
+        {"url": "https://b.example/1"},
+        {"url": "https://c.example/1"},
+    ]
+    ordered = [r["url"] for r in clips_tasks._interleave_by_domain(rows)]
+    assert ordered == [
+        "https://a.example/1",
+        "https://b.example/1",
+        "https://c.example/1",
+        "https://a.example/2",
+        "https://a.example/3",
+    ]
+
+
+# --- Extension-fed hydration (client queue) ---
+
+
+async def _needs_client_row(pool, owner_id: str, url: str, title: str | None = None) -> UUID:
+    import_id = await _make_import(owner_id, url, title)
+    await url_import_service.mark_needs_client(import_id, "HTTP 403")
+    return import_id
+
+
+@pytest.mark.asyncio
+async def test_client_queue_claims_are_owner_scoped_and_leased(client: AsyncClient, pool) -> None:
+    headers, owner_id = await _register(client)
+    other_headers, _ = await _register(client)
+    import_id = await _needs_client_row(pool, owner_id, "https://example.com/walled")
+
+    other = await client.get("/api/v1/me/imports/client-queue", headers=other_headers)
+    assert other.json()["items"] == []
+
+    mine = await client.get("/api/v1/me/imports/client-queue", headers=headers)
+    assert [i["id"] for i in mine.json()["items"]] == [str(import_id)]
+
+    # Claimed rows are leased — an immediate re-poll must not hand them out again.
+    again = await client.get("/api/v1/me/imports/client-queue", headers=headers)
+    assert again.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_client_result_html_hydrates_the_clip(client: AsyncClient, pool) -> None:
+    headers, owner_id = await _register(client)
+    import_id = await _needs_client_row(pool, owner_id, "https://example.com/walled")
+
+    resp = await client.post(
+        f"/api/v1/me/imports/{import_id}/client-result",
+        json={"html": ARTICLE_HTML},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "done"
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert row["error"] is None
+    page = await pool.fetchrow("SELECT name FROM pages WHERE id = $1", row["result_page_id"])
+    assert page["name"] == "Why Simplicity Wins"
+
+
+@pytest.mark.asyncio
+async def test_client_result_error_saves_link_only(client: AsyncClient, pool) -> None:
+    headers, owner_id = await _register(client)
+    import_id = await _needs_client_row(
+        pool, owner_id, "https://example.com/walled", title="Walled"
+    )
+
+    resp = await client.post(
+        f"/api/v1/me/imports/{import_id}/client-result",
+        json={"error": "HTTP 403"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "link_only"
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert "client fetch failed" in row["error"]
+    bookmarks = await _bookmark_rows(pool, owner_id)
+    assert "Walled" in bookmarks[0].values()
+
+
+@pytest.mark.asyncio
+async def test_client_result_rejects_wrong_state_and_bad_body(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    headers, owner_id = await _register(client)
+    monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda ids: None)
+    import_id = await _make_import(owner_id, "https://example.com/normal")
+
+    wrong_state = await client.post(
+        f"/api/v1/me/imports/{import_id}/client-result",
+        json={"html": "<html></html>"},
+        headers=headers,
+    )
+    assert wrong_state.status_code == 409
+
+    await url_import_service.mark_needs_client(import_id, "HTTP 403")
+    both = await client.post(
+        f"/api/v1/me/imports/{import_id}/client-result",
+        json={"html": "<html></html>", "error": "x"},
+        headers=headers,
+    )
+    assert both.status_code == 422
+    neither = await client.post(
+        f"/api/v1/me/imports/{import_id}/client-result", json={}, headers=headers
+    )
+    assert neither.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_needs_client_rows_expire_to_link_only(client: AsyncClient, pool) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _needs_client_row(
+        pool, owner_id, "https://example.com/walled", title="Walled"
+    )
+    await pool.execute(
+        "UPDATE url_imports SET updated_at = now() - INTERVAL '25 hours' WHERE id = $1",
+        import_id,
+    )
+
+    expired = await clips_tasks._expire_needs_client()
+    assert expired == 1
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert "no browser extension" in row["error"]
+    bookmarks = await _bookmark_rows(pool, owner_id)
+    assert "Walled" in bookmarks[0].values()

--- a/backend/tests/test_url_imports.py
+++ b/backend/tests/test_url_imports.py
@@ -364,9 +364,12 @@ def _status_error(code: int, url: str) -> httpx.HTTPStatusError:
 
 
 @pytest.mark.asyncio
-async def test_429_parks_row_without_burning_an_attempt(
+async def test_429_parks_row_then_escalates_to_client(
     client: AsyncClient, pool, monkeypatch
 ) -> None:
+    """A rate limit parks the row for a spaced-out retry; a site that 429s
+    every retry is blocking us, so the row escalates to needs_client instead
+    of cycling forever."""
     _, owner_id = await _register(client)
     import_id = await _make_import(owner_id, "https://example.com/busy")
 
@@ -378,10 +381,19 @@ async def test_429_parks_row_without_burning_an_attempt(
 
     row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
     assert row["status"] == "pending"
-    assert row["attempts"] == 0
+    assert row["attempts"] == 1
     assert row["retry_at"] is not None
     # Parked rows are not claimable until the retry window passes.
     assert await url_import_service.claim(import_id) is None
+
+    # Two more 429s across elapsed retry windows exhaust the attempts and
+    # hand the row to the extension.
+    for _ in range(2):
+        await pool.execute("UPDATE url_imports SET retry_at = now() WHERE id = $1", import_id)
+        await clips_tasks._process_batch([import_id])
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "needs_client"
+    assert "429" in row["error"]
 
 
 @pytest.mark.asyncio

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stash Sync",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Saves webpages, PDFs, and your ChatGPT/Claude conversations to Stash.",
   "permissions": [
     "storage",
@@ -14,12 +14,7 @@
     "cookies"
   ],
   "host_permissions": [
-    "https://api.joinstash.ai/*",
-    "http://localhost:3456/*",
-    "https://chatgpt.com/*",
-    "https://chat.openai.com/*",
-    "https://claude.ai/*",
-    "https://www.instagram.com/*"
+    "<all_urls>"
   ],
   "background": {
     "service_worker": "dist/background.js"

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -13,6 +13,7 @@ import {
   initClipper,
   uploadPageClip,
 } from './background/clip';
+import { initImportFetch } from './background/import_fetch';
 import {
   initInstagram,
   receiveSavedItems,
@@ -27,6 +28,7 @@ const DEFAULT_API_BASE = 'https://api.joinstash.ai';
 initClipper();
 initChatPoll(syncConversation);
 initInstagram();
+initImportFetch();
 
 // The X bookmark harvest was removed (X syncs server-side over OAuth now); clear
 // any stale harvest error it left behind so the popup doesn't keep showing it.

--- a/chrome_extension/src/background/clip.ts
+++ b/chrome_extension/src/background/clip.ts
@@ -5,6 +5,7 @@
 // also run here so credentials stay in the worker.
 
 import { flashOkBadge, setBadge, stashConfig } from '../lib/stash';
+import { drainQueue } from './import_fetch';
 
 export interface PageClip {
   url: string;
@@ -166,6 +167,12 @@ export async function clipAllTabs(): Promise<any> {
   }
   const data = await response.json();
   await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'tabs' } });
+  chrome.notifications.create({
+    type: 'basic',
+    iconUrl: 'icons/icon128.png',
+    title: 'Saved to Stash',
+    message: `Saving ${data.total} tab${data.total === 1 ? '' : 's'} — check the popup for progress.`,
+  });
   return { ok: true, importId: data.import_id, total: data.total };
 }
 
@@ -191,6 +198,12 @@ export async function importBookmarks(name: string, content: string): Promise<an
   }
   const data = await response.json();
   await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'bookmarks' } });
+  chrome.notifications.create({
+    type: 'basic',
+    iconUrl: 'icons/icon128.png',
+    title: 'Bookmark import started',
+    message: `Importing ${data.total} bookmarks — Stash fetches them in the background.`,
+  });
   return { ok: true, importId: data.import_id, total: data.total };
 }
 
@@ -201,5 +214,11 @@ export async function importProgress(importId: string): Promise<any> {
     headers: { Authorization: `Bearer ${cfg.apiKey}` },
   });
   if (!response.ok) return { ok: false, error: `Progress check failed (${response.status})` };
-  return { ok: true, progress: await response.json() };
+  const progress = await response.json();
+  if (progress.needs_client > 0) {
+    // Rows are waiting on this browser's session — no need to wait for the
+    // next 5-minute alarm.
+    void drainQueue();
+  }
+  return { ok: true, progress };
 }

--- a/chrome_extension/src/background/import_fetch.ts
+++ b/chrome_extension/src/background/import_fetch.ts
@@ -1,0 +1,78 @@
+// Extension-fed hydration: URLs the server can't fetch (login walls, IP
+// blocks) land in a needs_client queue server-side; this module polls the
+// queue, refetches each URL with the user's own browser session (cookies
+// attach via the <all_urls> host permission), and posts the raw HTML back
+// — article extraction stays server-side. Claims are lease-based
+// (locked_at), so a worker killed mid-batch is retried in 10 minutes.
+
+import { stashConfig, type StashConfig } from '../lib/stash';
+
+const ALARM_NAME = 'import-fetch';
+const POLL_PERIOD_MINUTES = 5;
+const BATCH_LIMIT = 5;
+const FETCH_TIMEOUT_MS = 30_000;
+const INTER_FETCH_DELAY_MS = 1000;
+const MAX_HTML_BYTES = 20 * 1024 * 1024;
+
+export function initImportFetch(): void {
+  chrome.runtime.onInstalled.addListener(schedule);
+  chrome.runtime.onStartup.addListener(schedule);
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === ALARM_NAME) void drainQueue();
+  });
+}
+
+function schedule(): void {
+  chrome.alarms.create(ALARM_NAME, { periodInMinutes: POLL_PERIOD_MINUTES });
+}
+
+let draining = false;
+
+/** Fetch-and-report until the server's queue is empty. Also called outside
+ * the alarm (import progress checks) — the flag keeps runs from overlapping. */
+export async function drainQueue(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    const cfg = await stashConfig();
+    if (!cfg.apiKey) return;
+    for (;;) {
+      const response = await fetch(
+        `${cfg.apiBase}/api/v1/me/imports/client-queue?limit=${BATCH_LIMIT}`,
+        { headers: { Authorization: `Bearer ${cfg.apiKey}` } }
+      );
+      if (!response.ok) return;
+      const { items } = await response.json();
+      if (!items.length) return;
+      for (const item of items) {
+        await fetchAndReport(cfg, item);
+        await new Promise((r) => setTimeout(r, INTER_FETCH_DELAY_MS));
+      }
+    }
+  } finally {
+    draining = false;
+  }
+}
+
+async function fetchAndReport(cfg: StashConfig, item: { id: string; url: string }): Promise<void> {
+  let body: { html?: string; error?: string };
+  try {
+    const page = await fetch(item.url, {
+      credentials: 'include',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!page.ok) {
+      body = { error: `HTTP ${page.status}` };
+    } else {
+      const html = await page.text();
+      body = html.length > MAX_HTML_BYTES ? { error: 'page larger than 20 MB' } : { html };
+    }
+  } catch (e: any) {
+    body = { error: String(e?.message || e).slice(0, 200) };
+  }
+  await fetch(`${cfg.apiBase}/api/v1/me/imports/${item.id}/client-result`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/chrome_extension/src/popup/popup.ts
+++ b/chrome_extension/src/popup/popup.ts
@@ -160,8 +160,14 @@ function renderAdvanced(status: any): HTMLElement {
       return;
     }
     const p = result.progress;
-    progressRow.textContent = `Import: ${p.done}/${p.total} done, ${p.failed} failed, ${p.pending} pending`;
-    if (p.pending > 0) setTimeout(() => void showProgress(importId), 2000);
+    const parts = [`${p.done} saved`];
+    if (p.link_only > 0) parts.push(`${p.link_only} link-only`);
+    if (p.needs_client > 0) parts.push(`${p.needs_client} fetching via this browser`);
+    if (p.pending > 0) parts.push(`${p.pending} pending`);
+    progressRow.textContent = `Import (${p.total} total): ${parts.join(', ')}`;
+    if (p.pending > 0 || p.needs_client > 0) {
+      setTimeout(() => void showProgress(importId), 2000);
+    }
   }
 
   const fileInput = el('input', { type: 'file', accept: '.html' });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4928,9 +4928,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5794,9 +5794,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -2733,9 +2733,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Why

Sam's real bookmark export is 62k bookmarks (41k unique), 27% YouTube. The old pipeline would have (a) been rejected by the 25k cap, (b) flooded the shared Celery queue and starved embeddings/syncs, (c) had yt-dlp bot-blocked by YouTube from the Render IP (the pre-rewrite stash repo hit exactly this and abandoned server-side YouTube fetching), and (d) silently stranded every login-walled/dead URL as a failed row.

## What

- **Windowed dispatch (A)**: at most 200 import URLs in flight; the 60s Beat sweep tops the window up. A 40k import leaves 2 of the worker's 4 slots free — verified live: embeddings/sources reconcile kept firing mid-import.
- **Domain throttling (B)**: dispatch interleaves rows round-robin across domains; per-batch per-domain concurrency is 2. 429s park the row (`retry_at`) for a 15-min spaced retry; a site that 429s every retry escalates to `needs_client` instead of cycling forever (found live via venturebeat/vrbo).
- **YouTube via ScrapeCreators (C)**: transcripts from the SC endpoint (same vendor/key/header as Instagram saves), title/channel from YouTube's key-free oEmbed — checked first, so private/deleted videos spend no credit. `yt-dlp` removed. **`SCRAPECREATORS_API_KEY` is now required for any YouTube clip** (it's already set on prod web + worker for IG).
- **Extension-fed hydration (D)**: 401/403 from the bookmark's own host → `needs_client`; the extension polls `GET /me/imports/client-queue` (5-min alarm + drain-on-progress-check), refetches with the user's cookies, and posts raw HTML to `POST /me/imports/{id}/client-result` — extraction stays server-side. Claims are leased (10-min `locked_at` reclaim); rows nobody fetches expire to link-only after 24h.
- **Every bookmark saves (E)**: all terminal outcomes (exhausted retries, unsupported content, unusable/failed client fetch, expiry) write a "Link"-type row to the Bookmarks table — an imported bookmark is never lost, and progress reports `done / link_only / needs_client / pending`. Cap raised 25k → 100k.
- **Extension feedback (F)**: notifications with counts on clip-all-tabs and bookmark import, richer popup progress line.
- **Race fixes**: `find_or_create_root_folder` / `clips_subfolder_id` now survive concurrent get-or-create (unique-index loser refetches); Bookmarks-table get-or-create serialized in-process.

Migration `0158`: `url_imports.retry_at` + `dispatched_at`, a partial index for the client queue, and a one-shot backfill adding "Link" to existing Bookmarks tables' Type options.

## E2E evidence (local stack, fresh `user_3`, real 500-bookmark subset of the export)

- **500/500 resolved: 388 hydrated, 112 link-only, 0 unresolved; exactly 500 Bookmarks-table rows.**
- In-flight never exceeded the 200 window (spot-checks: 65, then 1+0 with 301 undispatched); beat tasks kept running throughout.
- YouTube hydrated real transcripts via SC (59 YT URLs ≈ 59 credits spent).
- `reddit.com/r/WhatIsMyCQS/` (Sam's example) → extraction failed loud on the JS shell → saved as a link-only bookmark.
- Client channel exercised with a scripted stand-in for the extension: claimed queue rows (what3words, jstor, The Information, Google Docs — exactly the right URLs), hydrated 12 of them from a residential IP, resolved the rest link-only. With real browser cookies more would hydrate.
- Full backend suite: 859 passed, 1 pre-existing failure (`test_github_index_success_logs_internal_source_id_only` hits the live GitHub API and 404s — fails identically on clean origin/main, not touched here).

## Flags for review

- **Extension `host_permissions` is now `<all_urls>`** (needed for cookie-attached fetches of arbitrary bookmark URLs). This escalates the Chrome install warning to "read and change all your data on all websites" and can slow Web Store review.
- Pre-existing latent race left unfixed and worth a follow-up: `tables` has no unique (owner, folder, name) index, so two *separate worker processes* doing a first-ever save simultaneously could still duplicate the Bookmarks table (in-process lock added here covers the common case).
- A full 41k import ≈ 16.5k SC credits on YouTube alone — decide before running it.
- No popup screenshots: the changed UI is inside the extension popup, which requires manually loading the unpacked extension (`chrome_extension/`, `npm run build`, load `dist/` via chrome://extensions). The changes are a progress text line and two OS notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j6cYiegKcF9j8eMoBpydg