### PR TITLE
Archive clip images into a public media bucket instead of hotlinking

### DIFF
--- a/backend/services/clip_service.py
+++ b/backend/services/clip_service.py
@@ -17,7 +17,7 @@ from uuid import UUID
 
 from ..config import settings
 from ..database import get_pool
-from . import files_tree_service, table_service
+from . import files_tree_service, image_archive_service, table_service
 from .article_extraction import ArticleExtractionError, extract_article
 
 CLIPS_FOLDER = "Clips"
@@ -189,6 +189,11 @@ async def _create_raw_page(
     folder_id: UUID | None,
 ) -> dict:
     """Create the clip page in Clips/raw and index it in the Bookmarks table."""
+    if image_archive_service.is_enabled():
+        if content:
+            content = await image_archive_service.archive_images(content)
+        if content_html:
+            content_html = await image_archive_service.archive_images(content_html)
     clipped_at = datetime.now(UTC)
     metadata = {"source_url": url, "clipped_at": clipped_at.isoformat()}
     if folder_id is None:

--- a/backend/services/image_archive_service.py
+++ b/backend/services/image_archive_service.py
@@ -1,0 +1,85 @@
+"""Archive a clip's images into the public media bucket.
+
+Clipped articles hotlink their images to the source site, so clips rot
+when the source dies. At save time each image reference (markdown or
+<img> tag — a clip page stores one syntax or the other) is copied into
+the public media bucket under a 128-bit random key and rewritten to the
+stable public URL, making the clip self-contained.
+
+A per-image failure keeps the original hotlink: an unreachable image must
+never lose the article, and a hotlink is strictly better than a broken
+reference. The whole pass is off (clips keep hotlinks, current behavior)
+until S3_PUBLIC_BUCKET / S3_PUBLIC_BASE_URL are configured.
+"""
+
+import logging
+import re
+from urllib.parse import urlparse
+
+import httpx
+
+from . import storage_service
+
+logger = logging.getLogger(__name__)
+
+MAX_IMAGES = 20
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+FETCH_TIMEOUT = 20
+
+_MD_IMAGE = re.compile(r"!\[[^\]]*\]\((https?://[^)\s]+)\)")
+_HTML_IMAGE = re.compile(r"<img[^>]+src=\"(https?://[^\"]+)\"", re.IGNORECASE)
+
+# Map archived content types to a filename extension so the public URL
+# stays recognizable as an image.
+_EXTENSIONS = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/avif": "avif",
+    "image/svg+xml": "svg",
+}
+
+
+def is_enabled() -> bool:
+    return storage_service.public_media_enabled()
+
+
+async def archive_images(content: str) -> str:
+    """Return `content` with every archivable image URL rewritten to its
+    public archived copy. Failures leave that image's original URL."""
+    urls: list[str] = []
+    for pattern in (_MD_IMAGE, _HTML_IMAGE):
+        for url in pattern.findall(content):
+            if url not in urls:
+                urls.append(url)
+    if len(urls) > MAX_IMAGES:
+        logger.info("archiving first %d of %d images", MAX_IMAGES, len(urls))
+        urls = urls[:MAX_IMAGES]
+
+    async with httpx.AsyncClient(timeout=FETCH_TIMEOUT, follow_redirects=True) as client:
+        for url in urls:
+            try:
+                archived = await _archive_one(client, url)
+            except Exception as exc:
+                logger.warning(
+                    "image archive failed host=%s exception_type=%s",
+                    urlparse(url).netloc,
+                    type(exc).__name__,
+                )
+                continue
+            content = content.replace(url, archived)
+    return content
+
+
+async def _archive_one(client: httpx.AsyncClient, url: str) -> str:
+    response = await client.get(url)
+    response.raise_for_status()
+    content_type = response.headers.get("content-type", "").split(";")[0].strip()
+    if content_type not in _EXTENSIONS:
+        raise ValueError(f"Not an archivable image: {content_type or 'unknown type'}")
+    if len(response.content) > MAX_IMAGE_BYTES:
+        raise ValueError(f"Image larger than {MAX_IMAGE_BYTES} bytes")
+    return await storage_service.upload_public_image(
+        f"image.{_EXTENSIONS[content_type]}", response.content, content_type
+    )

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -20,11 +20,22 @@ S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY", "")
 S3_SECRET_KEY = os.getenv("S3_SECRET_KEY", "")
 S3_REGION = os.getenv("S3_REGION", "us-east-1")
 
+# Separate bucket with public read access (R2 has no per-object ACLs, so
+# public objects can't share the private bucket). Objects are addressed by
+# 128-bit random keys — the key IS the access control. Used for archived
+# clip images, which must load from a plain <img> tag with no auth header.
+S3_PUBLIC_BUCKET = os.getenv("S3_PUBLIC_BUCKET", "")
+S3_PUBLIC_BASE_URL = os.getenv("S3_PUBLIC_BASE_URL", "")
+
 _client: httpx.AsyncClient | None = None
 
 
 def is_configured() -> bool:
     return bool(S3_BUCKET and S3_ENDPOINT and S3_ACCESS_KEY and S3_SECRET_KEY)
