### PR TITLE
Commonplace book v1: X threads, feed home page, output skills, curator topic lists

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -522,7 +522,7 @@ async def _fetch_thread_context(client: httpx.AsyncClient, tweet_id: str) -> lis
         response = await client.get(TAPI_THREAD_URL, params=params)
         response.raise_for_status()
         payload = response.json()
-        tweets.extend(_normalize(t) for t in payload.get("replies") or [] if t.get("id"))
+        tweets.extend(_normalize(t) for t in payload.get("tweets") or [] if t.get("id"))
         cursor = payload.get("next_cursor")
         if not payload.get("has_next_page") or not cursor:
             break

--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -4,10 +4,11 @@ Each sync enqueues skeleton rows (tweet ids + a kind): Bookmarks from the X
 API with the OAuth token, the user's own Posts/Replies/Articles from
 twitterapi.io by account id. A bounded hydration batch then fills them in:
 the full tweet text + author (or, for an Article, the full long-form body)
-from twitterapi.io, the conversation root for reply context, and the tweet's
-images/video archived into object storage — so the save survives the tweet
-being deleted or the account going private. Per-item failures land on the
-row, loudly; rows are never deleted by sync (archive semantics).
+from twitterapi.io, the author's whole thread + the reply's direct parent
+for context, and the tweet's images/video archived into object storage — so
+the save survives the tweet being deleted or the account going private.
+Per-item failures land on the row, loudly; rows are never deleted by sync
+(archive semantics).
 """
 
 from __future__ import annotations
@@ -28,10 +29,19 @@ logger = logging.getLogger(__name__)
 TAPI_TWEETS_URL = "https://api.twitterapi.io/twitter/tweets"
 TAPI_USER_TWEETS_URL = "https://api.twitterapi.io/twitter/user/last_tweets"
 TAPI_ARTICLE_URL = "https://api.twitterapi.io/twitter/article"
+TAPI_THREAD_URL = "https://api.twitterapi.io/twitter/tweet/thread_context"
 X_BOOKMARKS_URL = "https://api.x.com/2/users/{user_id}/bookmarks"
 TAPI_TIMEOUT = 60
 MAX_MEDIA_BYTES = 100 * 1024 * 1024
 MAX_MEDIA_PER_TWEET = 4
+# Thread context pages fetched per save. A page carries the ancestors plus a
+# slice of the replies; on a viral tweet the author's own continuation sits
+# early, so a small cap finds real self-threads without walking whole reply
+# storms.
+MAX_THREAD_PAGES = 3
+# Media archived per save across the whole thread (the saved tweet's own
+# media is archived first and can never be squeezed out by thread posts).
+MAX_MEDIA_PER_SAVE = 12
 # Hydration is per-tweet (each commits on its own), and a sync can be killed
 # mid-run by a worker redeploy — so keep the batch small enough that a sync
 # usually finishes before that happens; the reconciler re-runs for the rest.
@@ -368,19 +378,26 @@ async def _hydrate_one(
         return
     tweet = await _fetch_tweet(client, tweet_id)
 
-    # A reply shows only its own text out of context, so pull the root of the
-    # conversation and keep it as "In reply to:" above the reply.
-    root = None
-    root_id = tweet.get("conversation_id")
-    if root_id and root_id != tweet_id:
+    # A saved tweet is often one post of a thread: pull the conversation and
+    # keep the author's whole chain, plus the direct parent when the save is
+    # a reply to someone else. Best-effort — the save itself matters.
+    thread = [tweet]
+    parent = None
+    if _in_conversation(tweet):
         try:
-            root = await _fetch_tweet(client, root_id)
-        except Exception:
-            root = None  # thread context is best-effort; the reply itself matters
+            context = await _fetch_thread_context(client, tweet_id)
+            thread = _author_chain(tweet, context)
+            parent = _direct_parent(tweet, context)
+        except Exception as exc:
+            logger.warning(
+                "x thread context fetch failed tweet=%s exception_type=%s",
+                tweet_id,
+                type(exc).__name__,
+            )
 
-    media = await _archive_media(owner_user_id, tweet_id, tweet["media"])
+    media = await _archive_thread_media(owner_user_id, tweet, thread)
 
-    content = _render(tweet, root)
+    content = _render(tweet, thread, parent)
     posted = tweet["created_at"]
     await source_service.upsert_content_document(
         table="x_save_docs",
@@ -488,17 +505,97 @@ def _article_media(article: dict) -> list[dict]:
     return [{"url": u, "is_video": False} for u in urls]
 
 
-def _render(tweet: dict, root: dict | None) -> str:
+def _in_conversation(tweet: dict) -> bool:
+    is_reply = bool(tweet["conversation_id"]) and tweet["conversation_id"] != tweet["id"]
+    return is_reply or tweet["reply_count"] > 0
+
+
+async def _fetch_thread_context(client: httpx.AsyncClient, tweet_id: str) -> list[dict]:
+    """The saved tweet's conversation from twitterapi.io: ancestors plus a
+    bounded number of reply pages, normalized."""
+    tweets: list[dict] = []
+    cursor: str | None = None
+    for _ in range(MAX_THREAD_PAGES):
+        params: dict = {"tweetId": tweet_id}
+        if cursor:
+            params["cursor"] = cursor
+        response = await client.get(TAPI_THREAD_URL, params=params)
+        response.raise_for_status()
+        payload = response.json()
+        tweets.extend(_normalize(t) for t in payload.get("replies") or [] if t.get("id"))
+        cursor = payload.get("next_cursor")
+        if not payload.get("has_next_page") or not cursor:
+            break
+    return tweets
+
+
+def _author_chain(tweet: dict, context: list[dict]) -> list[dict]:
+    """The author's own connected run of posts (the self-thread) containing
+    the saved tweet, chronological. Other users' replies never enter the
+    chain. Tweet ids are snowflakes, so numeric id order is time order."""
+    own = {t["id"]: t for t in context if t["author"] == tweet["author"]}
+    own[tweet["id"]] = tweet
+
+    # Walk up to the top of the author's chain (visited-guard against
+    # malformed reply cycles), then collect every own post chained under it.
+    top = tweet
+    visited = {tweet["id"]}
+    while (parent_id := top.get("in_reply_to_id")) in own and parent_id not in visited:
+        top = own[parent_id]
+        visited.add(parent_id)
+
+    chain = [top]
+    included = {top["id"]}
+    for t in sorted(own.values(), key=lambda t: int(t["id"])):
+        if t["id"] not in included and t.get("in_reply_to_id") in included:
+            chain.append(t)
+            included.add(t["id"])
+    return chain
+
+
+def _direct_parent(tweet: dict, context: list[dict]) -> dict | None:
+    """The other-author tweet the save replies to; the author's own parents
+    are already covered by the thread chain."""
+    parent_id = tweet.get("in_reply_to_id")
+    if not parent_id:
+        return None
+    parent = next((t for t in context if t["id"] == parent_id), None)
+    if parent is None or parent["author"] == tweet["author"]:
+        return None
+    return parent
+
+
+async def _archive_thread_media(owner_user_id: UUID, tweet: dict, thread: list[dict]) -> list[dict]:
+    """Archive the saved tweet's media first, then the rest of the thread's,
+    up to MAX_MEDIA_PER_SAVE total."""
+    stored: list[dict] = []
+    ordered = [tweet] + [t for t in thread if t["id"] != tweet["id"]]
+    for t in ordered:
+        room = MAX_MEDIA_PER_SAVE - len(stored)
+        if room <= 0:
+            break
+        if t["media"]:
+            stored.extend(await _archive_media(owner_user_id, t["id"], t["media"][:room]))
+    return stored
+
+
+def _render(tweet: dict, thread: list[dict], parent: dict | None) -> str:
     # Tweet text first so the listing's preview (first paragraph of content) is
     # the tweet itself, not metadata. Everything after the blank line is the
-    # byline, reply context, and link.
+    # byline, reply context, thread, and link.
     parts: list[str] = [tweet["text"] or "", ""]
     byline = f"— @{tweet['author']}"
     if tweet["created_at"]:
         byline += f" · {tweet['created_at'].date().isoformat()}"
     parts.append(byline)
-    if root is not None:
-        parts.append(f"In reply to @{root['author']}: {root['text']}")
+    if parent is not None:
+        parts.append(f"In reply to @{parent['author']}: {parent['text']}")
+    if len(thread) > 1:
+        parts.append("")
+        parts.append(f"## Thread by @{tweet['author']} ({len(thread)} posts)")
+        for t in thread:
+            parts.append("")
+            parts.append(t["text"] or "")
     parts.append(tweet_url(tweet["id"]))
     return "\n".join(parts)
 
@@ -523,6 +620,8 @@ def _normalize(t: dict) -> dict:
         "author": (t.get("author") or {}).get("userName") or "unknown",
         "created_at": _parse_time(t.get("createdAt")),
         "conversation_id": t.get("conversationId"),
+        "in_reply_to_id": t.get("inReplyToId"),
+        "reply_count": t.get("replyCount") or 0,
         "media": _media_urls(t),
     }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from .routers import (
     demo,
     discover,
     exports,
+    feed,
     files,
     files_tree,
     machine,
@@ -117,6 +118,7 @@ app.include_router(users.router)
 app.include_router(collab.router)
 app.include_router(user_knowledge.router)
 app.include_router(discover.router)
+app.include_router(feed.router)
 app.include_router(skills.me_router)
 app.include_router(skills.public_router)
 app.include_router(files_tree.router)

--- a/backend/migrations/versions/0163_rehydrate_x_saves_threads.py
+++ b/backend/migrations/versions/0163_rehydrate_x_saves_threads.py
@@ -1,0 +1,34 @@
+"""Send existing X saves back through hydration to pick up full threads.
+
+Hydration now captures the author's whole thread plus a reply's direct
+parent instead of just the conversation root, so rows hydrated under the
+old renderer hold single-tweet content. Scope: the user's own Replies and
+Posts — they gain the most context and, being the user's own tweets, are
+rarely deleted (a vanished tweet leaves the row failed with its old content
+preserved, since content only updates on success). Bookmarks are excluded:
+they are other people's deletion-prone tweets, and re-archiving media mints
+fresh storage keys, orphaning the old blobs.
+
+Revision ID: 0163
+Revises: 0162
+"""
+
+from alembic import op
+
+revision = "0163"
+down_revision = "0162"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE x_save_docs SET hydration_status = 'pending', hydration_attempts = 0 "
+        "WHERE kind IN ('Reply', 'Post') AND hydration_status = 'done'"
+    )
+
+
+def downgrade() -> None:
+    # Data-only nudge: rows re-hydrate on the next sync either way, and the
+    # old single-tweet content is not recoverable. Nothing to restore.
+    pass

--- a/backend/routers/feed.py
+++ b/backend/routers/feed.py
@@ -1,0 +1,19 @@
+"""The home-page feed. Public — a signed-out visitor gets the community
+stream (skills + public pages); a signed-in user's feed also resurfaces
+items from their own stash."""
+
+from fastapi import APIRouter, Depends
+
+from ..auth import get_current_user_optional
+from ..services import feed_service
+
+router = APIRouter(prefix="/api/v1", tags=["feed"])
+
+
+@router.get("/feed")
+async def home_feed(
+    cursor: int = 0,
+    current_user: dict | None = Depends(get_current_user_optional),
+):
+    user_id = current_user["id"] if current_user else None
+    return await feed_service.home_feed(user_id, max(cursor, 0))

--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -47,3 +47,26 @@ async def run_vfs(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except VfsBudgetExceeded as e:
         raise HTTPException(status_code=413, detail=str(e)) from e
+
+
+@router.get("/resolve")
+async def resolve_path(
+    path: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    """The app route of the Stash object behind a VFS path (`app_url` is null
+    for synthetic nodes like `_index.jsonl`). Chat citations deep-link
+    through this."""
+    authorization = request.headers.get("authorization")
+    if not authorization:
+        raise HTTPException(
+            status_code=401,
+            detail="The VFS runs every read as the calling credential; use an API key, not a cookie.",
+        )
+    try:
+        return await vfs_service.resolve_vfs_path(request.app, authorization, path)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=f"No such path: {path}") from e
+    except MountError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -23,6 +23,7 @@ from . import files_tree_service, source_service
 _MAX_EVENTS = 500
 _MAX_PAGES = 100
 _MAX_FILES = 100
+_MAX_SAVES = 100
 _SNIPPET = 280
 
 
@@ -45,6 +46,12 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
                             OR folder_id <> ALL($3)))
           OR EXISTS (SELECT 1 FROM files
                      WHERE owner_user_id = $1 AND created_at > $2)
+          OR EXISTS (SELECT 1 FROM x_save_docs
+                     WHERE owner_user_id = $1 AND updated_at > $2
+                       AND hydration_status = 'done' AND deleted_at IS NULL)
+          OR EXISTS (SELECT 1 FROM instagram_save_docs
+                     WHERE owner_user_id = $1 AND updated_at > $2
+                       AND hydration_status = 'done' AND deleted_at IS NULL)
         """,
         owner_user_id,
         since,
