### PR TITLE
audit: tag automated reads so analytics count only intentional ones

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -200,13 +200,16 @@ def _enforce_key_access(user: dict, request: Request) -> None:
 
 def _set_request_via(request: Request, user: dict | None) -> None:
     """Tag the request's caller surface for audit rows: 'ask' for the
-    server-side VFS's nested reads (it marks them itself), 'cli' for API-key
-    callers, 'web' for browser JWTs and anonymous reads. Analytics-grade only —
-    the X-Stash-Via header is spoofable and must never gate authorization."""
+    server-side VFS's nested reads (it marks them itself), 'auto' for
+    automated machinery (skills sync, plugin hooks — reads nobody asked for,
+    excluded from content-activity analytics), 'cli' for API-key callers,
+    'web' for browser JWTs and anonymous reads. Analytics-grade only — the
+    X-Stash-Via header is spoofable and must never gate authorization."""
     from .services.security_audit_service import request_via
 
-    if request.headers.get("x-stash-via") == "ask":
-        request_via.set("ask")
+    marker = request.headers.get("x-stash-via")
+    if marker in ("ask", "auto"):
+        request_via.set(marker)
     elif user is not None and user.get("key_type"):
         request_via.set("cli")
     else:

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -268,7 +268,9 @@ LISTING_ACTIONS = [
 # Caller surfaces stamped on audit rows by auth._set_request_via. Web reads
 # and listings are UI noise (sidebar refetches, page opens while editing), so
 # only web *searches* count; cli and ask count for everything. Untagged rows
-# (pre-`via` history, anonymous pastes) are excluded.
+# (pre-`via` history, anonymous pastes) are excluded, as are 'auto' rows —
+# automated machinery like the session-start skills sync, which reads content
+# nobody asked to see.
 ACTIVITY_SURFACES = {
     "reads": ["cli", "ask"],
     "searches": ["web", "cli", "ask"],

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -453,6 +453,10 @@ async def test_content_activity_splits_by_surface_and_drops_web_reads(client: As
         owner_user_id=user_id,
         target_type="source_collection",
     )
+    security_audit_service.request_via.set("auto")
+    await security_audit_service.record_content_read(  # automated read: must NOT count
+        target_type="skill", target_id="s1", actor_user_id=user_id, owner_user_id=user_id
+    )
     security_audit_service.request_via.set(None)
     await security_audit_service.record_content_read(  # untagged legacy row: excluded
         target_type="page", target_id="p3", actor_user_id=user_id, owner_user_id=user_id

--- a/backend/tests/test_content_read_audit.py
+++ b/backend/tests/test_content_read_audit.py
@@ -173,3 +173,22 @@ async def test_transcript_export_is_logged(client: AsyncClient, pool):
     assert rows[0]["actor_user_id"] == user_id
     assert rows[0]["target_id"] == session_id
     assert _metadata(rows[0]) == {"kind": "export"}
+
+
+async def test_auto_marked_read_is_audited_with_via_auto(client: AsyncClient, pool):
+    """Automated machinery (skills sync, plugin hooks) sends X-Stash-Via: auto.
+    The read is still audited, but tagged so content-activity analytics can
+    exclude it — only reads someone asked for count as document reads."""
+    api_key, user_id = await _register(client)
+    page_id = await _make_page(client, api_key, "Auto.md", "hello")
+
+    resp = await client.get(
+        f"/api/v1/me/pages/{page_id}",
+        headers={**_auth(api_key), "X-Stash-Via": "auto"},
+    )
+    assert resp.status_code == 200
+
+    rows = await _read_events(pool, "content.page_read")
+    assert len(rows) == 1
+    assert rows[0]["actor_user_id"] == user_id
+    assert rows[0]["via"] == "auto"

--- a/cli/client.py
+++ b/cli/client.py
@@ -29,10 +29,13 @@ SOURCE_ENTRIES_PAGE = 1000
 
 
 class StashClient:
-    def __init__(self, base_url: str, api_key: str = "", scope: str = ""):
+    def __init__(self, base_url: str, api_key: str = "", scope: str = "", auto: bool = False):
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._scope = scope
+        # Automated housekeeping (skills sync) — its reads are tagged so
+        # content-activity analytics can exclude them (see auth._set_request_via).
+        self._auto = auto
         self._http = httpx.Client(base_url=self._base_url, timeout=30)
 
     def close(self) -> None:
@@ -50,6 +53,8 @@ class StashClient:
         headers = {"Authorization": f"Bearer {self._api_key}"}
         if self._scope:
             headers["X-Stash-Scope"] = self._scope
+        if self._auto:
+            headers["X-Stash-Via"] = "auto"
         return headers
 
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:

--- a/cli/main.py
+++ b/cli/main.py
@@ -94,12 +94,15 @@ def upgrade() -> None:
     raise typer.Exit(result.returncode)
 
 
-def _client() -> StashClient:
+def _client(auto: bool = False) -> StashClient:
+    """auto=True tags every request as automated housekeeping so content-
+    activity analytics can exclude its reads (see auth._set_request_via)."""
     cfg = load_config()
     return StashClient(
         base_url=cfg["base_url"],
         api_key=cfg.get("api_key", ""),
         scope=cfg.get("scope", ""),
+        auto=auto,
     )
 
 
@@ -2063,7 +2066,9 @@ def skills_sync(
     manifest = _load_installed_manifest()
     installed = _installed_entry(manifest, root)
 
-    with _client() as c:
+    # Sync reads every skill's contents to compare hashes — housekeeping, not
+    # someone reading a document, so its requests are tagged auto.
+    with _client(auto=True) as c:
         try:
             summary, new_state = _sync_skills(
                 c,

--- a/cli/tests/test_skills_sync.py
+++ b/cli/tests/test_skills_sync.py
@@ -67,6 +67,12 @@ class _FakeSyncClient:
         folder_id, _, rel = url.removeprefix("fake://").partition("/")
         return self.skills[folder_id]["files"][rel]
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
 
 def _sync(c, root, state, push_new=False):
     return main._sync_skills(c, root, state, push_new, c.fetch_bytes)
@@ -146,3 +152,34 @@ def test_untracked_name_collision_is_a_conflict(tmp_path):
 
     assert len(summary["conflicts"]) == 1
     assert (tmp_path / "deploy" / "SKILL.md").read_text() == "# mine, never synced"
+
+
+def test_sync_command_tags_its_requests_as_auto(tmp_path, monkeypatch):
+    """The plugin runs sync at every session start and sync reads every
+    skill's contents to compare hashes — housekeeping the backend must be
+    able to tell apart from someone actually reading a document, or it
+    inflates the content-activity dashboard's read counts."""
+    c = _FakeSyncClient()
+    seen = {}
+
+    def fake_client(auto=False):
+        seen["auto"] = auto
+        return c
+
+    monkeypatch.setattr(main, "_client", fake_client)
+    monkeypatch.setattr(main, "_sync_state_path", lambda root: tmp_path / "state.json")
+    monkeypatch.setattr(main, "_installed_manifest_path", lambda: tmp_path / "installed.json")
+
+    main.skills_sync(directory=str(tmp_path / "skills"), project=False, as_json=True)
+
+    assert seen["auto"] is True
+
+
+def test_client_sends_auto_marker_only_when_asked():
+    from cli.client import StashClient
+
+    auto = StashClient("https://example.test", api_key="k", auto=True)
+    assert auto._headers()["X-Stash-Via"] == "auto"
+
+    normal = StashClient("https://example.test", api_key="k")
+    assert "X-Stash-Via" not in normal._headers()

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -263,3 +263,12 @@ def test_no_data_dir_no_queue(tmp_path):
     with pytest.raises(Exception):
         client.push_event(agent_name="a", event_type="t", content="x", session_id="s1")
     assert not (tmp_path / QUEUE_FILENAME).exists()
