### PR TITLE
CI: audit dependencies nightly, not on every PR

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,61 @@
+name: Dependency audit
+
+# Audits query live advisory databases, so their outcome changes with the
+# outside world, not the diff. Running them on every PR meant a new advisory
+# anywhere in the transitive tree redlined every open PR at once (and
+# un-redlined them when withdrawn). Instead: audit nightly on main, and on
+# PRs only when a dependency manifest actually changed.
+on:
+  schedule:
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "backend/requirements.txt"
+      - "backend/requirements-dev.txt"
+      - "pyproject.toml"
+      - "sdk/pyproject.toml"
+      - "frontend/package-lock.json"
+      - "www/package-lock.json"
+      - "collab/package-lock.json"
+
+jobs:
+  dependency-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install audit tools
+        run: python -m pip install pip-audit
+
+      # PYSEC-2026-1325: ecdsa (transitive via python-jose) has no fixed
+      # release yet. Suppressed 2026-07-13; drop the flag once a fix ships.
+      - name: Audit backend Python requirements
+        run: python -m pip_audit -r backend/requirements.txt -r backend/requirements-dev.txt --ignore-vuln PYSEC-2026-1325
+
+      - name: Audit CLI Python package
+        run: python -m pip_audit . --ignore-vuln PYSEC-2026-1325
+
+      - name: Audit SDK Python package
+        run: python -m pip_audit sdk --ignore-vuln PYSEC-2026-1325
+
+      - name: Audit frontend npm lock
+        run: npm audit --audit-level=moderate --package-lock-only
+        working-directory: frontend
+
+      - name: Audit www npm lock
+        run: npm audit --audit-level=moderate --package-lock-only
+        working-directory: www
+
+      - name: Audit collab npm lock
+        run: npm audit --audit-level=moderate --package-lock-only
+        working-directory: collab

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,46 +83,6 @@ jobs:
       - name: Run plugin tests
         run: python -m pytest plugins/tests --no-cov
 
-  dependency-audit:
-    name: Dependency audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install audit tools
-        run: python -m pip install pip-audit
-
-      # PYSEC-2026-1325: ecdsa (transitive via python-jose) has no fixed
-      # release yet. Suppressed 2026-07-13; drop the flag once a fix ships.
-      - name: Audit backend Python requirements
-        run: python -m pip_audit -r backend/requirements.txt -r backend/requirements-dev.txt --ignore-vuln PYSEC-2026-1325
-
-      - name: Audit CLI Python package
-        run: python -m pip_audit . --ignore-vuln PYSEC-2026-1325
-
-      - name: Audit SDK Python package
-        run: python -m pip_audit sdk --ignore-vuln PYSEC-2026-1325
-
-      - name: Audit frontend npm lock
-        run: npm audit --audit-level=moderate --package-lock-only
-        working-directory: frontend
-
-      - name: Audit www npm lock
-        run: npm audit --audit-level=moderate --package-lock-only
-        working-directory: www
-
-      - name: Audit collab npm lock
-        run: npm audit --audit-level=moderate --package-lock-only
-        working-directory: collab
-
   backend-test:
     name: Backend tests (pytest)
     runs-on: ubuntu-latest


### PR DESCRIPTION
only flag a pr if it *introduces* a new suspicious dependency, not just *has* one

## Why

The dependency audit queries live advisory databases (`pip-audit` → PyPI, `npm audit` → npm/GitHub), so its outcome depends on the state of the world, not the PR's diff. Today's linkify-it advisory (GHSA-v245-v573-v5vm) redlined every open PR at 20:05 UTC and was withdrawn upstream ~6 hours later — zero commits, checks flipped red then green on their own. That's the fifth advisory-churn episode since June (#715, www/collab audit fix, #788 ecdsa suppression, #877 sharp override this morning).

## What

- Extract `dependency-audit` from `test.yml` into its own workflow, unchanged in substance.
- Triggers: nightly cron (14:00 UTC) on main + `workflow_dispatch`, and on PRs **only when a dependency manifest changed** (backend requirements, root/sdk `pyproject.toml`, the three npm lockfiles) — the one case where a PR can actually introduce a vulnerability.
- A real advisory now surfaces as one failing nightly run on main to fix once, instead of N red PRs.

## Testing

- Both workflow files parse as valid YAML; `test.yml` job list is unchanged minus the audit job.
- The audit job body is a verbatim move (including the PYSEC-2026-1325 suppression comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)