### PR TITLE
Feed provenance, onboarding cleanup, tab/explorer UX, general GitHub import, X-thread clips

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -473,6 +473,35 @@ async def _hydrate_article(
     )
 
 
+async def fetch_tweet_markdown(tweet_id: str) -> dict:
+    """One tweet rendered as markdown, with its author thread and reply
+    parent — the standalone fetch behind web clips of x.com status URLs.
+    No user_source or media archiving involved. Returns {title, markdown}."""
+    if not settings.TWITTERAPI_IO_KEY:
+        raise RuntimeError("TWITTERAPI_IO_KEY is not set")
+    async with httpx.AsyncClient(
+        timeout=TAPI_TIMEOUT, headers={"X-API-Key": settings.TWITTERAPI_IO_KEY}
+    ) as client:
+        tweet = await _fetch_tweet(client, tweet_id)
+        thread = [tweet]
+        parent = None
+        if _in_conversation(tweet):
+            # Best-effort, like the saves indexer — the tweet itself matters.
+            try:
+                context = await _fetch_thread_context(client, tweet_id)
+                thread = _author_chain(tweet, context)
+                parent = _direct_parent(tweet, context)
+            except Exception as exc:
+                logger.warning(
+                    "x thread context fetch failed tweet=%s exception_type=%s",
+                    tweet_id,
+                    type(exc).__name__,
+                )
+    posted = tweet["created_at"]
+    title = f"@{tweet['author']} - {posted.date().isoformat()}" if posted else f"@{tweet['author']}"
+    return {"title": title, "markdown": _render(tweet, thread, parent)}
+
+
 # Draft.js-style block types twitterapi.io uses for article bodies.
 _ARTICLE_HEADINGS = {"header-one": "# ", "header-two": "## ", "header-three": "### "}
 _ARTICLE_LIST_ITEMS = ("unordered-list-item", "ordered-list-item")

--- a/backend/routers/clips.py
+++ b/backend/routers/clips.py
@@ -33,11 +33,11 @@ async def clip_page(
     body: ClipPageRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Save a clipped page. Returns 201 + the created page, except for URLs
-    whose content isn't in the posted DOM (YouTube, arXiv abstracts) — those
-    become async import jobs and return 202 + the import id."""
+    """Save a clipped page. Returns 201 + the created page, except for special
+    pages whose content isn't in the posted DOM (YouTube, X threads, arXiv
+    abstracts) — those become async import jobs and return 202 + the import id."""
     url = str(body.url)
-    if clip_router.is_async_url(url):
+    if clip_router.is_special_page(url):
         from ..tasks.clips import dispatch_url_imports
 
         ids = await url_import_service.create_url_imports(

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -77,20 +77,34 @@ class GithubImportRequest(BaseModel):
     repo_url: str
 
 
-@me_router.post("/skills/import-github")
-async def import_github_skill(
+@me_router.post("/import/github")
+async def import_github_repo(
     req: GithubImportRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Import every SKILL.md folder in a public GitHub repo as private skills in
-    the caller's own scope (folders with SKILL.md)."""
+    """Copy a whole GitHub repo into the caller's scope as one new root folder.
+    Folders containing SKILL.md derive as skills automatically. Private repos
+    work when the caller's GitHub connection can read them."""
     try:
