### PR TITLE
Rescue JS-shell pages with a Chromium render before giving up

### DIFF
--- a/backend/services/clip_router.py
+++ b/backend/services/clip_router.py
@@ -13,7 +13,8 @@ from urllib.parse import urlparse
 
 import httpx
 
-from . import clip_service, youtube_transcript
+from . import clip_service, page_render_service, youtube_transcript
+from .article_extraction import ArticleExtractionError
 
 MAX_FETCH_BYTES = 20 * 1024 * 1024
 FETCH_TIMEOUT = 30
@@ -93,14 +94,30 @@ async def process_url_import(row: dict) -> dict:
         return {"file_id": response.id}
 
     if "text/html" in content_type or content.lstrip()[:1] == b"<":
-        page = await clip_service.save_page_clip(
-            owner_user_id=owner_user_id,
-            user_id=user_id,
-            url=url,
-            html=content.decode("utf-8", errors="replace"),
-            title=row.get("title"),
-            folder_id=row["folder_id"],
-        )
+        try:
+            html = content.decode("utf-8", errors="replace")
+            page = await clip_service.save_page_clip(
+                owner_user_id=owner_user_id,
+                user_id=user_id,
+                url=url,
+                html=html,
+                title=row.get("title"),
+                folder_id=row["folder_id"],
+            )
+        except ArticleExtractionError:
+            # Escalation tier: the fetched HTML had no article — SPAs and
+            # consent walls serve empty shells over HTTP. Render the page in
+            # Chromium and extract from the settled DOM; a second extraction
+            # failure is terminal (the caller saves the link-only bookmark).
+            html = await page_render_service.render_page(url)
+            page = await clip_service.save_page_clip(
+                owner_user_id=owner_user_id,
+                user_id=user_id,
+                url=url,
+                html=html,
+                title=row.get("title"),
+                folder_id=row["folder_id"],
+            )
         return {"page_id": page["id"]}
 
     raise UnsupportedUrlContent(f"Unsupported content type: {content_type or 'unknown'}")

--- a/backend/services/page_render_service.py
+++ b/backend/services/page_render_service.py
@@ -1,0 +1,34 @@
+"""Render a URL in headless Chromium and return the settled DOM.
+
+The escalation tier between a plain HTTP fetch and giving up: SPAs and
+consent-walled pages serve an empty shell over HTTP but render fine in
+the worker's Chromium (already shipped in the image for PDF exports).
+A render costs seconds of CPU where a fetch costs milliseconds, so this
+runs only after plain-fetch extraction failed, and at most two renders
+run at once per worker process.
+"""
+
+import asyncio
+
+from playwright.async_api import async_playwright
+
+RENDER_TIMEOUT_MS = 30_000
+# Give client-side rendering a beat to settle after `load` — networkidle
+# never fires on pages with long-polling/analytics, so it can't be the wait.
+SETTLE_MS = 2_000
+
+_semaphore = asyncio.Semaphore(2)
+
+
+async def render_page(url: str) -> str:
+    """Return the rendered DOM's HTML. Raises on navigation failure or
+    timeout — the caller records the error on the import row."""
+    async with _semaphore, async_playwright() as p:
+        browser = await p.chromium.launch(args=["--no-sandbox", "--disable-dev-shm-usage"])
+        try:
+            page = await browser.new_page()
+            await page.goto(url, wait_until="load", timeout=RENDER_TIMEOUT_MS)
+            await page.wait_for_timeout(SETTLE_MS)
+            return await page.content()
+        finally:
+            await browser.close()

--- a/backend/tests/test_url_imports.py
+++ b/backend/tests/test_url_imports.py
@@ -288,6 +288,63 @@ async def test_worker_turns_youtube_url_into_transcript_page(
     assert "words words" in page["content_markdown"]
 
 
+SHELL_HTML = "<html><body><div id='root'></div></body></html>"
+
+
+@pytest.mark.asyncio
+async def test_js_shell_pages_are_rescued_by_chromium_render(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """SPAs serve an empty shell over HTTP; the worker must escalate to a
+    Chromium render and extract from the settled DOM instead of giving up."""
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://spa.example/post")
+    rendered: list[str] = []
+
+    async def fake_fetch(url: str):
+        return SHELL_HTML.encode(), "text/html"
+
+    async def fake_render(url: str) -> str:
+        rendered.append(url)
+        return ARTICLE_HTML
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    monkeypatch.setattr(clip_router.page_render_service, "render_page", fake_render)
+    await clips_tasks._process_batch([import_id])
+
+    assert rendered == ["https://spa.example/post"]
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert row["error"] is None
+    page = await pool.fetchrow("SELECT name FROM pages WHERE id = $1", row["result_page_id"])
+    assert page["name"] == "Why Simplicity Wins"
+
+
+@pytest.mark.asyncio
+async def test_render_that_still_has_no_article_goes_link_only(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://spa.example/app", title="An App")
+
+    async def fake_fetch(url: str):
+        return SHELL_HTML.encode(), "text/html"
+
+    async def fake_render(url: str) -> str:
+        return SHELL_HTML
+
+    monkeypatch.setattr(clip_router, "_fetch", fake_fetch)
+    monkeypatch.setattr(clip_router.page_render_service, "render_page", fake_render)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    assert "ArticleExtractionError" in row["error"]
+    assert row["result_page_id"] is None
+    bookmarks = await _bookmark_rows(pool, owner_id)
+    assert "An App" in bookmarks[0].values()
+
+
 @pytest.mark.asyncio
 async def test_worker_records_fetch_failure_on_row(client: AsyncClient, pool, monkeypatch) -> None:
     _, owner_id = await _register(client)


### PR DESCRIPTION
## Why

JS-rendered pages (Reddit, SPAs, consent walls) serve an empty shell over HTTP, so bulk imports could only save them link-only. This is the gap Raindrop closes by rendering every page in real Chrome — we get the same rescue using the Playwright + Chromium already baked into the worker image for PDF exports. No new infrastructure.

## What

- New `page_render_service.render_page()`: headless Chromium (same `--no-sandbox` launch args as the exports pipeline), `load` + 2s settle (networkidle never fires on chatty pages), 30s timeout, max 2 concurrent renders per worker process.
- `clip_router`: when fetched HTML raises `ArticleExtractionError`, render the URL and re-extract from the settled DOM. Second failure is terminal (link-only bookmark, as before). HTTP-level failures (401/403/429) still route to needs_client/parking — the render tier only fires for 200-with-no-article.
- Cost profile: renders only run for the extraction-failure subset (~10–15% of a real bookmark corpus), bounded by the semaphore and existing batch concurrency.

## Verification

- Tests: shell HTML → render mocked → page created (render called exactly once); render still yielding no article → link-only with error recorded.
- Real-Chromium smoke test: `https://www.reddit.com/r/WhatIsMyCQS/` — plain fetch fails extraction, rendered DOM (190KB) extracts successfully.
- Import/clip suites green (42 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j6cYiegKcF9j8eMoBpydg