@@ -56,7 +63,7 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
 
 async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> dict:
     """The delta the curator reads: history events, changed pages (excl. Memory),
-    new files, and connected-source pointers."""
+    new files, newly hydrated X/Instagram saves, and connected-source pointers."""
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
     exclude = list(memory_ids) or None
@@ -123,6 +130,46 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         for r in file_rows
     ]
 
+    # Newly hydrated X/Instagram saves, as items rather than source pointers —
+    # a save the user made is deliberate curation input, like an upload.
+    save_rows = await pool.fetch(
+        """
+        SELECT source, kind, name, url, updated_at, snippet FROM (
+            SELECT 'x' AS source, kind, name,
+                   'https://x.com/i/status/' || external_ref AS url,
+                   updated_at, left(coalesce(content, ''), $4) AS snippet
+            FROM x_save_docs
+            WHERE owner_user_id = $1
+              AND ($2::timestamptz IS NULL OR updated_at > $2)
+              AND hydration_status = 'done' AND deleted_at IS NULL
+            UNION ALL
+            SELECT 'instagram', kind, name,
+                   'https://www.instagram.com/p/' || external_ref || '/',
+                   updated_at, left(coalesce(content, ''), $4)
+            FROM instagram_save_docs
+            WHERE owner_user_id = $1
+              AND ($2::timestamptz IS NULL OR updated_at > $2)
+              AND hydration_status = 'done' AND deleted_at IS NULL
+        ) all_saves
+        ORDER BY updated_at DESC LIMIT $3
+        """,
+        owner_user_id,
+        since,
+        _MAX_SAVES,
+        _SNIPPET,
+    )
+    saves = [
+        {
+            "source": r["source"],
+            "kind": r["kind"],
+            "name": r["name"],
+            "url": r["url"],
+            "updated_at": _iso(r["updated_at"]),
+            "snippet": r["snippet"],
+        }
+        for r in save_rows
+    ]
+
     all_sources = await source_service.list_sources(owner_user_id, user_id)
     sources = [
         {"source": s.get("source"), "type": s.get("type"), "display_name": s.get("display_name")}
@@ -136,12 +183,14 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "history": len(history),
             "pages": len(pages),
             "files": len(files),
+            "saves": len(saves),
             "sources": len(sources),
         },
         "history": history,
         "history_has_more": history_has_more,
         "pages": pages,
         "files": files,
+        "saves": saves,
         "sources": sources,
     }
 

--- a/backend/services/feed_service.py
+++ b/backend/services/feed_service.py
@@ -1,0 +1,149 @@
+"""The home-page feed: one continuous stream of community skills to copy,
+fresh public pages, and — for a signed-in user — resurfaced items from their
+own stash (clips and X/Instagram saves old enough to be worth re-encountering).
+
+Interleave happens server-side so the client renders a flat list. Resurface
+selection is deterministic per (user, day): an md5 sort seeded by user id +
+date gives the same sample all day and a fresh one tomorrow, without storing
+any state.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from uuid import UUID
+
+from ..database import get_pool
+from ..integrations.social_saves.indexer import post_url
+from ..integrations.x_saves.indexer import tweet_url
+from . import paste_service, shared_skill_service, storage_service
+from .clip_service import CLIPS_FOLDER, RAW_FOLDER
+
+PAGE_SKILLS = 6
+PAGE_PUBLIC_PAGES = 3
+PAGE_RESURFACE = 3
+# Only items past this age resurface — the feed re-encounters the archive,
+# it doesn't echo what the user just saved.
+RESURFACE_MIN_AGE_DAYS = 7
+PREVIEW_CHARS = 280
+
+
+async def home_feed(user_id: UUID | None, cursor: int) -> dict:
+    skills = await shared_skill_service.list_public_skills(
+        sort="trending", limit=PAGE_SKILLS, offset=cursor * PAGE_SKILLS
+    )
+    pages = await paste_service.list_recent(
+        limit=PAGE_PUBLIC_PAGES, offset=cursor * PAGE_PUBLIC_PAGES
+    )
+    resurfaced = await _resurface_items(user_id, cursor) if user_id else []
+    has_more = (
+        len(skills) == PAGE_SKILLS
+        or len(pages) == PAGE_PUBLIC_PAGES
+        or len(resurfaced) == PAGE_RESURFACE
+    )
+    return {
+        "items": _interleave(skills, pages, resurfaced),
+        "next_cursor": cursor + 1 if has_more else None,
+    }
+
+
+def _interleave(skills: list[dict], pages: list[dict], resurfaced: list[dict]) -> list[dict]:
+    """Flat feed order: two skills per public page in the community stream,
+    with a resurface card landing every 4th slot."""
+    community: list[dict] = []
+    si, pi = 0, 0
+    while si < len(skills) or pi < len(pages):
+        for _ in range(2):
+            if si < len(skills):
+                community.append({"kind": "skill", "data": skills[si]})
+                si += 1
+        if pi < len(pages):
+            community.append({"kind": "public_page", "data": pages[pi]})
+            pi += 1
+
+    items: list[dict] = []
+    ci, ri = 0, 0
+    while ci < len(community) or ri < len(resurfaced):
+        resurface_slot = len(items) % 4 == 3
+        if ri < len(resurfaced) and (resurface_slot or ci >= len(community)):
+            items.append({"kind": "resurface", "data": resurfaced[ri]})
+            ri += 1
+        else:
+            items.append(community[ci])
+            ci += 1
+    return items
+
+
+async def _resurface_items(user_id: UUID, cursor: int) -> list[dict]:
+    seed = f"{user_id}:{datetime.now(UTC).date().isoformat()}:"
+    rows = await get_pool().fetch(
+        f"""
+        WITH pool AS (
+            SELECT 'x' AS source, id::text AS item_id, name AS title, content,
+                   created_at, external_ref, NULL::uuid AS page_id,
+                   media->0->>'storage_key' AS media_key
+            FROM x_save_docs
+            WHERE owner_user_id = $1 AND hydration_status = 'done'
+              AND deleted_at IS NULL AND content IS NOT NULL
+              AND created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
+            UNION ALL
+            SELECT 'instagram', id::text, name, content,
+                   created_at, external_ref, NULL::uuid, media_storage_key
+            FROM instagram_save_docs
+            WHERE owner_user_id = $1 AND hydration_status = 'done'
+              AND deleted_at IS NULL AND content IS NOT NULL
+              AND created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
+            UNION ALL
+            SELECT 'clip', p.id::text, p.name,
+                   coalesce(p.content_markdown, p.content_html),
+                   p.created_at, NULL, p.id, NULL
+            FROM pages p
+            JOIN folders raw_f ON p.folder_id = raw_f.id AND raw_f.name = $4
+            JOIN folders clips_f ON raw_f.parent_folder_id = clips_f.id
+                 AND clips_f.name = $5 AND clips_f.parent_folder_id IS NULL
+            WHERE p.owner_user_id = $1 AND p.deleted_at IS NULL
+              AND p.created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
+        )
+        SELECT * FROM pool ORDER BY md5($2::text || item_id) LIMIT $3 OFFSET $6
+        """,
+        user_id,
+        seed,
+        PAGE_RESURFACE,
+        RAW_FOLDER,
+        CLIPS_FOLDER,
+        cursor * PAGE_RESURFACE,
+    )
+    return [await _resurface_card(dict(r)) for r in rows]
+
+
+async def _resurface_card(row: dict) -> dict:
+    source = row["source"]
+    if source == "x":
+        app_url = None
+        external_url = tweet_url(row["external_ref"])
+    elif source == "instagram":
+        app_url = None
+        external_url = post_url(row["external_ref"])
+    else:
+        app_url = f"/p/{row['page_id']}"
+        external_url = None
+
+    image_url = None
+    if row["media_key"] and storage_service.is_configured():
+        image_url = await storage_service.get_file_url(row["media_key"])
+
+    return {
+        "source": source,
+        "title": row["title"],
+        "preview": _preview(row["content"]),
+        "saved_at": row["created_at"].isoformat(),
+        "app_url": app_url,
+        "external_url": external_url,
+        "image_url": image_url,
+    }
+
+
+def _preview(content: str | None) -> str:
+    text = re.sub(r"<[^>]+>", " ", content or "")
+    return re.sub(r"\s+", " ", text).strip()[:PREVIEW_CHARS]

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -135,8 +135,9 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Read the inputs
 - `{changes_cmd}` — the delta to curate: recent
-  history/chats, changed pages, new files, and connected sources. This IS your
-  work set; do not re-scan the whole corpus.
+  history/chats, changed pages, new files, new saves (clips and X/Instagram
+  saves), and connected sources. This IS your work set; do not re-scan the
+  whole corpus.
 - `history_has_more: true` means the history overflowed this run's cap. The
   remainder is already queued for your next run (the watermark only advances
   through what you were shown) — curate what's present, don't try to page.
@@ -193,6 +194,11 @@ pages themselves.
   the best-fit category, adding a new category when none fits. The >=2 rule
   above is for chat mentions and never applies to documents. After curation,
   each upload must be findable by searching the wiki.
+- **Saved content becomes topic list pages.** Clips and X/Instagram saves in
+  the delta are maintained as list pages in a `Saved & Reading` category: one
+  page per recurring topic, one linked line per save (title, source link, date,
+  a one-clause takeaway). A multi-post thread is a single entry. One-off saves
+  with no topic yet go on a `Reading — unsorted` list page, never their own page.
 - **Tag confidence.** Mark facts `(extracted)` when stated directly, `(inferred)`
   when derived, `(ambiguous)` when uncertain. Never create a page from
   ambiguous-only material.

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -31,7 +31,10 @@ def render_ask_system(stash_name: str, sources: list[dict] | None = None) -> str
         "name, session id, skill title, or table). Be concise. "
         "When the user asks for slides, a slide deck, a presentation, a pitch, "
         "or a deck, call read_skill('slides') before generating any HTML so you "
-        "follow the scope's canvas, format, and library conventions."
+        "follow the scope's canvas, format, and library conventions. "
+        "When they ask for a briefing, a study guide, or a timeline over their "
+        "saved material, read the matching skill (briefing / study-guide / "
+        "timeline) first — each defines the structure and grounding rules."
     )
 
 

--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -308,6 +308,7 @@ async def list_public_skills(
     query: str | None = None,
     sort: str = "trending",
     limit: int = 48,
+    offset: int = 0,
 ) -> list[dict]:
     """Discover catalog: public + discoverable skills."""
     pool = get_pool()
@@ -330,7 +331,8 @@ async def list_public_skills(
         f"SELECT {_SKILL_COLS}, COALESCE(scope_user.display_name, scope_user.name) AS scope_name "
         f"{_SKILL_FROM} "
         f"JOIN users scope_user ON scope_user.id = v.owner_user_id "
-        f"WHERE {' AND '.join(where)} ORDER BY {order} LIMIT {int(limit)}",
+        f"WHERE {' AND '.join(where)} ORDER BY {order} "
+        f"LIMIT {int(limit)} OFFSET {int(offset)}",
         *args,
     )
 