-        result = await github_skill_import.import_repo_for_user(current_user["id"], req.repo_url)
+        return await github_skill_import.import_repo_for_user(current_user["id"], req.repo_url)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    if result["skills"] == 0:
-        raise HTTPException(status_code=404, detail="No SKILL.md folders found in that repo")
-    return result
+
+
+@me_router.get("/import/github/repos")
+async def list_github_import_repos(
+    current_user: dict = Depends(get_current_user),
+):
+    """Repos the caller's GitHub connection can access, for the import picker.
+    connected=false when GitHub isn't connected — the picker then offers URL
+    paste only."""
+    token = await github_skill_import.user_github_token(current_user["id"])
+    if token is None:
+        return {"connected": False, "repos": []}
+    return {
+        "connected": True,
+        "repos": await github_skill_import.list_user_repos(current_user["id"]),
+    }
 
 
 @me_router.get("/skills/{name}")

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -91,6 +91,22 @@ async def import_github_repo(
         raise HTTPException(status_code=400, detail=str(exc))
 
 
+@me_router.get("/import/github/inspect")
+async def inspect_github_import(
+    repo_url: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Tree-only look at a repo before importing: which of its folders are
+    skills ('' = the repo root itself). The dialog uses this to warn when the
+    repo's content won't surface in the section the user imported from."""
+    token = await github_skill_import.user_github_token(current_user["id"])
+    try:
+        skill_dirs = await github_skill_import.inspect_repo(repo_url, token)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"skill_dirs": skill_dirs}
+
+
 @me_router.get("/import/github/repos")
 async def list_github_import_repos(
     current_user: dict = Depends(get_current_user),

--- a/backend/services/clip_router.py
+++ b/backend/services/clip_router.py
@@ -1,11 +1,13 @@
 """Route a URL-only clip to its handler.
 
-All URL special-casing lives here — the extension and importers just send
-URLs. YouTube watch pages have no extractable article (the transcript is
-the content) and arXiv abstract pages are landing pages for the actual
-paper, so both get dedicated handling before the generic fetch. Everything
-else is fetched and routed by content: PDF → file clip, HTML → article
-page, anything else fails loud.
+All URL special-casing lives in SPECIAL_PAGES: pages whose real content
+isn't in their HTML (YouTube transcripts, X threads) or whose URL is a
+landing page for the actual artifact (arXiv abstract → paper PDF).
+To add one, write a small class with `matches(url)` and `clip(row)` and
+append an instance to SPECIAL_PAGES; to retire one, delete it.
+
+Everything else is fetched and routed by content: PDF → file clip,
+HTML → article page, anything else fails loud.
 """
 
 import re
@@ -13,6 +15,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ..integrations.x_saves import indexer as x_indexer
 from . import clip_service, page_render_service, youtube_transcript
 from .article_extraction import ArticleExtractionError
 
@@ -20,53 +23,32 @@ MAX_FETCH_BYTES = 20 * 1024 * 1024
 FETCH_TIMEOUT = 30
 USER_AGENT = "Stash/1.0 (+https://joinstash.ai)"
 
-_YOUTUBE_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}
-_ARXIV_ABS = re.compile(r"^https?://(?:www\.)?arxiv\.org/abs/(?P<paper>[^?#]+)")
-
 
 class UnsupportedUrlContent(Exception):
     """The URL resolved to content we can't clip."""
 
 
-def is_youtube(url: str) -> bool:
-    parsed = urlparse(url)
-    if parsed.hostname not in _YOUTUBE_HOSTS:
-        return False
-    if parsed.hostname == "youtu.be":
-        return bool(parsed.path.strip("/"))
-    return parsed.path.startswith(("/watch", "/shorts"))
+class YouTubeTranscriptPage:
+    """YouTube watch pages have no extractable article — the transcript is
+    the content."""
 
+    _HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}
 
-def normalize_arxiv(url: str) -> str:
-    """arXiv abstract pages are landing pages — clip the paper PDF instead."""
-    match = _ARXIV_ABS.match(url)
-    if match:
-        return f"https://arxiv.org/pdf/{match.group('paper')}"
-    return url
+    def matches(self, url: str) -> bool:
+        parsed = urlparse(url)
+        if parsed.hostname not in self._HOSTS:
+            return False
+        if parsed.hostname == "youtu.be":
+            return bool(parsed.path.strip("/"))
+        return parsed.path.startswith(("/watch", "/shorts"))
 
-
-def is_async_url(url: str) -> bool:
-    """URLs the clip endpoint must hand to the worker instead of extracting
-    the posted DOM: the useful content isn't in the page HTML."""
-    return is_youtube(url) or bool(_ARXIV_ABS.match(url))
-
-
-async def process_url_import(row: dict) -> dict:
-    """Fetch one url_imports row's content and create its page/file.
-
-    Returns {"page_id": ...} or {"file_id": ...}; raises on any failure —
-    the caller records the error on the row.
-    """
-    owner_user_id = row["owner_user_id"]
-    user_id = row["created_by"]
-    url = row["url"]
-
-    if is_youtube(url):
+    async def clip(self, row: dict) -> dict:
+        url = row["url"]
         video = await youtube_transcript.fetch_transcript(url)
         markdown = f"**{video['channel']}**\n\n{video['transcript']}"
         page = await clip_service.create_clip_page(
-            owner_user_id=owner_user_id,
-            user_id=user_id,
+            owner_user_id=row["owner_user_id"],
+            user_id=row["created_by"],
             url=url,
             name=video["title"],
             markdown=markdown,
@@ -75,7 +57,82 @@ async def process_url_import(row: dict) -> dict:
         )
         return {"page_id": page["id"]}
 
-    fetch_url = normalize_arxiv(url)
+
+class XThreadPage:
+    """x.com/twitter.com status pages are JS shells — the tweet (and its
+    thread) comes from the twitterapi.io scraper instead."""
+
+    _HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com", "mobile.twitter.com"}
+    _STATUS_PATH = re.compile(r"^/(?:[^/]+)/status(?:es)?/(?P<id>\d+)")
+
+    def matches(self, url: str) -> bool:
+        return self._tweet_id(url) is not None
+
+    def _tweet_id(self, url: str) -> str | None:
+        parsed = urlparse(url)
+        if parsed.hostname not in self._HOSTS:
+            return None
+        match = self._STATUS_PATH.match(parsed.path)
+        return match.group("id") if match else None
+
+    async def clip(self, row: dict) -> dict:
+        url = row["url"]
+        tweet = await x_indexer.fetch_tweet_markdown(self._tweet_id(url))
+        page = await clip_service.create_clip_page(
+            owner_user_id=row["owner_user_id"],
+            user_id=row["created_by"],
+            url=url,
+            name=tweet["title"],
+            markdown=tweet["markdown"],
+            folder_id=row["folder_id"],
+            kind=clip_service.KIND_TWEET,
+        )
+        return {"page_id": page["id"]}
+
+
+class ArxivPdfPage:
+    """arXiv abstract pages are landing pages — clip the paper PDF instead."""
+
+    _ABS = re.compile(r"^https?://(?:www\.)?arxiv\.org/abs/(?P<paper>[^?#]+)")
+
+    def matches(self, url: str) -> bool:
+        return bool(self._ABS.match(url))
+
+    async def clip(self, row: dict) -> dict:
+        paper = self._ABS.match(row["url"]).group("paper")
+        return await _fetch_and_save(row, f"https://arxiv.org/pdf/{paper}")
+
+
+SPECIAL_PAGES = [YouTubeTranscriptPage(), XThreadPage(), ArxivPdfPage()]
+
+
+def special_page_for(url: str):
+    return next((h for h in SPECIAL_PAGES if h.matches(url)), None)
+
+
+def is_special_page(url: str) -> bool:
+    """URLs the clip endpoint must hand to the worker instead of extracting
+    the posted DOM: the useful content isn't in the page HTML."""
+    return special_page_for(url) is not None
+
+
+async def process_url_import(row: dict) -> dict:
+    """Fetch one url_imports row's content and create its page/file.
+
+    Returns {"page_id": ...} or {"file_id": ...}; raises on any failure —
+    the caller records the error on the row.
+    """
+    handler = special_page_for(row["url"])
+    if handler:
+        return await handler.clip(row)
+    return await _fetch_and_save(row, row["url"])
+
+
+async def _fetch_and_save(row: dict, fetch_url: str) -> dict:
+    """The generic path: fetch the URL and route by content type."""
+    owner_user_id = row["owner_user_id"]
+    user_id = row["created_by"]
+    url = row["url"]
     content, content_type = await _fetch(fetch_url)
 
     if "application/pdf" in content_type or content[:5] == b"%PDF-":

--- a/backend/services/clip_service.py
+++ b/backend/services/clip_service.py
@@ -28,6 +28,7 @@ BOOKMARKS_TABLE = "Bookmarks"
 KIND_PAGE = "Page"
 KIND_PDF = "PDF"
 KIND_VIDEO = "Video"
+KIND_TWEET = "Tweet"
 # A bookmark whose content could not be captured (login wall, no captions,
 # unsupported content) — the link itself is still worth keeping.
 KIND_LINK = "Link"

--- a/backend/services/feed_service.py
+++ b/backend/services/feed_service.py
@@ -1,6 +1,7 @@
 """The home-page feed: one continuous stream of community skills to copy,
 fresh public pages, and — for a signed-in user — resurfaced items from their
-own stash (clips and X/Instagram saves old enough to be worth re-encountering).
+own stash (docs, files, memory pages, clips, and X/Instagram saves old enough
+to be worth re-encountering).
 
 Interleave happens server-side so the client renders a flat list. Resurface
 selection is deterministic per (user, day): an md5 sort seeded by user id +
@@ -22,7 +23,7 @@ from .clip_service import CLIPS_FOLDER, RAW_FOLDER
 
 PAGE_SKILLS = 6
 PAGE_PUBLIC_PAGES = 3
-PAGE_RESURFACE = 3
+PAGE_RESURFACE = 4
 # Only items past this age resurface — the feed re-encounters the archive,
 # it doesn't echo what the user just saved.
 RESURFACE_MIN_AGE_DAYS = 7
@@ -50,7 +51,7 @@ async def home_feed(user_id: UUID | None, cursor: int) -> dict:
 
 def _interleave(skills: list[dict], pages: list[dict], resurfaced: list[dict]) -> list[dict]:
     """Flat feed order: two skills per public page in the community stream,
-    with a resurface card landing every 4th slot."""
+    with a resurface card landing every 3rd slot."""
     community: list[dict] = []
     si, pi = 0, 0
     while si < len(skills) or pi < len(pages):
@@ -65,7 +66,7 @@ def _interleave(skills: list[dict], pages: list[dict], resurfaced: list[dict]) -
     items: list[dict] = []
     ci, ri = 0, 0
     while ci < len(community) or ri < len(resurfaced):
-        resurface_slot = len(items) % 4 == 3
+        resurface_slot = len(items) % 3 == 2
         if ri < len(resurfaced) and (resurface_slot or ci >= len(community)):
             items.append({"kind": "resurface", "data": resurfaced[ri]})
             ri += 1
@@ -79,9 +80,27 @@ async def _resurface_items(user_id: UUID, cursor: int) -> list[dict]:
     seed = f"{user_id}:{datetime.now(UTC).date().isoformat()}:"
     rows = await get_pool().fetch(
         f"""
-        WITH pool AS (
+        WITH RECURSIVE memory_folders AS (
+            SELECT id FROM folders WHERE owner_user_id = $1 AND is_memory
+            UNION
+            SELECT f.id FROM folders f
+            JOIN memory_folders m ON f.parent_folder_id = m.id
+        ), clip_folders AS (
+            SELECT raw_f.id FROM folders raw_f
+            JOIN folders clips_f ON raw_f.parent_folder_id = clips_f.id
+                 AND clips_f.name = $5 AND clips_f.parent_folder_id IS NULL
+            WHERE raw_f.owner_user_id = $1 AND raw_f.name = $4
+        ), skill_folders AS (
+            SELECT f.id FROM folders f
+            WHERE f.owner_user_id = $1
+              AND EXISTS (SELECT 1 FROM pages sp WHERE sp.folder_id = f.id
+                          AND sp.name = 'SKILL.md' AND sp.deleted_at IS NULL)
+            UNION
+            SELECT f.id FROM folders f
+            JOIN skill_folders st ON f.parent_folder_id = st.id
+        ), pool AS (
             SELECT 'x' AS source, id::text AS item_id, name AS title, content,
-                   created_at, external_ref, NULL::uuid AS page_id,
+                   created_at, external_ref,
                    media->0->>'storage_key' AS media_key
             FROM x_save_docs
             WHERE owner_user_id = $1 AND hydration_status = 'done'
@@ -89,21 +108,30 @@ async def _resurface_items(user_id: UUID, cursor: int) -> list[dict]:
               AND created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
             UNION ALL
             SELECT 'instagram', id::text, name, content,
-                   created_at, external_ref, NULL::uuid, media_storage_key
+                   created_at, external_ref, media_storage_key
             FROM instagram_save_docs
             WHERE owner_user_id = $1 AND hydration_status = 'done'
               AND deleted_at IS NULL AND content IS NOT NULL
               AND created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
             UNION ALL
-            SELECT 'clip', p.id::text, p.name,
+            SELECT CASE
+                     WHEN p.folder_id IN (SELECT id FROM memory_folders) THEN 'memory'
+                     WHEN p.folder_id IN (SELECT id FROM clip_folders) THEN 'clip'
+                     ELSE 'doc'
+                   END,
+                   p.id::text, p.name,
                    coalesce(p.content_markdown, p.content_html),
-                   p.created_at, NULL, p.id, NULL
+                   p.created_at, NULL, NULL
             FROM pages p
-            JOIN folders raw_f ON p.folder_id = raw_f.id AND raw_f.name = $4
-            JOIN folders clips_f ON raw_f.parent_folder_id = clips_f.id
-                 AND clips_f.name = $5 AND clips_f.parent_folder_id IS NULL
             WHERE p.owner_user_id = $1 AND p.deleted_at IS NULL
               AND p.created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
+            UNION ALL
+            SELECT 'file', f.id::text, f.name, f.extracted_text,
+                   f.created_at, NULL,
+                   CASE WHEN f.content_type LIKE 'image/%' THEN f.storage_key END
+            FROM files f
+            WHERE f.owner_user_id = $1 AND f.deleted_at IS NULL
+              AND f.created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
         )
         SELECT * FROM pool ORDER BY md5($2::text || item_id) LIMIT $3 OFFSET $6
         """,
@@ -125,8 +153,11 @@ async def _resurface_card(row: dict) -> dict:
     elif source == "instagram":
         app_url = None
         external_url = post_url(row["external_ref"])
+    elif source == "file":
+        app_url = f"/f/{row['item_id']}"
+        external_url = None
     else:
-        app_url = f"/p/{row['page_id']}"
+        app_url = f"/p/{row['item_id']}"
         external_url = None
 
     image_url = None

--- a/backend/services/github_skill_import.py
+++ b/backend/services/github_skill_import.py
@@ -169,6 +169,17 @@ async def fetch_repo_files(repo_url: str, token: str | None = None) -> tuple[str
         return repo, files
 
 
+async def inspect_repo(repo_url: str, token: str | None = None) -> list[str]:
+    """Which directories in the repo are skills (contain a SKILL.md), without
+    downloading any blobs — the pre-import check behind the section-mismatch
+    confirmation in the import dialog."""
+    owner, repo = parse_repo_url(repo_url)
+    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        branch = await _fetch_default_branch(client, owner, repo, token)
+        tree = await _fetch_tree(client, owner, repo, branch, token)
+    return discover_skill_dirs(tree)
+
+
 # ===== Import into the curator scope =====
 
 

--- a/backend/services/github_skill_import.py
+++ b/backend/services/github_skill_import.py
@@ -1,12 +1,16 @@
-"""Import public GitHub repos containing SKILL.md folders as curated Skills.
+"""GitHub repo imports.
 
-Every directory whose immediate children include a SKILL.md (the repo root
-counts) becomes one published, discoverable skill in the curator scope,
-attributed via skills.source_github_url. Re-imports are idempotent: skills
-are matched by source_github_url and their folder contents replaced in
-place, so the slug and view count survive upstream updates.
-
-Run via scripts/import_github_skills.py.
+Two flavors:
+- User-facing (`import_repo_for_user`): straight copy of a whole repo into
+  the caller's scope as one root folder. Folders containing SKILL.md derive
+  as skills automatically. Uses the caller's GitHub connection when present,
+  so private repos work too.
+- Curator (`import_repo`, via scripts/import_github_skills.py): every
+  directory whose immediate children include a SKILL.md becomes one
+  published, discoverable skill in the curator scope, attributed via
+  skills.source_github_url. Re-imports are idempotent: skills are matched by
+  source_github_url and their folder contents replaced in place, so the slug
+  and view count survive upstream updates.
 """
 
 from __future__ import annotations
@@ -18,9 +22,11 @@ import secrets
 from uuid import UUID
 
 import httpx
+from fastapi import HTTPException
 
 from ..auth import hash_password
 from ..database import get_pool
+from ..integrations import storage as integration_storage
 from . import files_tree_service, shared_skill_service, skill_service
 
 logger = logging.getLogger(__name__)
@@ -64,35 +70,45 @@ def discover_skill_dirs(tree: list[dict]) -> list[str]:
 # ===== GitHub fetchers (monkeypatched in tests) =====
 
 
-def _api_headers() -> dict:
+def _api_headers(token: str | None = None) -> dict:
     headers = {"Accept": "application/vnd.github+json"}
-    token = os.environ.get("GITHUB_TOKEN")
+    token = token or os.environ.get("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
 
 
-async def _fetch_default_branch(client: httpx.AsyncClient, owner: str, repo: str) -> str:
-    resp = await client.get(f"{_API}/repos/{owner}/{repo}", headers=_api_headers())
+async def _fetch_default_branch(
+    client: httpx.AsyncClient, owner: str, repo: str, token: str | None = None
+) -> str:
+    resp = await client.get(f"{_API}/repos/{owner}/{repo}", headers=_api_headers(token))
     resp.raise_for_status()
     return resp.json()["default_branch"]
 
 
-async def _fetch_tree(client: httpx.AsyncClient, owner: str, repo: str, ref: str) -> list[dict]:
+async def _fetch_tree(
+    client: httpx.AsyncClient, owner: str, repo: str, ref: str, token: str | None = None
+) -> list[dict]:
     resp = await client.get(
         f"{_API}/repos/{owner}/{repo}/git/trees/{ref}",
         params={"recursive": "1"},
-        headers=_api_headers(),
+        headers=_api_headers(token),
     )
     resp.raise_for_status()
     return resp.json()["tree"]
 
 
 async def _fetch_blob(
-    client: httpx.AsyncClient, owner: str, repo: str, ref: str, path: str
+    client: httpx.AsyncClient,
+    owner: str,
+    repo: str,
+    ref: str,
+    path: str,
+    token: str | None = None,
 ) -> bytes:
-    # raw.githubusercontent.com serves blobs without burning API rate limit.
-    resp = await client.get(f"{_RAW}/{owner}/{repo}/{ref}/{path}")
+    # raw.githubusercontent.com serves blobs without burning API rate limit;
+    # with the user's token it serves their private repos too.
+    resp = await client.get(f"{_RAW}/{owner}/{repo}/{ref}/{path}", headers=_api_headers(token))
     resp.raise_for_status()
     return resp.content
 
@@ -126,6 +142,31 @@ async def fetch_repo_skills(repo_url: str) -> list[dict]:
                 }
             )
         return skills
+
+
+async def fetch_repo_files(repo_url: str, token: str | None = None) -> tuple[str, list]:
+    """Every blob in a repo, paths relative to the repo root.
+    Returns (repo name, [(path, bytes)])."""
+    owner, repo = parse_repo_url(repo_url)
+    async with httpx.AsyncClient(timeout=60, follow_redirects=True) as client:
+        branch = await _fetch_default_branch(client, owner, repo, token)
+        tree = await _fetch_tree(client, owner, repo, branch, token)
+        files = []
+        for entry in tree:
+            if entry["type"] != "blob":
+                continue
+            if entry.get("size", 0) > MAX_FILE_BYTES:
+                logger.warning(
+                    "skipping oversized file %s (%s bytes)", entry["path"], entry["size"]
+                )
+                continue
+            files.append(
+                (
+                    entry["path"],
+                    await _fetch_blob(client, owner, repo, branch, entry["path"], token),
+                )
+            )
+        return repo, files
 
 
 # ===== Import into the curator scope =====
@@ -188,12 +229,12 @@ async def import_skill(
         )
         return "updated"
 
-    folder_id = await _create_root_folder(owner_user_id, owner_id, title)
-    await files_tree_service.write_folder_files(owner_user_id, owner_id, folder_id, files)
+    folder = await _create_root_folder(owner_user_id, owner_id, title)
+    await files_tree_service.write_folder_files(owner_user_id, owner_id, folder["id"], files)
     await shared_skill_service.publish_folder(
         owner_user_id,
         owner_id,
-        folder_id,
+        folder["id"],
         title=title,
         description=description,
         discoverable=True,
@@ -202,16 +243,15 @@ async def import_skill(
     return "created"
 
 
-async def _create_root_folder(owner_user_id: UUID, owner_id: UUID, title: str) -> UUID:
-    # Skills from different repos can share a title; folder names are unique
-    # per parent, so suffix like fork_skill does.
+async def _create_root_folder(owner_user_id: UUID, owner_id: UUID, title: str) -> dict:
+    # Imports can share a title; folder names are unique per parent, so
+    # suffix like fork_skill does.
     name = title
     for n in range(2, 50):
         try:
-            folder = await files_tree_service.create_folder(
+            return await files_tree_service.create_folder(
                 owner_user_id=owner_user_id, name=name, created_by=owner_id
             )
-            return folder["id"]
         except files_tree_service.DuplicateFolderName:
             name = f"{title} ({n})"
     raise ValueError(f"Could not find a free folder name for {title!r}")
@@ -220,24 +260,49 @@ async def _create_root_folder(owner_user_id: UUID, owner_id: UUID, title: str) -
 # ===== Whole-repo operations (script + admin dashboard) =====
 
 
+async def user_github_token(user_id: UUID) -> str | None:
+    """The user's GitHub connection token, or None when not connected.
+    Auth is opportunistic here — public repos import without it."""
+    try:
+        return await integration_storage.get_valid_token(user_id, "github")
+    except HTTPException:
+        return None
+
+
 async def import_repo_for_user(owner_user_id: UUID, repo_url: str) -> dict:
-    """Import every SKILL.md folder in a repo into a user's OWN scope as private
-    skills — a skill is just a folder containing SKILL.md, so we create the
-    folder and write the repo files; no publish/discover record. Returns
-    {skills, imported}. A user is their own scope (owner_user_id == created_by)."""
-    skills = await fetch_repo_skills(repo_url)
-    imported = 0
-    for skill in skills:
-        files = skill["files"]
-        skill_md = next((blob for path, blob in files if path == "SKILL.md"), None)
-        if skill_md is None:
-            continue
-        meta, _body = skill_service.parse_frontmatter(skill_md.decode("utf-8", errors="replace"))
-        title = str(meta.get("name") or skill["fallback_title"])
-        folder_id = await _create_root_folder(owner_user_id, owner_user_id, title)
-        await files_tree_service.write_folder_files(owner_user_id, owner_user_id, folder_id, files)
-        imported += 1
-    return {"skills": len(skills), "imported": imported}
+    """Copy a whole repo into the user's own scope as one new root folder — a
+    straight copy preserving structure. Any folder containing a SKILL.md
+    derives as a skill automatically (skill-ness is never stored). Private
+    repos work when the user's GitHub connection can read them."""
+    token = await user_github_token(owner_user_id)
+    repo_name, files = await fetch_repo_files(repo_url, token)
+    if not files:
+        raise ValueError("That repo has no importable files")
+    folder = await _create_root_folder(owner_user_id, owner_user_id, repo_name)
+    await files_tree_service.write_folder_files(owner_user_id, owner_user_id, folder["id"], files)
+    return {"folder_id": str(folder["id"]), "name": folder["name"], "files": len(files)}
+
+
+async def list_user_repos(user_id: UUID) -> list[dict]:
+    """Repos the user's GitHub connection can access, most recently pushed
+    first. Raises 401 when GitHub isn't connected."""
+    token = await integration_storage.get_valid_token(user_id, "github")
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(
+            f"{_API}/user/repos",
+            params={"per_page": 100, "sort": "pushed"},
+            headers=_api_headers(token),
+        )
+        resp.raise_for_status()
+        return [
+            {
+                "full_name": r["full_name"],
+                "html_url": r["html_url"],
+                "private": r["private"],
+                "description": r["description"] or "",
+            }
+            for r in resp.json()
+        ]
 
 
 async def import_repo(repo_url: str) -> dict:

--- a/backend/tests/test_feed.py
+++ b/backend/tests/test_feed.py
@@ -139,14 +139,68 @@ async def test_resurfaces_only_old_saves_and_is_deterministic(client: AsyncClien
     assert first.json()["items"] == second.json()["items"]
 
 
-async def test_interleave_lands_a_resurface_card_every_fourth_slot():
+async def test_interleave_lands_a_resurface_card_every_third_slot():
     skills = [{"slug": f"s{i}"} for i in range(6)]
     pages = [{"slug": f"p{i}"} for i in range(3)]
-    resurfaced = [{"title": f"r{i}"} for i in range(3)]
+    resurfaced = [{"title": f"r{i}"} for i in range(4)]
 
     items = feed_service._interleave(skills, pages, resurfaced)
 
-    assert len(items) == 12
-    assert [items[i]["kind"] for i in (3, 7, 11)] == ["resurface"] * 3
-    # Community keeps its own rhythm: two skills, then a public page.
-    assert [i["kind"] for i in items[:3]] == ["skill", "skill", "public_page"]
+    assert len(items) == 13
+    assert [items[i]["kind"] for i in (2, 5, 8, 11)] == ["resurface"] * 4
+    # Community keeps its own rhythm: two skills before the first resurface.
+    assert [i["kind"] for i in items[:2]] == ["skill", "skill"]
+
+
+async def test_resurfaces_docs_files_and_memory_pages(client: AsyncClient, pool):
+    api_key, owner_id = await _register(client)
+
+    doc = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Quarterly notes", "content": "# planning"},
+        headers=_auth(api_key),
+    )
+    assert doc.status_code == 201
+    await pool.execute(
+        "UPDATE pages SET created_at = now() - interval '30 days' WHERE id = $1",
+        UUID(doc.json()["id"]),
+    )
+
+    memory_folder = await pool.fetchval(
+        "INSERT INTO folders (owner_user_id, name, created_by, is_memory) "
+        "VALUES ($1, 'Memory', $1, true) RETURNING id",
+        UUID(owner_id),
+    )
+    await pool.execute(
+        "INSERT INTO pages (owner_user_id, folder_id, name, content_markdown, created_by, "
+        "created_at) "
+        "VALUES ($1, $2, 'People', '# People I met', $1, now() - interval '30 days')",
+        UUID(owner_id),
+        memory_folder,
+    )
+
+    file_id = await pool.fetchval(
+        "INSERT INTO files (owner_user_id, name, content_type, size_bytes, storage_key, "
+        "extracted_text, uploaded_by, created_at) "
+        "VALUES ($1, 'deck.pdf', 'application/pdf', 10, $2, 'the pitch deck text', $1, "
+        "now() - interval '30 days') RETURNING id",
+        UUID(owner_id),
+        unique_name("key"),
+    )
+
+    resurfaced = []
+    cursor = 0
+    while cursor is not None:
+        resp = await client.get(f"/api/v1/feed?cursor={cursor}", headers=_auth(api_key))
+        assert resp.status_code == 200
+        body = resp.json()
+        resurfaced += [i["data"] for i in body["items"] if i["kind"] == "resurface"]
+        cursor = body["next_cursor"]
+
+    by_source = {r["source"]: r for r in resurfaced}
+    assert by_source["doc"]["title"] == "Quarterly notes"
+    assert by_source["doc"]["app_url"] == f"/p/{doc.json()['id']}"
+    assert by_source["memory"]["title"] == "People"
+    assert by_source["file"]["title"] == "deck.pdf"
+    assert by_source["file"]["app_url"] == f"/f/{file_id}"
+    assert by_source["file"]["preview"] == "the pitch deck text"

--- a/backend/tests/test_github_skill_import.py
+++ b/backend/tests/test_github_skill_import.py
@@ -28,13 +28,13 @@ FAKE_REPO = {
 
 
 def _fake_github(monkeypatch, files: dict[str, bytes], branch: str = "main") -> None:
-    async def fake_branch(client, owner, repo):
+    async def fake_branch(client, owner, repo, token=None):
         return branch
 
-    async def fake_tree(client, owner, repo, ref):
+    async def fake_tree(client, owner, repo, ref, token=None):
         return [{"path": p, "type": "blob", "size": len(b)} for p, b in files.items()]
 
-    async def fake_blob(client, owner, repo, ref, path):
+    async def fake_blob(client, owner, repo, ref, path, token=None):
         return files[path]
 
     monkeypatch.setattr(gsi, "_fetch_default_branch", fake_branch)
@@ -166,3 +166,38 @@ async def test_import_requires_skill_md(pool):
             fallback_title="empty",
             files=[("README.md", b"hi")],
         )
+
+
+@pytest.mark.asyncio
+async def test_import_repo_for_user_copies_whole_repo(client: AsyncClient, pool, monkeypatch):
+    """The user-facing import is a straight copy: one root folder named after
+    the repo, full structure preserved, and SKILL.md folders derive as skills."""
+    from uuid import UUID
+
+    from .conftest import unique_name
+
+    _fake_github(monkeypatch, FAKE_REPO)
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("importer"), "password": "securepassword1"},
+    )
+    assert reg.status_code == 201
+    user_id, api_key = reg.json()["id"], reg.json()["api_key"]
+
+    result = await gsi.import_repo_for_user(UUID(user_id), "https://github.com/acme/skills")
+
+    assert result["name"] == "skills"
+    assert result["files"] == len(FAKE_REPO)
+    root_id = UUID(result["folder_id"])
+    readme = await pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = 'README.md'", root_id
+    )
+    assert readme is not None
+    cooking = await pool.fetchval(
+        "SELECT id FROM folders WHERE parent_folder_id = $1 AND name = 'cooking'", root_id
+    )
+    assert cooking is not None
+
+    skills = await client.get("/api/v1/me/skills", headers={"Authorization": f"Bearer {api_key}"})
+    names = {s["name"] for s in skills.json()["skills"]}
+    assert "Cooking Wizard" in names  # derived from the copied SKILL.md, no publish record

