### PR TITLE
Usage analytics: server-side read logging + admin content-activity dashboard

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -198,6 +198,21 @@ def _enforce_key_access(user: dict, request: Request) -> None:
     )
 
 
+def _set_request_via(request: Request, user: dict | None) -> None:
+    """Tag the request's caller surface for audit rows: 'ask' for the
+    server-side VFS's nested reads (it marks them itself), 'cli' for API-key
+    callers, 'web' for browser JWTs and anonymous reads. Analytics-grade only —
+    the X-Stash-Via header is spoofable and must never gate authorization."""
+    from .services.security_audit_service import request_via
+
+    if request.headers.get("x-stash-via") == "ask":
+        request_via.set("ask")
+    elif user is not None and user.get("key_type"):
+        request_via.set("cli")
+    else:
+        request_via.set("web")
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
@@ -210,6 +225,7 @@ async def get_current_user(
 
     user = await authenticate_token(credentials.credentials)
     _enforce_key_access(user, request)
+    _set_request_via(request, user)
     return user
 
 
@@ -246,6 +262,7 @@ async def get_current_user_optional(
     credentials: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),
 ) -> dict | None:
     if credentials is None:
+        _set_request_via(request, None)
         return None
     try:
         return await get_current_user(request, credentials)

--- a/backend/migrations/versions/0164_security_audit_via.py
+++ b/backend/migrations/versions/0164_security_audit_via.py
@@ -1,0 +1,22 @@
+"""Add via (caller surface) to security_audit_events.
+
+Tags every audit row with how the request arrived — 'web' (browser JWT or
+anonymous), 'cli' (API key), or 'ask' (ask-the-stash's nested VFS reads) — so
+the admin content-activity dashboard can split reads/searches/listings by
+source. Pre-existing rows stay NULL and are excluded from per-surface stats.
+"""
+
+from alembic import op
+
+revision = "0164"
+down_revision = "0163"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE security_audit_events ADD COLUMN via text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE security_audit_events DROP COLUMN via")

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -118,6 +118,11 @@ async def analytics_surface_mix(
     return await admin_analytics_service.get_surface_mix(days=days, bucket=bucket)
 
 
+@router.get("/analytics/content-activity", dependencies=[Depends(require_admin_token)])
+async def analytics_content_activity(days: int = Query(30, ge=1, le=180)):
+    return await admin_analytics_service.get_content_activity(days=days)
+
+
 @router.get("/analytics/top-events", dependencies=[Depends(require_admin_token)])
 async def analytics_top_events(
     days: int = Query(30, ge=1, le=180),

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -404,6 +404,12 @@ async def download_my_file(
     if not await _can_access_file(file_id, row["owner_user_id"], viewer_id):
         raise HTTPException(status_code=404, detail="File not found")
     content = await _download_storage_file_or_502(row["storage_key"], "file download")
+    await security_audit_service.record_content_read(
+        target_type="file",
+        target_id=str(file_id),
+        actor_user_id=viewer_id,
+        owner_user_id=row["owner_user_id"],
+    )
     content_type = row["content_type"] or "application/octet-stream"
     # content_type is stored verbatim from the upload, so normalize away MIME
     # parameters and casing before the SVG check — 'image/svg+xml;charset=utf-8'
@@ -442,6 +448,13 @@ async def get_my_file_text(
     )
     if not row:
         raise HTTPException(status_code=404, detail="File not found")
+    await security_audit_service.record_content_read(
+        target_type="file",
+        target_id=str(file_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "text"},
+    )
     return {
         "text": row["extracted_text"],
         "status": row["extraction_status"],

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -153,6 +153,12 @@ async def get_scope_tree(
     owner_user_id = scope_user_id
     await _check_scope_access(owner_user_id, current_user["id"])
     tree = await files_tree_service.list_scope_tree(owner_user_id, current_user["id"])
+    await security_audit_service.record_entries_listed(
+        target_type="tree",
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"result_count": len(tree["folders"]) + len(tree["pages"])},
+    )
     return ScopeTreeResponse(**tree)
 
 
@@ -163,6 +169,11 @@ async def get_memory_folder(
 ):
     """The scope's reserved Memory folder (created on first access)."""
     folder = await files_tree_service.get_or_create_memory_folder(scope_user_id, current_user["id"])
+    await security_audit_service.record_entries_listed(
+        target_type="memory_folder",
+        actor_user_id=current_user["id"],
+        owner_user_id=scope_user_id,
+    )
     return FolderResponse(**folder)
 
 
@@ -173,6 +184,12 @@ async def get_memory_tree(
     """The Memory wiki as a nested file-system tree (folders + pages), rooted
     at the caller's Memory folder. Drives the wiki browser page."""
     tree = await files_tree_service.memory_tree(current_user["id"], current_user["id"])
+    await security_audit_service.record_entries_listed(
+        target_type="memory_tree",
+        actor_user_id=current_user["id"],
+        owner_user_id=current_user["id"],
+        metadata={"result_count": len(tree["folders"]) + len(tree["pages"])},
+    )
     return ScopeTreeResponse(**tree)
 
 
@@ -660,6 +677,12 @@ async def get_page_by_id(
     page = await files_tree_service.get_page_by_id(page_id, viewer_id)
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    await security_audit_service.record_content_read(
+        target_type="page",
+        target_id=str(page_id),
+        actor_user_id=viewer_id,
+        owner_user_id=page["owner_user_id"],
+    )
     return PageResponse(**page)
 
 
@@ -677,6 +700,12 @@ async def get_page(
     page = await files_tree_service.get_page(page_id, owner_user_id, current_user["id"])
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    await security_audit_service.record_content_read(
+        target_type="page",
+        target_id=str(page_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+    )
     return PageResponse(**page)
 
 
@@ -697,6 +726,12 @@ async def download_page(
     page = await files_tree_service.get_page(page_id, owner_user_id, current_user["id"])
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    await security_audit_service.record_content_read(
+        target_type="page",
+        target_id=str(page_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+    )
     is_html = (page.get("content_type") or "").lower() == "html"
     body = (page.get("content_html") if is_html else page.get("content_markdown")) or ""
     suffix = ".html" if is_html else ".md"

--- a/backend/routers/machine.py
+++ b/backend/routers/machine.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 from starlette.websockets import WebSocketDisconnect
 
 from ..auth import authenticate_token, get_current_user
-from ..services import sprite_service
+from ..services import security_audit_service, sprite_service
 from .files import ingest_bytes
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,15 @@ async def list_machine_dir(path: str = "", current_user: dict = Depends(get_curr
         raise HTTPException(status_code=400, detail=str(e)) from e
     except sprite_service.SpriteError as e:
         raise HTTPException(status_code=502, detail=str(e)) from e
+    await security_audit_service.record_entries_listed(
+        target_type="machine",
+        actor_user_id=current_user["id"],
+        owner_user_id=current_user["id"],
+        metadata={
+            "path_hash": security_audit_service.hash_value(path),
+            "result_count": len(entries),
+        },
+    )
     return {"path": path, "entries": entries}
 
 
@@ -66,6 +75,14 @@ async def read_machine_file(path: str, current_user: dict = Depends(get_current_
         raise HTTPException(status_code=400, detail=str(e)) from e
     except sprite_service.SpriteError as e:
         raise HTTPException(status_code=502, detail=str(e)) from e
+    # Live-machine paths can carry PII, so redact like source refs.
+    await security_audit_service.record_content_read(
+        target_type="machine_file",
+        target_id=None,
+        actor_user_id=current_user["id"],
+        owner_user_id=current_user["id"],
+        metadata={"path_hash": security_audit_service.hash_value(path)},
+    )
     try:
         text = content.decode("utf-8")
         return {"path": path, "size": len(content), "text": text}

--- a/backend/routers/pastes.py
+++ b/backend/routers/pastes.py
@@ -12,7 +12,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
 
 from ..middleware import limiter
-from ..services import paste_service
+from ..services import paste_service, security_audit_service
 
 router = APIRouter(prefix="/api/v1/pastes", tags=["pastes"])
 
@@ -73,6 +73,13 @@ async def get_paste(request: Request, slug: str, format: str = ""):
     paste = await paste_service.get_paste(slug)
     if not paste:
         raise HTTPException(status_code=404, detail="Paste not found")
+    # Pastes are anonymous on both sides: no actor, no owner scope.
+    await security_audit_service.record_content_read(
+        target_type="paste",
+        target_id=slug,
+        actor_user_id=None,
+        owner_user_id=None,
+    )
     if format == "raw":
         media_type = "text/markdown" if paste["content_type"] == "markdown" else "text/plain"
         return PlainTextResponse(paste["content"], media_type=media_type)

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -128,6 +128,12 @@ async def get_skill_contents(
     owner_user_id = current_user["id"]
     folder = await _require_skill_folder(owner_user_id, folder_id, current_user["id"])
     contents = await shared_skill_service.folder_contents({"folder_id": folder_id})
+    await security_audit_service.record_content_read(
+        target_type="skill",
+        target_id=str(folder_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+    )
     return {"folder_id": str(folder_id), "folder_name": folder["name"], "contents": contents}
 
 
@@ -322,6 +328,12 @@ async def get_public_skill(
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
     contents = await shared_skill_service.folder_contents(skill, viewer_id=viewer_id)
+    await security_audit_service.record_content_read(
+        target_type="skill",
+        target_id=slug,
+        actor_user_id=viewer_id,
+        owner_user_id=skill["owner_user_id"],
+    )
 
     owner_name = skill.pop("_owner_name", "")
     folder_name = skill.pop("_folder_name", "")
@@ -368,6 +380,13 @@ async def get_public_skill_item(
     item = shared_skill_service.find_in_contents(contents, object_type, str(object_id))
     if not item:
         raise HTTPException(status_code=404, detail="Skill item not found")
+    await security_audit_service.record_content_read(
+        target_type="skill",
+        target_id=slug,
+        actor_user_id=viewer_id,
+        owner_user_id=skill["owner_user_id"],
+        metadata={"item_type": object_type, "item_id": str(object_id)},
+    )
 
     owner_name = skill.pop("_owner_name", "")
     skill.pop("_folder_name", "")

--- a/backend/routers/tables.py
+++ b/backend/routers/tables.py
@@ -24,7 +24,12 @@ from ..models import (
     TableResponse,
     TableUpdateRequest,
 )
-from ..services import permission_service, table_service, user_scope_service
+from ..services import (
+    permission_service,
+    security_audit_service,
+    table_service,
+    user_scope_service,
+)
 
 me_router = APIRouter(prefix="/api/v1/me/tables", tags=["tables"])
 router = APIRouter(prefix="/api/v1/tables", tags=["tables"])
@@ -115,6 +120,13 @@ async def get_table_by_id(
     if not table or not table.get("owner_user_id"):
         raise HTTPException(status_code=404, detail="Table not found")
     await _check_table_access(table["owner_user_id"], table_id, current_user["id"])
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=table["owner_user_id"],
+        metadata={"kind": "schema"},
+    )
     return TableResponse(**table)
 
 
@@ -152,6 +164,12 @@ async def list_ws_tables(
     owner_user_id = scope_user_id
     await _check_read(owner_user_id, current_user["id"])
     tables = await table_service.list_tables(owner_user_id, current_user["id"])
+    await security_audit_service.record_entries_listed(
+        target_type="tables",
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"result_count": len(tables)},
+    )
     return TableListResponse(tables=[TableResponse(**t) for t in tables])
 
 
@@ -165,6 +183,13 @@ async def get_ws_table(
     await _check_read(owner_user_id, current_user["id"])
     table = await _check_ws_table(owner_user_id, table_id, with_row_count=True)
     await _check_table_access(owner_user_id, table_id, current_user["id"])
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "schema"},
+    )
     return TableResponse(**table)
 
 
@@ -311,6 +336,13 @@ async def list_ws_rows(
         limit=limit,
         offset=offset,
     )
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "rows"},
+    )
     return RowListResponse(
         rows=[RowResponse(**r) for r in rows],
         total_count=total,
@@ -370,6 +402,13 @@ async def semantic_search_ws_rows(
     if query_embedding is None:
         raise HTTPException(status_code=500, detail="Failed to embed query")
     rows = await table_service.search_rows_vector(table_id, query_embedding, limit)
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "search"},
+    )
     return {"rows": rows}
 
 
@@ -511,6 +550,13 @@ async def export_ws_csv(
         sort_by=sort_by,
         sort_order=sort_order,
     )
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "export"},
+    )
     cols = sorted(table["columns"], key=lambda c: c.get("order", 0))
 
     def generate():
@@ -551,6 +597,13 @@ async def search_ws_rows(
     await _check_ws_table(owner_user_id, table_id)
     await _check_table_access(owner_user_id, table_id, current_user["id"])
     rows, total = await table_service.search_rows(table_id, q, limit=limit, offset=offset)
+    await security_audit_service.record_content_read(
+        target_type="table",
+        target_id=str(table_id),
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "search"},
+    )
     return RowListResponse(
         rows=[RowResponse(**r) for r in rows],
         total_count=total,

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -22,6 +22,7 @@ from ..auth import get_current_user, get_scope
 from ..database import get_pool
 from ..services import (
     memory_service,
+    security_audit_service,
     session_folder_service,
     session_service,
     transcript_import,
@@ -238,6 +239,12 @@ async def get_transcript_events(
             owner_user_id, session_id, limit, offset
         )
         if total:
+            await security_audit_service.record_content_read(
+                target_type="transcript",
+                target_id=session_id,
+                actor_user_id=current_user["id"],
+                owner_user_id=owner_user_id,
+            )
             return {
                 "events": _events_to_viewer_shape(events),
                 "total": total,
@@ -259,7 +266,14 @@ async def export_transcript_jsonl(
     resolved = await _resolve_readable_events(session_id, current_user["id"])
     if not resolved:
         raise HTTPException(status_code=404, detail="Transcript not found")
-    _, events = resolved
+    owner_user_id, events = resolved
+    await security_audit_service.record_content_read(
+        target_type="transcript",
+        target_id=session_id,
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"kind": "export"},
+    )
 
     lines: list[str] = []
     for ev in events:

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -19,6 +19,7 @@ from ..services import (
     llm,
     memory_service,
     permission_service,
+    security_audit_service,
     session_title_service,
     skill_service,
     sprite_service,
@@ -324,6 +325,12 @@ async def get_scope_overview(
         _files_tree(owner_user_id, current_user["id"]),
         _list_sidebar_skills(owner_user_id, current_user["id"]),
         sprite_service.existing(owner_user_id),
+    )
+    await security_audit_service.record_entries_listed(
+        target_type="overview",
+        actor_user_id=current_user["id"],
+        owner_user_id=owner_user_id,
+        metadata={"result_count": len(sessions) + len(files) + len(skills)},
     )
     # The VFS mounts /computer only when a machine exists — checking must not
     # provision one, so this is a row lookup, never a sprites API call.

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -241,3 +241,101 @@ async def get_summary(*, days: int = 7) -> dict:
         "cli_active_users": int(cli_active or 0),
         "generated_at": datetime.now(UTC).isoformat(),
     }
+
+
+# Read/search/listing actions written to security_audit_events by
+# record_content_read / record_entries_listed and source_service's
+# _audit_source_read. The dashboard's content-activity segment is a straight
+# aggregation of these — extend the lists when a new content action ships.
+CONTENT_READ_ACTIONS = [
+    "content.page_read",
+    "content.file_read",
+    "content.transcript_read",
+    "content.table_read",
+    "content.skill_read",
+    "content.machine_file_read",
+    "content.paste_read",
+    "source.document_read",
+]
+SEARCH_ACTION = "source.searched"
+LISTING_ACTIONS = [
+    "content.entries_listed",
+    "source.entries_listed",
+    "source.tree_listed",
+]
+
+
+# Caller surfaces stamped on audit rows by auth._set_request_via. Web reads
+# and listings are UI noise (sidebar refetches, page opens while editing), so
+# only web *searches* count; cli and ask count for everything. Untagged rows
+# (pre-`via` history, anonymous pastes) are excluded.
+ACTIVITY_SURFACES = {
+    "reads": ["cli", "ask"],
+    "searches": ["web", "cli", "ask"],
+    "listings": ["cli", "ask"],
+}
+
+
+async def get_content_activity(*, days: int = 30) -> dict:
+    """Document reads, searches, and listings split by caller surface (web /
+    cli / ask-the-stash), from the security_audit_events read trail: totals
+    over the window plus a daily series for the dashboard's top segment."""
+    pool = get_pool()
+    since = datetime.now(UTC) - timedelta(days=days)
+    all_actions = CONTENT_READ_ACTIONS + [SEARCH_ACTION] + LISTING_ACTIONS
+
+    kind_case = """
+        CASE
+            WHEN action = $2 THEN 'searches'
+            WHEN action = ANY($3::text[]) THEN 'listings'
+            ELSE 'reads'
+        END
+    """
+    counted = """
+        action = ANY($1::text[])
+        AND created_at >= $4
+        AND (via IN ('cli', 'ask') OR (via = 'web' AND action = $2))
+    """
+
+    total_rows = await pool.fetch(
+        f"""
+        SELECT {kind_case} AS kind, via, COUNT(*) AS n
+        FROM security_audit_events
+        WHERE {counted}
+        GROUP BY 1, 2
+        """,
+        all_actions,
+        SEARCH_ACTION,
+        LISTING_ACTIONS,
+        since,
+    )
+    totals = {
+        kind: {surface: 0 for surface in surfaces} for kind, surfaces in ACTIVITY_SURFACES.items()
+    }
+    for r in total_rows:
+        totals[r["kind"]][r["via"]] = int(r["n"])
+
+    series_rows = await pool.fetch(
+        f"""
+        SELECT date_trunc('day', created_at) AS ts,
+               {kind_case} AS kind,
+               COUNT(*) AS n
+        FROM security_audit_events
+        WHERE {counted}
+        GROUP BY 1, 2
+        ORDER BY ts ASC
+        """,
+        all_actions,
+        SEARCH_ACTION,
+        LISTING_ACTIONS,
+        since,
+    )
+    return {
+        "days": days,
+        "totals": totals,
+        "rows": [
+            {"ts": r["ts"].isoformat(), "kind": r["kind"], "count": int(r["n"])}
+            for r in series_rows
+        ],
+        "generated_at": datetime.now(UTC).isoformat(),
+    }

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -315,14 +315,17 @@ async def get_content_activity(*, days: int = 30) -> dict:
     for r in total_rows:
         totals[r["kind"]][r["via"]] = int(r["n"])
 
+    # via is carried per row so the dashboard's chart can filter by source
+    # client-side; the client sums across surfaces for its combined view.
     series_rows = await pool.fetch(
         f"""
         SELECT date_trunc('day', created_at) AS ts,
                {kind_case} AS kind,
+               via,
                COUNT(*) AS n
         FROM security_audit_events
         WHERE {counted}
-        GROUP BY 1, 2
+        GROUP BY 1, 2, 3
         ORDER BY ts ASC
         """,
         all_actions,
@@ -334,7 +337,7 @@ async def get_content_activity(*, days: int = 30) -> dict:
         "days": days,
         "totals": totals,
         "rows": [
-            {"ts": r["ts"].isoformat(), "kind": r["kind"], "count": int(r["n"])}
+            {"ts": r["ts"].isoformat(), "kind": r["kind"], "via": r["via"], "count": int(r["n"])}
             for r in series_rows
         ],
         "generated_at": datetime.now(UTC).isoformat(),

--- a/backend/services/security_audit_service.py
+++ b/backend/services/security_audit_service.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from contextvars import ContextVar
 from uuid import UUID
 
 from ..config import settings
 from ..database import get_pool
+
+# The caller surface of the current request — 'web', 'cli', or 'ask' — set by
+# auth on every authenticated request and stamped onto each audit row. A
+# contextvar (not a parameter) so the many record_event call sites don't all
+# have to thread a Request through. None (e.g. the anonymous paste route)
+# stores NULL, which the per-surface dashboard excludes.
+request_via: ContextVar[str | None] = ContextVar("request_via", default=None)
 
 
 def hash_value(value: str | None) -> str | None:
@@ -29,6 +37,7 @@ def _event_row(row) -> dict:
         "owner_user_id": str(row["owner_user_id"]) if row["owner_user_id"] else None,
         "actor_user_id": str(row["actor_user_id"]) if row["actor_user_id"] else None,
         "action": row["action"],
+        "via": row["via"],
         "target_type": row["target_type"],
         "target_id": row["target_id"],
         "provider": row["provider"],
@@ -53,9 +62,9 @@ async def record_event(
         """
         INSERT INTO security_audit_events (
             owner_user_id, actor_user_id, action, target_type, target_id,
-            provider, source_type, metadata
+            provider, source_type, metadata, via
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
         """,
         owner_user_id,
         actor_user_id,
@@ -65,6 +74,7 @@ async def record_event(
         provider,
         source_type,
         json.dumps(metadata or {}),
+        request_via.get(),
     )
 
 

--- a/backend/services/security_audit_service.py
+++ b/backend/services/security_audit_service.py
@@ -87,6 +87,47 @@ async def record_content_lifecycle_event(
     )
 
 
+async def record_content_read(
+    *,
+    target_type: str,
+    target_id: str | None,
+    actor_user_id: UUID | None,
+    owner_user_id: UUID | None,
+    metadata: dict | None = None,
+) -> None:
+    """Read trail for native content (pages, files, transcripts, tables, ...).
+
+    Connected-source reads are audited separately in source_service
+    (source.document_read); together the two cover every document read.
+    actor_user_id is None for anonymous public-link reads."""
+    await record_event(
+        action=f"content.{target_type}_read",
+        actor_user_id=actor_user_id,
+        owner_user_id=owner_user_id,
+        target_type=target_type,
+        target_id=target_id,
+        metadata=metadata,
+    )
+
+
+async def record_entries_listed(
+    *,
+    target_type: str,
+    actor_user_id: UUID,
+    owner_user_id: UUID,
+    metadata: dict | None = None,
+) -> None:
+    """Listing trail for native content (tree, overview, tables, ...) —
+    parallel to source.entries_listed for connected sources."""
+    await record_event(
+        action="content.entries_listed",
+        actor_user_id=actor_user_id,
+        owner_user_id=owner_user_id,
+        target_type=target_type,
+        metadata=metadata,
+    )
+
+
 async def record_user_event(
     *,
     action: str,

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -176,7 +176,9 @@ async def run_vfs_script(app, authorization: str, script: str, cwd: str) -> dict
     async with httpx.AsyncClient(
         transport=transport,
         base_url="http://vfs.internal",
-        headers={"Authorization": authorization},
+        # X-Stash-Via tags nested reads as ask-the-stash traffic in the audit
+        # trail (see auth._set_request_via).
+        headers={"Authorization": authorization, "X-Stash-Via": "ask"},
         timeout=None,
     ) as http:
         return await anyio.to_thread.run_sync(
@@ -200,7 +202,9 @@ async def resolve_vfs_path(app, authorization: str, path: str) -> dict:
     async with httpx.AsyncClient(
         transport=transport,
         base_url="http://vfs.internal",
-        headers={"Authorization": authorization},
+        # X-Stash-Via tags nested reads as ask-the-stash traffic in the audit
+        # trail (see auth._set_request_via).
+        headers={"Authorization": authorization, "X-Stash-Via": "ask"},
         timeout=None,
     ) as http:
         return await anyio.to_thread.run_sync(functools.partial(_resolve_node, http, loop, path))

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -471,6 +471,14 @@ async def test_content_activity_splits_by_surface_and_drops_web_reads(client: As
     for r in body["rows"]:
         by_kind[r["kind"]] = by_kind.get(r["kind"], 0) + r["count"]
     assert by_kind == {"reads": 2, "searches": 2, "listings": 1}
+    # Rows carry the surface so the dashboard chart can filter by source.
+    assert {(r["kind"], r["via"]) for r in body["rows"]} == {
+        ("reads", "cli"),
+        ("reads", "ask"),
+        ("searches", "web"),
+        ("searches", "cli"),
+        ("listings", "cli"),
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -7,6 +7,7 @@ Covers:
 """
 
 import json
+from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
@@ -171,6 +172,7 @@ async def test_admin_endpoints_require_token(client: AsyncClient):
         "/api/v1/admin/analytics/path-mix",
         "/api/v1/admin/analytics/surface-mix",
         "/api/v1/admin/analytics/top-events",
+        "/api/v1/admin/analytics/content-activity",
     ]:
         resp = await client.get(path)
         assert resp.status_code == 401, f"{path} should require admin token"
@@ -389,6 +391,86 @@ async def test_summary_counts_signups_and_cli_active(client: AsyncClient):
     assert body["signups"] >= 1
     assert body["cli_active_users"] == 1  # one distinct user, regardless of cmd count
     assert body["active_users"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_content_activity_zero_state(client: AsyncClient):
+    resp = await client.get("/api/v1/admin/analytics/content-activity", headers=_admin())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["totals"] == {
+        "reads": {"cli": 0, "ask": 0},
+        "searches": {"web": 0, "cli": 0, "ask": 0},
+        "listings": {"cli": 0, "ask": 0},
+    }
+    assert body["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_content_activity_splits_by_surface_and_drops_web_reads(client: AsyncClient):
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("activity"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    api_key, user_id = body["api_key"], UUID(body["id"])
+
+    # API-key traffic tags as 'cli': one page read + the tree listing.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Activity.md", "content": "x"},
+        headers=_auth(api_key),
+    )
+    page_id = resp.json()["id"]
+    assert (
+        await client.get(f"/api/v1/me/pages/{page_id}", headers=_auth(api_key))
+    ).status_code == 200
+    assert (await client.get("/api/v1/me/tree", headers=_auth(api_key))).status_code == 200
+
+    # Directly seeded rows stand in for the other surfaces.
+    security_audit_service.request_via.set("ask")
+    await security_audit_service.record_content_read(
+        target_type="page", target_id="p1", actor_user_id=user_id, owner_user_id=user_id
+    )
+    security_audit_service.request_via.set("web")
+    await security_audit_service.record_content_read(  # web read: must NOT count
+        target_type="page", target_id="p2", actor_user_id=user_id, owner_user_id=user_id
+    )
+    await security_audit_service.record_entries_listed(  # web listing: must NOT count
+        target_type="tree", actor_user_id=user_id, owner_user_id=user_id
+    )
+    await security_audit_service.record_event(  # web search: counts
+        action="source.searched",
+        actor_user_id=user_id,
+        owner_user_id=user_id,
+        target_type="source_collection",
+    )
+    security_audit_service.request_via.set("cli")
+    await security_audit_service.record_event(
+        action="source.searched",
+        actor_user_id=user_id,
+        owner_user_id=user_id,
+        target_type="source_collection",
+    )
+    security_audit_service.request_via.set(None)
+    await security_audit_service.record_content_read(  # untagged legacy row: excluded
+        target_type="page", target_id="p3", actor_user_id=user_id, owner_user_id=user_id
+    )
+
+    resp = await client.get(
+        "/api/v1/admin/analytics/content-activity?days=30",
+        headers=_admin(),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["totals"]["reads"] == {"cli": 1, "ask": 1}
+    assert body["totals"]["searches"] == {"web": 1, "cli": 1, "ask": 0}
+    assert body["totals"]["listings"] == {"cli": 1, "ask": 0}
+    by_kind: dict[str, int] = {}
+    for r in body["rows"]:
+        by_kind[r["kind"]] = by_kind.get(r["kind"], 0) + r["count"]
+    assert by_kind == {"reads": 2, "searches": 2, "listings": 1}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_content_read_audit.py
+++ b/backend/tests/test_content_read_audit.py
@@ -70,6 +70,7 @@ async def test_page_read_is_logged(client: AsyncClient, pool):
     assert rows[0]["owner_user_id"] == user_id
     assert rows[0]["target_type"] == "page"
     assert rows[0]["target_id"] == page_id
+    assert rows[0]["via"] == "cli"
 
 
 async def test_public_page_read_logs_anonymous_actor(client: AsyncClient, pool):
@@ -90,6 +91,7 @@ async def test_public_page_read_logs_anonymous_actor(client: AsyncClient, pool):
     assert rows[0]["actor_user_id"] is None
     assert rows[0]["owner_user_id"] == user_id
     assert rows[0]["target_id"] == page_id
+    assert rows[0]["via"] == "web"
 
 
 async def test_source_front_door_page_read_logs_exactly_once(client: AsyncClient, pool):
@@ -127,6 +129,7 @@ async def test_vfs_cat_logs_page_read(client: AsyncClient, pool):
     rows = await _read_events(pool, "content.page_read")
     assert len(rows) == 1
     assert rows[0]["actor_user_id"] == user_id
+    assert rows[0]["via"] == "ask"
 
 
 async def test_tree_listing_is_logged(client: AsyncClient, pool):

--- a/backend/tests/test_content_read_audit.py
+++ b/backend/tests/test_content_read_audit.py
@@ -1,0 +1,172 @@
+"""Native content reads land in security_audit_events.
+
+Connected-source reads were already audited (source.document_read); these
+tests pin the new content.* trail: every native document read and listing
+writes exactly one row with the actor, the owning scope, and the target —
+the raw feed for the usage-analytics page.
+"""
+
+import json
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import source_service
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("readaudit"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _make_page(client: AsyncClient, api_key: str, name: str, content: str) -> str:
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": name, "content": content},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _metadata(row) -> dict:
+    # record_event json.dumps() into a jsonb column whose codec encodes again,
+    # so raw fetches see a JSON string — same decode the service's reader does.
+    metadata = row["metadata"]
+    return json.loads(metadata) if isinstance(metadata, str) else metadata
+
+
+async def _read_events(pool, action: str) -> list:
+    return await pool.fetch(
+        "SELECT * FROM security_audit_events WHERE action = $1 ORDER BY created_at",
+        action,
+    )
+
+
+async def test_page_read_is_logged(client: AsyncClient, pool):
+    api_key, user_id = await _register(client)
+    page_id = await _make_page(client, api_key, "Notes.md", "hello")
+
+    resp = await client.get(f"/api/v1/me/pages/{page_id}", headers=_auth(api_key))
+    assert resp.status_code == 200
+
+    rows = await _read_events(pool, "content.page_read")
+    assert len(rows) == 1
+    assert rows[0]["actor_user_id"] == user_id
+    assert rows[0]["owner_user_id"] == user_id
+    assert rows[0]["target_type"] == "page"
+    assert rows[0]["target_id"] == page_id
+
+
+async def test_public_page_read_logs_anonymous_actor(client: AsyncClient, pool):
+    api_key, user_id = await _register(client)
+    page_id = await _make_page(client, api_key, "Public.md", "shared with the world")
+    resp = await client.patch(
+        "/api/v1/share/general-access",
+        json={"object_type": "page", "object_id": page_id, "public_permission": "read"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/api/v1/pages/{page_id}")
+    assert resp.status_code == 200
+
+    rows = await _read_events(pool, "content.page_read")
+    assert len(rows) == 1
+    assert rows[0]["actor_user_id"] is None
+    assert rows[0]["owner_user_id"] == user_id
+    assert rows[0]["target_id"] == page_id
+
+
+async def test_source_front_door_page_read_logs_exactly_once(client: AsyncClient, pool):
+    """A native page read via /sources/files/doc must produce one
+    source.document_read row and no content.page_read row — the front door
+    calls the service layer directly, so the page route never fires."""
+    api_key, _ = await _register(client)
+    page_id = await _make_page(client, api_key, "ViaSource.md", "front door")
+
+    resp = await client.get(
+        f"/api/v1/me/sources/{source_service.NATIVE_FILES}/doc",
+        params={"ref": page_id},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    assert len(await _read_events(pool, "source.document_read")) == 1
+    assert len(await _read_events(pool, "content.page_read")) == 0
+
+
+async def test_vfs_cat_logs_page_read(client: AsyncClient, pool):
+    """The server-side VFS re-enters the REST routes over nested ASGI, so an
+    ask-the-stash `cat` shows up in the read trail like any other caller."""
+    api_key, user_id = await _register(client)
+    await _make_page(client, api_key, "Runbook.md", "step one")
+
+    resp = await client.post(
+        "/api/v1/me/vfs",
+        json={"script": "cat '/files/Runbook.md'", "cwd": "/"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+    rows = await _read_events(pool, "content.page_read")
+    assert len(rows) == 1
+    assert rows[0]["actor_user_id"] == user_id
+
+
+async def test_tree_listing_is_logged(client: AsyncClient, pool):
+    api_key, user_id = await _register(client)
+    await _make_page(client, api_key, "One.md", "x")
+
+    resp = await client.get("/api/v1/me/tree", headers=_auth(api_key))
+    assert resp.status_code == 200
+
+    rows = await _read_events(pool, "content.entries_listed")
+    tree_rows = [r for r in rows if r["target_type"] == "tree"]
+    assert len(tree_rows) == 1
+    assert tree_rows[0]["actor_user_id"] == user_id
+    assert _metadata(tree_rows[0])["result_count"] >= 1
+
+
+async def test_transcript_export_is_logged(client: AsyncClient, pool):
+    api_key, user_id = await _register(client)
+    session_id = "read-audit-session"
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "session_id": session_id,
+            "agent_name": "tester",
+            "event_type": "user_message",
+            "content": "hi",
+            "created_at": "2026-01-02T00:00:00Z",
+        },
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201, resp.text
+
+    resp = await client.get(
+        f"/api/v1/me/transcripts/{session_id}/export.jsonl",
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+
+    rows = await _read_events(pool, "content.transcript_read")
+    assert len(rows) == 1
+    assert rows[0]["actor_user_id"] == user_id
+    assert rows[0]["target_id"] == session_id
+    assert _metadata(rows[0]) == {"kind": "export"}

--- a/www/app/admin/analytics/AnalyticsClient.tsx
+++ b/www/app/admin/analytics/AnalyticsClient.tsx
@@ -326,6 +326,14 @@ const SURFACE_LABELS: Record<string, string> = {
   ask: "Ask the stash",
 };
 
+// Fixed per-kind chart colors: the shared PALETTE is all greens, which made
+// listings indistinguishable from reads/searches. Light orange for listings.
+const ACTIVITY_COLORS: Record<(typeof ACTIVITY_KINDS)[number], string> = {
+  reads: PALETTE[0],
+  searches: PALETTE[1],
+  listings: "#fdba74",
+};
+
 function ContentActivitySection({
   activity,
 }: {
@@ -384,12 +392,14 @@ function ContentActivitySection({
           <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
           <Tooltip />
           <Legend />
-          {ACTIVITY_KINDS.map((kind, i) => (
+          {ACTIVITY_KINDS.map((kind) => (
             <Line
               key={kind}
-              type="monotone"
+              // linear, not monotone: smoothed curves imply activity between
+              // days that never happened
+              type="linear"
               dataKey={kind}
-              stroke={PALETTE[i % PALETTE.length]}
+              stroke={ACTIVITY_COLORS[kind]}
               strokeWidth={2}
               dot={false}
               isAnimationActive={false}

--- a/www/app/admin/analytics/AnalyticsClient.tsx
+++ b/www/app/admin/analytics/AnalyticsClient.tsx
@@ -49,6 +49,18 @@ export type CohortResponse = {
   generated_at: string;
 };
 
+type ContentActivityRow = { ts: string; kind: string; count: number };
+type ContentActivityResponse = {
+  days: number;
+  totals: {
+    reads: { cli: number; ask: number };
+    searches: { web: number; cli: number; ask: number };
+    listings: { cli: number; ask: number };
+  };
+  rows: ContentActivityRow[];
+  generated_at: string;
+};
+
 type SummaryResponse = {
   days: number;
   signups: number;
@@ -85,6 +97,7 @@ type TopEventsRow = { event_name: string; total: number; users: number };
 type TopEventsResponse = { days: number; rows: TopEventsRow[] };
 
 export type AnalyticsPayload = {
+  contentActivity: ContentActivityResponse;
   summary: SummaryResponse;
   funnel: FunnelResponse;
   pathMix: PathMixResponse;
@@ -252,6 +265,7 @@ export default function AnalyticsClient({
           />
         </div>
 
+        <ContentActivitySection activity={data.contentActivity} />
         <SummarySection summary={data.summary} />
         <FunnelSection
           funnel={data.funnel}
@@ -288,6 +302,102 @@ function GeneratedAt({ iso }: { iso: string }) {
     <span className="text-[11px] text-gray-400" suppressHydrationWarning>
       generated {pretty ?? iso}
     </span>
+  );
+}
+
+// ---- Section 0: Content activity (docs read / searches / listings) ----
+
+const ACTIVITY_KINDS = ["reads", "searches", "listings"] as const;
+
+const ACTIVITY_LABELS: Record<(typeof ACTIVITY_KINDS)[number], string> = {
+  reads: "Docs read",
+  searches: "Searches",
+  listings: "Listings",
+};
+
+// Web reads/listings are UI noise and aren't counted server-side, so those
+// kinds only ever carry cli + ask surfaces. Fixed render order keeps each
+// grid column a single source (web last, since only searches carry it).
+const SURFACE_ORDER = ["cli", "ask", "web"] as const;
+
+const SURFACE_LABELS: Record<string, string> = {
+  web: "Web",
+  cli: "CLI",
+  ask: "Ask the stash",
+};
+
+function ContentActivitySection({
+  activity,
+}: {
+  activity: ContentActivityResponse;
+}) {
+  const chartData = useMemo(() => {
+    const { data } = pivot(
+      activity.rows,
+      (r) => r.kind,
+      (r) => r.count,
+    );
+    // pivot only zero-fills kinds it has seen; a kind with no rows in the
+    // window would otherwise vanish from the tooltip instead of reading 0.
+    for (const row of data) {
+      for (const kind of ACTIVITY_KINDS) {
+        if (row[kind] == null) row[kind] = 0;
+      }
+    }
+    return data;
+  }, [activity.rows]);
+
+  return (
+    <div className="mt-6 space-y-6">
+      <h2 className="text-base font-semibold text-gray-800">
+        Content activity
+      </h2>
+
+      {ACTIVITY_KINDS.map((kind) => {
+        const totals: Record<string, number> = activity.totals[kind];
+        return (
+          <div key={kind} className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {SURFACE_ORDER.filter((surface) => surface in totals).map(
+              (surface) => (
+                <Stat
+                  key={`${kind}-${surface}`}
+                  label={`${ACTIVITY_LABELS[kind]} — ${SURFACE_LABELS[surface]} (${activity.days}d)`}
+                  value={totals[surface]}
+                />
+              ),
+            )}
+          </div>
+        );
+      })}
+
+      <ChartCard
+        title={`Daily reads, searches & listings — last ${activity.days}d`}
+        height={280}
+      >
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 10 }}
+            interval="preserveStartEnd"
+          />
+          <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+          <Tooltip />
+          <Legend />
+          {ACTIVITY_KINDS.map((kind, i) => (
+            <Line
+              key={kind}
+              type="monotone"
+              dataKey={kind}
+              stroke={PALETTE[i % PALETTE.length]}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ChartCard>
+    </div>
   );
 }
 

--- a/www/app/admin/analytics/AnalyticsClient.tsx
+++ b/www/app/admin/analytics/AnalyticsClient.tsx
@@ -49,7 +49,12 @@ export type CohortResponse = {
   generated_at: string;
 };
 
-type ContentActivityRow = { ts: string; kind: string; count: number };
+type ContentActivityRow = {
+  ts: string;
+  kind: string;
+  via: string;
+  count: number;
+};
 type ContentActivityResponse = {
   days: number;
   totals: {
@@ -334,14 +339,28 @@ const ACTIVITY_COLORS: Record<(typeof ACTIVITY_KINDS)[number], string> = {
   listings: "#fdba74",
 };
 
+const CHART_SURFACE_OPTS = [
+  { value: "all", label: "All" },
+  { value: "cli", label: "CLI" },
+  { value: "ask", label: "Ask the stash" },
+  { value: "web", label: "Web" },
+] as const;
+
 function ContentActivitySection({
   activity,
 }: {
   activity: ContentActivityResponse;
 }) {
+  // Chart-only source filter; the stat cards always show every surface.
+  const [chartSurface, setChartSurface] = useState("all");
+
   const chartData = useMemo(() => {
+    const rows =
+      chartSurface === "all"
+        ? activity.rows
+        : activity.rows.filter((r) => r.via === chartSurface);
     const { data } = pivot(
-      activity.rows,
+      rows,
       (r) => r.kind,
       (r) => r.count,
     );
@@ -353,7 +372,7 @@ function ContentActivitySection({
       }
     }
     return data;
-  }, [activity.rows]);
+  }, [activity.rows, chartSurface]);
 
   return (
     <div className="mt-6 space-y-6">
@@ -381,6 +400,14 @@ function ContentActivitySection({
       <ChartCard
         title={`Daily reads, searches & listings — last ${activity.days}d`}
         height={280}
+        controls={
+          <Toggle
+            label=""
+            value={chartSurface}
+            options={CHART_SURFACE_OPTS}
+            onChange={setChartSurface}
+          />
+        }
       >
         <LineChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/www/app/admin/analytics/page.tsx
+++ b/www/app/admin/analytics/page.tsx
@@ -79,8 +79,12 @@ export default async function AnalyticsAdminPage({
 
   // All four payloads + cohorts fetched in parallel — same admin secret on
   // every request, single network round-trip from the user's perspective.
-  const [summary, funnel, pathMix, surfaceMix, topEvents, cohorts] =
+  const [contentActivity, summary, funnel, pathMix, surfaceMix, topEvents, cohorts] =
     await Promise.all([
+      fetchJSON(
+        fmt("/api/v1/admin/analytics/content-activity", { days: windowDays }),
+        token,
+      ),
       fetchJSON(fmt("/api/v1/admin/analytics/summary", { days: 7 }), token),
       fetchJSON(
         fmt("/api/v1/admin/analytics/onboarding-funnel", {
@@ -121,6 +125,7 @@ export default async function AnalyticsAdminPage({
     ]);
 
   for (const [name, v] of [
+    ["content-activity", contentActivity],
     ["summary", summary],
     ["onboarding-funnel", funnel],
     ["path-mix", pathMix],
@@ -134,6 +139,7 @@ export default async function AnalyticsAdminPage({
   }
 
   const payload: AnalyticsPayload = {
+    contentActivity: contentActivity as AnalyticsPayload["contentActivity"],
     summary: summary as AnalyticsPayload["summary"],
     funnel: funnel as AnalyticsPayload["funnel"],
     pathMix: pathMix as AnalyticsPayload["pathMix"],


### PR DESCRIPTION
## Changes
Added analytics. Reads, searches, and listings are logged through the backend and fed to an admin dashboard that can show how many of each action were performed by all users (in aggregate), and differentiate between calls to the CLI, usage in ask-the-stash, and web searches.

## What (LLM-written beyond this point)

Server-guaranteed usage analytics for Stash: every document read, search, and listing is now logged backend-side (no client opt-out), and a new **Content activity** segment at the top of `/admin/analytics` surfaces the numbers split by caller surface.

### Logging (`security_audit_events`)
- New `content.*_read` events at every native content-serving route — pages (incl. anonymous public-link reads), file downloads/text, transcripts, tables (schema/rows/search/export), skills, machine files, pastes — plus `content.entries_listed` for native listings (tree, overview, memory, tables, machine `ls`). Connected-source reads/searches/listings were already audited (`source.*`); together the two trails cover every read.
- One row per read, guaranteed: the source front door calls the service layer directly, so router hooks never double-log; CLI, web, and ask-the-stash all funnel through the same REST routes (server VFS re-enters over nested ASGI).
- New `via` column (migration `0164`) stamps the caller surface at auth time: `ask` (marked nested VFS requests), `cli` (API keys), `web` (JWT/anonymous). One classification point in `auth.py` feeding a contextvar — no audit call sites changed. Analytics-grade only; never used for authorization.

### Admin dashboard (`www` `/admin/analytics`)
- New top segment: per-surface stat cards (docs read / searches / listings × CLI / ask-the-stash / web) driven by the page's existing 7d/30d/90d window toggle, columns aligned by source.
- Web reads/listings are excluded (sidebar refetches are UI noise); web searches count. Untagged pre-`via` rows are excluded from per-surface stats.
- Daily chart with straight (linear) segments, light-orange listings line, and a source filter chip (All / CLI / Ask the stash / Web).
- Backend: `GET /api/v1/admin/analytics/content-activity` (admin-token-gated), aggregating with the table's existing `(action, created_at)` index.

## Screenshots

Per-surface stat cards, columns aligned by source:

<img src="https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/c56322cc-809b-4768-b4e4-0f8c245d73a9/809fa3ae829d/screenshot-1784845469358-5.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=1ab0d01cd44f96f480be9e227d6057f6%2F20260723%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260723T224407Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=39211aec16bac64e905a5a13e6e296c126226c5492de4c442571ccf48edf6d44" width="900">

Daily chart — straight segments, orange listings, source chip (seeded multi-day QA data):

<img src="https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/c56322cc-809b-4768-b4e4-0f8c245d73a9/80c6e5b60e95/screenshot-1784846392214-7.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=1ab0d01cd44f96f480be9e227d6057f6%2F20260723%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260723T224408Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=88ef444480a052d6c2ff362dc9dc06142c5b39bfdd6e657c92abb1e49a31d18d" width="900">

Chart filtered to ask-the-stash via the chip:

<img src="https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/c56322cc-809b-4768-b4e4-0f8c245d73a9/0edd4540a923/screenshot-1784846411778-8.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=1ab0d01cd44f96f480be9e227d6057f6%2F20260723%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260723T224409Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=1763d23527ee4fda9caf7655546ea56a38e2f98d2e30ded6c1eab6d365bd9e7b" width="900">

## Testing

- `pytest backend/tests/` — 932 passed (includes new suites: `test_content_read_audit.py` for per-route logging, no-double-count, nested-ASGI coverage, and `via` classification; `test_analytics.py` for the endpoint shape, surface split, web-read exclusion, and admin-token gate).
- `ruff check` + `format` clean; `www` lint (pre-existing warnings only) and build pass.
- Live QA against the local stack: CLI reads/searches/listings landed in `cli`, ask-the-stash `cat` in `ask` (mount-refresh listings included), untagged legacy rows excluded; chip filtering verified in-browser.

Note for deploy: migration `0164` applies automatically at backend boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
