### PR TITLE
Count a VFS grep as one search instead of hundreds of "ask" reads

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -26,6 +26,7 @@ _READ_KEY_WRITE_ALLOWLIST = {
     ("POST", "/api/v1/me/sessions/events"),
     ("POST", "/api/v1/me/sessions/events/batch"),
     ("POST", "/api/v1/me/ask"),
+    ("POST", "/api/v1/me/vfs/searches"),
 }
 
 
@@ -202,14 +203,16 @@ def _set_request_via(request: Request, user: dict | None) -> None:
     """Tag the request's caller surface for audit rows: 'ask' for the
     server-side VFS's nested reads (it marks them itself), 'auto' for
     automated machinery (skills sync, plugin hooks, VFS mount refreshes —
-    reads nobody asked for, excluded from content-activity analytics), 'cli'
-    for API-key callers, 'web' for browser JWTs and anonymous reads.
+    reads nobody asked for, excluded from content-activity analytics), 'scan'
+    for a VFS grep's per-document reads (kept in the audit trail but excluded
+    from analytics; the grep is counted as the one search event it records),
+    'cli' for API-key callers, 'web' for browser JWTs and anonymous reads.
     Analytics-grade only — the X-Stash-Via header is spoofable and must never
     gate authorization."""
     from .services.security_audit_service import request_via
 
     marker = request.headers.get("x-stash-via")
-    if marker in ("ask", "auto"):
+    if marker in ("ask", "auto", "scan"):
         request_via.set(marker)
     elif user is not None and user.get("key_type"):
         request_via.set("cli")

--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from stashvfs import MountError
 
 from ..auth import get_current_user
-from ..services import vfs_service
+from ..services import security_audit_service, vfs_service
 from ..services.vfs_service import VfsBudgetExceeded
 
 router = APIRouter(prefix="/api/v1/me/vfs", tags=["vfs"])
@@ -21,6 +21,12 @@ MAX_SCRIPT_LENGTH = 4096
 class VfsRequest(BaseModel):
     script: str = Field(max_length=MAX_SCRIPT_LENGTH)
     cwd: str = "/"
+
+
+class VfsSearch(BaseModel):
+    pattern: str = Field(max_length=MAX_SCRIPT_LENGTH)
+    roots: list[str] = Field(max_length=64)
+    docs_scanned: int = Field(ge=0)
 
 
 @router.post("")