--- a/backend/tests/test_github_skill_import.py
+++ b/backend/tests/test_github_skill_import.py
@@ -201,3 +201,31 @@ async def test_import_repo_for_user_copies_whole_repo(client: AsyncClient, pool,
     skills = await client.get("/api/v1/me/skills", headers={"Authorization": f"Bearer {api_key}"})
     names = {s["name"] for s in skills.json()["skills"]}
     assert "Cooking Wizard" in names  # derived from the copied SKILL.md, no publish record
+
+
+@pytest.mark.asyncio
+async def test_inspect_reports_skill_dirs_before_import(client: AsyncClient, monkeypatch):
+    """The import dialog warns on section mismatch using this tree-only look."""
+    from .conftest import unique_name
+
+    _fake_github(monkeypatch, FAKE_REPO)
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("inspector"), "password": "securepassword1"},
+    )
+    auth = {"Authorization": f"Bearer {reg.json()['api_key']}"}
+
+    resp = await client.get(
+        "/api/v1/me/import/github/inspect",
+        params={"repo_url": "https://github.com/acme/skills"},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"skill_dirs": ["baking", "cooking"]}
+
+    bad = await client.get(
+        "/api/v1/me/import/github/inspect",
+        params={"repo_url": "https://gitlab.com/acme/skills"},
+        headers=auth,
+    )
+    assert bad.status_code == 400

--- a/backend/tests/test_url_imports.py
+++ b/backend/tests/test_url_imports.py
@@ -37,31 +37,37 @@ async def _register(client: AsyncClient) -> tuple[dict, str]:
 # --- URL classification ---
 
 
