### PR TITLE
Alert loudly when scheduled agent runs fail or curation goes stale

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -15,6 +15,7 @@ the same scheduled task multiple times.
 """
 
 from celery import Celery
+from celery.schedules import crontab
 
 from .config import settings
 
@@ -100,6 +101,14 @@ celery.conf.update(
         "agent-schedules-run-due": {
             "task": "backend.tasks.agent_schedules.run_due",
             "schedule": 60.0,
+        },
+        "agent-schedules-alert-stale-curators": {
+            "task": "backend.tasks.agent_schedules.alert_stale_curators",
+            # A crontab, not an interval: interval timers restart from zero on
+            # every deploy, and we deploy often enough that a daily interval
+            # might never fire. 15:30 UTC is right after the nightly curator
+            # window (08:00–11:59 UTC), so a bad night alerts the same morning.
+            "schedule": crontab(hour=15, minute=30),
         },
         "sources-reconcile-due": {
             "task": "backend.tasks.sources.reconcile_due",

--- a/backend/config.py
+++ b/backend/config.py
@@ -189,6 +189,11 @@ class Settings:
     # --- Email (Postmark) ---
     POSTMARK_SERVER_TOKEN: str | None = os.getenv("POSTMARK_SERVER_TOKEN")
 
+    # --- Ops alerts ---
+    # Slack incoming-webhook URL for operational alerts (scheduled agent run
+    # failures, stale curators). Unset → alerts are ERROR logs only.
+    ALERT_SLACK_WEBHOOK_URL: str | None = os.getenv("ALERT_SLACK_WEBHOOK_URL")
+
     # --- Admin ---
     # Shared secret for /api/v1/admin/* endpoints. The www admin page sends
     # this in X-Admin-Token from server-side fetches; never exposed to the

--- a/backend/services/alert_service.py
+++ b/backend/services/alert_service.py
@@ -1,0 +1,25 @@
+"""Ops alerts for failures an operator must see.
+
+Every alert is logged at ERROR. When ALERT_SLACK_WEBHOOK_URL is set, the
+alert is also posted to the team Slack channel; a failed post raises, so a
+broken webhook is itself loud instead of silently eating alerts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def send_alert(text: str) -> None:
+    logger.error("ALERT: %s", text)
+    if not settings.ALERT_SLACK_WEBHOOK_URL:
+        return
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.post(settings.ALERT_SLACK_WEBHOOK_URL, json={"text": text})
+        response.raise_for_status()

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -8,7 +8,7 @@ agent's own turn lock (Redis) prevents overlap with an in-flight run.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from croniter import croniter
@@ -66,7 +66,13 @@ async def _run_curator_now(agent_id: UUID) -> None:
 async def _run_due() -> int:
     from ..config import settings
     from ..database import get_pool
-    from ..services import agent_auth, agent_service, curation_service, sprite_agent_service
+    from ..services import (
+        agent_auth,
+        agent_service,
+        alert_service,
+        curation_service,
+        sprite_agent_service,
+    )
 
     now = datetime.now(UTC)
     stamp = now.strftime("%Y%m%d%H%M")
@@ -116,4 +122,61 @@ async def _run_due() -> int:
         except Exception as e:
             logger.exception("agent schedule: run failed for agent %s", agent["id"])
             await agent_service.mark_run_failed(agent["id"], str(e))
+            email = await get_pool().fetchval("SELECT email FROM users WHERE id = $1", user_id)
+            await alert_service.send_alert(
+                f"Scheduled agent run failed: {agent['name']!r} for {email}: {str(e)[:300]}"
+            )
     return ran
