### PR TITLE
Preserve harness CLIs' raw error output instead of generic error strings

### DIFF
--- a/backend/services/harness.py
+++ b/backend/services/harness.py
@@ -270,7 +270,7 @@ def _map_codex(obj: dict, state: TurnState) -> list[dict]:
             ]
         return []
     if kind == "error":
-        state.error = str(obj.get("message") or "codex error")
+        state.error = str(obj.get("message") or f"codex error: {json.dumps(obj)[:400]}")
         return []
     return []
 
@@ -303,6 +303,9 @@ def _map_opencode(obj: dict, state: TurnState) -> list[dict]:
             )
         return events
     if ptype == "error":
-        state.error = str(part.get("message") or "opencode error")
+        # When the CLI omits `message`, the raw event is the only diagnostic —
+        # dropping it once left four days of failures logged as the literal
+        # string "opencode error".
+        state.error = str(part.get("message") or f"opencode error: {json.dumps(obj)[:400]}")
         return []
     return []

--- a/backend/services/sprite_agent_service.py
+++ b/backend/services/sprite_agent_service.py
@@ -133,6 +133,11 @@ async def _run_harness(
         tail = _redact(" ".join(state.unparsed), provider_env)[-400:]
         if tail:
             state.error += f": {tail}"
+    if state.error:
+        # Harness-emitted errors can carry raw request/response fragments
+        # (the mappers now preserve them) — scrub the injected key like the
+        # plain-text tail above.
+        state.error = _redact(state.error, provider_env)
     if state.error and harness_mod.RESUME_MISSING_RE.search(state.error):
         state.resume_missing = True
 

--- a/backend/tests/test_sprite_agent_mapping.py
+++ b/backend/tests/test_sprite_agent_mapping.py
@@ -160,6 +160,28 @@ def test_opencode_captures_session_and_maps_text():
     assert events == [{"type": "text", "delta": "hi there"}]
 
 
+def test_opencode_error_uses_message_when_present():
+    state = h.TurnState()
+    h.map_line(h.OPENCODE, '{"part":{"type":"error","message":"insufficient credits"}}', state)
+    assert state.error == "insufficient credits"
+
+
+def test_opencode_error_without_message_keeps_raw_event():
+    # An error part with no `message` must surface the raw event — reducing it
+    # to the bare string "opencode error" leaves failures undiagnosable.
+    state = h.TurnState()
+    h.map_line(h.OPENCODE, '{"part":{"type":"error","name":"ProviderError","status":402}}', state)
+    assert state.error.startswith("opencode error: ")
+    assert "ProviderError" in state.error and "402" in state.error
+
+
+def test_codex_error_without_message_keeps_raw_event():
+    state = h.TurnState()
+    h.map_line(h.CODEX, '{"type":"error","code":"rate_limited"}', state)
+    assert state.error.startswith("codex error: ")
+    assert "rate_limited" in state.error
+
+
 def test_get_unknown_harness_raises():
     with pytest.raises(ValueError):
         h.get("nonesuch")
@@ -194,6 +216,34 @@ async def test_nonzero_exit_surfaces_cli_output(monkeypatch):
     assert events == []
     assert state.error.startswith("agent exited with code 127: ")
     assert "command not found" in state.error
+    assert "sk-live-secret" not in state.error
+
+
+@pytest.mark.asyncio
+async def test_harness_emitted_error_is_redacted(monkeypatch):
+    # Raw error events preserved by the mappers can echo request fragments —
+    # the injected key must be scrubbed from state.error too.
+    from backend.services import sprite_service
+
+    async def fake_exec_stream(sprite, argv, *, env, cwd=None):
+        yield {
+            "stream": "stdout",
+            "data": b'{"part":{"type":"error","detail":"auth sk-live-secret rejected"}}\n',
+        }
+        yield {"exit_code": 0}
+
+    monkeypatch.setattr(sprite_service, "exec_stream", fake_exec_stream)
+    state = h.TurnState()
+    async for _ in svc._run_harness(
+        h.OPENCODE,
+        sprite_service.Sprite(name="s"),
+        ["opencode", "run", "hi"],
+        state,
+        {"OPENROUTER_API_KEY": "sk-live-secret"},
+    ):
+        pass
+    assert state.error.startswith("opencode error: ")
+    assert "rejected" in state.error
     assert "sk-live-secret" not in state.error
 
 


### PR DESCRIPTION
## Why

The Memory curator has failed nightly since 7/20 for every managed-path user, and all four days of celery logs and stored sessions contain only the literal string `opencode error` — because `_map_opencode` throws away the error event when it has no `message` field (`_map_codex` has the same bug). The root cause is still unknown *because* of this; tonight's run will tell us once this deploys.

## What

- `_map_opencode` / `_map_codex`: when the error event has no `message`, keep the raw JSON event (truncated to 400 chars) in `state.error` instead of a generic string. It flows to the celery ERROR log, the stored session's `⚠️ Agent run failed` message, and the SSE stream.
- `_run_harness`: redact the injected provider key from harness-emitted errors, matching the existing redaction of plain-text CLI output — raw error events can echo request fragments.
- Tests: error-with-message passthrough, raw-event preservation for both mappers, and redaction of a harness-emitted error containing the injected key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)