### PR TITLE
Agents view hides Claude sub-agent transcripts; chat renders markdown inline

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -134,10 +134,13 @@ async def list_my_sessions(
     # The Agents view lists only chats that ran through our platform agents —
     # web/scheduled (`agent-*`), Slack (`slack-agent-*`), Telegram
     # (`telegram-agent-*`) — not CLI transcripts, which live in Sessions.
+    # Claude Code sub-agent transcripts uploaded from client machines also have
+    # `agent-*` session ids (their local filenames), so exclude them by the
+    # agent_name the uploader stamps.
     if agent_chats_only:
-        prefix = "session_id ~ '^(agent|slack-agent|telegram-agent)-'"
-        where.append(f"he.{prefix}")
-        title_where.append(f"he_title.{prefix}")
+        for alias, conds in (("he", where), ("he_title", title_where)):
+            conds.append(f"{alias}.session_id ~ '^(agent|slack-agent|telegram-agent)-'")
+            conds.append(f"{alias}.agent_name <> 'claude-subagent'")
 
     rows = await pool.fetch(
         f"""

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -213,6 +213,42 @@ async def test_empty_session_shell_is_hidden_from_default_views(client: AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_agent_chats_view_excludes_claude_subagent_transcripts(client: AsyncClient):
+    """Claude Code sub-agent transcripts upload with `agent-*` session ids
+    (their local filenames), same prefix as platform agent chats. The Agents
+    view must show only platform chats; sub-agents belong in Sessions."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    for session_id, agent_name in [
+        ("agent-" + "a" * 32, "Stash Agent"),
+        ("agent-a0097f26bede1b16d", "claude-subagent"),
+        ("sess-cli", "claude"),
+    ]:
+        up = await client.post(
+            "/api/v1/me/transcripts",
+            files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
+            data={"session_id": session_id, "agent_name": agent_name},
+            headers=headers,
+        )
+        assert up.status_code == 201, up.text
+
+    agent_chats = await client.get(
+        "/api/v1/me/sessions", params={"agent_chats_only": "true"}, headers=headers
+    )
+    assert agent_chats.status_code == 200
+    assert [s["session_id"] for s in agent_chats.json()["sessions"]] == ["agent-" + "a" * 32]
+
+    all_sessions = await client.get("/api/v1/me/sessions", headers=headers)
+    assert all_sessions.status_code == 200
+    assert {s["session_id"] for s in all_sessions.json()["sessions"]} == {
+        "agent-" + "a" * 32,
+        "agent-a0097f26bede1b16d",
+        "sess-cli",
+    }
+
+
+@pytest.mark.asyncio
 async def test_event_created_session_lands_in_default_folder(client: AsyncClient):
     """An un-targeted push hook (e.g. Codex, which has no session-start hook so
     the first event creates the row) must land in the Default folder, never at

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import {
   type ChatMessage,
@@ -309,33 +311,38 @@ function CitationChip({ citation }: { citation: Citation }) {
   return <span className="font-mono">{citation.label}</span>;
 }
 
+// User turns get a right-aligned bubble; assistant turns render inline across
+// the full width (Claude Code / Codex style) as markdown.
 function MessageBubble({ message }: { message: ChatMessage }) {
-  const isUser = message.role === "user";
-  return (
-    <div className={isUser ? "flex justify-end" : "flex justify-start"}>
-      <div
-        className={
-          "max-w-[85%] rounded-2xl px-3.5 py-2 text-[13px] leading-relaxed whitespace-pre-wrap " +
-          (isUser
-            ? "bg-[var(--color-brand-600)] text-white"
-            : "border border-border bg-surface text-foreground")
-        }
-      >
-        {message.content || (
-          <span className="inline-block h-3 w-1.5 animate-pulse bg-brand align-baseline" />
-        )}
-        {!isUser && message.citations && message.citations.length > 0 && (
-          <div className="mt-2 border-t border-border-subtle pt-2 text-[11px] text-muted-foreground">
-            <span className="font-medium text-foreground">Grounded on:</span>{" "}
-            {message.citations.map((c, i) => (
-              <span key={c.id}>
-                {i > 0 && ", "}
-                <CitationChip citation={c} />
-              </span>
-            ))}
-          </div>
-        )}
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-2xl bg-[var(--color-brand-600)] px-3.5 py-2 text-[13px] leading-relaxed whitespace-pre-wrap text-white">
+          {message.content}
+        </div>
       </div>
+    );
+  }
+  return (
+    <div className="text-[13px] leading-relaxed text-foreground">
+      {message.content ? (
+        <div className="markdown-content">
+          <Markdown remarkPlugins={[remarkGfm]}>{message.content}</Markdown>
+        </div>
+      ) : (
+        <span className="inline-block h-3 w-1.5 animate-pulse bg-brand align-baseline" />
+      )}
+      {message.citations && message.citations.length > 0 && (
+        <div className="mt-2 border-t border-border-subtle pt-2 text-[11px] text-muted-foreground">
+          <span className="font-medium text-foreground">Grounded on:</span>{" "}
+          {message.citations.map((c, i) => (
+            <span key={c.id}>
+              {i > 0 && ", "}
+              <CitationChip citation={c} />
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

**Agents view no longer shows Claude Code sub-agents.** Sub-agent transcripts run on the client machine and upload with their local filenames as session ids (`agent-<hex>`), which collided with the `agent-*` prefix the Agents view uses to identify platform chats. The `agent_chats_only` filter now also excludes the `claude-subagent` agent_name the uploader stamps. Sub-agent sessions still appear in Sessions.

**Chat panel matches the Claude Code / Codex layout, with markdown.** User turns keep the right-aligned bubble; assistant turns render inline across the full chat width — no bordered bubble — as markdown (react-markdown + remark-gfm with the existing `markdown-content` typography, same as the session viewer).

## Testing

- New backend test: platform chat / sub-agent transcript / CLI session uploaded side by side — the Agents view returns only the platform chat, the unfiltered list returns all three. Full `test_transcripts.py` passes (19).
- ChatPanel vitest passes; frontend lint clean.
- Verified live: seeded a sub-agent session and a markdown-heavy chat locally; the sub-agent stays out of the Agents sidebar, and headings, lists, code blocks, GFM tables, links, and blockquotes render correctly (screenshot below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8KhhTwg6xkSCksPckNTvX