### PR TITLE
X saves: sync replies, articles, and the full timeline history

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -1,9 +1,10 @@
 """Hydrate X (Twitter) saves via twitterapi.io.
 
-Skeleton rows arrive from the extension push (routers/sources.py
-x_items_router) as tweet ids + a kind (Bookmark/Post/Reply/Article). Each
-sync pass fills a bounded batch: the full tweet text + author from
-twitterapi.io, the conversation root for reply context, and the tweet's
+Each sync enqueues skeleton rows (tweet ids + a kind): Bookmarks from the X
+API with the OAuth token, the user's own Posts/Replies/Articles from
+twitterapi.io by account id. A bounded hydration batch then fills them in:
+the full tweet text + author (or, for an Article, the full long-form body)
+from twitterapi.io, the conversation root for reply context, and the tweet's
 images/video archived into object storage — so the save survives the tweet
 being deleted or the account going private. Per-item failures land on the
 row, loudly; rows are never deleted by sync (archive semantics).
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 TAPI_TWEETS_URL = "https://api.twitterapi.io/twitter/tweets"
 TAPI_USER_TWEETS_URL = "https://api.twitterapi.io/twitter/user/last_tweets"
+TAPI_ARTICLE_URL = "https://api.twitterapi.io/twitter/article"
 X_BOOKMARKS_URL = "https://api.x.com/2/users/{user_id}/bookmarks"
 TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
@@ -35,9 +37,14 @@ MAX_MEDIA_PER_TWEET = 4
 # usually finishes before that happens; the reconciler re-runs for the rest.
 HYDRATION_BATCH = 50
 MAX_HYDRATION_ATTEMPTS = 3
-# Pages of the user's own timeline pulled per sync (20 tweets/page). Bounded so
-# one sync doesn't run away; older tweets keep arriving over subsequent syncs.
+# Pages of the user's own timeline pulled from the top each sync (20/page),
+# catching activity since the last sync. Stops early once a page brings
+# nothing new; the page cap bounds a burst.
 MAX_USER_TWEET_PAGES = 5
+# Pages per sync spent walking the rest of the timeline history. The walk
+# resumes from a cursor stored in source settings and runs until the entire
+# reachable timeline has been ingested once (x_timeline_complete).
+MAX_TIMELINE_BACKFILL_PAGES = 25
 # Pages of bookmarks pulled per sync (100/page via the X API).
 MAX_BOOKMARK_PAGES = 5
 
@@ -77,7 +84,9 @@ async def index_x_saves(source: dict) -> str | None:
         # pending skeleton rows — the hydration pass below fills them in.
         if x_user_id:
             await _backfill_bookmarks(source_id, owner_user_id, str(x_user_id))
-            await _backfill_user_tweets(client, source_id, owner_user_id, str(x_user_id))
+            await _backfill_user_tweets(
+                client, source_id, owner_user_id, str(x_user_id), source.get("settings") or {}
+            )
 
         # Hydrate a bounded batch of pending rows. Bounding the batch is what
         # lets a stuck account keep making progress across syncs even when the
@@ -132,19 +141,29 @@ async def _backfill_bookmarks(source_id: UUID, owner_user_id: UUID, x_user_id: s
                 params["pagination_token"] = next_token
             response = await client.get(X_BOOKMARKS_URL.format(user_id=x_user_id), params=params)
             if response.status_code in (401, 402, 403, 429):
+                # The body carries X's actual reason (e.g. UsageCapExceeded vs
+                # no enrolled credits) — the status alone can't distinguish.
                 logger.warning(
-                    "x bookmarks unavailable status=%s (X API tier/quota) source=%s",
+                    "x bookmarks unavailable status=%s (X API tier/quota) source=%s body=%s",
                     response.status_code,
                     source_id,
+                    response.text[:300],
+                )
+                await source_service.set_sync_warning(
+                    source_id,
+                    f"X bookmarks are unavailable (HTTP {response.status_code}): the X API "
+                    "bookmarks endpoint needs a paid tier with remaining monthly quota. "
+                    "Posts, replies, and articles still sync.",
                 )
                 return
             response.raise_for_status()
             payload = response.json()
+            inserted = 0
             for tweet in payload.get("data") or []:
                 tweet_id = tweet.get("id")
                 if not tweet_id:
                     continue
-                await pool.execute(
+                status = await pool.execute(
                     "INSERT INTO x_save_docs "
                     "(owner_user_id, source_id, path, name, kind, external_ref) "
                     "VALUES ($1, $2, $3, $4, 'Bookmark', $4) "
@@ -154,48 +173,119 @@ async def _backfill_bookmarks(source_id: UUID, owner_user_id: UUID, x_user_id: s
                     save_path("Bookmark", tweet_id),
                     tweet_id,
                 )
+                if status == "INSERT 0 1":
+                    inserted += 1
+            # Bookmarks come newest-first, so a page of already-known ids means
+            # the rest is known too. Every page read counts against the X API's
+            # paid read allowance — stop as early as possible.
+            if payload.get("data") and not inserted:
+                return
             next_token = (payload.get("meta") or {}).get("next_token")
             if not next_token:
                 break
 
 
 async def _backfill_user_tweets(
-    client: httpx.AsyncClient, source_id: UUID, owner_user_id: UUID, x_user_id: str
+    client: httpx.AsyncClient,
+    source_id: UUID,
+    owner_user_id: UUID,
+    x_user_id: str,
+    source_settings: dict,
 ) -> None:
-    """Insert pending rows for the user's own posts + replies (from their
-    timeline), which then hydrate through the same path as bookmarks. Retweets
-    are skipped — they aren't the user's own writing. Idempotent per tweet."""
-    pool = get_pool()
+    """Insert pending rows for the user's own posts + replies + articles (from
+    their timeline), which then hydrate through the same path as bookmarks.
+    Two passes, both idempotent per tweet:
+    - a fresh pass from the top of the timeline that stops once a page brings
+      nothing new, catching activity since the last sync;
+    - a history walk that resumes from a cursor stored in source settings, a
+      bounded number of pages per sync, until the whole reachable timeline has
+      been ingested once — then never runs again (x_timeline_complete)."""
     cursor: str | None = None
     for _ in range(MAX_USER_TWEET_PAGES):
-        params = {"userId": x_user_id}
-        if cursor:
-            params["cursor"] = cursor
-        response = await client.get(TAPI_USER_TWEETS_URL, params=params)
-        response.raise_for_status()
-        payload = response.json()
-        tweets = (payload.get("data") or {}).get("tweets") or []
-        for tweet in tweets:
-            tweet_id = tweet.get("id")
-            if not tweet_id or tweet.get("isRetweet"):
-                continue
-            kind = "Reply" if tweet.get("isReply") else "Post"
-            await pool.execute(
-                "INSERT INTO x_save_docs "
-                "(owner_user_id, source_id, path, name, kind, external_ref) "
-                "VALUES ($1, $2, $3, $4, $5, $4) "
-                "ON CONFLICT (source_id, path) DO NOTHING",
-                owner_user_id,
-                source_id,
-                save_path(kind, tweet_id),
-                tweet_id,
-                kind,
-            )
-        if not payload.get("has_next_page"):
-            break
+        payload = await _fetch_timeline_page(client, x_user_id, cursor)
+        inserted, considered = await _insert_timeline_page(payload, source_id, owner_user_id)
         cursor = payload.get("next_cursor")
-        if not cursor:
+        # A page of already-known tweets means we've reached familiar
+        # territory. An all-retweet page proves nothing — keep going.
+        if (considered and not inserted) or not payload.get("has_next_page") or not cursor:
             break
+
+    if source_settings.get("x_timeline_complete"):
+        return
+    cursor = source_settings.get("x_timeline_cursor")
+    for _ in range(MAX_TIMELINE_BACKFILL_PAGES):
+        payload = await _fetch_timeline_page(client, x_user_id, cursor)
+        await _insert_timeline_page(payload, source_id, owner_user_id)
+        cursor = payload.get("next_cursor")
+        if not payload.get("has_next_page") or not cursor:
+            await _merge_source_settings(source_id, {"x_timeline_complete": True})
+            return
+    await _merge_source_settings(source_id, {"x_timeline_cursor": cursor})
+
+
+async def _fetch_timeline_page(
+    client: httpx.AsyncClient, x_user_id: str, cursor: str | None
+) -> dict:
+    # `includeReplies` is required: twitterapi.io omits replies from
+    # last_tweets by default.
+    params = {"userId": x_user_id, "includeReplies": "true"}
+    if cursor:
+        params["cursor"] = cursor
+    response = await client.get(TAPI_USER_TWEETS_URL, params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+async def _insert_timeline_page(
+    payload: dict, source_id: UUID, owner_user_id: UUID
+) -> tuple[int, int]:
+    """Insert a skeleton row per tweet on the page; returns (newly inserted,
+    total considered). Retweets are skipped — they aren't the user's own
+    writing — and don't count as considered."""
+    pool = get_pool()
+    inserted = 0
+    considered = 0
+    for tweet in (payload.get("data") or {}).get("tweets") or []:
+        tweet_id = tweet.get("id")
+        if not tweet_id or tweet.get("isRetweet"):
+            continue
+        considered += 1
+        if tweet.get("article"):
+            kind = "Article"
+            # Articles synced before article detection existed landed as
+            # Posts; drop the stale row so the save doesn't appear twice.
+            await pool.execute(
+                "DELETE FROM x_save_docs WHERE source_id = $1 AND path = $2",
+                source_id,
+                save_path("Post", tweet_id),
+            )
+        elif tweet.get("isReply"):
+            kind = "Reply"
+        else:
+            kind = "Post"
+        status = await pool.execute(
+            "INSERT INTO x_save_docs "
+            "(owner_user_id, source_id, path, name, kind, external_ref) "
+            "VALUES ($1, $2, $3, $4, $5, $4) "
+            "ON CONFLICT (source_id, path) DO NOTHING",
+            owner_user_id,
+            source_id,
+            save_path(kind, tweet_id),
+            tweet_id,
+            kind,
+        )
+        if status == "INSERT 0 1":
+            inserted += 1
+    return inserted, considered
+
+
+async def _merge_source_settings(source_id: UUID, patch: dict) -> None:
+    await get_pool().execute(
+        "UPDATE user_sources SET settings = coalesce(settings, '{}'::jsonb) || $2::jsonb, "
+        "updated_at = now() WHERE id = $1",
+        source_id,
+        patch,
+    )
 
 
 async def _hydrate_one(
@@ -206,6 +296,9 @@ async def _hydrate_one(
     kind: str,
 ) -> None:
     tweet_id = _tweet_id_from_path(path)
+    if kind == "Article":
+        await _hydrate_article(client, source_id, owner_user_id, path)
+        return
     tweet = await _fetch_tweet(client, tweet_id)
 
     # A reply shows only its own text out of context, so pull the root of the
@@ -242,6 +335,90 @@ async def _hydrate_one(
         path,
         media,
     )
+
+
+async def _hydrate_article(
+    client: httpx.AsyncClient, source_id: UUID, owner_user_id: UUID, path: str
+) -> None:
+    """Articles are long-form X posts. The regular tweet lookup only carries a
+    title + preview, so the full body comes from twitterapi.io's article
+    endpoint; the cover image and any body images are archived like tweet
+    media."""
+    tweet_id = _tweet_id_from_path(path)
+    response = await client.get(TAPI_ARTICLE_URL, params={"tweet_id": tweet_id})
+    response.raise_for_status()
+    payload = response.json()
+    article = payload.get("article") or {}
+    if payload.get("status") != "success" or not article.get("title"):
+        raise RuntimeError(f"article {tweet_id} is unavailable (deleted, private, or suspended)")
+
+    author = (article.get("author") or {}).get("userName") or "unknown"
+    posted = _parse_time(article.get("createdAt"))
+    media = await _archive_media(owner_user_id, tweet_id, _article_media(article))
+
+    byline = f"— @{author}"
+    if posted:
+        byline += f" · {posted.date().isoformat()}"
+    content = "\n".join(
+        [
+            article["title"],
+            "",
+            _render_article_blocks(article.get("contents") or []),
+            "",
+            byline,
+            tweet_url(tweet_id),
+        ]
+    )
+    await source_service.upsert_content_document(
+        table="x_save_docs",
+        source_id=source_id,
+        owner_user_id=owner_user_id,
+        path=path,
+        name=article["title"],
+        kind="Article",
+        content=content,
+        external_ref=tweet_id,
+        external_updated_at=posted,
+    )
+    await get_pool().execute(
+        "UPDATE x_save_docs SET media = $3, hydration_status = 'done', "
+        "hydration_error = NULL, updated_at = now() WHERE source_id = $1 AND path = $2",
+        source_id,
+        path,
+        media,
+    )
+
+
+# Draft.js-style block types twitterapi.io uses for article bodies.
+_ARTICLE_HEADINGS = {"header-one": "# ", "header-two": "## ", "header-three": "### "}
+_ARTICLE_LIST_ITEMS = ("unordered-list-item", "ordered-list-item")
+
+
+def _render_article_blocks(blocks: list[dict]) -> str:
+    lines: list[str] = []
+    for block in blocks:
+        block_type = block.get("type") or ""
+        text = (block.get("text") or "").strip()
+        if block_type in _ARTICLE_HEADINGS and text:
+            lines.append(_ARTICLE_HEADINGS[block_type] + text)
+        elif block_type in _ARTICLE_LIST_ITEMS and text:
+            lines.append("- " + text)
+        elif block_type == "divider":
+            lines.append("---")
+        elif text:
+            lines.append(text)
+    return "\n\n".join(lines)
+
+
+def _article_media(article: dict) -> list[dict]:
+    """Cover image + any image/gif blocks in the body, in _archive_media shape."""
+    urls: list[str] = []
+    if article.get("cover_media_img_url"):
+        urls.append(article["cover_media_img_url"])
+    for block in article.get("contents") or []:
+        if block.get("type") in ("image", "gif") and block.get("url"):
+            urls.append(block["url"])
+    return [{"url": u, "is_video": False} for u in urls]
 
 
 def _render(tweet: dict, root: dict | None) -> str:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -483,6 +483,19 @@ async def mark_sync_done(source_id: UUID, cursor: str | None) -> None:
     )
 
 
