### PR TITLE
VFS: warn loudly when head/tail/sed drop lines

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -3719,7 +3719,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /`
 - `stash vfs "find / -maxdepth 3 -type f"`
 - `stash vfs "rg 'query' /"`
-- `stash vfs "cat '/files/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/files/README.md'"`
 
 Common reads:
 - `stash search "<query>" --json` — full-text search across files, sessions, and connected sources
@@ -4672,7 +4672,7 @@ virtual Stash tree:
 - `stash vfs ls /`
 - `stash vfs "find / -maxdepth 3 -type f"`
 - `stash vfs "rg 'query' /"`
-- `stash vfs "cat '/files/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/files/README.md'"`
 
 Anti-pattern: minting one Stash per file you happen to share. Skills
 exist to group related things; one item per Stash defeats the model and

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -141,6 +141,45 @@ def test_app_vfs_pipes_cat_to_sed_and_grep():
     assert "transcript.md:" in shell.run("rg -n hello /").stdout
 
 
+def test_app_vfs_head_and_tail_warn_when_lines_are_dropped():
+    shell, _client = _shell()
+
+    result = shell.run(r"printf 'a\nb\nc\nd\ne\n' | head -2")
+
+    assert result.exit_code == 0
+    assert result.stdout == "a\nb\n"
+    assert "head: showing the first 2 of 5 lines; 3 lines were NOT shown." in result.stderr
+
+    result = shell.run(r"printf 'a\nb\nc\nd\ne\n' | tail -1")
+
+    assert result.stdout == "e\n"
+    assert "tail: showing the last 1 of 5 lines; 4 lines were NOT shown." in result.stderr
+
+
+def test_app_vfs_head_is_silent_when_nothing_is_dropped():
+    shell, _client = _shell()
+
+    result = shell.run(r"printf 'a\nb\n' | head -5")
+
+    assert result.stdout == "a\nb\n"
+    assert result.stderr == ""
+
+
+def test_app_vfs_sed_range_warns_when_lines_are_dropped():
+    shell, _client = _shell()
+
+    result = shell.run(r"printf 'a\nb\nc\nd\ne\n' | sed -n '2,3p'")
+
+    assert result.exit_code == 0
+    assert result.stdout == "b\nc\n"
+    assert "sed: showing lines 2-3 of 5; 3 lines were NOT shown." in result.stderr
+
+    full = shell.run(r"printf 'a\nb\n' | sed -n '1,2p'")
+
+    assert full.stdout == "a\nb\n"
+    assert full.stderr == ""
+
+
 def test_app_vfs_grep_no_match_stops_and_chain():
     shell, _client = _shell()
 

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -43,7 +43,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 stash vfs ls /
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"query\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 ```
 
 ### Plugin control

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -89,7 +89,7 @@ The plugin also gives Claude access to the rest of the `stash` CLI. Key commands
 ```bash
 stash vfs "find /me -maxdepth 3 -type f"               # Browse Stash like a filesystem without an OS mount
 stash vfs "rg \"database migration\" /me"              # Search the virtual Stash tree
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash search "database migration"                       # Full-text search events
 stash vfs "cat '/me/sessions/_index.jsonl'"            # Recent events
 stash vfs "find /me -name '*.md'"                      # List all pages

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -70,8 +70,7 @@ CONTEXT = (
     "Browse Stash through the virtual filesystem first when you need "
     'context: `stash vfs ls /me`, `stash vfs "find /me -maxdepth 3 '
     '-type f"`, `stash vfs "rg \\"query\\" /me"`, or '
-    "`stash vfs \"cat '/me/files/README.md' | sed -n "
-    "'1,80p'\"`.\n\n"
+    "`stash vfs \"cat '/me/files/README.md'\"`.\n\n"
     "Common direct reads: "
     '`stash search "<query>"`, '
     "`stash vfs \"cat '/me/sessions/_index.jsonl'\"`, "

--- a/plugins/codex-plugin/AGENTS.md
+++ b/plugins/codex-plugin/AGENTS.md
@@ -27,7 +27,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 ## Common reads (all support `--json`)
 

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -78,7 +78,7 @@ the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mou
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -81,7 +81,7 @@ shell out to the `stash` CLI. Use `stash vfs` for filesystem-style browsing with
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/plugins/cursor-plugin/stash.mdc
+++ b/plugins/cursor-plugin/stash.mdc
@@ -13,7 +13,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 Your activity in this repo is streamed to your Stash, so your other agents and you can see what you're working on.
 

