### PR TITLE
analytics: exclude internal accounts from the dashboard, with a Hide/Show toggle

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -80,55 +80,77 @@ async def engagement_cohorts(
     mode: str = Query("standard", pattern="^(standard|future)$"),
     max_period: int | None = Query(None, ge=1, le=104),
     events_filter: str = Query("all", pattern="^(all|active)$"),
+    exclude_internal: bool = Query(True),
 ):
     return await cohort_service.get_engagement_cohorts(
         bucket=bucket,
         mode=mode,
         max_period=max_period,
         events_filter=events_filter,
+        exclude_internal=exclude_internal,
     )
 
 
 @router.get("/analytics/summary", dependencies=[Depends(require_admin_token)])
-async def analytics_summary(days: int = Query(7, ge=1, le=90)):
-    return await admin_analytics_service.get_summary(days=days)
+async def analytics_summary(
+    days: int = Query(7, ge=1, le=90),
+    exclude_internal: bool = Query(True),
+):
+    return await admin_analytics_service.get_summary(days=days, exclude_internal=exclude_internal)
 
 
 @router.get("/analytics/onboarding-funnel", dependencies=[Depends(require_admin_token)])
 async def analytics_onboarding_funnel(
     days: int = Query(30, ge=1, le=180),
     path: str | None = Query(None, pattern="^(migrant|memory|sharing)$"),
+    exclude_internal: bool = Query(True),
 ):
-    return await admin_analytics_service.get_onboarding_funnel(days=days, path=path)
+    return await admin_analytics_service.get_onboarding_funnel(
+        days=days, path=path, exclude_internal=exclude_internal
+    )
 
 
 @router.get("/analytics/path-mix", dependencies=[Depends(require_admin_token)])
 async def analytics_path_mix(
     days: int = Query(30, ge=1, le=180),
     bucket: str = Query("day", pattern="^(day|week)$"),
+    exclude_internal: bool = Query(True),
 ):
-    return await admin_analytics_service.get_path_mix(days=days, bucket=bucket)
+    return await admin_analytics_service.get_path_mix(
+        days=days, bucket=bucket, exclude_internal=exclude_internal
+    )
 
 
 @router.get("/analytics/surface-mix", dependencies=[Depends(require_admin_token)])
 async def analytics_surface_mix(
     days: int = Query(30, ge=1, le=180),
     bucket: str = Query("day", pattern="^(day|week)$"),
+    exclude_internal: bool = Query(True),
 ):
-    return await admin_analytics_service.get_surface_mix(days=days, bucket=bucket)
+    return await admin_analytics_service.get_surface_mix(
+        days=days, bucket=bucket, exclude_internal=exclude_internal
+    )
 
 
 @router.get("/analytics/content-activity", dependencies=[Depends(require_admin_token)])
-async def analytics_content_activity(days: int = Query(30, ge=1, le=180)):
-    return await admin_analytics_service.get_content_activity(days=days)
+async def analytics_content_activity(
+    days: int = Query(30, ge=1, le=180),
+    exclude_internal: bool = Query(True),
+):
+    return await admin_analytics_service.get_content_activity(
+        days=days, exclude_internal=exclude_internal
+    )
 
 
 @router.get("/analytics/top-events", dependencies=[Depends(require_admin_token)])
 async def analytics_top_events(
     days: int = Query(30, ge=1, le=180),
     limit: int = Query(20, ge=1, le=100),
+    exclude_internal: bool = Query(True),
 ):
-    return await admin_analytics_service.get_top_events(days=days, limit=limit)
+    return await admin_analytics_service.get_top_events(
+        days=days, limit=limit, exclude_internal=exclude_internal
+    )
 
 
 # --- Discover catalog: import / remove GitHub skill repos ---

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -13,16 +13,20 @@ from ..database import get_pool
 
 # Our own team's usage would pollute every dashboard number, so every
 # aggregation here (and the engagement-cohort query) excludes accounts whose