+
+
+def public_media_enabled() -> bool:
+    return bool(is_configured() and S3_PUBLIC_BUCKET and S3_PUBLIC_BASE_URL)
 
 
 def _get_client() -> httpx.AsyncClient:
@@ -57,9 +68,22 @@ async def upload_file(
         raise RuntimeError("S3 storage is not configured")
 
     key = _storage_key(owner_user_id, filename)
+    await _signed_put(S3_BUCKET, key, content, content_type)
+    return key
 
-    # Use S3 PUT Object with presigned-style direct upload
-    # For simplicity, use the S3 REST API directly via httpx
+
+async def upload_public_image(filename: str, content: bytes, content_type: str) -> str:
+    """Store an archived clip image in the public media bucket. Returns the
+    stable public URL (no expiry — safe to embed in page content)."""
+    if not public_media_enabled():
+        raise RuntimeError("Public media storage is not configured")
+    key = f"{uuid4().hex}/{filename}"
+    await _signed_put(S3_PUBLIC_BUCKET, key, content, content_type)
+    return f"{S3_PUBLIC_BASE_URL.rstrip('/')}/{quote(key, safe='/')}"
+
+
+async def _signed_put(bucket: str, key: str, content: bytes, content_type: str) -> None:
+    """SigV4-signed S3 PUT via the REST API directly (no boto dependency)."""
     import hashlib
     import hmac
     from datetime import datetime
@@ -71,7 +95,7 @@ async def upload_file(
     # Canonical request components
     host = S3_ENDPOINT.replace("https://", "").replace("http://", "").rstrip("/")
     scheme = "https" if S3_ENDPOINT.startswith("https") else "http"
-    uri = _object_uri(key)
+    uri = f"/{bucket}/{quote(key, safe='/')}"
 
     payload_hash = hashlib.sha256(content).hexdigest()
 
@@ -124,7 +148,6 @@ async def upload_file(
         },
     )
     resp.raise_for_status()
-    return key
 
 
 async def get_file_url(key: str, expires_in: int = 3600) -> str:

--- a/backend/tests/test_image_archive.py
+++ b/backend/tests/test_image_archive.py
@@ -1,0 +1,153 @@
+"""Image archiving for clips.
+
+A clip must become self-contained: its image references are copied into
+public storage and rewritten at save time. A failed image keeps its
+original hotlink (never lose the article over an image), and the whole
+pass is inert until the public bucket is configured.
+"""
+
+import httpx
+import pytest
+
+from backend.services import image_archive_service, storage_service
+
+
+class _Response:
+    def __init__(self, content_type: str = "image/png", body: bytes = b"png-bytes"):
+        self.headers = {"content-type": content_type}
+        self.content = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    """Serves canned responses by URL; raises for URLs marked broken."""
+
+    def __init__(self, responses: dict):
+        self.responses = responses
+        self.fetched: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url: str) -> _Response:
+        self.fetched.append(url)
+        result = self.responses[url]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _enable(monkeypatch, uploads: list):
+    async def fake_upload(filename: str, content: bytes, content_type: str) -> str:
+        uploads.append((filename, content_type))
+        return f"https://media.example/{len(uploads)}/{filename}"
+
+    monkeypatch.setattr(storage_service, "public_media_enabled", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_public_image", fake_upload)
+
+
+def _fake_http(monkeypatch, responses: dict) -> _FakeClient:
+    client = _FakeClient(responses)
+    monkeypatch.setattr(image_archive_service.httpx, "AsyncClient", lambda **kw: client)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_markdown_and_html_images_are_rewritten(monkeypatch) -> None:
+    uploads: list = []
+    _enable(monkeypatch, uploads)
+    _fake_http(
+        monkeypatch,
+        {
+            "https://site.example/a.png": _Response("image/png"),
+            "https://cdn.example/b.jpg": _Response("image/jpeg"),
+        },
+    )
+
+    content = (
+        "Intro ![diagram](https://site.example/a.png) text\n"
+        '<img class="x" src="https://cdn.example/b.jpg"> end'
+    )
+    result = await image_archive_service.archive_images(content)
+
+    assert "https://site.example/a.png" not in result
+    assert "https://cdn.example/b.jpg" not in result
+    assert "https://media.example/1/image.png" in result
+    assert "https://media.example/2/image.jpg" in result
+    assert [u[1] for u in uploads] == ["image/png", "image/jpeg"]
+
+
+@pytest.mark.asyncio
+async def test_failed_image_keeps_its_hotlink(monkeypatch) -> None:
+    uploads: list = []
+    _enable(monkeypatch, uploads)
+    _fake_http(
+        monkeypatch,
+        {
+            "https://dead.example/x.png": httpx.ConnectError("refused"),
+            "https://site.example/ok.png": _Response("image/png"),
+        },
+    )
+
+    content = "![a](https://dead.example/x.png) ![b](https://site.example/ok.png)"
+    result = await image_archive_service.archive_images(content)
+
+    assert "https://dead.example/x.png" in result
+    assert "https://site.example/ok.png" not in result
+    assert len(uploads) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_image_and_oversize_responses_are_skipped(monkeypatch) -> None:
+    uploads: list = []
+    _enable(monkeypatch, uploads)
+    _fake_http(
+        monkeypatch,
+        {
+            "https://site.example/page.html": _Response("text/html", b"<html>"),
+            "https://site.example/huge.png": _Response(
+                "image/png", b"x" * (image_archive_service.MAX_IMAGE_BYTES + 1)
+            ),
+        },
+    )
+
+    content = "![a](https://site.example/page.html) ![b](https://site.example/huge.png)"
+    result = await image_archive_service.archive_images(content)
+
+    assert result == content
+    assert uploads == []
+
+
+@pytest.mark.asyncio
+async def test_image_count_is_capped(monkeypatch) -> None:
+    uploads: list = []
+    _enable(monkeypatch, uploads)
+    urls = [f"https://site.example/{i}.png" for i in range(image_archive_service.MAX_IMAGES + 5)]
+    client = _fake_http(monkeypatch, {u: _Response("image/png") for u in urls})
+
+    content = " ".join(f"![i]({u})" for u in urls)
+    await image_archive_service.archive_images(content)
+
+    assert len(client.fetched) == image_archive_service.MAX_IMAGES
+
+
+@pytest.mark.asyncio
+async def test_duplicate_urls_archive_once(monkeypatch) -> None:
+    uploads: list = []
+    _enable(monkeypatch, uploads)
+    client = _fake_http(monkeypatch, {"https://site.example/a.png": _Response("image/png")})
+
+    content = "![a](https://site.example/a.png) ![again](https://site.example/a.png)"
+    result = await image_archive_service.archive_images(content)
+
+    assert len(client.fetched) == 1
+    assert result.count("https://media.example/1/image.png") == 2
+
+
+def test_disabled_without_public_bucket_config() -> None:
+    assert image_archive_service.is_enabled() is False


### PR DESCRIPTION
## Why

Both clip paths (interactive Readability clips and bulk-import extractions) keep images as hotlinks to the source site, so clips rot when sources die. Sam's call: clips should be self-contained archives, using public-read storage with unguessable keys.

## What

- `storage_service`: SigV4 PUT extracted into `_signed_put(bucket, …)`; new `upload_public_image()` writes to a dedicated public bucket (`S3_PUBLIC_BUCKET`) under a 128-bit random key and returns the stable `S3_PUBLIC_BASE_URL` URL. A separate bucket because prod is R2 (no per-object ACLs) and the private bucket must stay private.
- New `image_archive_service`: finds image refs in clip content (markdown `![]()` and `<img src>`), downloads each (20-image cap, 10 MB cap, 20s timeout, image/* content types only, dedup), uploads, and rewrites the reference. **A failed image keeps its original hotlink** — never lose the article over an image. Explicitly documented as best-effort enrichment, not a fallback codepath.
- Wired at the single choke point both clip paths share (`clip_service._create_raw_page`), covering interactive clips, bulk imports, and extension client-result hydrations.
- **Config-gated**: with `S3_PUBLIC_BUCKET`/`S3_PUBLIC_BASE_URL` unset the pass is fully inert (current hotlink behavior), so merging is safe before the bucket exists — same on/off-switch pattern as `STRIPE_SECRET_KEY`.

Why public-read instead of presigning: `<img>` tags can't carry the app's localStorage bearer token, and read-time presign-rewriting would leak expiring URLs into *editable* page content via autosave.

## Activation (one-time, after merge)

1. Cloudflare R2 → create bucket `stash-public-media` → Settings → enable public access (r2.dev subdomain or custom domain).
2. Set `S3_PUBLIC_BUCKET=stash-public-media` and `S3_PUBLIC_BASE_URL=<public base URL>` on `stash_backend` **and** `stash-celery-worker` (bulk imports archive from the worker — env parity or it silently stays off on one side… it fails loud, actually: it stays uniformly off per-process, so set both).

## Verification

- New `test_image_archive.py`: markdown+HTML rewriting, failed-image-keeps-hotlink, non-image/oversize skipped, 20-image cap, dedup, disabled-by-default.
- Full backend suite: **879 passed, 0 failed** (main's GitHub log-security test is fixed as of #862).
- Live R2 round-trip can't be exercised until the bucket exists; the deployed default (unset config) is bit-identical to current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j6cYiegKcF9j8eMoBpydg