### PR TITLE
perf: aggregate engagement cohorts in SQL

### DIFF
--- a/backend/services/cohort_service.py
+++ b/backend/services/cohort_service.py
@@ -4,10 +4,15 @@ Ports the engagement-only path of github.com/Fergana-Labs/cohort-analysis.
 Users are grouped by their first activity, then retention is tracked across
 period offsets (months, ISO weeks, or rolling 7-day windows anchored to each
 user's first activity).
+
+The heavy lifting happens in SQL: Postgres reduces the raw event stream to
+one row per user × active period, so the rows crossing the wire scale with
+user count, not event count. Python only pivots those aggregates into the
+retention matrix.
 """
 
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from ..database import get_pool
 from .admin_analytics_service import internal_filter_sql
@@ -20,16 +25,33 @@ _DEFAULT_MAX_PERIOD = {"month": 12, "week": 26, "rolling_7d": 12}
 _DEFAULT_COHORT_CAP = {"month": 24, "week": 52, "rolling_7d": 60}
 
 
-def _bucket_start(ts: datetime, bucket: Bucket) -> datetime:
-    """Floor a timestamp to the start of its calendar bucket (UTC)."""
-    ts = ts.astimezone(UTC)
+def _bucket_sql(bucket: Bucket) -> tuple[str, str]:
+    """SQL for (cohort start over min(event_utc), period offset of one event).
+
+    Both expressions work on naive-UTC timestamps (event_at AT TIME ZONE
+    'UTC'), matching the UTC flooring the retention math is defined in.
+    `ue` is an event row, `c` carries the user's cohort_start.
+    """
     if bucket == "month":
-        return datetime(ts.year, ts.month, 1, tzinfo=UTC)
+        return (
+            "date_trunc('month', min(event_utc))",
+            "(EXTRACT(YEAR FROM ue.event_utc)::int * 12 + EXTRACT(MONTH FROM ue.event_utc)::int)"
+            " - (EXTRACT(YEAR FROM c.cohort_start)::int * 12"
+            " + EXTRACT(MONTH FROM c.cohort_start)::int)",
+        )
     if bucket == "week":
-        d = ts.date() - timedelta(days=ts.weekday())  # Monday
-        return datetime(d.year, d.month, d.day, tzinfo=UTC)
+        # date_trunc('week') floors to the ISO Monday. The cohort start is a
+        # Monday, so integer-dividing the day gap by 7 lands each event in
+        # its calendar week without flooring the event separately.
+        return (
+            "date_trunc('week', min(event_utc))",
+            "(ue.event_utc::date - c.cohort_start::date) / 7",
+        )
     if bucket == "rolling_7d":
-        return datetime(ts.year, ts.month, ts.day, tzinfo=UTC)
+        return (
+            "date_trunc('day', min(event_utc))",
+            "(ue.event_utc::date - c.cohort_start::date) / 7",
+        )
     raise ValueError(f"unknown bucket: {bucket}")
 
 
@@ -41,30 +63,18 @@ def _bucket_label(start: datetime, bucket: Bucket) -> str:
     return start.strftime("%Y-%m-%d")
 
 
-def _period_offset(cohort_start: datetime, event_start: datetime, bucket: Bucket) -> int:
-    """How many bucket-periods after cohort_start does event_start fall in?"""
-    if bucket == "month":
-        return (event_start.year - cohort_start.year) * 12 + (
-            event_start.month - cohort_start.month
-        )
-    if bucket == "week":
-        return (event_start.date() - cohort_start.date()).days // 7
-    if bucket == "rolling_7d":
-        return (event_start.date() - cohort_start.date()).days // 7
-    raise ValueError(f"unknown bucket: {bucket}")
-
-
 def compute_engagement_cohorts(
     rows: list[dict],
     bucket: Bucket = "month",
     mode: Mode = "standard",
     max_period: int | None = None,
 ) -> dict:
-    """Compute cohort retention from raw (user_id, signup_at, event_at) rows.
+    """Pivot per-user period aggregates into the retention matrix.
 
-    Rows are pre-sorted by user_id, event_at ASC. event_at may be None for
-    users with no events — they're placed in their signup cohort with zero
-    activity.
+    Each row is one user × active period: {user_id, cohort_start, period,
+    events}, with periods already limited to [0, max_period]. Users with no
+    events have no rows and belong to no cohort — including them would leave
+    all-zero rows in the denominator and pull period-0 retention below 100%.
     """
     if bucket not in _DEFAULT_MAX_PERIOD:
         raise ValueError(f"unknown bucket: {bucket}")
@@ -73,32 +83,12 @@ def compute_engagement_cohorts(
     if max_period is None:
         max_period = _DEFAULT_MAX_PERIOD[bucket]
 
-    # Cohorts are defined by first activity in the filtered event set.
-    # Users with zero events in the filter are NOT in any cohort — including
-    # them would leave them in the denominator with all-zero rows and pull
-    # period-0 retention below 100%.
     user_cohort: dict[str, datetime] = {}
-    user_active_periods: dict[str, set[int]] = defaultdict(set)
-    user_event_counts_by_period: dict[str, dict[int, int]] = defaultdict(lambda: defaultdict(int))
-
-    by_user: dict[str, list[dict]] = defaultdict(list)
+    user_period_counts: dict[str, dict[int, int]] = defaultdict(dict)
     for r in rows:
-        if r["event_at"] is None:
-            continue
-        by_user[str(r["id"])].append(r)
-
-    for uid, events in by_user.items():
-        user_cohort[uid] = _bucket_start(events[0]["event_at"], bucket)
-
-    for uid, events in by_user.items():
-        cohort_start = user_cohort[uid]
-        for e in events:
-            event_start = _bucket_start(e["event_at"], bucket)
-            p = _period_offset(cohort_start, event_start, bucket)
-            if p < 0 or p > max_period:
-                continue
-            user_active_periods[uid].add(p)
-            user_event_counts_by_period[uid][p] += 1
+        uid = str(r["user_id"])
+        user_cohort[uid] = r["cohort_start"]
+        user_period_counts[uid][int(r["period"])] = int(r["events"])
 
     cohort_users: dict[datetime, list[str]] = defaultdict(list)
     for uid, cs in user_cohort.items():
@@ -115,12 +105,12 @@ def compute_engagement_cohorts(
         running_cum_total = 0
         for p in range(max_period + 1):
             if mode == "standard":
-                active = sum(1 for u in uids if p in user_active_periods[u])
+                active = sum(1 for u in uids if p in user_period_counts[u])
             else:
-                active = sum(1 for u in uids if any(q >= p for q in user_active_periods[u]))
+                active = sum(1 for u in uids if any(q >= p for q in user_period_counts[u]))
             retention.append(active / size if size else 0.0)
             active_users.append(active)
-            period_actions = sum(user_event_counts_by_period[u].get(p, 0) for u in uids)
+            period_actions = sum(user_period_counts[u].get(p, 0) for u in uids)
             actions.append(period_actions)
             running_cum_total += period_actions
             avg_cum_actions.append(running_cum_total / size if size else 0.0)
@@ -141,7 +131,7 @@ def compute_engagement_cohorts(
     cohorts_out = cohorts_out[:cap]
 
     total_users = sum(c["size"] for c in cohorts_out)
-    total_events = sum(sum(counts.values()) for counts in user_event_counts_by_period.values())
+    total_events = sum(sum(counts.values()) for counts in user_period_counts.values())
 
     return {
         "bucket": bucket,
@@ -171,6 +161,9 @@ async def get_engagement_cohorts(
 ) -> dict:
     if events_filter not in ("all", "active"):
         raise ValueError(f"unknown events_filter: {events_filter}")
+    cohort_start_sql, period_sql = _bucket_sql(bucket)
+    if max_period is None:
+        max_period = _DEFAULT_MAX_PERIOD[bucket]
     pool = get_pool()
     # Pull from both event tables. history_events is the agent-transcript log;
     # analytics_events is product telemetry. UNION ALL lets web-only users
@@ -178,24 +171,44 @@ async def get_engagement_cohorts(
     he_filter = f"AND {_ACTIVE_EVENTS_PREDICATE}" if events_filter == "active" else ""
     sql = f"""
         WITH user_events AS (
-            SELECT he.created_by AS user_id, he.created_at AS event_at
+            SELECT he.created_by AS user_id,
+                   he.created_at AT TIME ZONE 'UTC' AS event_utc
             FROM history_events he
             WHERE he.created_by IS NOT NULL
               {he_filter}
             UNION ALL
-            SELECT ae.user_id, ae.created_at AS event_at
+            SELECT ae.user_id, ae.created_at AT TIME ZONE 'UTC'
             FROM analytics_events ae
             WHERE ae.user_id IS NOT NULL
+        ),
+        cohort_starts AS (
+            SELECT user_id, {cohort_start_sql} AS cohort_start
+            FROM user_events
+            WHERE {internal_filter_sql("user_events.user_id", exclude_internal)}
+            GROUP BY user_id
         )
-        SELECT u.id, u.created_at AS signup_at, ue.event_at
-        FROM users u
-        LEFT JOIN user_events ue ON ue.user_id = u.id
-        WHERE {internal_filter_sql("u.id", exclude_internal)}
-        ORDER BY u.id, ue.event_at NULLS FIRST
+        SELECT c.user_id,
+               c.cohort_start,
+               {period_sql} AS period,
+               COUNT(*) AS events
+        FROM user_events ue
+        JOIN cohort_starts c ON c.user_id = ue.user_id
+        WHERE {period_sql} <= $1
+        GROUP BY 1, 2, 3
     """
-    rows = await pool.fetch(sql)
+    rows = await pool.fetch(sql, max_period)
+    # date_trunc over a naive-UTC timestamp comes back naive; re-attach UTC so
+    # cohort_start serializes with an offset, as the API always has.
     out = compute_engagement_cohorts(
-        [dict(r) for r in rows],
+        [
+            {
+                "user_id": r["user_id"],
+                "cohort_start": r["cohort_start"].replace(tzinfo=UTC),
+                "period": r["period"],
+                "events": r["events"],
+            }
+            for r in rows
+        ],
         bucket=bucket,
         mode=mode,
         max_period=max_period,

--- a/backend/tests/test_cohorts.py
+++ b/backend/tests/test_cohorts.py
@@ -1,0 +1,149 @@
+"""Tests for /admin/cohorts/engagement.
+
+The retention matrix is aggregated in SQL (one row per user × active period),
+so these tests seed real rows in both event tables and assert the numbers the
+dashboard renders: cohort sizes, retention, action counts, and the
+events_filter=active exclusion of plugin firehose rows.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+ADMIN_TOKEN = "test-admin-token-with-32-plus-chars"
+
+
+@pytest.fixture(autouse=True)
+def _set_admin_token(monkeypatch):
+    monkeypatch.setenv("ADMIN_PASSWORD", ADMIN_TOKEN)
+    from backend.config import settings
+
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", ADMIN_TOKEN)
+
+
+async def _register_user(client: AsyncClient) -> UUID:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    api_key = resp.json()["api_key"]
+    me = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {api_key}"})
+    return UUID(me.json()["id"])
+
+
+async def _insert_history_event(pool, user_id: UUID, created_at: datetime, metadata: str = "{}"):
+    await pool.execute(
+        "INSERT INTO history_events "
+        "(owner_user_id, created_by, agent_name, event_type, content, metadata, "
+        " created_at, session_id) "
+        # $2 goes over the wire as text and is cast in SQL: the pool's jsonb
+        # codec would otherwise re-encode the string into a double-encoded
+        # JSON string, breaking ->> lookups.
+        "VALUES ($1, $1, 'agent', 'message', 'hello', (($2)::text)::jsonb, $3, gen_random_uuid())",
+        user_id,
+        metadata,
+        created_at,
+    )
+
+
+async def _insert_analytics_event(pool, user_id: UUID, created_at: datetime):
+    await pool.execute(
+        "INSERT INTO analytics_events (user_id, surface, event_name, created_at) "
+        "VALUES ($1, 'web', 'onboarding.viewed', $2)",
+        user_id,
+        created_at,
+    )
+
+
+async def _fetch_cohorts(client: AsyncClient, **params) -> dict:
+    resp = await client.get(
+        "/api/v1/admin/cohorts/engagement",
+        params=params,
+        headers={"X-Admin-Token": ADMIN_TOKEN},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_monthly_retention_across_both_event_tables(client: AsyncClient, _db_pool):
+    """User A is active in Jan and Feb, user B in Jan only: one January
+    cohort with 100% period-0 and 50% period-1 retention. A's events live in
+    history_events and B's in analytics_events, so the union feeds cohorts."""
+    user_a = await _register_user(client)
+    user_b = await _register_user(client)
+    await _insert_history_event(_db_pool, user_a, datetime(2026, 1, 10, tzinfo=UTC))
+    await _insert_history_event(_db_pool, user_a, datetime(2026, 2, 5, tzinfo=UTC))
+    await _insert_analytics_event(_db_pool, user_b, datetime(2026, 1, 20, tzinfo=UTC))
+
+    data = await _fetch_cohorts(client, bucket="month")
+
+    assert data["bucket"] == "month"
+    assert data["totals"] == {"users": 2, "events": 3}
+    [cohort] = data["cohorts"]
+    assert cohort["cohort_label"] == "2026-01"
+    assert cohort["cohort_start"] == "2026-01-01T00:00:00+00:00"
+    assert cohort["size"] == 2
+    assert cohort["retention"][:3] == [1.0, 0.5, 0.0]
+    assert cohort["active_users"][:3] == [2, 1, 0]
+    assert cohort["actions"][:3] == [2, 1, 0]
+    assert cohort["avg_cumulative_actions"][:3] == [1.0, 1.5, 1.5]
+
+
+@pytest.mark.asyncio
+async def test_future_mode_counts_later_activity(client: AsyncClient, _db_pool):
+    """In future mode a user active in period 1 also counts as retained at
+    period 1's predecessors — retention answers 'still around at or after p'."""
+    user_a = await _register_user(client)
+    user_b = await _register_user(client)
+    await _insert_history_event(_db_pool, user_a, datetime(2026, 1, 10, tzinfo=UTC))
+    await _insert_history_event(_db_pool, user_a, datetime(2026, 3, 5, tzinfo=UTC))
+    await _insert_analytics_event(_db_pool, user_b, datetime(2026, 1, 20, tzinfo=UTC))
+
+    data = await _fetch_cohorts(client, bucket="month", mode="future")
+
+    [cohort] = data["cohorts"]
+    # Standard mode would show period 1 as 0 (A skipped February); future
+    # mode keeps A retained through period 2 because activity exists at p>=1.
+    assert cohort["retention"][:3] == [1.0, 0.5, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_active_filter_excludes_plugin_events(client: AsyncClient, _db_pool):
+    """Plugin hook events (metadata.client set) are firehose, not engagement.
+    With events_filter=active the user's cohort starts at their first real
+    event, not the earlier plugin event."""
+    user = await _register_user(client)
+    await _insert_history_event(
+        _db_pool, user, datetime(2026, 1, 10, tzinfo=UTC), metadata='{"client": "claude_code"}'
+    )
+    await _insert_analytics_event(_db_pool, user, datetime(2026, 2, 20, tzinfo=UTC))
+
+    all_events = await _fetch_cohorts(client, bucket="month")
+    active_only = await _fetch_cohorts(client, bucket="month", events_filter="active")
+
+    assert all_events["cohorts"][0]["cohort_label"] == "2026-01"
+    assert all_events["totals"] == {"users": 1, "events": 2}
+    assert active_only["cohorts"][0]["cohort_label"] == "2026-02"
+    assert active_only["totals"] == {"users": 1, "events": 1}
+
+
+@pytest.mark.asyncio
+async def test_week_bucket_floors_to_monday(client: AsyncClient, _db_pool):
+    """Week cohorts anchor to the ISO Monday: a Wednesday first event lands
+    in Monday's cohort, and the next week's event is period 1."""
+    user = await _register_user(client)
+    # 2026-03-04 is a Wednesday; its ISO week starts Monday 2026-03-02.
+    await _insert_analytics_event(_db_pool, user, datetime(2026, 3, 4, tzinfo=UTC))
+    await _insert_analytics_event(_db_pool, user, datetime(2026, 3, 9, tzinfo=UTC))
+
+    data = await _fetch_cohorts(client, bucket="week")
+
+    [cohort] = data["cohorts"]
+    assert cohort["cohort_label"] == "2026-03-02"
+    assert cohort["active_users"][:3] == [1, 1, 0]


### PR DESCRIPTION
## Why

The admin analytics dashboard's slowest request is `/admin/cohorts/engagement`. The old query shipped **every raw event row** — the full `history_events` plugin firehose plus all of `analytics_events` — to Python, sorted the entire stream in Postgres, and computed retention row by row on every dashboard load. Latency grew linearly with total events ever recorded.

## What changed

- `get_engagement_cohorts` now reduces both event tables inside Postgres to **one row per user × active period**: a CTE unions the two streams, floors each user's first event to its cohort bucket (`date_trunc` on month / ISO week / day), computes each event's period offset in SQL, and groups to counts (filtered to `period <= max_period`). Transferred rows now scale with user count, not event count, and the big `ORDER BY` sort is gone.
- `compute_engagement_cohorts` stays a pure function but now just pivots those small aggregates into the retention matrix; the bucket date-math helpers moved into the SQL.
- The JSON response is byte-for-byte compatible, including the `+00:00` offset on `cohort_start` (re-attached after `AT TIME ZONE 'UTC'` strips it).

## Tests

New `backend/tests/test_cohorts.py` exercises the endpoint end-to-end against real Postgres:
- monthly retention math across both event tables (sizes, retention, actions, cumulative averages)
- `mode=future` counting later activity at earlier periods
- `events_filter=active` excluding plugin firehose rows
- week buckets flooring to the ISO Monday

All 4 pass, plus the 15 existing `test_analytics.py` tests; ruff check/format clean.

Backend-only change — no UI screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)