### PR TITLE
perf: cut unified search latency without changing results

### DIFF
--- a/backend/migrations/versions/0165_pages_fts_weighted_index.py
+++ b/backend/migrations/versions/0165_pages_fts_weighted_index.py
@@ -1,0 +1,41 @@
+"""Index the weighted pages search vector; drop the unusable plain one.
+
+search_pages_fts matches against setweight(content)||setweight(keywords), but
+the only FTS index on pages covered plain to_tsvector(content_markdown) — an
+expression Postgres can't match to the query, so every page search was a
+sequential scan that regex-stripped each page's HTML. Build the index on the
+query's exact expression (PAGES_FTS_VECTOR_EXPR in files_tree_service.py —
+keep the two in sync) and drop the index nothing can use.
+"""
+
+from alembic import op
+
+revision = "0165"
+down_revision = "0164"
+branch_labels = None
+depends_on = None
+
+# Must stay character-for-character in sync with
+# files_tree_service.PAGES_FTS_VECTOR_EXPR.
+PAGES_FTS_VECTOR_EXPR = (
+    "setweight(to_tsvector('english', CASE WHEN content_type = 'html' "
+    "THEN regexp_replace(COALESCE(content_html, ''), '<[^>]+>', ' ', 'g') "
+    "ELSE COALESCE(content_markdown, '') END), 'B') || "
+    "setweight(to_tsvector('english', COALESCE(metadata->>'keywords', '')), 'A')"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pages_fts_weighted "
+        f"ON pages USING GIN (({PAGES_FTS_VECTOR_EXPR}))"
+    )
+    op.execute("DROP INDEX IF EXISTS idx_pages_fts")
+
+
+def downgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pages_fts "
+        "ON pages USING GIN (to_tsvector('english', content_markdown))"
+    )
+    op.execute("DROP INDEX IF EXISTS idx_pages_fts_weighted")

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1428,6 +1428,26 @@ async def list_scope_tree(owner_user_id: UUID, user_id: UUID | None = None) -> d
     return root
 
 