+async def set_sync_warning(source_id: UUID, message: str) -> None:
+    """A non-fatal, owner-facing sync notice (e.g. one feed of a source needs a
+    paid provider tier while the rest keeps syncing). Stored in sync_error but
+    the source stays idle; the next sync start clears it, so a resolved warning
+    disappears on its own. Same safety rule as SourceSyncUserError: the message
+    must never contain tokens or provider payloads."""
+    await get_pool().execute(
+        "UPDATE user_sources SET sync_error = $2, updated_at = now() WHERE id = $1",
+        source_id,
+        message[:500],
+    )
+
+
 async def mark_sync_failed(source_id: UUID, error: str) -> None:
     await get_pool().execute(
         "UPDATE user_sources SET sync_status = 'failed', sync_error = $2, updated_at = now() "

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -1,10 +1,11 @@
 """X (Twitter) saves: OAuth bookmarks + twitterapi.io hydration.
 
 X connects over OAuth. Each sync the indexer pulls bookmark ids from the X API
-(with the OAuth token) and the user's own posts/replies from twitterapi.io by
-account id, then hydrates every tweet the same way — full text, reply thread
-root, archived media. Bookmarks sit behind a paid X API tier, so a 402/403 is
-best-effort (logged, never fatal) and must not stop posts/replies.
+(with the OAuth token) and the user's own posts/replies/articles from
+twitterapi.io by account id, then hydrates every tweet the same way — full
+text (long-form body for articles), reply thread root, archived media.
+Bookmarks sit behind a paid X API tier, so a 402/403 is best-effort (an
+owner-facing warning, never fatal) and must not stop posts/replies/articles.
 """
 
 from types import SimpleNamespace
@@ -43,11 +44,36 @@ _TIMELINE = {
             {"id": "200", "isReply": False, "isRetweet": False},
             {"id": "201", "isReply": True, "isRetweet": False},
             {"id": "202", "isReply": False, "isRetweet": True},  # retweet — skipped
+            # An article tweet: last_tweets carries a stub `article` object;
+            # the full body comes from the article endpoint at hydration.
+            {
+                "id": "203",
+                "isReply": False,
+                "isRetweet": False,
+                "article": {"title": "On agents", "preview_text": "For years..."},
+            },
         ]
     },
     "has_next_page": False,
 }
 _BOOKMARKS = {"data": [{"id": "900"}, {"id": "901"}], "meta": {}}
