### PR TITLE
Disconnecting an integration keeps its data; deletion is explicit

### DIFF
--- a/backend/integrations/base.py
+++ b/backend/integrations/base.py
@@ -24,10 +24,16 @@ class TokenSet:
 
 @dataclass
 class AccountInfo:
-    """Identity surface shown back to the user in the integration card."""
+    """Identity surface shown back to the user in the integration card.
+
+    account_ref is the provider's STABLE account id (X user id, Google email,
+    GitHub login) — the anchor for the reconnect identity check. Providers
+    that can supply it must; without it a reconnect under a different account
+    cannot be detected."""
 
     email: str | None
     display_name: str | None
+    account_ref: str | None = None
 
 
 @dataclass

--- a/backend/integrations/github/provider.py
+++ b/backend/integrations/github/provider.py
@@ -113,4 +113,8 @@ class GitHubIntegration(Integration):
                         if e.get("primary") and e.get("verified"):
                             email = e.get("email")
                             break
-        return AccountInfo(email=email, display_name=user.get("name") or user.get("login"))
+        return AccountInfo(
+            email=email,
+            display_name=user.get("name") or user.get("login"),
+            account_ref=user.get("login"),
+        )

--- a/backend/integrations/gmail/provider.py
+++ b/backend/integrations/gmail/provider.py
@@ -106,7 +106,11 @@ class GmailIntegration(Integration):
             resp = await client.get(USERINFO_URL)
             resp.raise_for_status()
             payload = resp.json()
-        return AccountInfo(email=payload.get("email"), display_name=payload.get("name"))
+        return AccountInfo(
+            email=payload.get("email"),
+            display_name=payload.get("name"),
+            account_ref=payload.get("email"),
+        )
 
 
 def _payload_to_tokenset(payload: dict) -> TokenSet:

--- a/backend/integrations/google/provider.py
+++ b/backend/integrations/google/provider.py
@@ -117,7 +117,11 @@ class GoogleIntegration(Integration):
             resp = await client.get(USERINFO_URL)
             resp.raise_for_status()
             payload = resp.json()
-        return AccountInfo(email=payload.get("email"), display_name=payload.get("name"))
+        return AccountInfo(
+            email=payload.get("email"),
+            display_name=payload.get("name"),
+            account_ref=payload.get("email"),
+        )
 
 
 def _payload_to_tokenset(payload: dict) -> TokenSet:

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -100,6 +100,8 @@ class IntegrationAccountItem(BaseModel):
     expires_at: str | None = None
     connected_at: str | None = None
     needs_reconnect: bool = False
+    # Disconnected-with-data-kept: no token, but sources/documents remain.
+    disconnected: bool = False
 
 
 class ProviderListItem(BaseModel):
@@ -107,6 +109,9 @@ class ProviderListItem(BaseModel):
     display_name: str
     scopes: list[str]
     connected: bool
+    # Disconnected-with-data-kept: not connected, but the provider still has
+    # sources/documents the user chose to keep.
+    disconnected: bool = False
     enabled: bool
     disabled_reason: str | None = None
     # "oauth" (the default redirect flow), "mcp_oauth" (DCR+PKCE via an MCP
@@ -249,7 +254,8 @@ async def list_integrations(current_user: dict = Depends(get_current_user)):
                 provider=p.name,
                 display_name=p.display_name,
                 scopes=p.scopes,
-                connected=conn is not None,
+                connected=conn is not None and not conn["disconnected"],
+                disconnected=bool(conn and conn["disconnected"]),
                 enabled=disabled_reason is None,
                 disabled_reason=disabled_reason,
                 auth_kind=getattr(p, "auth_kind", "oauth"),
@@ -369,6 +375,20 @@ async def integration_callback(
                     type(e).__name__,
                 )
                 account = AccountInfo(email=None, display_name=None)
