### PR TITLE
fix: refresh sidebar Tools connected badges immediately on disconnect

### DIFF
--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { useWorkspace, type TabKind } from "@/lib/workspace-store";
 import { urlForTab } from "@/lib/workspace-routes";
 import { CONNECTORS, connectorIcon, providerForSourceType } from "@/components/integrations/connectors";
-import { listIntegrations } from "@/lib/integrations";
+import { INTEGRATIONS_CHANGED_EVENT, listIntegrations } from "@/lib/integrations";
 import { opensNewTab } from "@/lib/tab-nav";
 import FilesExplorer, { type Item } from "./files-explorer";
 
@@ -69,11 +69,16 @@ function ToolsSection() {
   // integrations like Heavi) — null until loaded, then the allowed set.
   const [allowed, setAllowed] = useState<Set<string> | null>(null);
   useEffect(() => {
-    listSources().then((all) => setSourceProviders(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type)))).catch(() => {});
-    listIntegrations().then((r) => {
-      setAllowed(new Set(r.providers.map((p) => p.provider)));
-      setConnectedProviders(new Set(r.providers.filter((p) => p.connected).map((p) => p.provider)));
-    }).catch(() => {});
+    const load = () => {
+      listSources().then((all) => setSourceProviders(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type)))).catch(() => {});
+      listIntegrations().then((r) => {
+        setAllowed(new Set(r.providers.map((p) => p.provider)));
+        setConnectedProviders(new Set(r.providers.filter((p) => p.connected).map((p) => p.provider)));
+      }).catch(() => {});
+    };
+    load();
+    window.addEventListener(INTEGRATIONS_CHANGED_EVENT, load);
+    return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
   }, []);
   if (allowed === null) return <LoadingRow />;
   return (

--- a/frontend/src/lib/integrations.test.ts
+++ b/frontend/src/lib/integrations.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api", () => ({ apiFetch: vi.fn() }));
+
+import { apiFetch } from "./api";
+import {
+  INTEGRATIONS_CHANGED_EVENT,
+  disconnectIntegration,
+  submitCredentials,
+} from "./integrations";
+
+// Status surfaces that stay mounted across a disconnect (the sidebar Tools
+// list) rely on this event to drop their "Connected" badge immediately —
+// without it the stale badge lingers until the surface remounts.
+describe("integrations-changed event", () => {
+  let fired: number;
+  const onChanged = () => fired++;
+  beforeEach(() => {
+    fired = 0;
+    vi.mocked(apiFetch).mockReset();
+    window.addEventListener(INTEGRATIONS_CHANGED_EVENT, onChanged);
+  });
+  afterEach(() => {
+    window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, onChanged);
+  });
+
+  it("fires after a successful disconnect", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+    await disconnectIntegration("github");
+    expect(fired).toBe(1);
+  });
+
+  it("does not fire when disconnect fails", async () => {
+    vi.mocked(apiFetch).mockRejectedValue(new Error("boom"));
+    await expect(disconnectIntegration("github")).rejects.toThrow("boom");
+    expect(fired).toBe(0);
+  });
+
+  it("fires after a successful credential connect", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+    await submitCredentials("gong", { api_key: "k" });
+    expect(fired).toBe(1);
+  });
+});

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -99,6 +99,10 @@ export async function startConnect(
   window.location.href = authorize_url;
 }
 
+// Open surfaces that show connection status (e.g. the sidebar Tools list)
+// listen for this to refresh immediately after a connect or disconnect.
+export const INTEGRATIONS_CHANGED_EVENT = "integrations-changed";
+
 export async function disconnectIntegration(
   provider: IntegrationProvider,
   deleteData = false,
@@ -107,6 +111,7 @@ export async function disconnectIntegration(
     method: "POST",
     body: JSON.stringify({ delete_data: deleteData }),
   });
+  window.dispatchEvent(new Event(INTEGRATIONS_CHANGED_EVENT));
 }
 
 /** Delete the kept data of a (disconnected) provider — documents, archived
@@ -127,6 +132,7 @@ export async function submitCredentials(
     method: "POST",
     body: JSON.stringify(values),
   });
+  window.dispatchEvent(new Event(INTEGRATIONS_CHANGED_EVENT));
 }
 
 export type GitHubRepoSummary = {


### PR DESCRIPTION
## Problem

The sidebar Tools section fetched integration statuses once on mount. After disconnecting a source, its green "Connected" badge stayed until you left and returned to the Tools tab (which remounts the section).

## Fix

Follows the existing `agents-changed` window-event pattern:

- `lib/integrations.ts`: `disconnectIntegration` and `submitCredentials` dispatch an `integrations-changed` event after the API call succeeds. One dispatch point covers both disconnect surfaces (connector list + per-provider integration page). OAuth connects don't need it — they do a full-page redirect, which remounts the sidebar.
- `explorer.tsx`: `ToolsSection` listens for the event and refetches, so the badge flips to "Connect" the moment the disconnect succeeds (and to "Connected" right after an API-key connect).

## Tests

- New `lib/integrations.test.ts`: event fires on successful disconnect and credential connect; does not fire when disconnect fails.
- Full frontend suite passes (54 files, 237 tests); lint clean.
- Verified live in the app (demo user + seeded fake GitHub connection): with the GitHub tool tab open, clicking Disconnect flips the sidebar badge instantly.

<img width="1372" height="871" alt="Disconnecting GitHub clears the sidebar Connected badge immediately" src="https://github.com/user-attachments/assets/d27c6124-4101-4ff2-b432-ebc7b7f5c8ed" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
