### PR TITLE
fix: require stable identity for OAuth reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- OAuth reconnects now require a stable provider account identity. Slack,
+  Asana, Jira, Linear, Notion, and Gong connections refuse to store new
+  credentials when identity lookup fails, preventing retained source data
+  from silently continuing under a different provider account.
 - Frontend server-side backend requests now require `BACKEND_INTERNAL_URL`
   or `NEXT_PUBLIC_API_URL` instead of guessing an environment, so missing
   managed deploy config fails during build rather than crashing public

--- a/backend/integrations/asana/provider.py
+++ b/backend/integrations/asana/provider.py
@@ -107,4 +107,8 @@ class AsanaIntegration(Integration):
             resp = await client.get(ME_URL)
             resp.raise_for_status()
             me = resp.json().get("data", {})
-        return AccountInfo(email=me.get("email"), display_name=me.get("name"))
+        return AccountInfo(
+            email=me.get("email"),
+            display_name=me.get("name"),
+            account_ref=me.get("gid"),
+        )

--- a/backend/integrations/gong/provider.py
+++ b/backend/integrations/gong/provider.py
@@ -113,7 +113,11 @@ class GongIntegration(Integration):
             resp.raise_for_status()
             workspaces = resp.json().get("workspaces", [])
         display_name = workspaces[0]["name"] if workspaces else "Gong"
-        return AccountInfo(email=None, display_name=display_name)
+        return AccountInfo(
+            email=None,
+            display_name=display_name,
+            account_ref=creds["api_base_url"],
+        )
 
 
 def _payload_to_tokenset(payload: dict) -> TokenSet:

--- a/backend/integrations/jira/provider.py
+++ b/backend/integrations/jira/provider.py
@@ -108,4 +108,8 @@ class JiraIntegration(Integration):
             resp = await client.get(ME_URL)
             resp.raise_for_status()
             me = resp.json()
-        return AccountInfo(email=me.get("email"), display_name=me.get("name"))
+        return AccountInfo(
+            email=me.get("email"),
+            display_name=me.get("name"),
+            account_ref=me.get("account_id"),
+        )

--- a/backend/integrations/linear/provider.py
+++ b/backend/integrations/linear/provider.py
@@ -21,7 +21,7 @@ from ..base import AccountInfo, Integration, TokenSet
 AUTHORIZE_URL = "https://linear.app/oauth/authorize"
 TOKEN_URL = "https://api.linear.app/oauth/token"
 REVOKE_URL = "https://api.linear.app/oauth/revoke"
-VIEWER_QUERY = "query { viewer { name email } }"
+VIEWER_QUERY = "query { viewer { id name email } }"
 
 
 class LinearIntegration(Integration):
@@ -104,4 +104,8 @@ class LinearIntegration(Integration):
             resp = await client.post(settings.LINEAR_API_URL, json={"query": VIEWER_QUERY})
             resp.raise_for_status()
             viewer = (resp.json().get("data") or {}).get("viewer") or {}
-        return AccountInfo(email=viewer.get("email"), display_name=viewer.get("name"))
+        return AccountInfo(
+            email=viewer.get("email"),
+            display_name=viewer.get("name"),
+            account_ref=viewer.get("id"),
+        )

--- a/backend/integrations/notion/provider.py
+++ b/backend/integrations/notion/provider.py
@@ -111,4 +111,5 @@ class NotionIntegration(Integration):
         return AccountInfo(
             email=person.get("email"),
             display_name=user.get("name") or bot.get("workspace_name") or "Notion workspace",
+            account_ref=bot.get("workspace_id"),
         )

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -30,7 +30,6 @@ from ..auth import get_current_user
 from ..config import settings
 from ..services import billing_service, security_audit_service, source_service
 from . import storage
-from .base import AccountInfo
 from .crypto import integration_fernet, integration_keyring_error
 from .github import account_sync as github_account_sync
 from .registry import get_provider, list_providers