-def test_is_youtube_matches_watch_shorts_and_short_links() -> None:
-    assert clip_router.is_youtube("https://www.youtube.com/watch?v=abc123")
-    assert clip_router.is_youtube("https://youtube.com/shorts/abc123")
-    assert clip_router.is_youtube("https://youtu.be/abc123")
-    assert not clip_router.is_youtube("https://youtu.be/")
-    assert not clip_router.is_youtube("https://www.youtube.com/@somechannel")
-    assert not clip_router.is_youtube("https://example.com/watch?v=abc123")
+def test_youtube_special_page_matches_watch_shorts_and_short_links() -> None:
+    yt = clip_router.YouTubeTranscriptPage()
+    assert yt.matches("https://www.youtube.com/watch?v=abc123")
+    assert yt.matches("https://youtube.com/shorts/abc123")
+    assert yt.matches("https://youtu.be/abc123")
+    assert not yt.matches("https://youtu.be/")
+    assert not yt.matches("https://www.youtube.com/@somechannel")
+    assert not yt.matches("https://example.com/watch?v=abc123")
 
 
-def test_normalize_arxiv_rewrites_abs_to_pdf() -> None:
-    assert (
-        clip_router.normalize_arxiv("https://arxiv.org/abs/2401.00001")
-        == "https://arxiv.org/pdf/2401.00001"
-    )
-    assert (
-        clip_router.normalize_arxiv("https://www.arxiv.org/abs/2401.00001v2")
-        == "https://arxiv.org/pdf/2401.00001v2"
-    )
-    assert clip_router.normalize_arxiv("https://example.com/abs/x") == "https://example.com/abs/x"
+def test_x_special_page_matches_status_urls_only() -> None:
+    x = clip_router.XThreadPage()
+    assert x.matches("https://x.com/someone/status/1808168603721650680")
+    assert x.matches("https://twitter.com/someone/statuses/9001?s=20")
+    assert x.matches("https://x.com/i/status/9001")
+    assert not x.matches("https://x.com/someone")
+    assert not x.matches("https://example.com/someone/status/9001")
 
 
-def test_is_async_url_covers_youtube_and_arxiv() -> None:
-    assert clip_router.is_async_url("https://www.youtube.com/watch?v=abc")
-    assert clip_router.is_async_url("https://arxiv.org/abs/2401.00001")
-    assert not clip_router.is_async_url("https://example.com/post")
+def test_arxiv_special_page_matches_abs_urls() -> None:
+    arxiv = clip_router.ArxivPdfPage()
+    assert arxiv.matches("https://arxiv.org/abs/2401.00001")
+    assert arxiv.matches("https://www.arxiv.org/abs/2401.00001v2")
+    assert not arxiv.matches("https://example.com/abs/x")
+
+
+def test_is_special_page_covers_youtube_x_and_arxiv() -> None:
+    assert clip_router.is_special_page("https://www.youtube.com/watch?v=abc")
+    assert clip_router.is_special_page("https://arxiv.org/abs/2401.00001")
+    assert clip_router.is_special_page("https://x.com/someone/status/9001")
+    assert not clip_router.is_special_page("https://example.com/post")
 
 
 # --- YouTube transcript fetching (ScrapeCreators + oEmbed) ---