+# The page text that FTS matches against: HTML pages stripped of tags,
+# markdown pages as-is.
+_PAGES_CONTENT_TEXT_EXPR = (
+    "CASE WHEN content_type = 'html' "
+    "THEN regexp_replace(COALESCE(content_html, ''), '<[^>]+>', ' ', 'g') "
+    "ELSE COALESCE(content_markdown, '') END"
+)
+
+# The weighted search vector for pages: keywords (A) over body text (B). Every
+# sub-expression is immutable — no subqueries — so the whole thing is an
+# indexable expression, and idx_pages_fts_weighted (migration 0165) is built on
+# this EXACT text. Postgres matches expression indexes syntactically: change
+# this and the migration together, or page search silently falls back to a
+# sequential scan that regex-strips every page's HTML per query.
+PAGES_FTS_VECTOR_EXPR = (
+    f"setweight(to_tsvector('english', {_PAGES_CONTENT_TEXT_EXPR}), 'B') || "
+    "setweight(to_tsvector('english', COALESCE(metadata->>'keywords', '')), 'A')"
+)
+
+
 async def search_pages_fts(
     owner_user_id: UUID,
     query: str,
@@ -1435,19 +1455,8 @@ async def search_pages_fts(
     user_id: UUID | None = None,
 ) -> list[dict]:
     pool = get_pool()
-    kw_text_expr = (
-        "COALESCE((SELECT string_agg(kw, ' ') "
-        "FROM jsonb_array_elements_text(COALESCE(metadata->'keywords', '[]'::jsonb)) AS kw), '')"
-    )
-    content_text_expr = (
-        "CASE WHEN content_type = 'html' "
-        "THEN regexp_replace(COALESCE(content_html, ''), '<[^>]+>', ' ', 'g') "
-        "ELSE COALESCE(content_markdown, '') END"
-    )
-    vec_expr = (
-        f"setweight(to_tsvector('english', {content_text_expr}), 'B') || "
-        f"setweight(to_tsvector('english', {kw_text_expr}), 'A')"
-    )
+    vec_expr = PAGES_FTS_VECTOR_EXPR
+    content_text_expr = _PAGES_CONTENT_TEXT_EXPR
     args: list = [owner_user_id, query]
     where = (
         f"p.owner_user_id = $1 "

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -375,10 +375,24 @@ async def read_session_events_page(
 
 async def list_scope_sessions(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     """One row per session_id in this scope. Powers the spine sessions
-    list — replaces a SELECT against session_transcripts."""
+    list — replaces a SELECT against session_transcripts.
+
+    Readability is decided once per SESSION (the readable_sessions CTE), not
+    once per event: the permission predicate is a function of the session row,
+    so evaluating it inside the per-event scan only multiplied its cost by the
+    event count. size_bytes is the stored (TOAST-compressed) size — summing
+    pg_column_size reads only value headers, where LENGTH would decompress
+    every transcript event on every sidebar load."""
     pool = get_pool()
+    readable_session = permission_service.readable_content_condition("session", "s", 2)
     rows = await pool.fetch(
-        "WITH title_sources AS ( "
+        "WITH readable_sessions AS ( "
+        "  SELECT s.id, s.owner_user_id, s.session_id "
+        "  FROM sessions s "
+        "  WHERE s.owner_user_id = $1 AND s.deleted_at IS NULL "
+        f"    AND {readable_session} "
+        "), "
+        "title_sources AS ( "
         "  SELECT DISTINCT ON (ht.owner_user_id, ht.session_id) "
         "    ht.owner_user_id, "
         "    ht.session_id, "
@@ -394,24 +408,24 @@ async def list_scope_sessions(owner_user_id: UUID, user_id: UUID) -> list[dict]:
         "  END, ht.created_at, ht.id "
         ") "
         "SELECT h.session_id, "
-        "       s.id::text AS id, "
-        f"       {linear_ticket_service.sql_json_agg('s')} AS linear_tickets, "
+        "       rs.id::text AS id, "
+        f"       {linear_ticket_service.sql_json_agg('rs')} AS linear_tickets, "
         "       MAX(h.agent_name) AS agent_name, "
         "       (ARRAY_AGG(NULLIF(u.display_name, '') ORDER BY h.created_at) "
         "        FILTER (WHERE NULLIF(u.display_name, '') IS NOT NULL))[1] AS user_name, "
         "       title_sources.title_source, "
         "       COUNT(*)::INT AS event_count, "
-        "       SUM(LENGTH(h.content))::BIGINT AS size_bytes, "
+        "       SUM(pg_column_size(h.content))::BIGINT AS size_bytes, "
         "       MIN(h.created_at) AS started_at, "
         "       MAX(h.created_at) AS last_at "
         "FROM history_events h "
-        "JOIN sessions s ON s.owner_user_id = h.owner_user_id AND s.session_id = h.session_id "
+        "JOIN readable_sessions rs ON rs.owner_user_id = h.owner_user_id "
+        "  AND rs.session_id = h.session_id "
         "LEFT JOIN title_sources ON title_sources.owner_user_id = h.owner_user_id "
         "  AND title_sources.session_id = h.session_id "
         "LEFT JOIN users u ON u.id = h.created_by "
         "WHERE h.owner_user_id = $1 AND h.session_id IS NOT NULL "
-        f"AND {readable_session_event_condition('h', 2)} "
-        "GROUP BY h.session_id, s.id, title_sources.title_source "
+        "GROUP BY h.session_id, rs.id, title_sources.title_source "
         "ORDER BY last_at DESC, user_name ASC, session_id ASC",
         owner_user_id,
         user_id,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -2198,11 +2198,8 @@ async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> 
     query = query.strip()
     if not query:
         return []
-    hits: list[dict] = []
-    for s in sources:
-        table = SOURCE_TABLE.get(s["source_type"])
-        if table is None:
-            continue
+
+    async def one_source(s: dict, table: str) -> list[dict]:
         rows = await get_pool().fetch(
             f"SELECT path, name, external_updated_at FROM {table} "
             f"WHERE source_id = $1 AND strpos(external_ref, $2) > 0 AND deleted_at IS NULL "
@@ -2211,7 +2208,7 @@ async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> 
             query,
             limit,
         )
-        hits += [
+        return [
             {
                 "source": s["id"],
                 "source_name": s["display_name"],
@@ -2223,7 +2220,14 @@ async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> 
             }
             for r in rows
         ]
-    return hits
+
+    with_tables = [
+        (s, SOURCE_TABLE[s["source_type"]])
+        for s in sources
+        if SOURCE_TABLE.get(s["source_type"]) is not None
+    ]
+    per_source = await asyncio.gather(*(one_source(s, table) for s, table in with_tables))
+    return [h for source_hits in per_source for h in source_hits]
 
 
 async def _uniform_ranks(query: str, texts: list[str]) -> list[float]:
@@ -2301,15 +2305,22 @@ async def _gather_search_candidates(
     search. Returns (hits, markers, connected), or None when a named source is
     unknown / not owned. Sub-searches keep their own caps (sessions and FTS
     docs 500, providers SEARCH_LIMIT) — asking for more than those yields
-    has_more = False, not deeper results."""
-    hits: list[dict] = []
-    markers: list[dict] = []
+    has_more = False, not deeper results. The sub-searches are independent, so
+    they run concurrently; a search's latency is its slowest sub-search, not
+    the sum of all of them."""
+    # Resolve a named connected source first: an unknown handle must return
+    # None before any sub-search runs.
+    connected: dict | None = None
+    if source not in (None, NATIVE_FILES, NATIVE_SESSIONS):
+        connected = await _resolve_connected(source, owner_user_id, user_id)
+        if connected is None:
+            return None
 
-    if NATIVE_SESSIONS in allowed and source in (None, NATIVE_SESSIONS):
+    async def session_hits() -> tuple[list[dict], list[dict]]:
         from .memory_service import search_scope_events
 
         events = await search_scope_events(owner_user_id, user_id, query, limit=fetch_limit)
-        hits += [
+        return [
             {
                 "source": NATIVE_SESSIONS,
                 "ref": e.get("session_id"),
@@ -2317,13 +2328,13 @@ async def _gather_search_candidates(
                 "date_modified": e.get("created_at"),
             }
             for e in events
-        ]
+        ], []
 
-    if NATIVE_FILES in allowed and source in (None, NATIVE_FILES):
+    async def page_hits() -> tuple[list[dict], list[dict]]:
         from .files_tree_service import search_pages_fts
 
         pages = await search_pages_fts(owner_user_id, query, limit=fetch_limit, user_id=user_id)
-        hits += [
+        return [
             {
                 "source": NATIVE_FILES,
                 "ref": str(p["id"]),
@@ -2336,15 +2347,11 @@ async def _gather_search_candidates(
                 "date_modified": p.get("updated_at"),
             }
             for p in pages
-        ]
+        ], []
 
-    # Connected sources: all of the scope's own when unscoped, else the one named.
-    connected: dict | None = None
-    if source not in (None, NATIVE_FILES, NATIVE_SESSIONS):
-        connected = await _resolve_connected(source, owner_user_id, user_id)
-        if connected is None:
-            return None
-    if source is None or connected is not None:
+    async def connected_hits() -> tuple[list[dict], list[dict]]:
+        # Connected sources: all of the scope's own when unscoped, else the one
+        # named.
         searched_sources = (
             [connected]
             if connected is not None
@@ -2355,23 +2362,42 @@ async def _gather_search_candidates(
             ]
         )
 
+        # Federated sources search the provider's native API live. Scoped → the
+        # one source, raising on provider errors so a dead connection is never
+        # mistaken for "no matches"; unscoped → fan out across the user's
+        # federated sources (each call keeps search alive by returning its own
+        # error as a marker instead of raising).
+        federated = [s for s in searched_sources if s["source_type"] in FEDERATED_SEARCH_TYPES]
+
         # A query that is (part of) a provider id (a Drive file id, a Gmail
         # message id, …) resolves to the indexed document directly. This is how
         # an agent holding only a provider URL finds the document's Stash path.
-        hits += await _external_ref_matches(searched_sources, query, fetch_limit)
-
+        #
         # Copied-content sources go through our FTS (returns [] for index-only /
         # federated sources, which have no stored content to match). Unscoped
         # search filters at the table level, not via searched_sources — FTS also
         # reads sources shared directly with the user, which searched_sources
         # never enumerates.
-        docs = await search_documents(
-            user_id=user_id,
-            query=query,
-            source=connected,
-            providers=None if connected is not None else allowed - {NATIVE_FILES, NATIVE_SESSIONS},
-            limit=fetch_limit,
+        ref_hits, docs, federated_results = await asyncio.gather(
+            _external_ref_matches(searched_sources, query, fetch_limit),
+            search_documents(
+                user_id=user_id,
+                query=query,
+                source=connected,
+                providers=None
+                if connected is not None
+                else allowed - {NATIVE_FILES, NATIVE_SESSIONS},
+                limit=fetch_limit,
+            ),
+            asyncio.gather(
+                *(
+                    _federated_search(s, query, fetch_limit, swallow_errors=connected is None)
+                    for s in federated
+                )
+            ),
         )
+
+        hits = ref_hits
         hits += [
             {
                 "source": d["source_id"],
@@ -2383,27 +2409,25 @@ async def _gather_search_candidates(
             }
             for d in docs
         ]
+        markers: list[dict] = []
+        for fed_hits, fed_markers in federated_results:
+            hits += fed_hits
+            markers += fed_markers
+        return hits, markers
 
-        # Federated sources search the provider's native API live. Scoped → the
-        # one source, raising on provider errors so a dead connection is never
-        # mistaken for "no matches"; unscoped → fan out across the user's
-        # federated sources (each call keeps search alive by returning its own
-        # error as a marker instead of raising).
-        if connected is not None:
-            if connected["source_type"] in FEDERATED_SEARCH_TYPES:
-                fed_hits, fed_markers = await _federated_search(
-                    connected, query, fetch_limit, swallow_errors=False
-                )
-                hits += fed_hits
-                markers += fed_markers
-        else:
-            federated = [s for s in searched_sources if s["source_type"] in FEDERATED_SEARCH_TYPES]
-            for fed_hits, fed_markers in await asyncio.gather(
-                *(_federated_search(s, query, fetch_limit) for s in federated)
-            ):
-                hits += fed_hits
-                markers += fed_markers
+    subsearches = []
+    if NATIVE_SESSIONS in allowed and source in (None, NATIVE_SESSIONS):
+        subsearches.append(session_hits())
+    if NATIVE_FILES in allowed and source in (None, NATIVE_FILES):
+        subsearches.append(page_hits())
+    if source is None or connected is not None:
+        subsearches.append(connected_hits())
 
+    hits: list[dict] = []
+    markers: list[dict] = []
+    for sub_hits, sub_markers in await asyncio.gather(*subsearches):
+        hits += sub_hits
+        markers += sub_markers
     return hits, markers, connected
 
 

--- a/backend/tests/test_files_search.py
+++ b/backend/tests/test_files_search.py
@@ -72,3 +72,23 @@ async def test_search_pages_finds_html_page_text(client: AsyncClient) -> None:
     pages = resp.json()["pages"]
     assert [page["name"] for page in pages] == ["HTML Guide"]
     assert pages[0]["content_type"] == "html"
+
+
+def test_fts_vector_expr_matches_index_expr() -> None:
+    """Postgres only uses an expression index when the query's expression is
+    syntactically identical to the indexed one. If PAGES_FTS_VECTOR_EXPR drifts
+    from the migration's copy, page search silently degrades to a sequential
+    scan that regex-strips every page's HTML on every query."""
+    import importlib.util
+    from pathlib import Path
+
+    migration_path = (
+        Path(__file__).parent.parent / "migrations/versions/0165_pages_fts_weighted_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0165", migration_path)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    from backend.services.files_tree_service import PAGES_FTS_VECTOR_EXPR
+
+    assert migration.PAGES_FTS_VECTOR_EXPR == PAGES_FTS_VECTOR_EXPR

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -78,6 +78,7 @@ function SearchPageInner() {
   const { user, loading, logout } = useAuth();
   const initialSessionId = searchParams.get("session") ?? "";
   const [skills, setSkills] = useState<Skill[]>([]);
+  const [tables, setTables] = useState<TableWithOwner[]>([]);
   const [sidebar, setSidebar] = useState<Sidebar | null>(null);
   const [selectedProductSkillId, setSelectedProductSkillId] = useState("");
   const [selectedProductSkillSlug, setSelectedProductSkillSlug] = useState(
@@ -131,12 +132,14 @@ function SearchPageInner() {
     setFetching(true);
     setError("");
     try {
-      const [skillList, sidebarData, sources] = await Promise.all([
+      const [skillList, sidebarData, sources, tableData] = await Promise.all([
         listSkills(),
         getSidebar(),
         listSources(),
+        listAllTables(),
       ]);
       setSkills(skillList);
+      setTables(tableData.tables);
       setSidebar(sidebarData);
       setConnectedProviders([...new Set(sources.map((s) => providerForSourceType[s.type]))]);
     } catch (err) {
@@ -292,8 +295,6 @@ function SearchPageInner() {
       }
 
       if (includeTables && !selectedFolderId && !selectedPageId) {
-        const { tables } = await listAllTables();
-        if (searchSeq.current !== seq) return;
         nextResults.push(...searchTables(tables, q));
       }
 
@@ -323,6 +324,7 @@ function SearchPageInner() {
     selectedSessionId,
     sidebar,
     sourceName,
+    tables,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Why

The web search UI was slow, and ~5x slower on servers with a large transcript corpus. Tracing the path showed the time going to sequential sub-searches, a sidebar query that decompressed every transcript event on every load, a pages FTS whose expression couldn't use its index, and a per-search tables refetch.

## What

Four contained fixes, none changing search results or permissions:

- **Concurrent sub-searches** — `search_all`'s sub-searches (sessions FTS, pages FTS, provider-id matches, copied-content FTS, federated fan-out) now run under `asyncio.gather` instead of back-to-back, so latency is the slowest sub-search, not the sum. Error semantics preserved: a scoped federated search still raises; unscoped still degrades to a marker.
- **Sidebar sessions query** (`list_scope_sessions`, which gates the search page's first search) — readability is decided once per *session* (CTE over `sessions`) instead of once per *event* (correlated EXISTS inside the event scan), and `SUM(pg_column_size(content))` replaces `SUM(LENGTH(content))` so listing sessions no longer decompresses every transcript event. `size_bytes` now reports stored (TOAST-compressed) size; nothing consumes the exact value.
- **Pages FTS is index-backed** (migration 0165) — the old GIN index covered a different expression than `search_pages_fts` queries, so every page search was a sequential scan regex-stripping each page's HTML. The keyword arm is rewritten subquery-free (verified identical lexemes and positions) so the whole weighted expression is indexable; the migration builds the index on that exact text and drops the unusable one. A test pins the service expression to the migration's copy, since drift would silently revert to seq scans.
- **Search page fetches the tables list once** at load instead of on every search and every infinite-scroll growth step.

No user-facing UI changes — screens render exactly as before, so no screenshots.

## Verification

- Full backend suite: 1000 passed. Frontend vitest: 234 passed. Ruff + eslint clean.
- `EXPLAIN` confirms `idx_pages_fts_weighted` is used (Bitmap Index Scan) for the exact predicate `search_pages_fts` issues.
- Old-vs-new `list_scope_sessions` visibility parity checked across all owner×user pairs on dev data: identical session sets.
- Old-vs-new keyword tsvector compared in Postgres: identical lexemes and positions.

## Deploy notes

Migration 0165 builds a GIN index on `pages` at backend boot (non-concurrent, matching existing migrations); brief write-lock on `pages` during the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)