### PR TITLE
audit: tag VFS mount-time tree refreshes as auto traffic

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -201,10 +201,11 @@ def _enforce_key_access(user: dict, request: Request) -> None:
 def _set_request_via(request: Request, user: dict | None) -> None:
     """Tag the request's caller surface for audit rows: 'ask' for the
     server-side VFS's nested reads (it marks them itself), 'auto' for
-    automated machinery (skills sync, plugin hooks — reads nobody asked for,
-    excluded from content-activity analytics), 'cli' for API-key callers,
-    'web' for browser JWTs and anonymous reads. Analytics-grade only — the
-    X-Stash-Via header is spoofable and must never gate authorization."""
+    automated machinery (skills sync, plugin hooks, VFS mount refreshes —
+    reads nobody asked for, excluded from content-activity analytics), 'cli'
+    for API-key callers, 'web' for browser JWTs and anonymous reads.
+    Analytics-grade only — the X-Stash-Via header is spoofable and must never
+    gate authorization."""
     from .services.security_audit_service import request_via
 
     marker = request.headers.get("x-stash-via")

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -269,8 +269,8 @@ LISTING_ACTIONS = [
 # and listings are UI noise (sidebar refetches, page opens while editing), so
 # only web *searches* count; cli and ask count for everything. Untagged rows
 # (pre-`via` history, anonymous pastes) are excluded, as are 'auto' rows —
-# automated machinery like the session-start skills sync, which reads content
-# nobody asked to see.
+# automated machinery like the session-start skills sync and the VFS's
+# mount-time tree refresh, which reads content nobody asked to see.
 ACTIVITY_SURFACES = {
     "reads": ["cli", "ask"],
     "searches": ["web", "cli", "ask"],

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import threading
+from contextlib import contextmanager
 
 import anyio
 import anyio.to_thread
@@ -48,16 +49,32 @@ class InProcessVfsClient:
     def __init__(self, http: httpx.AsyncClient, loop: asyncio.AbstractEventLoop) -> None:
         self._http = http
         self._loop = loop
+        self._internal = False
         self._document_reads = 0
         self._reads_lock = threading.Lock()
+
+    @contextmanager
+    def internal_calls(self):
+        """VFS mount bookkeeping (see stashvfs.VfsClient.internal_calls):
+        overrides the client-wide `ask` tag with `auto` so analytics don't
+        count tree refreshes as user-driven listings. Only `refresh()` runs
+        inside this, single-threaded — prefetch's pool threads fire loaders
+        long after the flag is back off."""
+        self._internal = True
+        try:
+            yield
+        finally:
+            self._internal = False
 
     def _request(self, method: str, endpoint: str, **params) -> httpx.Response:
         # Dispatched onto the app's event loop from whichever thread we are on.
         # `StashVfsModel.prefetch` calls loaders from a pool, so this must work
         # from an arbitrary thread — not just anyio's worker, which is all
         # `anyio.from_thread.run` supports.
+        headers = {"X-Stash-Via": "auto"} if self._internal else None
         future = asyncio.run_coroutine_threadsafe(
-            self._http.request(method, endpoint, params=params or None), self._loop
+            self._http.request(method, endpoint, params=params or None, headers=headers),
+            self._loop,
         )
         response = future.result()
         if response.status_code >= 400:

--- a/backend/tests/test_content_read_audit.py
+++ b/backend/tests/test_content_read_audit.py
@@ -132,6 +132,30 @@ async def test_vfs_cat_logs_page_read(client: AsyncClient, pool):
     assert rows[0]["via"] == "ask"
 
 
+async def test_vfs_mount_listings_are_tagged_auto_not_ask(client: AsyncClient, pool):
+    """Every VFS command rebuilds the tree, firing the overview/memory-folder/
+    tables listing routes. Those rows must carry via='auto' (excluded from
+    content-activity analytics, like the skills sync) — otherwise one `cat`
+    shows up as several listings the user never asked for. The read itself
+    keeps its real surface tag."""
+    api_key, _ = await _register(client)
+    await _make_page(client, api_key, "Runbook.md", "step one")
+
+    resp = await client.post(
+        "/api/v1/me/vfs",
+        json={"script": "cat '/files/Runbook.md'", "cwd": "/"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+    listings = await _read_events(pool, "content.entries_listed")
+    assert {r["target_type"] for r in listings} == {"overview", "memory_folder", "tables"}
+    assert all(r["via"] == "auto" for r in listings)
+    reads = await _read_events(pool, "content.page_read")
+    assert [r["via"] for r in reads] == ["ask"]
+
+
 async def test_tree_listing_is_logged(client: AsyncClient, pool):
     api_key, user_id = await _register(client)
     await _make_page(client, api_key, "One.md", "x")

--- a/cli/client.py
+++ b/cli/client.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import time
 from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import httpx
@@ -43,6 +44,7 @@ class StashClient:
         # Automated housekeeping (skills sync) — its reads are tagged so
         # content-activity analytics can exclude them (see auth._set_request_via).
         self._auto = auto
+        self._internal = False
         self._http = httpx.Client(base_url=self._base_url, timeout=30)
 
     def close(self) -> None:
@@ -54,13 +56,24 @@ class StashClient:
     def __exit__(self, *args):
         self.close()
 
+    @contextmanager
+    def internal_calls(self):
+        """VFS mount bookkeeping (see stashvfs.VfsClient.internal_calls):
+        requests in this block are tagged like `auto` traffic so analytics
+        don't count tree refreshes as user-driven listings."""
+        self._internal = True
+        try:
+            yield
+        finally:
+            self._internal = False
+
     def _headers(self) -> dict[str, str]:
         if not self._api_key:
             return {}
         headers = {"Authorization": f"Bearer {self._api_key}"}
         if self._scope:
             headers["X-Stash-Scope"] = self._scope