@@ -286,6 +292,29 @@ async def test_worker_turns_youtube_url_into_transcript_page(
     assert page["name"] == "A Great Talk"
     assert page["folder_name"] == "raw"
     assert "words words" in page["content_markdown"]
+
+
+@pytest.mark.asyncio
+async def test_worker_turns_x_status_url_into_tweet_page(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    _, owner_id = await _register(client)
+    import_id = await _make_import(owner_id, "https://x.com/someone/status/9001")
+
+    async def fake_tweet(tweet_id: str) -> dict:
+        assert tweet_id == "9001"
+        return {"title": "@someone - 2026-07-01", "markdown": "a banger\n\n— @someone"}
+
+    monkeypatch.setattr(clip_router.x_indexer, "fetch_tweet_markdown", fake_tweet)
+    await clips_tasks._process_batch([import_id])
+
+    row = await pool.fetchrow("SELECT * FROM url_imports WHERE id = $1", import_id)
+    assert row["status"] == "done"
+    page = await pool.fetchrow(
+        "SELECT name, content_markdown FROM pages WHERE id = $1", row["result_page_id"]
+    )
+    assert page["name"] == "@someone - 2026-07-01"
+    assert "a banger" in page["content_markdown"]
 
 
 SHELL_HTML = "<html><body><div id='root'></div></body></html>"

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -579,7 +579,6 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
   return (
     <div className="flex h-full flex-col">
       <FileViewerHeader
-        compact
         icon={isHtml ? <HtmlGlyph /> : <PageGlyph />}
         iconColor={isHtml ? "var(--color-brand-600)" : "var(--text-muted)"}
         breadcrumbs={ancestorCrumbs}

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -248,7 +248,7 @@ function ExtensionCta() {
           Download the extension
         </div>
         <div className="mt-0.5 text-[12.5px] text-muted-foreground">
-          Clip pages, import bookmarks, and sync your Instagram saves and AI chats into Stash.
+          Import bookmarks, save tabs, and sync Claude or ChatGPT chats into Stash.
         </div>
       </div>
       <span className="shrink-0 rounded-full bg-brand px-4 py-1.5 text-[12px] font-semibold text-white">

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -63,17 +63,24 @@ export default function HomePage() {
     <div className="min-h-full">
       {/* Header */}
       <div className="border-b border-border">
-        <div className="mx-auto max-w-[720px] px-6 py-8">
+        <div className="mx-auto flex max-w-[720px] items-baseline justify-between gap-4 px-6 py-8">
           <h1 className="font-display text-[28px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground">
             Your feed
           </h1>
+          <Link
+            href="/discover"
+            className="shrink-0 text-[13px] font-medium text-brand-600 hover:underline"
+          >
+            View all collections →
+          </Link>
         </div>
       </div>
 
       {/* Feed */}
       <div className="mx-auto max-w-[720px] px-6 pb-20 pt-6">
+        <ExtensionCta />
         {initialLoad ? (
-          <CardGridSkeleton className="mt-2" />
+          <CardGridSkeleton className="mt-5" />
         ) : items.length === 0 ? (
           <section className="mt-12 rounded-lg border border-dashed border-border bg-base px-6 py-12 text-center">
             <h2 className="font-display text-[20px] font-bold text-foreground">Nothing here yet.</h2>
@@ -82,12 +89,9 @@ export default function HomePage() {
             </p>
           </section>
         ) : (
-          <div className="flex flex-col gap-5">
+          <div className="mt-5 flex flex-col gap-5">
             {items.map((item, i) => (
-              <span key={feedKey(item, i)} className="contents">
-                <FeedCard item={item} index={i} />
-                {i === 3 && <ExtensionCta />}
-              </span>
+              <FeedCard key={feedKey(item, i)} item={item} index={i} />
             ))}
           </div>
         )}

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FileText, Code2, ExternalLink } from "lucide-react";
+import { FileText, Code2, ExternalLink, Globe, Lock } from "lucide-react";
 import Link from "next/link";
 import { CardGridSkeleton } from "@/components/SkeletonStates";
 import { GitHubIcon } from "@/components/integrations/BrandIcons";
 import ForkSkillCardButton from "@/components/skill/ForkSkillCardButton";
 import SkillCard from "@/components/skill/SkillCard";
-import { StashIcon } from "@/components/SkillIcons";
 import {
   getHomeFeed,
   githubOwner,
@@ -62,23 +61,12 @@ export default function HomePage() {
 
   return (
     <div className="min-h-full">
-      {/* Hero */}
-      <div className="relative overflow-hidden border-b border-border bg-gradient-to-br from-brand-100 via-brand-50 to-[color:var(--bg-surface)]">
-        <div className="mx-auto max-w-[720px] px-6 py-10">
-          <div className="flex items-center gap-2 text-brand-600">
-            <StashIcon className="text-[26px]" />
-            <span className="text-[13px] font-semibold uppercase tracking-[0.14em]">Home</span>
-          </div>
-          <h1 className="mt-3 font-display text-[32px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground">
-            Your feed.
+      {/* Header */}
+      <div className="border-b border-border">
+        <div className="mx-auto max-w-[720px] px-6 py-8">
+          <h1 className="font-display text-[28px] font-bold leading-[1.05] tracking-[-0.02em] text-foreground">
+            Your feed
           </h1>
-          <p className="mt-2 max-w-[560px] text-[14.5px] leading-[1.6] text-dim">
-            Skills to copy, pages from the community, and things you saved that are worth another
-            look.{" "}
-            <Link href="/discover" className="font-medium text-brand-600 hover:underline">
-              Browse the full catalog →
-            </Link>
-          </p>
         </div>
       </div>
 
@@ -94,7 +82,7 @@ export default function HomePage() {
             </p>
           </section>
         ) : (
-          <div className="flex flex-col gap-3.5">
+          <div className="flex flex-col gap-5">
             {items.map((item, i) => (
               <span key={feedKey(item, i)} className="contents">
                 <FeedCard item={item} index={i} />
@@ -119,6 +107,37 @@ function feedKey(item: FeedItem, index: number): string {
 }
 
 function FeedCard({ item, index }: { item: FeedItem; index: number }) {
+  return (
+    <div>
+      <ProvenanceLabel internal={item.kind === "resurface"} />
+      <FeedCardBody item={item} index={index} />
+    </div>
+  );
+}
+
+// Every card says where it came from, so the user never has to wonder whether
+// they are looking at public community content or their own private data.
+function ProvenanceLabel({ internal }: { internal: boolean }) {
+  if (internal) {
+    return (
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-brand-600">
+        <Lock className="h-3 w-3" />
+        From your stash
+        <span className="font-normal normal-case tracking-normal text-muted-foreground">
+          · only visible to you
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+      <Globe className="h-3 w-3" />
+      From the community
+    </div>
+  );
+}
+
+function FeedCardBody({ item, index }: { item: FeedItem; index: number }) {
   if (item.kind === "skill") {
     const skill = item.data;
     return (
@@ -153,14 +172,11 @@ function FeedCard({ item, index }: { item: FeedItem; index: number }) {
 function ResurfaceCard({ data }: { data: ResurfaceCardData }) {
   const body = (
     <>
-      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-brand-600">
-        From your stash
-        <span className="rounded bg-brand-50 px-1.5 py-0.5 font-mono text-[10px] normal-case tracking-normal text-brand-600">
+      <div className="flex items-center gap-2 text-[11px]">
+        <span className="rounded bg-brand-50 px-1.5 py-0.5 font-mono text-[10px] text-brand-600">
           {sourceLabel(data.source)}
         </span>
-        <span className="font-normal normal-case tracking-normal text-muted-foreground">
-          saved {savedAgo(data.saved_at)}
-        </span>
+        <span className="text-muted-foreground">saved {savedAgo(data.saved_at)}</span>
       </div>
       <div className="mt-2 flex items-start gap-3">
         <div className="min-w-0 flex-1">
@@ -204,6 +220,9 @@ function ResurfaceCard({ data }: { data: ResurfaceCardData }) {
 function sourceLabel(source: ResurfaceCardData["source"]): string {
   if (source === "x") return "X";
   if (source === "instagram") return "Instagram";
+  if (source === "doc") return "Doc";
+  if (source === "file") return "File";
+  if (source === "memory") return "Memory";
   return "Clip";
 }
 

--- a/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
@@ -1329,7 +1329,7 @@ function TableEditorPageInner({
           }
         />
         {/* Toolbar */}
-        <div className="mt-2 flex items-center gap-2 px-4 py-2.5 border-y border-border bg-surface flex-shrink-0 flex-wrap">
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface flex-shrink-0 flex-wrap">
           {/* Search */}
           <div className="flex-1 max-w-xs">
             <input value={searchQuery} onChange={(e) => { setSearchQuery(e.target.value); setIsSearching(true); }} placeholder="Search all columns..." className="w-full px-3 py-1.5 text-xs bg-raised border border-border rounded text-foreground outline-none focus:ring-1 focus:ring-brand" />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -792,12 +792,6 @@ details > summary::-webkit-details-marker {
 .tag-warning { background: rgba(234,179,8,0.18); color: #854D0E; }
 .tag-muted { background: var(--bg-raised); color: var(--text-dim); }
 
-/* Soft brand-gradient banner — used at top of pages */
-.brand-banner {
-  height: 56px;
-  background: linear-gradient(90deg, #FED7AA, #FFEDD5, #FEF3C7);
-}
-
 /* Card variants */
 .card {
   background: var(--bg-base);

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -43,7 +43,10 @@ function LoginPageInner() {
   const cliSession = searchParams.get("cli");
   const nextPath = localNextPath(searchParams.get("next"));
   const { user, loading, logout, refresh } = useAuth();
-  const [mode, setMode] = useState<"login" | "register">("login");
+  // The landing page's "Sign up free" links here with ?mode=register.
+  const [mode, setMode] = useState<"login" | "register">(
+    searchParams.get("mode") === "register" ? "register" : "login",
+  );
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");

--- a/frontend/src/app/onboarding/page.test.tsx
+++ b/frontend/src/app/onboarding/page.test.tsx
@@ -52,25 +52,18 @@ describe("about step pills", () => {
     render(<OnboardingPage />);
     const role = screen.getByRole("button", { name: "Engineer" });
     const referral = screen.getByRole("button", { name: "Search" });
-    const plan = screen.getByRole("button", { name: "Personal — Free" });
     const continueButton = screen.getByRole("button", { name: "Continue" });
 
     fireEvent.click(role);
     fireEvent.click(referral);
-    fireEvent.click(plan);
     expect(continueButton).toBeEnabled();
 
     fireEvent.click(role);
     expect(continueButton).toBeDisabled();
   });
 
-  it("plan choice is required before Continue unlocks", () => {
+  it("there is no plan question — role and referral are the only requirements", () => {
     render(<OnboardingPage />);
-    fireEvent.click(screen.getByRole("button", { name: "Engineer" }));
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Production agent — Enterprise" }));
-    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+    expect(screen.queryByText("Which plan fits you?")).toBeNull();
   });
 });

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -491,7 +491,7 @@ function TryItOutStep({
               Get the browser extension
             </div>
             <div className="text-[12px] text-muted-foreground">
-              Clip pages, import bookmarks, sync Instagram saves and ChatGPT/Claude chats.
+              Import bookmarks, save tabs, and sync Claude or ChatGPT chats into Stash.
             </div>
           </div>
           <span className="text-muted-foreground transition-colors group-hover:text-brand">&rarr;</span>

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -6,7 +6,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Header from "../../components/Header";
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
-import { TEAMS_CONTACT_EMAIL } from "../../lib/contact";
 import {
   createMyKey,
   createPage,
@@ -21,8 +20,9 @@ import SourceConnectorList from "../../components/integrations/SourceConnectorLi
 
 import MemoryAskStep from "./paths/memory/MemoryAskStep";
 
-// The linear flow: a few questions about the user, explain Stash, try one of
-// the three entry points, then ask the agent a real question, then launch.
+// The linear flow: a few questions about the user, explain Stash, then try
+// one of five entry points. The ask step only exists off the Connect path —
+// asking the agent needs a connected source to ask about.
 const STEP_NAMES = ["about", "intro", "try", "ask"] as const;
 
 const CLI_INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
@@ -44,12 +44,6 @@ const REFERRAL_OPTIONS = [
   "GitHub",
   "LinkedIn",
   "Other",
-];
-
-const PLAN_OPTIONS = [
-  "Personal — Free",
-  "Team — Pro",
-  "Production agent — Enterprise",
 ];
 
 export default function OnboardingPage() {
@@ -74,7 +68,6 @@ function OnboardingInner() {
   const [referralSource, setReferralSource] = useState("");
   const [referralOther, setReferralOther] = useState("");
   const [useCase, setUseCase] = useState("");
-  const [planIntent, setPlanIntent] = useState("");
 
   const stepIdx = useMemo(() => {
     const raw = searchParams.get("step");
@@ -150,19 +143,23 @@ function OnboardingInner() {
   const isTryItOut = stepIdx === 2;
   const isAsk = stepIdx >= 3;
 
-  const continueLabel = isIntro ? "Get started" : isAsk ? "Launch" : "Continue";
+  const continueLabel = isIntro
+    ? "Get started"
+    : isTryItOut
+      ? "Finish"
+      : isAsk
+        ? "Launch"
+        : "Continue";
   const roleAnswer = role === "Other" ? roleOther.trim() && `Other: ${roleOther.trim()}` : role;
   const referralAnswer =
     referralSource === "Other"
       ? referralOther.trim() && `Other: ${referralOther.trim()}`
       : referralSource;
   // About: role + referral are required, and "Other" needs to be spelled out
-  // (use-case is optional). Try it out: Continue lives inside the Connect
-  // option and is gated on a connected source. Ask: only let them launch once
-  // the agent has actually replied.
-  const canContinue = isAbout
-    ? Boolean(roleAnswer && referralAnswer && planIntent)
-    : !isAsk || answered;
+  // (use-case is optional). Try it out: Finish ends onboarding from any option;
+  // the Connect option additionally offers the ask step once a source is
+  // connected. Ask: only let them launch once the agent has actually replied.
+  const canContinue = isAbout ? Boolean(roleAnswer && referralAnswer) : !isAsk || answered;
   const onContinue = async () => {
     if (isAbout) {
       try {
@@ -170,7 +167,6 @@ function OnboardingInner() {
           role: roleAnswer,
           referral_source: referralAnswer,
           use_case: useCase || undefined,
-          plan_intent: planIntent || undefined,
         });
       } catch {
         // Best-effort — don't block onboarding on a profile write.
@@ -178,11 +174,10 @@ function OnboardingInner() {
       track("onboarding.about_submitted", {
         role: roleAnswer,
         referral_source: referralAnswer,
-        plan_intent: planIntent,
       });
       return goToStep(stepIdx + 1);
     }
-    if (isAsk) return void finishAndExit();
+    if (isTryItOut || isAsk) return void finishAndExit();
     goToStep(stepIdx + 1);
   };
 
@@ -199,20 +194,18 @@ function OnboardingInner() {
               referralSource={referralSource}
               referralOther={referralOther}
               useCase={useCase}
-              planIntent={planIntent}
               onRole={setRole}
               onRoleOther={setRoleOther}
               onReferral={setReferralSource}
               onReferralOther={setReferralOther}
               onUseCase={setUseCase}
-              onPlanIntent={setPlanIntent}
             />
           )}
           {isIntro && <IntroStep />}
           {isTryItOut && (
             <TryItOutStep
               onCollabDoc={finishToCollabDoc}
-              onContinue={() => goToStep(stepIdx + 1)}
+              onAsk={() => goToStep(stepIdx + 1)}
             />
           )}
           {isAsk && <AskStep onAnswered={() => setAnswered(true)} />}
@@ -221,7 +214,6 @@ function OnboardingInner() {
             onSkip={skip}
             continueLabel={continueLabel}
             canContinue={canContinue}
-            hideContinue={isTryItOut}
           />
         </div>
       </main>
@@ -235,26 +227,22 @@ function AboutStep({
   referralSource,
   referralOther,
   useCase,
-  planIntent,
   onRole,
   onRoleOther,
   onReferral,
   onReferralOther,
   onUseCase,
-  onPlanIntent,
 }: {
   role: string;
   roleOther: string;
   referralSource: string;
   referralOther: string;
   useCase: string;
-  planIntent: string;
   onRole: (v: string) => void;
   onRoleOther: (v: string) => void;
   onReferral: (v: string) => void;
   onReferralOther: (v: string) => void;
   onUseCase: (v: string) => void;
-  onPlanIntent: (v: string) => void;
 }) {
   return (
     <div className="space-y-6">
@@ -280,24 +268,6 @@ function AboutStep({
             onChange={onReferralOther}
             placeholder="Where did you hear about us?"
           />
-        )}
-      </Field>
-      <Field label="Which plan fits you?">
-        <PillGroup options={PLAN_OPTIONS} value={planIntent} onChange={onPlanIntent} />
-        {planIntent === "Team — Pro" && (
-          <p className="text-[12px] text-dim">
-            Team workspaces are set up for you — email{" "}
-            <a className="underline" href={`mailto:${TEAMS_CONTACT_EMAIL}`}>
-              {TEAMS_CONTACT_EMAIL}
-            </a>{" "}
-            and we&rsquo;ll get your team going.
-          </p>
-        )}
-        {planIntent === "Production agent — Enterprise" && (
-          <p className="text-[12px] text-dim">
-            Your API key is free and instant. Unlimited sleep-time memory curation is part
-            of Enterprise — we&rsquo;ll reach out to get you set up.
-          </p>
         )}
       </Field>
       <Field label="What do you want to use Stash for?" optional>
@@ -415,6 +385,10 @@ function IntroStep() {
           HTML docs, Markdown, dashboards, decks — your agents&rsquo; work lands as
           real files. Edit visually, and share any folder or file as a link.
         </IntroPoint>
+        <IntroPoint title="A curated context graph">
+          While you sleep, curator agents dream over everything you saved and
+          distill it into a living memory wiki every agent you run can read.
+        </IntroPoint>
       </ul>
     </div>
   );
@@ -434,31 +408,29 @@ function IntroPoint({ title, children }: { title: string; children: React.ReactN
 
 function TryItOutStep({
   onCollabDoc,
-  onContinue,
+  onAsk,
 }: {
   onCollabDoc: () => void;
-  onContinue: () => void;
+  onAsk: () => void;
 }) {
+  const [sourceConnected, setSourceConnected] = useState(false);
   return (
-    <div className="space-y-7">
+    <div className="space-y-4">
       <div className="space-y-2">
         <h1 className="font-display text-[28px] leading-[1.1] font-bold tracking-tight text-foreground">
           Try it out
         </h1>
         <p className="text-sm text-dim max-w-md">
-          Five ways to start — pick whichever fits.
+          Five ways to start — open whichever fits.
         </p>
       </div>
       <TryOption
         badge="Build"
-        lead="Using Stash as the memory store for your agent? Mint an API key."
+        lead="Use Stash as the memory store for your agent, over a plain API."
       >
         <BuildOption />
       </TryOption>
-      <TryOption
-        badge="Create"
-        lead="Just want a place to write with your agent?"
-      >
+      <TryOption badge="Create" lead="A place to write with your agent — two cursors, one doc.">
         <button
           type="button"
           onClick={onCollabDoc}
@@ -477,34 +449,37 @@ function TryItOutStep({
       </TryOption>
       <TryOption
         badge="Connect"
-        lead="Connect a data source and your agent can navigate it like a file system."
+        lead="Connect a data source your agent can navigate like a file system."
       >
         <div className="space-y-3">
-          <SourceConnectorList returnTo="/onboarding?step=3" />
-          <div className="flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={onContinue}
-              className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors"
-            >
-              Continue
-            </button>
-          </div>
+          <SourceConnectorList
+            returnTo="/onboarding?step=3"
+            onConnectedChange={setSourceConnected}
+          />
+          {sourceConnected && (
+            <div className="flex items-center justify-end">
+              <button
+                type="button"
+                onClick={onAsk}
+                className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors"
+              >
+                Ask your agent about it &rarr;
+              </button>
+            </div>
+          )}
         </div>
       </TryOption>
       <TryOption
         badge="Capture"
-        lead="Run this in your terminal — every Claude Code / Codex session streams into Stash automatically."
+        lead="Stream every Claude Code / Codex session into Stash automatically."
       >
         <div className="space-y-2">
+          <p className="text-[12px] text-dim">Run this in your terminal:</p>
           <CommandBlock command={CLI_INSTALL_COMMAND} />
           <CommandBlock command="stash signin" />
         </div>
       </TryOption>
-      <TryOption
-        badge="Save"
-        lead="Save anything you read, straight from your browser."
-      >
+      <TryOption badge="Clip" lead="Save anything you read, straight from your browser.">
         <a
           href={routes.extension}
           target="_blank"
@@ -526,6 +501,8 @@ function TryItOutStep({
   );
 }
 
+// Each way to start is a collapsed accordion: badge + one-line description
+// up front, the actual steps revealed on open.
 function TryOption({
   badge,
   lead,
@@ -536,15 +513,18 @@ function TryOption({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-2.5">
-      <div className="flex items-center gap-2.5">
+    <details className="group rounded-lg border border-border bg-surface">
+      <summary className="flex cursor-pointer list-none items-center gap-2.5 px-4 py-3 [&::-webkit-details-marker]:hidden">
         <span className="rounded bg-brand/10 px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-brand">
           {badge}
         </span>
-        <span className="text-[13px] text-dim">{lead}</span>
-      </div>
-      {children}
-    </div>
+        <span className="flex-1 text-[13px] text-dim">{lead}</span>
+        <span className="text-muted-foreground transition-transform group-open:rotate-90">
+          &rsaquo;
+        </span>
+      </summary>
+      <div className="border-t border-border px-4 py-3">{children}</div>
+    </details>
   );
 }
 
@@ -599,10 +579,24 @@ function BuildOption() {
 }
 
 function CommandBlock({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
   return (
-    <pre className="overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
-      {command}
-    </pre>
+    <div className="flex items-stretch gap-1.5">
+      <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
+        {command}
+      </pre>
+      <button
+        type="button"
+        onClick={async () => {
+          await navigator.clipboard.writeText(command);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+        className="shrink-0 cursor-pointer rounded-md border border-border bg-surface px-2.5 text-[11px] text-muted-foreground transition-colors hover:border-brand hover:text-foreground"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
   );
 }
 
@@ -622,8 +616,10 @@ function AskStep({ onAnswered }: { onAnswered: () => void }) {
   );
 }
 
+// "Ask" is deliberately absent — that step only exists off the Connect path,
+// so it doesn't belong in the always-visible progress trail.
 function ProgressBar({ stepIdx }: { stepIdx: number }) {
-  const labels = ["About you", "Welcome", "Try it out", "Ask"];
+  const labels = ["About you", "Welcome", "Try it out"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, i) => {
@@ -654,13 +650,11 @@ function StepControls({
   onSkip,
   continueLabel,
   canContinue,
-  hideContinue,
 }: {
   onContinue: () => void;
   onSkip: () => void;
   continueLabel: string;
   canContinue: boolean;
-  hideContinue?: boolean;
 }) {
   return (
     <div className="flex items-center justify-between pt-2">
@@ -671,16 +665,14 @@ function StepControls({
       >
         Skip onboarding
       </button>
-      {!hideContinue && (
-        <button
-          type="button"
-          onClick={onContinue}
-          disabled={!canContinue}
-          className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {continueLabel}
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={onContinue}
+        disabled={!canContinue}
+        className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[12px] font-medium text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {continueLabel}
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/content/FileViewerHeader.tsx
+++ b/frontend/src/components/content/FileViewerHeader.tsx
@@ -54,23 +54,17 @@ interface FileViewerHeaderProps {
   downloadOptions?: DownloadOption[];
   /** Anything that should sit between the save-status and the download menu. */
   rightExtras?: ReactNode;
-  /** Render a compact single-row bar (for the tabbed workbench) instead of the
-   *  banner + big-icon document header. */
-  compact?: boolean;
 }
 
 const SAVE_LABEL = { saving: "Saving…", dirty: "Unsaved", saved: "Saved" } as const;
 const SAVE_TONE = { saving: "text-amber-500", dirty: "text-amber-600", saved: "text-emerald-600" } as const;
 
 /**
- * Standard header for the file/page/table viewers. Renders a thin brand
- * banner, a big rounded icon, the file title (editable or read-only),
- * and a meta row with type tags, save status, and a Download menu.
- *
- * The page viewer (`/p/[id]`), the file viewer
- * (`/f/[id]`), and the table viewer (`/tables/[id]`) all
- * use this so the entry visual for "you are looking at a thing" is the
- * same shape across kinds.
+ * Standard header for the file/page/table viewers: one clean single-row bar —
+ * icon, breadcrumbs, title (editable or read-only), tags, meta, save status,
+ * and a Download menu. The page viewer (`/p/[id]`), the file viewer
+ * (`/f/[id]`), and the table viewer (`/tables/[id]`) all use this so the
+ * entry visual for "you are looking at a thing" is the same shape across kinds.
  */
 export default function FileViewerHeader({
   icon,
@@ -86,133 +80,44 @@ export default function FileViewerHeader({
   saveStatus,
   downloadOptions,
   rightExtras,
-  compact,
 }: FileViewerHeaderProps) {
   const iconStyle: CSSProperties = {
     color: iconColor ?? "var(--text-muted)",
   };
 
-  // Compact bar: a persistent document toolbar for the tabbed workbench —
-  // name, date modified, save status, actions, download — no banner.
-  if (compact) {
-    return (
-      <div className="flex h-11 shrink-0 items-center gap-2.5 border-b border-border bg-base px-4">
-        <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border bg-base text-[14px]" style={iconStyle}>
-          {icon}
-        </span>
-        {breadcrumbs?.map((crumb) => (
-          <span key={crumb.href} className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
-            <Link href={crumb.href} className="max-w-[160px] truncate hover:text-foreground">{crumb.label}</Link>
-            <span className="text-muted-foreground/50">/</span>
-          </span>
-        ))}
-        <span className="min-w-0 shrink truncate text-[13.5px] font-semibold text-foreground">
-          {readOnly || !onRenameTitle ? title : <EditableTitle value={title} onSave={onRenameTitle} />}
-        </span>
-        {tags?.map((tag, i) => (
-          <span key={`${tag.label}-${i}`} className={"tag shrink-0 " + (tag.tone === "brand" ? "tag-brand" : "tag-muted")}>{tag.label}</span>
-        ))}
-        <span className="flex min-w-0 items-center gap-2 truncate text-[12px] text-muted-foreground">
-          {meta?.map((item, i) => <span key={i} className="shrink-0">{item}</span>)}
-          {!readOnly && saveStatus && <span className={SAVE_TONE[saveStatus]}>{SAVE_LABEL[saveStatus]}</span>}
-          {readOnly && <span className="rounded-md bg-surface px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-wide">{readOnlyLabel}</span>}
-        </span>
-        <span className="flex-1" />
-        <div className="flex shrink-0 items-center gap-2">
-          {rightExtras}
-          {downloadOptions && downloadOptions.length > 0 && <DownloadMenu options={downloadOptions} />}
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <>
-      <div className="brand-banner" />
-      {/* `w-full` is load-bearing: when the parent is a `flex-col`, `mx-auto`
-          alone collapses this container to shrink-to-fit and centers it,
-          so PDF / HTML / image / table headers end up indented while the
-          markdown page (block-level parent) lays out left-aligned. With
-          `w-full` the container always claims its parent's cross-axis
-          width before the max-width cap kicks in, so all viewers align
-          to the same left edge. */}
-      <div className="mx-auto w-full -mt-[22px] max-w-[1100px] px-12 pt-0">
-        {backLink && (
-          <Link
-            href={backLink.href}
-            className="mb-2 inline-flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
-          >
-            &larr; {backLink.label}
-          </Link>
-        )}
-        {!backLink && breadcrumbs && breadcrumbs.length > 0 && (
-          <div className="mb-2 flex flex-wrap items-center gap-1.5 text-[12px] text-muted-foreground">
-            {breadcrumbs.map((crumb, i) => (
-              <span key={crumb.href} className="inline-flex items-center gap-1.5">
-                {i > 0 && <span className="text-muted-foreground/50">/</span>}
-                <Link href={crumb.href} className="hover:text-foreground">{crumb.label}</Link>
-              </span>
-            ))}
-          </div>
-        )}
-        <span
-          className="inline-flex h-14 w-14 items-center justify-center rounded-[12px] border border-border bg-base"
-          style={iconStyle}
-        >
-          {icon}
+    <div className="flex h-11 shrink-0 items-center gap-2.5 border-b border-border bg-base px-4">
+      <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border bg-base text-[14px]" style={iconStyle}>
+        {icon}
+      </span>
+      {backLink && (
+        <span className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
+          <Link href={backLink.href} className="max-w-[160px] truncate hover:text-foreground">&larr; {backLink.label}</Link>
+          <span className="text-muted-foreground/50">/</span>
         </span>
-        <h1 className="mb-1 mt-3 font-display text-[38px] font-bold leading-tight tracking-[-0.025em]">
-          {readOnly || !onRenameTitle ? (
-            <span>{title}</span>
-          ) : (
-            <EditableTitle value={title} onSave={onRenameTitle} />
-          )}
-        </h1>
-
-        <div className="flex flex-wrap items-center gap-2.5 text-[12px] text-muted-foreground">
-          {tags?.map((tag, i) => (
-            <span
-              key={`${tag.label}-${i}`}
-              className={"tag " + (tag.tone === "brand" ? "tag-brand" : "tag-muted")}
-            >
-              {tag.label}
-            </span>
-          ))}
-          {meta?.map((item, i) => (
-            <span key={i}>{item}</span>
-          ))}
-          {!readOnly && saveStatus && (
-            <>
-              <span>·</span>
-              <span
-                className={
-                  saveStatus === "saving"
-                    ? "text-amber-500"
-                    : saveStatus === "dirty"
-                      ? "text-amber-600"
-                      : "text-emerald-600"
-                }
-              >
-                {saveStatus === "saving"
-                  ? "Saving…"
-                  : saveStatus === "dirty"
-                    ? "Unsaved"
-                    : "Saved"}
-              </span>
-            </>
-          )}
-          {readOnly && (
-            <span className="rounded-md bg-surface px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
-              {readOnlyLabel}
-            </span>
-          )}
-          <span className="flex-1" />
-          {rightExtras}
-          {downloadOptions && downloadOptions.length > 0 && (
-            <DownloadMenu options={downloadOptions} />
-          )}
-        </div>
+      )}
+      {breadcrumbs?.map((crumb) => (
+        <span key={crumb.href} className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
+          <Link href={crumb.href} className="max-w-[160px] truncate hover:text-foreground">{crumb.label}</Link>
+          <span className="text-muted-foreground/50">/</span>
+        </span>
+      ))}
+      <span className="min-w-0 shrink truncate text-[13.5px] font-semibold text-foreground">
+        {readOnly || !onRenameTitle ? title : <EditableTitle value={title} onSave={onRenameTitle} />}
+      </span>
+      {tags?.map((tag, i) => (
+        <span key={`${tag.label}-${i}`} className={"tag shrink-0 " + (tag.tone === "brand" ? "tag-brand" : "tag-muted")}>{tag.label}</span>
+      ))}
+      <span className="flex min-w-0 items-center gap-2 truncate text-[12px] text-muted-foreground">
+        {meta?.map((item, i) => <span key={i} className="shrink-0">{item}</span>)}
+        {!readOnly && saveStatus && <span className={SAVE_TONE[saveStatus]}>{SAVE_LABEL[saveStatus]}</span>}
+        {readOnly && <span className="rounded-md bg-surface px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-wide">{readOnlyLabel}</span>}
+      </span>
+      <span className="flex-1" />
+      <div className="flex shrink-0 items-center gap-2">
+        {rightExtras}
+        {downloadOptions && downloadOptions.length > 0 && <DownloadMenu options={downloadOptions} />}
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/integrations/SourceConnectorList.tsx
+++ b/frontend/src/components/integrations/SourceConnectorList.tsx
@@ -23,7 +23,7 @@ import PaywallModal from "../PaywallModal";
 type Props = {
   returnTo: string;
   includeObsidian?: boolean;
-  onSourceCountChange?: (count: number) => void;
+  onConnectedChange?: (connected: boolean) => void;
   onObsidianUploaded?: () => void;
 };
 
@@ -32,6 +32,7 @@ type Props = {
 export default function SourceConnectorList({
   returnTo,
   includeObsidian = true,
+  onConnectedChange,
   onObsidianUploaded,
 }: Props) {
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus>>({});
@@ -60,7 +61,10 @@ export default function SourceConnectorList({
     }
     setExtensionSources(extension);
     setLoaded(true);
-  }, []);
+    onConnectedChange?.(
+      integrations.providers.some((p) => p.connected) || Object.keys(extension).length > 0,
+    );
+  }, [onConnectedChange]);
 
   useEffect(() => {
     refresh().catch((e) => {
@@ -68,10 +72,12 @@ export default function SourceConnectorList({
     });
   }, [refresh]);
 
+  // Only reasons for providers we actually render a card for — the server may
+  // list providers this surface doesn't offer (no card, so no banner either).
   const disabledReasons = useMemo(() => {
-    const reasons = Object.values(statuses)
-      .map((status) => status.disabled_reason)
-      .filter((reason): reason is string => Boolean(reason));
+    const reasons = CONNECTORS.map((c) => statuses[c.provider]?.disabled_reason).filter(
+      (reason): reason is string => Boolean(reason),
+    );
     return Array.from(new Set(reasons));
   }, [statuses]);
 

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -370,6 +370,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
           }
           openRootTab={isSessions ? () => open("sessions-home", "sessions", "Sessions") : undefined}
           showImport={!isSessions}
+          importIntent={section === "skills" ? "skills" : "files"}
           vfsWritable={!isSessions}
           headerAction={
             section === "memory"

--- a/frontend/src/components/workspace/files-explorer.test.tsx
+++ b/frontend/src/components/workspace/files-explorer.test.tsx
@@ -20,6 +20,10 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({ user: null, loading: false }),
 }));
 
+vi.mock("@/components/ConfirmDialog", () => ({
+  useConfirm: () => async () => true,
+}));
+
 vi.mock("@/components/share/ResourceShareButton", () => ({
   ResourceShareDialog: () => null,
 }));
@@ -41,6 +45,7 @@ vi.mock("@/lib/api", () => ({
   updateSessionFolder: vi.fn(),
   uploadFileOrPage: vi.fn(),
   importGithubRepo: vi.fn(),
+  inspectGithubImport: vi.fn().mockResolvedValue({ skill_dirs: [] }),
   listGithubImportRepos: vi.fn().mockResolvedValue({ connected: false, repos: [] }),
 }));
 

--- a/frontend/src/components/workspace/files-explorer.test.tsx
+++ b/frontend/src/components/workspace/files-explorer.test.tsx
@@ -16,6 +16,14 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn() },
 }));
 
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
+vi.mock("@/components/share/ResourceShareButton", () => ({
+  ResourceShareDialog: () => null,
+}));
+
 vi.mock("@/lib/api", () => ({
   getTree: vi.fn(),
   getFolderContents: vi.fn(),
@@ -32,7 +40,8 @@ vi.mock("@/lib/api", () => ({
   deleteSessionFolder: vi.fn(),
   updateSessionFolder: vi.fn(),
   uploadFileOrPage: vi.fn(),
-  importGithubSkill: vi.fn(),
+  importGithubRepo: vi.fn(),
+  listGithubImportRepos: vi.fn().mockResolvedValue({ connected: false, repos: [] }),
 }));
 
 const MEMORY_FOLDER = "memory-folder-1";

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -11,9 +11,10 @@ import {
 import {
   getTree, getFolderContents, createPage, createFolder, createTable, updateFolder, updatePage,
   updateFile, updateTable, trashItem, deleteFolder, deleteTable, deleteSessionFolder, updateSessionFolder,
-  uploadFileOrPage, importGithubRepo, listGithubImportRepos,
+  uploadFileOrPage, importGithubRepo, inspectGithubImport, listGithubImportRepos,
   type FolderBreadcrumb, type GithubImportRepo,
 } from "@/lib/api";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import { useWorkspace } from "@/lib/workspace-store";
@@ -61,6 +62,7 @@ export default function FilesExplorer({
   newRootItem,
   openRootTab,
   showImport = true,
+  importIntent = "files",
   vfsWritable = true,
   headerAction,
   confirmMemoryWrites = false,
@@ -88,6 +90,10 @@ export default function FilesExplorer({
   openRootTab?: () => void;
   /** Show the GitHub import button. Default true. */
   showImport?: boolean;
+  /** Where the user expects a GitHub import to surface. Content decides where
+   *  it actually lands (SKILL.md folders derive as skills), so a mismatch
+   *  gets a confirmation first. */
+  importIntent?: "files" | "skills";
   /** This section can create VFS items (new file/folder/upload). Default true;
    *  Sessions is a read-through view, so false. */
   vfsWritable?: boolean;
@@ -102,6 +108,7 @@ export default function FilesExplorer({
 }) {
   const router = useRouter();
   const { user } = useAuth();
+  const confirm = useConfirm();
   const openTab = useWorkspace((s) => s.openTab);
   const [folderId, setFolderId] = useState<string | null>(rootFolderId);
   // Item being shared from the context menu, anchored at the menu's position.
@@ -266,6 +273,26 @@ export default function FilesExplorer({
     if (!target) return;
     setImporting(true);
     try {
+      // Content decides where the import surfaces (SKILL.md folders derive as
+      // skills) — when that won't match the section the user is importing
+      // from, say so before copying anything.
+      const { skill_dirs } = await inspectGithubImport(target);
+      if (importIntent === "skills" && skill_dirs.length === 0) {
+        const ok = await confirm({
+          title: "No SKILL.md in this repo",
+          body: "It will be imported as a plain folder under Files, not Skills. You can add a SKILL.md afterwards to turn it into a skill.",
+          confirmLabel: "Import to Files",
+        });
+        if (!ok) return;
+      }
+      if (importIntent === "files" && skill_dirs.length > 0) {
+        const ok = await confirm({
+          title: "This repo contains skills",
+          body: `${skill_dirs.length} folder${skill_dirs.length !== 1 ? "s" : ""} with a SKILL.md will show up under Skills instead of Files. Everything else lands in Files as usual.`,
+          confirmLabel: "Import",
+        });
+        if (!ok) return;
+      }
       const r = await importGithubRepo(target);
       toast.success(`Imported ${r.name} (${r.files} file${r.files !== 1 ? "s" : ""})`);
       setImportOpen(false);

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -6,16 +6,20 @@ import { toast } from "sonner";
 import {
   Loader2, FilePlus, FolderPlus, Upload, Trash2, Pencil, FolderInput,
   Plus, ArrowDownAZ, Clock, FileText, Code2, Table2, GitBranch, GraduationCap, MessagesSquare,
+  ExternalLink, Share2,
 } from "lucide-react";
 import {
   getTree, getFolderContents, createPage, createFolder, createTable, updateFolder, updatePage,
   updateFile, updateTable, trashItem, deleteFolder, deleteTable, deleteSessionFolder, updateSessionFolder,
-  uploadFileOrPage, importGithubSkill, type FolderBreadcrumb,
+  uploadFileOrPage, importGithubRepo, listGithubImportRepos,
+  type FolderBreadcrumb, type GithubImportRepo,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 import { useWorkspace } from "@/lib/workspace-store";
 import { urlForTab } from "@/lib/workspace-routes";
 import { opensNewTab } from "@/lib/tab-nav";
+import { ResourceShareDialog } from "@/components/share/ResourceShareButton";
 import { FolderIcon, PageIcon, FileIcon, TableIcon } from "@/components/SkillIcons";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
@@ -26,6 +30,20 @@ type Kind = "folder" | "page" | "file" | "table" | "skill" | "session-folder" | 
 export type Item = { kind: Kind; id: string; name: string; ts?: string };
 // Kinds that live in the VFS (draggable, rename/move/delete via folder/page APIs).
 const VFS_KINDS = new Set<Kind>(["folder", "page", "file", "table", "skill"]);
+
+// VFS kinds map onto the generic object-share model; a skill is just a folder.
+function shareObjectType(kind: Kind): "folder" | "page" | "file" | "table" {
+  if (kind === "page") return "page";
+  if (kind === "file") return "file";
+  if (kind === "table") return "table";
+  return "folder";
+}
+function shareUrlPath(item: Item): string {
+  if (item.kind === "page") return `/p/${item.id}`;
+  if (item.kind === "file") return `/f/${item.id}`;
+  if (item.kind === "table") return `/tables/${item.id}`;
+  return `/folders/${item.id}`;
+}
 type Menu = { x: number; y: number; item: Item } | null;
 type Sort = "name" | "date";
 const DND = "application/x-fx-item";
@@ -83,8 +101,12 @@ export default function FilesExplorer({
   confirmMemoryWrites?: boolean;
 }) {
   const router = useRouter();
+  const { user } = useAuth();
   const openTab = useWorkspace((s) => s.openTab);
   const [folderId, setFolderId] = useState<string | null>(rootFolderId);
+  // Item being shared from the context menu, anchored at the menu's position.
+  const [sharing, setSharing] = useState<{ x: number; y: number; item: Item } | null>(null);
+  const shareRef = useRef<HTMLDivElement>(null);
 
   const [items, setItems] = useState<Item[] | null>(null);
   const [crumbs, setCrumbs] = useState<FolderBreadcrumb[]>([]);
@@ -96,6 +118,10 @@ export default function FilesExplorer({
   const [importOpen, setImportOpen] = useState(false);
   const [repoUrl, setRepoUrl] = useState("");
   const [importing, setImporting] = useState(false);
+  // Repos from the user's GitHub connection (null until loaded; [] = connected
+  // but empty; stays null when GitHub isn't connected → URL paste only).
+  const [githubRepos, setGithubRepos] = useState<GithubImportRepo[] | null>(null);
+  const [repoFilter, setRepoFilter] = useState("");
   // A write action waiting on the "Add to Memory?" confirmation. `run` receives
   // the destination folder: the browsed Memory folder, or null for Files root.
   const [pendingWrite, setPendingWrite] = useState<{ run: (folder: string | null) => Promise<void> } | null>(null);
@@ -144,11 +170,12 @@ export default function FilesExplorer({
 
   // Open an item as a workbench tab (folder → folder tab; skill → skill tab; …).
   // Session folders have no tab view, so they only ever navigate in the explorer.
-  function openAsTab(item: Item) {
+  function openAsTab(item: Item, opts?: { forceNewTab?: boolean }) {
     if (item.kind === "session-folder") { setFolderId(item.id); return; }
     const kind = item.kind === "folder" ? "folder" : item.kind === "skill" ? "skill" : item.kind === "session" ? "session" : item.kind === "table" ? "table" : item.kind === "page" ? "page" : "file";
-    // Plain click navigates the current tab; cmd/ctrl-click opens a new one.
-    openTab(kind, item.id, item.name, { newTab: opensNewTab() });
+    // Plain click navigates the current tab; cmd/ctrl-click (or the explicit
+    // "Open in new tab" menu item) opens a new one.
+    openTab(kind, item.id, item.name, { newTab: opts?.forceNewTab || opensNewTab() });
     const suffix = tabSection ? `?section=${tabSection}` : "";
     router.replace(urlForTab({ kind, refId: item.id }) + suffix);
   }
@@ -234,19 +261,29 @@ export default function FilesExplorer({
     if (files.length === 0) return;
     guardWrite((folder) => uploadFiles(files, folder));
   }
-  async function doImport() {
-    if (!repoUrl.trim()) return;
+  async function doImport(url?: string) {
+    const target = (url ?? repoUrl).trim();
+    if (!target) return;
     setImporting(true);
     try {
-      const r = await importGithubSkill(repoUrl.trim());
-      toast.success(`Imported ${r.imported} skill${r.imported !== 1 ? "s" : ""} from GitHub`);
+      const r = await importGithubRepo(target);
+      toast.success(`Imported ${r.name} (${r.files} file${r.files !== 1 ? "s" : ""})`);
       setImportOpen(false);
       setRepoUrl("");
+      await load();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Import failed");
     } finally {
       setImporting(false);
     }
+  }
+  function openImport() {
+    setImportOpen(true);
+    setRepoFilter("");
+    // Repo picker only lights up for users with a GitHub connection.
+    listGithubImportRepos()
+      .then((r) => setGithubRepos(r.connected ? r.repos : null))
+      .catch(() => setGithubRepos(null));
   }
 
   // A virtual root (Skills list) has no folder to create loose files into.
@@ -307,7 +344,7 @@ export default function FilesExplorer({
               <ToolBtn icon={<Upload className="h-4 w-4" />} label="Upload" onClick={() => fileRef.current?.click()} />
             </>
           ) : null}
-          {showImport && <ToolBtn icon={<GitBranch className="h-4 w-4" />} label="Import from GitHub" onClick={() => setImportOpen(true)} />}
+          {showImport && <ToolBtn icon={<GitBranch className="h-4 w-4" />} label="Import from GitHub" onClick={openImport} />}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button title="Sort" aria-label="Sort" className="flex h-7 w-7 items-center justify-center rounded text-sidebar-foreground hover:bg-sidebar-accent">
@@ -381,11 +418,32 @@ export default function FilesExplorer({
       </div>
 
       {menu && (
-        <div className="fixed z-50 w-40 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg" style={{ left: menu.x, top: menu.y }} onClick={(e) => e.stopPropagation()}>
-          <button onClick={() => { const it = menu.item; setMenu(null); if (isFolderLike(it)) setFolderId(it.id); else openAsTab(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><FolderInput className="h-3.5 w-3.5" /> Open</button>
+        <div className="fixed z-50 w-44 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg" style={{ left: menu.x, top: menu.y }} onClick={(e) => e.stopPropagation()}>
           {(menu.item.kind === "folder" || menu.item.kind === "skill") && <button onClick={() => { const it = menu.item; setMenu(null); openAsTab(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><FolderInput className="h-3.5 w-3.5" /> Open in tab</button>}
+          {menu.item.kind !== "session-folder" && <button onClick={() => { const it = menu.item; setMenu(null); openAsTab(it, { forceNewTab: true }); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><ExternalLink className="h-3.5 w-3.5" /> Open in new tab</button>}
+          {VFS_KINDS.has(menu.item.kind) && user && <button onClick={() => { setSharing({ x: menu.x, y: menu.y, item: menu.item }); setMenu(null); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><Share2 className="h-3.5 w-3.5" /> Share</button>}
           {menu.item.kind !== "session" && <button onClick={() => { setRenaming(menu.item.id); setMenu(null); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><Pencil className="h-3.5 w-3.5" /> Rename</button>}
           <button onClick={async () => { const it = menu.item; setMenu(null); await del(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-destructive hover:bg-raised"><Trash2 className="h-3.5 w-3.5" /> Delete</button>
+        </div>
+      )}
+
+      {sharing && user && (
+        <div
+          ref={shareRef}
+          className="fixed z-50"
+          style={{ left: Math.min(sharing.x, typeof window === "undefined" ? sharing.x : window.innerWidth - 440), top: sharing.y }}
+        >
+          <div className="relative w-[420px]">
+            <ResourceShareDialog
+              objectType={shareObjectType(sharing.item.kind)}
+              objectId={sharing.item.id}
+              resourceName={sharing.item.name}
+              resourceUrlPath={shareUrlPath(sharing.item)}
+              currentUser={user}
+              boundaryRef={shareRef}
+              onClose={() => setSharing(null)}
+            />
+          </div>
         </div>
       )}
 
@@ -415,11 +473,38 @@ export default function FilesExplorer({
       <Dialog open={importOpen} onOpenChange={setImportOpen}>
         <DialogContent>
           <DialogHeader><DialogTitle>Import from GitHub</DialogTitle></DialogHeader>
-          <p className="text-[13px] text-muted-foreground">Paste a public repo URL to import its <code>SKILL.md</code> folders as Skills.</p>
+          <p className="text-[13px] text-muted-foreground">
+            Copies the repo into a new folder. Folders with a <code>SKILL.md</code> show up as Skills.
+          </p>
           <Input placeholder="https://github.com/owner/repo" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") void doImport(); }} />
+          {githubRepos && (
+            <div className="space-y-1.5">
+              <Input placeholder="Or pick one of your repos…" value={repoFilter} onChange={(e) => setRepoFilter(e.target.value)} />
+              <div className="max-h-52 overflow-y-auto rounded-md border border-border">
+                {githubRepos
+                  .filter((r) => r.full_name.toLowerCase().includes(repoFilter.toLowerCase()))
+                  .map((r) => (
+                    <button
+                      key={r.full_name}
+                      type="button"
+                      disabled={importing}
+                      onClick={() => void doImport(r.html_url)}
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] hover:bg-raised disabled:opacity-50"
+                    >
+                      <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1 truncate">{r.full_name}</span>
+                      {r.private && <span className="shrink-0 rounded bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">private</span>}
+                    </button>
+                  ))}
+                {githubRepos.length === 0 && (
+                  <div className="px-3 py-2 text-[12.5px] text-muted-foreground">No repos on your GitHub connection.</div>
+                )}
+              </div>
+            </div>
+          )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setImportOpen(false)}>Cancel</Button>
-            <Button onClick={doImport} disabled={importing}>{importing ? "Importing…" : "Import"}</Button>
+            <Button onClick={() => void doImport()} disabled={importing}>{importing ? "Importing…" : "Import"}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -67,6 +67,7 @@ function NewTabMenu() {
  *  (left) or 1 (right, only present when split). */
 function TabPane({ pane }: { pane: 0 | 1 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const tabs = useWorkspace((s) => s.tabs);
   const paneOf = useWorkspace((s) => s.paneOf);
   const activeTabId = useWorkspace((s) => s.activeTabId);
@@ -82,9 +83,12 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
   const activeId = pane === 0 ? activeTabId : activeTab1;
   const { shareAction } = useShellChromeValue(activeId ?? undefined);
 
+  // Keep ?section= when refocusing a tab — the explorer sidebar's section is
+  // derived from the URL, and switching tabs must never move the sidebar.
   function focus(tab: WorkbenchTab) {
     setActiveTab(tab.id);
-    router.replace(urlForTab(tab));
+    const section = searchParams.get("section");
+    router.replace(urlForTab(tab) + (section ? `?section=${section}` : ""));
   }
 
   function onDrop(e: React.DragEvent) {
@@ -210,7 +214,9 @@ export default function Workbench() {
     if (!match) return;
     const existing = useWorkspace.getState().tabs.find((t) => t.kind === match.kind && t.refId === match.refId);
     if (existing) setActiveTab(existing.id);
-    else openTab(match.kind, match.refId, match.kind === "sessions-home" ? "Sessions" : match.refId);
+    // Deep links navigate the current tab — only cmd/ctrl-click and the
+    // explicit new-tab affordances ever add tabs.
+    else openTab(match.kind, match.refId, match.kind === "sessions-home" ? "Sessions" : match.refId, { newTab: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname, searchParams]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -495,11 +495,11 @@ export function githubOwner(sourceGithubUrl: string): string {
 
 // --- Home feed ---
 
-// An item from the caller's own stash the feed resurfaces: an old clip
-// (opens in-app via app_url) or an X/Instagram save (opens the original
-// via external_url; the archived text is the preview).
+// An item from the caller's own stash the feed resurfaces: an old doc, file,
+// memory page, or clip (opens in-app via app_url) or an X/Instagram save
+// (opens the original via external_url; the archived text is the preview).
 export interface ResurfaceCardData {
-  source: "x" | "instagram" | "clip";
+  source: "x" | "instagram" | "clip" | "doc" | "file" | "memory";
   title: string;
   preview: string;
   saved_at: string;
@@ -1416,13 +1416,29 @@ export async function listSkills(): Promise<Skill[]> {
 }
 
 // Import a public GitHub repo's SKILL.md folders as private skills in your scope.
-export async function importGithubSkill(
+// Straight copy of a whole repo into a new root folder; folders containing a
+// SKILL.md derive as skills automatically.
+export async function importGithubRepo(
   repoUrl: string,
-): Promise<{ skills: number; imported: number }> {
-  return apiFetch(`${ME}/skills/import-github`, {
+): Promise<{ folder_id: string; name: string; files: number }> {
+  return apiFetch(`${ME}/import/github`, {
     method: "POST",
     body: JSON.stringify({ repo_url: repoUrl }),
   });
+}
+
+export interface GithubImportRepo {
+  full_name: string;
+  html_url: string;
+  private: boolean;
+  description: string;
+}
+
+export async function listGithubImportRepos(): Promise<{
+  connected: boolean;
+  repos: GithubImportRepo[];
+}> {
+  return apiFetch(`${ME}/import/github/repos`);
 }
 
 // The full publish record, as returned by publish/update.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1427,6 +1427,11 @@ export async function importGithubRepo(
   });
 }
 
+// Tree-only pre-import look: which repo folders are skills ('' = repo root).
+export async function inspectGithubImport(repoUrl: string): Promise<{ skill_dirs: string[] }> {
+  return apiFetch(`${ME}/import/github/inspect?repo_url=${encodeURIComponent(repoUrl)}`);
+}
+
 export interface GithubImportRepo {
   full_name: string;
   html_url: string;

--- a/www/app/_components/CtaPair.tsx
+++ b/www/app/_components/CtaPair.tsx
@@ -3,13 +3,16 @@ import Link from "next/link";
 import ScrollLink from "./ScrollLink";
 
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+// Signup must land on the auth flow — the app root is the public feed and
+// shows a signed-out visitor no way to create an account.
+const SIGNUP_URL = `${APP_URL}/login?mode=register`;
 const CALL_URL = "/contact-sales";
 
 // One consistent CTA pair everywhere across the landing: orange "Sign up free"
 // as the primary goal, outlined "Book a call" as the enterprise secondary.
 // Variant pages pass signupHref="#survey" so the primary scrolls to their form.
 export default function CtaPair({
-  signupHref = APP_URL,
+  signupHref = SIGNUP_URL,
   align = "start",
 }: {
   signupHref?: string;

--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -4,11 +4,14 @@ import Logo from "./Logo";
 import ScrollLink from "./ScrollLink";
 
 const APP_URL = process.env.MANAGED_APP_URL || "https://app.joinstash.ai";
+// Signup must land on the auth flow — the app root is the public feed and
+// shows a signed-out visitor no way to create an account.
+const SIGNUP_URL = `${APP_URL}/login?mode=register`;
 
 // Shared top nav for the landing page and the use-case pages, so the two
 // primary use-case links stay identical everywhere they appear. The
 // message-test pages pass ctaHref="#survey" so signup leads to their form.
-export default function SiteHeader({ ctaHref = APP_URL }: { ctaHref?: string }) {
+export default function SiteHeader({ ctaHref = SIGNUP_URL }: { ctaHref?: string }) {
   const ctaClassName =
     "hidden h-10 items-center rounded-lg bg-brand px-[18px] text-[14px] font-medium text-white shadow-sm transition hover:bg-brand-hover sm:inline-flex";
   return (


### PR DESCRIPTION
## What this does

**Home feed**
- Header is just "Your feed" with a "View all collections →" link; the gradient hero and tagline are gone. The extension CTA is pinned above the feed (copy: "Import bookmarks, save tabs, and sync Claude or ChatGPT chats into Stash").
- Every card states its provenance: muted "From the community" (skills, public pages) vs. brand-colored "🔒 From your stash · only visible to you" (resurfaced items), so public vs. private is unmistakable.
- The resurface pool now includes the user's docs, uploaded files, and Memory wiki pages (previously only X/Instagram saves and clips — files and memory never surfaced). Skill scaffolding (SKILL.md subtrees) is excluded. Internal cards land every 3rd slot (was 4th), `PAGE_RESURFACE` 3→4.

**Onboarding**
- "Which plan fits you?" question removed; role + referral remain required, use-case optional.
- Welcome page gains a 4th value prop: "A curated context graph" (sleep-time curator agents dreaming over your saves).
- The five entry points (Build / Create / Connect / Capture / Clip) are collapsed accordions; every command block has a Copy button; a Finish button completes onboarding from any path.
- "Ask" is off the progress trail; it's reachable only from the Connect option once a source is actually connected ("Ask your agent about it →").
- The "Gong OAuth is not configured" banner is fixed at the root: the disabled-reasons banner now only shows reasons for providers that render a card.

**Explorer / tabs**
- Tab focus and deep links preserve `?section=`, so switching tabs never moves the sidebar; deep-link navigation replaces the current tab instead of stacking new ones (cmd/ctrl-click still opens new tabs).
- Context menu: "Open" removed (single click does that); "Open in new tab" and "Share" added — Share opens the full share dialog straight from the sidebar.

**Viewers**
- PDF and table viewers use the same flat single-row header as markdown pages; the `brand-banner` gradient and the tall big-icon header mode are deleted (single codepath).

**Auth**
- www "Sign up free" CTAs now land on `/login?mode=register` (they pointed at the app root, which is the public feed — a visitor saw no signup at all); the login page honors `?mode=register`.

**GitHub import**
- Now a straight whole-repo copy into one new root folder (was: extract only SKILL.md dirs). SKILL.md folders derive as skills automatically.
- Repo picker in the dialog when the user has GitHub connected (private repos import via their token); URL paste still works.
- Tree-only pre-import inspect confirms section mismatches: importing a no-SKILL.md repo from Skills warns it lands in Files; importing a repo with skills from Files warns those surface under Skills.

**X/Twitter clips**
- `clip_router` is now a modular `SPECIAL_PAGES` registry (YouTube transcript, X thread, arXiv PDF) — each handler is a small class with `matches(url)` + `clip(row)`; add/remove = one class + one list entry.
- New: clipping or bookmark-importing an x.com/twitter.com status URL hydrates the tweet + author thread + reply parent via the existing twitterapi.io scraper (`fetch_tweet_markdown`), stored as a "Tweet" clip. Server-side only — no extension change. Needs `TWITTERAPI_IO_KEY` (already set in prod for X saves).

## Screenshots

Full gallery (browsable): https://app.joinstash.ai/skills/feed-ux-cleanup-pr-screenshots-jajiow

1. Feed top — extension CTA pinned, collections link, community provenance labels
2. Feed — "From your stash · only visible to you" resurfaced doc between community cards
3. Onboarding "About you" — no plan question
4. Onboarding "Welcome" — 4 value props incl. curated context graph
5. Onboarding "Try it out" — five accordions + Finish
6. Capture accordion open — Copy buttons on commands
7. Explorer right-click menu — Open in new tab / Share / Rename / Delete
8. Share dialog opened from the sidebar
9. GitHub import dialog (straight-copy copy text)

## Test plan
- Backend: full suite green (965 passed); new tests for doc/file/memory resurfacing, whole-repo import, inspect endpoint, X-status special page.
- Frontend: vitest 234 passed; eslint 0 errors; tsc clean on touched files.
- Manual QA via agent-browser on the local stack: register → onboarding (all steps) → feed provenance cards → tab replace/decouple → sidebar share → real `octocat/Hello-World` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AeMYjDaK7Ab1mLRihvnsQ