-# email is on one of these domains.
+# email is on one of these domains by default. The dashboard's "Internal
+# accounts" toggle passes exclude_internal=False to count them anyway.
 INTERNAL_EMAIL_DOMAINS = ("ferganalabs.com", "joinstash.ai")
 
 
-def not_internal_user_sql(user_id_col: str) -> str:
-    """SQL predicate dropping rows whose user has an internal email domain.
+def internal_filter_sql(user_id_col: str, exclude_internal: bool) -> str:
+    """SQL predicate dropping rows whose user has an internal email domain,
+    or TRUE when internal usage should be counted.
 
-    Rows with a NULL user id (anonymous events) are kept. The domain list is
-    a code constant, so inlining it as SQL literals is safe.
+    Rows with a NULL user id (anonymous events) are always kept. The domain
+    list is a code constant, so inlining it as SQL literals is safe.
     """
+    if not exclude_internal:
+        return "TRUE"
     domains = ", ".join(f"'{d}'" for d in INTERNAL_EMAIL_DOMAINS)
     return (
         f"NOT EXISTS (SELECT 1 FROM users iu WHERE iu.id = {user_id_col} "
@@ -40,7 +44,9 @@ ONBOARDING_FUNNEL_STAGES: list[tuple[str, str]] = [
 ]
 
 
-async def get_onboarding_funnel(*, days: int = 30, path: str | None = None) -> dict:
+async def get_onboarding_funnel(
+    *, days: int = 30, path: str | None = None, exclude_internal: bool = True
+) -> dict:
     """Distinct-user counts per stage in the canonical onboarding order.
 
     A user 'enters' a stage if they emitted *any* event of that name in the
@@ -55,7 +61,7 @@ async def get_onboarding_funnel(*, days: int = 30, path: str | None = None) -> d
         FROM analytics_events
         WHERE created_at >= $1 AND event_name = ANY($2::text[])
           AND ($3::text IS NULL OR properties->>'path' = $3)
-          AND {not_internal_user_sql("analytics_events.user_id")}
+          AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
         GROUP BY event_name
         """,
         since,
@@ -87,7 +93,9 @@ async def get_onboarding_funnel(*, days: int = 30, path: str | None = None) -> d
     }
 
 
-async def get_path_mix(*, days: int = 30, bucket: str = "day") -> dict:
+async def get_path_mix(
+    *, days: int = 30, bucket: str = "day", exclude_internal: bool = True
+) -> dict:
     """Onboarding starts by path, counting one viewed event per start."""
     if bucket not in ("day", "week"):
         raise ValueError(f"unknown bucket: {bucket}")
@@ -106,7 +114,7 @@ async def get_path_mix(*, days: int = 30, bucket: str = "day") -> dict:
                COUNT(*) AS n
         FROM analytics_events
         WHERE created_at >= $1 AND event_name = 'onboarding.viewed'
-          AND {not_internal_user_sql("analytics_events.user_id")}
+          AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
         GROUP BY 1, 2
         ORDER BY ts ASC
         """,
@@ -123,7 +131,9 @@ async def get_path_mix(*, days: int = 30, bucket: str = "day") -> dict:
     }
 
 
