### PR TITLE
Bulk imports skip URLs the owner already imported

### DIFF
--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -121,24 +121,34 @@ async def _create_import(
     filename: str | None,
     items: list[dict],
 ) -> JSONResponse:
-    """Shared tail of both import endpoints: batch row, url_imports rows,
-    then top up the windowed dispatcher — the Beat sweep drains the rest."""
+    """Shared tail of both import endpoints: drop URLs this owner already
+    imported (re-importing a bookmarks file must not re-clip the library),
+    then batch row, url_imports rows, and a top-up of the windowed
+    dispatcher — the Beat sweep drains the rest."""
     from ..tasks.clips import top_up_url_imports
+
+    known = await url_import_service.existing_urls(owner_user_id, [item["url"] for item in items])
+    new_items = [item for item in items if item["url"] not in known]
+    skipped = len(items) - len(new_items)
 
     batch_id = await url_import_service.create_batch(
         owner_user_id=owner_user_id,
         kind=kind,
         filename=filename,
-        total=len(items),
+        total=len(new_items),
     )
-    await url_import_service.create_url_imports(
-        owner_user_id=owner_user_id,
-        created_by=owner_user_id,
-        items=items,
-        batch_id=batch_id,
+    if new_items:
+        await url_import_service.create_url_imports(
+            owner_user_id=owner_user_id,
+            created_by=owner_user_id,
+            items=new_items,
+            batch_id=batch_id,
+        )
+        await top_up_url_imports()
+    return JSONResponse(
+        status_code=201,
+        content={"import_id": str(batch_id), "total": len(new_items), "skipped": skipped},
     )
-    await top_up_url_imports()
-    return JSONResponse(status_code=201, content={"import_id": str(batch_id), "total": len(items)})
 
 
 @imports_router.post("/bookmarks")

--- a/backend/services/url_import_service.py
+++ b/backend/services/url_import_service.py
@@ -38,6 +38,18 @@ async def create_url_imports(
     return [r["id"] for r in rows]
 
 
+async def existing_urls(owner_user_id: UUID, urls: list[str]) -> set[str]:
+    """URLs this owner has already imported, in any state. Failed and
+    needs_client rows count too — they are still on their way to a clip or
+    a link-only bookmark, and re-importing must not double them."""
+    rows = await get_pool().fetch(
+        "SELECT DISTINCT url FROM url_imports WHERE owner_user_id = $1 AND url = ANY($2)",
+        owner_user_id,
+        urls,
+    )
+    return {r["url"] for r in rows}
+
+
 async def create_batch(
     *,
     owner_user_id: UUID,

--- a/backend/tests/test_bookmark_imports.py
+++ b/backend/tests/test_bookmark_imports.py
@@ -105,6 +105,35 @@ async def test_bookmark_import_enqueues_all_urls(client: AsyncClient, pool, monk
 
 
 @pytest.mark.asyncio
+async def test_reimporting_skips_already_imported_urls(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """Re-importing a bookmarks file (or overlapping tab sets) must not
+    re-clip the owner's library — known URLs are skipped and reported."""
+    monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda ids: None)
+    headers, owner_id = await _register(client)
+
+    first = await client.post("/api/v1/me/imports/bookmarks", headers=headers, **_upload_kwargs())
+    assert first.json() == {**first.json(), "total": 3, "skipped": 0}
+
+    again = await client.post("/api/v1/me/imports/bookmarks", headers=headers, **_upload_kwargs())
+    body = again.json()
+    assert body["total"] == 0
+    assert body["skipped"] == 3
+    rows = await pool.fetchval(
+        "SELECT count(*) FROM url_imports WHERE owner_user_id = $1", UUID(owner_id)
+    )
+    assert rows == 3
+
+    # Another owner importing the same file is unaffected by this owner's history.
+    other_headers, _ = await _register(client)
+    other = await client.post(
+        "/api/v1/me/imports/bookmarks", headers=other_headers, **_upload_kwargs()
+    )
+    assert other.json()["total"] == 3
+
+
+@pytest.mark.asyncio
 async def test_bookmark_import_rejects_empty_and_oversized(
     client: AsyncClient, monkeypatch
 ) -> None:

--- a/chrome_extension/src/background/clip.ts
+++ b/chrome_extension/src/background/clip.ts
@@ -171,9 +171,13 @@ export async function clipAllTabs(): Promise<any> {
     type: 'basic',
     iconUrl: 'icons/icon128.png',
     title: 'Saved to Stash',
-    message: `Saving ${data.total} tab${data.total === 1 ? '' : 's'} — check the popup for progress.`,
+    message: `Saving ${data.total} tab${data.total === 1 ? '' : 's'}${skippedNote(data.skipped)} — check the popup for progress.`,
   });
   return { ok: true, importId: data.import_id, total: data.total };
+}
+
+function skippedNote(skipped: number): string {
+  return skipped > 0 ? ` (${skipped} already in your Stash)` : '';
 }
 
 export async function importBookmarks(name: string, content: string): Promise<any> {
@@ -202,7 +206,7 @@ export async function importBookmarks(name: string, content: string): Promise<an
     type: 'basic',
     iconUrl: 'icons/icon128.png',
     title: 'Bookmark import started',
-    message: `Importing ${data.total} bookmarks — Stash fetches them in the background.`,
+    message: `Importing ${data.total} bookmarks${skippedNote(data.skipped)} — Stash fetches them in the background.`,
   });
   return { ok: true, importId: data.import_id, total: data.total };
 }


### PR DESCRIPTION
## Why

Re-importing a bookmarks export (or repeatedly saving overlapping tab sets) re-clipped every URL — at 41k-bookmark scale that's hours of work and thousands of ScrapeCreators credits spent re-fetching a library that already exists. (Raindrop ships duplicate detection; this is our equivalent for the bulk paths.)

## What

- `url_import_service.existing_urls()`: one query for the owner's already-imported URLs, any state — failed/needs_client rows count too since they're still on their way to a clip or link-only bookmark.
- `_create_import` filters both bulk endpoints (bookmarks.html + clip-all-tabs) through it and returns `skipped` alongside `total`.
- Extension notifications say "(N already in your Stash)" when something was skipped.
- Interactive single clips deliberately do NOT dedupe — an explicit re-clip is a request for a fresh copy.

Known tradeoff: a URL that ended link-only is skipped on re-import rather than retried; retrying failures wants an explicit "retry failed" affordance, not a silent re-import side effect.

## Verification

- New test: same file imported twice → second import `total=0, skipped=3`, no new rows; a different owner importing the same file is unaffected.
- Import/clip suites green (41 passed); ruff clean; extension builds + typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j6cYiegKcF9j8eMoBpydg