### PR TITLE
perf: store content tsvectors; rank before building snippets

### DIFF
--- a/backend/migrations/versions/0166_content_tsv_columns.py
+++ b/backend/migrations/versions/0166_content_tsv_columns.py
@@ -1,0 +1,48 @@
+"""Store each content document's tsvector instead of re-parsing it per query.
+
+search_documents ranked hits with ts_rank(to_tsvector(content), query), which
+re-parses every matching document's full text on every search — seconds per
+query for a user with a large corpus. A stored generated column computes the
+same expression once at write time, so matching and ranking read the
+pre-built vector. The GIN index moves to the stored column (same lexemes, so
+identical matches and ranks) and the old expression index is dropped.
+"""
+
+from alembic import op
+
+revision = "0166"
+down_revision = "0165"
+branch_labels = None
+depends_on = None
+
+CONTENT_TABLES = [
+    "github_documents",
+    "slack_messages",
+    "granola_notes",
+    "gong_documents",
+    "notion_index",
+    "drive_documents",
+    "instagram_save_docs",
+    "x_save_docs",
+]
+
+
+def upgrade() -> None:
+    for table in CONTENT_TABLES:
+        op.execute(
+            f"ALTER TABLE {table} ADD COLUMN content_tsv tsvector "
+            f"GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED"
+        )
+        op.execute(f"CREATE INDEX {table}_tsv_idx ON {table} USING gin (content_tsv)")
+        op.execute(f"DROP INDEX {table}_fts_idx")
+        op.execute(f"ANALYZE {table}")
+
+
+def downgrade() -> None:
+    for table in CONTENT_TABLES:
+        op.execute(
+            f"CREATE INDEX {table}_fts_idx ON {table} "
+            f"USING gin (to_tsvector('english', coalesce(content, '')))"
+        )
+        op.execute(f"DROP INDEX {table}_tsv_idx")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN content_tsv")

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1615,22 +1615,29 @@ async def search_documents(
             )
         return ""
 
+    # Each arm ranks on the stored vector and keeps only its own top `limit`
+    # BEFORE the snippet expression runs: the 20KB substr detoasts the full
+    # document, so it must touch the few returned rows, never every match.
     parts = [
         f"""
-        SELECT d.source_id, d.path, d.name, d.external_updated_at,
-               substr(d.content,
-                      GREATEST(1, LEAST(strpos(lower(d.content), lower(btrim($2)))
+        SELECT sub.source_id, sub.path, sub.name, sub.external_updated_at,
+               substr(sub.content,
+                      GREATEST(1, LEAST(strpos(lower(sub.content), lower(btrim($2)))
                                           - {SEARCH_SNIPPET_CHARS // 2},
-                                        length(d.content) - {SEARCH_SNIPPET_CHARS} + 1)),
+                                        length(sub.content) - {SEARCH_SNIPPET_CHARS} + 1)),
                       {SEARCH_SNIPPET_CHARS}) AS snippet,
-               ts_rank(to_tsvector('english', coalesce(d.content, '')),
-                       websearch_to_tsquery('english', $2)) AS rank
-        FROM {t} d
-        JOIN user_sources s ON s.id = d.source_id
-        WHERE d.source_id = ANY($1) AND d.deleted_at IS NULL
-          AND to_tsvector('english', coalesce(d.content, ''))
-              @@ websearch_to_tsquery('english', $2)
-          {visibility_clause(t)}
+               sub.rank
+        FROM (
+            SELECT d.source_id, d.path, d.name, d.external_updated_at, d.content,
+                   ts_rank(d.content_tsv, websearch_to_tsquery('english', $2)) AS rank
+            FROM {t} d
+            JOIN user_sources s ON s.id = d.source_id
+            WHERE d.source_id = ANY($1) AND d.deleted_at IS NULL
+              AND d.content_tsv @@ websearch_to_tsquery('english', $2)
+              {visibility_clause(t)}
+            ORDER BY rank DESC
+            LIMIT $3
+        ) sub
         """
         for t in tables
     ]


### PR DESCRIPTION
## Problem

Follow-up to #912, targeting users who *own* a large corpus. For them the copied-content FTS still spent seconds per search: `ts_rank(to_tsvector(content))` re-tokenized every matching document's full text on every query, and the 20KB snippet `substr` detoasted every match — all to return the top ~20 rows. A seeded heavy user (13 sources, 27k docs / ~300MB text, 30k session events, 800 pages) measured **24.5s** per unified search, ~26s end-to-end in the browser.

## Fix (results unchanged)

- **Migration 0166**: adds a stored generated column `content_tsv = to_tsvector('english', coalesce(content, ''))` to the 8 content tables, moves the GIN index onto it, and drops the old expression index. Identical expression → identical matches and identical `ts_rank` scores, computed once at write time instead of on every search.
- **`search_documents`**: each union arm ranks on the stored vector and applies its `LIMIT` *before* the snippet expression runs, so the 20KB substr detoasts only the returned rows, never every match.

## Verification

- Same heavy user after: **0.4s** worst-case (a query matching every document), **0.06s** for selective queries, **1.39s** browser Enter→results (Next dev mode). ~60× on the API call.
- Response payloads diffed old-code vs new-code across 14 query/limit/scope combinations on the same data: identical hits, ranks, snippets, and ordering — the only difference is order *within* equal-rank ties, which has no defined order today either.
- Full backend suite green (two unrelated agent-test flakes pass in isolation); `ruff check` + `ruff format --check` clean.

## Deploy note

The migration rewrites each content table and rebuilds its FTS index at backend boot, so the first deploy after merge will have a one-time slower start (proportional to content-table size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)