-async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
+async def get_surface_mix(
+    *, days: int = 30, bucket: str = "day", exclude_internal: bool = True
+) -> dict:
     """Daily activity by surface across both tables.
 
     Surfaces we expose:
@@ -149,7 +159,7 @@ async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
                    COUNT(*) AS n
             FROM analytics_events
             WHERE created_at >= $1
-              AND {not_internal_user_sql("analytics_events.user_id")}
+              AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
             GROUP BY 1, 2
         ),
         he AS (
@@ -160,7 +170,7 @@ async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
             WHERE created_at >= $1
               AND metadata->>'client' IS NOT NULL
               AND COALESCE(metadata->>'source', '') <> 'history_import'
-              AND {not_internal_user_sql("history_events.created_by")}
+              AND {internal_filter_sql("history_events.created_by", exclude_internal)}
             GROUP BY 1, 2
         )
         SELECT * FROM ae
@@ -182,7 +192,7 @@ async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
     }
 
 
-async def get_top_events(*, days: int = 30, limit: int = 20) -> dict:
+async def get_top_events(*, days: int = 30, limit: int = 20, exclude_internal: bool = True) -> dict:
     """Most-frequent event names in analytics_events over the window."""
     pool = get_pool()
     since = datetime.now(UTC) - timedelta(days=days)
@@ -193,7 +203,7 @@ async def get_top_events(*, days: int = 30, limit: int = 20) -> dict:
                COUNT(DISTINCT user_id) AS users
         FROM analytics_events
         WHERE created_at >= $1
-          AND {not_internal_user_sql("analytics_events.user_id")}
+          AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
         GROUP BY event_name
         ORDER BY total DESC
         LIMIT $2
@@ -215,7 +225,7 @@ async def get_top_events(*, days: int = 30, limit: int = 20) -> dict:
     }
 
 
-async def get_summary(*, days: int = 7) -> dict:
+async def get_summary(*, days: int = 7, exclude_internal: bool = True) -> dict:
     """Top-of-dashboard stat boxes: signups, completions, active users, CLI installs."""
     pool = get_pool()
     since = datetime.now(UTC) - timedelta(days=days)
@@ -223,7 +233,7 @@ async def get_summary(*, days: int = 7) -> dict:
     signups = await pool.fetchval(
         f"""
         SELECT COUNT(*) FROM users
-        WHERE created_at >= $1 AND {not_internal_user_sql("users.id")}
+        WHERE created_at >= $1 AND {internal_filter_sql("users.id", exclude_internal)}
         """,
         since,
     )
@@ -231,7 +241,7 @@ async def get_summary(*, days: int = 7) -> dict:
         f"""
         SELECT COUNT(DISTINCT user_id) FROM analytics_events
         WHERE event_name = 'onboarding.completed' AND created_at >= $1
-          AND {not_internal_user_sql("analytics_events.user_id")}
+          AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
         """,
         since,
     )
@@ -243,7 +253,7 @@ async def get_summary(*, days: int = 7) -> dict:
         f"""
         SELECT COUNT(DISTINCT user_id) FROM analytics_events
         WHERE event_name = 'cli.command_invoked' AND created_at >= $1
-          AND {not_internal_user_sql("analytics_events.user_id")}
+          AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
         """,
         since,
     )
@@ -254,14 +264,14 @@ async def get_summary(*, days: int = 7) -> dict:
         SELECT COUNT(*) FROM (
             SELECT user_id FROM analytics_events
             WHERE user_id IS NOT NULL AND created_at >= $1
-              AND {not_internal_user_sql("analytics_events.user_id")}
+              AND {internal_filter_sql("analytics_events.user_id", exclude_internal)}
             UNION
             SELECT created_by AS user_id FROM history_events
             WHERE created_by IS NOT NULL
               AND created_at >= $1
               AND (metadata->>'client') IS NULL
               AND COALESCE(metadata->>'source', '') <> 'history_import'
-              AND {not_internal_user_sql("history_events.created_by")}
+              AND {internal_filter_sql("history_events.created_by", exclude_internal)}
         ) u
         """,
         since,
@@ -314,7 +324,7 @@ ACTIVITY_SURFACES = {
 }
 
 
-async def get_content_activity(*, days: int = 30) -> dict:
+async def get_content_activity(*, days: int = 30, exclude_internal: bool = True) -> dict:
     """Document reads, searches, and listings split by caller surface (web /
     cli / ask-the-stash), from the security_audit_events read trail: totals
     over the window plus a daily series for the dashboard's top segment."""
