### PR TITLE
Extension & clips UX: visible progress, staleness signal, install path

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -517,8 +517,11 @@ async def integration_purge(
     current_user: dict = Depends(get_current_user),
 ):
     """Delete the kept data of a disconnected (or connected) provider. The
-    explicit, destructive counterpart to disconnect-keeps-data."""
-    get_provider(provider)  # 404 if unknown
+    explicit, destructive counterpart to disconnect-keeps-data. Gated on the
+    source-type map, not the OAuth registry — extension-fed providers
+    (Instagram) have data to purge but no OAuth provider."""
+    if provider not in source_service.PROVIDER_SOURCE_TYPES:
+        raise HTTPException(status_code=404, detail=f"unknown provider: {provider}")
     purged = await _purge_provider_data(current_user["id"], provider, reason="purge")
     return {"ok": True, "sources": len(purged)}
 

--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -282,6 +282,17 @@ async def client_result(
     return {"status": "done"}
 
 
+@imports_router.get("")
+async def list_import_progress(
+    current_user: dict = Depends(get_current_user),
+):
+    """Recent import batches with their progress, newest first — the app-side
+    progress surface for bulk imports that grind for days. Additive: the
+    extension keeps using the per-batch endpoint below."""
+    batches = await url_import_service.list_batches_progress(current_user["id"])
+    return {"batches": batches}
+
+
 @imports_router.get("/{batch_id}")
 async def get_import_progress(
     batch_id: UUID,

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
@@ -481,6 +481,16 @@ async def push_saved_items(
     source_id = UUID(source["id"])
 
     pool = get_pool()
+    # The push itself is the liveness signal for an extension-fed source —
+    # there is no token to check. The UI warns when this stamp goes stale
+    # (extension uninstalled, Instagram logged out). A push also clears any
+    # standing sync warning: the pipeline is demonstrably alive again.
+    await pool.execute(
+        "UPDATE user_sources SET settings = coalesce(settings, '{}'::jsonb) || $2::jsonb, "
+        "sync_error = NULL, updated_at = now() WHERE id = $1",
+        source_id,
+        {"extension_last_push_at": datetime.now(UTC).isoformat()},
+    )
     new = 0
     for shortcode, item in parsed:
         inserted = await pool.fetchval(

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -395,13 +395,46 @@ async def get_readable_source(source_id: UUID, user_id: UUID) -> dict | None:
 
 
 async def delete_source(source_id: UUID, user_id: UUID) -> bool:
-    """Remove a connected source the user owns. Its documents cascade."""
-    result = await get_pool().execute(
-        "DELETE FROM user_sources WHERE id = $1 AND owner_user_id = $2",
+    """Remove a connected source the user owns: archived media blobs, share
+    grants, then the row (documents cascade). Same cleanup as the provider
+    purge — one deletion codepath, nothing orphaned."""
+    owned = await get_pool().fetchval(
+        "SELECT 1 FROM user_sources WHERE id = $1 AND owner_user_id = $2",
         source_id,
         user_id,
     )
+    if not owned:
+        return False
+    await _cleanup_source_data([source_id])
+    result = await get_pool().execute("DELETE FROM user_sources WHERE id = $1", source_id)
     return result.endswith("1")
+
+
+async def _cleanup_source_data(source_ids: list[UUID]) -> None:
+    """What the FK cascade can't reach when source rows are deleted: media
+    archives in object storage (X/Instagram saves) and share grants."""
+    from . import storage_service
+
+    pool = get_pool()
+    x_rows = await pool.fetch(
+        "SELECT media FROM x_save_docs WHERE source_id = ANY($1::uuid[]) "
+        "AND jsonb_array_length(media) > 0",
+        source_ids,
+    )
+    for row in x_rows:
+        for item in row["media"]:
+            await storage_service.delete_file(item["storage_key"])
+    ig_rows = await pool.fetch(
+        "SELECT media_storage_key FROM instagram_save_docs "
+        "WHERE source_id = ANY($1::uuid[]) AND media_storage_key IS NOT NULL",
+        source_ids,
+    )
+    for row in ig_rows:
+        await storage_service.delete_file(row["media_storage_key"])
+    await pool.execute(
+        "DELETE FROM shares WHERE object_type = 'source' AND object_id = ANY($1::uuid[])",
+        source_ids,
+    )
 
 
 def _provider_source_types(provider: str) -> list[str]:
@@ -429,8 +462,6 @@ async def purge_sources_for_provider(user_id: UUID, provider: str) -> list[dict]
     """The explicit delete-my-data path: archived media blobs, share grants,
     then the source rows (documents cascade). Returns the deleted sources so
     callers audit exactly what was removed."""
-    from . import storage_service
-
     pool = get_pool()
     source_types = _provider_source_types(provider)
     source_ids = [
@@ -444,28 +475,7 @@ async def purge_sources_for_provider(user_id: UUID, provider: str) -> list[dict]
     if not source_ids:
         return []
 
-    # Media archives (X/Instagram saves) live in object storage; the row
-    # cascade below cannot reach them, so they're deleted first.
-    x_rows = await pool.fetch(
-        "SELECT media FROM x_save_docs WHERE source_id = ANY($1::uuid[]) "
-        "AND jsonb_array_length(media) > 0",
-        source_ids,
-    )
-    for row in x_rows:
-        for item in row["media"]:
-            await storage_service.delete_file(item["storage_key"])
-    ig_rows = await pool.fetch(
-        "SELECT media_storage_key FROM instagram_save_docs "
-        "WHERE source_id = ANY($1::uuid[]) AND media_storage_key IS NOT NULL",
-        source_ids,
-    )
-    for row in ig_rows:
-        await storage_service.delete_file(row["media_storage_key"])
-
-    await pool.execute(
-        "DELETE FROM shares WHERE object_type = 'source' AND object_id = ANY($1::uuid[])",
-        source_ids,
-    )
+    await _cleanup_source_data(source_ids)
     rows = await pool.fetch(
         "DELETE FROM user_sources WHERE id = ANY($1::uuid[]) RETURNING *",
         source_ids,

--- a/backend/services/url_import_service.py
+++ b/backend/services/url_import_service.py
@@ -177,6 +177,34 @@ async def claim_client_batch(owner_user_id: UUID, *, limit: int) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+async def list_batches_progress(owner_user_id: UUID) -> list[dict]:
+    """Recent batches (last 14 days) with aggregate progress, newest first.
+    Per-URL failure details stay on the per-batch endpoint."""
+    rows = await get_pool().fetch(
+        """
+        SELECT b.id, b.kind, b.filename, b.total, b.created_at,
+               count(u.id) FILTER (WHERE u.status = 'done' AND u.error IS NULL) AS done,
+               count(u.id) FILTER (WHERE u.status = 'done' AND u.error IS NOT NULL) AS link_only,
+               count(u.id) FILTER (WHERE u.status = 'needs_client') AS needs_client,
+               count(u.id) FILTER (
+                   WHERE u.status IN ('pending', 'processing')
+                      OR (u.status = 'failed' AND u.attempts < 3)
+               ) AS pending
+        FROM import_batches b
+        LEFT JOIN url_imports u ON u.batch_id = b.id
+        WHERE b.owner_user_id = $1 AND b.created_at > now() - interval '14 days'
+        GROUP BY b.id, b.kind, b.filename, b.total, b.created_at
+        ORDER BY b.created_at DESC
+        LIMIT 20
+        """,
+        owner_user_id,
+    )
+    return [
+        {**dict(row), "id": str(row["id"]), "created_at": row["created_at"].isoformat()}
+        for row in rows
+    ]
+
+
 async def batch_progress(batch_id: UUID, owner_user_id: UUID) -> dict | None:
     pool = get_pool()
     batch = await pool.fetchrow(

--- a/backend/tests/test_bookmark_imports.py
+++ b/backend/tests/test_bookmark_imports.py
@@ -217,6 +217,30 @@ async def test_import_progress_reports_failures_per_url(
 
 
 @pytest.mark.asyncio
+async def test_imports_list_reports_progress_per_batch(client: AsyncClient, monkeypatch) -> None:
+    # The app-side progress pill lists all recent batches with aggregate
+    # counts — a days-long import must be visible outside the extension popup.
+    monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda ids: None)
+    headers, owner_id = await _register(client)
+
+    resp = await client.post("/api/v1/me/imports/bookmarks", headers=headers, **_upload_kwargs())
+    batch_id = resp.json()["import_id"]
+
+    listing = await client.get("/api/v1/me/imports", headers=headers)
+    assert listing.status_code == 200
+    batches = listing.json()["batches"]
+    assert [b["id"] for b in batches] == [batch_id]
+    assert batches[0]["total"] == 3
+    assert batches[0]["pending"] == 3
+    assert batches[0]["done"] == 0
+
+    # Owner-scoped: another user sees nothing.
+    other_headers, _ = await _register(client)
+    other = await client.get("/api/v1/me/imports", headers=other_headers)
+    assert other.json()["batches"] == []
+
+
+@pytest.mark.asyncio
 async def test_import_progress_is_owner_scoped(client: AsyncClient, monkeypatch) -> None:
     monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda ids: None)
     headers, _ = await _register(client)

--- a/backend/tests/test_disconnect_retention.py
+++ b/backend/tests/test_disconnect_retention.py
@@ -157,6 +157,59 @@ async def test_reconnect_reenables_source_and_preserves_settings(pool) -> None:
 
 
 @pytest.mark.asyncio
+async def test_per_source_delete_cleans_blobs_and_shares(pool, monkeypatch) -> None:
+    # The per-source Remove button is the only delete path extension-fed
+    # sources have — it must clean up exactly what the provider purge does.
+    from backend.services import storage_service
+
+    deleted_blobs: list[str] = []
+
+    async def fake_delete_file(key):
+        deleted_blobs.append(key)
+
+    monkeypatch.setattr(storage_service, "delete_file", fake_delete_file)
+
+    user_id = await _user()
+    grantee_id = await _user()
+    source = await source_service.create_source(
+        owner_user_id=user_id,
+        source_type="x_saves",
+        external_ref="222",
+        display_name="X",
+        settings={},
+    )
+    source_id = UUID(source["id"])
+    await pool.execute(
+        "INSERT INTO x_save_docs (owner_user_id, source_id, path, name, kind, external_ref, media) "
+        "VALUES ($1, $2, 'Bookmarks/2', '2', 'Bookmark', '2', "
+        '\'[{"storage_key": "store/x-2-0.jpg", "content_type": "image/jpeg"}]\')',
+        user_id,
+        source_id,
+    )
+    await pool.execute(
+        "INSERT INTO shares (owner_user_id, created_by, object_type, object_id, "
+        "principal_type, principal_id, permission) "
+        "VALUES ($1, $1, 'source', $2, 'user', $3, 'read')",
+        user_id,
+        source_id,
+        grantee_id,
+    )
+
+    assert await source_service.delete_source(source_id, user_id) is True
+
+    assert deleted_blobs == ["store/x-2-0.jpg"]
+    assert (
+        await pool.fetchval(
+            "SELECT count(*) FROM shares WHERE object_type = 'source' AND object_id = $1",
+            source_id,
+        )
+        == 0
+    )
+    # A non-owner can't trigger the cleanup path at all.
+    assert await source_service.delete_source(source_id, grantee_id) is False
+
+
+@pytest.mark.asyncio
 async def test_purge_deletes_documents_media_blobs_and_shares(pool, monkeypatch) -> None:
     from backend.services import storage_service
 

--- a/backend/tests/test_instagram_saves.py
+++ b/backend/tests/test_instagram_saves.py
@@ -152,6 +152,72 @@ async def test_push_creates_source_and_skeleton_rows(
 
 
 @pytest.mark.asyncio
+async def test_push_stamps_liveness_and_clears_warning(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    # The push is the only liveness signal an extension-fed source has: it
+    # must stamp extension_last_push_at (the UI's staleness anchor) and clear
+    # any standing sync warning — a push proves the pipeline is alive.
+    from backend.routers import sources as sources_router
+
+    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
+    monkeypatch.setattr(sources_router.celery, "send_task", lambda name, args: None)
+    headers, owner_id = await _register(client)
+
+    await client.post(
+        "/api/v1/me/saved-items",
+        json=_push_body(["https://www.instagram.com/p/AAA111bbb/"]),
+        headers=headers,
+    )
+    row = await pool.fetchrow(
+        "SELECT id, settings FROM user_sources WHERE owner_user_id = $1 "
+        "AND source_type = 'instagram_saves'",
+        UUID(owner_id),
+    )
+    assert row["settings"]["extension_last_push_at"]
+
+    await pool.execute(
+        "UPDATE user_sources SET sync_error = 'stale warning' WHERE id = $1", row["id"]
+    )
+    await client.post(
+        "/api/v1/me/saved-items",
+        json=_push_body(["https://www.instagram.com/p/AAA111bbb/"]),
+        headers=headers,
+    )
+    assert (
+        await pool.fetchval("SELECT sync_error FROM user_sources WHERE id = $1", row["id"]) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_purge_endpoint_covers_extension_fed_providers(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    # Instagram has no OAuth provider, so purge must gate on the source-type
+    # map — the Delete data button is the only delete path extension users have.
+    from backend.routers import sources as sources_router
+
+    monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
+    monkeypatch.setattr(sources_router.celery, "send_task", lambda name, args: None)
+    headers, owner_id = await _register(client)
+    await client.post(
+        "/api/v1/me/saved-items",
+        json=_push_body(["https://www.instagram.com/p/AAA111bbb/"]),
+        headers=headers,
+    )
+
+    resp = await client.post("/api/v1/integrations/instagram/purge", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "sources": 1}
+    assert (
+        await pool.fetchval(
+            "SELECT count(*) FROM instagram_save_docs WHERE owner_user_id = $1", UUID(owner_id)
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
 async def test_push_rejects_non_instagram_urls(client: AsyncClient, monkeypatch) -> None:
     monkeypatch.setattr(settings, "SCRAPECREATORS_API_KEY", "sc-key")
     headers, _ = await _register(client)

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stash Sync",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Saves webpages, PDFs, and your ChatGPT/Claude conversations to Stash.",
   "permissions": [
     "storage",
@@ -21,18 +21,31 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
-      "js": ["dist/chatgpt.js"],
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*"
+      ],
+      "js": [
+        "dist/chatgpt.js"
+      ],
       "run_at": "document_idle"
     },
     {
-      "matches": ["https://claude.ai/*"],
-      "js": ["dist/claude.js"],
+      "matches": [
+        "https://claude.ai/*"
+      ],
+      "js": [
+        "dist/claude.js"
+      ],
       "run_at": "document_idle"
     },
     {
-      "matches": ["https://www.instagram.com/*"],
-      "js": ["dist/instagram.js"],
+      "matches": [
+        "https://www.instagram.com/*"
+      ],
+      "js": [
+        "dist/instagram.js"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -11,9 +11,11 @@ import {
   importBookmarks,
   importProgress,
   initClipper,
+  initImportWatch,
   uploadPageClip,
 } from './background/clip';
 import { initImportFetch } from './background/import_fetch';
+import { clearSurfaceError, getSurfaceErrors, setSurfaceError } from './lib/errors';
 import {
   initInstagram,
   receiveSavedItems,
@@ -30,13 +32,11 @@ initChatPoll(syncConversation);
 initInstagram();
 initImportFetch();
 
-// The X bookmark harvest was removed (X syncs server-side over OAuth now); clear
-// any stale harvest error it left behind so the popup doesn't keep showing it.
-void chrome.storage.local.get('lastError').then(({ lastError }) => {
-  if (typeof lastError === 'string' && lastError.includes('X bookmarks')) {
-    void chrome.storage.local.set({ lastError: null });
-  }
-});
+initImportWatch();
+
+// The single `lastError` slot was replaced by per-surface slots — drop the
+// legacy key so pre-0.5.0 errors don't linger unreadably in storage.
+void chrome.storage.local.remove('lastError');
 // Auth sessions live 15 min server-side. The poll loop covers most of that,
 // and checkPendingConnect() collects an approval that lands after the loop
 // gave up (e.g. MV3 suspended the worker mid-wait).
@@ -70,7 +70,7 @@ async function handle(message: any, sender: chrome.runtime.MessageSender): Promi
     case 'SAVED_ITEMS_FAILED':
       return savedItemsFailed(message.error, sender);
     case 'CLIP_FAILED':
-      await chrome.storage.local.set({ lastError: `Save failed: ${message.error}` });
+      await setSurfaceError('clip', `Save failed: ${message.error}`);
       await setBadge('!', 'Save failed — click for details');
       return { ok: false, error: message.error };
     case 'PLATFORM_STATUS':
@@ -80,7 +80,7 @@ async function handle(message: any, sender: chrome.runtime.MessageSender): Promi
     case 'CONNECT':
       return connect();
     case 'DISCONNECT':
-      await chrome.storage.local.remove(['apiKey', 'username', 'folderId', 'folderName', 'folders', 'lastSync', 'lastClip', 'lastImport', 'lastError']);
+      await chrome.storage.local.remove(['apiKey', 'username', 'folderId', 'folderName', 'folders', 'lastSync', 'lastClip', 'lastImport', 'surfaceErrors']);
       return { ok: true };
     case 'GET_STATUS':
       return getStatus();
@@ -137,7 +137,7 @@ async function syncConversation(snapshot: ConversationSnapshot): Promise<any> {
   });
   if (!upsert.ok) {
     const detail = (await upsert.text()).slice(0, 200);
-    await chrome.storage.local.set({ lastError: `Session upsert failed (${upsert.status}): ${detail}` });
+    await setSurfaceError('chat', `Session upsert failed (${upsert.status}): ${detail}`);
     await setBadge('!', `Stash sync failing (${upsert.status}) — click for details`);
     return { ok: false, error: `upsert_failed_${upsert.status}` };
   }
@@ -155,7 +155,7 @@ async function syncConversation(snapshot: ConversationSnapshot): Promise<any> {
   });
   if (!res.ok) {
     const detail = (await res.text()).slice(0, 200);
-    await chrome.storage.local.set({ lastError: `Upload failed (${res.status}): ${detail}` });
+    await setSurfaceError('chat', `Upload failed (${res.status}): ${detail}`);
     await setBadge('!', `Stash sync failing (${res.status}) — click for details`);
     return { ok: false, error: `upload_failed_${res.status}` };
   }
@@ -163,8 +163,8 @@ async function syncConversation(snapshot: ConversationSnapshot): Promise<any> {
   await chrome.storage.session.set({ [hashKey]: hash });
   await chrome.storage.local.set({
     lastSync: { title: snapshot.title, sessionId, at: Date.now() },
-    lastError: null,
   });
+  await clearSurfaceError('chat');
   await setBadge('', 'Stash Chat Sync');
   return { ok: true };
 }
@@ -246,7 +246,7 @@ async function checkPendingConnect(): Promise<boolean> {
   const data = await res.json();
   if (data.status !== 'complete') return false;
 
-  await chrome.storage.local.set({ apiKey: data.api_key, username: data.username, lastError: null });
+  await chrome.storage.local.set({ apiKey: data.api_key, username: data.username, surfaceErrors: [] });
   await chrome.storage.local.remove(['pendingConnect']);
   await setBadge('', 'Stash Chat Sync');
   await refreshFolders();
@@ -294,7 +294,6 @@ async function getStatus(): Promise<any> {
     'lastSync',
     'lastClip',
     'lastImport',
-    'lastError',
   ]);
   return {
     ok: true,
@@ -306,6 +305,6 @@ async function getStatus(): Promise<any> {
     lastSync: cfg.lastSync || null,
     lastClip: cfg.lastClip || null,
     lastImport: cfg.lastImport || null,
-    lastError: cfg.lastError || null,
+    errors: await getSurfaceErrors(),
   };
 }

--- a/chrome_extension/src/background/chat_poll.ts
+++ b/chrome_extension/src/background/chat_poll.ts
@@ -4,6 +4,7 @@
 // — the origins are in host_permissions) and syncs anything updated since the
 // last successful pass. Each platform tracks its own watermark.
 
+import { setSurfaceError } from '../lib/errors';
 import {
   chatgptAccessToken,
   chatgptExtract,
@@ -49,9 +50,10 @@ async function pollAll(): Promise<void> {
   const errors = results.filter((r) => !r.ok);
   if (errors.length > 0) {
     // No notification — a logged-out site would nag daily. Badge + popup error.
-    await chrome.storage.local.set({
-      lastError: `Daily chat sync failed — ${errors.map((e) => e.error).join('; ')}`,
-    });
+    await setSurfaceError(
+      'chat',
+      `Daily chat sync failed — ${errors.map((e) => e.error).join('; ')}`
+    );
     await setBadge('!', 'Stash daily sync failed — click for details');
   }
 }

--- a/chrome_extension/src/background/clip.ts
+++ b/chrome_extension/src/background/clip.ts
@@ -4,8 +4,55 @@
 // byte-fetch path instead. Bulk imports (clip-all-tabs, bookmarks.html)
 // also run here so credentials stay in the worker.
 
+import { clearSurfaceError, setSurfaceError } from '../lib/errors';
 import { flashOkBadge, setBadge, stashConfig } from '../lib/stash';
 import { drainQueue } from './import_fetch';
+
+// While a bulk import is running, a periodic alarm keeps the action badge
+// showing the remaining count and fires one OS notification the moment the
+// import finishes — a days-long 41k grind gets a visible "done".
+const IMPORT_WATCH_ALARM = 'stash-import-watch';
+
+export function initImportWatch(): void {
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === IMPORT_WATCH_ALARM) void watchImport();
+  });
+  void watchImport(); // resume after a worker restart mid-import
+}
+
+async function watchImport(): Promise<void> {
+  const { lastImport } = await chrome.storage.local.get('lastImport');
+  if (!lastImport?.id || lastImport.doneNotified) {
+    await chrome.alarms.clear(IMPORT_WATCH_ALARM);
+    return;
+  }
+  const result = await importProgress(lastImport.id);
+  if (!result?.ok) return; // transient (offline, auth blip) — next alarm retries
+  const p = result.progress;
+  const remaining = p.pending + p.needs_client;
+  if (remaining > 0) {
+    await chrome.action.setBadgeText({ text: compactCount(remaining) });
+    await chrome.action.setBadgeBackgroundColor({ color: '#6366f1' });
+    await chrome.action.setTitle({ title: `Stash import: ${remaining} of ${p.total} remaining` });
+    chrome.alarms.create(IMPORT_WATCH_ALARM, { periodInMinutes: 5 });
+    return;
+  }
+  await chrome.alarms.clear(IMPORT_WATCH_ALARM);
+  await setBadge('', 'Stash');
+  chrome.notifications.create({
+    type: 'basic',
+    iconUrl: 'icons/icon128.png',
+    title: 'Stash import finished',
+    message:
+      `${p.done} of ${p.total} saved` +
+      (p.link_only > 0 ? `; ${p.link_only} kept as link-only (content unavailable).` : '.'),
+  });
+  await chrome.storage.local.set({ lastImport: { ...lastImport, doneNotified: true } });
+}
+
+function compactCount(n: number): string {
+  return n >= 1000 ? `${Math.floor(n / 1000)}k` : String(n);
+}
 
 export interface PageClip {
   url: string;
@@ -120,16 +167,14 @@ async function clipSucceeded(clip: {
   appUrl?: string;
   importId?: string;
 }): Promise<any> {
-  await chrome.storage.local.set({
-    lastClip: { ...clip, at: Date.now() },
-    lastError: null,
-  });
+  await chrome.storage.local.set({ lastClip: { ...clip, at: Date.now() } });
+  await clearSurfaceError('clip');
   await flashOkBadge(`Saved "${clip.title}" to Stash`);
   return { ok: true, clip };
 }
 
 async function clipFailed(url: string, error: string): Promise<any> {
-  await chrome.storage.local.set({ lastError: `Clip failed: ${error}` });
+  await setSurfaceError('clip', `Clip failed: ${error}`);
   await setBadge('!', 'Stash clip failed — click for details');
   chrome.notifications.create({
     type: 'basic',
@@ -167,6 +212,7 @@ export async function clipAllTabs(): Promise<any> {
   }
   const data = await response.json();
   await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'tabs' } });
+  void watchImport();
   chrome.notifications.create({
     type: 'basic',
     iconUrl: 'icons/icon128.png',
@@ -202,6 +248,7 @@ export async function importBookmarks(name: string, content: string): Promise<an
   }
   const data = await response.json();
   await chrome.storage.local.set({ lastImport: { id: data.import_id, kind: 'bookmarks' } });
+  void watchImport();
   chrome.notifications.create({
     type: 'basic',
     iconUrl: 'icons/icon128.png',

--- a/chrome_extension/src/background/instagram.ts
+++ b/chrome_extension/src/background/instagram.ts
@@ -7,6 +7,7 @@
 // POST /me/saved-items, which auto-creates the source and hydrates
 // server-side.
 
+import { clearSurfaceError, setSurfaceError } from '../lib/errors';
 import { setBadge, stashConfig } from '../lib/stash';
 
 const VISIT_ALARM = 'instagram-saves-visit';
@@ -51,14 +52,15 @@ export async function receiveSavedItems(
   });
   if (!response.ok) {
     const detail = (await response.text()).slice(0, 180);
-    await chrome.storage.local.set({
-      lastError: `Instagram saves push failed (${response.status}): ${detail}`,
-    });
+    await setSurfaceError(
+      'instagram',
+      `Instagram saves push failed (${response.status}): ${detail}`
+    );
     await setBadge('!', 'Instagram saves push failed — click for details');
     return { ok: false, error: `push_failed_${response.status}` };
   }
   const data = await response.json();
-  await chrome.storage.local.set({ lastError: null });
+  await clearSurfaceError('instagram');
   return { ok: true, ...data };
 }
 
@@ -67,7 +69,7 @@ export async function savedItemsFailed(
   sender: chrome.runtime.MessageSender
 ): Promise<any> {
   await closeVisitTab(sender.tab?.id);
-  await chrome.storage.local.set({ lastError: `Instagram saves harvest failed: ${error}` });
+  await setSurfaceError('instagram', `Instagram saves harvest failed: ${error}`);
   await setBadge('!', 'Instagram saves harvest failed — click for details');
   return { ok: false, error };
 }
@@ -103,9 +105,10 @@ async function visitTimedOut(): Promise<void> {
   if (igVisitTabId == null) return;
   await chrome.storage.session.remove(['igVisitTabId']);
   await chrome.tabs.remove(igVisitTabId).catch(() => undefined);
-  await chrome.storage.local.set({
-    lastError: 'Instagram saves harvest timed out — are you signed in to instagram.com?',
-  });
+  await setSurfaceError(
+    'instagram',
+    'Instagram saves harvest timed out — are you signed in to instagram.com?'
+  );
   await setBadge('!', 'Instagram saves harvest timed out — click for details');
 }
 

--- a/chrome_extension/src/lib/errors.ts
+++ b/chrome_extension/src/lib/errors.ts
@@ -1,0 +1,34 @@
+// Per-surface error slots. The old single `lastError` string meant a clip
+// failure could silently hide a broken Instagram sync (and vice versa);
+// each subsystem now owns one slot, and the popup lists whichever are set.
+
+export type ErrorSurface = 'clip' | 'chat' | 'instagram' | 'import';
+
+export interface SurfaceError {
+  surface: ErrorSurface;
+  message: string;
+  at: number;
+}
+
+export async function setSurfaceError(surface: ErrorSurface, message: string): Promise<void> {
+  const { surfaceErrors } = await chrome.storage.local.get('surfaceErrors');
+  const others = ((surfaceErrors as SurfaceError[] | undefined) ?? []).filter(
+    (e) => e.surface !== surface
+  );
+  await chrome.storage.local.set({
+    surfaceErrors: [...others, { surface, message, at: Date.now() }],
+  });
+}
+
+export async function clearSurfaceError(surface: ErrorSurface): Promise<void> {
+  const { surfaceErrors } = await chrome.storage.local.get('surfaceErrors');
+  const others = ((surfaceErrors as SurfaceError[] | undefined) ?? []).filter(
+    (e) => e.surface !== surface
+  );
+  await chrome.storage.local.set({ surfaceErrors: others });
+}
+
+export async function getSurfaceErrors(): Promise<SurfaceError[]> {
+  const { surfaceErrors } = await chrome.storage.local.get('surfaceErrors');
+  return (surfaceErrors as SurfaceError[] | undefined) ?? [];
+}

--- a/chrome_extension/src/popup/popup.ts
+++ b/chrome_extension/src/popup/popup.ts
@@ -86,8 +86,16 @@ async function render(): Promise<void> {
     ])
   );
 
-  if (status.lastError) {
-    app.append(el('div', { className: 'error', textContent: status.lastError }));
+  for (const err of status.errors ?? []) {
+    app.append(el('div', { className: 'error', textContent: err.message }));
+  }
+
+  // A running bulk import is the thing the user most wants to see — top
+  // level, not tucked in Advanced (its file input stays there).
+  if (status.lastImport?.id) {
+    const progressRow = el('div', { className: 'row muted' });
+    app.append(progressRow);
+    void showImportProgress(status.lastImport.id, progressRow);
   }
 
   app.append(await renderSources());
@@ -149,26 +157,27 @@ async function renderSources(): Promise<HTMLElement> {
   return section;
 }
 
+async function showImportProgress(importId: string, row: HTMLElement): Promise<void> {
+  const result = await send({ type: 'IMPORT_PROGRESS', id: importId });
+  if (!result?.ok) {
+    row.textContent = result?.error || 'Progress check failed';
+    return;
+  }
+  const p = result.progress;
+  const running = p.pending > 0 || p.needs_client > 0;
+  const parts = [`${p.done} saved`];
+  if (p.link_only > 0) parts.push(`${p.link_only} link-only`);
+  if (p.needs_client > 0) parts.push(`${p.needs_client} fetching via this browser`);
+  if (p.pending > 0) parts.push(`${p.pending} pending`);
+  row.textContent = running
+    ? `Importing (${p.total} total): ${parts.join(', ')}`
+    : `Import finished: ${parts.join(', ')}`;
+  if (running) setTimeout(() => void showImportProgress(importId, row), 2000);
+}
+
 // Advanced: import a bookmarks.html export + the Stash API URL. Tucked away.
 function renderAdvanced(status: any): HTMLElement {
   const progressRow = el('div', { className: 'row muted' });
-
-  async function showProgress(importId: string): Promise<void> {
-    const result = await send({ type: 'IMPORT_PROGRESS', id: importId });
-    if (!result?.ok) {
-      progressRow.textContent = result?.error || 'Progress check failed';
-      return;
-    }
-    const p = result.progress;
-    const parts = [`${p.done} saved`];
-    if (p.link_only > 0) parts.push(`${p.link_only} link-only`);
-    if (p.needs_client > 0) parts.push(`${p.needs_client} fetching via this browser`);
-    if (p.pending > 0) parts.push(`${p.pending} pending`);
-    progressRow.textContent = `Import (${p.total} total): ${parts.join(', ')}`;
-    if (p.pending > 0 || p.needs_client > 0) {
-      setTimeout(() => void showProgress(importId), 2000);
-    }
-  }
 
   const fileInput = el('input', { type: 'file', accept: '.html' });
   fileInput.addEventListener('change', async () => {
@@ -184,7 +193,7 @@ function renderAdvanced(status: any): HTMLElement {
       progressRow.textContent = result?.error || 'Import failed';
       return;
     }
-    void showProgress(result.importId);
+    void showImportProgress(result.importId, progressRow);
   });
 
   const apiBaseInput = el('input', { value: status.apiBase, spellcheck: false });
@@ -209,7 +218,6 @@ function renderAdvanced(status: any): HTMLElement {
     ]),
   ]);
 
-  if (status.lastImport?.id) void showProgress(status.lastImport.id);
   return details;
 }
 

--- a/frontend/src/app/(app)/extension/page.tsx
+++ b/frontend/src/app/(app)/extension/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { BookMarked, Camera, Globe, MessagesSquare } from "lucide-react";
+
+// The one stable URL for getting the extension. Every CTA in the product
+// links here, so when the Chrome Web Store listing goes live only this
+// constant changes.
+const CHROME_WEB_STORE_URL: string | null = null;
+
+const FEATURES = [
+  {
+    icon: Globe,
+    title: "Clip any page",
+    body: "Save the page you're reading — or every open tab — as a clean, readable copy in your Stash. PDFs included.",
+  },
+  {
+    icon: BookMarked,
+    title: "Import your bookmarks",
+    body: "Bring your whole bookmarks file. Stash fetches every page's content in the background and files them under Clips.",
+  },
+  {
+    icon: Camera,
+    title: "Instagram saves",
+    body: "Your saved posts sync automatically — captions, images, and video archived so they outlive the post.",
+  },
+  {
+    icon: MessagesSquare,
+    title: "AI chats",
+    body: "ChatGPT and Claude conversations stream into your Stash as transcripts, searchable like everything else.",
+  },
+];
+
+export default function ExtensionPage() {
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-2xl px-8 py-12">
+        <h1 className="font-display text-[30px] font-bold tracking-tight text-foreground">
+          The Stash browser extension
+        </h1>
+        <p className="mt-2 max-w-lg text-[14px] leading-relaxed text-dim">
+          Everything you read, save, and discuss — captured into your Stash while you browse.
+        </p>
+
+        <div className="mt-7">
+          {CHROME_WEB_STORE_URL ? (
+            <a
+              href={CHROME_WEB_STORE_URL}
+              target="_blank"
+              rel="noopener"
+              className="inline-flex items-center gap-2 rounded-lg bg-brand px-5 py-2.5 text-[13.5px] font-semibold text-white transition-colors hover:bg-brand-hover"
+            >
+              Add to Chrome — it&apos;s free
+            </a>
+          ) : (
+            <div className="rounded-lg border border-border bg-surface px-4 py-3 text-[13px] text-muted-foreground">
+              The extension is in Chrome Web Store review — the install button lands here the
+              moment it&apos;s approved.
+            </div>
+          )}
+        </div>
+
+        <div className="mt-9 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {FEATURES.map((f) => (
+            <div key={f.title} className="rounded-xl border border-border bg-base p-4">
+              <f.icon className="h-4.5 w-4.5 text-brand" />
+              <div className="mt-2.5 text-[14px] font-semibold text-foreground">{f.title}</div>
+              <div className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">{f.body}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-9 rounded-xl border border-border bg-base p-5">
+          <div className="text-[13.5px] font-semibold text-foreground">How it connects</div>
+          <p className="mt-1.5 text-[12.5px] leading-relaxed text-muted-foreground">
+            After installing, click the extension icon and hit <span className="font-medium text-foreground">Connect</span>.
+            You&apos;ll sign in to Stash once in a normal tab — no tokens to copy. The extension
+            gets its own key you can revoke any time from Settings.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -47,11 +47,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { User } from "@/lib/types";
+import { routes } from "@/lib/workspace-routes";
 
 // How often a row re-checks a source that is mid-sync, and how many times before
 // it gives up. A sync that hasn't settled in ~5 minutes is wedged; polling it for
 // as long as the tab happens to be open buys nothing.
 const SYNC_POLL_INTERVAL_MS = 3000;
+// The extension auto-syncs daily; silence for two cycles means it's dead.
+const EXTENSION_STALE_AFTER_MS = 48 * 3600 * 1000;
 const SYNC_POLL_MAX_ATTEMPTS = 100;
 
 export default function IntegrationRoute() {
@@ -152,6 +155,15 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   // Extension-fed connectors (X, Instagram) have no OAuth integration — they're
   // "connected" once the browser extension has pushed at least one source.
   const isExtension = connector.kind === "extension";
+  // Extension-fed sources have no token to health-check — the server stamps
+  // extension_last_push_at on every push, and silence beyond two daily push
+  // cycles means the pipeline is dead (extension uninstalled, IG logged out).
+  const extensionLastPush = isExtension
+    ? ((sources[0]?.settings?.extension_last_push_at as string | undefined) ?? null)
+    : null;
+  const extensionStale =
+    !!extensionLastPush &&
+    Date.now() - new Date(extensionLastPush).getTime() > EXTENSION_STALE_AFTER_MS;
   const singleSource = !!connector.singleSource;
   const connected = isExtension ? sources.length > 0 : !!status?.connected;
   const account = connectedAccountLabel(status);
@@ -287,9 +299,30 @@ export function IntegrationDetail({ provider }: { provider: string }) {
               </span>
             )}
             {isExtension ? (
-              <span className="text-[12.5px] text-muted-foreground">
-                {connected ? "Synced from the browser extension" : "Save items with the browser extension"}
-              </span>
+              <>
+                <span className="text-[12.5px] text-muted-foreground">
+                  {extensionLastPush
+                    ? `Extension ${relativeTime(extensionLastPush)}`
+                    : connected
+                    ? "Synced from the browser extension"
+                    : null}
+                </span>
+                {!connected && (
+                  <Link href={routes.extension} className="text-[12.5px] font-semibold text-brand hover:underline">
+                    Get the extension
+                  </Link>
+                )}
+                {sources.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => void deleteKeptData()}
+                    disabled={busy === "purge"}
+                    className="cursor-pointer rounded-lg px-3 py-1.5 text-[12px] font-semibold text-muted-foreground hover:bg-raised hover:text-foreground disabled:opacity-60"
+                  >
+                    {busy === "purge" ? "Deleting..." : "Delete data…"}
+                  </button>
+                )}
+              </>
             ) : connected ? (
               <>
                 {canConnectAnother && (
@@ -353,6 +386,18 @@ export function IntegrationDetail({ provider }: { provider: string }) {
           </Link>
         </div>
 
+        {extensionStale && (
+          <div className="mt-4 flex items-center justify-between gap-3 rounded-md border border-warning/40 bg-warning-muted px-3 py-2 text-[12px] text-foreground">
+            <span>
+              {`The browser extension hasn't synced since ${new Date(
+                extensionLastPush!,
+              ).toLocaleDateString()} — check that it's installed and that you're signed in to ${connector.label}.`}
+            </span>
+            <Link href={routes.extension} className={secondaryButton()}>
+              Extension setup
+            </Link>
+          </div>
+        )}
         {staleAccounts.length > 0 && (
           <div className="mt-4 flex items-center justify-between gap-3 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-[12px] text-error">
             <span>
@@ -492,11 +537,18 @@ export function IntegrationDetail({ provider }: { provider: string }) {
           )}
           {sources.length === 0 ? (
             <div className="py-3 text-[12.5px] text-muted-foreground">
-              {isExtension
-                ? `Install the Stash browser extension and save on ${connector.label} — your items will appear here.`
-                : connected
-                  ? "Nothing added yet."
-                  : "Connect to add sources."}
+              {isExtension ? (
+                <>
+                  <Link href={routes.extension} className="font-semibold text-brand hover:underline">
+                    Install the Stash browser extension
+                  </Link>{" "}
+                  and save on {connector.label} — your items will appear here.
+                </>
+              ) : connected ? (
+                "Nothing added yet."
+              ) : (
+                "Connect to add sources."
+              )}
             </div>
           ) : (
             <div>

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ReactNode, useEffect } from "react";
 
 import WorkspaceShell from "@/components/workspace/workspace-shell";
+import ImportProgressPill from "@/components/ImportProgressPill";
 import {
   AppShellSkeleton,
   PublicSkillSkeleton,
@@ -63,6 +64,7 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
   return (
     <WorkspaceShell user={user} onLogout={logout}>
       {children}
+      <ImportProgressPill />
     </WorkspaceShell>
   );
 }

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -9,6 +9,7 @@ import ForkSkillCardButton from "@/components/skill/ForkSkillCardButton";
 import SkillCard from "@/components/skill/SkillCard";
 import { StashIcon } from "@/components/SkillIcons";
 import { API_BASE, githubOwner, listPublicPages, type PublicSkillCard, type PublicPageCard } from "@/lib/api";
+import { routes } from "@/lib/workspace-routes";
 
 const SORTS = ["trending", "newest", "popular"] as const;
 type Sort = (typeof SORTS)[number];
@@ -69,6 +70,23 @@ export default function HomePage() {
 
       {/* Catalog */}
       <div className="mx-auto max-w-[1180px] px-12 pb-20 pt-8">
+        {/* Extension CTA — the product's one distribution surface for the clipper. */}
+        <Link
+          href={routes.extension}
+          className="group mb-8 flex items-center justify-between gap-4 rounded-xl border border-brand-300/60 bg-gradient-to-r from-brand-50 to-base px-5 py-4 transition hover:border-brand-400 hover:shadow-sm"
+        >
+          <div>
+            <div className="text-[14.5px] font-semibold text-foreground group-hover:text-brand-600">
+              Download the extension
+            </div>
+            <div className="mt-0.5 text-[12.5px] text-muted-foreground">
+              Clip pages, import bookmarks, and sync your Instagram saves and AI chats into Stash.
+            </div>
+          </div>
+          <span className="shrink-0 rounded-full bg-brand px-4 py-1.5 text-[12px] font-semibold text-white">
+            Get it →
+          </span>
+        </Link>
         <div className="flex items-center gap-3">
           <div className="inline-flex gap-0.5 rounded-lg border border-border bg-base p-[3px]">
             {SORTS.map((o) => (

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -436,7 +436,7 @@ function TryItOutStep({
           Try it out
         </h1>
         <p className="text-sm text-dim max-w-md">
-          Four ways to start — pick whichever fits.
+          Five ways to start — pick whichever fits.
         </p>
       </div>
       <TryOption
@@ -490,6 +490,27 @@ function TryItOutStep({
           <CommandBlock command={CLI_INSTALL_COMMAND} />
           <CommandBlock command="stash signin" />
         </div>
+      </TryOption>
+      <TryOption
+        badge="Save"
+        lead="Save anything you read, straight from your browser."
+      >
+        <a
+          href={routes.extension}
+          target="_blank"
+          rel="noopener"
+          className="group flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-surface px-4 py-3 text-left transition-colors hover:border-brand"
+        >
+          <div>
+            <div className="text-[13.5px] font-medium text-foreground">
+              Get the browser extension
+            </div>
+            <div className="text-[12px] text-muted-foreground">
+              Clip pages, import bookmarks, sync Instagram saves and ChatGPT/Claude chats.
+            </div>
+          </div>
+          <span className="text-muted-foreground transition-colors group-hover:text-brand">&rarr;</span>
+        </a>
       </TryOption>
     </div>
   );

--- a/frontend/src/components/ImportProgressPill.tsx
+++ b/frontend/src/components/ImportProgressPill.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ChevronUp, Loader2 } from "lucide-react";
+import {
+  getImportBatch,
+  listImportBatches,
+  type ImportBatchDetail,
+  type ImportBatchProgress,
+} from "@/lib/api";
+
+const POLL_MS = 60_000;
+
+function isActive(batch: ImportBatchProgress): boolean {
+  return batch.pending + batch.needs_client > 0;
+}
+
+/** Floating progress for bulk imports (extension bookmark/tab imports), which
+ * can grind for days. Renders nothing unless a batch is actively importing —
+ * then a fixed pill with live counts, expandable to per-batch detail
+ * including which URLs were saved link-only and why. */
+export default function ImportProgressPill() {
+  const [batches, setBatches] = useState<ImportBatchProgress[]>([]);
+  const [open, setOpen] = useState(false);
+  const [detail, setDetail] = useState<ImportBatchDetail | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setBatches(await listImportBatches());
+    } catch {
+      // Progress is decorative; an auth blip must not error-loop the shell.
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  const active = batches.filter(isActive);
+  if (active.length === 0) return null;
+
+  const totals = active.reduce(
+    (acc, b) => ({
+      done: acc.done + b.done + b.link_only,
+      total: acc.total + b.total,
+    }),
+    { done: 0, total: 0 },
+  );
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
+      {open && (
+        <div className="w-[340px] rounded-xl border border-border bg-base p-4 shadow-xl">
+          {active.map((b) => (
+            <div key={b.id} className="mb-3 last:mb-0">
+              <div className="text-[13px] font-medium text-foreground">
+                {b.filename ?? (b.kind === "tabs" ? "Open tabs" : "Bookmarks import")}
+              </div>
+              <div className="mt-1 text-[12px] text-muted-foreground">
+                {b.done} saved · {b.link_only} link-only · {b.pending} pending
+                {b.needs_client > 0 && ` · ${b.needs_client} waiting for your browser extension`}
+              </div>
+              {b.link_only > 0 && (
+                <button
+                  type="button"
+                  className="mt-1 cursor-pointer text-[11.5px] font-medium text-brand hover:underline"
+                  onClick={() => {
+                    if (detail?.id === b.id) {
+                      setDetail(null);
+                    } else {
+                      void getImportBatch(b.id).then(setDetail);
+                    }
+                  }}
+                >
+                  {detail?.id === b.id ? "Hide link-only detail" : "Why are some link-only?"}
+                </button>
+              )}
+              {detail?.id === b.id && (
+                <ul className="scroll-thin mt-2 max-h-40 space-y-1.5 overflow-y-auto rounded-md border border-border bg-surface p-2">
+                  {detail.failures.map((f) => (
+                    <li key={f.url} className="text-[11px] leading-snug">
+                      <span className="block truncate font-medium text-foreground">{f.url}</span>
+                      <span className="text-muted-foreground">{f.error}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex cursor-pointer items-center gap-2 rounded-full border border-border bg-base px-3.5 py-2 text-[12.5px] font-medium text-foreground shadow-lg hover:bg-raised"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-brand" />
+        Importing · {totals.done.toLocaleString()}/{totals.total.toLocaleString()}
+        <ChevronUp className={"h-3.5 w-3.5 text-muted-foreground transition-transform " + (open ? "rotate-180" : "")} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2150,3 +2150,31 @@ export type AgentPrompt = { system_prompt: string; run_prompt: string };
 export async function getAgentPrompt(id: string): Promise<AgentPrompt> {
   return apiFetch(`/api/v1/me/agents/${id}/prompt`);
 }
+
+// --- Bulk URL imports (extension bookmark/tab imports) ---
+
+export type ImportBatchProgress = {
+  id: string;
+  kind: string;
+  filename: string | null;
+  total: number;
+  created_at: string;
+  done: number;
+  link_only: number;
+  needs_client: number;
+  pending: number;
+};
+
+export type ImportBatchDetail = ImportBatchProgress & {
+  // URLs whose content could not be fetched — saved as link-only rows, with why.
+  failures: { url: string; error: string }[];
+};
+
+export async function listImportBatches(): Promise<ImportBatchProgress[]> {
+  const res = await apiFetch<{ batches: ImportBatchProgress[] }>("/api/v1/me/imports");
+  return res.batches;
+}
+
+export async function getImportBatch(batchId: string): Promise<ImportBatchDetail> {
+  return apiFetch(`/api/v1/me/imports/${batchId}`);
+}

--- a/frontend/src/lib/workspace-routes.ts
+++ b/frontend/src/lib/workspace-routes.ts
@@ -3,6 +3,7 @@ import type { TabKind, WorkbenchTab } from "@/lib/workspace-store";
 // Single source of truth for app-internal route paths. Every deep link,
 // share URL, and router.push in the frontend goes through these.
 export const routes = {
+  extension: "/extension",
   page: (id: string) => `/page/${id}`,
   file: (id: string) => `/file/${id}`,
   table: (id: string) => `/tables/${id}`,


### PR DESCRIPTION
Implements the extension/clips UX plan. **Server changes are strictly additive — extension v0.4.0 (currently in Chrome Web Store review) keeps working unchanged**; the extension-side improvements are versioned v0.5.0 and ship with the next CWS submission.

## App

- **Import progress, finally visible**: a floating pill (bottom-right, everywhere in the app) while a bulk import runs, fed by the new `GET /api/v1/me/imports`. Expands to per-batch counts and the per-URL link-only reasons that the backend always recorded but no UI ever showed.
- **Extension liveness**: every saved-items push stamps `extension_last_push_at` on the source and clears any standing sync warning. The Instagram page now shows "Extension synced Xh ago" and an amber staleness warning after 48h of silence — it previously claimed "connected" forever even with the extension uninstalled.
- **An install path exists now**: new `/extension` page as the one stable URL (Chrome Web Store link is a single constant swap when the listing is approved). Linked from a Discover home-page card, a fifth "Save" onboarding option, and the previously dead install text on the Instagram page.
- **Delete data for extension-fed providers**: purge gates on the source-type map (Instagram has no OAuth provider, so it 404'd before); the button now shows on extension connector pages.
- **One deletion codepath**: per-source Remove runs the same media-blob + share-grant cleanup as the provider purge — it used to orphan both.

## Extension (v0.5.0, ships with next CWS submission)

- Import watcher: action badge shows the remaining count during an import; one OS notification when it finishes (a 41k grind gets a "done" moment). Progress promoted out of the popup's collapsed Advanced section.
- Per-surface error slots (clip / chat / instagram / import) replace the single overwrite-only `lastError`.

## Screenshots

- [Home: Download-the-extension card + import pill](https://app.joinstash.ai/f/1979aebf-e990-4456-b2a6-ccab066fd63a)
- [The /extension page](https://app.joinstash.ai/f/87e293cd-c9ac-4232-9a31-dafef65d9d41)
- [Instagram: last-synced header, staleness warning, Delete data](https://app.joinstash.ai/f/ea2c9084-30ea-4e21-858d-e262cfd2d903)
- [Onboarding: fifth "Save" option](https://app.joinstash.ai/f/3bd6bf0e-fabc-4a57-9c36-ba8803bd0632)
- [Import pill expanded with link-only reasons](https://app.joinstash.ai/f/6e5a7f2c-019d-4415-8e6f-09a2036247b0)

## Tests

Full backend suite green (909); new tests: push stamps liveness + clears warning, purge covers extension-fed providers, per-source delete cleans blobs/shares, imports-list endpoint (owner-scoped). Frontend 211 green; extension tsc + esbuild clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaexpwwBZH8PsvQbYz1ddM