@@ -363,18 +362,12 @@ async def integration_callback(
                 token = await p.exchange_code(code, code_verifier)
             else:
                 token = await p.exchange_code(code)
-            # The account profile is display-only — a failure fetching it must
-            # NOT block the connection (the token is what matters). Degrade to
-            # an empty identity instead.
-            try:
-                account = await p.fetch_account(token.access_token)
-            except Exception as e:
-                logger.warning(
-                    "fetch_account failed for %s; connecting without profile (%s)",
-                    provider,
-                    type(e).__name__,
-                )
-                account = AccountInfo(email=None, display_name=None)
+            # The provider identity anchors reconnect safety. Storing a token
+            # without it would make a later account switch indistinguishable
+            # from a same-account reconnect.
+            account = await p.fetch_account(token.access_token)
+            if not account.account_ref:
+                raise RuntimeError(f"{provider} returned no stable account identity")
             # Reconnect identity check: refuse to link a DIFFERENT provider
             # account while the previous account's connection (and possibly
             # its kept data) exists. The identity comes from the provider's

--- a/backend/integrations/slack/provider.py
+++ b/backend/integrations/slack/provider.py
@@ -138,7 +138,11 @@ class SlackIntegration(Integration):
 
     async def fetch_account(self, access_token: str) -> AccountInfo:
         info = await self.team_info(access_token)
-        return AccountInfo(email=None, display_name=info["team_name"])
+        return AccountInfo(
+            email=None,
+            display_name=info["team_name"],
+            account_ref=info["team_id"],
+        )
 
     async def team_info(self, access_token: str) -> dict:
         """auth.test → {team_id, team_name, user_id}. Used both for the account

--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -61,10 +61,9 @@ async def account_mismatch(user_id: UUID, provider: str, account: AccountInfo) -
     """The reconnect identity check. Returns the stored account's label when
     this connect is under a DIFFERENT provider account than the one already
     linked (whose data may be kept) — the caller must refuse the connect. The
-    check needs both sides' account_ref; a provider that doesn't supply one
-    cannot be checked."""
+    check needs both sides' account_ref."""
     if not account.account_ref:
-        return None
+        raise ValueError(f"{provider} account identity is required")
     row = await get_pool().fetchrow(
         "SELECT account_ref, account_display_name, account_email FROM user_integrations "
         "WHERE user_id = $1 AND provider = $2 AND account_key = $3",

--- a/backend/tests/test_disconnect_retention.py
+++ b/backend/tests/test_disconnect_retention.py
@@ -106,9 +106,17 @@ async def test_reconnect_under_a_different_account_is_refused(
     same = AccountInfo(email=None, display_name="@sam", account_ref="111")
     assert await storage.account_mismatch(user_id, "x", same) is None
 
-    # A provider that can't supply an id can't be checked — never a false block.
+    await pool.execute(
+        "UPDATE user_integrations SET account_ref = NULL WHERE user_id = $1 AND provider = 'x'",
+        user_id,
+    )
+    assert await storage.account_mismatch(user_id, "x", same) is None
+
+    # Missing identity must fail closed; otherwise a different account could
+    # inherit the disconnected account's retained source data.
     unknown = AccountInfo(email=None, display_name=None, account_ref=None)
-    assert await storage.account_mismatch(user_id, "x", unknown) is None
+    with pytest.raises(ValueError, match="x account identity is required"):
+        await storage.account_mismatch(user_id, "x", unknown)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_integration_callback_security.py
+++ b/backend/tests/test_integration_callback_security.py
@@ -71,7 +71,31 @@ class SlackProvider:
         )
 
     async def fetch_account(self, access_token: str):
-        return AccountInfo(email=None, display_name=None)
+        return AccountInfo(email=None, display_name=None, account_ref="T123")
+
+
+class IdentityProvider:
+    name = "identity"
+    auth_kind = "oauth"
+
+    def __init__(self, access_token: str, account_ref: str):
+        self.access_token = access_token
+        self.account_ref = account_ref
+
+    async def exchange_code(self, code: str):
+        return TokenSet(
+            access_token=self.access_token,
+            refresh_token=None,
+            expires_at=None,
+            scopes=["read"],
+        )
+
+    async def fetch_account(self, access_token: str):
+        return AccountInfo(
+            email=None,
+            display_name=f"Account {self.account_ref}",
+            account_ref=self.account_ref,
+        )
 
 
 class FailingCredentialProvider:
@@ -123,10 +147,11 @@ async def test_oauth_callback_failure_does_not_redirect_or_log_secrets(
 
 
 @pytest.mark.asyncio
-async def test_oauth_profile_failure_does_not_log_tokens(
+async def test_oauth_profile_failure_refuses_connection_without_logging_tokens(
     client: AsyncClient,
     monkeypatch,
     caplog,
+    pool,
 ):
     provider = FailingProfileProvider()
     _configure_callback(monkeypatch, provider)
@@ -140,9 +165,110 @@ async def test_oauth_profile_failure_does_not_log_tokens(
     )
 
     assert response.status_code == 302
-    assert response.headers["location"] == f"{PUBLIC_URL}/settings?connected=profile"
+    assert (
+        response.headers["location"]
+        == f"{PUBLIC_URL}/settings?integration_error=profile&reason=connection_failed"
+    )
     assert "at_should_not_be_logged" not in caplog.text
     assert "rt_should_not_be_logged" not in caplog.text
+    assert (
+        await pool.fetchval(
+            "SELECT count(*) FROM user_integrations WHERE user_id = $1 AND provider = $2",
+            user_id,
+            provider.name,
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_refuses_account_without_stable_identity(
+    client: AsyncClient,
+    monkeypatch,
+    pool,
+):
+    provider = SlackProvider()
+    _configure_callback(monkeypatch, provider)
+    user_id = await _register(client)
+    state = integration_router._encode_state(user_id, provider.name, "/settings")
+
+    async def missing_identity(access_token: str):
+        return AccountInfo(email=None, display_name="Acme")
+
+    monkeypatch.setattr(provider, "fetch_account", missing_identity)
+
+    response = await client.get(
+        f"/api/v1/integrations/{provider.name}/callback",
+        params={"code": "ok", "state": state},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == f"{PUBLIC_URL}/settings?integration_error=slack&reason=connection_failed"
+    )
+    assert (
+        await pool.fetchval(
+            "SELECT count(*) FROM user_integrations WHERE user_id = $1 AND provider = $2",
+            user_id,
+            provider.name,
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_updates_same_account_and_refuses_different_account(
+    client: AsyncClient,
+    monkeypatch,
+    pool,
+):
+    user_id = await _register(client)
+
+    async def connect(provider: IdentityProvider):
+        _configure_callback(monkeypatch, provider)
+        state = integration_router._encode_state(user_id, provider.name, "/settings")
+        return await client.get(
+            f"/api/v1/integrations/{provider.name}/callback",
+            params={"code": "ok", "state": state},
+            follow_redirects=False,
+        )
+
+    first = await connect(IdentityProvider("token-1", "account-1"))
+    assert first.headers["location"] == f"{PUBLIC_URL}/settings?connected=identity"
+
+    await pool.execute(
+        "UPDATE user_integrations SET account_ref = NULL WHERE user_id = $1 AND provider = $2",
+        user_id,
+        "identity",
+    )
+    same = await connect(IdentityProvider("token-2", "account-1"))
+    assert same.headers["location"] == f"{PUBLIC_URL}/settings?connected=identity"
+    assert (
+        await pool.fetchval(
+            "SELECT account_ref FROM user_integrations WHERE user_id = $1 AND provider = $2",
+            user_id,
+            "identity",
+        )
+        == "account-1"
+    )
+
+    different = await connect(IdentityProvider("token-3", "account-2"))
+    assert (
+        different.headers["location"] == f"{PUBLIC_URL}/integrations/identity"
+        "?integration_error=account_mismatch&expected=Account+account-1"
+    )
+
+    encrypted_token = await pool.fetchval(
+        "SELECT access_token_encrypted FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        user_id,
+        "identity",
+    )
+    assert (
+        integration_router.integration_fernet().decrypt(bytes(encrypted_token)).decode()
+        == "token-2"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_integration_sources.py
+++ b/backend/tests/test_integration_sources.py
@@ -18,16 +18,23 @@ import httpx
 import pytest
 
 from backend.config import settings
+from backend.integrations.asana import provider as asana_provider
 from backend.integrations.asana.indexer import _render_task
+from backend.integrations.asana.provider import AsanaIntegration
 from backend.integrations.gmail import indexer as gmail_indexer
 from backend.integrations.gmail.provider import GmailIntegration
 from backend.integrations.gong import indexer as gong_indexer
 from backend.integrations.gong.indexer import _render_call
 from backend.integrations.gong.provider import GongIntegration
+from backend.integrations.jira import provider as jira_provider
 from backend.integrations.jira.indexer import _adf_to_text, _render_issue
+from backend.integrations.jira.provider import JiraIntegration
 from backend.integrations.linear import provider as linear_provider
 from backend.integrations.linear.provider import LinearIntegration
+from backend.integrations.notion import provider as notion_provider
+from backend.integrations.notion.provider import NotionIntegration
 from backend.integrations.registry import list_providers
+from backend.integrations.slack.provider import SlackIntegration
 from backend.services import agent_runtime, prompts, source_service
 from backend.tasks import sources as source_tasks
 
@@ -322,6 +329,79 @@ async def test_gong_exchange_refresh_and_fetch_account(monkeypatch):
     account = await GongIntegration().fetch_account(refreshed.access_token)
     assert account.email is None
     assert account.display_name == "Acme"
+    assert account.account_ref == "https://company-17.api.gong.io"
+
+
+@pytest.mark.asyncio
+async def test_slack_account_uses_team_id_as_stable_identity(monkeypatch):
+    integration = SlackIntegration()
+
+    async def team_info(access_token: str):
+        assert access_token == "slack-token"
+        return {"team_id": "T123", "team_name": "Acme", "user_id": "U123"}
+
+    monkeypatch.setattr(integration, "team_info", team_info)
+
+    account = await integration.fetch_account("slack-token")
+
+    assert account.display_name == "Acme"
+    assert account.account_ref == "T123"
+
+
+@pytest.mark.parametrize(
+    ("provider_module", "integration", "payload", "expected_ref"),
+    [
+        (
+            asana_provider,
+            AsanaIntegration(),
+            {"data": {"gid": "asana-user-1", "email": "a@example.com", "name": "Ada"}},
+            "asana-user-1",
+        ),
+        (
+            jira_provider,
+            JiraIntegration(),
+            {"account_id": "jira-user-1", "email": "j@example.com", "name": "Jules"},
+            "jira-user-1",
+        ),
+        (
+            notion_provider,
+            NotionIntegration(),
+            {
+                "bot": {
+                    "workspace_id": "notion-workspace-1",
+                    "workspace_name": "Acme",
+                }
+            },
+            "notion-workspace-1",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_oauth_provider_account_uses_stable_identity(
+    monkeypatch,
+    provider_module,
+    integration,
+    payload,
+    expected_ref,
+):
+    monkeypatch.setattr(provider_module.httpx, "AsyncClient", _FakeClient(payload))
+
+    account = await integration.fetch_account("token")
+
+    assert account.account_ref == expected_ref
+
+
+@pytest.mark.asyncio
+async def test_linear_account_requests_and_returns_stable_identity(monkeypatch):
+    client = _FakeClient(
+        {"data": {"viewer": {"id": "linear-user-1", "name": "Lin", "email": "l@example.com"}}}
+    )
+    monkeypatch.setattr(linear_provider.httpx, "AsyncClient", client)
+
+    account = await LinearIntegration().fetch_account("token")
+
+    assert account.account_ref == "linear-user-1"
+    assert client.posts[0][1]["query"] == "query { viewer { id name email } }"
 
 
 @pytest.mark.asyncio
@@ -467,8 +547,8 @@ class _FakeClient:
         self.requests.append((url, params or {}))
         return self._response()
 
-    async def post(self, url, data=None, auth=None, headers=None):
-        self.posts.append((url, data or {}))
+    async def post(self, url, data=None, json=None, auth=None, headers=None):
+        self.posts.append((url, data if data is not None else json or {}))
         return self._response()
 
 


### PR DESCRIPTION
## Summary

Require generic OAuth connections to resolve a stable provider account identity before credentials are stored. Reconnects can now distinguish the same provider account from a different one for Slack, Asana, Jira, Linear, Notion, and Gong.

## Changes

- Stop treating provider profile lookup as best-effort during OAuth callbacks; failed lookup or a missing stable identity now refuses the connection without storing credentials.
- Persist stable provider identifiers for Slack teams, Asana users, Jira users, Linear users, Notion workspaces, and Gong customer API endpoints.
- Preserve existing connections whose pre-change rows have no identity anchor: their first successful reconnect records the stable identity, and subsequent account changes are rejected.
- Add callback-level regression coverage proving failed identity resolution stores no token, same-account reconnects update credentials, different-account reconnects do not overwrite credentials, and legacy rows acquire an identity anchor.
- Document the user-visible behavior in the changelog.

## Root cause

The callback treated account lookup as display-only. If lookup failed, it stored an empty account profile, and the reconnect comparison treated a missing account reference as a match. Providers that already returned stable upstream identifiers also discarded them when constructing `AccountInfo`.

## Related issues

No linked issue.

## Test plan

- [ ] Existing tests pass (`python -m pytest backend/tests/ -v`) — full local Linux run exceeded the 10-minute WSL bound; GitHub CI will run the complete suite.
- [x] New tests added.
- [x] Targeted backend tests: 43 passed.
- [x] Python lint: `ruff check backend/ cli/`.
- [x] Python format: `ruff format --check backend/ cli/`.
- [x] Migration graph: single head `0163`.
- [x] Frontend tests: 51 files, 226 tests passed.
- [x] Frontend lint: zero errors; three pre-existing unused-variable warnings.

## Checklist

- [x] No hardcoded secrets or credentials.
- [x] Documentation updated if behaviour changed.
- [x] `CHANGELOG.md` updated for the user-facing change.