@@ -47,6 +53,28 @@ async def run_vfs(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except VfsBudgetExceeded as e:
         raise HTTPException(status_code=413, detail=str(e)) from e
+
+
+@router.post("/searches", status_code=204)
+async def record_vfs_search(
+    body: VfsSearch,
+    current_user: dict = Depends(get_current_user),
+):
+    """The one search audit event standing in for a VFS grep. The grep's
+    per-document reads carry via='scan' and are excluded from content-activity
+    analytics; this row is what the dashboard counts, on the caller's real
+    surface (cli for `stash vfs`, ask for the server-side VFS)."""
+    await security_audit_service.record_event(
+        action="source.searched",
+        actor_user_id=current_user["id"],
+        owner_user_id=current_user["id"],
+        target_type="vfs",
+        target_id=" ".join(body.roots),
+        metadata={
+            "query_hash": security_audit_service.hash_value(body.pattern),
+            "docs_scanned": body.docs_scanned,
+        },
+    )
 
 
 @router.get("/resolve")

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -270,7 +270,9 @@ LISTING_ACTIONS = [
 # only web *searches* count; cli and ask count for everything. Untagged rows
 # (pre-`via` history, anonymous pastes) are excluded, as are 'auto' rows —
 # automated machinery like the session-start skills sync and the VFS's
-# mount-time tree refresh, which reads content nobody asked to see.
+# mount-time tree refresh, which reads content nobody asked to see — and
+# 'scan' rows: a VFS grep's per-document sweep, counted instead as the one
+# source.searched event the grep records.
 ACTIVITY_SURFACES = {
     "reads": ["cli", "ask"],
     "searches": ["web", "cli", "ask"],

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -50,6 +50,7 @@ class InProcessVfsClient:
         self._http = http
         self._loop = loop
         self._internal = False
+        self._scan = False
         self._document_reads = 0
         self._reads_lock = threading.Lock()
 
@@ -66,12 +67,42 @@ class InProcessVfsClient:
         finally:
             self._internal = False
 
+    @contextmanager
+    def scan_calls(self):
+        """A grep's per-document reads (see stashvfs.VfsClient.scan_calls):
+        overrides the client-wide `ask` tag with `scan` so analytics count
+        the grep as the one search `record_search` writes, not as hundreds
+        of reads. Safe with prefetch's pool threads: the shell holds this
+        block open until `prefetch` returns, and prefetch joins its pool."""
+        self._scan = True
+        try:
+            yield
+        finally:
+            self._scan = False
+
+    def record_search(self, pattern: str, roots: list[str], docs_scanned: int) -> None:
+        future = asyncio.run_coroutine_threadsafe(
+            self._http.post(
+                "/api/v1/me/vfs/searches",
+                json={"pattern": pattern, "roots": roots, "docs_scanned": docs_scanned},
+            ),
+            self._loop,
+        )
+        response = future.result()
+        if response.status_code >= 400:
+            raise VfsClientError(_error_detail(response))
+
     def _request(self, method: str, endpoint: str, **params) -> httpx.Response:
         # Dispatched onto the app's event loop from whichever thread we are on.
         # `StashVfsModel.prefetch` calls loaders from a pool, so this must work
         # from an arbitrary thread — not just anyio's worker, which is all
         # `anyio.from_thread.run` supports.
-        headers = {"X-Stash-Via": "auto"} if self._internal else None
+        if self._internal:
+            headers = {"X-Stash-Via": "auto"}
+        elif self._scan:
+            headers = {"X-Stash-Via": "scan"}
+        else:
+            headers = None
         future = asyncio.run_coroutine_threadsafe(
             self._http.request(method, endpoint, params=params or None, headers=headers),
             self._loop,

--- a/backend/tests/test_content_read_audit.py
+++ b/backend/tests/test_content_read_audit.py
@@ -156,6 +156,40 @@ async def test_vfs_mount_listings_are_tagged_auto_not_ask(client: AsyncClient, p
     assert [r["via"] for r in reads] == ["ask"]
 
 
+async def test_vfs_grep_counts_as_one_search_not_many_reads(client: AsyncClient, pool):
+    """A recursive grep reads every document it walks — one agent search used
+    to land in analytics as hundreds of user-driven 'ask' reads. The sweep's
+    reads must carry via='scan' (kept for the security trail, excluded from
+    analytics) and the grep itself one source.searched row on the caller's
+    real surface."""
+    api_key, user_id = await _register(client)
+    await _make_page(client, api_key, "One.md", "alpha needle")
+    await _make_page(client, api_key, "Two.md", "beta")
+    await _make_page(client, api_key, "Three.md", "gamma needle")
+
+    resp = await client.post(
+        "/api/v1/me/vfs",
+        json={"script": "grep -r 'needle' /files", "cwd": "/"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+    reads = await _read_events(pool, "content.page_read")
+    assert len(reads) == 3
+    assert all(r["via"] == "scan" for r in reads)
+
+    searches = await _read_events(pool, "source.searched")
+    assert len(searches) == 1
+    assert searches[0]["actor_user_id"] == user_id
+    assert searches[0]["target_type"] == "vfs"
+    assert searches[0]["target_id"] == "/files"
+    # The nested search POST arrives via the server-side VFS's client, so it
+    # carries the ask surface — a `stash vfs` grep records the same row as cli.
+    assert searches[0]["via"] == "ask"
+    assert _metadata(searches[0])["docs_scanned"] == 3
+
+
 async def test_tree_listing_is_logged(client: AsyncClient, pool):
     api_key, user_id = await _register(client)
     await _make_page(client, api_key, "One.md", "x")

--- a/cli/client.py
+++ b/cli/client.py
@@ -45,6 +45,7 @@ class StashClient:
         # content-activity analytics can exclude them (see auth._set_request_via).
         self._auto = auto
         self._internal = False
+        self._scan = False
         self._http = httpx.Client(base_url=self._base_url, timeout=30)
 
     def close(self) -> None:
@@ -67,6 +68,23 @@ class StashClient:
         finally:
             self._internal = False
 
+    @contextmanager
+    def scan_calls(self):
+        """A grep's per-document reads (see stashvfs.VfsClient.scan_calls):
+        requests in this block are tagged `scan` so analytics count the grep
+        as the one search `record_search` writes, not as hundreds of reads."""
+        self._scan = True
+        try:
+            yield
+        finally:
+            self._scan = False
+
+    def record_search(self, pattern: str, roots: list[str], docs_scanned: int) -> None:
+        self._post(
+            "/api/v1/me/vfs/searches",
+            json={"pattern": pattern, "roots": roots, "docs_scanned": docs_scanned},
+        )
+
     def _headers(self) -> dict[str, str]:
         if not self._api_key:
             return {}
@@ -75,6 +93,8 @@ class StashClient:
             headers["X-Stash-Scope"] = self._scope
         if self._auto or self._internal:
             headers["X-Stash-Via"] = "auto"
+        elif self._scan:
+            headers["X-Stash-Via"] = "scan"
         return headers
 
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -11,6 +11,10 @@ class FakeClient:
         # snapshot it so tests can pin what counts as internal traffic.
         self.internal = False
         self.internal_at_call: dict[str, bool] = {}
+        # Same idea for grep sweeps: True while the shell scans documents.
+        self.scan = False
+        self.scan_at_call: dict[str, bool] = {}
+        self.searches: list[tuple[str, list[str], int]] = []
 
     @contextmanager
     def internal_calls(self):
@@ -19,6 +23,17 @@ class FakeClient:
             yield
         finally:
             self.internal = False
+
+    @contextmanager
+    def scan_calls(self):
+        self.scan = True
+        try:
+            yield
+        finally:
+            self.scan = False
+
+    def record_search(self, pattern, roots, docs_scanned):
+        self.searches.append((pattern, roots, docs_scanned))
 
     def get_memory_folder(self):
         self.internal_at_call["get_memory_folder"] = self.internal
@@ -129,6 +144,7 @@ class FakeClient:
     def read_source_doc(self, source, ref):
         assert source == "src-gmail-1"
         self.internal_at_call["read_source_doc"] = self.internal
+        self.scan_at_call["read_source_doc"] = self.scan
         return {"content": f"BODY of {ref}"}
 
     def get_transcript_events(self, session_id):
@@ -390,6 +406,25 @@ def _grep_gmail(concurrency: int) -> tuple[str, CountingLoaderClient]:
         return result.stdout, client
     finally:
         model_module.PREFETCH_CONCURRENCY = original
+
+
+def test_grep_reads_are_scan_tagged_and_recorded_as_one_search():
+    """A recursive grep reads every document it walks. Those reads must run
+    inside scan_calls (so analytics exclude them) and the grep must record
+    exactly one search — before this, one agent grep landed on the analytics
+    dashboard as hundreds of user-driven reads."""
+    from stashvfs import SkillAppVfsShell
+
+    client = FakeClient()
+    model = StashVfsModel(client, include_computer=True)
+    model.refresh()
+    SkillAppVfsShell(model).run("grep -ri BODY /sources/gmail")
+
+    assert client.scan_at_call["read_source_doc"] is True
+    [(pattern, roots, docs_scanned)] = client.searches
+    assert pattern == "BODY"
+    assert roots == ["/sources/gmail"]
+    assert docs_scanned >= 2
 
 
 def test_prefetch_does_not_change_what_grep_finds():

--- a/stashvfs/client.py
+++ b/stashvfs/client.py
@@ -37,6 +37,21 @@ class VfsClient(Protocol):
         several listings per command, even for a `cat`."""
         ...
 
+    def scan_calls(self) -> AbstractContextManager[None]:
+        """Requests issued inside this block are a `grep` sweeping documents
+        for a pattern. Implementations tag them `X-Stash-Via: scan` so
+        content-activity analytics exclude them (see auth._set_request_via):
+        one recursive grep reads every document it walks, which used to land
+        as hundreds of user-driven reads. The grep itself is represented by
+        the single search event `record_search` writes afterwards."""
+        ...
+
+    def record_search(self, pattern: str, roots: list[str], docs_scanned: int) -> None:
+        """Write the one search audit event standing in for a grep's scan
+        reads (see `scan_calls`). Called once per grep invocation, after the
+        scan completes."""
+        ...
+
     def get_overview(self) -> dict: ...
 
     def get_memory_folder(self) -> dict: ...

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -458,30 +458,40 @@ class SkillAppVfsShell:
         if not paths:
             paths = ["."]
         matches = []
-        for raw_path in paths:
-            path = self._resolve_path(raw_path)
-            node = self.model._get_node(path)
-            file_paths = [path] if node.is_file else self._file_paths(path) if recursive else []
-            if node.is_dir and not recursive:
-                raise VfsShellError(f"{raw_path}: is a directory")
-            self.model.prefetch(file_paths)
-            for file_path in file_paths:
-                try:
-                    text = self._read_text(file_path)
-                except VfsClientError as e:
-                    self._warn(f"{name}: {file_path}: {e.detail}")
-                    continue
-                matches.append(
-                    _grep_text(
-                        regex,
-                        text,
-                        file_path,
-                        show_line_numbers=show_line_numbers,
-                        prefix_path=len(file_paths) > 1 or recursive,
-                        before=before,
-                        after=after,
+        roots = []
+        docs_scanned = 0
+        # The per-document reads below are the mechanics of one search, not
+        # documents the user asked to see — scan_calls tags them so analytics
+        # skip them, and record_search writes the single search event that
+        # stands in for the whole sweep.
+        with self.model.client.scan_calls():
+            for raw_path in paths:
+                path = self._resolve_path(raw_path)
+                roots.append(path)
+                node = self.model._get_node(path)
+                file_paths = [path] if node.is_file else self._file_paths(path) if recursive else []
+                if node.is_dir and not recursive:
+                    raise VfsShellError(f"{raw_path}: is a directory")
+                self.model.prefetch(file_paths)
+                for file_path in file_paths:
+                    docs_scanned += 1
+                    try:
+                        text = self._read_text(file_path)
+                    except VfsClientError as e:
+                        self._warn(f"{name}: {file_path}: {e.detail}")
+                        continue
+                    matches.append(
+                        _grep_text(
+                            regex,
+                            text,
+                            file_path,
+                            show_line_numbers=show_line_numbers,
+                            prefix_path=len(file_paths) > 1 or recursive,
+                            before=before,
+                            after=after,
+                        )
                     )
-                )
+        self.model.client.record_search(pattern, roots, docs_scanned)
         output = "".join(matches)
         if not output:
             raise VfsShellExit(1)


### PR DESCRIPTION
## Summary

Follow-up to #896. The admin content-activity dashboard counted every document a VFS `grep` swept as a user-driven read — a single agent inbox search landed as ~970 "ask"-classified document reads between two dashboard refreshes.

- The VFS shell now runs `grep`/`rg`'s per-document sweep inside a new `scan_calls()` client context: those audit rows carry `via='scan'`, staying in the security audit trail but excluded from content-activity analytics (the surface allowlists are explicit, so exclusion is automatic).
- After the sweep, the shell records **one `source.searched` event** via `POST /api/v1/me/vfs/searches` (pattern hashed, roots + docs-scanned in metadata). The event lands on the caller's real surface: `cli` for `stash vfs`, `ask` for the server-side VFS used by agents and ask-the-stash.
- Read-only API keys may post the search event (it's read bookkeeping, same rationale as `/ask` in the allowlist).
- `cat`/`sed`/`head` etc. are unchanged — deliberate single-document reads still count as reads. Piped `grep` over stdin records nothing (the upstream `cat` already counted the read).

## Testing

- New backend test: a `grep -r` over three pages produces 3 `via='scan'` page-read rows, zero ask reads, and exactly one `source.searched` row with `docs_scanned=3`.
- New stashvfs test: grep's reads run inside `scan_calls` and record exactly one search.
- Full suite: 965 passed. `ruff check` / `ruff format --check` clean (including `stashvfs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)