+_ARTICLE = {
+    "status": "success",
+    "article": {
+        "id": "203",
+        "title": "On agents",
+        "preview_text": "For years...",
+        "cover_media_img_url": "https://cdn.x/img.jpg",
+        "createdAt": "Sat Jul 18 22:20:40 +0000 2026",
+        "author": {"userName": "me"},
+        "contents": [
+            {"type": "unstyled", "text": "For years, tech went one way."},
+            {"type": "header-one", "text": "The shift"},
+            {"type": "unordered-list-item", "text": "copy the crowd"},
+            {"type": "divider"},
+        ],
+    },
+}
 
 
 class _FakeResponse:
@@ -56,6 +82,7 @@ class _FakeResponse:
         self.content = content
         self.headers = {"content-type": content_type}
         self.status_code = status_code
+        self.text = "{}"
 
     def raise_for_status(self):
         pass
@@ -107,6 +134,9 @@ class _FakeApi:
     media_streams: list = []
 
     bookmarks_status = 200
+    # cursor/token (None = first page) -> payload; overridable per test.
+    timeline_pages: dict = {}
+    bookmarks_pages: dict = {}
 
     def __init__(self, **kwargs):
         pass
@@ -123,11 +153,17 @@ class _FakeApi:
             tweet = {"1001": _REPLY, "1000": _ROOT}.get(tid) or _generic_tweet(tid)
             return _FakeResponse(payload={"tweets": [tweet]})
         if url == x_indexer.TAPI_USER_TWEETS_URL:
