### PR TITLE
Show OAuth callback failures in the UI instead of dropping them

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -331,13 +331,32 @@ async def integration_connect(
     return ConnectStartResponse(authorize_url=p.authorize_url(state))
 
 
+def _error_redirect(provider: str, reason: str) -> RedirectResponse:
+    """Land the browser back on settings with the failure flagged. The callback
+    is always a top-window navigation, so a JSON error body would strand the
+    user on the API host — every failure must end in a redirect the UI can
+    render as a banner."""
+    base = settings.PUBLIC_URL.rstrip("/")
+    query = {"integration_error": provider, "reason": reason}
+    return RedirectResponse(url=f"{base}/settings?{urlencode(query)}", status_code=302)
+
+
 @router.get("/{provider}/callback")
 async def integration_callback(
     provider: str,
-    code: str = Query(...),
-    state: str = Query(...),
+    code: str | None = Query(None),
+    state: str | None = Query(None),
+    error: str | None = Query(None),
 ):
     p = get_provider(provider)
+    # A denied consent screen redirects back with ?error=access_denied and no
+    # code (RFC 6749 §4.1.2.1) — there is nothing to exchange.
+    if error or not code or not state:
+        logger.warning(
+            "OAuth callback aborted for provider %s (%s)", provider, error or "missing code/state"
+        )
+        reason = "access_denied" if error == "access_denied" else "connection_failed"
+        return _error_redirect(provider, reason)
     # The token exchange / account fetch talks to the provider — it can fail for
     # reasons outside our control (bad client secret, provider error, expired
     # code). Surface those as a clean redirect back to the UI with an error flag
@@ -423,13 +442,15 @@ async def integration_callback(
                     logger.warning(
                         "x: failed to auto-create source exception_type=%s", type(exc).__name__
                     )
-    except HTTPException:
-        raise  # already a clean client error (e.g. invalid/expired state → 400)
+    except HTTPException as e:
+        # Invalid/expired state (a consent tab left open past STATE_TTL) is a
+        # browser-facing failure like any other — a bare 400 JSON page on the
+        # API host is a dead end for the user.
+        logger.warning("OAuth callback rejected for provider %s (%s)", provider, e.detail)
+        return _error_redirect(provider, "connection_failed")
     except Exception as e:
         logger.warning("OAuth callback failed for provider %s (%s)", provider, type(e).__name__)
-        base = settings.PUBLIC_URL.rstrip("/")
-        query = {"integration_error": provider, "reason": "connection_failed"}
-        return RedirectResponse(url=f"{base}/settings?{urlencode(query)}", status_code=302)
+        return _error_redirect(provider, "connection_failed")
 
     base = settings.PUBLIC_URL.rstrip("/")
     target = _safe_return_to(return_to) or "/settings"

--- a/backend/tests/test_integration_callback_security.py
+++ b/backend/tests/test_integration_callback_security.py
@@ -122,6 +122,71 @@ async def test_oauth_callback_failure_does_not_redirect_or_log_secrets(
     assert "access_token" not in caplog.text
 
 
+# The callback is always a top-window navigation: every failure must end in a
+# redirect the UI renders as a banner — a JSON error body (422 for a missing
+# code, 400 for a stale state) strands the user on the API host with no UI.
+@pytest.mark.asyncio
+async def test_consent_denial_redirects_with_access_denied(
+    client: AsyncClient,
+    monkeypatch,
+):
+    provider = FailingExchangeProvider()
+    _configure_callback(monkeypatch, provider)
+
+    response = await client.get(
+        f"/api/v1/integrations/{provider.name}/callback",
+        params={"error": "access_denied", "state": "opaque"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == f"{PUBLIC_URL}/settings?integration_error=leaky&reason=access_denied"
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_code_redirects_instead_of_422(
+    client: AsyncClient,
+    monkeypatch,
+):
+    provider = FailingExchangeProvider()
+    _configure_callback(monkeypatch, provider)
+
+    response = await client.get(
+        f"/api/v1/integrations/{provider.name}/callback",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == f"{PUBLIC_URL}/settings?integration_error=leaky&reason=connection_failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_state_redirects_instead_of_400(
+    client: AsyncClient,
+    monkeypatch,
+):
+    provider = FailingExchangeProvider()
+    _configure_callback(monkeypatch, provider)
+
+    response = await client.get(
+        f"/api/v1/integrations/{provider.name}/callback",
+        params={"code": "ok", "state": "not-a-valid-fernet-token"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == f"{PUBLIC_URL}/settings?integration_error=leaky&reason=connection_failed"
+    )
+
+
 @pytest.mark.asyncio
 async def test_oauth_profile_failure_does_not_log_tokens(
     client: AsyncClient,

--- a/frontend/src/components/integrations/SourceConnectorList.test.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.test.tsx
@@ -52,6 +52,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  window.history.replaceState(null, "", "/");
 });
 
 // Disconnect lives in the connect modal itself so a connected source can be
@@ -92,6 +93,107 @@ describe("SourceConnectorList disconnect", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
 
     expect(disconnectIntegration).not.toHaveBeenCalled();
+  });
+});
+
+// A failed OAuth callback is a top-window navigation, so the backend can't
+// return a JSON error — it redirects to /settings?integration_error=<provider>.
+// That failure must be shown loudly (a silent bounce reads as a dead button)
+// and the param stripped so a refresh doesn't resurrect a stale error.
+describe("SourceConnectorList OAuth callback errors", () => {
+  // jsdom has no scrollIntoView; the banner scrolls itself into view because
+  // it renders in the fourth settings section, below the fold.
+  const scrollIntoView = vi.fn();
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  it("shows a banner for ?integration_error and strips it from the URL", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/settings?integration_error=github&reason=connection_failed"
+    );
+    listIntegrations.mockResolvedValue({ providers: [connectedGithub(false)] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(await screen.findByText(/GitHub connection failed/)).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/settings");
+    expect(window.location.search).toBe("");
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("says the authorization was cancelled for reason=access_denied", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/settings?integration_error=github&reason=access_denied"
+    );
+    listIntegrations.mockResolvedValue({ providers: [connectedGithub(false)] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(
+      await screen.findByText(/GitHub connection failed — the authorization was cancelled/)
+    ).toBeInTheDocument();
+  });
+
+  it("never echoes an unrecognized provider slug into the banner", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/settings?integration_error=Billing%20overdue%20renew%20now&reason=connection_failed"
+    );
+    listIntegrations.mockResolvedValue({ providers: [connectedGithub(false)] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(await screen.findByText(/^Connection failed/)).toBeInTheDocument();
+    expect(screen.queryByText(/Billing overdue/)).not.toBeInTheDocument();
+  });
+
+  it("keeps unrelated query params when stripping the error", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/settings?tab=sources&integration_error=github&reason=connection_failed"
+    );
+    listIntegrations.mockResolvedValue({ providers: [connectedGithub(false)] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(await screen.findByText(/GitHub connection failed/)).toBeInTheDocument();
+    expect(window.location.search).toBe("?tab=sources");
+  });
+
+  it("shows no banner without the param", async () => {
+    listIntegrations.mockResolvedValue({ providers: [connectedGithub(false)] });
+
+    render(
+      <ConfirmDialogProvider>
+        <SourceConnectorList returnTo="/" includeObsidian={false} />
+      </ConfirmDialogProvider>
+    );
+
+    expect(await screen.findByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText(/connection failed/)).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ApiError, listSources, type Source } from "@/lib/api";
 import {
@@ -15,7 +15,13 @@ import {
 
 import { useConfirm } from "../ConfirmDialog";
 import { ObsidianIcon } from "./BrandIcons";
-import { CONNECTORS, connectorIcon, providerForSourceType, type Connector } from "./connectors";
+import {
+  CONNECTORS,
+  connectorForProvider,
+  connectorIcon,
+  providerForSourceType,
+  type Connector,
+} from "./connectors";
 import { CredentialForm, primaryButton, secondaryButton } from "./pickers";
 import ObsidianVaultDropZone from "./ObsidianVaultDropZone";
 import PaywallModal from "../PaywallModal";
@@ -43,6 +49,10 @@ export default function SourceConnectorList({
   const [expanded, setExpanded] = useState<IntegrationProvider | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // A failed OAuth callback is a top-window navigation, so the backend can't
+  // return a JSON error — it redirects back with ?integration_error=<provider>.
+  // Held separately from `error` because refresh() clears that on every load.
+  const [callbackError, setCallbackError] = useState<string | null>(null);
   const [paymentRequired, setPaymentRequired] = useState(false);
   const confirm = useConfirm();
 
@@ -67,6 +77,38 @@ export default function SourceConnectorList({
       setError(e instanceof Error ? e.message : "Could not load sources");
     });
   }, [refresh]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const provider = params.get("integration_error");
+    if (!provider) return;
+    // The slug is URL-controlled: an unknown value must never be echoed into a
+    // first-party banner (content spoofing), so it maps to a generic message.
+    const label = connectorForProvider(provider)?.label;
+    const what = label ? `${label} connection failed` : "Connection failed";
+    setCallbackError(
+      params.get("reason") === "access_denied"
+        ? `${what} — the authorization was cancelled before finishing.`
+        : `${what} — the provider rejected the sign-in. Try again, or check the server logs for details.`
+    );
+    // Strip the params so a refresh or copied link doesn't resurrect the error.
+    params.delete("integration_error");
+    params.delete("reason");
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + (query ? `?${query}` : "") + window.location.hash
+    );
+  }, []);
+
+  // The error redirect lands on /settings, where this list is the fourth
+  // section — without scrolling, the banner sits below the fold and the
+  // failure stays invisible, which is the bug this banner exists to fix.
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (callbackError) bannerRef.current?.scrollIntoView({ block: "center" });
+  }, [callbackError]);
 
   const disabledReasons = useMemo(() => {
     const reasons = Object.values(statuses)
@@ -136,6 +178,17 @@ export default function SourceConnectorList({
           {disabledReasons.length === 1
             ? disabledReasons[0]
             : "Some integrations need server configuration before they can be connected."}
+        </div>
+      )}
+
+      {/* Above the cards: on a long connector list a bottom banner sits below
+          the fold, which is how OAuth callback failures went unnoticed. */}
+      {(error ?? callbackError) && (
+        <div
+          ref={bannerRef}
+          className="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error"
+        >
+          {error ?? callbackError}
         </div>
       )}
 
@@ -211,12 +264,6 @@ export default function SourceConnectorList({
       })}
 
       {includeObsidian && <ObsidianSourceCard onUploaded={onObsidianUploaded} />}
-
-      {error && (
-        <div className="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
-          {error}
-        </div>
-      )}
 
       {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
     </div>


### PR DESCRIPTION
## Problem

When an OAuth token exchange failed, the backend redirected to `/settings?integration_error=<provider>&reason=connection_failed` — but no frontend code consumed that param. Because a re-authorization on an already-approved app auto-redirects instantly, the whole failed round-trip (settings → provider → callback → settings) took under a second and looked exactly like a dead Connect button. Worse, the two most common real failures never emitted the param at all: cancelling on the consent screen returned a raw FastAPI 422 JSON page on the API host (missing required `code` param), and an expired state (consent tab left open past the 10-minute TTL) returned bare 400 JSON.

## What changed

**Frontend** (`SourceConnectorList`):
- Reads `integration_error` + `reason` on mount and shows an error banner **above** the connector cards (the old error slot rendered below ~10 cards, under the fold).
- Scrolls the banner into view — the Sources section is the fourth card on `/settings`, below the fold on typical viewports.
- Distinct message for `reason=access_denied` ("authorization was cancelled") vs exchange failures.
- Strips the params from the URL so refresh/copied links don't resurrect a stale error.
- Never echoes the URL-controlled provider slug: unknown slugs get a generic "Connection failed" (content-spoofing guard).

**Backend** (`integrations/router.py`):
- `code`/`state` are now optional; a consent denial (`?error=access_denied`, no code — RFC 6749 §4.1.2.1) or missing params redirects with `integration_error` instead of 422 JSON.
- Invalid/expired state redirects instead of raising bare 400 JSON — the callback is always a top-window navigation, so every failure must end in a redirect the UI can render.

## Screenshot

Banner on `/settings` after a failed GitHub connect (captured live in dev): https://app.joinstash.ai/f/7a11943b-2ed0-4b0e-83fe-64fefad3e150

## Tests

- Frontend: 9/9 vitest (banner shown + params stripped, unrelated params preserved, access-denied wording, unknown-slug no-echo, scroll-into-view, plus existing disconnect/visibility tests).
- Backend: `test_integration_callback_security.py` 8/8 — new: consent denial → 302 `reason=access_denied`, missing code → 302, invalid state → 302.
- Full backend suite: 397 passed; 1 failure (`test_github_index_success_logs_internal_source_id_only`) reproduces on pristine main with this change stashed — pre-existing, unrelated.
- `ruff check`/`format` clean; eslint 0 errors; `tsc` clean in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)