### PR TITLE
Search page reaches connected sources, with deep links into integrations

### DIFF
--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -606,6 +606,10 @@ CONTENT_TABLES = {
     # stays empty (no indexer); see the note on DEFAULT_SYNC_INTERVAL_S.
 }
 
+# Archive-style save tables: rows exist before their content is hydrated, so
+# they carry a hydration_status that listings and reads must surface.
+SAVE_TABLES = {"x_save_docs", "instagram_save_docs"}
+
 # Index-only source types whose `search` is federated live to the provider's
 # native search instead of our FTS (no copied content). source_type -> the
 # provider search coroutine, resolved lazily to avoid an import cycle.
@@ -853,9 +857,10 @@ async def list_documents(
 ) -> list[dict]:
     """List a source's live documents, optionally under a path prefix. `source`
     is the registry row (from get_owned_source / get_source_for_sync). `after`
-    is a keyset cursor: only paths strictly greater (in the ORDER BY path
-    ordering) are returned, so callers page through big sources by passing the
-    last path of the previous page."""
+    is a keyset cursor: only paths strictly beyond it in the listing order are
+    returned, so callers page through big sources by passing the last path of
+    the previous page. Most sources list ascending by path; X saves list
+    newest-first (see the ordering note below)."""
     table = _table_for(source["source_type"])
     if table == "slack_messages":
         allowed_channel_ids = slack_allowed_channel_ids(source)
@@ -933,11 +938,26 @@ async def list_documents(
         if is_content
         else "NULL::text"
     )
+    # Saves carry their archive status so listings can mark a save that failed
+    # to archive (or is still archiving) instead of rendering it like the rest.
+    status_column = "hydration_status" if table in SAVE_TABLES else "NULL::text"
+    # X saves list newest-first — a bookmark list you can only read oldest-first
+    # buries the thing you saved five minutes ago. The path's tweet id grows
+    # over time but varies in digit count, so numeric order is (length, value).
+    # The keyset cursor flips with the ordering: a page continues strictly
+    # below the last path served.
+    if table == "x_save_docs":
+        order_by = "length(path) DESC, path DESC"
+        cursor_predicate = "($4 = '' OR (length(path), path) < (length($4), $4))"
+    else:
+        order_by = "path"
+        cursor_predicate = "path > $4"
     rows = await get_pool().fetch(
         f"SELECT path, name, kind, external_ref, external_updated_at, "
-        f"{size_column} AS size, {snippet_column} AS snippet FROM {table} "
-        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND path > $4 "
-        f"ORDER BY path LIMIT $3",
+        f"{size_column} AS size, {snippet_column} AS snippet, {status_column} AS status "
+        f"FROM {table} "
+        f"WHERE source_id = $1 AND deleted_at IS NULL AND path LIKE $2 AND {cursor_predicate} "
+        f"ORDER BY {order_by} LIMIT $3",
         UUID(source["id"]),
         f"{prefix}%",
         limit,
@@ -956,6 +976,7 @@ def _entry_row(r) -> dict:
         "external_updated_at": (external_updated_at.isoformat() if external_updated_at else None),
         "size": r["size"],
         "snippet": r["snippet"] if "snippet" in r.keys() else None,
+        "status": r["status"] if "status" in r.keys() else None,
     }
 
 
@@ -1215,6 +1236,19 @@ async def _read_drive_document(source_id: UUID, path: str) -> dict | None:
     }
 
 
+def _save_pending_error(status: str, provider_label: str) -> str:
+    """The user-facing body for a save whose content isn't archived yet. The
+    raw hydration_error stays on the row for diagnosis; the API serves a human
+    sentence — nobody should read a Python exception in their bookmark list."""
+    if status == "failed":
+        return (
+            "This post couldn't be archived — it was probably deleted, made private, "
+            f"or its account suspended before we could copy it. It may still be open "
+            f"on {provider_label}."
+        )
+    return "Still archiving this post — check back in a minute."
+
+
 async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
     """An Instagram save, or a loud explanation while hydration is pending —
     same contract as drive_documents: never hand back a blank body as if the
@@ -1232,14 +1266,13 @@ async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
     if not row:
         return None
     if row["content"] is None:
-        status = row["hydration_status"]
         return {
             "path": row["path"],
             "name": row["name"],
             "kind": row["kind"],
             "content": "",
-            "error": row["hydration_error"] or f"hydration {status}",
-            "http_status": 422 if status == "failed" else 409,
+            "error": _save_pending_error(row["hydration_status"], "Instagram"),
+            "http_status": 422 if row["hydration_status"] == "failed" else 409,
         }
     doc = {
         "path": row["path"],
@@ -1269,14 +1302,13 @@ async def _read_x_save(source_id: UUID, path: str) -> dict | None:
     if not row:
         return None
     if row["content"] is None:
-        status = row["hydration_status"]
         return {
             "path": row["path"],
             "name": row["name"],
             "kind": row["kind"],
             "content": "",
-            "error": row["hydration_error"] or f"hydration {status}",
-            "http_status": 422 if status == "failed" else 409,
+            "error": _save_pending_error(row["hydration_status"], "X"),
+            "http_status": 422 if row["hydration_status"] == "failed" else 409,
         }
     doc = {
         "path": row["path"],

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1458,6 +1458,7 @@ async def _federated_search(
             {
                 "source": source["id"],
                 "source_name": source["display_name"],
+                "source_type": source["source_type"],
                 "error": detail,
                 "needs_reconnect": needs_reconnect,
             }
@@ -1476,6 +1477,7 @@ async def _federated_search(
         {
             "source": source["id"],
             "source_name": source["display_name"],
+            "source_type": source["source_type"],
             "ref": h["ref"],
             "name": h.get("name", ""),
             "snippet": h.get("snippet", ""),
@@ -1487,6 +1489,7 @@ async def _federated_search(
             {
                 "source": source["id"],
                 "source_name": source["display_name"],
+                "source_type": source["source_type"],
                 "truncated": True,
                 "returned": len(hits),
                 "estimated_total": estimated_total,
@@ -1550,7 +1553,8 @@ async def search_documents(
     ]
     union = " UNION ALL ".join(parts)
     rows = await get_pool().fetch(
-        f"SELECT u.source_id, ws.display_name AS source_name, u.path, u.name, u.snippet "
+        f"SELECT u.source_id, ws.display_name AS source_name, "
+        f"ws.source_type AS source_type, u.path, u.name, u.snippet "
         f"FROM ({union}) u JOIN user_sources ws ON ws.id = u.source_id "
         f"ORDER BY u.rank DESC LIMIT $4",
         user_id,
@@ -1562,6 +1566,7 @@ async def search_documents(
         {
             "source_id": str(r["source_id"]),
             "source_name": r["source_name"],
+            "source_type": r["source_type"],
             "path": r["path"],
             "name": r["name"],
             "snippet": r["snippet"] or "",
@@ -2154,6 +2159,7 @@ async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> 
             {
                 "source": s["id"],
                 "source_name": s["display_name"],
+                "source_type": s["source_type"],
                 "ref": r["path"],
                 "name": r["name"],
                 "snippet": "",
@@ -2230,6 +2236,7 @@ async def search_all(
             {
                 "source": d["source_id"],
                 "source_name": d["source_name"],
+                "source_type": d["source_type"],
                 "ref": d["path"],
                 "name": d["name"],
                 "snippet": d["snippet"],

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -35,7 +35,10 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
-SYNC_FAILED_MESSAGE = "Source sync failed; check server logs"
+# Owner-facing (rendered on the integration page). Raw exceptions stay in the
+# server logs; next_sync_at was already advanced at sync start, so a failed
+# source genuinely retries on its own.
+SYNC_FAILED_MESSAGE = "Sync hit an unexpected error — it will retry automatically."
 
 # source_type -> indexer. Each returns the new sync cursor (or None).
 INDEXERS: dict[str, Callable[[dict], Awaitable[str | None]]] = {

--- a/backend/tests/test_instagram_saves.py
+++ b/backend/tests/test_instagram_saves.py
@@ -262,9 +262,11 @@ async def test_hydration_failure_lands_on_the_row(
     assert "scrapecreators exploded" in row["hydration_error"]
     assert row["hydration_attempts"] == 1
 
-    # Reading an unhydrated doc fails loud, not blank.
+    # Reading an unhydrated doc fails loud, not blank — but with a human
+    # sentence, never the raw exception (that stays on the row, above).
     ok, doc = await source_service.source_document(
         UUID(owner_id), UUID(owner_id), str(source["id"]), "ABC123xyz"
     )
     assert ok and doc["http_status"] == 422
-    assert "scrapecreators exploded" in doc["error"]
+    assert "couldn't be archived" in doc["error"]
+    assert "scrapecreators exploded" not in doc["error"]

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -2086,6 +2086,7 @@ async def test_federated_search_logs_only_failure_metadata(client: AsyncClient, 
         {
             "source": src["id"],
             "source_name": "PROJ",
+            "source_type": "jira_project",
             "error": "PROJ search failed",
             "needs_reconnect": False,
         }
@@ -2134,6 +2135,7 @@ async def test_unscoped_search_surfaces_dead_federated_source(client: AsyncClien
         {
             "source": src["id"],
             "source_name": "Gmail (henry@ferganalabs.com)",
+            "source_type": "gmail",
             "error": "gmail token expired; reconnect required",
             "needs_reconnect": True,
         }
@@ -2171,6 +2173,7 @@ async def test_search_appends_truncation_marker_when_provider_caps(
         {
             "source": src["id"],
             "source_name": "Gmail (henry@ferganalabs.com)",
+            "source_type": "gmail",
             "ref": "m0",
             "name": "msg 0",
             "snippet": "",
@@ -2178,6 +2181,7 @@ async def test_search_appends_truncation_marker_when_provider_caps(
         {
             "source": src["id"],
             "source_name": "Gmail (henry@ferganalabs.com)",
+            "source_type": "gmail",
             "ref": "m1",
             "name": "msg 1",
             "snippet": "",
@@ -2187,6 +2191,7 @@ async def test_search_appends_truncation_marker_when_provider_caps(
         {
             "source": src["id"],
             "source_name": "Gmail (henry@ferganalabs.com)",
+            "source_type": "gmail",
             "truncated": True,
             "returned": 2,
             "estimated_total": 213,

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -609,6 +609,11 @@ async def test_bookmarks_list_newest_first_across_id_lengths(client, pool) -> No
     )
     assert [e["path"] for e in rest] == ["Bookmarks/999"]
 
+    # Search results carry the source type so clients can deep-link into the
+    # owning integration page.
+    hits = await source_service.search_documents(user_id=UUID(owner_id), query="newest tweet")
+    assert [(h["path"], h["source_type"]) for h in hits] == [("Bookmarks/1815550002", "x_saves")]
+
 
 @pytest.mark.asyncio
 async def test_unarchived_saves_read_as_human_sentences(client, pool) -> None:

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -562,3 +562,88 @@ async def test_bookmarks_paid_tier_gate_is_best_effort(client, pool, fake_sync) 
     )
     assert status["sync_status"] != "failed"
     assert "paid tier" in status["sync_error"]
+
+
+async def _insert_done(pool, owner_id, source_id, path, content):
+    await _insert_pending(pool, owner_id, source_id, path, "Bookmark")
+    await pool.execute(
+        "UPDATE x_save_docs SET content = $3, hydration_status = 'done' "
+        "WHERE source_id = $1 AND path = $2",
+        UUID(source_id),
+        path,
+        content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_bookmarks_list_newest_first_across_id_lengths(client, pool) -> None:
+    """A bookmark list you can only read oldest-first buries the thing you
+    saved five minutes ago; the listing must order by numeric tweet id (which
+    grows over time), not lexicographic path — a 2010-era short id is old."""
+    _, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/999", "old tweet")
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/1815550001", "newer tweet")
+    await _insert_done(pool, owner_id, source["id"], "Bookmarks/1815550002", "newest tweet")
+
+    entries = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks"
+    )
+    assert [e["path"] for e in entries] == [
+        "Bookmarks/1815550002",
+        "Bookmarks/1815550001",
+        "Bookmarks/999",
+    ]
+
+    # Keyset continuation: the cursor is the last path served; the next page
+    # continues strictly older, in the same order.
+    first = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks", limit=2
+    )
+    rest = await source_service.source_entries(
+        UUID(owner_id),
+        UUID(owner_id),
+        str(source["id"]),
+        prefix="Bookmarks",
+        after=first[-1]["path"],
+    )
+    assert [e["path"] for e in rest] == ["Bookmarks/999"]
+
+
+@pytest.mark.asyncio
+async def test_unarchived_saves_read_as_human_sentences(client, pool) -> None:
+    """A failed archive must never serve the raw exception text to the reader,
+    and a pending one must say it's still archiving — while the listing marks
+    both so they are distinguishable from healthy saves without opening them."""
+    _, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/2001", "Bookmark")
+    await pool.execute(
+        "UPDATE x_save_docs SET hydration_status = 'failed', "
+        "hydration_error = 'RuntimeError: tweet 2001 is unavailable' "
+        "WHERE source_id = $1 AND path = 'Bookmarks/2001'",
+        UUID(source["id"]),
+    )
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/2002", "Bookmark")
+
+    ok, failed = await source_service.source_document(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), "Bookmarks/2001"
+    )
+    assert ok
+    assert failed["http_status"] == 422
+    assert "couldn't be archived" in failed["error"]
+    assert "RuntimeError" not in failed["error"]
+
+    ok, pending = await source_service.source_document(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), "Bookmarks/2002"
+    )
+    assert ok
+    assert pending["http_status"] == 409
+    assert "Still archiving" in pending["error"]
+
+    entries = await source_service.source_entries(
+        UUID(owner_id), UUID(owner_id), str(source["id"]), prefix="Bookmarks"
+    )
+    statuses = {e["path"]: e["status"] for e in entries}
+    assert statuses["Bookmarks/2001"] == "failed"
+    assert statuses["Bookmarks/2002"] == "pending"

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -819,9 +819,14 @@ function BrowsePanel({
 // bordered header that deep-links back to the provider when a url is available.
 // Hydrated saves lead with the tweet text, then a blank line, then the byline /
 // reply-context / link meta. Show the tweet prominently and mute the rest.
-function TweetBody({ content }: { content: string }) {
+function TweetBody({ content, linkedUrl }: { content: string; linkedUrl?: string | null }) {
   const [body, ...rest] = content.split("\n\n");
-  const meta = rest.join("\n\n").trim();
+  let meta = rest.join("\n\n").trim();
+  // The archived body ends with the post's URL; when the header already links
+  // there ("Open in X ↗"), printing it again is noise.
+  if (linkedUrl && meta.endsWith(linkedUrl)) {
+    meta = meta.slice(0, meta.length - linkedUrl.length).trim();
+  }
   return (
     <div className="scroll-thin max-h-96 space-y-3 overflow-auto bg-base px-4 py-4">
       <p className="whitespace-pre-wrap break-words text-[14px] leading-relaxed text-foreground">
@@ -836,14 +841,26 @@ function TweetBody({ content }: { content: string }) {
   );
 }
 
+// The provider URL a save points at, derivable from its path alone — so the
+// "open on the platform" link survives a failed archive (which has no stored
+// url to serve).
+function saveExternalUrl(sourceType: string | undefined, ref: string): string | null {
+  const leaf = ref.slice(ref.lastIndexOf("/") + 1);
+  if (sourceType === "x_saves") return `https://x.com/i/status/${leaf}`;
+  if (sourceType === "instagram_saves") return `https://www.instagram.com/p/${leaf}/`;
+  return null;
+}
+
 function DocViewer({
   source,
+  sourceType,
   providerLabel,
   refValue,
   name,
   onClose,
 }: {
   source: string;
+  sourceType?: string;
   providerLabel: string;
   refValue: string;
   name?: string;
@@ -905,7 +922,19 @@ function DocViewer({
         </div>
       </div>
       {error ? (
-        <div className="bg-base px-3 py-3 text-[12px] text-error">{error}</div>
+        <div className="bg-base px-3 py-3 text-[12px] text-error">
+          {error}
+          {saveExternalUrl(sourceType, refValue) && (
+            <a
+              href={saveExternalUrl(sourceType, refValue)!}
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 font-semibold text-brand hover:underline"
+            >
+              Open in {providerLabel} ↗
+            </a>
+          )}
+        </div>
       ) : content === null ? (
         <div className="bg-base px-3 py-3 text-[12px] text-muted-foreground">Loading…</div>
       ) : (
@@ -920,7 +949,7 @@ function DocViewer({
               <img key={i} src={m.url} alt={title} className="max-h-72 w-full bg-black object-contain" />
             ),
           )}
-          <TweetBody content={content} />
+          <TweetBody content={content} linkedUrl={url} />
         </>
       )}
     </div>
@@ -1022,6 +1051,7 @@ function SearchablePanel({
                     {isOpen && (
                       <DocViewer
                         source={source.source}
+                        sourceType={source.type}
                         providerLabel={providerLabel}
                         refValue={hit.ref!}
                         name={hit.name}
@@ -1060,6 +1090,7 @@ function SearchablePanel({
                 {isOpen && (
                   <DocViewer
                     source={source.source}
+                    sourceType={source.type}
                     providerLabel={providerLabel}
                     refValue={ref}
                     name={entry.name}
@@ -1272,8 +1303,11 @@ function NavigablePanel({
             const folder = isFolder(entry);
             const ref = entry.id ?? entry.path ?? entry.name;
             const isOpen = !folder && openDoc?.ref === ref;
-            // An un-hydrated save still has its raw numeric tweet id as its name.
-            const pending = !folder && /^\d+$/.test(entry.name);
+            // Saves report their archive state; an un-hydrated save also still
+            // has its raw numeric tweet id as its name.
+            const pending =
+              !folder && (entry.status === "pending" || /^\d+$/.test(entry.name));
+            const failed = !folder && entry.status === "failed";
             const key = `${folder ? "dir" : "doc"}:${ref}`;
             return (
               <div key={key}>
@@ -1289,12 +1323,19 @@ function NavigablePanel({
                     {folder ? "📁" : "📄"}
                   </span>
                   <span className="min-w-0 flex-1">
-                    {pending ? (
-                      <span className="truncate text-[12.5px] italic text-muted-foreground">Loading…</span>
+                    {failed ? (
+                      <span className="flex items-center gap-2">
+                        <span className="truncate text-[12.5px] text-foreground">{entry.name}</span>
+                        <span className="shrink-0 rounded-full border border-error/40 bg-error/10 px-1.5 text-[10px] font-semibold text-error">
+                          not archived
+                        </span>
+                      </span>
+                    ) : pending ? (
+                      <span className="truncate text-[12.5px] italic text-muted-foreground">Archiving…</span>
                     ) : (
                       <span className="block truncate text-[12.5px] text-foreground">{entry.name}</span>
                     )}
-                    {entry.snippet && !pending && (
+                    {entry.snippet && !pending && !failed && (
                       <span className="mt-0.5 block truncate text-[11.5px] text-muted-foreground">
                         {entry.snippet}
                       </span>
@@ -1304,6 +1345,7 @@ function NavigablePanel({
                 {isOpen && (
                   <DocViewer
                     source={source.source}
+                    sourceType={source.type}
                     providerLabel={providerLabel}
                     refValue={ref}
                     name={entry.name}

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -67,6 +67,9 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const highlightSourceId = searchParams.get("source");
+  // Deep link from search results: ?doc=<path> opens the browse panel with
+  // that document expanded (and its folder as the listing path).
+  const initialDocRef = searchParams.get("doc");
   // The OAuth callback lands here with an error flag when a reconnect was
   // refused because it used a different provider account than the one whose
   // data is kept.
@@ -525,6 +528,7 @@ export function IntegrationDetail({ provider }: { provider: string }) {
             <BrowsePanel
               source={openSource}
               providerLabel={connector.label}
+              initialDocRef={openSource.source === highlightSourceId || connector.singleSource ? initialDocRef : null}
               onRefresh={() => void refresh()}
             />
           </section>
@@ -791,10 +795,12 @@ function rowButton(): string {
 function BrowsePanel({
   source,
   providerLabel,
+  initialDocRef,
   onRefresh,
 }: {
   source: Source;
   providerLabel: string;
+  initialDocRef?: string | null;
   onRefresh: () => void;
 }) {
   if (source.capability === "searchable") {
@@ -802,6 +808,7 @@ function BrowsePanel({
       <SearchablePanel
         source={source}
         providerLabel={providerLabel}
+        initialDocRef={initialDocRef}
         onRefresh={onRefresh}
       />
     );
@@ -810,6 +817,7 @@ function BrowsePanel({
     <NavigablePanel
       source={source}
       providerLabel={providerLabel}
+      initialDocRef={initialDocRef}
       onRefresh={onRefresh}
     />
   );
@@ -959,10 +967,12 @@ function DocViewer({
 function SearchablePanel({
   source,
   providerLabel,
+  initialDocRef,
   onRefresh,
 }: {
   source: Source;
   providerLabel: string;
+  initialDocRef?: string | null;
   onRefresh: () => void;
 }) {
   const [query, setQuery] = useState("");
@@ -970,7 +980,9 @@ function SearchablePanel({
   const [searchError, setSearchError] = useState<string | null>(null);
   const [recent, setRecent] = useState<SourceEntry[] | null>(null);
   const [searching, setSearching] = useState(false);
-  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
+  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(
+    initialDocRef ? { ref: initialDocRef } : null
+  );
 
   const showHistory = source.type === "slack" || source.type === "gong_calls";
 
@@ -1028,6 +1040,20 @@ function SearchablePanel({
       {searchError && (
         <div className="mb-2 px-1.5 py-1 text-[12.5px] text-error">{searchError}</div>
       )}
+
+      {/* A deep-linked doc renders here until a search/recent row matches it. */}
+      {openDoc &&
+        !(hits ?? []).some((h) => h.ref === openDoc.ref) &&
+        !(hits === null && (recent ?? []).some((e) => (e.id ?? e.path ?? e.name) === openDoc.ref)) && (
+          <DocViewer
+            source={source.source}
+            sourceType={source.type}
+            providerLabel={providerLabel}
+            refValue={openDoc.ref}
+            name={openDoc.name}
+            onClose={() => setOpenDoc(null)}
+          />
+        )}
 
       {hits !== null && (() => {
         const realHits = hits.filter((hit) => hit.ref);
@@ -1154,18 +1180,36 @@ function HitRow({
 function NavigablePanel({
   source,
   providerLabel,
+  initialDocRef,
   onRefresh,
 }: {
   source: Source;
   providerLabel: string;
+  initialDocRef?: string | null;
   onRefresh: () => void;
 }) {
-  const [path, setPath] = useState("");
+  // A ?doc= deep link (from a search result) starts the panel inside the
+  // document's folder with the document itself expanded.
+  const initialDir = initialDocRef?.includes("/")
+    ? initialDocRef.slice(0, initialDocRef.lastIndexOf("/"))
+    : "";
+  const [path, setPath] = useState(initialDir);
   const [entries, setEntries] = useState<SourceEntry[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [crumbs, setCrumbs] = useState<{ label: string; path: string }[]>([{ label: source.display_name, path: "" }]);
-  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
+  const [crumbs, setCrumbs] = useState<{ label: string; path: string }[]>(() => {
+    const base = [{ label: source.display_name, path: "" }];
+    if (!initialDir) return base;
+    let acc = "";
+    for (const segment of initialDir.split("/")) {
+      acc = acc ? `${acc}/${segment}` : segment;
+      base.push({ label: segment, path: acc });
+    }
+    return base;
+  });
+  const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(
+    initialDocRef ? { ref: initialDocRef } : null
+  );
   const [error, setError] = useState("");
   // Bumped whenever the listing target changes, so an in-flight Load more for
   // the previous directory can't clobber the new one.
@@ -1292,6 +1336,19 @@ function NavigablePanel({
       </div>
 
       {error && <div className="mb-2 text-[12px] text-error">{error}</div>}
+
+      {/* A deep-linked doc renders here until its row is on a loaded page. */}
+      {openDoc &&
+        !(visibleEntries ?? []).some((e) => (e.id ?? e.path ?? e.name) === openDoc.ref) && (
+          <DocViewer
+            source={source.source}
+            sourceType={source.type}
+            providerLabel={providerLabel}
+            refValue={openDoc.ref}
+            name={openDoc.name}
+            onClose={() => setOpenDoc(null)}
+          />
+        )}
 
       {visibleEntries === null ? (
         <div className="text-[12px] text-muted-foreground">Loading…</div>

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -16,16 +16,19 @@ import {
   listSkills,
   searchEvents,
   searchPages as searchPagesApi,
+  searchSource,
   type HistoryEvent,
   type PublicSkillDetail,
   type SessionEvent,
   type Sidebar,
   type Skill,
+  type SourceSearchHit,
   type TreeFolder,
 } from "../../lib/api";
+import { providerForSourceType } from "@/components/integrations/connectors";
 import type { Page, TableWithOwner } from "../../lib/types";
 
-type ContentScope = "all" | "sessions" | "pages" | "tables" | "skills";
+type ContentScope = "all" | "sessions" | "pages" | "tables" | "skills" | "integrations";
 
 // Coarse buckets for analytics — actual counts have high cardinality
 // and add no signal beyond "no results / few / many."
@@ -39,13 +42,23 @@ function bucketCount(n: number): string {
 
 interface SearchResult {
   id: string;
-  kind: "Session" | "Page" | "Table" | "Skill";
+  kind: "Session" | "Page" | "Table" | "Skill" | "Source";
   title: string;
   href: string;
   sourceName: string;
   detail: ReactNode;
-  updatedAt: string;
+  // Connected-source hits carry no timestamp; the time column stays empty.
+  updatedAt: string | null;
   relevance: number;
+}
+
+// A federated source that couldn't be searched (dead token, rate limit) or
+// that truncated its results — shown as a notice so "no matches from Gmail"
+// is never silently conflated with "Gmail wasn't searched".
+interface SourceSearchNotice {
+  sourceName: string;
+  message: string;
+  href: string | null;
 }
 
 const CONTENT_SCOPES: { id: ContentScope; label: string }[] = [
@@ -54,11 +67,18 @@ const CONTENT_SCOPES: { id: ContentScope; label: string }[] = [
   { id: "pages", label: "Pages" },
   { id: "skills", label: "Skills" },
   { id: "tables", label: "Tables" },
+  { id: "integrations", label: "Integrations" },
 ];
 
 function initialContentScope(value: string | null, sessionId: string): ContentScope {
   if (sessionId) return "sessions";
-  if (value === "sessions" || value === "pages" || value === "tables" || value === "skills") {
+  if (
+    value === "sessions" ||
+    value === "pages" ||
+    value === "tables" ||
+    value === "skills" ||
+    value === "integrations"
+  ) {
     return value;
   }
   return "all";
@@ -92,6 +112,7 @@ function SearchPageInner() {
     () => initialContentScope(searchParams.get("content"), initialSessionId)
   );
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [sourceNotices, setSourceNotices] = useState<SourceSearchNotice[]>([]);
   const [searchedQuery, setSearchedQuery] = useState("");
   const [fetching, setFetching] = useState(true);
   const [searching, setSearching] = useState(false);
@@ -162,6 +183,7 @@ function SearchPageInner() {
     const q = rawQuery.trim();
     if (!q) {
       setResults([]);
+      setSourceNotices([]);
       setSearchedQuery("");
       setSearching(false);
       return;
@@ -169,6 +191,7 @@ function SearchPageInner() {
 
     setSearching(true);
     setError("");
+    setSourceNotices([]);
     setSearchedQuery(q);
     try {
       const nextResults: SearchResult[] = [];
@@ -176,6 +199,7 @@ function SearchPageInner() {
       const includePages = contentScope === "all" || contentScope === "pages";
       const includeTables = contentScope === "all" || contentScope === "tables";
       const includeSkills = contentScope === "all" || contentScope === "skills";
+      const includeIntegrations = contentScope === "all" || contentScope === "integrations";
 
       if (selectedSessionId) {
         const events = await getSessionEvents(selectedSessionId);
@@ -224,6 +248,18 @@ function SearchPageInner() {
       if (includeTables && !selectedFolderId && !selectedPageId) {
         const { tables } = await listAllTables();
         nextResults.push(...searchTables(tables, q));
+      }
+
+      if (includeIntegrations && !selectedFolderId && !selectedPageId) {
+        // The unified sources search also covers native files/sessions, which
+        // the sections above already searched with richer metadata — keep only
+        // the connected-source hits here.
+        const hits = await searchSource(q);
+        const connected = hits.filter(
+          (hit) => hit.source !== "files" && hit.source !== "sessions"
+        );
+        nextResults.push(...searchSourceResults(connected, q));
+        setSourceNotices(sourceSearchNotices(connected));
       }
 
       setResults(sortResults(nextResults));
@@ -342,6 +378,28 @@ function SearchPageInner() {
 
             {searching && <SearchResultsSkeleton />}
 
+            {!searching && sourceNotices.length > 0 && (
+              <div className="mt-4 flex flex-col gap-1.5">
+                {sourceNotices.map((notice, i) => (
+                  <div
+                    key={`${notice.sourceName}:${i}`}
+                    className="rounded-md border border-border bg-surface px-3 py-2 text-[12px] text-muted-foreground"
+                  >
+                    <span className="font-semibold text-foreground">{notice.sourceName}</span>:{" "}
+                    {notice.message}
+                    {notice.href && (
+                      <>
+                        {" "}
+                        <Link href={notice.href} className="font-semibold text-brand hover:underline">
+                          Open integration
+                        </Link>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
             {!searching && searchedQuery && results.length === 0 && !error && (
               <p className="py-10 text-center text-[13px] text-muted-foreground">
                 No results found for &ldquo;{searchedQuery}&rdquo;.
@@ -381,7 +439,7 @@ function SearchPageInner() {
                         </div>
                         <div className="shrink-0 text-right text-[11px] text-muted-foreground">
                           <div>{result.sourceName}</div>
-                          <div>{relativeTime(result.updatedAt)}</div>
+                          {result.updatedAt && <div>{relativeTime(result.updatedAt)}</div>}
                         </div>
                       </div>
                     </Link>
@@ -500,7 +558,9 @@ function searchSessionsFromEvents(
       existing &&
       (existing.relevance > relevance ||
         (existing.relevance === relevance &&
-          new Date(existing.updatedAt) >= new Date(event.created_at)))
+          // Session results always carry a timestamp; the null case is
+          // connected-source results, which never reach this map.
+          new Date(existing.updatedAt ?? 0) >= new Date(event.created_at)))
     ) {
       continue;
     }
@@ -583,6 +643,66 @@ function searchPages(
       updatedAt: page.updated_at,
       relevance: scorePage(query, page),
     }));
+}
+
+// Connected-source hits (X saves, GitHub files, Slack messages, Gmail…) from
+// the unified sources search. Each links into its integration page with the
+// document pre-opened.
+function searchSourceResults(hits: SourceSearchHit[], query: string): SearchResult[] {
+  const seen = new Set<string>();
+  const results: SearchResult[] = [];
+  for (const hit of hits) {
+    if (!hit.ref) continue; // marker rows (errors / truncation) render as notices
+    const key = `${hit.source}:${hit.ref}`;
+    if (seen.has(key)) continue; // an id match can also FTS-match
+    seen.add(key);
+    // A type without an integration page still gets an honest link — the
+    // provider route renders "Unknown integration" rather than hiding the hit.
+    const provider = providerForSourceType[hit.source_type ?? ""] ?? hit.source_type ?? "";
+    results.push({
+      id: key,
+      kind: "Source",
+      title: hit.name || hit.ref,
+      href: `/integrations/${provider}?source=${encodeURIComponent(hit.source)}&doc=${encodeURIComponent(hit.ref)}`,
+      sourceName: hit.source_name ?? provider,
+      detail: contextSnippet(hit.snippet, query) ?? (hit.snippet || "").slice(0, 220),
+      updatedAt: null,
+      relevance: scoreValues(query, [
+        { value: hit.name, weight: 8 },
+        { value: hit.snippet, weight: 2 },
+      ]),
+    });
+  }
+  return results;
+}
+
+function sourceSearchNotices(hits: SourceSearchHit[]): SourceSearchNotice[] {
+  const notices: SourceSearchNotice[] = [];
+  for (const hit of hits) {
+    if (!hit.error && !hit.truncated) continue;
+    const provider = providerForSourceType[hit.source_type ?? ""];
+    const href = provider ? `/integrations/${provider}` : null;
+    const sourceName = hit.source_name ?? provider ?? "source";
+    if (hit.error) {
+      notices.push({
+        sourceName,
+        message: hit.needs_reconnect
+          ? `${hit.error} — reconnect it to include it in search.`
+          : hit.error,
+        href,
+      });
+    } else {
+      notices.push({
+        sourceName,
+        message:
+          hit.estimated_total != null
+            ? `showing the first ${hit.returned} of about ${hit.estimated_total} matches.`
+            : `showing the first ${hit.returned} matches.`,
+        href,
+      });
+    }
+  }
+  return notices;
 }
 
 function searchTables(tables: TableWithOwner[], query: string): SearchResult[] {
@@ -774,9 +894,10 @@ function pageSnippet(markdown?: string | null, html?: string | null): string {
 }
 
 function sortResults(results: SearchResult[]): SearchResult[] {
+  const time = (iso: string | null) => (iso ? new Date(iso).getTime() : 0);
   return [...results].sort((a, b) => {
     if (b.relevance !== a.relevance) return b.relevance - a.relevance;
-    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    return time(b.updatedAt) - time(a.updatedAt);
   });
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -323,6 +323,9 @@ export interface SourceEntry {
   external_ref?: string | null;
   // One-line preview of the copied content (e.g. the tweet text).
   snippet?: string | null;
+  // Archive state for save-type sources: 'done' | 'pending' | 'failed'.
+  // Null/absent for sources without an archive pipeline.
+  status?: string | null;
 }
 
 const NATIVE_SOURCE_TYPES = new Set(["native_files", "native_sessions"]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -402,6 +402,9 @@ export async function readSourceDoc(
 export interface SourceSearchHit {
   source: string;
   source_name?: string;
+  // The connected source's type ('x_saves', 'github_repo', …); absent on
+  // native files/sessions hits.
+  source_type?: string;
   // A real hit carries a ref; marker entries (see below) omit it.
   ref?: string;
   name?: string;
@@ -411,6 +414,9 @@ export interface SourceSearchHit {
   truncated?: boolean;
   returned?: number;
   estimated_total?: number | null;
+  // Marker: a federated source's live search failed (dead token, rate limit).
+  error?: string;
+  needs_reconnect?: boolean;
 }
 
 export async function searchSource(


### PR DESCRIPTION
**Stacked on #878** — merge that first, then rebase this onto main.

## What

The `/search` page only queried pages and sessions, so a synced X bookmark — or any connected-source document (GitHub, Slack, Granola, Gong, Notion, Drive-folder, Instagram), or a federated source's live results (Gmail, Drive, Jira, Asana, Linear, PostHog) — was invisible to the product search bar, even though the backend's unified sources search (`search_all`, what `stash search` and agents use) already found all of it.

- The search page now also runs the sources search. Connected-source hits render as `SOURCE` results; new "Integrations" entry in the type filter.
- Clicking a hit deep-links into the integration page with the document expanded: new `?doc=` support on the browse panels (folder path + open doc for navigable sources, open doc for searchable ones), with a standalone viewer until the row is on a loaded page.
- A federated source that failed or truncated its live search surfaces as a notice ("Gmail: token expired — reconnect it to include it in search", "showing the first N of about M matches") instead of silently reading as "no matches".
- Backend search results (FTS, federated, external-ref matches) carry `source_type` so clients can route a hit to its owning integration page.

## Screenshot (local E2E, seeded data)

- [Search result for an X bookmark + dead-federated-source notices](https://app.joinstash.ai/f/8028708b-4b0f-4c8f-a354-49365f66ed9c)

## Tests

- 110 passed across `test_x_saves` / `test_sources` / `test_security_audit` (marker shapes now pin `source_type`; the x_saves listing test asserts search results carry it); vitest 210 passed; `next build` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z5kuhA5wjHHySJBtoJ1fJ