+            # Reconnect identity check: refuse to link a DIFFERENT provider
+            # account while the previous account's connection (and possibly
+            # its kept data) exists. The identity comes from the provider's
+            # own answer to the new token — never from the client.
+            mismatched = await storage.account_mismatch(user_id, provider, account)
+            if mismatched:
+                logger.warning(
+                    "OAuth callback account mismatch for %s: stored account differs", provider
+                )
+                base = settings.PUBLIC_URL.rstrip("/")
+                query = {"integration_error": "account_mismatch", "expected": mismatched}
+                return RedirectResponse(
+                    url=f"{base}/integrations/{provider}?{urlencode(query)}", status_code=302
+                )
             await storage.store_token(user_id, provider, token, account)
             await security_audit_service.record_user_event(
                 action="integration.connected",
@@ -440,34 +460,67 @@ async def integration_callback(
     )
 
 
+class DisconnectRequest(BaseModel):
+    delete_data: bool = False
+
+
+async def _purge_provider_data(user_id: UUID, provider: str, reason: str) -> list[dict]:
+    """Delete a provider's data (sources, documents, media blobs, shares) and
+    forget the stored account entirely, so a different account may connect."""
+    purged = await source_service.purge_sources_for_provider(user_id, provider)
+    await storage.revoke_stored(user_id, provider)
+    for source in purged:
+        await security_audit_service.record_event(
+            action="source.purged",
+            actor_user_id=user_id,
+            owner_user_id=UUID(source["owner_user_id"]),
+            target_type="source",
+            target_id=source["id"],
+            provider=provider,
+            source_type=source["source_type"],
+            metadata={"reason": reason},
+        )
+    return purged
+
+
 @router.post("/{provider}/disconnect")
 async def integration_disconnect(
     provider: str,
+    body: DisconnectRequest | None = None,
     current_user: dict = Depends(get_current_user),
 ):
+    """Disconnect stops syncing and revokes credentials; it deletes data ONLY
+    when the user explicitly chose that in the disconnect dialog."""
     get_provider(provider)  # 404 if unknown
-    removed = await source_service.delete_sources_for_provider(current_user["id"], provider)
-    await storage.revoke_stored(current_user["id"], provider)
+    delete_data = bool(body and body.delete_data)
+    if delete_data:
+        removed = await _purge_provider_data(
+            current_user["id"], provider, reason="integration_disconnect"
+        )
+    else:
+        removed = await source_service.disable_sources_for_provider(current_user["id"], provider)
+        await storage.disconnect_stored(current_user["id"], provider)
     await security_audit_service.record_user_event(
         action="integration.disconnected",
         actor_user_id=current_user["id"],
         target_type="integration",
         target_id=provider,
         provider=provider,
-        metadata={"removed_sources": len(removed)},
+        metadata={"sources": len(removed), "data_deleted": delete_data},
     )
-    for source in removed:
-        await security_audit_service.record_event(
-            action="source.deleted",
-            actor_user_id=current_user["id"],
-            owner_user_id=UUID(source["owner_user_id"]),
-            target_type="source",
-            target_id=source["id"],
-            provider=provider,
-            source_type=source["source_type"],
-            metadata={"reason": "integration_disconnect"},
-        )
-    return {"ok": True, "removed_sources": len(removed)}
+    return {"ok": True, "sources": len(removed), "data_deleted": delete_data}
+
+
+@router.post("/{provider}/purge")
+async def integration_purge(
+    provider: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Delete the kept data of a disconnected (or connected) provider. The
+    explicit, destructive counterpart to disconnect-keeps-data."""
+    get_provider(provider)  # 404 if unknown
+    purged = await _purge_provider_data(current_user["id"], provider, reason="purge")
+    return {"ok": True, "sources": len(purged)}
 
 
 class CredentialConnectResponse(BaseModel):

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -57,6 +57,26 @@ def _account_row(row) -> dict:
     }
 
 
+async def account_mismatch(user_id: UUID, provider: str, account: AccountInfo) -> str | None:
+    """The reconnect identity check. Returns the stored account's label when
+    this connect is under a DIFFERENT provider account than the one already
+    linked (whose data may be kept) — the caller must refuse the connect. The
+    check needs both sides' account_ref; a provider that doesn't supply one
+    cannot be checked."""
+    if not account.account_ref:
+        return None
+    row = await get_pool().fetchrow(
+        "SELECT account_ref, account_display_name, account_email FROM user_integrations "
+        "WHERE user_id = $1 AND provider = $2 AND account_key = $3",
+        user_id,
+        provider,
+        _account_key_for(provider, account),
+    )
+    if row is None or not row["account_ref"] or row["account_ref"] == account.account_ref:
+        return None
+    return row["account_display_name"] or row["account_email"] or row["account_ref"]
+
+
 async def store_token(
     user_id: UUID,
     provider: str,
@@ -71,10 +91,10 @@ async def store_token(
             user_id, provider, account_key,
             access_token_encrypted, refresh_token_encrypted,
             scopes, expires_at,
-            account_email, account_display_name,
+            account_email, account_display_name, account_ref,
             updated_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now())
         ON CONFLICT (user_id, provider, account_key) DO UPDATE SET
             access_token_encrypted = EXCLUDED.access_token_encrypted,
             refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, user_integrations.refresh_token_encrypted),
@@ -82,6 +102,7 @@ async def store_token(
             expires_at = EXCLUDED.expires_at,
             account_email = EXCLUDED.account_email,
             account_display_name = EXCLUDED.account_display_name,
+            account_ref = COALESCE(EXCLUDED.account_ref, user_integrations.account_ref),
             updated_at = now()
         """,
         user_id,
@@ -93,6 +114,7 @@ async def store_token(
         token.expires_at,
         account.email,
         account.display_name,
+        account.account_ref,
     )
 
 
@@ -101,6 +123,18 @@ _TOKEN_QUERY = """
     FROM user_integrations
     WHERE user_id = $1 AND provider = $2 AND account_key = $3
 """
+
+
+def _require_token_row(row, provider: str) -> None:
+    """A missing row means never connected; a row with nulled tokens means
+    disconnected-with-data-kept. Both fail loud, with distinct messages."""
+    if row is None:
+        raise HTTPException(status_code=401, detail=f"not connected to {provider}")
+    if row["access_token_encrypted"] is None:
+        raise HTTPException(
+            status_code=401,
+            detail=f"{provider} is disconnected — reconnect to read",
+        )
 
 
 def _needs_refresh(expires_at: datetime | None) -> bool:
@@ -119,11 +153,7 @@ async def get_valid_token(
 
     pool = get_pool()
     row = await pool.fetchrow(_TOKEN_QUERY, user_id, provider, account_key)
-    if row is None:
-        raise HTTPException(
-            status_code=401,
-            detail=f"not connected to {provider}",
-        )
+    _require_token_row(row, provider)
     if not _needs_refresh(row["expires_at"]):
         return _decrypt(row["access_token_encrypted"])  # type: ignore[return-value]
 
@@ -138,11 +168,7 @@ async def get_valid_token(
             f"user_integrations:{user_id}:{provider}:{account_key}",
         )
         row = await conn.fetchrow(_TOKEN_QUERY, user_id, provider, account_key)
-        if row is None:
-            raise HTTPException(
-                status_code=401,
-                detail=f"not connected to {provider}",
-            )
+        _require_token_row(row, provider)
         if not _needs_refresh(row["expires_at"]):
             return _decrypt(row["access_token_encrypted"])  # type: ignore[return-value]
 
@@ -173,6 +199,37 @@ async def get_valid_token(
             account_key,
         )
         return new_token.access_token
+
+
+async def disconnect_stored(user_id: UUID, provider: str) -> None:
+    """Disconnect without forgetting who was connected: revoke the tokens at
+    the provider and null them locally, but KEEP the row — account_ref must
+    survive so a later reconnect can be verified against the same account
+    (see account_mismatch). Full row deletion is revoke_stored, reached only
+    from the explicit data-purge path."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT access_token_encrypted FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        user_id,
+        provider,
+    )
+    await pool.execute(
+        "UPDATE user_integrations SET access_token_encrypted = NULL, "
+        "refresh_token_encrypted = NULL, expires_at = NULL, updated_at = now() "
+        "WHERE user_id = $1 AND provider = $2",
+        user_id,
+        provider,
+    )
+    provider_impl = get_provider(provider)
+    for row in rows:
+        try:
+            access_token = _decrypt(row["access_token_encrypted"])
+            if access_token:
+                await provider_impl.revoke(access_token)
+        except Exception:
+            # Provider revocation is best effort — tokens may already be
+            # invalid; the local nulling above is what disconnect guarantees.
+            pass
 
 
 async def revoke_stored(
@@ -220,7 +277,8 @@ async def status(user_id: UUID, provider: str) -> dict:
     pool = get_pool()
     rows = await pool.fetch(
         """
-        SELECT account_key, scopes, expires_at, account_email, account_display_name, created_at
+        SELECT account_key, scopes, expires_at, account_email, account_display_name,
+               created_at, access_token_encrypted IS NULL AS disconnected
         FROM user_integrations WHERE user_id = $1 AND provider = $2
         ORDER BY account_email NULLS LAST, account_display_name NULLS LAST, account_key
         """,
@@ -228,17 +286,20 @@ async def status(user_id: UUID, provider: str) -> dict:
         provider,
     )
     if not rows:
-        return {"connected": False, "accounts": []}
+        return {"connected": False, "disconnected": False, "accounts": []}
     accounts = []
     for row in rows:
         account = _account_row(row)
-        account["needs_reconnect"] = await _account_needs_reconnect(
+        account["disconnected"] = row["disconnected"]
+        # A disconnected account has no token to verify; reconnect is implied.
+        account["needs_reconnect"] = row["disconnected"] or await _account_needs_reconnect(
             user_id, provider, row["account_key"]
         )
         accounts.append(account)
     first = accounts[0]
     return {
-        "connected": True,
+        "connected": any(not a["disconnected"] for a in accounts),
+        "disconnected": all(a["disconnected"] for a in accounts),
         "scopes": first["scopes"],
         "expires_at": first["expires_at"],
         "account_email": first["account_email"],
@@ -283,7 +344,8 @@ async def list_connections(user_id: UUID) -> list[dict]:
     rows = await pool.fetch(
         """
         SELECT provider, account_key, scopes, expires_at,
-               account_email, account_display_name, created_at
+               account_email, account_display_name, created_at,
+               access_token_encrypted IS NULL AS disconnected
         FROM user_integrations WHERE user_id = $1
         ORDER BY provider, account_email NULLS LAST, account_display_name NULLS LAST, account_key
         """,
@@ -293,7 +355,8 @@ async def list_connections(user_id: UUID) -> list[dict]:
     for row in rows:
         provider = row["provider"]
         account = _account_row(row)
-        account["needs_reconnect"] = await _account_needs_reconnect(
+        account["disconnected"] = row["disconnected"]
+        account["needs_reconnect"] = row["disconnected"] or await _account_needs_reconnect(
             user_id, provider, row["account_key"]
         )
         if provider not in connections:
@@ -304,7 +367,10 @@ async def list_connections(user_id: UUID) -> list[dict]:
                 "account_email": account["account_email"],
                 "account_display_name": account["account_display_name"],
                 "connected_at": account["connected_at"],
+                "disconnected": True,
                 "accounts": [],
             }
         connections[provider]["accounts"].append(account)
+        if not account["disconnected"]:
+            connections[provider]["disconnected"] = False
     return list(connections.values())

--- a/backend/integrations/x_saves/provider.py
+++ b/backend/integrations/x_saves/provider.py
@@ -103,7 +103,7 @@ class XIntegration(Integration):
         user = await fetch_me(access_token)
         username = user.get("username")
         display_name = f"@{username}" if username else user.get("name")
-        return AccountInfo(email=None, display_name=display_name)
+        return AccountInfo(email=None, display_name=display_name, account_ref=user["id"])
 
 
 async def fetch_me(access_token: str) -> dict:

--- a/backend/migrations/versions/0160_disconnect_keeps_data.py
+++ b/backend/migrations/versions/0160_disconnect_keeps_data.py
@@ -1,0 +1,45 @@
+"""Disconnect keeps data: provider account identity + nullable tokens.
+
+Disconnecting an integration now keeps the user_integrations row with its
+tokens nulled, so the provider-account identity survives disconnect and a
+later reconnect can be verified against it. account_ref is the provider's
+stable account id (X user id, Google email, GitHub login), recorded at
+connect; the mismatch check refuses a reconnect under a different account
+while kept data exists.
+
+Backfilled where the id already lives on our side — X from the x_saves
+source external_ref, Gmail from its per-email account_key — so those are
+protected immediately; other providers record it at their next connect.
+
+Revision ID: 0160
+Revises: 0159
+"""
+
+from alembic import op
+
+revision = "0160"
+down_revision = "0159"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE user_integrations ADD COLUMN account_ref text")
+    op.execute("ALTER TABLE user_integrations ALTER COLUMN access_token_encrypted DROP NOT NULL")
+    op.execute("""
+        UPDATE user_integrations ui
+        SET account_ref = us.external_ref
+        FROM user_sources us
+        WHERE ui.provider = 'x'
+          AND ui.account_ref IS NULL
+          AND us.owner_user_id = ui.user_id
+          AND us.source_type = 'x_saves'
+        """)
+    op.execute(
+        "UPDATE user_integrations SET account_ref = account_key "
+        "WHERE provider = 'gmail' AND account_ref IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE user_integrations DROP COLUMN IF EXISTS account_ref")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -280,7 +280,11 @@ async def create_source(
         ON CONFLICT (owner_user_id, source_type, external_ref)
         DO UPDATE SET
             display_name = EXCLUDED.display_name,
-            settings = EXCLUDED.settings,
+            -- Merge, don't replace: a reconnect must not wipe sync cursors
+            -- and one-time-walk state accumulated under this source.
+            settings = coalesce(user_sources.settings, '{}'::jsonb) || EXCLUDED.settings,
+            -- A disconnected-with-data source resumes syncing on reconnect.
+            sync_enabled = EXCLUDED.sync_enabled,
             updated_at = now()
         RETURNING *
         """,
@@ -400,19 +404,71 @@ async def delete_source(source_id: UUID, user_id: UUID) -> bool:
     return result.endswith("1")
 
 
-async def delete_sources_for_provider(user_id: UUID, provider: str) -> list[dict]:
-    """Remove all connected sources backed by one disconnected provider.
-    Returns the deleted rows so callers audit exactly what was removed."""
+def _provider_source_types(provider: str) -> list[str]:
     source_types = PROVIDER_SOURCE_TYPES.get(provider)
     if source_types is None:
         raise ValueError(f"unknown provider source mapping: {provider}")
+    return list(source_types)
 
+
+async def disable_sources_for_provider(user_id: UUID, provider: str) -> list[dict]:
+    """Disconnect-keeps-data: stop syncing every source of the provider but
+    keep the rows and their documents. Reconnecting re-enables them (the
+    connect upsert sets sync_enabled back)."""
     rows = await get_pool().fetch(
-        "DELETE FROM user_sources "
+        "UPDATE user_sources SET sync_enabled = false, updated_at = now() "
         "WHERE owner_user_id = $1 AND source_type = ANY($2::text[]) "
         "RETURNING *",
         user_id,
-        list(source_types),
+        _provider_source_types(provider),
+    )
+    return [_source_row(row) for row in rows]
+
+
+async def purge_sources_for_provider(user_id: UUID, provider: str) -> list[dict]:
+    """The explicit delete-my-data path: archived media blobs, share grants,
+    then the source rows (documents cascade). Returns the deleted sources so
+    callers audit exactly what was removed."""
+    from . import storage_service
+
+    pool = get_pool()
+    source_types = _provider_source_types(provider)
+    source_ids = [
+        row["id"]
+        for row in await pool.fetch(
+            "SELECT id FROM user_sources WHERE owner_user_id = $1 AND source_type = ANY($2::text[])",
+            user_id,
+            source_types,
+        )
+    ]
+    if not source_ids:
+        return []
+
+    # Media archives (X/Instagram saves) live in object storage; the row
+    # cascade below cannot reach them, so they're deleted first.
+    x_rows = await pool.fetch(
+        "SELECT media FROM x_save_docs WHERE source_id = ANY($1::uuid[]) "
+        "AND jsonb_array_length(media) > 0",
+        source_ids,
+    )
+    for row in x_rows:
+        for item in row["media"]:
+            await storage_service.delete_file(item["storage_key"])
+    ig_rows = await pool.fetch(
+        "SELECT media_storage_key FROM instagram_save_docs "
+        "WHERE source_id = ANY($1::uuid[]) AND media_storage_key IS NOT NULL",
+        source_ids,
+    )
+    for row in ig_rows:
+        await storage_service.delete_file(row["media_storage_key"])
+
+    await pool.execute(
+        "DELETE FROM shares WHERE object_type = 'source' AND object_id = ANY($1::uuid[])",
+        source_ids,
+    )
+    rows = await pool.fetch(
+        "DELETE FROM user_sources WHERE id = ANY($1::uuid[]) RETURNING *",
+        source_ids,
     )
     return [_source_row(row) for row in rows]
 

--- a/backend/tests/test_disconnect_retention.py
+++ b/backend/tests/test_disconnect_retention.py
@@ -1,0 +1,209 @@
+"""Disconnect keeps data; deletion is explicit; reconnect is identity-checked.
+
+Disconnecting an integration is a credentials operation: tokens are revoked
+and nulled but the user_integrations row (carrying account_ref) and all
+source rows/documents survive. A reconnect under a DIFFERENT provider
+account is refused while the previous account's connection exists — kept
+data must never silently continue under a new identity. The explicit purge
+path is the only way data, media blobs, and share grants are removed.
+"""
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import HTTPException
+
+from backend.integrations import crypto as integration_crypto
+from backend.integrations import storage
+from backend.integrations.base import AccountInfo, TokenSet
+from backend.services import source_service, user_service
+
+
+@pytest.fixture
+def fernet_key(monkeypatch):
+    monkeypatch.setattr(
+        integration_crypto.settings,
+        "INTEGRATIONS_ENCRYPTION_KEY",
+        Fernet.generate_key().decode(),
+    )
+
+
+@pytest.fixture
+def quiet_provider(monkeypatch):
+    """Providers whose revoke/refresh never leave the process."""
+
+    async def revoke(token):
+        return None
+
+    monkeypatch.setattr(storage, "get_provider", lambda p: SimpleNamespace(revoke=revoke))
+
+
+async def _user() -> UUID:
+    user, _api_key = await user_service.register_user(
+        name=f"retain_{uuid4().hex[:8]}",
+        display_name="Retention User",
+        password="securepassword1",
+    )
+    return user["id"]
+
+
+def _token() -> TokenSet:
+    return TokenSet(
+        access_token="access-token",
+        refresh_token=None,
+        expires_at=None,
+        scopes=["read"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_stored_keeps_row_and_fails_reads_loud(
+    pool, fernet_key, quiet_provider
+) -> None:
+    user_id = await _user()
+    await storage.store_token(
+        user_id, "x", _token(), AccountInfo(email=None, display_name="@sam", account_ref="111")
+    )
+
+    await storage.disconnect_stored(user_id, "x")
+
+    # The row survives with its identity; the tokens are gone.
+    row = await pool.fetchrow(
+        "SELECT account_ref, access_token_encrypted FROM user_integrations "
+        "WHERE user_id = $1 AND provider = 'x'",
+        user_id,
+    )
+    assert row["account_ref"] == "111"
+    assert row["access_token_encrypted"] is None
+
+    # Reads that need the token fail loud with the disconnected message, not
+    # the never-connected one.
+    with pytest.raises(HTTPException) as exc:
+        await storage.get_valid_token(user_id, "x")
+    assert "disconnected" in exc.value.detail
+
+    status = await storage.status(user_id, "x")
+    assert status["connected"] is False
+    assert status["disconnected"] is True
+    assert status["accounts"][0]["needs_reconnect"] is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_under_a_different_account_is_refused(
+    pool, fernet_key, quiet_provider
+) -> None:
+    user_id = await _user()
+    await storage.store_token(
+        user_id, "x", _token(), AccountInfo(email=None, display_name="@sam", account_ref="111")
+    )
+    await storage.disconnect_stored(user_id, "x")
+
+    other = AccountInfo(email=None, display_name="@intruder", account_ref="222")
+    assert await storage.account_mismatch(user_id, "x", other) == "@sam"
+
+    same = AccountInfo(email=None, display_name="@sam", account_ref="111")
+    assert await storage.account_mismatch(user_id, "x", same) is None
+
+    # A provider that can't supply an id can't be checked — never a false block.
+    unknown = AccountInfo(email=None, display_name=None, account_ref=None)
+    assert await storage.account_mismatch(user_id, "x", unknown) is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reenables_source_and_preserves_settings(pool) -> None:
+    user_id = await _user()
+    source = await source_service.create_source(
+        owner_user_id=user_id,
+        source_type="x_saves",
+        external_ref="111",
+        display_name="X",
+        settings={},
+    )
+    source_id = UUID(source["id"])
+    # The connect flow merges connect-time keys after the upsert (router.py).
+    await pool.execute(
+        "UPDATE user_sources SET settings = coalesce(settings, '{}'::jsonb) || "
+        '\'{"x_user_id": "111"}\' WHERE id = $1',
+        source_id,
+    )
+    # Sync state accumulated while connected (cursors, one-time-walk marks).
+    await pool.execute(
+        "UPDATE user_sources SET settings = settings || '{\"x_timeline_complete\": true}' "
+        "WHERE id = $1",
+        source_id,
+    )
+    await source_service.disable_sources_for_provider(user_id, "x")
+    assert (
+        await pool.fetchval("SELECT sync_enabled FROM user_sources WHERE id = $1", source_id)
+        is False
+    )
+
+    # The connect flow runs the same create_source again.
+    reconnected = await source_service.create_source(
+        owner_user_id=user_id,
+        source_type="x_saves",
+        external_ref="111",
+        display_name="X",
+        settings={},
+    )
+    assert UUID(reconnected["id"]) == source_id  # same row, same documents
+    row = await pool.fetchrow(
+        "SELECT sync_enabled, settings FROM user_sources WHERE id = $1", source_id
+    )
+    assert row["sync_enabled"] is True
+    assert row["settings"]["x_timeline_complete"] is True  # walk state survived
+
+
+@pytest.mark.asyncio
+async def test_purge_deletes_documents_media_blobs_and_shares(pool, monkeypatch) -> None:
+    from backend.services import storage_service
+
+    deleted_blobs: list[str] = []
+
+    async def fake_delete_file(key):
+        deleted_blobs.append(key)
+
+    monkeypatch.setattr(storage_service, "delete_file", fake_delete_file)
+
+    user_id = await _user()
+    grantee_id = await _user()
+    source = await source_service.create_source(
+        owner_user_id=user_id,
+        source_type="x_saves",
+        external_ref="111",
+        display_name="X",
+        settings={},
+    )
+    source_id = UUID(source["id"])
+    await pool.execute(
+        "INSERT INTO x_save_docs (owner_user_id, source_id, path, name, kind, external_ref, media) "
+        "VALUES ($1, $2, 'Bookmarks/1', '1', 'Bookmark', '1', "
+        '\'[{"storage_key": "store/x-1-0.jpg", "content_type": "image/jpeg"}]\')',
+        user_id,
+        source_id,
+    )
+    await pool.execute(
+        "INSERT INTO shares (owner_user_id, created_by, object_type, object_id, "
+        "principal_type, principal_id, permission) "
+        "VALUES ($1, $1, 'source', $2, 'user', $3, 'read')",
+        user_id,
+        source_id,
+        grantee_id,
+    )
+
+    purged = await source_service.purge_sources_for_provider(user_id, "x")
+
+    assert [UUID(p["id"]) for p in purged] == [source_id]
+    assert deleted_blobs == ["store/x-1-0.jpg"]
+    assert (
+        await pool.fetchval("SELECT count(*) FROM x_save_docs WHERE source_id = $1", source_id) == 0
+    )
+    assert (
+        await pool.fetchval(
+            "SELECT count(*) FROM shares WHERE object_type = 'source' AND object_id = $1",
+            source_id,
+        )
+        == 0
+    )

--- a/backend/tests/test_security_audit.py
+++ b/backend/tests/test_security_audit.py
@@ -725,30 +725,33 @@ async def test_integration_disconnect_audits_source_purge(
 
     monkeypatch.setattr(integrations_router.storage, "revoke_stored", fake_revoke_stored)
 
+    # Data deletion happens only on the explicit delete_data path, and the
+    # audit trail must record each purged source.
     disconnected = await client.post(
         "/api/v1/integrations/slack/disconnect",
         headers=_auth(api_key),
+        json={"delete_data": True},
     )
     assert disconnected.status_code == 200
-    assert disconnected.json()["removed_sources"] == 1
+    assert disconnected.json()["sources"] == 1
 
     events_resp = await client.get(
         "/api/v1/me/security-events",
         headers=_auth(api_key),
     )
     events = events_resp.json()["events"]
-    deleted = next(event for event in events if event["action"] == "source.deleted")
-    assert deleted["target_id"] == source["id"]
-    assert deleted["provider"] == "slack"
-    assert deleted["source_type"] == "slack"
-    assert deleted["metadata"] == {"reason": "integration_disconnect"}
+    purged = next(event for event in events if event["action"] == "source.purged")
+    assert purged["target_id"] == source["id"]
+    assert purged["provider"] == "slack"
+    assert purged["source_type"] == "slack"
+    assert purged["metadata"] == {"reason": "integration_disconnect"}
     # The credential revocation itself must be visible through the only read
     # surface (per-scope), not written as an unreadable NULL-scope row.
     disconnected_event = next(
         event for event in events if event["action"] == "integration.disconnected"
     )
     assert disconnected_event["provider"] == "slack"
-    assert disconnected_event["metadata"] == {"removed_sources": 1}
+    assert disconnected_event["metadata"] == {"sources": 1, "data_deleted": True}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -170,15 +170,7 @@ async def test_add_list_remove_source(client: AsyncClient):
     assert source_id not in {s["source"] for s in after.json()["sources"]}
 
 
-@pytest.mark.asyncio
-async def test_disconnect_provider_removes_sources_and_copied_documents(
-    client: AsyncClient,
-    monkeypatch,
-    _db_pool,
-):
-    from backend.integrations import router as integrations_router
-
-    api_key, owner_id = await _register(client)
+async def _slack_source_with_document(client: AsyncClient, api_key: str, owner_id) -> UUID:
     ws = await _user_scope(client, api_key)
     slack = await source_service.create_source(
         owner_user_id=owner_id,
@@ -187,14 +179,7 @@ async def test_disconnect_provider_removes_sources_and_copied_documents(
         display_name="Acme Slack",
         settings={"allowed_channel_ids": ["C123"]},
     )
-    github = await source_service.create_source(
-        owner_user_id=owner_id,
-        source_type="github_repo",
-        external_ref="acme/widgets",
-        display_name="acme/widgets",
-    )
     slack_id = UUID(slack["id"])
-    github_id = UUID(github["id"])
     await source_service.upsert_content_document(
         table="slack_messages",
         source_id=slack_id,
@@ -203,24 +188,83 @@ async def test_disconnect_provider_removes_sources_and_copied_documents(
         name="launch-discussion",
         content="confidential launch plan",
     )
+    return slack_id
+
+
+@pytest.mark.asyncio
+async def test_disconnect_keeps_sources_and_documents(
+    client: AsyncClient,
+    monkeypatch,
+    _db_pool,
+):
+    # Disconnect is a credentials operation, not a data operation: the source
+    # and its archived documents must survive, with syncing stopped. This is
+    # the product promise of a stash — fixing a token problem must never cost
+    # the user their data.
+    from backend.integrations import router as integrations_router
+
+    api_key, owner_id = await _register(client)
+    slack_id = await _slack_source_with_document(client, api_key, owner_id)
+
+    called = {}
+
+    async def fake_disconnect_stored(user_id, provider):
+        called["provider"] = provider
+
+    monkeypatch.setattr(integrations_router.storage, "disconnect_stored", fake_disconnect_stored)
+
+    resp = await client.post("/api/v1/integrations/slack/disconnect", headers=_auth(api_key))
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "sources": 1, "data_deleted": False}
+    assert called["provider"] == "slack"
+
+    kept = await source_service.get_owned_source(slack_id, owner_id)
+    assert kept is not None
+    assert (
+        await _db_pool.fetchval("SELECT sync_enabled FROM user_sources WHERE id = $1", slack_id)
+        is False
+    )
+    assert (
+        await _db_pool.fetchval(
+            "SELECT count(*) FROM slack_messages WHERE source_id = $1", slack_id
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_with_delete_data_removes_everything(
+    client: AsyncClient,
+    monkeypatch,
+    _db_pool,
+):
+    # The destructive path exists only behind the explicit choice in the
+    # disconnect dialog.
+    from backend.integrations import router as integrations_router
+
+    api_key, owner_id = await _register(client)
+    slack_id = await _slack_source_with_document(client, api_key, owner_id)
 
     async def fake_revoke_stored(user_id, provider):
-        assert user_id == owner_id
         assert provider == "slack"
 
     monkeypatch.setattr(integrations_router.storage, "revoke_stored", fake_revoke_stored)
 
-    resp = await client.post("/api/v1/integrations/slack/disconnect", headers=_auth(api_key))
+    resp = await client.post(
+        "/api/v1/integrations/slack/disconnect",
+        headers=_auth(api_key),
+        json={"delete_data": True},
+    )
     assert resp.status_code == 200
-    assert resp.json() == {"ok": True, "removed_sources": 1}
+    assert resp.json() == {"ok": True, "sources": 1, "data_deleted": True}
 
     assert await source_service.get_owned_source(slack_id, owner_id) is None
-    assert await source_service.get_owned_source(github_id, owner_id) is not None
-    copied_rows = await _db_pool.fetchval(
-        "SELECT count(*) FROM slack_messages WHERE source_id = $1",
-        slack_id,
+    assert (
+        await _db_pool.fetchval(
+            "SELECT count(*) FROM slack_messages WHERE source_id = $1", slack_id
+        )
+        == 0
     )
-    assert copied_rows == 0
 
 
 @pytest.mark.asyncio
@@ -250,7 +294,7 @@ async def test_provider_cleanup_removes_source_and_retained_rows(
     source_id = UUID(source["id"])
     await _insert_representative_source_document(owner_user_id=ws, source=source)
 
-    removed_sources = await source_service.delete_sources_for_provider(owner_id, provider)
+    removed_sources = await source_service.purge_sources_for_provider(owner_id, provider)
 
     assert [UUID(removed["id"]) for removed in removed_sources] == [source_id]
     assert await source_service.get_owned_source(source_id, owner_id) is None

--- a/docs/proposals/source-disconnect-data-retention.md
+++ b/docs/proposals/source-disconnect-data-retention.md
@@ -1,0 +1,197 @@
+# Disconnecting a source should not delete its data
+
+Status: proposal (2026-07-21)
+Owner: Sam
+Trigger incident: reconnecting X to fix a billing problem wiped the entire X
+archive (534 bookmarks + posts/replies/articles + archived media) because
+disconnect hard-deletes. Anything deleted on X since the original save is
+unrecoverable — which is exactly what the archive existed to prevent.
+
+## Current behavior (verified in code)
+
+- `POST /integrations/{provider}/disconnect` calls
+  `delete_sources_for_provider` → `DELETE FROM user_sources` for every source
+  of that provider (`backend/services/source_service.py:403`), then revokes
+  stored tokens.
+- Every per-integration document table has
+  `source_id REFERENCES user_sources(id) ON DELETE CASCADE` — the delete
+  silently destroys all synced/archived documents.
+- Archived media blobs (x_saves, instagram_saves) live in object storage and
+  are NOT deleted — the cascade orphans them.
+- Shares reference sources generically (`object_type='source'`, no FK) — the
+  delete orphans grantees' access rows.
+- Reconnecting auto-creates a fresh source row (upsert on
+  `(owner_user_id, source_type, external_ref)`), which also RESETS `settings`
+  (`settings = EXCLUDED.settings`), discarding sync cursors and walk state.
+
+So today, "Disconnect" is really "delete everything, quietly." Fixing a
+token problem requires a disconnect and therefore costs the user their data.
+
+## Decision
+
+**Disconnect stops syncing and revokes credentials. It never deletes data.
+Deletion is a separate, explicit action.**
+
+This matches the product promise — Stash is an archive; several sources
+(x_saves, instagram_saves) exist specifically so saves outlive the upstream
+content. It also matches user expectation from every comparable product
+(disconnecting Google from a backup tool does not delete your backups).
+
+## Semantics
+
+One rule for all integrations — no per-provider forks:
+
+### Disconnect (`POST /{provider}/disconnect`)
+1. Revoke + delete stored tokens (unchanged, `storage.revoke_stored`).
+2. `UPDATE user_sources SET sync_enabled = false` for the provider's sources.
+   Rows and documents stay. No new column: "disconnected" is derivable —
+   token absent — and the integrations page already computes token presence.
+3. Audit event `integration.disconnected` (unchanged), without the
+   `source.deleted` events.
+
+What still works after disconnect:
+- Content-copying tables (`CONTENT_TABLES`: github_documents, slack_messages,
+  granola_notes, gong_documents, notion_index, drive_documents,
+  instagram_save_docs, x_save_docs): browse, read, FTS, embeddings,
+  ask-the-stash — everything except freshness.
+- Index-only / federated types (gmail, whole-Drive, jira, asana, linear,
+  posthog): listings still render, but reads and federated search need a live
+  token and MUST fail loud with a clear "source is disconnected — reconnect
+  to read" error (get_valid_token already raises when the token is gone; we
+  surface that error instead of a 500). No fallbacks, no cached-body shims.
+
+### Reconnect (existing connect flow)
+1. Upsert hits the same natural key → same source row, same documents.
+2. Change the upsert to PRESERVE settings on conflict
+   (`settings = user_sources.settings || EXCLUDED.settings`) so sync cursors
+   and one-time-walk state survive; connect-time keys (e.g. `x_user_id`)
+   merge on top as they do today.
+3. Set `sync_enabled = true` on conflict so syncing resumes.
+
+### Reconnect identity — same account, enforced
+
+Today nothing guarantees a reconnect is the same provider account: tokens
+sit in one slot per provider (`account_key = "default"` except Gmail), so
+connecting a different account silently overwrites the token, auto-creates a
+second source, and strands the kept data — and the old source would half-sync
+under the new identity (public reads work, private reads 403).
+
+Rule: **one account per provider, enforced at the OAuth callback.**
+- At connect, after the token exchange, the server derives the stable
+  provider account id from the provider's own API (`fetch_account` /
+  `/users/me`) — never from anything client-supplied — and stores it as
+  `account_ref` on the `user_integrations` row.
+- On a later connect, if a stored `account_ref` (on the token row or implied
+  by disconnected-with-data sources) differs from the new token's account:
+  reject the connect with a loud, specific error — "Stash is linked to
+  @samzliu, whose data is kept. Reconnect with that account, or delete its
+  data first to link a different one." No token overwrite, no second source.
+- Same account → proceed: token replaced, same source rows, syncing resumes.
+
+Gmail's per-email `account_key` already follows this shape; this generalizes
+the identity check without taking on multi-account support (deliberately out
+of scope — revisit only if we decide to support multiple accounts per
+provider, which means per-account token keys everywhere).
+
+### Delete data (new, explicit)
+`POST /{provider}/purge` (and per-source `DELETE /sources/{id}`, which
+already exists and stays):
+1. Today's behavior: delete source rows, cascade documents.
+2. Plus what today's path forgets:
+   - delete archived media blobs from object storage (walk the docs' `media`
+     keys before the row delete; `storage_service.delete_file` exists),
+   - delete share rows for the purged sources.
+3. Audit event `source.purged` per source.
+
+## UI
+
+**Disconnect modal** (the Disconnect button opens it; choice is made at
+disconnect time, keep is the default):
+
+    Disconnect X?
+    Syncing stops and Stash's access is revoked.
+    (•) Keep my data — N saved items stay browsable and searchable.
+        You can reconnect or delete them later.
+    ( ) Delete everything — permanently removes all N items, including
+        archived images/video. Cannot be undone.   [Cancel] [Disconnect]
+
+The item count is fetched live so the destructive option states its cost.
+"Delete everything" turns the confirm red.
+
+**Integrations page, disconnected state**: provider row reads
+"Disconnected — data kept · N items" with two actions: **Reconnect** (normal
+OAuth flow; same source row, settings preserved) and **Delete data…** (same
+red confirm). Keep-now-delete-later is always available.
+
+**VFS/explorer**: the source folder stays in `/sources` with a
+"disconnected" badge. Content-copy sources open normally; index-only
+documents show the fail-loud "reconnect to read" state with a Reconnect
+button. The folder's context menu gets **Delete source data…** and
+**Reconnect** — both are pointers to the same two endpoints, not a third
+codepath.
+
+No "keep but hide" state: disconnected data is visible or it's deleted.
+
+## Special cases checked
+
+- **Slack**: tokens are team-scoped and the bot install
+  (`slack_bot_installs`) is separate from the user's source. Disconnect
+  revokes the user token and disables the source; the bot install is managed
+  by its own uninstall flow. Push events for a disabled source are dropped by
+  the existing owner-lookup failing — verify it fails loud, not silently.
+- **GitHub all-repos mode**: the sync-all reconciler iterates users from
+  stored tokens (`storage.sync_all_user_ids`), so a disconnected user drops
+  out naturally. Source rows stay disabled until reconnect.
+- **Push sources (Granola/Slack)**: nothing to poll; `sync_enabled = false`
+  plus missing token means webhook ingest for that user rejects loudly.
+- **Seed/dev**: `seed_dev` fakes tokens; unaffected.
+
+## What does NOT change
+
+- Per-source deletion (`delete_source`) — already explicit, keeps cascade.
+- The FK `ON DELETE CASCADE` stays: it is correct for the explicit purge
+  path; we simply stop reaching it from disconnect.
+- Account deletion continues to hard-delete everything.
+
+## Migration
+
+One small migration: `user_integrations.account_ref text` (nullable), filled
+at connect. The migration backfills it where the id already exists on our
+side — X from the x_saves source `external_ref`, Gmail from `account_key` —
+so those are protected immediately; other providers fill in at their next
+connect (the mismatch check only fires once an `account_ref` exists, so
+current users are never blocked).
+Everything else is behavior-only. One shot, all providers at once — no
+compatibility flag, no per-provider rollout.
+
+Follow-up (separate, optional): a one-time R2/S3 sweep for media blobs
+orphaned by historical disconnects (including today's X wipe).
+
+## Implementation sketch (single PR)
+
+1. `source_service.disable_sources_for_provider(user_id, provider)` replaces
+   `delete_sources_for_provider` in the disconnect endpoint (the delete
+   helper survives for the purge endpoint).
+2. Connect upsert: `settings` merge + `sync_enabled = true` on conflict.
+   Callback records `account_ref` and rejects on mismatch (see Reconnect
+   identity) before any token write.
+3. `POST /{provider}/purge` endpoint = old disconnect behavior + blob and
+   share cleanup.
+4. Read-path: map missing-token errors on index-only reads/federated search
+   to a 409 "source disconnected" instead of 500.
+5. Frontend: integrations page three-state row + purge confirmation dialog.
+6. Tests: disconnect keeps docs and disables sync; reconnect reuses the row
+   and preserves settings; purge removes docs, blobs, and shares; index-only
+   read after disconnect returns the 409.
+
+## Open questions for Sam
+
+1. Should **shared-to-me** views of a disconnected source stay readable
+   (content-copy types)? Proposal: yes — the data exists; sharing semantics
+   shouldn't depend on the owner's token state.
+2. Purge granularity: provider-level only, or also per-kind (e.g. "delete my
+   X bookmarks but keep articles")? Proposal: provider-level + existing
+   per-source delete; per-kind is scope creep until someone asks.
+3. Retention cap: do we ever auto-expire data from disconnected sources
+   (e.g. free-tier storage pressure)? Proposal: not now; revisit with
+   billing/storage limits.

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -26,6 +26,7 @@ import {
 import {
   disconnectIntegration,
   listIntegrations,
+  purgeIntegrationData,
   startConnect,
   submitCredentials,
   type IntegrationStatus,
@@ -66,6 +67,13 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const highlightSourceId = searchParams.get("source");
+  // The OAuth callback lands here with an error flag when a reconnect was
+  // refused because it used a different provider account than the one whose
+  // data is kept.
+  const mismatchExpected =
+    searchParams.get("integration_error") === "account_mismatch"
+      ? searchParams.get("expected")
+      : null;
   const { user, loading } = useAuth();
   const confirm = useConfirm();
 
@@ -79,6 +87,8 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   const [sources, setSources] = useState<Source[]>([]);
   const [openSourceId, setOpenSourceId] = useState<string | null>(highlightSourceId);
   const [showCreds, setShowCreds] = useState(false);
+  const [showDisconnect, setShowDisconnect] = useState(false);
+  const [disconnectDelete, setDisconnectDelete] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [paymentRequired, setPaymentRequired] = useState(false);
@@ -146,7 +156,10 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   const connected = isExtension ? sources.length > 0 : !!status?.connected;
   const account = connectedAccountLabel(status);
   const canConnectAnother = connected && connector.provider === "gmail" && status?.auth_kind !== "api_key";
-  const staleAccounts = status?.accounts.filter((a) => a.needs_reconnect) ?? [];
+  // Deliberately-disconnected accounts get the "data kept" header state, not
+  // the expired-access warning banner.
+  const staleAccounts =
+    status?.accounts.filter((a) => a.needs_reconnect && !a.disconnected) ?? [];
 
   async function connect() {
     setBusy("connect");
@@ -183,20 +196,37 @@ export function IntegrationDetail({ provider }: { provider: string }) {
     }
   }
 
-  async function disconnect() {
-    const ok = await confirm({
-      title: `Disconnect ${connector!.label}?`,
-      body: "You'll need to reconnect to sync its sources again.",
-      confirmLabel: "Disconnect",
-    });
-    if (!ok) return;
+  async function confirmDisconnect(deleteData: boolean) {
+    setShowDisconnect(false);
     setBusy("disconnect");
     setError("");
     try {
-      await disconnectIntegration(connector!.provider);
+      await disconnectIntegration(connector!.provider, deleteData);
       await refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not disconnect");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function deleteKeptData() {
+    const ok = await confirm({
+      title: `Delete all ${connector!.label} data?`,
+      body:
+        `Permanently removes ${sources.length === 1 ? "its source" : `all ${sources.length} sources`} ` +
+        "and every saved item, including archived images and video. Cannot be undone.",
+      confirmLabel: "Delete everything",
+    });
+    if (!ok) return;
+    setBusy("purge");
+    setError("");
+    try {
+      await purgeIntegrationData(connector!.provider);
+      setOpenSourceId(null);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete data");
     } finally {
       setBusy(null);
     }
@@ -269,7 +299,10 @@ export function IntegrationDetail({ provider }: { provider: string }) {
                 )}
                 <button
                   type="button"
-                  onClick={() => void disconnect()}
+                  onClick={() => {
+                    setDisconnectDelete(false);
+                    setShowDisconnect(true);
+                  }}
                   disabled={busy === "disconnect"}
                   className="cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted-foreground hover:bg-raised hover:text-foreground disabled:opacity-60"
                 >
@@ -278,6 +311,21 @@ export function IntegrationDetail({ provider }: { provider: string }) {
                     : connector.provider === "gmail" && (status?.accounts.length ?? 0) > 1
                     ? "Disconnect all"
                     : "Disconnect"}
+                </button>
+              </>
+            ) : status?.disconnected && sources.length > 0 ? (
+              <>
+                <span className="text-[12.5px] text-warning">Disconnected — data kept</span>
+                <button
+                  type="button"
+                  onClick={() => void deleteKeptData()}
+                  disabled={busy === "purge"}
+                  className="cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted-foreground hover:bg-raised hover:text-foreground disabled:opacity-60"
+                >
+                  {busy === "purge" ? "Deleting..." : "Delete data…"}
+                </button>
+                <button type="button" onClick={() => void connect()} disabled={busy === "connect"} className={primaryButton()}>
+                  {busy === "connect" ? "Connecting..." : "Reconnect"}
                 </button>
               </>
             ) : status?.auth_kind === "api_key" ? (
@@ -326,6 +374,13 @@ export function IntegrationDetail({ provider }: { provider: string }) {
           />
         )}
 
+        {mismatchExpected && (
+          <div className="mt-4 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
+            That&apos;s a different account. This connection belongs to {mismatchExpected}, whose
+            data is kept — reconnect with {mismatchExpected}, or delete its data first to link
+            another account.
+          </div>
+        )}
         {error && (
           <div className="mt-4 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
             {error}
@@ -333,6 +388,83 @@ export function IntegrationDetail({ provider }: { provider: string }) {
         )}
 
         {paymentRequired && <PaywallModal onClose={() => setPaymentRequired(false)} />}
+        {showDisconnect && (
+          <div
+            className="fixed inset-0 z-[60] flex cursor-pointer items-center justify-center bg-black/30 px-4"
+            onClick={() => setShowDisconnect(false)}
+          >
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-label={`Disconnect ${connector.label}?`}
+              className="w-full max-w-sm rounded-xl border border-border bg-base p-5 shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="text-[14px] font-medium text-foreground">
+                Disconnect {connector.label}?
+              </div>
+              <div className="mt-1.5 text-[12.5px] text-muted-foreground">
+                Syncing stops and Stash&apos;s access is revoked.
+              </div>
+              <div className="mt-3 flex flex-col gap-2">
+                <label className="flex cursor-pointer items-start gap-2 rounded-lg border border-border p-2.5 text-[12.5px]">
+                  <input
+                    type="radio"
+                    name="disconnect-mode"
+                    checked={!disconnectDelete}
+                    onChange={() => setDisconnectDelete(false)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium text-foreground">Keep my data</span>
+                    <span className="block text-muted-foreground">
+                      Saved items stay browsable and searchable. You can reconnect or delete
+                      them later.
+                    </span>
+                  </span>
+                </label>
+                <label className="flex cursor-pointer items-start gap-2 rounded-lg border border-border p-2.5 text-[12.5px]">
+                  <input
+                    type="radio"
+                    name="disconnect-mode"
+                    checked={disconnectDelete}
+                    onChange={() => setDisconnectDelete(true)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium text-foreground">Delete everything</span>
+                    <span className="block text-muted-foreground">
+                      Permanently removes{" "}
+                      {sources.length === 1 ? "its source" : `all ${sources.length} sources`} and
+                      every saved item, including archived images and video. Cannot be undone.
+                    </span>
+                  </span>
+                </label>
+              </div>
+              <div className="mt-4 flex justify-end gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setShowDisconnect(false)}
+                  className="cursor-pointer rounded-md border border-border bg-base px-3 py-1.5 text-[12.5px] text-foreground hover:bg-raised"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void confirmDisconnect(disconnectDelete)}
+                  className={
+                    "cursor-pointer rounded-md px-3 py-1.5 text-[12.5px] font-medium text-white " +
+                    (disconnectDelete
+                      ? "bg-red-600 hover:bg-red-700"
+                      : "bg-[var(--color-brand-600)] hover:bg-[var(--color-brand-700)]")
+                  }
+                >
+                  {disconnectDelete ? "Disconnect & delete" : "Disconnect"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Add a <thing> (for GitHub: the all-vs-select repository access chooser).
             Extension-fed and single-source connectors (X) have nothing to add by

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -61,30 +61,41 @@ function LoadingRow() {
 // not. Clicking opens the integrations manager to connect/configure.
 function ToolsSection() {
   const open = useOpenTab();
-  const [connected, setConnected] = useState<Set<string>>(new Set());
+  // Extension connectors have no token — source presence is their "connected".
+  // OAuth/api-key connectors use the integration status, so a provider that
+  // was disconnected with its data kept reads "Connect", not "Connected".
+  const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
+  const [connectedProviders, setConnectedProviders] = useState<Set<string>>(new Set());
   // The server omits providers this user may not use (customer-specific
   // integrations like Heavi) — null until loaded, then the allowed set.
   const [allowed, setAllowed] = useState<Set<string> | null>(null);
   useEffect(() => {
-    listSources().then((all) => setConnected(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type)))).catch(() => {});
-    listIntegrations().then((r) => setAllowed(new Set(r.providers.map((p) => p.provider)))).catch(() => {});
+    listSources().then((all) => setSourceProviders(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type)))).catch(() => {});
+    listIntegrations().then((r) => {
+      setAllowed(new Set(r.providers.map((p) => p.provider)));
+      setConnectedProviders(new Set(r.providers.filter((p) => p.connected).map((p) => p.provider)));
+    }).catch(() => {});
   }, []);
   if (allowed === null) return <LoadingRow />;
   return (
     <div className="py-1">
-      {CONNECTORS.filter((c) => c.kind === "extension" || allowed.has(c.provider)).map((c) => (
-        <LeafRow
-          key={c.provider}
-          icon={connectorIcon(c.provider) ?? <Plug className="h-3.5 w-3.5" />}
-          label={c.label}
-          trailing={
-            <span className={cn("text-[10px]", connected.has(c.provider) ? "text-[var(--color-success)]" : "text-muted-foreground opacity-0 group-hover:opacity-100")}>
-              {connected.has(c.provider) ? "Connected" : "Connect"}
-            </span>
-          }
-          onOpen={() => open("tool", c.provider, c.label)}
-        />
-      ))}
+      {CONNECTORS.filter((c) => c.kind === "extension" || allowed.has(c.provider)).map((c) => {
+        const isConnected =
+          c.kind === "extension" ? sourceProviders.has(c.provider) : connectedProviders.has(c.provider);
+        return (
+          <LeafRow
+            key={c.provider}
+            icon={connectorIcon(c.provider) ?? <Plug className="h-3.5 w-3.5" />}
+            label={c.label}
+            trailing={
+              <span className={cn("text-[10px]", isConnected ? "text-[var(--color-success)]" : "text-muted-foreground opacity-0 group-hover:opacity-100")}>
+                {isConnected ? "Connected" : "Connect"}
+              </span>
+            }
+            onOpen={() => open("tool", c.provider, c.label)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -45,6 +45,9 @@ export type IntegrationAccount = {
   // True when the stored token no longer works (revoked access or an expired
   // refresh token) — the account is listed as connected but must be reconnected.
   needs_reconnect: boolean;
+  // True when the user disconnected but kept the data: no token, sources and
+  // documents intact.
+  disconnected: boolean;
 };
 
 export type IntegrationStatus = {
@@ -52,6 +55,8 @@ export type IntegrationStatus = {
   display_name: string;
   scopes: string[];
   connected: boolean;
+  // Disconnected-with-data-kept: not connected, but sources/documents remain.
+  disconnected?: boolean;
   enabled: boolean;
   disabled_reason: string | null;
   account_email: string | null;
@@ -94,8 +99,20 @@ export async function startConnect(
   window.location.href = authorize_url;
 }
 
-export async function disconnectIntegration(provider: IntegrationProvider): Promise<void> {
-  await apiFetch(`/api/v1/integrations/${provider}/disconnect`, { method: "POST" });
+export async function disconnectIntegration(
+  provider: IntegrationProvider,
+  deleteData = false,
+): Promise<void> {
+  await apiFetch(`/api/v1/integrations/${provider}/disconnect`, {
+    method: "POST",
+    body: JSON.stringify({ delete_data: deleteData }),
+  });
+}
+
+/** Delete the kept data of a (disconnected) provider — documents, archived
+ * media, and shares. The destructive counterpart to disconnect-keeps-data. */
+export async function purgeIntegrationData(provider: IntegrationProvider): Promise<void> {
+  await apiFetch(`/api/v1/integrations/${provider}/purge`, { method: "POST" });
 }
 
 /**


### PR DESCRIPTION
Implements docs/proposals/source-disconnect-data-retention.md (included in this PR). Motivated by a real incident: reconnecting X to fix billing wiped the entire X archive, because disconnect hard-deleted every source with cascade — exactly what an archive exists to prevent.

## Semantics (one rule, all integrations)

- **Disconnect** revokes tokens and stops syncing (`sync_enabled=false`), but keeps the `user_integrations` row (tokens nulled) and all sources/documents. Content-copying sources stay fully browsable/searchable; index-only reads fail loud with "disconnected — reconnect to read" (401). The disconnect dialog offers **Keep my data** (default) or **Delete everything**.
- **Reconnect identity check**: `account_ref` (the provider's stable account id — X user id, Google email, GitHub login) is recorded at connect and compared server-side on every reconnect, derived from the provider's own answer to the new token. A different account is refused with a clear error; kept data never silently continues under a new identity. Backfilled for X and Gmail in migration 0160. The connect upsert now *preserves* source settings (sync cursors, walk state) and re-enables syncing.
- **Explicit purge** (`POST /{provider}/purge`, or the dialog's delete choice) removes documents, **archived media blobs in object storage**, and **share grants** — two things the old cascade always missed.

## Screenshots

- [Disconnect dialog with keep/delete choice](https://app.joinstash.ai/f/ece8ec66-6087-4859-899b-fb62a4a25f14)
- [Disconnected — data kept: folders still browsable, Reconnect + Delete data actions](https://app.joinstash.ai/f/52c304a1-f2ce-402d-8e05-54898057be38)
- [Account-mismatch refusal after OAuth with the wrong account](https://app.joinstash.ai/f/e761b7be-4b11-4f00-b088-4c9c00009f27)

## Migration

`0160`: `user_integrations.account_ref` + `access_token_encrypted` nullable + backfill (X from x_saves `external_ref`, Gmail from `account_key`).

## Tests

New `test_disconnect_retention.py` (keep-row + loud reads, mismatch refusal, settings-preserving re-enable on reconnect, purge removes blobs/shares); disconnect endpoint tests rewritten for keep-vs-delete; provider cleanup tests moved to the purge path; audit test asserts `source.purged`. 144 backend tests green in the affected files, full suite green (2 known local-S3-env flakes pass with blank S3 env), 211 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaexpwwBZH8PsvQbYz1ddM