### PR TITLE
VFS grep: reject BRE escapes loudly, accept -E, support -F

### DIFF
--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -151,6 +151,33 @@ def test_app_vfs_grep_no_match_stops_and_chain():
     assert result.stderr == ""
 
 
+def test_app_vfs_grep_rejects_bre_escapes_loudly():
+    """Patterns compile as extended regex, where BRE's `\\|` means a literal pipe —
+    a default-grep caller writing `foo\\|bar` would silently match nothing (this
+    burned Heavi's agent in prod). The shell must refuse with a correction, never
+    return a clean no-match exit 1."""
+    shell, _client = _shell()
+
+    result = shell.run("grep -ri 'hello\\|missing' /")
+
+    assert result.exit_code == 2
+    assert "extended" in result.stderr
+
+    # The same intent written as extended regex works.
+    assert shell.run("grep -ri 'hello|missing' /").exit_code == 0
+
+
+def test_app_vfs_grep_accepts_extended_and_fixed_string_flags():
+    shell, _client = _shell()
+
+    # -E is a no-op: patterns are already extended regex.
+    assert shell.run("grep -rE 'hello|missing' /").exit_code == 0
+
+    # -F matches the pattern as literal text, regex metacharacters included.
+    assert shell.run("printf 'a|b\\n' | grep -F 'a|b'").stdout == "a|b\n"
+    assert shell.run("printf 'ab\\n' | grep -F 'a|b'").exit_code == 1
+
+
 def test_app_vfs_printf_supports_string_formats():
     shell, _client = _shell()
 

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -364,6 +364,7 @@ class SkillAppVfsShell:
         ignore_case = False
         recursive = name == "rg"
         show_line_numbers = name == "rg"
+        fixed_strings = False
         before = 0
         after = 0
         options_done = False
@@ -383,6 +384,10 @@ class SkillAppVfsShell:
                         show_line_numbers = True
                     elif arg == "--recursive":
                         recursive = True
+                    elif arg == "--extended-regexp":
+                        pass  # patterns are always extended regex here
+                    elif arg == "--fixed-strings":
+                        fixed_strings = True
                     else:
                         raise VfsShellError(f"unsupported {name} option: {arg}", exit_code=2)
                     index += 1
@@ -407,7 +412,7 @@ class SkillAppVfsShell:
                     index += 1
                     continue
                 flags = arg[1:]
-                unsupported = sorted(set(flags) - set("inrR"))
+                unsupported = sorted(set(flags) - set("inrREF"))
                 if unsupported:
                     raise VfsShellError(
                         f"unsupported {name} option: -{unsupported[0]}",
@@ -416,6 +421,7 @@ class SkillAppVfsShell:
                 ignore_case = ignore_case or "i" in flags
                 recursive = recursive or "r" in flags or "R" in flags
                 show_line_numbers = show_line_numbers or "n" in flags
+                fixed_strings = fixed_strings or "F" in flags
                 index += 1
                 continue
             values.append(arg)
@@ -426,10 +432,14 @@ class SkillAppVfsShell:
         pattern = values[0]
         paths = values[1:]
         flags = re.IGNORECASE if ignore_case else 0
-        try:
-            regex = re.compile(pattern, flags)
-        except re.error as e:
-            raise VfsShellError(str(e)) from e
+        if fixed_strings:
+            regex = re.compile(re.escape(pattern), flags)
+        else:
+            _reject_bre_escapes(pattern)
+            try:
+                regex = re.compile(pattern, flags)
+            except re.error as e:
+                raise VfsShellError(str(e)) from e
 
         if stdin is not None and not paths:
             output = _grep_text(
@@ -821,6 +831,25 @@ def _render_printf_template(template: str, values: list[str]) -> tuple[str, int]
         index += 2
 
     return "".join(output), used
+
+
+def _reject_bre_escapes(pattern: str) -> None:
+    """Patterns compile as Python (extended) regex, where BRE's operator escapes
+    `\\|` `\\(` `\\)` mean the *literal* character — so a caller writing default-grep
+    syntax like `foo\\|bar` would silently match nothing. Refuse loudly instead."""
+    index = 0
+    while index < len(pattern) - 1:
+        if pattern[index] != "\\":
+            index += 1
+            continue
+        escaped = pattern[index + 1]
+        if escaped in "|()":
+            raise VfsShellError(
+                f"pattern escape \\{escaped} is BRE syntax; patterns here are extended "
+                f"regex — use {escaped} as the operator, or -F to match text literally",
+                exit_code=2,
+            )
+        index += 2
 
 
 def _grep_text(


### PR DESCRIPTION
this is an (immediate) fix for the bug nate found. his agent was trying to use a different dialect of grep than we support, so no we just just fail loudly when the wrong dialect is passed in.


## The bug

The VFS shell's grep compiles patterns with Python `re` — extended-regex semantics — but callers write default-grep (BRE) syntax, where alternation is `\|`. In Python regex `\|` is a *literal pipe*, so a BRE pattern silently matches nothing and exits 1 with empty stderr: indistinguishable from a genuine no-match.

This bit Heavi in prod (Nate's report in #heavi-stash, session `0c2ff4ca…`): their agent ran

```
grep -ri -n -A 4 -B 4 "brake shoe\|International 4900\|rear air brake" /memory /sources
```

got exit 1, concluded Stash had nothing on brake shoes, and fell back to guessing a brake foundation — while an 8,378-char **Brake Shoes** cheat sheet (plus two brake-shoes expert-call pages) sat in `/memory/cheat_sheets` and would have matched.

## The fix

Commit to **one dialect — extended regex — and fail loud on the other**. Deliberately no BRE→ERE translation layer: `\|` is a legitimate literal-pipe escape in ERE, so guessing intent would silently change meaning; the only non-fallback behavior is a corrective error.

- Patterns containing the BRE operator escapes `\|` `\(` `\)` now raise exit 2:
  `grep: pattern escape \| is BRE syntax; patterns here are extended regex — use | as the operator, or -F to match text literally`
  An agent that sees this fixes its pattern on the next call — versus the old clean exit 1, which read as "the corpus has nothing".
- `-E` / `--extended-regexp` accepted as a no-op (previously rejected as unsupported, penalizing the *correct* dialect).
- `-F` / `--fixed-strings` supported via `re.escape`, the escape hatch the error message points to.

One implementation in `stashvfs/shell.py`, so the CLI and the HTTP `/api/v1/me/vfs` endpoint (the path Heavi's `search_stash` subagent uses) both get it; merging deploys it for them.

## Verification

- New tests: BRE escape → exit 2 with guidance (docstring encodes the Heavi failure mode so it can't regress quietly); `-E` no-op; `-F` literal matching.
- All 62 VFS tests pass (`backend/tests/test_vfs.py`, `cli/tests/test_app_vfs.py`, `cli/tests/test_mount_vfs.py`); ruff check + format clean.
- Reproduced the original failure against a live Stash before the fix: `grep -ri 'Heavi\|benchmark' <file>` → exit 1, same pattern with `|` → exit 0 with matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)