-            return _FakeResponse(payload=_TIMELINE)
+            # Replies must be requested explicitly; twitterapi.io omits them
+            # from last_tweets by default.
+            assert params.get("includeReplies") == "true"
+            return _FakeResponse(payload=type(self).timeline_pages[params.get("cursor")])
+        if url == x_indexer.TAPI_ARTICLE_URL:
+            assert params == {"tweet_id": "203"}
+            return _FakeResponse(payload=_ARTICLE)
         if url.startswith("https://api.x.com/2/users/") and url.endswith("/bookmarks"):
             if type(self).bookmarks_status != 200:
                 return _FakeResponse(payload={}, status_code=type(self).bookmarks_status)
-            return _FakeResponse(payload=_BOOKMARKS)
+            return _FakeResponse(payload=type(self).bookmarks_pages[params.get("pagination_token")])
         raise AssertionError(f"unexpected URL {url}")
 
     def stream(self, method, url):
@@ -152,6 +188,8 @@ def fake_sync(monkeypatch):
         return "oauth-token"
 
     _FakeApi.bookmarks_status = 200
+    _FakeApi.bookmarks_pages = {None: _BOOKMARKS}
+    _FakeApi.timeline_pages = {None: _TIMELINE}
     _FakeApi.media_bytes = b"fake image bytes"
     _FakeApi.media_headers = {"content-type": "image/jpeg"}
     _FakeApi.media_streams = []
