### PR TITLE
fix: pass sweep markers to the gemini hooks merge

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -626,7 +626,7 @@ def _install_gemini(force: bool) -> tuple[str, str]:
     root = _assets_dir("gemini")
     dest = Path.home() / ".gemini" / "settings.json"
     template = (root / "settings.snippet.json").read_text()
-    status_ = _merge_json_hooks(dest, template, root)
+    status_ = _merge_json_hooks(dest, template, root, ("stashai/plugin/assets/gemini",))
 
     agents_dest = Path.home() / ".gemini" / "GEMINI.md"
     _upsert_agents_md(agents_dest, (root / "GEMINI.md").read_text())


### PR DESCRIPTION
CLI tests on `main` have been red since #886 and #891 landed together: #886 made `markers` a required argument of `_merge_json_hooks` and updated the cursor and codex call sites, but missed gemini's at `cli/main.py:629`. #891 added the CLI-tests CI job that catches it — each PR was green alone, red combined.

`stash install gemini` crashes with a TypeError on every invocation; this shipped to PyPI in 0.1.302 and 0.1.303.

One-line fix: pass the plugin-root path as the sweep marker, same idiom as the cursor call site. Full CLI suite passes locally (173/173).

Unblocks #865, whose only failing check is this inherited breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)