+
+
+def test_every_plugin_request_carries_the_auto_marker(tmp_path):
+    """Everything this client sends is plugin machinery (hook streaming,
+    session watcher, detached uploads) — never a user or agent reading
+    content on purpose — so it must be tagged for the backend to keep it
+    out of content-activity analytics."""
+    client = StashClient(base_url="https://example.test", api_key="k", data_dir=tmp_path)
+    assert client._headers()["X-Stash-Via"] == "auto"

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -106,6 +106,11 @@ class StashClient:
         headers = {"Authorization": f"Bearer {self._api_key}"}
         if self._scope:
             headers["X-Stash-Scope"] = self._scope
+        # Everything through this client is plugin machinery (hook streaming,
+        # session watcher, detached uploads) — never a user or agent reading
+        # content on purpose, so content-activity analytics exclude it (see
+        # backend auth._set_request_via).
+        headers["X-Stash-Via"] = "auto"
         return headers
 
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:


### PR DESCRIPTION
## Problem

The `/admin/analytics` content-activity dashboard counted plugin housekeeping as document reads. The Stash plugin spawns `stash skills sync` at every session start; sync fetches **every owned skill's contents on every run** (`cli/main.py` `_sync_skills`, it needs remote hashes even when nothing changed), and each fetch logs a `content.skill_read` audit row with `via='cli'` — indistinguishable from an agent deliberately reading a document.

Found while investigating why 4 CLI searches produced "4 searches **and** 4 docs read": the searches were counted correctly (one `source.searched` row each, verified by reproducing against the local stack and diffing `security_audit_events`); the 4 reads were two session-start syncs × 2 owned skills.

## Fix

Extend the existing spoofable, analytics-only `X-Stash-Via` marker with a new value, `auto`, sent by everything that talks to the API without a human or agent asking to see content:

- **`stash skills sync`** — the one CLI command that runs as machinery (`_client(auto=True)`); every command a user or agent types still tags `cli`.
- **The plugin's client** (`stashai/plugin/stash_client.py`) — hook streaming, session watcher, detached uploads — sends the marker unconditionally.
- **`backend/auth.py`** — `_set_request_via` stamps those rows `via='auto'`.

Rows stay in the audit trail (automatic reads are still audited); the dashboard's existing surface filter (`cli`/`ask`, plus web searches) excludes them with **no query change** and no migration (`via` is an unconstrained text column).

## Tests

- Auto-marked read is still audited, stamped `via='auto'` (`test_content_read_audit.py`)
- An `auto` skill-read row moves no dashboard total (`test_analytics.py`)
- Sync wires `auto=True`; default client omits the header (`test_skills_sync.py`)
- Plugin client always carries the marker (`test_event_queue.py`)

## Deployment note

Merging fixes the backend immediately, but sync/plugin traffic only starts carrying the marker once a new `stashai` release ships (needs a version bump, deliberately not included here). Until then each session start keeps logging N-skills `cli` reads.

No GUI changes — the dashboard renders the same tiles from the same fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)