--- a/plugins/opencode-plugin/AGENTS.md
+++ b/plugins/opencode-plugin/AGENTS.md
@@ -27,7 +27,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 ## Common reads (all support `--json`)
 

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -65,7 +65,7 @@ opencode agents have shell access. Point the agent at the `stash` CLI for reads 
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -27,7 +27,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 ## Common reads (all support `--json`)
 

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -78,7 +78,7 @@ the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mou
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -81,7 +81,7 @@ shell out to the `stash` CLI. Use `stash vfs` for filesystem-style browsing with
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/stashai/plugin/assets/cursor/stash.mdc
+++ b/stashai/plugin/assets/cursor/stash.mdc
@@ -13,7 +13,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 Your activity in this repo is streamed to your Stash, so your other agents and you can see what you're working on.
 

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -27,7 +27,7 @@ Use `stash vfs` when you want to browse Stash like a filesystem without mounting
 - `stash vfs ls /me`
 - `stash vfs "find /me -maxdepth 3 -type f"`
 - `stash vfs "rg \"query\" /me"`
-- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+- `stash vfs "cat '/me/README.md'"`
 
 ## Common reads (all support `--json`)
 

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -65,7 +65,7 @@ opencode agents have shell access. Point the agent at the `stash` CLI for reads 
 ```
 stash vfs "find /me -maxdepth 3 -type f"
 stash vfs "rg \"database migration\" /me"
-stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/README.md'"
 stash vfs "cat '/me/sessions/_index.jsonl'"
 stash search "<query>"
 stash whoami --json

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -503,7 +503,14 @@ class SkillAppVfsShell:
             start = int(match.group(1))
             end = int(match.group(2))
         lines = text.splitlines(keepends=True)
-        return "".join(lines[start - 1 : end])
+        selected = lines[start - 1 : end]
+        dropped = len(lines) - len(selected)
+        if dropped > 0:
+            self._warn(
+                f"sed: showing lines {start}-{min(end, len(lines))} of {len(lines)}; "
+                f"{dropped} lines were NOT shown."
+            )
+        return "".join(selected)
 
     def _head_or_tail(self, args: list[str], stdin: str | None, *, from_tail: bool) -> str:
         count = 10
@@ -527,6 +534,14 @@ class SkillAppVfsShell:
         text = stdin if not paths and stdin is not None else self._cat(paths)
         lines = text.splitlines(keepends=True)
         selected = lines[-count:] if from_tail else lines[:count]
+        dropped = len(lines) - len(selected)
+        if dropped > 0:
+            name = "tail" if from_tail else "head"
+            which = "last" if from_tail else "first"
+            self._warn(
+                f"{name}: showing the {which} {len(selected)} of {len(lines)} lines; "
+                f"{dropped} lines were NOT shown."
+            )
         return "".join(selected)
 
     def _wc(self, args: list[str], stdin: str | None) -> str:


### PR DESCRIPTION
## Why

Heavi's parts agent read their longest cheat sheet with `cat ... | head -240` — clean output, exit 0, and no signal that the file had 265 lines. The agent had no way to know it missed the tail, so it never went back. (Reported by Nate in #heavi-stash.)

Worse, our own agent guidance was teaching this habit: every example modeled reading a file as `cat '/me/README.md' | sed -n '1,80p'`.

## What

- `head`, `tail`, and `sed -n 'N,Mp'` in the VFS shell now emit a stderr warning whenever their selection drops lines:
  ```
  head: showing the first 240 of 265 lines; 25 lines were NOT shown.
  ```
  Same channel and tone as the existing INCOMPLETE warnings on truncated `ls`/`find`/`tree` listings. Agents reliably react to this by re-reading the rest.
- All agent-guidance examples (CLI `prompts agent-guidance`, claude/codex/cursor/opencode plugin docs + session-start hook, synced `stashai/plugin/assets` copies) now read files whole instead of demonstrating partial reads.

## Testing

- New unit tests: head/tail/sed warn when lines are dropped, stay silent when nothing is dropped.
- `pytest cli/` 130 passed, `pytest plugins/tests/` 107 passed, ruff clean. (Backend suite needs the `stash_test` DB, not available in this environment — CI will run it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)