@@ -333,7 +343,7 @@ async def get_content_activity(*, days: int = 30) -> dict:
         action = ANY($1::text[])
         AND created_at >= $4
         AND (via IN ('cli', 'ask') OR (via = 'web' AND action = $2))
-        AND {not_internal_user_sql("security_audit_events.actor_user_id")}
+        AND {internal_filter_sql("security_audit_events.actor_user_id", exclude_internal)}
     """
 
     total_rows = await pool.fetch(

--- a/backend/services/admin_analytics_service.py
+++ b/backend/services/admin_analytics_service.py
@@ -11,6 +11,25 @@ from datetime import UTC, datetime, timedelta
 
 from ..database import get_pool
 
+# Our own team's usage would pollute every dashboard number, so every
+# aggregation here (and the engagement-cohort query) excludes accounts whose
+# email is on one of these domains.
+INTERNAL_EMAIL_DOMAINS = ("ferganalabs.com", "joinstash.ai")
+
+
+def not_internal_user_sql(user_id_col: str) -> str:
+    """SQL predicate dropping rows whose user has an internal email domain.
+
+    Rows with a NULL user id (anonymous events) are kept. The domain list is
+    a code constant, so inlining it as SQL literals is safe.
+    """
+    domains = ", ".join(f"'{d}'" for d in INTERNAL_EMAIL_DOMAINS)
+    return (
+        f"NOT EXISTS (SELECT 1 FROM users iu WHERE iu.id = {user_id_col} "
+        f"AND lower(split_part(iu.email, '@', 2)) IN ({domains}))"
+    )
+
+
 # Canonical funnel order. Reads top-of-funnel → bottom; missing steps render
 # as gaps so dashboards can show drop-off honestly.
 # Canonical funnel for the linear Connect → Ask onboarding (no path picker).
@@ -31,11 +50,12 @@ async def get_onboarding_funnel(*, days: int = 30, path: str | None = None) -> d
     pool = get_pool()
     since = datetime.now(UTC) - timedelta(days=days)
     rows = await pool.fetch(
-        """
+        f"""
         SELECT event_name, COUNT(DISTINCT user_id) AS users
         FROM analytics_events
         WHERE created_at >= $1 AND event_name = ANY($2::text[])
           AND ($3::text IS NULL OR properties->>'path' = $3)
+          AND {not_internal_user_sql("analytics_events.user_id")}
         GROUP BY event_name
         """,
         since,
@@ -86,6 +106,7 @@ async def get_path_mix(*, days: int = 30, bucket: str = "day") -> dict:
                COUNT(*) AS n
         FROM analytics_events
         WHERE created_at >= $1 AND event_name = 'onboarding.viewed'
+          AND {not_internal_user_sql("analytics_events.user_id")}
         GROUP BY 1, 2
         ORDER BY ts ASC
         """,
@@ -128,6 +149,7 @@ async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
                    COUNT(*) AS n
             FROM analytics_events
             WHERE created_at >= $1
+              AND {not_internal_user_sql("analytics_events.user_id")}
             GROUP BY 1, 2
         ),
         he AS (
@@ -138,6 +160,7 @@ async def get_surface_mix(*, days: int = 30, bucket: str = "day") -> dict:
             WHERE created_at >= $1
               AND metadata->>'client' IS NOT NULL
               AND COALESCE(metadata->>'source', '') <> 'history_import'
+              AND {not_internal_user_sql("history_events.created_by")}
             GROUP BY 1, 2
         )
         SELECT * FROM ae
@@ -164,12 +187,13 @@ async def get_top_events(*, days: int = 30, limit: int = 20) -> dict:
     pool = get_pool()
     since = datetime.now(UTC) - timedelta(days=days)
     rows = await pool.fetch(
-        """
+        f"""
         SELECT event_name,
                COUNT(*) AS total,
                COUNT(DISTINCT user_id) AS users
         FROM analytics_events
         WHERE created_at >= $1
+          AND {not_internal_user_sql("analytics_events.user_id")}
         GROUP BY event_name
         ORDER BY total DESC
         LIMIT $2
@@ -196,11 +220,18 @@ async def get_summary(*, days: int = 7) -> dict:
     pool = get_pool()
     since = datetime.now(UTC) - timedelta(days=days)
 
-    signups = await pool.fetchval("SELECT COUNT(*) FROM users WHERE created_at >= $1", since)
+    signups = await pool.fetchval(
+        f"""
+        SELECT COUNT(*) FROM users
+        WHERE created_at >= $1 AND {not_internal_user_sql("users.id")}
+        """,
+        since,
+    )
     completed = await pool.fetchval(
-        """
+        f"""
         SELECT COUNT(DISTINCT user_id) FROM analytics_events
         WHERE event_name = 'onboarding.completed' AND created_at >= $1
+          AND {not_internal_user_sql("analytics_events.user_id")}
         """,
         since,
     )
