### PR TITLE
Agent turns run detached from the SSE stream — disconnects can't kill or brick a chat

### DIFF
--- a/backend/routers/agent_chat.py
+++ b/backend/routers/agent_chat.py
@@ -83,12 +83,12 @@ async def run_now(
 ):
     """Run a prompt-scheduled agent on demand, streamed live like a chat turn.
     The server builds the prompt from schedule_prompt, so the run is identical
-    to what the beat task fires.
+    to what the beat task fires. The turn runs detached (see stream_chat), so
+    closing the tab doesn't kill it.
 
-    Curator runs are refused here: a curation pass takes minutes and an SSE
-    run dies with the browser tab (the disconnect cancels the stream with no
-    trace). They enqueue on the worker via POST /me/memory/recompute — the
-    same path the daily schedule and the CLI use."""
+    Curator runs are refused here: they enqueue on the worker via POST
+    /me/memory/recompute — the same path the daily schedule and the CLI use —
+    so credit metering and the curated_through watermark stay in one place."""
     agent = await agent_service.get_agent(current_user["id"], UUID(req.agent_id))
     if agent["run_mode"] != "scheduled":
         raise HTTPException(status_code=400, detail="Only scheduled agents can be run on demand.")

--- a/backend/services/sprite_agent_service.py
+++ b/backend/services/sprite_agent_service.py
@@ -405,37 +405,43 @@ async def run_scheduled(agent: dict, run_stamp: str) -> str:
     )
 
 
-async def stream_chat(
+# Detached turn tasks need a strong reference until they finish — asyncio
+# holds only weak refs, and a GC'd task is a silently killed turn.
+_detached_turns: set[asyncio.Task] = set()
+
+_TURN_DONE = object()
+
+
+async def _pump_turn(
+    queue: asyncio.Queue,
     owner_user_id: UUID,
     owner_name: str,
     user_id: UUID,
     session_id: str,
     message: str,
     auth: agent_auth.RunAuth,
-    persona: str | None = None,
-    agent_name: str = AGENT_NAME,
-) -> AsyncIterator[str]:
-    """Multi-turn agent chat over a stored session, streamed as SSE.
+    persona: str | None,
+    agent_name: str,
+) -> None:
+    """One chat turn, decoupled from its viewer.
 
-    `auth` is the harness + credentials resolved (and gated) by the router
-    before the stream started, so a 402 is a clean HTTP error, not an SSE one.
-    `persona` is the selected agent's extra system prompt.
-    """
+    Events go to `queue`, but execution, recording, and the turn lock never
+    depend on anyone reading them: the sandboxed turn is the real work and
+    must survive a closed tab — the stream is only a live view of it."""
+
+    def put(event: dict) -> None:
+        queue.put_nowait(event)
+
     try:
         async with _TurnLock(session_id):
             history = await _load_history(owner_user_id, session_id, user_id)
             await memory_service.push_event(
                 owner_user_id, agent_name, "user_message", message, user_id, session_id=session_id
             )
-            yield _sse({"type": "session", "session_id": session_id})
-            yield _sse({"type": "status", "stage": "waking"})
+            put({"type": "session", "session_id": session_id})
+            put({"type": "status", "stage": "waking"})
 
-            acquire = asyncio.create_task(sprite_service.acquire(user_id))
-            while not acquire.done():
-                # SSE comment keepalives while a first-ever provision runs.
-                yield ": ping\n\n"
-                await asyncio.wait({acquire}, timeout=10)
-            sprite = acquire.result()
+            sprite = await sprite_service.acquire(user_id)
             await sprite_service.touch(user_id)
             # Registered MCP servers reach the harness via the workdir's
             # .mcp.json, rewritten every turn so removals propagate too.
@@ -461,11 +467,11 @@ async def stream_chat(
                         await _record_tool_event(
                             owner_user_id, user_id, session_id, event, auth.env, agent_name
                         )
-                    yield _sse(event)
+                    put(event)
             except TurnStopped:
                 final = STOPPED_NOTE
-                yield _sse({"type": "text", "delta": STOPPED_NOTE})
-                yield _sse({"type": "end"})
+                put({"type": "text", "delta": STOPPED_NOTE})
+                put({"type": "end"})
 
             if final:
                 await memory_service.push_event(
@@ -479,11 +485,10 @@ async def stream_chat(
             elif error:
                 await _record_run_failure(owner_user_id, user_id, session_id, agent_name, error)
     except TurnInProgress:
-        yield _sse({"type": "error", "message": "A turn is already running in this chat."})
-        yield _sse({"type": "end"})
+        put({"type": "error", "message": "A turn is already running in this chat."})
+        put({"type": "end"})
     except Exception:
-        # SSE has already started, so an exception can't become an HTTP error —
-        # without this the stream just dies and the client sees nothing.
+        # The client may be long gone, so the log is the only reliable trace.
         logger.exception("cloud agent: turn failed for session %s", session_id)
         try:
             await _record_run_failure(
@@ -493,8 +498,58 @@ async def stream_chat(
             # Recording is best-effort here — the client must still get its
             # error + end events even if the DB write is what's broken.
             logger.exception("cloud agent: could not record failure for %s", session_id)
-        yield _sse({"type": "error", "message": "The agent turn failed. Try again."})
-        yield _sse({"type": "end"})
+        put({"type": "error", "message": "The agent turn failed. Try again."})
+        put({"type": "end"})
+    finally:
+        queue.put_nowait(_TURN_DONE)
+
+
+async def stream_chat(
+    owner_user_id: UUID,
+    owner_name: str,
+    user_id: UUID,
+    session_id: str,
+    message: str,
+    auth: agent_auth.RunAuth,
+    persona: str | None = None,
+    agent_name: str = AGENT_NAME,
+) -> AsyncIterator[str]:
+    """Multi-turn agent chat over a stored session, streamed as SSE.
+
+    `auth` is the harness + credentials resolved (and gated) by the router
+    before the stream started, so a 402 is a clean HTTP error, not an SSE one.
+    `persona` is the selected agent's extra system prompt.
+
+    The turn itself runs as a detached task (_pump_turn): a dropped stream —
+    closed tab, in-app navigation — never cancels it, the reply is still
+    recorded into the session, and the turn lock still releases. A returning
+    client reloads the stored session and polls the status endpoint."""
+    queue: asyncio.Queue = asyncio.Queue()
+    turn = asyncio.create_task(
+        _pump_turn(
+            queue,
+            owner_user_id,
+            owner_name,
+            user_id,
+            session_id,
+            message,
+            auth,
+            persona,
+            agent_name,
+        )
+    )
+    _detached_turns.add(turn)
+    turn.add_done_callback(_detached_turns.discard)
+    while True:
+        try:
+            event = await asyncio.wait_for(queue.get(), timeout=10)
+        except TimeoutError:
+            # SSE comment keepalive through provisioning waits and long tool calls.
+            yield ": ping\n\n"
+            continue
+        if event is _TURN_DONE:
+            return
+        yield _sse(event)
 
 
 # Slack messages are an untrusted surface: strip the harness's own mutating

--- a/backend/tests/test_agent_chat.py
+++ b/backend/tests/test_agent_chat.py
@@ -289,6 +289,58 @@ async def test_stop_kills_a_running_turn(client: AsyncClient, sprite_exec, monke
 
 
 @pytest.mark.asyncio
+async def test_disconnect_does_not_kill_the_turn(client: AsyncClient, sprite_exec, monkeypatch):
+    """The sandbox isolates the turn from the chat UI: a dropped SSE stream
+    (closed tab, in-app navigation) must not cancel the run. The reply still
+    records into the session and the turn lock still releases — without this,
+    every disconnect bricked the chat with 'a turn is already running' for
+    the full lock TTL and lost the reply."""
+    import asyncio
+
+    from backend.services import sprite_service
+    from backend.tests.conftest import stream_json_reply
+
+    key, _ = await _register(client)
+
+    started = asyncio.Event()
+
+    async def slow_exec(sprite, argv, *, env, cwd=None):
+        started.set()
+        await asyncio.sleep(0.3)
+        for line in stream_json_reply("finished after you left"):
+            yield {"stream": "stdout", "data": (line + "\n").encode()}
+        yield {"exit_code": 0}
+
+    monkeypatch.setattr(sprite_service, "exec_stream", slow_exec)
+
+    session_id = "agent-disconnecttest"
+    # Open the stream and abandon it as soon as the turn is underway.
+    async with client.stream(
+        "POST",
+        "/api/v1/me/agent-chat",
+        json={"message": "keep going without me", "session_id": session_id},
+        headers=_auth(key),
+    ) as response:
+        assert response.status_code == 200
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+    # The detached turn finishes: reply recorded, lock released.
+    async def _settled() -> bool:
+        st = await client.get(f"/api/v1/me/agent-chat/{session_id}/status", headers=_auth(key))
+        return st.json()["running"] is False
+
+    async with asyncio.timeout(10):
+        while not await _settled():
+            await asyncio.sleep(0.05)
+
+    got = await client.get(f"/api/v1/me/agent-chat/{session_id}", headers=_auth(key))
+    assert got.json()["messages"] == [
+        {"role": "user", "content": "keep going without me"},
+        {"role": "assistant", "content": "finished after you left"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stop_and_status_require_an_owned_session(client: AsyncClient, sprite_exec):
     """Stop is a real action on another process's run — a caller must not be
     able to stop (or probe) a session that isn't theirs or doesn't exist."""

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import {
   type ChatMessage,
   type Citation,
+  agentTurnRunning,
   getAgentChat,
   streamAgentChat,
 } from "@/lib/agentChat";
@@ -47,6 +48,28 @@ export default function ChatPanel({
       })
       .catch(() => {});
   }, [sessionId, loadedSession]);
+
+  // Turns run detached on the sandbox, so one can outlive the panel that
+  // started it (closed tab, navigation). If this session's turn is still
+  // running, watch for it to finish and pull the recorded reply.
+  useEffect(() => {
+    if (!sessionId || streaming) return;
+    let stopped = false;
+    void (async () => {
+      if (!(await agentTurnRunning(sessionId).catch(() => false))) return;
+      setStatus("Agent is still working…");
+      while (!stopped && (await agentTurnRunning(sessionId).catch(() => false))) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+      if (stopped) return;
+      setStatus(null);
+      const msgs = await getAgentChat(sessionId).catch(() => null);
+      if (msgs && !stopped) setMessages(msgs);
+    })();
+    return () => {
+      stopped = true;
+    };
+  }, [sessionId, streaming]);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });

--- a/frontend/src/lib/agentChat.ts
+++ b/frontend/src/lib/agentChat.ts
@@ -132,6 +132,15 @@ export async function getAgentChat(sessionId: string): Promise<ChatMessage[]> {
   return messages;
 }
 
+/** Whether a turn is still running server-side for this session. Turns are
+ *  detached from the stream, so one can outlive the panel that started it. */
+export async function agentTurnRunning(sessionId: string): Promise<boolean> {
+  const data = await apiFetch<{ running: boolean }>(
+    `/api/v1/me/agent-chat/${encodeURIComponent(sessionId)}/status`,
+  );
+  return data.running;
+}
+
 type StreamHandlers = {
   onSession?: (sessionId: string) => void;
   onStatus?: (stage: string) => void;


### PR DESCRIPTION
## The prod incident

Chat looked dead tonight: messages sent, no replies, retries erroring. Diagnosis from Render logs + prod repro:

- The turn ran **inline in the SSE generator**, so a client disconnect (closed tab, or the workbench remounting the panel on navigation) cancelled the run mid-flight via `CancelledError`.
- Cancellation also skipped the turn lock's release, leaking `agent-turn:<session>` in Redis for the full `AGENT_TURN_TIMEOUT_SECONDS` (600s) — every retry for 10 minutes bounced with **"A turn is already running in this chat."** with no server log and no recorded failure.
- Verified the pipeline itself was healthy: direct turns against the affected sessions returned normally once the lock TTL expired.

## The fix

The sandbox is supposed to isolate the turn from the chat UI — now it does:

- `stream_chat` spawns the turn as a **detached task** (`_pump_turn`) that owns the lock, runs the harness on the sprite, records tool events + the reply, and releases the lock — regardless of whether anyone is watching. The SSE generator just drains an event queue; dropping the stream abandons the view, not the work.
- Keepalive pings now fire on any 10s event gap (previously only during sprite provisioning), so long tool calls can't stall proxies.
- Stop semantics unchanged: `POST /stop` sets the Redis flag the turn polls.
- `ChatPanel` picks up orphaned turns: on mount it checks `/status`, shows "Agent is still working…" while a detached turn runs, then loads the recorded reply.
- `run_now`'s docstring updated — on-demand scheduled runs now survive tab closes too (curator runs still route to the worker for credit metering).

## Testing

- New regression test: opens a stream, abandons it mid-turn, asserts the reply still records and the lock releases (`test_disconnect_does_not_kill_the_turn`).
- All agent-chat/agents/transcripts/telegram tests pass (46); frontend 234 tests + lint clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8KhhTwg6xkSCksPckNTvX