@@ -317,10 +355,11 @@ async def test_backfills_bookmarks_and_own_posts(client, pool, fake_sync) -> Non
         UUID(source["id"]),
     )
     got = [(r["path"], r["kind"], r["hydration_status"]) for r in rows]
-    # bookmarks (900/901) from the X API + own post/reply (200/201) from the
-    # timeline; the retweet (202) is skipped. Each lands under its kind folder,
-    # all hydrated in this one pass.
+    # bookmarks (900/901) from the X API + own post/reply/article (200/201/203)
+    # from the timeline; the retweet (202) is skipped. Each lands under its
+    # kind folder, all hydrated in this one pass.
     assert got == [
+        ("Articles/203", "Article", "done"),
         ("Bookmarks/900", "Bookmark", "done"),
         ("Bookmarks/901", "Bookmark", "done"),
         ("Posts/200", "Post", "done"),
@@ -329,9 +368,126 @@ async def test_backfills_bookmarks_and_own_posts(client, pool, fake_sync) -> Non
 
 
 @pytest.mark.asyncio
+async def test_article_hydrates_full_body_with_title_name(client, pool, fake_sync) -> None:
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow(
+        "SELECT * FROM x_save_docs WHERE source_id = $1 AND path = 'Articles/203'",
+        UUID(source["id"]),
+    )
+    assert row["hydration_status"] == "done"
+    assert row["name"] == "On agents"  # articles are named by title, not @author-date
+    assert "For years, tech went one way." in row["content"]
+    assert "# The shift" in row["content"]  # heading blocks render as markdown
+    assert "- copy the crowd" in row["content"]
+    assert "— @me · 2026-07-18" in row["content"]
+    # The cover image is archived like tweet media.
+    assert row["media"] == [{"storage_key": "store/x-203-0.jpg", "content_type": "image/jpeg"}]
+
+
+@pytest.mark.asyncio
+async def test_article_previously_synced_as_post_is_rekinded(client, pool, fake_sync) -> None:
+    # Articles synced before article detection existed landed as Posts; the
+    # backfill must replace that row, not duplicate the save under two folders.
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+    await _insert_pending(pool, owner_id, source["id"], "Posts/203", "Post")
+
+    await x_indexer.index_x_saves(source)
+
+    paths = [
+        r["path"]
+        for r in await pool.fetch(
+            "SELECT path FROM x_save_docs WHERE source_id = $1 AND path LIKE '%/203'",
+            UUID(source["id"]),
+        )
+    ]
+    assert paths == ["Articles/203"]
+
+
+@pytest.mark.asyncio
+async def test_bookmark_backfill_stops_at_known_ids(client, pool, fake_sync) -> None:
+    # Every bookmarks page read costs paid X API reads. Bookmarks come
+    # newest-first, so once a page brings nothing new the rest of the list is
+    # already saved — deeper pages must not be fetched.
+    _FakeApi.bookmarks_pages = {
+        None: {"data": [{"id": "900"}, {"id": "901"}], "meta": {"next_token": "b2"}},
+        "b2": {"data": [{"id": "902"}], "meta": {}},
+    }
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/900", "Bookmark")
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/901", "Bookmark")
+
+    await x_indexer.index_x_saves(source)
+
+    count = await pool.fetchval(
+        "SELECT count(*) FROM x_save_docs WHERE source_id = $1 AND path = 'Bookmarks/902'",
+        UUID(source["id"]),
+    )
+    assert count == 0  # page 2 was never fetched
+
+
+@pytest.mark.asyncio
+async def test_timeline_history_walk_resumes_across_syncs(
+    client, pool, fake_sync, monkeypatch
+) -> None:
+    # The whole timeline must be ingested even when one sync's page budget
+    # can't cover it: the walk parks its cursor in source settings, the next
+    # sync resumes there, and once the end is reached the walk never runs
+    # again.
+    monkeypatch.setattr(x_indexer, "MAX_USER_TWEET_PAGES", 1)
+    monkeypatch.setattr(x_indexer, "MAX_TIMELINE_BACKFILL_PAGES", 1)
+    _FakeApi.timeline_pages = {
+        None: {
+            "data": {"tweets": [{"id": "300", "isReply": False, "isRetweet": False}]},
+            "has_next_page": True,
+            "next_cursor": "c2",
+        },
+        "c2": {
+            "data": {"tweets": [{"id": "301", "isReply": True, "isRetweet": False}]},
+            "has_next_page": False,
+        },
+    }
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+
+    await x_indexer.index_x_saves(source)
+
+    # Sync 1: the fresh pass took page 1; the walk's budget ran out at c2.
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert settings_["x_timeline_cursor"] == "c2"
+    assert "x_timeline_complete" not in settings_
+
+    source = await source_service.get_source_for_sync(UUID(source["id"]))
+    await x_indexer.index_x_saves(source)
+
+    # Sync 2: the walk resumed at c2 and reached the end of the timeline.
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert settings_["x_timeline_complete"] is True
+    paths = [
+        r["path"]
+        for r in await pool.fetch(
+            "SELECT path FROM x_save_docs WHERE source_id = $1 AND kind != 'Bookmark' "
+            "ORDER BY path",
+            UUID(source["id"]),
+        )
+    ]
+    assert paths == ["Posts/300", "Replies/301"]
+
+
+@pytest.mark.asyncio
 async def test_bookmarks_paid_tier_gate_is_best_effort(client, pool, fake_sync) -> None:
     # A 403 on the bookmarks endpoint (paid X tier) must not stop the user's
-    # own posts/replies from syncing.
+    # own posts/replies/articles from syncing — but the owner must be able to
+    # see WHY bookmarks stopped, so it lands as a warning on the source.
     _FakeApi.bookmarks_status = 403
     headers, owner_id = await _register(client)
     source = await _x_source(pool, owner_id, x_user_id="999")
@@ -342,4 +498,9 @@ async def test_bookmarks_paid_tier_gate_is_best_effort(client, pool, fake_sync) 
         "SELECT DISTINCT kind FROM x_save_docs WHERE source_id = $1 ORDER BY kind",
         UUID(source["id"]),
     )