@@ -347,6 +349,7 @@ async def list_public_skills(
                 "cover_image_url": skill["cover_image_url"],
                 "source_github_url": skill["source_github_url"],
                 "view_count": skill["view_count"],
+                "install_count": skill["install_count"],
                 "owner_name": skill.get("scope_name"),
                 "owner_display_name": skill.get("owner_display_name"),
                 "owner_user_id": str(skill["owner_user_id"]),

--- a/backend/services/skill_seeds.py
+++ b/backend/services/skill_seeds.py
@@ -1,9 +1,11 @@
 """Default skill markdown seeded into every scope.
 
-Each scope gets a `Skills/slides/SKILL.md` page so the ask-the-stash
-agent can discover it via `list_skills` / `read_skill` when the user asks
-for a deck. Seeding is idempotent — if the folder already has a SKILL.md
-we leave it alone (users may have edited it).
+Each scope gets a set of `<skill>/SKILL.md` folders so agents can discover
+them via `list_skills` / `read_skill`: `slides` (deck format), plus the
+generate-output skills that turn saved material into documents —
+`briefing`, `study-guide`, and `timeline`. Seeding is idempotent — if a
+skill folder already has a SKILL.md we leave it alone (users may have
+edited it).
 """
 
 from __future__ import annotations
@@ -21,8 +23,8 @@ SLIDES_SKILL_FOLDER = "slides"
 SKILL_MD_NAME = "SKILL.md"
 
 # Env knob so the test suite can create blank scopes. Production
-# leaves this unset; tests that need the seeded skill flip it off and
-# call `seed_slides_skill` directly.
+# leaves this unset; tests that need the seeded skills flip it off and
+# call `seed_default_skills` directly.
 DISABLE_ENV_VAR = "STASH_DISABLE_DEFAULT_SKILL_SEEDS"
 
 
@@ -132,16 +134,155 @@ Don't ship interactive controls — they won't survive the export.
 """
 
 
-async def seed_slides_skill(owner_user_id: UUID, creator_id: UUID) -> bool:
-    """Create `Skills/slides/SKILL.md` in the scope if it doesn't exist.
+BRIEFING_SKILL_MARKDOWN = """---
+name: briefing
+description: Synthesize a set of saved items (clips, X/Instagram saves, pages, source docs) into a one-page brief with links back to every source.
+when_to_use: When the user asks for a briefing, a brief, a summary of what they've saved, or "catch me up" on a topic, folder, or collection.
+version: "1"
+---
+
+# Writing a briefing
+
+Turn a set of the user's saved material into one page they can read in two
+minutes, with every claim one click from its source.
+
+## Scope the source set
+
+The user names the set: a topic ("my saves about agent memory"), a folder,
+or explicit items. Gather it from their Stash — search for the topic, list
+the folder, read each item. Read everything in the set before writing;
+name anything you could not read in a "Not covered" line rather than
+silently skipping it.
+
+## Structure
+
+1. **TL;DR** — at most three sentences.
+2. **Key points, grouped by theme** — each point is a claim from the
+   material with an inline link to the item it came from (the page, or the
+   original post URL for an X/Instagram save). Never a claim without a link.
+3. **Tensions and open questions** — where saved items disagree or leave a
+   question hanging, say so explicitly and link both sides.
+4. **Sources** — one line per item: title, where it came from, saved date.
+
+## Rules
+
+- Only the user's material. No outside knowledge presented as if it were
+  in the set; if you add context, mark it "(context, not from your saves)".
+- One page. Cut ruthlessly; the sources list carries the long tail.
+- If you can write pages (e.g. via the `stash` CLI), save the brief as a
+  page next to the material it covers; otherwise present it in the chat.
+"""
+
+
+STUDY_GUIDE_SKILL_MARKDOWN = """---
+name: study-guide
+description: Turn saved material into a study guide - key concepts, a reading order, and a question bank grounded in the user's own saves.
+when_to_use: When the user wants to learn, study, review, or be quizzed on material they've saved on a topic.
+version: "1"
+---
+
+# Writing a study guide
+
+Turn the user's saved material on a topic into something they can actually
+learn from, not just a summary.
+
+## Scope the source set
+
+Same as any synthesis: the user names a topic, folder, or items; gather
+and read all of it from their Stash first. Name what you could not read.
+
+## Structure
+
+1. **Overview** — what this material collectively teaches, in a paragraph.
+2. **Key concepts** — each with a one-sentence definition in your words and
+   a link to the saved item that introduces it best.
+3. **Reading order** — the saved items sequenced for learning (foundations
+   first, applications later), one line on why each earns its place.
+4. **Question bank** — 8-15 questions: recall questions ("what is X"),
+   then application questions ("how would X handle Y"). Put answers with
+   source links in a collapsed section or at the end, never inline.
+5. **Review plan** — three checkpoints (a day, a week, a month out) with
+   the two or three questions worth re-asking at each.
+
+## Rules
+
+- Ground every concept and answer in a linked saved item.
+- Questions test the material, not trivia about it.
+- If you can write pages, save the guide as a page; offer to quiz the user
+  from its question bank in chat.
+"""
+
+
+TIMELINE_SKILL_MARKDOWN = """---
+name: timeline
+description: Build a chronological narrative from saved items - what happened when, how thinking evolved, with each entry linked to its source.
+when_to_use: When the user asks how something evolved or unfolded, for a chronology, or for a timeline over their saved material.
+version: "1"
+---
+
+# Writing a timeline
+
+Order the user's saved material in time and narrate what changed.
+
+## Scope and dates
+
+Gather the set (topic, folder, or named items) and read it. Date each item
+by the strongest signal available, in this order: a date stated in the
+content itself (a post's date, an article's publication date), otherwise
+the item's saved date — and say which you used when they differ enough to
+matter.
+
+## Structure
+
+1. **Arc** — two or three sentences: where the story starts, where it ends.
+2. **Entries, oldest first** — `date — what happened / what was claimed`,
+   each linked to its saved item. Group same-week items when the timeline
+   is dense.
+3. **Turning points** — call out the two or three entries where the
+   picture actually changed, and what changed.
+4. **Gaps** — where the saved record goes quiet, say so; a missing month
+   is information.
+
+## Rules
+
+- Every entry links to its source; never interpolate events that are not
+  in the material.
+- Keep entries to one or two lines — the links carry the detail.
+- If you can write pages, save the timeline as a page next to its material.
+"""
+
+
+# folder name -> seeded SKILL.md body. Order is seed order.
+DEFAULT_SKILLS: list[tuple[str, str]] = [
+    (SLIDES_SKILL_FOLDER, SLIDES_SKILL_MARKDOWN),
+    ("briefing", BRIEFING_SKILL_MARKDOWN),
+    ("study-guide", STUDY_GUIDE_SKILL_MARKDOWN),
+    ("timeline", TIMELINE_SKILL_MARKDOWN),
+]
+
+
+async def seed_default_skills(owner_user_id: UUID, creator_id: UUID) -> int:
+    """Seed every default skill the scope doesn't already have. Returns how
+    many SKILL.md pages were created. No-op when the env knob
+    `STASH_DISABLE_DEFAULT_SKILL_SEEDS=1` is set (test mode)."""
+    if os.environ.get(DISABLE_ENV_VAR) == "1":
+        return 0
+    created = 0
+    for folder_name, markdown in DEFAULT_SKILLS:
+        if await _seed_skill(owner_user_id, creator_id, folder_name, markdown):
+            created += 1
+    return created
+
+
+async def _seed_skill(
+    owner_user_id: UUID, creator_id: UUID, folder_name: str, markdown: str
+) -> bool:
+    """Create `<folder_name>/SKILL.md` in the scope if it doesn't exist.
 
     Returns True if the SKILL.md was created in this call, False if a
-    SKILL.md was already present in any folder named `slides` (we treat
-    that as "already seeded" and leave it alone), or if the env knob
-    `STASH_DISABLE_DEFAULT_SKILL_SEEDS=1` is set (test mode).
+    SKILL.md was already present in any folder with that name (we treat
+    that as "already seeded" and leave it alone — users may have edited it).
     """
-    if os.environ.get(DISABLE_ENV_VAR) == "1":
-        return False
     pool = get_pool()
 
     existing = await pool.fetchval(
@@ -151,7 +292,7 @@ async def seed_slides_skill(owner_user_id: UUID, creator_id: UUID) -> bool:
         "  AND p.name = $3 AND p.deleted_at IS NULL "
         "LIMIT 1",
         owner_user_id,
-        SLIDES_SKILL_FOLDER,
+        folder_name,
         SKILL_MD_NAME,
     )
     if existing:
@@ -161,14 +302,14 @@ async def seed_slides_skill(owner_user_id: UUID, creator_id: UUID) -> bool:
         "SELECT id FROM folders WHERE owner_user_id = $1 AND lower(name) = $2 "
         "  AND parent_folder_id IS NULL LIMIT 1",
         owner_user_id,
-        SLIDES_SKILL_FOLDER,
+        folder_name,
     )
     if folder_row:
         folder_id = folder_row["id"]
     else:
         folder = await files_tree_service.create_folder(
             owner_user_id=owner_user_id,
-            name=SLIDES_SKILL_FOLDER,
+            name=folder_name,
             created_by=creator_id,
         )
         folder_id = folder["id"]
@@ -178,8 +319,8 @@ async def seed_slides_skill(owner_user_id: UUID, creator_id: UUID) -> bool:
         name=SKILL_MD_NAME,
         created_by=creator_id,
         folder_id=folder_id,
-        content=SLIDES_SKILL_MARKDOWN,
+        content=markdown,
         content_type="markdown",
     )
-    logger.info("seeded slides skill for scope %s", owner_user_id)
+    logger.info("seeded %s skill for scope %s", folder_name, owner_user_id)
     return True

--- a/backend/services/user_scope_service.py
+++ b/backend/services/user_scope_service.py
@@ -40,16 +40,17 @@ async def can_write(owner_user_id: UUID | None, user_id: UUID | None) -> bool:
 
 
 async def seed_user_scope(user_id: UUID) -> None:
-    """Provision a new user's scope: seed the default slides skill so the agent
-    can discover it, and the daily Memory curator so sleep-time curation works
-    for every account — including API-key-only production integrations that
-    never touch chat. Best-effort; failures must not block signup."""
+    """Provision a new user's scope: seed the default skills (slides + the
+    generate-output skills) so agents can discover them, and the daily Memory
+    curator so sleep-time curation works for every account — including
+    API-key-only production integrations that never touch chat. Best-effort;
+    failures must not block signup."""
     from . import agent_service
 
     try:
-        await skill_seeds.seed_slides_skill(user_id, user_id)
+        await skill_seeds.seed_default_skills(user_id, user_id)
     except Exception:
-        logger.exception("seed_slides_skill failed for user %s", user_id)
+        logger.exception("seed_default_skills failed for user %s", user_id)
     try:
         await agent_service.get_or_create_curator(user_id)
     except Exception:

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -182,3 +182,25 @@ async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict
         return await anyio.to_thread.run_sync(
             functools.partial(_run_script, http, loop, script, cwd)
         )
+
+
+def _resolve_node(http: httpx.AsyncClient, loop: asyncio.AbstractEventLoop, path: str) -> dict:
+    model = StashVfsModel(InProcessVfsClient(http, loop), include_computer=False)
+    model.refresh()
+    node = model._get_node(path)
+    return {"path": node.path, "app_url": node.app_url}
+
+
+async def resolve_vfs_path(app, authorization: str, path: str) -> dict:
+    """Map a VFS path to the app route of the Stash object behind it (chat
+    citations deep-link through this). Raises FileNotFoundError for a path
+    that doesn't exist in the caller's Stash."""
+    loop = asyncio.get_running_loop()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://vfs.internal",
+        headers={"Authorization": authorization},
+        timeout=None,
+    ) as http:
+        return await anyio.to_thread.run_sync(functools.partial(_resolve_node, http, loop, path))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,10 +26,9 @@ _TEST_DB_URL = os.getenv(
 )
 os.environ["TEST_DATABASE_URL"] = _TEST_DB_URL
 os.environ["DATABASE_URL"] = _TEST_DB_URL
