### PR TITLE
Integrations: stop reporting configuration and dead grants as sync failures

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -36,6 +36,7 @@ celery = Celery(
         "backend.tasks.sources",
         "backend.tasks.agent_schedules",
         "backend.integrations.google.exporters.slides",
+        "backend.integrations.x_saves.tasks",
         "backend.exports.pdf",
         "backend.exports.pptx",
     ],
@@ -117,6 +118,13 @@ celery.conf.update(
         "sources-reconcile-github-sync-all": {
             "task": "backend.tasks.sources.reconcile_github_sync_all",
             "schedule": 3600.0,
+        },
+        "x-keep-tokens-fresh": {
+            "task": "backend.integrations.x_saves.keep_tokens_fresh",
+            # X kills grants whose rotating refresh token idles for ~a day; a
+            # 30-min tick refreshes each access token as it expires (~2h),
+            # keeping the refresh token exercised (see x_saves/tasks.py).
+            "schedule": 1800.0,
         },
         "cli-auth-cleanup-expired": {
             "task": "backend.tasks.cli_auth.cleanup_expired_sessions",

--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -157,9 +157,11 @@ async def index_slack(source: dict) -> str | None:
     allowed_channel_ids = set(source_service.slack_allowed_channel_ids(source))
     await source_service.purge_disallowed_copied_documents(source)
     if not allowed_channel_ids:
-        # Fail loudly so the sync records a sync_error instead of reporting a
-        # successful sync that ingested nothing.
-        raise RuntimeError("no allowed channels configured")
+        # Nothing is wrong and no retry can help — Slack indexes only the
+        # channels the owner picks, and none are picked yet.
+        raise source_service.SourceSetupRequired(
+            "Choose the Slack channels to index — nothing syncs until you do."
+        )
 
     token = await get_valid_token(owner_user_id, "slack")
     headers = {"Authorization": f"Bearer {token}"}

--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -18,6 +18,8 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import httpx
+from fastapi import HTTPException
+from httpx import HTTPError
 
 from ...config import settings
 from ...database import get_pool
@@ -167,7 +169,24 @@ async def _backfill_bookmarks(
         source_id, {"x_bookmarks_checked_at": datetime.now(UTC).isoformat()}
     )
 
-    token = await integration_storage.get_valid_token(owner_user_id, "x")
+    try:
+        token = await integration_storage.get_valid_token(owner_user_id, "x")
+    except (HTTPException, HTTPError) as exc:
+        # X rotates refresh tokens single-use and kills grants that sit idle,
+        # so a dead grant is an expected end state only a reconnect can fix.
+        # Like the paid-tier gate below, it must not stop posts/replies/articles.
+        logger.warning(
+            "x oauth grant is dead source=%s exception_type=%s",
+            source_id,
+            type(exc).__name__,
+        )
+        await source_service.set_sync_warning(
+            source_id,
+            "The X connection is no longer valid, so bookmarks can't sync — "
+            "reconnect X from the integrations page. "
+            "Posts, replies, and articles still sync.",
+        )
+        return
     async with httpx.AsyncClient(
         timeout=30.0, headers={"Authorization": f"Bearer {token}"}
     ) as client:

--- a/backend/integrations/x_saves/tasks.py
+++ b/backend/integrations/x_saves/tasks.py
@@ -1,0 +1,51 @@
+"""Keep X OAuth grants alive between daily bookmark checks.
+
+X rotates refresh tokens single-use and kills a grant whose refresh token
+sits unused for about a day: in prod, a grant that had been refreshed every
+~2h for days died with a 401 from the token endpoint on its first refresh
+after the daily bookmark gate left it idle for 24h (2026-07-22). Exercising
+`get_valid_token` on a short interval refreshes each access token as it
+expires (~2h), keeping the refresh token rotating on the cadence X
+demonstrably tolerates.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+from httpx import HTTPError
+
+from ...celery_app import celery
+from ...database import get_pool
+from ...tasks._celery_helpers import run_async
+from .. import storage as integration_storage
+
+logger = logging.getLogger(__name__)
+
+
+@celery.task(name="backend.integrations.x_saves.keep_tokens_fresh")
+def keep_tokens_fresh() -> int:
+    return run_async(_keep_tokens_fresh())
+
+
+async def _keep_tokens_fresh() -> int:
+    rows = await get_pool().fetch(
+        "SELECT user_id, account_key FROM user_integrations "
+        "WHERE provider = 'x' AND access_token_encrypted IS NOT NULL"
+    )
+    alive = 0
+    for row in rows:
+        try:
+            await integration_storage.get_valid_token(row["user_id"], "x", row["account_key"])
+            alive += 1
+        except (HTTPException, HTTPError) as exc:
+            # A dead grant stays dead until the user reconnects — the daily
+            # bookmark check surfaces that on the source. One user's dead
+            # grant must not stop other users' tokens from being kept warm.
+            logger.warning(
+                "x token keep-fresh failed user=%s exception_type=%s",
+                row["user_id"],
+                type(exc).__name__,
+            )
+    return alive

--- a/backend/services/github_pr_service.py
+++ b/backend/services/github_pr_service.py
@@ -181,6 +181,12 @@ async def fetch_pull_request(
         response = await client.get(base_url)
         if response.status_code == 404:
             return None
+        if response.status_code in (401, 403) and not _rate_limited(response):
+            # A PR this token can't read: someone else's private repo, or a
+            # dead GitHub grant. Permanent for this token — returning None
+            # records the check, otherwise the reconciler re-enqueues the
+            # session every 5 minutes forever.
+            return None
         response.raise_for_status()
         payload = response.json()
 
@@ -201,6 +207,13 @@ async def fetch_pull_request(
         head_ref=(payload.get("head") or {}).get("ref") or "",
         commit_messages=commit_messages,
     )
+
+
+def _rate_limited(response: httpx.Response) -> bool:
+    """GitHub reports rate limiting as 403 too — a transient condition where
+    raising (so the reconciler retries later) is right, unlike a plain
+    no-access 403, which is permanent for this token."""
+    return response.headers.get("x-ratelimit-remaining") == "0" or "retry-after" in response.headers
 
 
 async def _github_token_for_user(user_id: UUID | None) -> str | None:

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -50,6 +50,14 @@ class SourceSyncUserError(Exception):
     constant (see tasks/sources.py)."""
 
 
+class SourceSetupRequired(Exception):
+    """The source can't sync until the owner configures something (Slack with
+    no channels chosen). Nothing is broken and retrying changes nothing, so
+    this is NOT a failure: it parks the source in 'needs_setup' with an
+    instruction instead of a red error. Same safety rule as
+    SourceSyncUserError — the message is shown verbatim."""
+
+
 # A Linear issue identifier (FER-199). Any such ref is readable live from the
 # API, so reads work even before a sync has indexed the issue.
 LINEAR_IDENTIFIER_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
@@ -562,6 +570,19 @@ async def set_sync_warning(source_id: UUID, message: str) -> None:
     must never contain tokens or provider payloads."""
     await get_pool().execute(
         "UPDATE user_sources SET sync_error = $2, updated_at = now() WHERE id = $1",
+        source_id,
+        message[:500],
+    )
+
+
+async def mark_needs_setup(source_id: UUID, message: str) -> None:
+    """Park a source that is waiting on the owner to configure it. Not a
+    failure: last_synced_at is left alone (nothing synced) and the status is
+    its own state so the UI can ask for the missing input instead of showing
+    a red error and promising an automatic retry that cannot help."""
+    await get_pool().execute(
+        "UPDATE user_sources SET sync_status = 'needs_setup', sync_error = $2, "
+        "updated_at = now() WHERE id = $1",
         source_id,
         message[:500],
     )

--- a/backend/tasks/sources.py
+++ b/backend/tasks/sources.py
@@ -71,6 +71,10 @@ async def _sync_source(source_id: UUID) -> dict:
     await source_service.mark_sync_started(source_id)
     try:
         cursor = await indexer(source)
+    except source_service.SourceSetupRequired as exc:
+        # Waiting on the owner, not broken: no error log, no failed status.
+        await source_service.mark_needs_setup(source_id, str(exc)[:500])
+        return {"status": "needs_setup"}
     except source_service.SourceSyncUserError as exc:
         # Deliberately owner-facing: the indexer vouches the message is safe
         # and actionable ("upgrade the X API tier"), unlike raw provider

--- a/backend/tests/test_github_pr_service.py
+++ b/backend/tests/test_github_pr_service.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from httpx import AsyncClient
 
@@ -140,3 +142,61 @@ async def test_discover_session_labels_records_pr_and_upserts_ticket(
     assert label["ticket_identifier"] == "FER-19"
     assert label["source"] == "github_pr_title"
     assert label["confidence"] == pytest.approx(0.9)
+
+
+class _FakeGitHubResponse:
+    def __init__(self, status_code=200, headers=None, payload=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeGitHubClient:
+    responses: dict = {}
+
+    def __init__(self, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, params=None):
+        return type(self).responses[url]
+
+
+async def test_fetch_pull_request_returns_none_when_token_cannot_read(monkeypatch):
+    # A 403 on someone else's private repo is permanent for this token; None
+    # records the check so the reconciler stops re-enqueueing the session
+    # every 5 minutes forever.
+    ref = PullRequestRef(owner="acme", repo="private", number=7)
+    _FakeGitHubClient.responses = {
+        "https://api.github.com/repos/acme/private/pulls/7": _FakeGitHubResponse(status_code=403)
+    }
+    monkeypatch.setattr(github_pr_service, "httpx", SimpleNamespace(AsyncClient=_FakeGitHubClient))
+
+    assert await github_pr_service.fetch_pull_request(ref, "token") is None
+
+
+async def test_fetch_pull_request_raises_on_rate_limit(monkeypatch):
+    # Rate limiting also arrives as 403 but is transient — it must raise so
+    # the reconciler retries later instead of permanently recording the check.
+    ref = PullRequestRef(owner="acme", repo="busy", number=8)
+    _FakeGitHubClient.responses = {
+        "https://api.github.com/repos/acme/busy/pulls/8": _FakeGitHubResponse(
+            status_code=403, headers={"x-ratelimit-remaining": "0"}
+        )
+    }
+    monkeypatch.setattr(github_pr_service, "httpx", SimpleNamespace(AsyncClient=_FakeGitHubClient))
+
+    with pytest.raises(RuntimeError):
+        await github_pr_service.fetch_pull_request(ref, "token")

--- a/backend/tests/test_integration_token_refresh.py
+++ b/backend/tests/test_integration_token_refresh.py
@@ -12,11 +12,12 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, HTTPError
 
 from backend.integrations import crypto as integration_crypto
 from backend.integrations import storage
 from backend.integrations.base import AccountInfo, TokenSet
+from backend.integrations.x_saves import tasks as x_tasks
 
 from .conftest import unique_name
 
@@ -78,3 +79,43 @@ async def test_concurrent_reads_of_expired_token_refresh_exactly_once(client, mo
 
     assert provider.refreshes == 1
     assert tokens == ["at-new"] * 4
+
+
+class _MixedRefreshProvider:
+    """One live grant, one dead one — like prod after X kills an idle grant."""
+
+    async def refresh(self, refresh_token: str) -> TokenSet:
+        if refresh_token == "rt-dead":
+            raise HTTPError("401 Unauthorized")
+        return TokenSet(
+            access_token="at-new",
+            refresh_token="rt-new",
+            expires_at=datetime.now(UTC) + timedelta(hours=2),
+            scopes=["tweet.read"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_keep_tokens_fresh_refreshes_x_and_survives_dead_grants(client, monkeypatch):
+    # The keep-warm beat tick must exercise every connected X grant (X kills
+    # refresh tokens that idle ~a day), and one user's dead grant must not
+    # stop other users' tokens from refreshing.
+    alive_user = await _register(client)
+    dead_user = await _register(client)
+    for user_id, refresh_token in ((alive_user, "rt-good"), (dead_user, "rt-dead")):
+        await storage.store_token(
+            user_id,
+            "x",
+            TokenSet(
+                access_token="at-old",
+                refresh_token=refresh_token,
+                expires_at=datetime.now(UTC) - timedelta(minutes=5),
+                scopes=["tweet.read"],
+            ),
+            AccountInfo(email=None, display_name="@someone"),
+        )
+    monkeypatch.setattr(storage, "get_provider", lambda name: _MixedRefreshProvider())
+
+    assert await x_tasks._keep_tokens_fresh() == 1
+
+    assert await storage.get_valid_token(alive_user, "x") == "at-new"

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1572,24 +1572,28 @@ async def test_slack_indexer_backfills_only_allowed_channels(
 
 
 @pytest.mark.asyncio
-async def test_slack_sync_without_channels_records_sync_error(client: AsyncClient):
+async def test_slack_sync_without_channels_needs_setup(client: AsyncClient):
     from backend.tasks import sources as sources_task
 
-    # A malformed Slack source with no channel allowlist must not report a
-    # successful sync that silently ingested nothing.
+    # Slack indexes only the channels the owner picks. Picking none must not
+    # report a successful sync that silently ingested nothing — but it is not a
+    # failure either: nothing is broken and no retry can fix it, so a red error
+    # promising an automatic retry is wrong twice over. The owner gets the
+    # instruction instead, and the source parks until they act.
     api_key, owner_id = await _register(client)
     ws = await _user_scope(client, api_key)
     src = await _insert_slack_source_without_channels(owner_id)
 
     result = await sources_task._sync_source(UUID(src["id"]))
 
-    assert result["status"] == "failed"
+    assert result["status"] == "needs_setup"
     sources = await source_service.list_sources(ws, owner_id)
     slack = next(s for s in sources if s["type"] == "slack")
-    assert slack["sync_status"] == "failed"
-    # The stored error is a redacted constant — raw exception text could carry
-    # secrets, so the detail lives only in server logs.
-    assert slack["sync_error"] == sources_task.SYNC_FAILED_MESSAGE
+    assert slack["sync_status"] == "needs_setup"
+    assert "Choose the Slack channels" in slack["sync_error"]
+    # A stale last_synced_at renders as "synced <old date>", which reads as a
+    # sync that ran and merely found nothing.
+    assert slack["last_synced_at"] is None
 
 
 def _fake_webhook_channel_resolution(monkeypatch, channel_name="general"):

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from uuid import UUID
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 
 from backend.config import settings
@@ -706,6 +707,32 @@ async def test_bookmarks_paid_tier_gate_is_best_effort(client, pool, fake_sync) 
     )
     assert status["sync_status"] != "failed"
     assert "paid tier" in status["sync_error"]
+
+
+@pytest.mark.asyncio
+async def test_dead_oauth_grant_is_best_effort(client, pool, fake_sync, monkeypatch) -> None:
+    # X kills grants whose refresh token sits idle (401 from the token
+    # endpoint). Bookmarks pause with an owner-facing reconnect warning —
+    # the user's own posts/replies/articles must keep syncing.
+    async def _dead_token(user_id, provider, account_key=None):
+        raise HTTPException(status_code=401, detail="x token expired; reconnect required")
+
+    monkeypatch.setattr(integration_storage, "get_valid_token", _dead_token)
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+
+    await x_indexer.index_x_saves(source)
+
+    kinds = await pool.fetch(
+        "SELECT DISTINCT kind FROM x_save_docs WHERE source_id = $1 ORDER BY kind",
+        UUID(source["id"]),
+    )
+    assert [k["kind"] for k in kinds] == ["Article", "Post", "Reply"]
+    status = await pool.fetchrow(
+        "SELECT sync_status, sync_error FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert status["sync_status"] != "failed"
+    assert "reconnect X" in status["sync_error"]
 
 
 async def _insert_done(pool, owner_id, source_id, path, content):

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -633,7 +633,8 @@ function relativeTime(iso: string | null | undefined): string {
 }
 
 // The lead-in to the status line. A healthy source shows a quiet green dot; a
-// syncing/failed source shows a labeled pill (failed is also surfaced in red below).
+// syncing/failed source shows a labeled pill (failed is also surfaced in red
+// below). A source waiting on the owner is amber, not red — nothing is broken.
 function SyncStatusMark({ syncStatus }: { syncStatus: string | null | undefined }) {
   const s = syncStatus ?? "idle";
   if (s === "idle") {
@@ -642,10 +643,12 @@ function SyncStatusMark({ syncStatus }: { syncStatus: string | null | undefined 
   const cls =
     s === "syncing"
       ? "border-blue-300/60 bg-blue-500/10 text-blue-600"
-      : "border-error/40 bg-error/10 text-error";
+      : s === "needs_setup"
+        ? "border-warning/40 bg-warning/10 text-warning"
+        : "border-error/40 bg-error/10 text-error";
   return (
     <span className={"inline-flex items-center rounded-full border px-2 py-0.5 text-[10.5px] font-semibold " + cls}>
-      {s}
+      {s === "needs_setup" ? "needs setup" : s}
     </span>
   );
 }
@@ -759,7 +762,12 @@ function SourceRow({
           <span>
             {syncs ? (
               <>
-                {relativeTime(status.last_synced_at)}
+                {/* A source awaiting setup has never synced under its current
+                    config; its last_synced_at is a stale date that reads as a
+                    sync that merely found nothing. */}
+                {status.sync_status === "needs_setup"
+                  ? "not syncing yet"
+                  : relativeTime(status.last_synced_at)}
                 {status.item_count !== null && ` · ${status.item_count} items`}
               </>
             ) : searchedLive ? (
@@ -1215,12 +1223,10 @@ function NavigablePanel({
 }) {
   const [path, setPath] = useState("");
   const [entries, setEntries] = useState<SourceEntry[] | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [crumbs, setCrumbs] = useState<{ label: string; path: string }[]>([{ label: source.display_name, path: "" }]);
   const [openDoc, setOpenDoc] = useState<{ ref: string; name?: string } | null>(null);
   const [error, setError] = useState("");
-  // Bumped whenever the listing target changes, so an in-flight Load more for
+  // Bumped whenever the listing target changes, so an in-flight fetch for
   // the previous directory can't clobber the new one.
   const listingSeq = useRef(0);
 
@@ -1234,51 +1240,34 @@ function NavigablePanel({
     return { page: more ? rows.slice(0, PAGE_SIZE) : rows, more };
   }
 
+  // Every page is loaded up front — folder rows are synthesized from the flat
+  // path-ordered listing, so a partial page would hide whole folders that sort
+  // after the cutoff (e.g. an X source with 200+ bookmarks showed no Posts or
+  // Replies). Pages render as they arrive so big listings appear progressively.
   useEffect(() => {
     const seq = ++listingSeq.current;
     setEntries(null);
-    setHasMore(false);
     setError("");
-    fetchPage(path, "")
-      .then(({ page, more }) => {
+    (async () => {
+      let acc: SourceEntry[] = [];
+      let more = true;
+      let cursor = "";
+      while (more) {
+        const result = await fetchPage(path, cursor);
         if (listingSeq.current !== seq) return;
-        setEntries(page);
-        setHasMore(more);
-      })
-      .catch((e) => {
-        if (listingSeq.current !== seq) return;
-        setEntries([]);
-        setError(e instanceof Error ? e.message : "Could not list entries");
-      });
+        acc = [...acc, ...result.page];
+        setEntries(acc);
+        more = result.more;
+        cursor = acc[acc.length - 1]?.path ?? "";
+        if (!cursor) break; // the cursor is a path; a path-less listing can't page
+      }
+    })().catch((e) => {
+      if (listingSeq.current !== seq) return;
+      setEntries((prev) => prev ?? []);
+      setError(e instanceof Error ? e.message : "Could not list entries");
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source.source, path]);
-
-  async function loadMore(all: boolean) {
-    if (!entries || loadingMore) return;
-    const seq = listingSeq.current;
-    setLoadingMore(true);
-    try {
-      let acc = entries;
-      let more = hasMore;
-      while (more) {
-        const cursor = acc[acc.length - 1]?.path;
-        if (!cursor) break; // the cursor is a path; a path-less listing can't page
-        const { page, more: nextMore } = await fetchPage(path, cursor);
-        if (listingSeq.current !== seq) return;
-        acc = [...acc, ...page];
-        more = nextMore;
-        if (!all) break;
-      }
-      setEntries(acc);
-      setHasMore(more);
-    } catch (e) {
-      if (listingSeq.current === seq) {
-        setError(e instanceof Error ? e.message : "Could not list entries");
-      }
-    } finally {
-      if (listingSeq.current === seq) setLoadingMore(false);
-    }
-  }
 
   // The entries endpoint returns every descendant file as a flat, path-ordered
   // list (the VFS builds its tree from the same shape). Fold that into one
@@ -1408,30 +1397,6 @@ function NavigablePanel({
               </div>
             );
           })}
-          {hasMore && (
-            <div className="flex items-center gap-3 px-2 py-1.5 text-[12px] text-muted-foreground">
-              {loadingMore ? (
-                <span>Loading…</span>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => loadMore(false)}
-                    className="cursor-pointer hover:text-foreground hover:underline"
-                  >
-                    Load more
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => loadMore(true)}
-                    className="cursor-pointer hover:text-foreground hover:underline"
-                  >
-                    Load all
-                  </button>
-                </>
-              )}
-            </div>
-          )}
         </div>
       )}
 


### PR DESCRIPTION
Four sync-state bugs found while chasing "why are my X bookmarks stale?". Each surfaced as a red error the user could do nothing about, and none of them retried their way out.

### Slack with no channels reads as a failure
An empty channel allowlist raised `RuntimeError`, so the source showed **failed** with the generic *"Sync hit an unexpected error — it will retry automatically."* Both halves are wrong: nothing is broken, and no retry can help — only the owner picking channels can.

Adds `SourceSetupRequired` → a `needs_setup` status that carries the instruction ("Choose the Slack channels to index"), rendered amber rather than red. The status line also stops showing `last_synced_at` in that state, where a six-week-old date read as *a sync that ran and found nothing* instead of *one that has never run*.

### X bookmarks silently stopped syncing
Bookmarks last updated July 20. X kills a refresh token that idles ~24h, and the daily bookmark gate (#870) left it idle for exactly that: refreshes succeeded every ~2h for days, then the first post-gate refresh got `401` from X's token endpoint and every daily attempt since has failed.

- New `keep_tokens_fresh` beat task (30-min tick) keeps X grants rotating on the cadence X demonstrably tolerates.
- A dead grant now sets a persistent "reconnect X" warning instead of throwing — the old behaviour also blanked that run's posts/replies sync and had its `failed` status erased by the next sync 30 minutes later, so it was invisible in the UI.

A grant already dead still needs one manual reconnect; this prevents the next one.

### GitHub PR discovery retried unreadable PRs forever
`fetch_pull_request` handled 404 but let 403 raise. Sessions referencing PRs in an org the token can't read (`heavi-inc/heavi`) therefore never got their "checked" row, so the 5-minute reconciler re-enqueued the same sessions indefinitely — hundreds of errored tasks a day. Now recorded like a 404; rate-limit 403s still raise so they retry.

### Source browser hid whole folders behind "Load more"
Entries loaded 200 at a time, but folder rows are synthesized from the loaded entries — so an X source with 200+ bookmarks (which sort first) showed **no Posts, Replies, or Articles folders at all** until you clicked "Load all". Now loads every page up front, rendering progressively.

## Testing

- 991 backend tests pass (`pytest`), 237 frontend tests pass (`vitest`), ruff + eslint clean.
- New coverage: Slack-without-channels parks as `needs_setup` with no `last_synced_at`; dead X grant warns while posts keep syncing; keep-warm refreshes live grants and survives dead ones; 403 returns None while rate-limit 403 raises.
- The existing `test_slack_sync_without_channels_records_sync_error` encoded the old "this is a failure" intent and was rewritten in place rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdacdeuYJ4PrPRRK84kS5E