-    assert [k["kind"] for k in kinds] == ["Post", "Reply"]  # no bookmarks, but posts/replies landed
+    assert [k["kind"] for k in kinds] == ["Article", "Post", "Reply"]
+    status = await pool.fetchrow(
+        "SELECT sync_status, sync_error FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert status["sync_status"] != "failed"
+    assert "paid tier" in status["sync_error"]

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -584,8 +584,16 @@ function SourceRow({
             )}
           </span>
         </div>
-        {status.sync_status === "failed" && status.sync_error && (
-          <div className="mt-1 truncate font-mono text-[11.5px] text-error">{status.sync_error}</div>
+        {status.sync_error && (
+          <div
+            className={
+              "mt-1 truncate font-mono text-[11.5px] " +
+              (status.sync_status === "failed" ? "text-error" : "text-warning")
+            }
+            title={status.sync_error}
+          >
+            {status.sync_error}
+          </div>
         )}
         {pollStopped && (
           <div className="mt-1 truncate text-[11.5px] text-muted-foreground">{pollStopped}</div>


### PR DESCRIPTION
## What

Prod X sync was bookmarks + posts only. This makes all four kinds sync and fixes the read-burn that likely contributed to the bookmarks 402:

- **Replies**: pass `includeReplies` to twitterapi.io `last_tweets` — it omits replies by default, which is why no Reply row ever existed in prod.
- **Articles**: article tweets carry an `article` stub in the timeline; hydrate them via twitterapi.io's `/twitter/article` endpoint — full long-form body rendered to markdown-ish text, save named by title, cover + body images archived. Articles previously mis-kinded as Posts are re-kinded when the backfill sees them.
- **Full timeline history**: a history walk resumes from a cursor persisted in source settings (25 pages/sync) until the whole reachable timeline is ingested once (`x_timeline_complete`); the fresh top-of-timeline pass stops as soon as a page brings nothing new.
- **Bookmark read burn**: bookmarks backfill stops at the first page of already-known ids. The old loop re-read up to 500 bookmarks every 32-minute sync (~22k paid X API reads/day).
- **402 visibility**: the bookmarks paid-tier failure now lands as an owner-facing warning on the source (new `source_service.set_sync_warning`, amber line on the integrations page — screenshot below) instead of worker-logs-only, and the log now includes X's response body so the exact 402 reason (`UsageCapExceeded` vs no enrolled credits) is diagnosable.

## Screenshots

Integrations page with the new amber sync warning on an idle (non-failed) source: [screenshot](https://app.joinstash.ai/f/5cb17e63-f70b-4d53-95ca-7e6319e0add9)

## Tests

10 backend tests in `test_x_saves.py` (4 new: article hydration, Post→Article re-kind, history-walk cursor resume, bookmark early-stop; bookmarks-gate test now asserts the warning). ruff + vitest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaexpwwBZH8PsvQbYz1ddM