### PR TITLE
perf: re-search from the search page without an RSC round-trip

### DIFF
--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -9,9 +9,11 @@ const searchPlaceholder = "Search Skill or jump to a page, session, file, or tab
 const router = vi.hoisted(() => ({
   push: vi.fn(),
 }));
+const navigation = vi.hoisted(() => ({ pathname: "/" }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => router,
+  usePathname: () => navigation.pathname,
 }));
 
 vi.mock("next/link", () => ({
@@ -81,6 +83,7 @@ describe("CommandPalette search", () => {
   beforeEach(() => {
     router.push.mockClear();
     vi.clearAllMocks();
+    navigation.pathname = "/";
     vi.mocked(getSidebar).mockResolvedValue(sidebar);
     vi.mocked(listAllTables).mockResolvedValue({ tables: [] });
     vi.mocked(semanticSearchPages).mockResolvedValue([]);
@@ -99,6 +102,44 @@ describe("CommandPalette search", () => {
     fireEvent.keyDown(window, { key: "Enter" });
 
     expect(router.push).toHaveBeenCalledWith("/search?q=roadmap");
+  });
+
+  it("re-searches from the search page with a shallow history push, not a navigation", () => {
+    // router.push from /search to /search?q=… costs an RSC round-trip to the
+    // Next server before the actual search API call can even fire; a shallow
+    // pushState updates useSearchParams without one.
+    navigation.pathname = "/search";
+    const pushState = vi.spyOn(window.history, "pushState");
+    renderPalette();
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "roadmap" },
+    });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(pushState).toHaveBeenCalledWith(null, "", "/search?q=roadmap");
+    expect(router.push).not.toHaveBeenCalled();
+    pushState.mockRestore();
+  });
+
+  it("still fully navigates from the search page to a non-search result", async () => {
+    navigation.pathname = "/search";
+    const pushState = vi.spyOn(window.history, "pushState");
+    renderPalette();
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "roadmap" },
+    });
+
+    expect(await screen.findByText("Launch Roadmap")).toBeInTheDocument();
+    await act(async () => {});
+
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(router.push).toHaveBeenCalledWith("/p/page-1");
+    expect(pushState).not.toHaveBeenCalled();
+    pushState.mockRestore();
   });
 
   it("keeps jump results available after the full-page search action", async () => {

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState, type MouseEvent, type RefObject } from "react";
 import { getSidebar, listAllTables, semanticSearchPages, type Sidebar } from "../lib/api";
 import type { TableWithOwner } from "../lib/types";
 import type { SearchScope } from "@/lib/searchScope";
@@ -29,6 +29,7 @@ export default function CommandPalette({
   searchScope,
 }: CommandPaletteProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const [query, setQuery] = useState("");
   const [spine, setSpine] = useState<Sidebar | null>(null);
   const [tables, setTables] = useState<TableWithOwner[]>([]);
@@ -38,6 +39,26 @@ export default function CommandPalette({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEscapeKey(open, onClose);
+
+  // Searching from the search page only changes its ?q= — the page is fully
+  // client-rendered and re-runs the search from useSearchParams, so its server
+  // payload doesn't depend on the query. A shallow history push updates the
+  // URL without router.push's RSC round-trip to the Next server, which
+  // otherwise serializes ahead of every search. With a click event and no
+  // shallow case, the surrounding Link performs the navigation itself.
+  const openResult = useCallback(
+    (href: string, event?: MouseEvent<HTMLAnchorElement>) => {
+      const isSearchHref = href === "/search" || href.startsWith("/search?");
+      if (isSearchHref && pathname === "/search") {
+        event?.preventDefault();
+        window.history.pushState(null, "", href);
+      } else if (event === undefined) {
+        router.push(href);
+      }
+      onClose();
+    },
+    [pathname, router, onClose]
+  );
 
   useEffect(() => {
     if (open) setAnchorRect(anchorRef.current?.getBoundingClientRect() ?? null);
@@ -168,13 +189,12 @@ export default function CommandPalette({
         e.preventDefault();
         setSelected((s) => Math.max(s - 1, 0));
       } else if (e.key === "Enter" && results[selected]) {
-        router.push(results[selected].href);
-        onClose();
+        openResult(results[selected].href);
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, results, selected, onClose, router]);
+  }, [open, results, selected, openResult]);
 
   if (!open) return null;
 
@@ -231,7 +251,7 @@ export default function CommandPalette({
               <Link
                 key={r.href + i}
                 href={r.href}
-                onClick={onClose}
+                onClick={(event) => openResult(r.href, event)}
                 className={
                   "flex items-center gap-2.5 rounded-md px-3 py-2 text-[13px] transition-colors " +
                   (i === selected ? "bg-[var(--color-brand-50)] text-foreground" : "text-dim hover:bg-raised")


### PR DESCRIPTION
## Why

Network traces of a search show two serialized ~1s requests: first `GET /search?q=…&_rsc=…` — the Next App Router fetching the route's RSC payload because the command palette navigates with `router.push` — and only then the actual search API call. The `/search` page is fully client-rendered and re-runs its search from `useSearchParams`, so its server payload doesn't depend on `?q=` at all; that first request is pure navigation overhead paid on every query.

## What

When a search is submitted from the palette **while already on `/search`** (Enter or click), the URL now updates via a shallow `window.history.pushState`, which Next (≥14.1) syncs into `useSearchParams` without any server request — the search API call fires immediately. Everything else is unchanged:

- Navigating to `/search` from any other page still uses `router.push` (a real navigation is required).
- Opening a non-search result (page, session, table) still navigates normally, from anywhere.
- `pushState` (not `replaceState`) keeps today's back-button behavior: each search remains a history entry.

No visual changes — no screenshots.

## Verification

- New vitest cases: same-page search submit calls `history.pushState` and not `router.push`; non-search results from `/search` still `router.push`; existing tests cover the from-elsewhere path.
- Frontend suite: 239 passed. Lint clean.

Complements #909 (backend/search-page latency); the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)