### PR TITLE
fix: ship compiled dist/index.js with the openclaw plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 venv/
 .venv/
 dist/
+# Openclaw requires compiled JS for installed plugins; its dist is committed.
+!plugins/openclaw-plugin/dist/
+!stashai/plugin/assets/openclaw/dist/
 build/
 .gstack/
 *.egg-info/

--- a/plugins/openclaw-plugin/dist/index.js
+++ b/plugins/openclaw-plugin/dist/index.js
@@ -1,0 +1,196 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, appendFileSync, readFileSync as read, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+const CONFIG_PATH = join(homedir(), ".stash", "config.json");
+const DATA_DIR = join(homedir(), ".stash", "plugins", "openclaw");
+const QUEUE_PATH = join(DATA_DIR, "event_queue.jsonl");
+const QUEUE_MAX = 1e3;
+const DRAIN_BATCH = 50;
+function readConfig() {
+  try {
+    return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+const EVENTS_PATH = "/api/v1/me/sessions/events";
+function extractText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && "type" in block) {
+      const b = block;
+      if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+  }
+  return parts.join("\n");
+}
+function stripSenderWrapper(text) {
+  if (!text.startsWith("Sender (untrusted metadata):")) return text;
+  const jsonStart = text.indexOf("```json");
+  if (jsonStart === -1) return text;
+  const jsonEnd = text.indexOf("```", jsonStart + 7);
+  if (jsonEnd === -1) return text;
+  return text.slice(jsonEnd + 3).trimStart();
+}
+function ensureDataDir() {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+  } catch {
+  }
+}
+function enqueue(path, body) {
+  try {
+    ensureDataDir();
+    appendFileSync(QUEUE_PATH, JSON.stringify({ path, body, ts: Date.now() / 1e3 }) + "\n");
+    trimQueue();
+  } catch {
+  }
+}
+function trimQueue() {
+  try {
+    const lines = read(QUEUE_PATH, "utf8").split("\n").filter(Boolean);
+    if (lines.length <= QUEUE_MAX) return;
+    const keep = lines.slice(-QUEUE_MAX);
+    writeFileSync(QUEUE_PATH, keep.join("\n") + "\n");
+  } catch {
+  }
+}
+async function postRaw(base, apiKey, path, body) {
+  try {
+    const res = await fetch(base.replace(/\/$/, "") + path, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "authorization": `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(3e3)
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+async function drainQueue(base, apiKey) {
+  if (!existsSync(QUEUE_PATH)) return;
+  let lines;
+  try {
+    lines = read(QUEUE_PATH, "utf8").split("\n").filter(Boolean);
+  } catch {
+    return;
+  }
+  if (lines.length === 0) return;
+  const remaining = [];
+  let sent = 0;
+  for (const line of lines) {
+    if (sent >= DRAIN_BATCH) {
+      remaining.push(line);
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line);
+      const ok = await postRaw(base, apiKey, entry.path, entry.body);
+      if (ok) {
+        sent += 1;
+      } else {
+        remaining.push(line);
+        sent = DRAIN_BATCH;
+      }
+    } catch {
+      remaining.push(line);
+    }
+  }
+  try {
+    writeFileSync(QUEUE_PATH, remaining.length ? remaining.join("\n") + "\n" : "");
+  } catch {
+  }
+}
+async function pushEvent(body) {
+  const cfg = readConfig();
+  const base = cfg.base_url ?? "https://joinstash.ai";
+  const apiKey = cfg.api_key ?? "";
+  if (!apiKey) return;
+  const fullBody = {
+    ...body,
+    agent_name: cfg.username ?? "openclaw",
+    metadata: { ...body.metadata ?? {}, client: "openclaw" }
+  };
+  const path = EVENTS_PATH;
+  const ok = await postRaw(base, apiKey, path, fullBody);
+  if (!ok) {
+    enqueue(path, fullBody);
+    return;
+  }
+  await drainQueue(base, apiKey);
+}
+function send(body) {
+  pushEvent(body).catch(() => {
+  });
+}
+function runHook(event, payload) {
+  try {
+    const child = spawn("stash", ["hook", "run", "openclaw", event], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true
+    });
+    child.on("error", () => {
+    });
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+    child.unref();
+  } catch {
+  }
+}
+var index_default = definePluginEntry({
+  id: "stash",
+  name: "Stash",
+  description: "Stream Openclaw sessions to your Stash.",
+  register(api) {
+    api.on("session_start", (event, ctx) => {
+      const sessionId = event.sessionKey ?? event.sessionId ?? ctx.sessionKey;
+      runHook("on_session_start", { session_id: sessionId, cwd: process.cwd() });
+      send({
+        agent_name: "",
+        event_type: "session_start",
+        content: "",
+        session_id: sessionId,
+        metadata: { cwd: process.cwd() }
+      });
+    });
+    api.on("before_message_write", (event, ctx) => {
+      const role = event.message?.role;
+      const content = event.message?.content;
+      const text = extractText(content);
+      if (!text) return;
+      if (role === "user") {
+        send({
+          agent_name: "",
+          event_type: "user_message",
+          content: stripSenderWrapper(text),
+          session_id: event.sessionKey ?? ctx.sessionKey
+        });
+        return;
+      }
+      if (role === "assistant") {
+        send({
+          agent_name: "",
+          event_type: "assistant_message",
+          content: text,
+          session_id: event.sessionKey ?? ctx.sessionKey
+        });
+        return;
+      }
+    });
+    api.on("session_end", (event, ctx) => {
+      const sessionId = event.sessionKey ?? event.sessionId ?? ctx.sessionKey;
+      runHook("on_session_end", { session_id: sessionId, cwd: process.cwd() });
+    });
+  }
+});
+export {
+  index_default as default
+};

--- a/plugins/openclaw-plugin/package.json
+++ b/plugins/openclaw-plugin/package.json
@@ -5,7 +5,11 @@
   "main": "index.ts",
   "description": "Stream Openclaw sessions to a Stash workspace.",
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": ["./index.ts"],
+    "runtimeExtensions": ["./dist/index.js"]
+  },
+  "scripts": {
+    "build": "npx -y esbuild@0.25.8 index.ts --outfile=dist/index.js --format=esm --target=node20"
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.0"

--- a/plugins/tests/test_openclaw_dist.py
+++ b/plugins/tests/test_openclaw_dist.py
@@ -1,0 +1,39 @@
+"""Assert that the committed `plugins/openclaw-plugin/dist/index.js` is a
+fresh build of `index.ts`.
+
+Openclaw refuses TypeScript entries for installed plugin packages, so the
+compiled output is committed and shipped inside the stashai assets
+(`test_assets_in_sync.py` covers the assets copy). This rebuilds with the
+pinned esbuild from the package.json `build` script into a temp dir and
+diffs bytes, so a source edit without a rebuild reds CI. Requires node/npm.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "openclaw-plugin"
+
+
+def test_committed_dist_matches_rebuild(tmp_path: Path):
+    shutil.copy(PLUGIN_DIR / "index.ts", tmp_path)
+    shutil.copy(PLUGIN_DIR / "package.json", tmp_path)
+
+    subprocess.run(
+        ["npm", "run", "build"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        timeout=120,
+    )
+
+    rebuilt = (tmp_path / "dist" / "index.js").read_bytes()
+    committed = (PLUGIN_DIR / "dist" / "index.js").read_bytes()
+    assert rebuilt == committed, (
+        "plugins/openclaw-plugin/dist/index.js is stale. Re-run `npm run build` "
+        "in plugins/openclaw-plugin and copy dist/ into "
+        "stashai/plugin/assets/openclaw/."
+    )

--- a/stashai/plugin/assets/openclaw/dist/index.js
+++ b/stashai/plugin/assets/openclaw/dist/index.js
@@ -1,0 +1,196 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, appendFileSync, readFileSync as read, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+const CONFIG_PATH = join(homedir(), ".stash", "config.json");
+const DATA_DIR = join(homedir(), ".stash", "plugins", "openclaw");
+const QUEUE_PATH = join(DATA_DIR, "event_queue.jsonl");
+const QUEUE_MAX = 1e3;
+const DRAIN_BATCH = 50;
+function readConfig() {
+  try {
+    return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+const EVENTS_PATH = "/api/v1/me/sessions/events";
+function extractText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && "type" in block) {
+      const b = block;
+      if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+  }
+  return parts.join("\n");
+}
+function stripSenderWrapper(text) {
+  if (!text.startsWith("Sender (untrusted metadata):")) return text;
+  const jsonStart = text.indexOf("```json");
+  if (jsonStart === -1) return text;
+  const jsonEnd = text.indexOf("```", jsonStart + 7);
+  if (jsonEnd === -1) return text;
+  return text.slice(jsonEnd + 3).trimStart();
+}
+function ensureDataDir() {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+  } catch {
+  }
+}
+function enqueue(path, body) {
+  try {
+    ensureDataDir();
+    appendFileSync(QUEUE_PATH, JSON.stringify({ path, body, ts: Date.now() / 1e3 }) + "\n");
+    trimQueue();
+  } catch {
+  }
+}
+function trimQueue() {
+  try {
+    const lines = read(QUEUE_PATH, "utf8").split("\n").filter(Boolean);
+    if (lines.length <= QUEUE_MAX) return;
+    const keep = lines.slice(-QUEUE_MAX);
+    writeFileSync(QUEUE_PATH, keep.join("\n") + "\n");
+  } catch {
+  }
+}
+async function postRaw(base, apiKey, path, body) {
+  try {
+    const res = await fetch(base.replace(/\/$/, "") + path, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "authorization": `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(3e3)
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+async function drainQueue(base, apiKey) {
+  if (!existsSync(QUEUE_PATH)) return;
+  let lines;
+  try {
+    lines = read(QUEUE_PATH, "utf8").split("\n").filter(Boolean);
+  } catch {
+    return;
+  }
+  if (lines.length === 0) return;
+  const remaining = [];
+  let sent = 0;
+  for (const line of lines) {
+    if (sent >= DRAIN_BATCH) {
+      remaining.push(line);
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line);
+      const ok = await postRaw(base, apiKey, entry.path, entry.body);
+      if (ok) {
+        sent += 1;
+      } else {
+        remaining.push(line);
+        sent = DRAIN_BATCH;
+      }
+    } catch {
+      remaining.push(line);
+    }
+  }
+  try {
+    writeFileSync(QUEUE_PATH, remaining.length ? remaining.join("\n") + "\n" : "");
+  } catch {
+  }
+}
+async function pushEvent(body) {
+  const cfg = readConfig();
+  const base = cfg.base_url ?? "https://joinstash.ai";
+  const apiKey = cfg.api_key ?? "";
+  if (!apiKey) return;
+  const fullBody = {
+    ...body,
+    agent_name: cfg.username ?? "openclaw",
+    metadata: { ...body.metadata ?? {}, client: "openclaw" }
+  };
+  const path = EVENTS_PATH;
+  const ok = await postRaw(base, apiKey, path, fullBody);
+  if (!ok) {
+    enqueue(path, fullBody);
+    return;
+  }
+  await drainQueue(base, apiKey);
+}
+function send(body) {
+  pushEvent(body).catch(() => {
+  });
+}
+function runHook(event, payload) {
+  try {
+    const child = spawn("stash", ["hook", "run", "openclaw", event], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true
+    });
+    child.on("error", () => {
+    });
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+    child.unref();
+  } catch {
+  }
+}
+var index_default = definePluginEntry({
+  id: "stash",
+  name: "Stash",
+  description: "Stream Openclaw sessions to your Stash.",
+  register(api) {
+    api.on("session_start", (event, ctx) => {
+      const sessionId = event.sessionKey ?? event.sessionId ?? ctx.sessionKey;
+      runHook("on_session_start", { session_id: sessionId, cwd: process.cwd() });
+      send({
+        agent_name: "",
+        event_type: "session_start",
+        content: "",
+        session_id: sessionId,
+        metadata: { cwd: process.cwd() }
+      });
+    });
+    api.on("before_message_write", (event, ctx) => {
+      const role = event.message?.role;
+      const content = event.message?.content;
+      const text = extractText(content);
+      if (!text) return;
+      if (role === "user") {
+        send({
+          agent_name: "",
+          event_type: "user_message",
+          content: stripSenderWrapper(text),
+          session_id: event.sessionKey ?? ctx.sessionKey
+        });
+        return;
+      }
+      if (role === "assistant") {
+        send({
+          agent_name: "",
+          event_type: "assistant_message",
+          content: text,
+          session_id: event.sessionKey ?? ctx.sessionKey
+        });
+        return;
+      }
+    });
+    api.on("session_end", (event, ctx) => {
+      const sessionId = event.sessionKey ?? event.sessionId ?? ctx.sessionKey;
+      runHook("on_session_end", { session_id: sessionId, cwd: process.cwd() });
+    });
+  }
+});
+export {
+  index_default as default
+};

--- a/stashai/plugin/assets/openclaw/package.json
+++ b/stashai/plugin/assets/openclaw/package.json
@@ -5,7 +5,11 @@
   "main": "index.ts",
   "description": "Stream Openclaw sessions to a Stash workspace.",
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": ["./index.ts"],
+    "runtimeExtensions": ["./dist/index.js"]
+  },
+  "scripts": {
+    "build": "npx -y esbuild@0.25.8 index.ts --outfile=dist/index.js --format=esm --target=node20"
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.0"


### PR DESCRIPTION
## Problem

`stash signin` fails to install the Openclaw hook on current Openclaw releases:

> Openclaw hook failed: package install requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ...

Openclaw ≥2026.7 rejects TypeScript-only entries for installed plugin packages — its installer (`validatePackageExtensionEntriesForInstall`) only allows raw TS for `--link`-style dev-path installs. Our plugin declared `extensions: ["./index.ts"]` with no compiled output, so the plain `openclaw plugins install <dir>` path our CLI uses fails.

## Fix

Commit the compiled output alongside the source (single codepath at install time — dev installs and PyPI wheels ship identical assets):

- `plugins/openclaw-plugin/package.json`: `build` script using pinned `esbuild@0.25.8` (transpile-only ESM; the `openclaw/plugin-sdk/core` import stays external), plus `openclaw.runtimeExtensions: ["./dist/index.js"]` so Openclaw validates the compiled entry explicitly.
- `plugins/openclaw-plugin/dist/index.js`: committed build output (byte-stable across rebuilds).
- `stashai/plugin/assets/openclaw/`: synced copies; the existing `plugin/assets/**/*` package-data glob ships them, and `test_assets_in_sync.py` covers them automatically.
- `.gitignore`: targeted negations — the blanket `dist/` rule was ignoring the new files.
- `plugins/tests/test_openclaw_dist.py`: freshness guard — rebuilds via `npm run build` (the single source of truth for the build command) in a temp dir and diffs bytes against the committed dist, so a source edit without a rebuild reds CI. Runs in the plugin-test job, whose ubuntu runner ships Node.

## Verification

- All 147 plugin tests pass, including the new freshness test.
- End-to-end: `openclaw plugins install` of the shipped assets dir succeeds on Openclaw 2026.7.1-2 (the exact version that produced the error), validated against a throwaway `HOME`.
- Two consecutive builds hash identically, so the CI rebuild-and-diff is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)