@@ -209,25 +240,28 @@ async def get_summary(*, days: int = 7) -> dict:
     # is the canonical first-run, but a user invoking `share` or `upload`
     # is just as much an active CLI user.
     cli_active = await pool.fetchval(
-        """
+        f"""
         SELECT COUNT(DISTINCT user_id) FROM analytics_events
         WHERE event_name = 'cli.command_invoked' AND created_at >= $1
+          AND {not_internal_user_sql("analytics_events.user_id")}
         """,
         since,
     )
     # Active users = distinct user_id across analytics_events + non-plugin
     # history_events. Plugin events are firehose and would dominate.
     active_users = await pool.fetchval(
-        """
+        f"""
         SELECT COUNT(*) FROM (
             SELECT user_id FROM analytics_events
             WHERE user_id IS NOT NULL AND created_at >= $1
+              AND {not_internal_user_sql("analytics_events.user_id")}
             UNION
             SELECT created_by AS user_id FROM history_events
             WHERE created_by IS NOT NULL
               AND created_at >= $1
               AND (metadata->>'client') IS NULL
               AND COALESCE(metadata->>'source', '') <> 'history_import'
+              AND {not_internal_user_sql("history_events.created_by")}
         ) u
         """,
         since,
@@ -295,10 +329,11 @@ async def get_content_activity(*, days: int = 30) -> dict:
             ELSE 'reads'
         END
     """
-    counted = """
+    counted = f"""
         action = ANY($1::text[])
         AND created_at >= $4
         AND (via IN ('cli', 'ask') OR (via = 'web' AND action = $2))
+        AND {not_internal_user_sql("security_audit_events.actor_user_id")}
     """
 
     total_rows = await pool.fetch(

--- a/backend/services/cohort_service.py
+++ b/backend/services/cohort_service.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
 from ..database import get_pool
-from .admin_analytics_service import not_internal_user_sql
+from .admin_analytics_service import internal_filter_sql
 
 Bucket = str  # "month" | "week" | "rolling_7d"
 Mode = str  # "standard" | "future"
@@ -167,6 +167,7 @@ async def get_engagement_cohorts(
     mode: Mode = "standard",
     max_period: int | None = None,
     events_filter: EventsFilter = "all",
+    exclude_internal: bool = True,
 ) -> dict:
     if events_filter not in ("all", "active"):
         raise ValueError(f"unknown events_filter: {events_filter}")
@@ -189,7 +190,7 @@ async def get_engagement_cohorts(
         SELECT u.id, u.created_at AS signup_at, ue.event_at
         FROM users u
         LEFT JOIN user_events ue ON ue.user_id = u.id
-        WHERE {not_internal_user_sql("u.id")}
+        WHERE {internal_filter_sql("u.id", exclude_internal)}
         ORDER BY u.id, ue.event_at NULLS FIRST
     """
     rows = await pool.fetch(sql)

--- a/backend/services/cohort_service.py
+++ b/backend/services/cohort_service.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
 from ..database import get_pool
+from .admin_analytics_service import not_internal_user_sql
 
 Bucket = str  # "month" | "week" | "rolling_7d"
 Mode = str  # "standard" | "future"
@@ -188,6 +189,7 @@ async def get_engagement_cohorts(
         SELECT u.id, u.created_at AS signup_at, ue.event_at
         FROM users u
         LEFT JOIN user_events ue ON ue.user_id = u.id
+        WHERE {not_internal_user_sql("u.id")}
         ORDER BY u.id, ue.event_at NULLS FIRST
     """
     rows = await pool.fetch(sql)

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -394,9 +394,10 @@ async def test_summary_counts_signups_and_cli_active(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_internal_email_domains_are_excluded(client: AsyncClient, pool):
+async def test_internal_email_domains_are_excluded_by_default(client: AsyncClient, pool):
     """Our own team's usage (ferganalabs/joinstash accounts) must not inflate
-    dashboard numbers — only the external user should count anywhere."""
+    dashboard numbers unless the "Internal accounts" toggle asks for them —
+    by default only the external user should count anywhere."""
     users = {}
     for label in ("internal", "external"):
         resp = await client.post(
@@ -447,6 +448,17 @@ async def test_internal_email_domains_are_excluded(client: AsyncClient, pool):
     assert resp.status_code == 200, resp.text
     by_stage = {s["stage"]: s["users"] for s in resp.json()["stages"]}
     assert by_stage["viewed"] == 1
+
+    # The dashboard's "Internal accounts: Show" toggle turns the filter off —
+    # both users must count again.
+    resp = await client.get(
+        "/api/v1/admin/analytics/summary?days=30&exclude_internal=false", headers=_admin()
+    )
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["signups"] == 2
+    assert summary["cli_active_users"] == 2
+    assert summary["active_users"] == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -394,6 +394,62 @@ async def test_summary_counts_signups_and_cli_active(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_internal_email_domains_are_excluded(client: AsyncClient, pool):
+    """Our own team's usage (ferganalabs/joinstash accounts) must not inflate
+    dashboard numbers — only the external user should count anywhere."""
+    users = {}
+    for label in ("internal", "external"):
+        resp = await client.post(
+            "/api/v1/users/register",
+            json={"name": unique_name(label), "password": "securepassword1"},
+        )
+        assert resp.status_code == 201
+        users[label] = resp.json()
+
+    await pool.execute(
+        "UPDATE users SET email = 'team@ferganalabs.com' WHERE id = $1",
+        UUID(users["internal"]["id"]),
+    )
+    await pool.execute(
+        "UPDATE users SET email = 'someone@example.com' WHERE id = $1",
+        UUID(users["external"]["id"]),
+    )
+
+    for label in ("internal", "external"):
+        resp = await client.post(
+            "/api/v1/analytics/events",
+            json={
+                "events": [
+                    {
+                        "surface": "web",
+                        "event_name": "onboarding.viewed",
+                        "properties": {"has_path": False},
+                    },
+                    {
+                        "surface": "cli",
+                        "event_name": "cli.command_invoked",
+                        "properties": {"command": "connect"},
+                    },
+                ]
+            },
+            headers=_auth(users[label]["api_key"]),
+        )
+        assert resp.status_code == 200, resp.text
+
+    resp = await client.get("/api/v1/admin/analytics/summary?days=30", headers=_admin())
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["signups"] == 1
+    assert summary["cli_active_users"] == 1
+    assert summary["active_users"] == 1
+
+    resp = await client.get("/api/v1/admin/analytics/onboarding-funnel", headers=_admin())
+    assert resp.status_code == 200, resp.text
+    by_stage = {s["stage"]: s["users"] for s in resp.json()["stages"]}
+    assert by_stage["viewed"] == 1
+
+
+@pytest.mark.asyncio
 async def test_content_activity_zero_state(client: AsyncClient):
     resp = await client.get("/api/v1/admin/analytics/content-activity", headers=_admin())
     assert resp.status_code == 200, resp.text

--- a/www/app/admin/analytics/AnalyticsClient.tsx
+++ b/www/app/admin/analytics/AnalyticsClient.tsx
@@ -142,6 +142,13 @@ const WINDOW_OPTS = [
   { value: "90", label: "90d" },
 ] as const;
 
+// Internal = ferganalabs/joinstash team accounts, excluded server-side by
+// default so team usage doesn't inflate the numbers.
+const INTERNAL_OPTS = [
+  { value: "hide", label: "Hide" },
+  { value: "show", label: "Show" },
+] as const;
+
 // ---- Helpers ----
 
 function pivot<R extends { ts: string }>(
@@ -208,6 +215,7 @@ export default function AnalyticsClient({
   eventsFilter,
   funnelPath,
   windowDays,
+  internal,
 }: {
   data: AnalyticsPayload;
   bucket: CohortResponse["bucket"];
@@ -215,6 +223,7 @@ export default function AnalyticsClient({
   eventsFilter: CohortResponse["events_filter"];
   funnelPath: "all" | "migrant" | "memory" | "sharing";
   windowDays: number;
+  internal: "hide" | "show";
 }) {
   const router = useRouter();
   const params = useSearchParams();
@@ -262,12 +271,20 @@ export default function AnalyticsClient({
               and engagement cohorts — all from one screen.
             </p>
           </div>
-          <Toggle
-            label="Window"
-            value={String(windowDays)}
-            options={WINDOW_OPTS}
-            onChange={(v) => setParam("days", v)}
-          />
+          <div className="flex flex-wrap items-end gap-4">
+            <Toggle
+              label="Internal accounts"
+              value={internal}
+              options={INTERNAL_OPTS}
+              onChange={(v) => setParam("internal", v)}
+            />
+            <Toggle
+              label="Window"
+              value={String(windowDays)}
+              options={WINDOW_OPTS}
+              onChange={(v) => setParam("days", v)}
+            />
+          </div>
         </div>
 
         <ContentActivitySection activity={data.contentActivity} />

--- a/www/app/admin/analytics/page.tsx
+++ b/www/app/admin/analytics/page.tsx
@@ -14,6 +14,7 @@ const VALID_BUCKETS = ["month", "week", "rolling_7d"] as const;
 const VALID_MODES = ["standard", "future"] as const;
 const VALID_FILTERS = ["all", "active"] as const;
 const VALID_PATHS = ["migrant", "memory", "sharing"] as const;
+const VALID_INTERNAL = ["hide", "show"] as const;
 
 type SearchParams = { [key: string]: string | string[] | undefined };
 
@@ -53,6 +54,10 @@ export default async function AnalyticsAdminPage({
   const mode = readParam(sp.mode, VALID_MODES, "standard");
   const eventsFilter = readParam(sp.events_filter, VALID_FILTERS, "all");
   const funnelPath = readOptionalParam(sp.path, VALID_PATHS);
+  const internal = readParam(sp.internal, VALID_INTERNAL, "hide");
+  // Backends exclude internal (ferganalabs/joinstash) accounts by default;
+  // only the "show" toggle position needs to be sent explicitly.
+  const excludeInternal = internal === "show" ? "false" : undefined;
   const windowDays = Math.min(
     180,
     Math.max(1, Number((Array.isArray(sp.days) ? sp.days[0] : sp.days) ?? 30)),
@@ -82,14 +87,24 @@ export default async function AnalyticsAdminPage({
   const [contentActivity, summary, funnel, pathMix, surfaceMix, topEvents, cohorts] =
     await Promise.all([
       fetchJSON(
-        fmt("/api/v1/admin/analytics/content-activity", { days: windowDays }),
+        fmt("/api/v1/admin/analytics/content-activity", {
+          days: windowDays,
+          exclude_internal: excludeInternal,
+        }),
         token,
       ),
-      fetchJSON(fmt("/api/v1/admin/analytics/summary", { days: 7 }), token),
+      fetchJSON(
+        fmt("/api/v1/admin/analytics/summary", {
+          days: 7,
+          exclude_internal: excludeInternal,
+        }),
+        token,
+      ),
       fetchJSON(
         fmt("/api/v1/admin/analytics/onboarding-funnel", {
           days: windowDays,
           path: funnelPath,
+          exclude_internal: excludeInternal,
         }),
         token,
       ),
@@ -97,6 +112,7 @@ export default async function AnalyticsAdminPage({
         fmt("/api/v1/admin/analytics/path-mix", {
           days: windowDays,
           bucket: "day",
+          exclude_internal: excludeInternal,
         }),
         token,
       ),
@@ -104,6 +120,7 @@ export default async function AnalyticsAdminPage({
         fmt("/api/v1/admin/analytics/surface-mix", {
           days: windowDays,
           bucket: "day",
+          exclude_internal: excludeInternal,
         }),
         token,
       ),
@@ -111,6 +128,7 @@ export default async function AnalyticsAdminPage({
         fmt("/api/v1/admin/analytics/top-events", {
           days: windowDays,
           limit: 20,
+          exclude_internal: excludeInternal,
         }),
         token,
       ),
@@ -119,6 +137,7 @@ export default async function AnalyticsAdminPage({
           bucket,
           mode,
           events_filter: eventsFilter,
+          exclude_internal: excludeInternal,
         }),
         token,
       ),
@@ -156,6 +175,7 @@ export default async function AnalyticsAdminPage({
       eventsFilter={eventsFilter}
       funnelPath={funnelPath ?? "all"}
       windowDays={windowDays}
+      internal={internal}
     />
   );
 }


### PR DESCRIPTION
## What

Excludes our own team's usage from the admin analytics dashboard, with a toggle to bring it back:

- Every admin analytics endpoint (summary, onboarding funnel, path mix, surface mix, top events, content activity, engagement cohorts) now drops users whose email is on `ferganalabs.com` or `joinstash.ai` — by default.
- Each endpoint takes `exclude_internal` (default `true`); the dashboard grows an **Internal accounts: Hide / Show** toggle next to the window picker that refetches every section with the filter off. The state is URL-driven (`?internal=show`) so it survives reloads and shared links.
- Events with no user id (anonymous) always count. The filter matches on `users.email`, so team accounts without an email set are not excluded.

## Screenshots

Default (**Hide** — internal accounts excluded):

<img src="https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/c56322cc-809b-4768-b4e4-0f8c245d73a9/6f25b456a598/analytics-internal-hidden.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=1ab0d01cd44f96f480be9e227d6057f6%2F20260724%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260724T181712Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=f28568e377219eb17569d8114382de5e952b24dd9fe1b3d852cff4cdc8dc7de2" width="720" alt="dashboard with internal accounts hidden">

**Show** — internal accounts counted (note signups 4→5, onboardings 1→2, active users 3→4, CLI active 2→3 with the seeded internal account):

<img src="https://48c5d73f37bc9124b23e718f0d82bd83.r2.cloudflarestorage.com/boozle/c56322cc-809b-4768-b4e4-0f8c245d73a9/3ca71927968f/analytics-internal-shown.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=1ab0d01cd44f96f480be9e227d6057f6%2F20260724%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260724T181713Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=03d0d2f531f61720683e7ea425213e16401e85b9288f181fd110d9e8a91fcbf5" width="720" alt="dashboard with internal accounts shown">

## Testing

- New API test seeds an internal (`@ferganalabs.com`) and an external user with identical events and asserts the default excludes the internal one everywhere, while `exclude_internal=false` counts both.
- `pytest backend/tests/test_analytics.py backend/tests/test_content_read_audit.py` — 24 passed; ruff clean.
- `www` builds clean; both toggle states click-tested in the browser against a seeded local stack (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