-        if self._auto:
+        if self._auto or self._internal:
             headers["X-Stash-Via"] = "auto"
         return headers
 

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -1,4 +1,5 @@
 import threading
+from contextlib import contextmanager
 
 from stashvfs import StashVfsModel, VfsClientError
 
@@ -6,11 +7,25 @@ from stashvfs import StashVfsModel, VfsClientError
 class FakeClient:
     def __init__(self):
         self.source_entry_calls = 0
+        # True while the model runs mount bookkeeping; individual methods
+        # snapshot it so tests can pin what counts as internal traffic.
+        self.internal = False
+        self.internal_at_call: dict[str, bool] = {}
+
+    @contextmanager
+    def internal_calls(self):
+        self.internal = True
+        try:
+            yield
+        finally:
+            self.internal = False
 
     def get_memory_folder(self):
+        self.internal_at_call["get_memory_folder"] = self.internal
         return {"id": "memfolder-12345678", "name": "Memory"}
 
     def get_overview(self):
+        self.internal_at_call["get_overview"] = self.internal
         return {
             "files": {
                 "folders": [
@@ -113,6 +128,7 @@ class FakeClient:
 
     def read_source_doc(self, source, ref):
         assert source == "src-gmail-1"
+        self.internal_at_call["read_source_doc"] = self.internal
         return {"content": f"BODY of {ref}"}
 
     def get_transcript_events(self, session_id):
@@ -127,6 +143,7 @@ class FakeClient:
         return []
 
     def list_tables(self):
+        self.internal_at_call["list_tables"] = self.internal
         return [{"id": "table-12345678", "name": "Ideas", "columns": [], "row_count": 1}]
 
     def get_table(self, table_id):
@@ -156,6 +173,25 @@ def _model():
     model = StashVfsModel(FakeClient(), include_computer=True)
     model.refresh()
     return model
+
+
+def test_refresh_marks_mount_calls_internal_but_not_user_reads():
+    """Every VFS command rebuilds the tree, so the mount's listing calls must
+    be distinguishable from reads the user drives — otherwise analytics count
+    several listings per command, even for a `cat` (and the audit trail did
+    exactly that before internal_calls existed)."""
+    client = FakeClient()
+    model = StashVfsModel(client, include_computer=True)
+    model.refresh()
+
+    assert client.internal_at_call == {
+        "get_overview": True,
+        "get_memory_folder": True,
+        "list_tables": True,
+    }
+
+    model.read_file("/sources/gmail/Welcome email")
+    assert client.internal_at_call["read_source_doc"] is False
 
 
 def test_vfs_exposes_user_sections():

--- a/cli/tests/test_skills_sync.py
+++ b/cli/tests/test_skills_sync.py
@@ -183,3 +183,15 @@ def test_client_sends_auto_marker_only_when_asked():
 
     normal = StashClient("https://example.test", api_key="k")
     assert "X-Stash-Via" not in normal._headers()
+
+
+def test_client_sends_auto_marker_during_internal_calls():
+    """The VFS mount refresh is housekeeping like the skills sync: its
+    requests must carry the auto marker only inside the block, so the user's
+    actual reads through the same client keep their cli surface tag."""
+    from cli.client import StashClient
+
+    c = StashClient("https://example.test", api_key="k")
+    with c.internal_calls():
+        assert c._headers()["X-Stash-Via"] == "auto"
+    assert "X-Stash-Via" not in c._headers()

--- a/stashvfs/client.py
+++ b/stashvfs/client.py
@@ -8,6 +8,7 @@ and knows about neither.
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from typing import Protocol
 
 
@@ -27,6 +28,14 @@ class VfsClientError(Exception):
 class VfsClient(Protocol):
     """Everything `StashVfsModel` reads. Listing calls run during `refresh()`;
     the rest are lazy loaders fired when a file's bytes are first read."""
+
+    def internal_calls(self) -> AbstractContextManager[None]:
+        """Requests issued inside this block are mount bookkeeping, not reads
+        the user asked for. Implementations tag them `X-Stash-Via: auto` so
+        content-activity analytics exclude them (see auth._set_request_via) —
+        every VFS command rebuilds the tree, so counting these would log
+        several listings per command, even for a `cat`."""
+        ...
 
     def get_overview(self) -> dict: ...
 

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -89,7 +89,10 @@ class StashVfsModel:
         self._expanders = {}
         self._truncated = {}
         self._add_dir("/")
-        self._add_root()
+        # Lazy loaders and source expanders fire later, outside this block, so
+        # reads and descents the user actually drives still count.
+        with self.client.internal_calls():
+            self._add_root()
         computer_lines = (
             [
                 "- `computer` is a live, read-only view of the agent's "


### PR DESCRIPTION
## Problem

Every VFS command rebuilds the tree before running, which fires the overview, memory-folder, and tables listing routes. Those listings were stamped with the caller's real surface (`ask`/`cli`), so the content-activity segment of the admin analytics dashboard counted several listings per command — even for a single `cat` — none of which the user actually asked for.

## Fix

- `stashvfs.VfsClient` grows an `internal_calls()` context manager; `StashVfsModel.refresh()` wraps its mount bookkeeping (`_add_root`) in it. Lazy loaders and source expanders fire outside the block, so reads and descents the user drives keep their real surface tag.
- Both implementations (the backend's `InProcessVfsClient` and the CLI's `StashClient`) tag requests inside the block with `X-Stash-Via: auto` — the same marker the skills sync already uses, which content-activity analytics exclude.

## Tests

- `backend/tests/test_content_read_audit.py`: a VFS `cat` logs its mount listings as `via='auto'` while the page read itself keeps `via='ask'`.
- `cli/tests/test_mount_vfs.py`: `refresh()` marks exactly the mount calls internal; user-driven reads are not.
- `cli/tests/test_skills_sync.py`: the auto marker is present only inside `internal_calls()`.

`ruff check` / `ruff format --check` clean; the touched CLI and backend test files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)