### PR TITLE
Workspace skills: Skills surfaces honor the active scope, members publish

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
-from ..auth import get_current_user, get_current_user_optional
+from ..auth import get_current_user, get_current_user_optional, get_scope
 from ..config import settings
 from ..models import (
     ForkSkillRequest,
@@ -33,18 +33,13 @@ public_router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 _PUBLIC_ITEM_TYPES = {"page", "file", "table", "folder"}
 
 
-async def _require_member(owner_user_id: UUID, user_id: UUID) -> None:
-    if not await user_scope_service.is_owner(owner_user_id, user_id):
-        raise HTTPException(status_code=403, detail="Not the scope owner")
-
-
 @me_router.post("/skills", response_model=SkillResponse, status_code=201)
 async def publish_skill(
     req: SkillPublishRequest,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """Mint the publish record for a skill folder (share/publish it)."""
-    owner_user_id = current_user["id"]
     try:
         skill = await shared_skill_service.publish_folder(
             owner_user_id,
@@ -66,9 +61,9 @@ async def publish_skill(
 @me_router.get("/skills")
 async def list_skills(
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
-    """Every skill folder in the scope, with publish info when shared."""
-    owner_user_id = current_user["id"]
+    """Every skill folder in the active scope, with publish info when shared."""
     skills = await skill_service.list_skills(owner_user_id, current_user["id"])
     return {"skills": skills}
 
@@ -81,12 +76,15 @@ class GithubImportRequest(BaseModel):
 async def import_github_repo(
     req: GithubImportRequest,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
-    """Copy a whole GitHub repo into the caller's scope as one new root folder.
+    """Copy a whole GitHub repo into the active scope as one new root folder.
     Folders containing SKILL.md derive as skills automatically. Private repos
     work when the caller's GitHub connection can read them."""
     try:
-        return await github_skill_import.import_repo_for_user(current_user["id"], req.repo_url)
+        return await github_skill_import.import_repo_for_user(
+            owner_user_id, current_user["id"], req.repo_url
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -127,9 +125,9 @@ async def list_github_import_repos(
 async def get_local_skill(
     name: str,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """Read a skill by name: SKILL.md + sibling files concatenated."""
-    owner_user_id = current_user["id"]
     skill = await skill_service.read_skill(owner_user_id, name, current_user["id"])
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
@@ -151,11 +149,11 @@ async def _require_skill_folder(owner_user_id: UUID, folder_id: UUID, user_id: U
 async def get_skill_contents(
     folder_id: UUID,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """The skill folder's full subtree, inlined — same shape as the public
     skill payload, but for the scope owner on unpublished skills. This is
     what `stash skills sync` pulls."""
-    owner_user_id = current_user["id"]
     folder = await _require_skill_folder(owner_user_id, folder_id, current_user["id"])
     contents = await shared_skill_service.folder_contents({"folder_id": folder_id})
     await security_audit_service.record_content_read(
@@ -172,11 +170,11 @@ async def replace_skill_contents(
     folder_id: UUID,
     files: list[UploadFile],
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """Replace the skill folder's contents with the uploaded file set — each
     upload's filename is its path relative to the skill folder. This is what
     `stash skills sync` pushes."""
-    owner_user_id = current_user["id"]
     await _require_skill_folder(owner_user_id, folder_id, current_user["id"])
     if not await permission_service.check_access(
         "folder", folder_id, current_user["id"], owner_user_id=owner_user_id, require="write"
@@ -252,10 +250,10 @@ async def snapshot_source(
     skill_id: UUID,
     req: SnapshotSourceRequest,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """Copy a point-in-time snapshot of one connected-source document into the
     skill's folder as a page, so the skill stays self-contained and curl-able."""
-    owner_user_id = current_user["id"]
     skill = await shared_skill_service.get_skill(skill_id)
     if not skill or skill["owner_user_id"] != owner_user_id:
         raise HTTPException(status_code=404, detail="Skill not found")
@@ -302,12 +300,12 @@ async def materialize_session(
     session_id: str,
     req: MaterializeSessionRequest,
     current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
 ):
     """Freeze a session transcript into a markdown page inside a folder —
     how sessions travel into skills (sessions can't live in folders)."""
-    owner_user_id = current_user["id"]
     if not await user_scope_service.can_write(owner_user_id, current_user["id"]):
-        raise HTTPException(status_code=403, detail="Only the owner can materialize sessions")
+        raise HTTPException(status_code=403, detail="Not allowed to write in this scope")
     page = await shared_skill_service.materialize_session_page(
         owner_user_id, session_id, req.folder_id, current_user["id"]
     )
@@ -446,8 +444,8 @@ async def fork_skill(
     req: ForkSkillRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Fork: deep-copy the skill's folder into the caller's scope."""
-    await _require_member(req.owner_user_id, current_user["id"])
+    """Fork: deep-copy the skill's folder into the target scope — the caller's
+    own, or a workspace they belong to."""
     # Forking writes new pages/files/sessions into the scope — same bar as
     # creating a Skill.
     if not await user_scope_service.can_write(req.owner_user_id, current_user["id"]):

--- a/backend/services/github_skill_import.py
+++ b/backend/services/github_skill_import.py
@@ -280,17 +280,18 @@ async def user_github_token(user_id: UUID) -> str | None:
         return None
 
 
-async def import_repo_for_user(owner_user_id: UUID, repo_url: str) -> dict:
-    """Copy a whole repo into the user's own scope as one new root folder — a
-    straight copy preserving structure. Any folder containing a SKILL.md
-    derives as a skill automatically (skill-ness is never stored). Private
-    repos work when the user's GitHub connection can read them."""
-    token = await user_github_token(owner_user_id)
+async def import_repo_for_user(owner_user_id: UUID, user_id: UUID, repo_url: str) -> dict:
+    """Copy a whole repo into the active scope (the user's own, or a workspace
+    they belong to) as one new root folder — a straight copy preserving
+    structure. Any folder containing a SKILL.md derives as a skill
+    automatically (skill-ness is never stored). Private repos work when the
+    user's GitHub connection can read them."""
+    token = await user_github_token(user_id)
     repo_name, files = await fetch_repo_files(repo_url, token)
     if not files:
         raise ValueError("That repo has no importable files")
-    folder = await _create_root_folder(owner_user_id, owner_user_id, repo_name)
-    await files_tree_service.write_folder_files(owner_user_id, owner_user_id, folder["id"], files)
+    folder = await _create_root_folder(owner_user_id, user_id, repo_name)
+    await files_tree_service.write_folder_files(owner_user_id, user_id, folder["id"], files)
     return {"folder_id": str(folder["id"]), "name": folder["name"], "files": len(files)}
 
 

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -422,17 +422,18 @@ async def check_access(
     if user_id is not None and owner_user_id is not None and owner_user_id == user_id:
         return True
 
-    # The publish record itself: existence == publicly readable; owner manages.
+    # The publish record itself: existence == publicly readable; managing it
+    # takes write access on its scope (owner, or workspace member).
     if object_type == "skill":
         pool = get_pool()
         row = await pool.fetchrow(
-            "SELECT id, owner_id FROM skills WHERE id = $1",
+            "SELECT id, owner_user_id FROM skills WHERE id = $1",
             object_id,
         )
         if not row:
             return False
         if require != "read":
-            return row["owner_id"] == user_id
+            return await is_workspace_member(row["owner_user_id"], user_id)
         return True
 
     # A session folder is a shareable bundle: public link, owner, or user share.

--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -160,8 +160,8 @@ async def publish_folder(
     )
     if not folder or folder["owner_user_id"] != owner_user_id:
         raise ValueError("Folder not found in this scope")
-    if not await user_scope_service.is_owner(owner_user_id, owner_id):
-        raise ValueError("Only scope owners can publish Skills")
+    if not await user_scope_service.can_write(owner_user_id, owner_id):
+        raise ValueError("Not allowed to publish Skills in this scope")
     if not await permission_service.check_access(
         "folder", folder_id, owner_id, owner_user_id=owner_user_id, require="write"
     ):
@@ -1012,8 +1012,9 @@ def contents_to_text(title: str, contents: dict) -> str:
 
 # --- Access checks (on the publish record) ---
 #
-# A publish record's existence means "publicly readable"; managing it is
-# owner-only. Person-to-person access rides folder shares, not this module.
+# A publish record's existence means "publicly readable"; managing it takes
+# write access on its scope — the scope owner, or any member when the scope
+# is a workspace. Person-to-person access rides folder shares, not this module.
 
 
 async def user_can_read(skill_id: UUID, user_id: UUID | None) -> bool:
@@ -1024,8 +1025,8 @@ async def user_can_read(skill_id: UUID, user_id: UUID | None) -> bool:
 
 async def user_can_manage(skill_id: UUID, user_id: UUID) -> bool:
     pool = get_pool()
-    owner_id = await pool.fetchval("SELECT owner_id FROM skills WHERE id = $1", skill_id)
-    return owner_id == user_id
+    owner_user_id = await pool.fetchval("SELECT owner_user_id FROM skills WHERE id = $1", skill_id)
+    return await user_scope_service.can_write(owner_user_id, user_id)
 
 
 async def user_can_write(skill_id: UUID, user_id: UUID) -> bool:

--- a/backend/services/user_scope_service.py
+++ b/backend/services/user_scope_service.py
@@ -3,8 +3,9 @@
 Each user IS their own scope. Everything a user owns is keyed by
 `owner_user_id` = their user id. A workspace is a scope owned by a dedicated
 login-less user; its members can read and write that scope's content like
-their own. Owner-only powers (sharing, sources, publishing, public links)
-stay with the scope user itself — `is_owner` never matches a member.
+their own — including publishing the scope's skills. Owner-only powers
+(sharing, sources, per-object public links) stay with the scope user itself —
+`is_owner` never matches a member.
 """
 
 import logging

--- a/backend/tests/test_github_skill_import.py
+++ b/backend/tests/test_github_skill_import.py
@@ -184,7 +184,9 @@ async def test_import_repo_for_user_copies_whole_repo(client: AsyncClient, pool,
     assert reg.status_code == 201
     user_id, api_key = reg.json()["id"], reg.json()["api_key"]
 
-    result = await gsi.import_repo_for_user(UUID(user_id), "https://github.com/acme/skills")
+    result = await gsi.import_repo_for_user(
+        UUID(user_id), UUID(user_id), "https://github.com/acme/skills"
+    )
 
     assert result["name"] == "skills"
     assert result["files"] == len(FAKE_REPO)

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -477,3 +477,124 @@ async def test_member_sessions_and_events_land_in_workspace_scope(client: AsyncC
         headers={**_auth(stranger_key), **scope_header},
     )
     assert denied.status_code == 403
+
+
+# --- Skills in the workspace scope ---
+
+
+async def _workspace_skill_folder(pool, scope_user_id, name="team-skill") -> uuid.UUID:
+    scope_id = uuid.UUID(scope_user_id)
+    folder = await pool.fetchrow(
+        "INSERT INTO folders (owner_user_id, name, created_by) VALUES ($1, $2, $1) RETURNING id",
+        scope_id,
+        name,
+    )
+    await pool.execute(
+        "INSERT INTO pages (owner_user_id, folder_id, name, content_markdown, created_by) "
+        "VALUES ($1, $2, 'SKILL.md', '---\nname: team-skill\n---\nhow we deploy', $1)",
+        scope_id,
+        folder["id"],
+    )
+    return folder["id"]
+
+
+@pytest.mark.asyncio
+async def test_member_sees_workspace_skills_via_scope_header(client: AsyncClient, pool):
+    """The Skills surface follows the scope switcher: workspace skills show up
+    when scoped, and never bleed into the member's personal list."""
+    domain = _domain()
+    key, body = await _register_with_email(client, f"m@{domain}")
+    await _verify_email(pool, uuid.UUID(body["id"]))
+    ws = await _create_workspace(client, domain)
+    await _workspace_skill_folder(pool, ws["scope_user_id"])
+
+    scoped = {**_auth(key), "X-Stash-Scope": ws["scope_user_id"]}
+    resp = await client.get("/api/v1/me/skills", headers=scoped)
+    assert resp.status_code == 200
+    assert "team-skill" in [s["name"] for s in resp.json()["skills"]]
+
+    resp = await client.get("/api/v1/me/skills", headers=_auth(key))
+    assert "team-skill" not in [s["name"] for s in resp.json()["skills"]]
+
+
+@pytest.mark.asyncio
+async def test_member_publishes_workspace_skill_and_teammate_manages_it(client: AsyncClient, pool):
+    """Publishing is a team power inside the workspace: any member can mint
+    the publish record, and any other member can update or unpublish it —
+    while outsiders cannot touch it."""
+    domain = _domain()
+    a_key, a_body = await _register_with_email(client, f"alice@{domain}")
+    b_key, b_body = await _register_with_email(client, f"bob@{domain}")
+    for body in (a_body, b_body):
+        await _verify_email(pool, uuid.UUID(body["id"]))
+    ws = await _create_workspace(client, domain)
+    folder_id = await _workspace_skill_folder(pool, ws["scope_user_id"])
+
+    scoped_a = {**_auth(a_key), "X-Stash-Scope": ws["scope_user_id"]}
+    published = await client.post(
+        "/api/v1/me/skills", json={"folder_id": str(folder_id)}, headers=scoped_a
+    )
+    assert published.status_code == 201, published.text
+    skill = published.json()
+    assert skill["owner_user_id"] == ws["scope_user_id"]
+
+    updated = await client.patch(
+        f"/api/v1/skills/{skill['id']}", json={"title": "Team Deploys"}, headers=_auth(b_key)
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["title"] == "Team Deploys"
+
+    outsider_key, _ = await _register_with_email(client, f"{unique_name('o')}@other.io")
+    denied = await client.patch(
+        f"/api/v1/skills/{skill['id']}", json={"title": "hijack"}, headers=_auth(outsider_key)
+    )
+    assert denied.status_code == 404
+
+    gone = await client.delete(f"/api/v1/skills/{skill['id']}", headers=_auth(b_key))
+    assert gone.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_member_forks_public_skill_into_workspace(client: AsyncClient, pool):
+    """Fork honors the workspace as a target scope: the copy lands in the org
+    KB, and non-members cannot fork into it."""
+    domain = _domain()
+    key, body = await _register_with_email(client, f"m@{domain}")
+    member_id = uuid.UUID(body["id"])
+    await _verify_email(pool, member_id)
+    ws = await _create_workspace(client, domain)
+
+    author_key, author = await _register_with_email(client, f"{unique_name('a')}@elsewhere.io")
+    author_folder = await pool.fetchrow(
+        "INSERT INTO folders (owner_user_id, name, created_by) "
+        "VALUES ($1, 'public-howto', $1) RETURNING id",
+        uuid.UUID(author["id"]),
+    )
+    published = await client.post(
+        "/api/v1/me/skills",
+        json={"folder_id": str(author_folder["id"]), "title": "public-howto"},
+        headers=_auth(author_key),
+    )
+    assert published.status_code == 201, published.text
+    slug = published.json()["slug"]
+
+    forked = await client.post(
+        f"/api/v1/skills/{slug}/add-to-stash",
+        json={"owner_user_id": ws["scope_user_id"]},
+        headers=_auth(key),
+    )
+    assert forked.status_code == 201, forked.text
+    row = await pool.fetchrow(
+        "SELECT owner_user_id, created_by FROM folders WHERE id = $1",
+        uuid.UUID(forked.json()["folder_id"]),
+    )
+    assert row["owner_user_id"] == uuid.UUID(ws["scope_user_id"])
+    assert row["created_by"] == member_id
+
+    outsider_key, _ = await _register_with_email(client, f"{unique_name('s')}@elsewhere.io")
+    denied = await client.post(
+        f"/api/v1/skills/{slug}/add-to-stash",
+        json={"owner_user_id": ws["scope_user_id"]},
+        headers=_auth(outsider_key),
+    )
+    assert denied.status_code == 403

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1578,15 +1578,15 @@ export async function getPublicSkill(slug: string): Promise<PublicSkillDetail> {
   return apiFetch(`/api/v1/skills/${slug}`);
 }
 
-// Fork: deep folder copy into the caller's own space, landing as a private
-// skill folder. The fork target is always the current user.
+// Fork: deep folder copy into the active scope, landing as a private skill
+// folder — the caller's own space, or the workspace they're working in.
 export async function forkSkill(
   slug: string
 ): Promise<{ folder_id: string; name: string }> {
-  const me = await getMe();
+  const targetScope = getScopeUserId() ?? (await getMe()).id;
   return apiFetch(`/api/v1/skills/${slug}/add-to-stash`, {
     method: "POST",
-    body: JSON.stringify({ owner_user_id: me.id }),
+    body: JSON.stringify({ owner_user_id: targetScope }),
   });
 }
 


### PR DESCRIPTION
## What

The workspace scope switcher (`X-Stash-Scope`) re-rooted files, sessions, memory, and the sidebar — but `backend/routers/skills.py` silently ignored it. Three user-visible consequences, all fixed here:

1. **Skills page showed the wrong scope.** Scoped into a workspace, the sidebar showed workspace skills while the Skills page showed your personal ones. Every `/me` skill route now takes `get_scope`.
2. **Skill-creating flows landed in the wrong scope.** GitHub import, session materialize, and fork wrote to the caller's personal stash even in workspace mode. Import now separates target scope from acting user (member's GitHub token, org's content); fork accepts a workspace target and the frontend passes the active scope.
3. **Nobody could publish a workspace skill.** Publish required `is_owner`, which never matches a member of a login-less workspace scope. Publishing/managing a publish record now takes write access on the skill's scope — the owner as before, or any workspace member. Sharing, sources, and per-object public links stay owner-only.

## Tests

- New: member sees workspace skills via scope header (and personal list stays clean); member publishes + teammate updates/unpublishes while outsiders 404; member forks a public skill into the workspace (outsiders 403).
- Full backend suite: 995 passed. The 3 failures in `test_github_skill_import.py` are pre-existing on a clean tree (sandboxed-network machine; they hit real network past the mock).
- Frontend: 234 passed, lint clean.

## QA (local stack, real workspace + verified member)

API flow: scoped `/me/skills` lists the workspace skill and personal list doesn't; member publish 201 with `owner_user_id` = workspace scope; anonymous public read works; member PATCH 200; fork into workspace 201.

Browser: member switched into QA Corp sees the workspace skill on the Skills page, and the skill folder page shows the Published state — no console errors.

| Skills page in workspace scope | Skill folder, member view |
|---|---|
| ![skills list](https://app.joinstash.ai/f/1a261309-a1a4-4e66-ad5e-483dc53cc0b1) | ![skill folder](https://app.joinstash.ai/f/a6c1204c-9a6f-4cb8-a2fe-fd5e195d21c8) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtowH6YiVWgwuS2dsdsVTA