-# Tests assume blank scopes. The default slides skill seed is
-# valuable in production but breaks empty-state assertions everywhere.
-# Tests that explicitly need the skill seeded call `seed_slides_skill`
-# themselves.
+# Tests assume blank scopes. The default skill seeds are valuable in
+# production but break empty-state assertions everywhere. Tests that
+# explicitly need the skills seeded call `seed_default_skills` themselves.
 os.environ.setdefault("STASH_DISABLE_DEFAULT_SKILL_SEEDS", "1")
 
 from backend import database as db_module  # noqa: E402

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -82,6 +82,39 @@ async def test_has_changes_and_feed_exclude_memory(client: AsyncClient, _db_pool
     assert all(p["name"] != "Wiki Page" for p in feed2["pages"])
 
 
+@pytest.mark.asyncio
+async def test_hydrated_saves_flow_through_the_feed(client: AsyncClient, _db_pool):
+    """An X/Instagram save is deliberate curation input like an upload, so a
+    newly hydrated save must both trip the cheap gate and appear as an item
+    in the delta — a still-pending skeleton row must do neither."""
+    from backend.services import source_service
+
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    source = await source_service.create_source(
+        owner_user_id=str(uid),
+        source_type="x_saves",
+        external_ref=unique_name("acct"),
+        display_name="X",
+    )
+    await _db_pool.execute(
+        "INSERT INTO x_save_docs (owner_user_id, source_id, path, name, kind, external_ref, "
+        "content, hydration_status) "
+        "VALUES ($1, $2, '77', '@bob - 77', 'Bookmark', '77', 'a saved thread', 'done'), "
+        "       ($1, $2, '78', '78', 'Bookmark', '78', NULL, 'pending')",
+        uid,
+        UUID(source["id"]),
+    )
+
+    assert await curation_service.has_changes_since(uid, uid, old) is True
+    feed = await curation_service.changes_since(uid, uid, old)
+    assert feed["counts"]["saves"] == 1
+    save = feed["saves"][0]
+    assert save["name"] == "@bob - 77"
+    assert save["url"] == "https://x.com/i/status/77"
+    assert save["snippet"] == "a saved thread"
+
+
 async def _push_events(client: AsyncClient, key: str, events: list[dict]) -> None:
     r = await client.post(
         "/api/v1/me/sessions/events/batch", json={"events": events}, headers=_auth(key)

--- a/backend/tests/test_feed.py
+++ b/backend/tests/test_feed.py
@@ -139,7 +139,7 @@ async def test_resurfaces_only_old_saves_and_is_deterministic(client: AsyncClien
     assert first.json()["items"] == second.json()["items"]
 
 
-def test_interleave_lands_a_resurface_card_every_fourth_slot():
+async def test_interleave_lands_a_resurface_card_every_fourth_slot():
     skills = [{"slug": f"s{i}"} for i in range(6)]
     pages = [{"slug": f"p{i}"} for i in range(3)]
     resurfaced = [{"title": f"r{i}"} for i in range(3)]

--- a/backend/tests/test_feed.py
+++ b/backend/tests/test_feed.py
@@ -1,0 +1,152 @@
+"""The home feed: one flat stream — community skills + public pages for
+everyone, resurfaced items from the caller's own stash when signed in.
+Resurfacing must be deterministic within a day and only ever offer old
+saves; the feed re-encounters the archive, it doesn't echo this week."""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import feed_service, source_service
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register(client: AsyncClient) -> tuple[str, str]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("feed"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body["id"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _publish_skill(client: AsyncClient, api_key: str, title: str) -> None:
+    folder = await client.post("/api/v1/me/folders", json={"name": title}, headers=_auth(api_key))
+    assert folder.status_code == 201
+    page = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": f"{title} brief", "content": f"# {title}", "folder_id": folder.json()["id"]},
+        headers=_auth(api_key),
+    )
+    assert page.status_code == 201
+    published = await client.post(
+        "/api/v1/me/skills",
+        json={"folder_id": folder.json()["id"], "title": title, "discoverable": True},
+        headers=_auth(api_key),
+    )
+    assert published.status_code == 201
+
+
+async def _old_x_save(pool, owner_id: str, tweet_id: str, text: str, days_old: int) -> None:
+    source = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="x_saves",
+        external_ref=f"acct-{unique_name('x')}",
+        display_name="X",
+    )
+    await pool.execute(
+        "INSERT INTO x_save_docs (owner_user_id, source_id, path, name, kind, external_ref, "
+        "content, hydration_status, created_at) "
+        f"VALUES ($1, $2, $3, $4, 'Bookmark', $3, $5, 'done', now() - interval '{int(days_old)} days')",
+        UUID(owner_id),
+        UUID(source["id"]),
+        tweet_id,
+        f"@someone - {tweet_id}",
+        text,
+    )
+
+
+async def _old_clip_page(client: AsyncClient, api_key: str, pool, name: str, days_old: int) -> str:
+    clips = await client.post("/api/v1/me/folders", json={"name": "Clips"}, headers=_auth(api_key))
+    assert clips.status_code == 201
+    raw = await client.post(
+        "/api/v1/me/folders",
+        json={"name": "raw", "parent_folder_id": clips.json()["id"]},
+        headers=_auth(api_key),
+    )
+    assert raw.status_code == 201
+    page = await client.post(
+        "/api/v1/me/pages/new",
+        json={
+            "name": name,
+            "content": "<p>a saved article body</p>",
+            "folder_id": raw.json()["id"],
+        },
+        headers=_auth(api_key),
+    )
+    assert page.status_code == 201
+    page_id = page.json()["id"]
+    await pool.execute(
+        f"UPDATE pages SET created_at = now() - interval '{int(days_old)} days' WHERE id = $1",
+        UUID(page_id),
+    )
+    return page_id
+
+
+async def test_signed_out_feed_is_community_only(client: AsyncClient):
+    api_key, _ = await _register(client)
+    await _publish_skill(client, api_key, unique_name("Skillful"))
+    paste = await client.post(
+        "/api/v1/pastes", json={"content": "# hello", "content_type": "markdown"}
+    )
+    assert paste.status_code == 201
+
+    resp = await client.get("/api/v1/feed")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    kinds = {item["kind"] for item in body["items"]}
+    assert "skill" in kinds
+    assert "public_page" in kinds
+    assert "resurface" not in kinds
+    skill = next(i for i in body["items"] if i["kind"] == "skill")
+    assert "install_count" in skill["data"]
+
+
+async def test_resurfaces_only_old_saves_and_is_deterministic(client: AsyncClient, pool):
+    api_key, owner_id = await _register(client)
+    await _old_x_save(pool, owner_id, "9001", "an old banger about memory systems", days_old=30)
+    await _old_x_save(pool, owner_id, "9002", "saved five minutes ago", days_old=0)
+    page_id = await _old_clip_page(client, api_key, pool, "Why wikis compound", days_old=30)
+
+    first = await client.get("/api/v1/feed", headers=_auth(api_key))
+    second = await client.get("/api/v1/feed", headers=_auth(api_key))
+
+    assert first.status_code == 200
+    resurfaced = [i["data"] for i in first.json()["items"] if i["kind"] == "resurface"]
+    titles = {r["title"] for r in resurfaced}
+    assert "@someone - 9001" in titles
+    assert "Why wikis compound" in titles
+    assert not any("9002" in r["title"] for r in resurfaced)  # this week never resurfaces
+
+    x_item = next(r for r in resurfaced if r["source"] == "x")
+    assert x_item["external_url"] == "https://x.com/i/status/9001"
+    assert x_item["preview"] == "an old banger about memory systems"
+    clip_item = next(r for r in resurfaced if r["source"] == "clip")
+    assert clip_item["app_url"] == f"/p/{page_id}"
+    assert "a saved article body" in clip_item["preview"]  # tags stripped
+
+    # Same day, same feed — the sample must not churn between requests.
+    assert first.json()["items"] == second.json()["items"]
+
+
+def test_interleave_lands_a_resurface_card_every_fourth_slot():
+    skills = [{"slug": f"s{i}"} for i in range(6)]
+    pages = [{"slug": f"p{i}"} for i in range(3)]
+    resurfaced = [{"title": f"r{i}"} for i in range(3)]
+
+    items = feed_service._interleave(skills, pages, resurfaced)
+
+    assert len(items) == 12
+    assert [items[i]["kind"] for i in (3, 7, 11)] == ["resurface"] * 3
+    # Community keeps its own rhythm: two skills, then a public page.
+    assert [i["kind"] for i in items[:3]] == ["skill", "skill", "public_page"]

--- a/backend/tests/test_slides_skill_seed.py
+++ b/backend/tests/test_slides_skill_seed.py
@@ -1,9 +1,9 @@
-"""Tests for the default slides skill seeded into every scope.
+"""Tests for the default skills seeded into every scope.
 
 The conftest disables the auto-seed (so empty-state assertions across
 the rest of the suite stay clean). These tests opt back in by calling
-`seed_slides_skill` directly with the disable knob cleared, then verify
-the skill is discoverable via the scope skills API.
+`seed_default_skills` directly with the disable knob cleared, then verify
+the skills are discoverable via the scope skills API.
 """
 
 import os
@@ -49,11 +49,11 @@ async def _seed(owner_user_id: str) -> None:
     """Run the seed against the scope as the registered owner."""
     from uuid import UUID
 
-    await skill_seeds.seed_slides_skill(UUID(owner_user_id), UUID(owner_user_id))
+    await skill_seeds.seed_default_skills(UUID(owner_user_id), UUID(owner_user_id))
 
 
 @pytest.mark.asyncio
-async def test_seeded_scope_has_slides_skill(client: AsyncClient, enable_seed):
+async def test_seeded_scope_has_all_default_skills(client: AsyncClient, enable_seed):
     api_key, owner_user_id = await _register_user(client)
     await _seed(owner_user_id)
 
@@ -64,7 +64,27 @@ async def test_seeded_scope_has_slides_skill(client: AsyncClient, enable_seed):
     assert resp.status_code == 200
     skills = resp.json()["skills"]
     names = [s["name"] for s in skills]
-    assert "slides" in names, f"slides skill missing after seed: {names}"
+    for expected in ("slides", "briefing", "study-guide", "timeline"):
+        assert expected in names, f"{expected} skill missing after seed: {names}"
+
+
+@pytest.mark.asyncio
+async def test_output_skills_demand_source_links(client: AsyncClient, enable_seed):
+    """The generate-output skills exist to produce grounded documents — each
+    body must require linking claims back to the saved items. Guard against
+    an edit that drops the grounding rule."""
+    api_key, owner_user_id = await _register_user(client)
+    await _seed(owner_user_id)
+
+    for slug in ("briefing", "study-guide", "timeline"):
+        resp = await client.get(
+            f"/api/v1/me/skills/{slug}",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        combined = body.get("combined", "") or body.get("body", "")
+        assert "link" in combined.lower(), f"{slug} skill must require source links"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -102,6 +102,34 @@ async def test_cat_reads_a_page_body(client: AsyncClient):
     assert "run the migration first" in resp.json()["stdout"]
 
 
+async def test_resolve_maps_a_vfs_path_to_its_app_route(client: AsyncClient):
+    """Chat citations deep-link through /resolve: a VFS path comes back with
+    the app route of the object behind it."""
+    api_key, _ = await _register(client)
+    page_id = await _make_page(client, api_key, "Runbook", "# Deploy")
+
+    resp = await client.get(
+        "/api/v1/me/vfs/resolve",
+        params={"path": "/files/Runbook.md"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"path": "/files/Runbook.md", "app_url": f"/p/{page_id}"}
+
+
+async def test_resolve_unknown_path_is_404(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    resp = await client.get(
+        "/api/v1/me/vfs/resolve",
+        params={"path": "/files/nope.md"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 404
+
+
 async def test_grep_searches_connected_source_documents(client: AsyncClient):
     api_key, owner_id = await _register(client)
     await _make_source_doc(owner_id, "specs/auth.md", "auth.md", "tokens rotate hourly")

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -3,7 +3,8 @@
 X connects over OAuth. Each sync the indexer pulls bookmark ids from the X API
 (with the OAuth token) and the user's own posts/replies/articles from
 twitterapi.io by account id, then hydrates every tweet the same way — full
-text (long-form body for articles), reply thread root, archived media.
+text (long-form body for articles), the author's thread + the reply's
+direct parent for context, archived media.
 Bookmarks sit behind a paid X API tier, so a 402/403 is best-effort (an
 owner-facing warning, never fatal) and must not stop posts/replies/articles.
 """
@@ -30,6 +31,7 @@ _REPLY = {
     "author": {"userName": "alice", "name": "Alice"},
     "createdAt": "Wed Jul 01 12:00:00 +0000 2025",
     "conversationId": "1000",
+    "inReplyToId": "1000",
     "extendedEntities": {"media": [{"type": "photo", "media_url_https": "https://cdn.x/img.jpg"}]},
 }
 _ROOT = {
@@ -86,7 +88,8 @@ class _FakeResponse:
         self.text = "{}"
 
     def raise_for_status(self):
-        pass
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
 
     def json(self):
         return self._payload
@@ -135,9 +138,13 @@ class _FakeApi:
     media_streams: list = []
 
     bookmarks_status = 200
+    thread_status = 200
     # cursor/token (None = first page) -> payload; overridable per test.
     timeline_pages: dict = {}
     bookmarks_pages: dict = {}
+    thread_pages: dict = {}
+    # Per-test tweet-by-id overrides, consulted before the shared fixtures.
+    tweets: dict = {}
     # (pagination_token, max_results) per bookmarks request, for read-cost asserts.
     bookmarks_calls: list = []
 
@@ -153,8 +160,16 @@ class _FakeApi:
     async def get(self, url, params=None):
         if url == x_indexer.TAPI_TWEETS_URL:
             tid = params["tweet_ids"]
-            tweet = {"1001": _REPLY, "1000": _ROOT}.get(tid) or _generic_tweet(tid)
+            tweet = (
+                type(self).tweets.get(tid)
+                or {"1001": _REPLY, "1000": _ROOT}.get(tid)
+                or _generic_tweet(tid)
+            )
             return _FakeResponse(payload={"tweets": [tweet]})
+        if url == x_indexer.TAPI_THREAD_URL:
+            if type(self).thread_status != 200:
+                return _FakeResponse(payload={}, status_code=type(self).thread_status)
+            return _FakeResponse(payload=type(self).thread_pages[params.get("cursor")])
         if url == x_indexer.TAPI_USER_TWEETS_URL:
             # Replies must be requested explicitly; twitterapi.io omits them
             # from last_tweets by default.
@@ -194,9 +209,12 @@ def fake_sync(monkeypatch):
         return "oauth-token"
 
     _FakeApi.bookmarks_status = 200
+    _FakeApi.thread_status = 200
     _FakeApi.bookmarks_pages = {None: _BOOKMARKS}
     _FakeApi.bookmarks_calls = []
     _FakeApi.timeline_pages = {None: _TIMELINE}
+    _FakeApi.thread_pages = {None: {"replies": [_ROOT], "has_next_page": False}}
+    _FakeApi.tweets = {}
     _FakeApi.media_bytes = b"fake image bytes"
     _FakeApi.media_headers = {"content-type": "image/jpeg"}
     _FakeApi.media_streams = []
@@ -277,6 +295,132 @@ async def test_hydrates_content_thread_root_and_media(client, pool, fake_sync) -
     entries = await source_service.source_entries(UUID(owner_id), UUID(owner_id), str(source["id"]))
     entry = next(e for e in entries if e["path"] == "1001")
     assert entry["snippet"] == "totally agree with this"
+
+
+_THREAD_ROOT = {
+    "id": "500",
+    "text": "thread: why agents need memory 1/",
+    "author": {"userName": "me"},
+    "createdAt": "Wed Jul 01 12:00:00 +0000 2025",
+    "conversationId": "500",
+    "replyCount": 12,
+}
+
+
+@pytest.mark.asyncio
+async def test_self_thread_renders_the_whole_author_chain(client, pool, fake_sync) -> None:
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    _FakeApi.tweets = {"500": _THREAD_ROOT}
+    # Thread context mixes the author's continuation with a stranger's reply;
+    # only the author's connected chain belongs in the save.
+    _FakeApi.thread_pages = {
+        None: {
+            "replies": [
+                {
+                    "id": "501",
+                    "text": "it compounds 2/",
+                    "author": {"userName": "me"},
+                    "createdAt": "Wed Jul 01 12:01:00 +0000 2025",
+                    "inReplyToId": "500",
+                },
+                {
+                    "id": "601",
+                    "text": "wrong take",
+                    "author": {"userName": "stranger"},
+                    "createdAt": "Wed Jul 01 12:02:00 +0000 2025",
+                    "inReplyToId": "500",
+                },
+                {
+                    "id": "502",
+                    "text": "ship it 3/",
+                    "author": {"userName": "me"},
+                    "createdAt": "Wed Jul 01 12:03:00 +0000 2025",
+                    "inReplyToId": "501",
+                },
+            ],
+            "has_next_page": False,
+        }
+    }
+    await _insert_pending(pool, owner_id, source["id"], "500", "Post")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow("SELECT * FROM x_save_docs WHERE source_id = $1", UUID(source["id"]))
+    assert row["hydration_status"] == "done"
+    content = row["content"]
+    assert content.startswith("thread: why agents need memory 1/")  # preview stays the tweet
+    assert "## Thread by @me (3 posts)" in content
+    assert content.index("it compounds 2/") < content.index("ship it 3/")
+    assert "wrong take" not in content
+
+
+@pytest.mark.asyncio
+async def test_thread_context_failure_never_fails_the_save(client, pool, fake_sync) -> None:
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    _FakeApi.thread_status = 500
+    await _insert_pending(pool, owner_id, source["id"], "1001", "Bookmark")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow("SELECT * FROM x_save_docs WHERE source_id = $1", UUID(source["id"]))
+    assert row["hydration_status"] == "done"
+    assert "totally agree with this" in row["content"]
+    assert "In reply to" not in row["content"]  # context lost, save kept
+
+
+@pytest.mark.asyncio
+async def test_thread_media_is_capped_with_saved_tweet_first(
+    client, pool, fake_sync, monkeypatch
+) -> None:
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id)
+    monkeypatch.setattr(x_indexer, "MAX_MEDIA_PER_SAVE", 2)
+    photo = {"media": [{"type": "photo", "media_url_https": "https://cdn.x/img.jpg"}]}
+    _FakeApi.tweets = {
+        "700": {
+            "id": "700",
+            "text": "look 1/",
+            "author": {"userName": "me"},
+            "createdAt": "Wed Jul 01 12:00:00 +0000 2025",
+            "conversationId": "700",
+            "replyCount": 2,
+            "extendedEntities": photo,
+        }
+    }
+    _FakeApi.thread_pages = {
+        None: {
+            "replies": [
+                {
+                    "id": "701",
+                    "text": "more 2/",
+                    "author": {"userName": "me"},
+                    "inReplyToId": "700",
+                    "extendedEntities": photo,
+                },
+                {
+                    "id": "702",
+                    "text": "even more 3/",
+                    "author": {"userName": "me"},
+                    "inReplyToId": "701",
+                    "extendedEntities": photo,
+                },
+            ],
+            "has_next_page": False,
+        }
+    }
+    await _insert_pending(pool, owner_id, source["id"], "700", "Post")
+
+    await x_indexer.index_x_saves(source)
+
+    row = await pool.fetchrow("SELECT * FROM x_save_docs WHERE source_id = $1", UUID(source["id"]))
+    assert row["hydration_status"] == "done"
+    assert fake_sync == [("x-700-0.jpg", "image/jpeg"), ("x-701-0.jpg", "image/jpeg")]
+    assert row["media"] == [
+        {"storage_key": "store/x-700-0.jpg", "content_type": "image/jpeg"},
+        {"storage_key": "store/x-701-0.jpg", "content_type": "image/jpeg"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -213,7 +213,7 @@ def fake_sync(monkeypatch):
     _FakeApi.bookmarks_pages = {None: _BOOKMARKS}
     _FakeApi.bookmarks_calls = []
     _FakeApi.timeline_pages = {None: _TIMELINE}
-    _FakeApi.thread_pages = {None: {"replies": [_ROOT], "has_next_page": False}}
+    _FakeApi.thread_pages = {None: {"tweets": [_ROOT], "has_next_page": False}}
     _FakeApi.tweets = {}
     _FakeApi.media_bytes = b"fake image bytes"
     _FakeApi.media_headers = {"content-type": "image/jpeg"}
@@ -316,7 +316,7 @@ async def test_self_thread_renders_the_whole_author_chain(client, pool, fake_syn
     # only the author's connected chain belongs in the save.
     _FakeApi.thread_pages = {
         None: {
-            "replies": [
+            "tweets": [
                 {
                     "id": "501",
                     "text": "it compounds 2/",
@@ -391,7 +391,7 @@ async def test_thread_media_is_capped_with_saved_tweet_first(
     }
     _FakeApi.thread_pages = {
         None: {
-            "replies": [
+            "tweets": [
                 {
                     "id": "701",
                     "text": "more 2/",

--- a/cli/main.py
+++ b/cli/main.py
@@ -2999,8 +2999,8 @@ def changes(
     since: str = typer.Option(None, "--since", help="ISO timestamp; omit for everything."),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """What changed since a timestamp — history, pages, files, sources. Feeds
-    the Memory curator's incremental pass."""
+    """What changed since a timestamp — history, pages, files, saves, sources.
+    Feeds the Memory curator's incremental pass."""
     with _client() as c:
         data = c.get_changes(since or None)
     if _use_json(as_json):
@@ -3010,7 +3010,8 @@ def changes(
     console.print(
         f"Changes since {data.get('since') or 'the beginning'}: "
         f"{counts.get('history', 0)} events, {counts.get('pages', 0)} pages, "
-        f"{counts.get('files', 0)} files, {counts.get('sources', 0)} sources"
+        f"{counts.get('files', 0)} files, {counts.get('saves', 0)} saves, "
+        f"{counts.get('sources', 0)} sources"
     )
 
 

--- a/frontend/src/app/(app)/page.test.tsx
+++ b/frontend/src/app/(app)/page.test.tsx
@@ -1,36 +1,71 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./page";
+
+// jsdom has no IntersectionObserver; the feed only uses it for infinite
+// scroll, which these tests don't exercise.
+vi.stubGlobal(
+  "IntersectionObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+const getHomeFeed = vi.fn(async () => ({
+  items: [
+    {
+      kind: "public_page",
+      data: {
+        slug: "my-page-abc123",
+        title: "My page",
+        content_type: "markdown",
+        view_count: 3,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    },
+    {
+      kind: "resurface",
+      data: {
+        source: "clip",
+        title: "Why wikis compound",
+        preview: "a saved article body",
+        saved_at: "2026-01-01T00:00:00Z",
+        app_url: "/p/11111111-1111-1111-1111-111111111111",
+        external_url: null,
+        image_url: null,
+      },
+    },
+    {
+      kind: "resurface",
+      data: {
+        source: "x",
+        title: "@someone - 9001",
+        preview: "an old banger",
+        saved_at: "2026-01-01T00:00:00Z",
+        app_url: null,
+        external_url: "https://x.com/i/status/9001",
+        image_url: null,
+      },
+    },
+  ],
+  next_cursor: null,
+}));
 
 vi.mock("@/lib/api", () => ({
   API_BASE: "",
   githubOwner: () => "",
-  listPublicPages: vi.fn(async () => [
-    {
-      slug: "my-page-abc123",
-      title: "My page",
-      content_type: "markdown",
-      view_count: 3,
-      created_at: "2026-01-01T00:00:00Z",
-    },
-  ]),
+  getHomeFeed: (...args: unknown[]) => getHomeFeed(...(args as [number])),
 }));
 
 vi.mock("@/components/skill/ForkSkillCardButton", () => ({
   default: () => null,
 }));
 
-describe("HomePage community page cards", () => {
-  beforeEach(() => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({ ok: true, json: async () => ({ skills: [] }) })),
-    );
-  });
-
+describe("HomePage feed", () => {
   afterEach(() => {
     cleanup();
-    vi.unstubAllGlobals();
   });
 
   // Community pages render inside the app at /pages/[slug], like skills do at
@@ -40,5 +75,17 @@ describe("HomePage community page cards", () => {
     const card = await screen.findByRole("link", { name: /my page/i });
     expect(card.getAttribute("href")).toBe("/pages/my-page-abc123");
     expect(card.getAttribute("target")).toBeNull();
+  });
+
+  // A resurfaced clip is our own archived copy — it opens in-app; a
+  // resurfaced X save has no in-app viewer, so it opens the original post
+  // in a new tab.
+  it("routes resurfaced items by their source", async () => {
+    render(<HomePage />);
+    const clip = await screen.findByRole("link", { name: /why wikis compound/i });
+    expect(clip.getAttribute("href")).toBe("/p/11111111-1111-1111-1111-111111111111");
+    const save = await screen.findByRole("link", { name: /9001/i });
+    expect(save.getAttribute("href")).toBe("https://x.com/i/status/9001");
+    expect(save.getAttribute("target")).toBe("_blank");
   });
 });

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -1,166 +1,238 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
-import { FileText, Code2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FileText, Code2, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { CardGridSkeleton } from "@/components/SkeletonStates";
 import { GitHubIcon } from "@/components/integrations/BrandIcons";
 import ForkSkillCardButton from "@/components/skill/ForkSkillCardButton";
 import SkillCard from "@/components/skill/SkillCard";
 import { StashIcon } from "@/components/SkillIcons";
-import { API_BASE, githubOwner, listPublicPages, type PublicSkillCard, type PublicPageCard } from "@/lib/api";
+import {
+  getHomeFeed,
+  githubOwner,
+  type FeedItem,
+  type PublicPageCard,
+  type ResurfaceCardData,
+} from "@/lib/api";
 import { routes } from "@/lib/workspace-routes";
 
-const SORTS = ["trending", "newest", "popular"] as const;
-type Sort = (typeof SORTS)[number];
 const COVERS = ["cover-1", "cover-2", "cover-3", "cover-4", "cover-5", "cover-6"];
 
-async function fetchPublicSkills(params: { q?: string; sort: Sort }): Promise<PublicSkillCard[]> {
-  const qs = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) if (v) qs.set(k, v);
-  const res = await fetch(`${API_BASE}/api/v1/discover/skills${qs.size ? `?${qs}` : ""}`);
-  if (!res.ok) return [];
-  return (await res.json()).skills ?? [];
-}
-
-/** The home / Discover feature — a dressed hero over the public-Skills catalog. */
+/** The home feature — one continuous feed: community skills to copy, public
+ *  pages, and (signed in) resurfaced items from your own stash. */
 export default function HomePage() {
-  const [sort, setSort] = useState<Sort>("trending");
-  const [query, setQuery] = useState("");
-  const [skills, setSkills] = useState<PublicSkillCard[]>([]);
-  const [pages, setPages] = useState<PublicPageCard[]>([]);
-  const [fetching, setFetching] = useState(true);
+  const [items, setItems] = useState<FeedItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(0);
+  const [fetching, setFetching] = useState(false);
+  const [initialLoad, setInitialLoad] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (fetching || nextCursor === null) return;
+    setFetching(true);
+    try {
+      const page = await getHomeFeed(nextCursor);
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.next_cursor);
+    } finally {
+      setFetching(false);
+      setInitialLoad(false);
+    }
+  }, [fetching, nextCursor]);
 
   useEffect(() => {
-    setFetching(true);
-    fetchPublicSkills({ q: query || undefined, sort }).then(setSkills).finally(() => setFetching(false));
-  }, [query, sort]);
+    loadMore();
+    // Load the first page once on mount; scrolling drives the rest.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Public pages (pastebin) are the same across sorts — fetched once, filtered client-side.
-  useEffect(() => { listPublicPages().then(setPages); }, []);
-  const q = query.trim().toLowerCase();
-  const visiblePages = q ? pages.filter((p) => p.title.toLowerCase().includes(q)) : pages;
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "600px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   return (
     <div className="min-h-full">
       {/* Hero */}
       <div className="relative overflow-hidden border-b border-border bg-gradient-to-br from-brand-100 via-brand-50 to-[color:var(--bg-surface)]">
-        <div className="mx-auto max-w-[1180px] px-12 py-14">
+        <div className="mx-auto max-w-[720px] px-6 py-10">
           <div className="flex items-center gap-2 text-brand-600">
             <StashIcon className="text-[26px]" />
-            <span className="text-[13px] font-semibold uppercase tracking-[0.14em]">Discover</span>
+            <span className="text-[13px] font-semibold uppercase tracking-[0.14em]">Home</span>
           </div>
-          <h1 className="mt-4 max-w-[680px] font-display text-[40px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground">
-            Get a head start with the community.
+          <h1 className="mt-3 font-display text-[32px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground">
+            Your feed.
           </h1>
-          <p className="mt-3 max-w-[580px] text-[15px] leading-[1.6] text-dim">
-            Explore public workflows, pages, and docs shared by the community — fork anything into your workspace and make it your own.
+          <p className="mt-2 max-w-[560px] text-[14.5px] leading-[1.6] text-dim">
+            Skills to copy, pages from the community, and things you saved that are worth another
+            look.{" "}
+            <Link href="/discover" className="font-medium text-brand-600 hover:underline">
+              Browse the full catalog →
+            </Link>
           </p>
-          <div className="mt-6 flex max-w-[520px] items-center gap-2 rounded-full border border-border bg-base px-4 py-2.5 shadow-sm">
-            <SearchGlyph />
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search the community…"
-              className="min-w-0 flex-1 border-0 bg-transparent text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none"
-            />
-          </div>
         </div>
       </div>
 
-      {/* Catalog */}
-      <div className="mx-auto max-w-[1180px] px-12 pb-20 pt-8">
-        {/* Extension CTA — the product's one distribution surface for the clipper. */}
-        <Link
-          href={routes.extension}
-          className="group mb-8 flex items-center justify-between gap-4 rounded-xl border border-brand-300/60 bg-gradient-to-r from-brand-50 to-base px-5 py-4 transition hover:border-brand-400 hover:shadow-sm"
-        >
-          <div>
-            <div className="text-[14.5px] font-semibold text-foreground group-hover:text-brand-600">
-              Download the extension
-            </div>
-            <div className="mt-0.5 text-[12.5px] text-muted-foreground">
-              Clip pages, import bookmarks, and sync your Instagram saves and AI chats into Stash.
-            </div>
-          </div>
-          <span className="shrink-0 rounded-full bg-brand px-4 py-1.5 text-[12px] font-semibold text-white">
-            Get it →
-          </span>
-        </Link>
-        <div className="flex items-center gap-3">
-          <div className="inline-flex gap-0.5 rounded-lg border border-border bg-base p-[3px]">
-            {SORTS.map((o) => (
-              <button
-                key={o}
-                onClick={() => setSort(o)}
-                className={"cursor-pointer rounded-md px-3 py-1 text-[12.5px] " + (sort === o ? "bg-raised font-semibold text-foreground" : "text-muted-foreground hover:text-foreground")}
-              >
-                {sortLabel(o)}
-              </button>
-            ))}
-          </div>
-          <span className="flex-1" />
-          <span className="sys-label" style={{ fontSize: 10.5 }}>{skills.length + visiblePages.length} result{skills.length + visiblePages.length === 1 ? "" : "s"}</span>
-        </div>
-
-        {fetching ? (
-          <CardGridSkeleton className="mt-6" />
-        ) : skills.length === 0 && visiblePages.length === 0 ? (
+      {/* Feed */}
+      <div className="mx-auto max-w-[720px] px-6 pb-20 pt-6">
+        {initialLoad ? (
+          <CardGridSkeleton className="mt-2" />
+        ) : items.length === 0 ? (
           <section className="mt-12 rounded-lg border border-dashed border-border bg-base px-6 py-12 text-center">
             <h2 className="font-display text-[20px] font-bold text-foreground">Nothing here yet.</h2>
-            <p className="mx-auto mt-2 max-w-[440px] text-[13.5px] leading-[1.6] text-muted-foreground">Community workflows, pages, and docs will show up here as people share them publicly.</p>
+            <p className="mx-auto mt-2 max-w-[440px] text-[13.5px] leading-[1.6] text-muted-foreground">
+              Community workflows, pages, and your own resurfaced saves will show up here.
+            </p>
           </section>
         ) : (
-          <>
-            {skills.length > 0 && (
-              <>
-                <SectionHeading>Workflows &amp; skills</SectionHeading>
-                <div className="mt-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
-                  {skills.map((skill, i) => (
-                    <SkillCard
-                      key={skill.id}
-                      href={`/skills/${skill.slug}`}
-                      skill={{
-                        title: skill.title,
-                        description: skill.description,
-                        cover_image_url: skill.cover_image_url,
-                        owner_name: skill.owner_name,
-                        owner_display_name: skill.source_github_url ? githubOwner(skill.source_github_url) : skill.owner_display_name,
-                        updated_at: skill.updated_at,
-                      }}
-                      cover={COVERS[i % COVERS.length]}
-                      badge={sort === "trending" && i < 2 ? (
-                        <span className="absolute left-3 top-2.5 inline-flex items-center gap-1 rounded-full bg-black/80 px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.04em] text-white">↗ trending</span>
-                      ) : undefined}
-                      cornerAction={
-                        <span className="flex items-center gap-1.5">
-                          {skill.source_github_url && <GitHubSourceGlyph href={skill.source_github_url} />}
-                          <ForkSkillCardButton slug={skill.slug} />
-                        </span>
-                      }
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-
-            {visiblePages.length > 0 && (
-              <>
-                <SectionHeading className="mt-12">Community pages</SectionHeading>
-                <div className="mt-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
-                  {visiblePages.map((p) => <PageCard key={p.slug} page={p} />)}
-                </div>
-              </>
-            )}
-          </>
+          <div className="flex flex-col gap-3.5">
+            {items.map((item, i) => (
+              <span key={feedKey(item, i)} className="contents">
+                <FeedCard item={item} index={i} />
+                {i === 3 && <ExtensionCta />}
+              </span>
+            ))}
+          </div>
+        )}
+        <div ref={sentinelRef} />
+        {fetching && !initialLoad && (
+          <div className="py-6 text-center text-[12.5px] text-muted-foreground">Loading…</div>
         )}
       </div>
     </div>
   );
 }
 
-function SectionHeading({ children, className = "" }: { children: ReactNode; className?: string }) {
-  return <h2 className={`text-[12px] font-semibold uppercase tracking-[0.1em] text-muted-foreground ${className}`}>{children}</h2>;
+function feedKey(item: FeedItem, index: number): string {
+  if (item.kind === "skill") return `skill-${item.data.id}`;
+  if (item.kind === "public_page") return `page-${item.data.slug}`;
+  return `resurface-${index}-${item.data.title}`;
+}
+
+function FeedCard({ item, index }: { item: FeedItem; index: number }) {
+  if (item.kind === "skill") {
+    const skill = item.data;
+    return (
+      <SkillCard
+        href={`/skills/${skill.slug}`}
+        skill={{
+          title: skill.title,
+          description: skill.description,
+          cover_image_url: skill.cover_image_url,
+          owner_name: skill.owner_name,
+          owner_display_name: skill.source_github_url
+            ? githubOwner(skill.source_github_url)
+            : skill.owner_display_name,
+          updated_at: skill.updated_at,
+        }}
+        cover={COVERS[index % COVERS.length]}
+        cornerAction={
+          <span className="flex items-center gap-1.5">
+            {skill.source_github_url && <GitHubSourceGlyph href={skill.source_github_url} />}
+            <ForkSkillCardButton slug={skill.slug} />
+          </span>
+        }
+      />
+    );
+  }
+  if (item.kind === "public_page") return <PageCard page={item.data} />;
+  return <ResurfaceCard data={item.data} />;
+}
+
+// A card from the user's own stash: the archived content is the preview; a
+// clip opens in-app, an X/Instagram save opens the original post.
+function ResurfaceCard({ data }: { data: ResurfaceCardData }) {
+  const body = (
+    <>
+      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-brand-600">
+        From your stash
+        <span className="rounded bg-brand-50 px-1.5 py-0.5 font-mono text-[10px] normal-case tracking-normal text-brand-600">
+          {sourceLabel(data.source)}
+        </span>
+        <span className="font-normal normal-case tracking-normal text-muted-foreground">
+          saved {savedAgo(data.saved_at)}
+        </span>
+      </div>
+      <div className="mt-2 flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="line-clamp-2 text-[14.5px] font-semibold leading-snug text-foreground group-hover:text-brand-600">
+            {data.title || "Untitled"}
+          </div>
+          {data.preview && (
+            <p className="mt-1 line-clamp-3 text-[13px] leading-[1.55] text-dim">{data.preview}</p>
+          )}
+        </div>
+        {data.image_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.image_url}
+            alt=""
+            className="h-16 w-16 shrink-0 rounded-lg border border-border object-cover"
+          />
+        )}
+      </div>
+    </>
+  );
+  const className =
+    "group block rounded-xl border border-brand-200/70 bg-gradient-to-br from-brand-50/60 to-base p-4 transition hover:border-brand-300 hover:shadow-sm";
+  if (data.app_url) {
+    return (
+      <Link href={data.app_url} className={className}>
+        {body}
+      </Link>
+    );
+  }
+  return (
+    <a href={data.external_url ?? "#"} target="_blank" rel="noreferrer" className={className}>
+      {body}
+      <span className="mt-2 inline-flex items-center gap-1 text-[11.5px] text-muted-foreground">
+        <ExternalLink className="h-3 w-3" /> View original
+      </span>
+    </a>
+  );
+}
+
+function sourceLabel(source: ResurfaceCardData["source"]): string {
+  if (source === "x") return "X";
+  if (source === "instagram") return "Instagram";
+  return "Clip";
+}
+
+function savedAgo(iso: string): string {
+  const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+function ExtensionCta() {
+  return (
+    <Link
+      href={routes.extension}
+      className="group flex items-center justify-between gap-4 rounded-xl border border-brand-300/60 bg-gradient-to-r from-brand-50 to-base px-5 py-4 transition hover:border-brand-400 hover:shadow-sm"
+    >
+      <div>
+        <div className="text-[14.5px] font-semibold text-foreground group-hover:text-brand-600">
+          Download the extension
+        </div>
+        <div className="mt-0.5 text-[12.5px] text-muted-foreground">
+          Clip pages, import bookmarks, and sync your Instagram saves and AI chats into Stash.
+        </div>
+      </div>
+      <span className="shrink-0 rounded-full bg-brand px-4 py-1.5 text-[12px] font-semibold text-white">
+        Get it →
+      </span>
+    </Link>
+  );
 }
 
 // A community page (pastebin) card — opens the in-app viewer at /pages/[slug].
@@ -169,15 +241,23 @@ function PageCard({ page }: { page: PublicPageCard }) {
   return (
     <Link
       href={`/pages/${page.slug}`}
-      className="group flex flex-col gap-3 rounded-xl border border-border bg-base p-4 transition hover:border-brand-300 hover:shadow-sm"
+      className="group flex items-center gap-3.5 rounded-xl border border-border bg-base p-4 transition hover:border-brand-300 hover:shadow-sm"
     >
-      <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface text-muted-foreground">
+      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-surface text-muted-foreground">
         <Icon className="h-4 w-4" />
       </span>
-      <span className="line-clamp-2 text-[14.5px] font-semibold leading-snug text-foreground group-hover:text-brand-600">{page.title || "Untitled"}</span>
-      <span className="mt-auto flex items-center gap-2 text-[11.5px] text-muted-foreground">
-        <span className="rounded bg-surface px-1.5 py-0.5 font-medium uppercase tracking-wide">{page.content_type}</span>
-        <span>{page.view_count} view{page.view_count === 1 ? "" : "s"}</span>
+      <span className="min-w-0 flex-1">
+        <span className="line-clamp-2 text-[14.5px] font-semibold leading-snug text-foreground group-hover:text-brand-600">
+          {page.title || "Untitled"}
+        </span>
+        <span className="mt-1 flex items-center gap-2 text-[11.5px] text-muted-foreground">
+          <span className="rounded bg-surface px-1.5 py-0.5 font-medium uppercase tracking-wide">
+            {page.content_type}
+          </span>
+          <span>
+            {page.view_count} view{page.view_count === 1 ? "" : "s"}
+          </span>
+        </span>
       </span>
     </Link>
   );
@@ -189,22 +269,21 @@ function GitHubSourceGlyph({ href }: { href: string }) {
       role="link"
       tabIndex={0}
       title="View source on GitHub"
-      onClick={(e) => { e.preventDefault(); e.stopPropagation(); window.open(href, "_blank", "noopener"); }}
-      onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); e.stopPropagation(); window.open(href, "_blank", "noopener"); } }}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.open(href, "_blank", "noopener");
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(href, "_blank", "noopener");
+        }
+      }}
       className="inline-flex cursor-pointer items-center rounded-full bg-white/85 p-1 text-foreground shadow-sm ring-1 ring-border backdrop-blur transition hover:bg-white"
     >
       <GitHubIcon size={13} />
     </span>
-  );
-}
-
-function sortLabel(sort: Sort): string {
-  return sort === "popular" ? "Most viewed" : sort === "trending" ? "Trending" : "Newest";
-}
-function SearchGlyph() {
-  return (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground">
-      <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
-    </svg>
   );
 }

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
@@ -8,6 +10,7 @@ import {
   getAgentChat,
   streamAgentChat,
 } from "@/lib/agentChat";
+import { apiFetch } from "@/lib/api";
 
 // A real multi-turn agent chat: a scrolling transcript + a composer. Enter
 // sends, Shift+Enter inserts a newline. Each turn is persisted server-side
@@ -257,6 +260,55 @@ function Code({ children }: { children: string }) {
   );
 }
 
+const chipLinkClass =
+  "font-mono underline decoration-dotted underline-offset-2 hover:text-foreground";
+
+// A grounding citation, linked to what it names: web fetches open the page,
+// app targets navigate in place, and VFS reads resolve their path to the
+// object's route on click (the stream only carries the path).
+function CitationChip({ citation }: { citation: Citation }) {
+  const router = useRouter();
+  const [resolving, setResolving] = useState(false);
+
+  if (citation.href && citation.href.startsWith("http")) {
+    return (
+      <a href={citation.href} target="_blank" rel="noreferrer" className={chipLinkClass}>
+        {citation.label}
+      </a>
+    );
+  }
+  if (citation.href) {
+    return (
+      <Link href={citation.href} className={chipLinkClass}>
+        {citation.label}
+      </Link>
+    );
+  }
+  if (citation.vfsPath) {
+    const open = async () => {
+      if (resolving) return;
+      setResolving(true);
+      try {
+        const { app_url } = await apiFetch<{ app_url: string | null }>(
+          `/api/v1/me/vfs/resolve?path=${encodeURIComponent(citation.vfsPath ?? "")}`,
+        );
+        if (app_url) router.push(app_url);
+      } catch {
+        // A stale citation (the object was deleted since the chat) resolves
+        // 404 — the chip stays inert rather than crashing the panel.
+      } finally {
+        setResolving(false);
+      }
+    };
+    return (
+      <button type="button" onClick={open} className={`${chipLinkClass} cursor-pointer`}>
+        {citation.label}
+      </button>
+    );
+  }
+  return <span className="font-mono">{citation.label}</span>;
+}
+
 function MessageBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === "user";
   return (
@@ -278,7 +330,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
             {message.citations.map((c, i) => (
               <span key={c.id}>
                 {i > 0 && ", "}
-                <span className="font-mono">{c.label}</span>
+                <CitationChip citation={c} />
               </span>
             ))}
           </div>

--- a/frontend/src/lib/agentChat.test.ts
+++ b/frontend/src/lib/agentChat.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/api", () => ({
   getAuthToken: () => "k",
 }));
 
-import { getAgentChat } from "./agentChat";
+import { citationFor, getAgentChat } from "./agentChat";
 
 describe("getAgentChat", () => {
   it("folds tool rows into the next assistant message's citations", async () => {
@@ -69,5 +69,39 @@ describe("getAgentChat", () => {
 
     // Grep grounds the answer; an Edit is work, not grounding.
     expect(messages[1].citations?.map((c) => c.label)).toEqual(['search "quokka"']);
+  });
+});
+
+describe("citationFor link targets", () => {
+  it("links a stash search to the app search page", () => {
+    expect(citationFor("Bash", { command: 'stash search "vector recall"' })).toEqual({
+      label: 'stash search "vector recall"',
+      href: "/search?q=vector%20recall",
+    });
+  });
+
+  it("links a stash page read straight to the page", () => {
+    const id = "0b5c2f6e-9d31-4a7e-8f00-1234567890ab";
+    expect(citationFor("Bash", { command: `stash read ${id}` })?.href).toBe(`/p/${id}`);
+  });
+
+  it("carries a VFS cat path for click-time resolution", () => {
+    expect(citationFor("Bash", { command: "stash vfs \"cat '/files/Runbook.md'\"" })).toEqual({
+      label: "stash vfs \"cat '/files/Runbook.md'\"",
+      vfsPath: "/files/Runbook.md",
+    });
+  });
+
+  it("links a web fetch to the fetched URL", () => {
+    expect(citationFor("WebFetch", { url: "https://example.com/post" })).toEqual({
+      label: "example.com",
+      href: "https://example.com/post",
+    });
+  });
+
+  it("leaves sprite-local reads unlinked", () => {
+    expect(citationFor("Read", { file_path: "/home/user/work/notes.md" })).toEqual({
+      label: "notes.md",
+    });
   });
 });

--- a/frontend/src/lib/agentChat.ts
+++ b/frontend/src/lib/agentChat.ts
@@ -15,7 +15,17 @@ function scopeHeader(): Record<string, string> {
   return scopeUserId ? { [SCOPE_HEADER]: scopeUserId } : {};
 }
 
-export type Citation = { id: string; tool: string; label: string };
+export type Citation = {
+  id: string;
+  tool: string;
+  label: string;
+  // Direct link target: an external URL (WebFetch) or an app route (search,
+  // page reads). VFS reads carry vfsPath instead and resolve to their app
+  // route at click time via /vfs/resolve.
+  href?: string;
+  vfsPath?: string;
+};
+export type CitationTarget = Pick<Citation, "label" | "href" | "vfsPath">;
 export type ChatRole = "user" | "assistant";
 export type ChatMessage = { role: ChatRole; content: string; citations?: Citation[] };
 
@@ -34,27 +44,47 @@ function host(url: string): string {
 
 // The "Grounded on" strip shows the reads that grounded the answer: file and
 // Stash reads, searches, and web lookups. Plain shell commands and file
-// edits are work, not grounding — they stay out of the strip.
+// edits are work, not grounding — they stay out of the strip. Reads of Stash
+// content and web pages also carry a link target, so a citation is one click
+// from the material it names; sprite-local reads (Read/Grep of ~/work
+// scratch) have no app-side object and stay plain labels.
 export function citationFor(
   name: string,
   args: Record<string, unknown> | undefined,
-): string | null {
+): CitationTarget | null {
   const a = args ?? {};
-  if (name === "Read" && typeof a.file_path === "string") return basename(a.file_path);
+  if (name === "Read" && typeof a.file_path === "string") {
+    return { label: basename(a.file_path) };
+  }
   if ((name === "Grep" || name === "Glob") && typeof a.pattern === "string") {
-    return `search "${a.pattern.slice(0, 40)}"`;
+    return { label: `search "${a.pattern.slice(0, 40)}"` };
   }
   if (name === "WebSearch" && typeof a.query === "string") {
-    return `web "${a.query.slice(0, 40)}"`;
+    return { label: `web "${a.query.slice(0, 40)}"` };
   }
-  if (name === "WebFetch" && typeof a.url === "string") return host(a.url);
+  if (name === "WebFetch" && typeof a.url === "string") {
+    return { label: host(a.url), href: a.url };
+  }
   if (name === "Task" && typeof a.description === "string") {
-    return `agent: ${a.description.slice(0, 40)}`;
+    return { label: `agent: ${a.description.slice(0, 40)}` };
   }
   if (name === "Bash" && typeof a.command === "string" && a.command.startsWith("stash ")) {
-    return a.command.slice(0, 48);
+    return { label: a.command.slice(0, 48), ...stashCommandTarget(a.command) };
   }
   return null;
+}
+
+// Where a `stash` CLI read points in the app: a search opens /search with the
+// same query, `stash read <page id>` opens the page, and a VFS cat carries
+// its path for click-time resolution.
+function stashCommandTarget(command: string): Omit<CitationTarget, "label"> {
+  const search = command.match(/^stash search\s+"([^"]+)"/);
+  if (search) return { href: `/search?q=${encodeURIComponent(search[1])}` };
+  const read = command.match(/^stash read\s+([0-9a-f][0-9a-f-]{34}[0-9a-f])/);
+  if (read) return { href: `/p/${read[1]}` };
+  const cat = command.match(/\bcat\s+'([^']+)'/);
+  if (cat) return { vfsPath: cat[1] };
+  return {};
 }
 
 type StoredMessage = {
@@ -88,8 +118,8 @@ export async function getAgentChat(sessionId: string): Promise<ChatMessage[]> {
   let pending: Citation[] = [];
   for (const [i, m] of data.messages.entries()) {
     if (m.role === "tool") {
-      const label = citationFor(m.tool_name ?? "tool", argsFromMetadata(m.metadata ?? {}));
-      if (label) pending.push({ id: `stored-${i}`, tool: m.tool_name ?? "tool", label });
+      const target = citationFor(m.tool_name ?? "tool", argsFromMetadata(m.metadata ?? {}));
+      if (target) pending.push({ id: `stored-${i}`, tool: m.tool_name ?? "tool", ...target });
       continue;
     }
     if (m.role === "assistant") {
@@ -151,12 +181,16 @@ async function consumeAgentStream(res: Response, handlers: StreamHandlers): Prom
       } else if (evt.type === "text" && typeof evt.delta === "string") {
         handlers.onText?.(evt.delta);
       } else if (evt.type === "tool") {
-        const label = citationFor(
+        const target = citationFor(
           evt.name as string,
           evt.args as Record<string, unknown> | undefined,
         );
-        if (label) {
-          handlers.onTool?.({ id: String(evt.id ?? label), tool: evt.name as string, label });
+        if (target) {
+          handlers.onTool?.({
+            id: String(evt.id ?? target.label),
+            tool: evt.name as string,
+            ...target,
+          });
         }
       } else if (evt.type === "tool_result" && evt.ok === false) {
         handlers.onToolError?.(String(evt.id));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -462,6 +462,7 @@ export interface PublicSkillCard {
   cover_image_url: string | null;
   source_github_url: string | null;
   view_count: number;
+  install_count: number;
   owner_name: string;
   owner_display_name: string;
   owner_user_id: string;
@@ -474,6 +475,42 @@ export interface PublicSkillCard {
 // belongs to the repo owner — derive it from the attribution URL.
 export function githubOwner(sourceGithubUrl: string): string {
   return sourceGithubUrl.replace("https://github.com/", "").split("/")[0];
+}
+
+// --- Home feed ---
+
+// An item from the caller's own stash the feed resurfaces: an old clip
+// (opens in-app via app_url) or an X/Instagram save (opens the original
+// via external_url; the archived text is the preview).
+export interface ResurfaceCardData {
+  source: "x" | "instagram" | "clip";
+  title: string;
+  preview: string;
+  saved_at: string;
+  app_url: string | null;
+  external_url: string | null;
+  image_url: string | null;
+}
+
+export type FeedItem =
+  | { kind: "skill"; data: PublicSkillCard }
+  | { kind: "public_page"; data: PublicPageCard }
+  | { kind: "resurface"; data: ResurfaceCardData };
+
+export interface HomeFeedPage {
+  items: FeedItem[];
+  next_cursor: number | null;
+}
+
+// Public for signed-out visitors (community stream only); a bearer token adds
+// resurfaced items from the caller's own stash.
+export async function getHomeFeed(cursor: number): Promise<HomeFeedPage> {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE}/api/v1/feed?cursor=${cursor}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!res.ok) throw new Error(`Feed failed: ${res.status}`);
+  return res.json();
 }
 
 // --- Files: folders (nested) and pages ---

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -50,6 +50,10 @@ class VfsNode:
     # Stash id of the connected source this node is the root of. It's the object
     # id `shares add source <id>` takes, so `stat` surfaces it for sharing.
     source_id: str | None = None
+    # App route of the Stash object behind this node (`/p/<id>`, `/f/<id>`,
+    # `/sessions/<id>`, …), so a VFS path can deep-link into the product —
+    # chat citations resolve through this.
+    app_url: str | None = None
     # Set when `prefetch` already tried this loader and it failed. `read_file`
     # re-raises it rather than fetching again — a second fetch would hit the
     # provider twice and, server-side, spend the document budget twice.
@@ -305,6 +309,7 @@ class StashVfsModel:
                 loader=lambda pid=page_id: self._load_page(pid),
                 created_at=page.get("created_at"),
                 updated_at=page.get("updated_at"),
+                app_url=f"/p/{page_id}",
             )
 
         for file in files:
@@ -321,6 +326,7 @@ class StashVfsModel:
                 size_hint=file.get("size_bytes"),
                 created_at=created_at,
                 updated_at=created_at,
+                app_url=f"/f/{file_id}",
             )
 
     def _add_skills(self, skills: list[dict]) -> None:
@@ -340,6 +346,7 @@ class StashVfsModel:
                 self._add_file(
                     f"{skills_path}/{basename}.md",
                     loader=lambda s=slug: _text_bytes(self.client.get_skill_text(s)),
+                    app_url=f"/skills/{slug}",
                 )
 
     def _add_sessions(self, sessions: list[dict]) -> None:
@@ -362,11 +369,13 @@ class StashVfsModel:
                     {"events": self.client.get_transcript_events(sid)}
                 ),
                 updated_at=updated_at,
+                app_url=f"/sessions/{session_id}",
             )
             self._add_file(
                 f"{session_path}/transcript.jsonl",
                 loader=lambda sid=session_id: _text_bytes(self.client.export_transcript_jsonl(sid)),
                 updated_at=updated_at,
+                app_url=f"/sessions/{session_id}",
             )
             self._add_file(
                 f"{session_path}/transcript.md",
@@ -374,6 +383,7 @@ class StashVfsModel:
                     _session_markdown(self.client.get_transcript_events(sid))
                 ),
                 updated_at=updated_at,
+                app_url=f"/sessions/{session_id}",
             )
 
     def _add_tables(self) -> None:
@@ -400,12 +410,14 @@ class StashVfsModel:
                 loader=lambda tid=table_id: _json_bytes(self.client.get_table(tid)),
                 created_at=created_at,
                 updated_at=updated_at,
+                app_url=f"/tables/{table_id}",
             )
             self._add_file(
                 f"{table_path}/rows.json",
                 loader=lambda tid=table_id: _json_bytes(self._load_all_table_rows(tid)),
                 created_at=created_at,
                 updated_at=updated_at,
+                app_url=f"/tables/{table_id}",
             )
             self._add_file(
                 f"{table_path}/rows.jsonl",
@@ -414,6 +426,7 @@ class StashVfsModel:
                 ),
                 created_at=created_at,
                 updated_at=updated_at,
+                app_url=f"/tables/{table_id}",
             )
 
     def _add_sources(self) -> None:
@@ -597,6 +610,7 @@ class StashVfsModel:
         created_at: str | None = None,
         updated_at: str | None = None,
         external_ref: str | None = None,
+        app_url: str | None = None,
     ) -> str:
         path = self._clean_path(path)
         parent, requested_name = self._split_parent(path)
@@ -615,6 +629,7 @@ class StashVfsModel:
             created_at=_parse_iso(created_at),
             updated_at=_parse_iso(updated_at),
             external_ref=external_ref,
+            app_url=app_url,
         )
         self.nodes[parent].children[name] = path
         return path

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -767,6 +767,8 @@ class SkillAppVfsShell:
             out += f"  external_ref: {node.external_ref}\n"
         if node.source_id:
             out += f"  source_id: {node.source_id}\n"
+        if node.app_url:
+            out += f"  app_url: {node.app_url}\n"
             out += f"  share: stash shares add source {node.source_id} <email>\n"
         return out
 


### PR DESCRIPTION
Four builds toward the commonplace-book product direction, plus clickable chat citations.

## 1. X saves capture the author's full thread
Hydration pulls the conversation from twitterapi.io's `thread_context` endpoint, keeps the author's connected chain chronologically, and shows a reply's direct parent. Media archives across the thread (saved tweet first, capped at 12/save). Migration **0163** re-hydrates existing Replies/Posts (the user's own tweets — rarely deleted; a vanished tweet leaves the row failed with old content preserved). Bookmarks excluded from the backfill: deletion-prone + re-archiving mints fresh storage keys.

## 2. Home page becomes one continuous feed
New public `GET /api/v1/feed` (`backend/services/feed_service.py`): community skills (two per public page) interleaved with a **resurface** card every 4th slot — old clips and X/Instagram saves from the caller's own stash. Selection is deterministic per (user, day) via an md5 sort seeded by user id + date, gated to items older than 7 days. Signed-out visitors get the community stream only; `/discover` keeps the sortable catalog. Skill cards now carry `install_count`.

Screenshots (Stash links):
- Signed-in feed (skills + community page + X resurface card): https://app.joinstash.ai/f/085993ba-8b70-45ba-88a4-0f694039bf5e
- Resurface cards + inline extension CTA + clip card: https://app.joinstash.ai/f/c1576acf-fc4b-44f2-bfca-65224de9d6ae
- Signed-out (community only): https://app.joinstash.ai/f/7b7e4cf2-c32e-4a1b-956b-5ada2aaf05fe

## 3. Generate-output skills seeded into every scope
`briefing`, `study-guide`, `timeline` join `slides` in `skill_seeds.py` (generalized to a `DEFAULT_SKILLS` list). Each turns saved material into a grounded document with every claim linked to its source. Seeded at signup like slides — existing scopes are untouched (same precedent as slides' introduction; a backfill can follow if wanted).

## 4. Curator maintains topic lists from saves
The change feed gains a `saves` section — newly hydrated X/Instagram saves as items (they previously appeared only as source *pointers*, so the curator couldn't scope-by-diff over them); the cheap gate now trips on them. The curator prompt gains **one additive ingest principle** (topic list pages in a `Saved & Reading` category, one linked line per save, a thread = one entry) — no restructuring, per the wiki-quality campaign's prompt sensitivity.

## 5. Chat citations link to the material they name
VFS nodes carry the app route of the object behind them (`/p`, `/f`, `/sessions`, `/tables`, `/skills`), surfaced via `stat` and a new `GET /api/v1/me/vfs/resolve`. The "Grounded on" strip becomes links: web fetches open the page, `stash search` opens `/search?q=`, VFS cat paths resolve on click. Sprite-local scratch reads stay plain labels.

## Verification
- Full backend suite: **937 passed** (includes 3 new thread tests, 3 feed tests, saves-in-feed curator test, 2 VFS resolve tests, seed tests). Fresh-DB migration chain to 0163 + linear-history smoke tests green.
- Frontend: **228 vitest passed**, eslint clean, `next build` clean.
- Live E2E: seeded dev DB, verified `GET /api/v1/feed` interleave order, browsed the feed signed-out/signed-in, clicked a resurfaced clip through to `/p/<id>` (screenshots above).
- **Not yet validated live:** a real curator "Run now" wiki-diff with fresh saves (needs a sprite-backed account), and a real X sync against twitterapi.io's `thread_context` (endpoint verified against their docs; hydration is mocked in tests). Suggested before/alongside merge: bookmark a known multi-post thread on a connected account and confirm the doc contains the chain.

Note: merging deploys to prod (migration 0163 runs at next backend boot and re-hydrates X Replies/Posts over subsequent syncs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwhB8K1YivKHVTpc9GtMbZ