+
+
+# A curator whose watermark is older than this while changes are pending has
+# been failing for multiple nightly runs — one bad night must not page.
+STALE_CURATOR_HOURS = 48
+
+
+@celery.task(name="backend.tasks.agent_schedules.alert_stale_curators")
+def alert_stale_curators() -> int:
+    return run_async(_alert_stale_curators())
+
+
+async def _alert_stale_curators() -> int:
+    """Alert on curators whose watermark stopped advancing despite pending
+    changes. Alerting on the stale *outcome* catches every cause — dead
+    provider keys, harness bugs, a wedged beat — where per-run failure alerts
+    only catch runs that started. `last_run_error IS NOT NULL` scopes this to
+    curators whose last attempted run actually failed; curators skipped by
+    design (credit allowance, no credential) keep a NULL error and stay quiet.
+    """
+    from ..database import get_pool
+    from ..services import alert_service, curation_service
+
+    cutoff = datetime.now(UTC) - timedelta(hours=STALE_CURATOR_HOURS)
+    rows = await get_pool().fetch(
+        """
+        SELECT a.user_id, a.curated_through, a.last_run_error, u.email
+        FROM agents a JOIN users u ON u.id = a.user_id
+        WHERE a.is_curator AND a.run_mode = 'scheduled'
+          AND a.curated_through IS NOT NULL AND a.curated_through < $1
+          AND a.last_run_error IS NOT NULL
+        """,
+        cutoff,
+    )
+    stale = [
+        r
+        for r in rows
+        if await curation_service.has_changes_since(
+            r["user_id"], r["user_id"], r["curated_through"]
+        )
+    ]
+    if not stale:
+        return 0
+    lines = [
+        f"- {r['email']}: last curated {r['curated_through']:%Y-%m-%d %H:%M} UTC "
+        f"({r['last_run_error'][:200]})"
+        for r in stale
+    ]
+    await alert_service.send_alert(
+        f"{len(stale)} Memory curator(s) stale >{STALE_CURATOR_HOURS}h with pending changes:\n"
+        + "\n".join(lines)
+    )
+    return len(stale)

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -1,0 +1,144 @@
+"""Scheduled-agent failures must page an operator, not just log.
+
+The Memory curator failed silently for four days in July 2026 (the managed
+harness broke; the only trace was an ERROR line in celery logs nobody reads).
+These tests pin the two alert paths that prevent a repeat: per-run failure
+alerts, and the daily stale-watermark watchdog.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from backend.database import get_pool
+from backend.services import agent_service, alert_service, memory_service
+from backend.tasks import agent_schedules
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> uuid.UUID:
+    name = unique_name("alerts")
+    response = await client.post(
+        "/api/v1/users/register",
+        json={"name": name, "password": "securepassword1", "email": f"{name}@example.com"},
+    )
+    assert response.status_code == 201
+    return uuid.UUID(response.json()["id"])
+
+
+def _capture_alerts(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    sent: list[str] = []
+
+    async def fake_send_alert(text: str) -> None:
+        sent.append(text)
+
+    monkeypatch.setattr(alert_service, "send_alert", fake_send_alert)
+    return sent
+
+
+async def _make_curator(
+    user_id: uuid.UUID, *, curated_hours_ago: int, last_run_error: str | None
+) -> dict:
+    agent = await agent_service.get_or_create_curator(user_id)
+    await get_pool().execute(
+        "UPDATE agents SET curated_through = $2, last_run_error = $3 WHERE id = $1",
+        agent["id"],
+        datetime.now(UTC) - timedelta(hours=curated_hours_ago),
+        last_run_error,
+    )
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_stale_failing_curator_alerts(client: AsyncClient, monkeypatch):
+    user_id = await _register(client)
+    await _make_curator(user_id, curated_hours_ago=72, last_run_error="opencode error")
+    # A pending change — staleness only matters when there is work to curate.
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 1
+    assert len(sent) == 1
+    assert "stale" in sent[0] and "opencode error" in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_skipped_by_design_curator_stays_quiet(client: AsyncClient, monkeypatch):
+    # Curators skipped on purpose (credit allowance, no credential) never run,
+    # so their error stays NULL — a stalled watermark there is not a failure.
+    user_id = await _register(client)
+    await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 0
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_stale_curator_without_pending_changes_stays_quiet(client: AsyncClient, monkeypatch):
+    # An idle user's curator legitimately never advances — nothing to curate.
+    user_id = await _register(client)
+    await _make_curator(user_id, curated_hours_ago=72, last_run_error="opencode error")
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 0
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_fresh_curator_stays_quiet(client: AsyncClient, monkeypatch):
+    # One bad night must not page — the watchdog only fires past the 48h bar.
+    user_id = await _register(client)
+    await _make_curator(user_id, curated_hours_ago=1, last_run_error="opencode error")
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 0
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
+    from backend.services import agent_auth, sprite_agent_service
+
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    # Make the curator due on the next tick and eligible to run.
+    await get_pool().execute(
+        "UPDATE agents SET schedule_cron = '* * * * *', last_run_at = $2 WHERE id = $1",
+        agent["id"],
+        datetime.now(UTC) - timedelta(minutes=5),
+    )
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+
+    async def fake_resolve(user_id, prefer_provider=None):
+        return None
+
+    async def fake_run_scheduled(agent, stamp):
+        raise RuntimeError("agent turn failed: opencode error")
+
+    monkeypatch.setattr(agent_auth, "resolve", fake_resolve)
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", fake_run_scheduled)
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._run_due() == 0
+    assert len(sent) == 1
+    assert "Scheduled agent run failed" in sent[0] and "opencode error" in sent[0]
+    # The failure is also stored on the agent, which is what the stale-curator
+    # watchdog keys off — the two alert paths must stay connected.
+    error = await get_pool().fetchval(
+        "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
+    )
+    assert error is not None and "opencode error" in error


### PR DESCRIPTION
## Why

The Memory curator failed every night from 7/20–7/23 (managed opencode/OpenRouter path, root cause under investigation in #902) and the only trace was an ERROR line in celery worker logs. Heavi's memory wiki sat four days stale before anyone noticed, during an audit, by accident.

## What

Two alert paths, both going to a Slack incoming webhook (`ALERT_SLACK_WEBHOOK_URL`, new setting) and always ERROR-logged:

1. **Per-run failure alert** — `_run_due`'s failure path now fires an alert naming the agent, user, and error, the same night it happens.
2. **Stale-curator watchdog** — a new daily beat task (15:30 UTC, right after the 08:00–11:59 UTC nightly curator window) alerts on curators whose `curated_through` is >48h old *with pending changes* and whose last attempted run failed. This alerts on the harmful outcome, so it catches causes the per-run alert can't see (wedged beat, runs that never start). Curators skipped by design — credit allowance, no credential — keep a NULL `last_run_error` and stay quiet, so no false pages for free-tier users.

The watchdog uses a crontab, not an interval: interval timers restart from zero on every deploy, and we deploy often enough that a daily interval might never fire.

A failed Slack post raises rather than being swallowed — a broken webhook is itself loud.

## Ops setup

Create a Slack incoming webhook for the alerts channel and set `ALERT_SLACK_WEBHOOK_URL` on `stash-celery-worker` (and `stash-celery-beat`) in Render. Unset, alerts degrade to ERROR logs only.

## Tests

Five new DB-backed tests pinning the intent: stale+failing+pending → alert; skipped-by-design stays quiet; no pending changes stays quiet; <48h stays quiet; a failed `_run_due` run alerts and records `last_run_error` (the field the watchdog keys off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)