### PR TITLE
X saves: newest-first listing, honest archive states, human sync errors

### DIFF
--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -606,6 +606,10 @@ CONTENT_TABLES = {
     # stays empty (no indexer); see the note on DEFAULT_SYNC_INTERVAL_S.
 }
 
+# Archive-style save tables: rows exist before their content is hydrated, so
+# they carry a hydration_status that listings and reads must surface.
+SAVE_TABLES = {"x_save_docs", "instagram_save_docs"}
+
 # Index-only source types whose `search` is federated live to the provider's
 # native search instead of our FTS (no copied content). source_type -> the
 # provider search coroutine, resolved lazily to avoid an import cycle.
@@ -853,9 +857,10 @@ async def list_documents(
 ) -> list[dict]:
     """List a source's live documents, optionally under a path prefix. `source`
     is the registry row (from get_owned_source / get_source_for_sync). `after`
-    is a keyset cursor: only paths strictly greater (in the ORDER BY path
-    ordering) are returned, so callers page through big sources by passing the
-    last path of the previous page."""
+    is a keyset cursor: only paths strictly beyond it in the listing order are
+    returned, so callers page through big sources by passing the last path of
+    the previous page. Most sources list ascending by path; X saves list
+    newest-first (see the ordering note below)."""
     table = _table_for(source["source_type"])
     if table == "slack_messages":
         allowed_channel_ids = slack_allowed_channel_ids(source)
@@ -933,11 +938,26 @@ async def list_documents(
         if is_content
         else "NULL::text"
     )
+    # Saves carry their archive status so listings can mark a save that failed
+    # to archive (or is still archiving) instead of rendering it like the rest.
+    status_column = "hydration_status" if table in SAVE_TABLES else "NULL::text"
+    # X saves list newest-first — a bookmark list you can only read oldest-first
+    # buries the thing you saved five minutes ago. The path's tweet id grows
+    # over time but varies in digit count, so numeric order is (length, value).
+    # The keyset cursor flips with the ordering: a page continues strictly
+    # below the last path served.
+    if table == "x_save_docs":
+        order_by = "length(path) DESC, path DESC"
+        cursor_predicate = "($4 = '' OR (length(path), path) < (length($4), $4))"
+    else:
+        order_by = "path"
+        cursor_predicate = "path > $4"
     rows = await get_pool().fetch(
         f"SELECT path, name, kind, external_ref, external_updated_at, "
-        f"{size_column} AS size, {snippet_column} AS snippet FROM {table} "
-        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
-        f"ORDER BY path LIMIT $3",
+        f"{size_column} AS size, {snippet_column} AS snippet, {status_column} AS status "
+        f"FROM {table} "
+        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND {cursor_predicate} "
+        f"ORDER BY {order_by} LIMIT $3",
         UUID(source["id"]),
         f"{prefix}%",
         limit,
@@ -956,6 +976,7 @@ def _entry_row(r) -> dict:
         "external_updated_at": (external_updated_at.isoformat() if external_updated_at else None),
         "size": r["size"],
         "snippet": r["snippet"] if "snippet" in r.keys() else None,
+        "status": r["status"] if "status" in r.keys() else None,
     }
 
 
@@ -1215,6 +1236,19 @@ async def _read_drive_document(source_id: UUID, path: str) -> dict | None:
     }
 
 
+def _save_pending_error(status: str, provider_label: str) -> str:
+    """The user-facing body for a save whose content isn't archived yet. The
+    raw hydration_error stays on the row for diagnosis; the API serves a human
+    sentence — nobody should read a Python exception in their bookmark list."""
+    if status == "failed":
+        return (
+            "This post couldn't be archived — it was probably deleted, made private, "
+            f"or its account suspended before we could copy it. It may still be open "
+            f"on {provider_label}."
+        )
+    return "Still archiving this post — check back in a minute."
+
+
 async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
     """An Instagram save, or a loud explanation while hydration is pending —
     same contract as drive_documents: never hand back a blank body as if the
@@ -1232,14 +1266,13 @@ async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
     if not row:
         return None
     if row["content"] is None:
-        status = row["hydration_status"]
         return {
             "path": row["path"],
             "name": row["name"],
             "kind": row["kind"],
             "content": "",
-            "error": row["hydration_error"] or f"hydration {status}",
-            "http_status": 422 if status == "failed" else 409,
+            "error": _save_pending_error(row["hydration_status"], "Instagram"),
+            "http_status": 422 if row["hydration_status"] == "failed" else 409,
         }
     doc = {
         "path": row["path"],
@@ -1269,14 +1302,13 @@ async def _read_x_save(source_id: UUID, path: str) -> dict | None:
     if not row:
         return None
     if row["content"] is None:
-        status = row["hydration_status"]
         return {
             "path": row["path"],
             "name": row["name"],
             "kind": row["kind"],
             "content": "",
-            "error": row["hydration_error"] or f"hydration {status}",
-            "http_status": 422 if status == "failed" else 409,
+            "error": _save_pending_error(row["hydration_status"], "X"),
+            "http_status": 422 if row["hydration_status"] == "failed" else 409,
         }
     doc = {
         "path": row["path"],

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -35,7 +35,10 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
-SYNC_FAILED_MESSAGE = "Source sync failed; check server logs"
+# Owner-facing (rendered on the integration page). Raw exceptions stay in the
+# server logs; next_sync_at was already advanced at sync start, so a failed
+# source genuinely retries on its own.
+SYNC_FAILED_MESSAGE = "Sync hit an unexpected error — it will retry automatically."
 
 # source_type -> indexer. Each returns the new sync cursor (or None).
 INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {

--- a/backend/tests/test_instagram_saves.py
+++ b/backend/tests/test_instagram_saves.py
@@ -262,9 +262,11 @@ async def test_hydration_failure_lands_on_the_row(
     assert "scrapecreators exploded" in row["hydration_error"]
     assert row["hydration_attempts"] == 1
 
-    # Reading an unhydrated doc fails loud, not blank.
+    # Reading an unhydrated doc fails loud, not blank — but with a human
+    # sentence, never the raw exception (that stays on the row, above).
     ok, doc = await source_service.source_document(
         UUID(owner_id), UUID(owner_id), str(source["id"]), "ABC123xyz"
     )
     assert ok and doc["http_status"] == 422
-    assert "scrapecreators exploded" in doc["error"]
+    assert "couldn't be archived" in doc["error"]
+    assert "scrapecreators exploded" not in doc["error"]

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -562,3 +562,88 @@ async def test_bookmarks_paid_tier_gate_is_best_effort(client, pool, fake_sync) 
     )
     assert status["sync_status"] != "failed"
     assert "paid tier" in status["sync_error"]
+
+
+async def _insert_done(pool, owner_id, source_id, path, content):
+    await _insert_pending(pool, owner_id, source_id, path, "Bookmark")
+    await pool.execute(
+        "UPDATE x_save_docs SET content = $3, hydration_status = 'done' "
+        "WHERE source_id = $1 AND path = $2",
+        UUID(source_id),
+        path,
+        content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_bookmarks_list_newest_first_across_id_lengths(client, pool) -> None:
+    """A bookmark list you can only read oldest-first buries the thing you
+    saved five minutes ago; the listing must order by numeric tweet id (which
+    grows over time), not lexicographic path — a 2010-era short id is old."""
+    _, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/999", "old tweet")
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/1815550001", "newer tweet")
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/1815550002", "newest tweet")
+
+    entries = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks"
+    )
+    assert [e["path"] for e in entries] == [
+        "Bookmarks/1815550002",
+        "Bookmarks/1815550001",
+        "Bookmarks/999",
+    ]
+
+    # Keyset continuation: the cursor is the last path served; the next page
+    # continues strictly older, in the same order.
+    first = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks", limit=2
+    )
+    rest = await source_service.source_entries(
+        UUID(owner_id),
+        UUID(owner_id),
+        str(source["id"]),
+        prefix="Bookmarks",
+        after=first[-1]["path"],
+    )
+    assert [e["path"] for e in rest] == ["Bookmarks/999"]
+
+
+@pytest.mark.asyncio
+async def test_unarchived_saves_read_as_human_sentences(client, pool) -> None:
+    """A failed archive must never serve the raw exception text to the reader,
+    and a pending one must say it's still archiving — while the listing marks
+    both so they are distinguishable from healthy saves without opening them."""
+    _, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/2001", "Bookmark")
+    await pool.execute(
+        "UPDATE x_save_docs SET hydration_status = 'failed', "
+        "hydration_error = 'RuntimeError: tweet 2001 is unavailable' "
+        "WHERE source_id = $1 AND path = 'Bookmarks/2001'",
+        UUID(source["id"]),
+    )
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/2002", "Bookmark")
+
+    ok, failed = await source_service.source_document(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), "Bookmarks/2001"
+    )
+    assert ok
+    assert failed["http_status"] == 422
+    assert "couldn't be archived" in failed["error"]
+    assert "RuntimeError" not in failed["error"]
+
+    ok, pending = await source_service.source_document(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), "Bookmarks/2002"
+    )
+    assert ok
+    assert pending["http_status"] == 409
+    assert "Still archiving" in pending["error"]
+
+    entries = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks"
+    )
+    statuses = {e["path"]: e["status"] for e in entries}
+    assert statuses["Bookmarks/2001"] == "failed"
+    assert statuses["Bookmarks/2002"] == "pending"

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -819,9 +819,14 @@ function BrowsePanel({
 // bordered header that deep-links back to the provider when a url is available.
 // Hydrated saves lead with the tweet text, then a blank line, then the byline /
 // reply-context / link meta. Show the tweet prominently and mute the rest.
-function TweetBody({ content }: { content: string }) {
+function TweetBody({ content, linkedUrl }: { content: string; linkedUrl?: string | null }) {
   const [body, ...rest] = content.split("\n\n");
-  const meta = rest.join("\n\n").trim();
+  let meta = rest.join("\n\n").trim();
+  // The archived body ends with the post's URL; when the header already links
+  // there ("Open in X ↗"), printing it again is noise.
+  if (linkedUrl && meta.endsWith(linkedUrl)) {
+    meta = meta.slice(0, meta.length - linkedUrl.length).trim();
+  }
   return (
     <div className="scroll-thin max-h-96 space-y-3 overflow-auto bg-base px-4 py-4">
       <p className="whitespace-pre-wrap break-words text-[14px] leading-relaxed text-foreground">
@@ -836,14 +841,26 @@ function TweetBody({ content }: { content: string }) {
   );
 }
 
+// The provider URL a save points at, derivable from its path alone — so the
+// "open on the platform" link survives a failed archive (which has no stored
+// url to serve).
+function saveExternalUrl(sourceType: string | undefined, ref: string): string | null {
+  const leaf = ref.slice(ref.lastIndexOf("/") + 1);
+  if (sourceType === "x_saves") return `https://x.com/i/status/${leaf}`;
+  if (sourceType === "instagram_saves") return `https://www.instagram.com/p/${leaf}/`;
+  return null;
+}
+
 function DocViewer({
   source,
+  sourceType,
   providerLabel,
   refValue,
   name,
   onClose,
 }: {
   source: string;
+  sourceType?: string;
   providerLabel: string;
   refValue: string;
   name?: string;
@@ -905,7 +922,19 @@ function DocViewer({
         </div>
       </div>
       {error ? (
-        <div className="bg-base px-3 py-3 text-[12px] text-error">{error}</div>
+        <div className="bg-base px-3 py-3 text-[12px] text-error">
+          {error}
+          {saveExternalUrl(sourceType, refValue) && (
+            <a
+              href={saveExternalUrl(sourceType, refValue)!}
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 font-semibold text-brand hover:underline"
+            >
+              Open in {providerLabel} ↗
+            </a>
+          )}
+        </div>
       ) : content === null ? (
         <div className="bg-base px-3 py-3 text-[12px] text-muted-foreground">Loading…</div>
       ) : (
@@ -920,7 +949,7 @@ function DocViewer({
               <img key={i} src={m.url} alt={title} className="max-h-72 w-full bg-black object-contain" />
             ),
           )}
-          <TweetBody content={content} />
+          <TweetBody content={content} linkedUrl={url} />
         </>
       )}
     </div>
@@ -1022,6 +1051,7 @@ function SearchablePanel({
                     {isOpen && (
                       <DocViewer
                         source={source.source}
+                        sourceType={source.type}
                         providerLabel={providerLabel}
                         refValue={hit.ref!}
                         name={hit.name}
@@ -1060,6 +1090,7 @@ function SearchablePanel({
                 {isOpen && (
                   <DocViewer
                     source={source.source}
+                    sourceType={source.type}
                     providerLabel={providerLabel}
                     refValue={ref}
                     name={entry.name}
@@ -1272,8 +1303,11 @@ function NavigablePanel({
             const folder = isFolder(entry);
             const ref = entry.id ?? entry.path ?? entry.name;
             const isOpen = !folder && openDoc?.ref === ref;
-            // An un-hydrated save still has its raw numeric tweet id as its name.
-            const pending = !folder && /^\d+$/.test(entry.name);
+            // Saves report their archive state; an un-hydrated save also still
+            // has its raw numeric tweet id as its name.
+            const pending =
+              !folder && (entry.status === "pending" || /^\d+$/.test(entry.name));
+            const failed = !folder && entry.status === "failed";
             const key = `${folder ? "dir" : "doc"}:${ref}`;
             return (
               <div key={key}>
@@ -1289,12 +1323,19 @@ function NavigablePanel({
                     {folder ? "📁" : "📄"}
                   </span>
                   <span className="min-w-0 flex-1">
-                    {pending ? (
-                      <span className="truncate text-[12.5px] italic text-muted-foreground">Loading…</span>
+                    {failed ? (
+                      <span className="flex items-center gap-2">
+                        <span className="truncate text-[12.5px] text-foreground">{entry.name}</span>
+                        <span className="shrink-0 rounded-full border border-error/40 bg-error/10 px-1.5 text-[10px] font-semibold text-error">
+                          not archived
+                        </span>
+                      </span>
+                    ) : pending ? (
+                      <span className="truncate text-[12.5px] italic text-muted-foreground">Archiving…</span>
                     ) : (
                       <span className="block truncate text-[12.5px] text-foreground">{entry.name}</span>
                     )}
-                    {entry.snippet && !pending && (
+                    {entry.snippet && !pending && !failed && (
                       <span className="mt-0.5 block truncate text-[11.5px] text-muted-foreground">
                         {entry.snippet}
                       </span>
@@ -1304,6 +1345,7 @@ function NavigablePanel({
                 {isOpen && (
                   <DocViewer
                     source={source.source}
+                    sourceType={source.type}
                     providerLabel={providerLabel}
                     refValue={ref}
                     name={entry.name}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -323,6 +323,9 @@ export interface SourceEntry {
   external_ref?: string | null;
   // One-line preview of the copied content (e.g. the tweet text).
   snippet?: string | null;
+  // Archive state for save-type sources: 'done' | 'pending' | 'failed'.
+  // Null/absent for sources without an archive pipeline.
+  status?: string | null;
 }
 
 const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);


### PR DESCRIPTION
## What

Bookmark-manager bug fixes for the X integration, from the product audit. (The search-across-sources feature that was previously in this PR moved to a stacked follow-up.)

- **Newest-first listing.** Was `ORDER BY path` ascending = oldest tweet first, with the newest save buried at the bottom of the Bookmarks folder. Now numeric-recency descending — `(length(path), path) DESC`, so a 2010-era short id sorts old — with the keyset cursor flipped to match. Generic pagers (frontend Load more, VFS) keep working: the cursor is still "the last path served".
- **Honest archive states.** A failed save read as `RuntimeError: tweet … is unavailable (deleted, private, or suspended)` and a pending one as `hydration pending`. Reads now serve a human sentence (the raw error stays on the row for diagnosis), the error view offers "Open in X ↗" (URL derivable from the path even when nothing was archived), and browse listings badge failed saves ("not archived") and render pending ones as "Archiving…" instead of identical to healthy saves. The shared saves pipeline serves Instagram the same copy.
- **Sync-failure copy.** `Source sync failed; check server logs` (rendered on the X page when a sync dies, and useless to hosted users) → "Sync hit an unexpected error — it will retry automatically." True: `next_sync_at` advances at sync start, so the beat reconciler retries on the next interval.
- The viewer no longer prints the archived body's trailing URL directly under the header's identical "Open in X" link.

## Screenshots (local E2E, seeded data)

- [Newest-first list with "Archiving…" + "not archived" badge, doc open](https://app.joinstash.ai/f/63b50908-28c5-49e1-8298-d74b33f99291)
- [Failed archive: human copy + Open in X](https://app.joinstash.ai/f/3ab8fcc8-0ccb-4ed5-853e-370e97357077)

## Tests

- 2 new pytest cases: newest-first ordering + keyset continuation across id lengths; human error sentences + listing statuses for failed/pending saves. The Instagram failure test now pins "raw exception stays on the row, human sentence on the read".
- 115 passed across `test_x_saves` / `test_instagram_saves` / `test_sources` / `test_security_audit`; vitest 210 passed; `next build` clean; ruff clean. Rebased on current main (post-#876).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z5kuhA5wjHHySJBtoJ1fJ