### PR TITLE
Sidebar Sessions tree shows folders shared with you

### DIFF
--- a/frontend/src/components/workspace/explorer.test.tsx
+++ b/frontend/src/components/workspace/explorer.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Explorer from "./explorer";
+import {
+  listMySessions,
+  listSessionFolders,
+  listSharedSessionFolderSessions,
+  listSharedWithMe,
+} from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/sessions",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/workspace-store", () => ({
+  useWorkspace: (selector: (s: { openTab: () => void }) => unknown) =>
+    selector({ openTab: vi.fn() }),
+}));
+
+vi.mock("@/lib/memory-folder", () => ({ useMemoryFolderId: () => "memory-folder-1" }));
+
+vi.mock("@/lib/integrations", () => ({
+  INTEGRATIONS_CHANGED_EVENT: "integrations-changed",
+  listIntegrations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn() },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  useConfirm: () => async () => true,
+}));
+
+vi.mock("@/components/share/ResourceShareButton", () => ({
+  ResourceShareDialog: () => null,
+}));
+
+vi.mock("@/lib/api", () => ({
+  listMySessions: vi.fn(),
+  listSessionFolders: vi.fn(),
+  listSharedWithMe: vi.fn(),
+  listSharedSessionFolderSessions: vi.fn(),
+  createSessionFolder: vi.fn(),
+  listSkills: vi.fn().mockResolvedValue([]),
+  listSources: vi.fn().mockResolvedValue([]),
+  listAgents: vi.fn().mockResolvedValue([]),
+  createAgent: vi.fn(),
+  machineFsList: vi.fn().mockResolvedValue([]),
+  getTree: vi.fn(),
+  getFolderContents: vi.fn(),
+  createPage: vi.fn(),
+  createFolder: vi.fn(),
+  createTable: vi.fn(),
+  updateFolder: vi.fn(),
+  updatePage: vi.fn(),
+  updateFile: vi.fn(),
+  updateTable: vi.fn(),
+  trashItem: vi.fn(),
+  deleteFolder: vi.fn(),
+  deleteTable: vi.fn(),
+  deleteSessionFolder: vi.fn(),
+  updateSessionFolder: vi.fn(),
+  uploadFileOrPage: vi.fn(),
+  importGithubRepo: vi.fn(),
+  inspectGithubImport: vi.fn().mockResolvedValue({ skill_dirs: [] }),
+  listGithubImportRepos: vi.fn().mockResolvedValue({ connected: false, repos: [] }),
+  ApiError: class ApiError extends Error {},
+}));
+
+const HENRY_DEFAULT = "henry-default-folder";
+
+function sharedFolder() {
+  return {
+    object_type: "session_folder",
+    object_id: HENRY_DEFAULT,
+    name: "Default",
+    owner_user_id: "henry-user",
+    owner_name: "Henry",
+    shared_by: "Henry",
+    permission: "read",
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(listSessionFolders).mockResolvedValue([
+    { id: "my-default", name: "Default" },
+  ] as never);
+  vi.mocked(listSharedWithMe).mockResolvedValue([
+    sharedFolder(),
+    { object_type: "page", object_id: "p1", name: "A page" },
+  ] as never);
+  // Every session is filed into a folder at upload, so the root's unfiled list
+  // is empty — the folder rows are the only way in.
+  vi.mocked(listMySessions).mockResolvedValue([] as never);
+  vi.mocked(listSharedSessionFolderSessions).mockResolvedValue([
+    { session_id: "s-1", title: "Henry's session", last_event_at: "2026-07-24T18:00:00Z" },
+  ] as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// A teammate's sessions are readable but reachable only through the folder they
+// were filed into. If the sidebar tree lists just your own folders, their
+// sessions are invisible here no matter what the share grants.
+describe("Explorer sessions tree", () => {
+  it("lists session folders shared with you next to your own", async () => {
+    render(<Explorer section="sessions" />);
+
+    expect(await screen.findByText("Default (Henry)")).toBeTruthy();
+    expect(screen.getByText("Default")).toBeTruthy();
+  });
+
+  it("loads a shared folder's sessions from the share endpoint, not your own scope", async () => {
+    render(<Explorer section="sessions" />);
+    fireEvent.click(await screen.findByText("Default (Henry)"));
+
+    await waitFor(() =>
+      expect(listSharedSessionFolderSessions).toHaveBeenCalledWith(HENRY_DEFAULT)
+    );
+    expect(await screen.findByText("Henry's session")).toBeTruthy();
+    expect(vi.mocked(listMySessions).mock.calls.some((c) => c[1] === HENRY_DEFAULT)).toBe(false);
+  });
+
+  it("offers no Rename or Delete on a folder someone shared with you", async () => {
+    render(<Explorer section="sessions" />);
+    fireEvent.contextMenu(await screen.findByText("Default (Henry)"));
+
+    expect(screen.queryByText("Rename")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  it("keeps Rename and Delete on your own folders", async () => {
+    render(<Explorer section="sessions" />);
+    fireEvent.contextMenu(await screen.findByText("Default"));
+
+    expect(await screen.findByText("Rename")).toBeTruthy();
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bot, ChevronRight, File, Folder, Loader2, MessagesSquare, GraduationCap, Monitor, Plus, Settings, FolderTree, Brain, Plug, Sparkles, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
-import { ApiError, listMySessions, listSessionFolders, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
+import { ApiError, listMySessions, listSessionFolders, listSharedWithMe, listSharedSessionFolderSessions, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
 import { useMemoryFolderId } from "@/lib/memory-folder";
 import { SKILL_MD, skillMdTemplate } from "@/lib/localSkill";
 import { requestAgentConfigView, requestCuratorRun } from "@/lib/agent-tab-view";
@@ -288,21 +288,44 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
   // Sessions are their own tree: session folders + loose sessions at the root,
   // sessions inside each folder. Flat (folders don't nest).
   const sessionLabel = (s: SessionSummary) => s.title || s.agent_name || "Session";
-  const sessionsRoot = useCallback(async (): Promise<Item[]> => {
-    const [folders, sessions] = await Promise.all([listSessionFolders(), listMySessions(100)]);
+
+  // Your own folders plus the ones shared with you. Without the shared half the
+  // tree can't reach another person's sessions at all: every session is filed
+  // into a folder at upload, and the root only lists unfiled ones.
+  // Shared rows carry the owner's name because folder names collide across
+  // people — everyone has a "Default".
+  const sessionFolderRows = useCallback(async () => {
+    const [own, shared] = await Promise.all([listSessionFolders(), listSharedWithMe()]);
     return [
-      ...folders.map((f) => ({ kind: "session-folder" as const, id: f.id, name: f.name })),
-      ...sessions.filter((s) => !s.session_folder_id).map((s) => ({ kind: "session" as const, id: s.session_id, name: sessionLabel(s), ts: s.last_event_at })),
+      ...own.map((f) => ({ id: f.id, name: f.name, shared: false })),
+      ...shared
+        .filter((s) => s.object_type === "session_folder")
+        .map((s) => ({ id: s.object_id, name: `${s.name} (${s.owner_name})`, shared: true })),
     ];
   }, []);
+
+  const sessionsRoot = useCallback(async (): Promise<Item[]> => {
+    const [folders, sessions] = await Promise.all([sessionFolderRows(), listMySessions(100)]);
+    return [
+      ...folders.map((f) => ({ kind: "session-folder" as const, id: f.id, name: f.name, readOnly: f.shared })),
+      ...sessions.filter((s) => !s.session_folder_id).map((s) => ({ kind: "session" as const, id: s.session_id, name: sessionLabel(s), ts: s.last_event_at })),
+    ];
+  }, [sessionFolderRows]);
+
   const sessionsFolder = useCallback(async (folderId: string) => {
-    const [folders, sessions] = await Promise.all([listSessionFolders(), listMySessions(100, folderId)]);
+    const folders = await sessionFolderRows();
     const folder = folders.find((f) => f.id === folderId);
+    if (!folder) throw new Error(`Session folder ${folderId} is neither yours nor shared with you`);
+    // A shared folder's sessions live in another scope, so they come from the
+    // share endpoint — the personal /me/sessions window is the wrong source.
+    const sessions = folder.shared
+      ? await listSharedSessionFolderSessions(folderId)
+      : await listMySessions(100, folderId);
     return {
-      crumbs: [{ id: folderId, name: folder?.name ?? "Folder", is_skill: false }],
+      crumbs: [{ id: folderId, name: folder.name, is_skill: false }],
       items: sessions.map((s) => ({ kind: "session" as const, id: s.session_id, name: sessionLabel(s), ts: s.last_event_at })),
     };
-  }, []);
+  }, [sessionFolderRows]);
   const createSessionFolderItem = useCallback(async () => { await createSessionFolder("New folder"); }, []);
 
   if (section === "agents") return <AgentsExplorer />;

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -28,7 +28,10 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 type Kind = "folder" | "page" | "file" | "table" | "skill" | "session-folder" | "session";
-export type Item = { kind: Kind; id: string; name: string; ts?: string };
+// `readOnly` marks an item you can browse but not manage — a session folder
+// someone shared with you. Rename/Delete are hidden rather than offered and
+// left to fail against the owner-only server check.
+export type Item = { kind: Kind; id: string; name: string; ts?: string; readOnly?: boolean };
 // Kinds that live in the VFS (draggable, rename/move/delete via folder/page APIs).
 const VFS_KINDS = new Set<Kind>(["folder", "page", "file", "table", "skill"]);
 
@@ -449,8 +452,8 @@ export default function FilesExplorer({
           {(menu.item.kind === "folder" || menu.item.kind === "skill") && <button onClick={() => { const it = menu.item; setMenu(null); openAsTab(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><FolderInput className="h-3.5 w-3.5" /> Open in tab</button>}
           {menu.item.kind !== "session-folder" && <button onClick={() => { const it = menu.item; setMenu(null); openAsTab(it, { forceNewTab: true }); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><ExternalLink className="h-3.5 w-3.5" /> Open in new tab</button>}
           {VFS_KINDS.has(menu.item.kind) && user && <button onClick={() => { setSharing({ x: menu.x, y: menu.y, item: menu.item }); setMenu(null); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><Share2 className="h-3.5 w-3.5" /> Share</button>}
-          {menu.item.kind !== "session" && <button onClick={() => { setRenaming(menu.item.id); setMenu(null); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><Pencil className="h-3.5 w-3.5" /> Rename</button>}
-          <button onClick={async () => { const it = menu.item; setMenu(null); await del(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-destructive hover:bg-raised"><Trash2 className="h-3.5 w-3.5" /> Delete</button>
+          {menu.item.kind !== "session" && !menu.item.readOnly && <button onClick={() => { setRenaming(menu.item.id); setMenu(null); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground hover:bg-raised"><Pencil className="h-3.5 w-3.5" /> Rename</button>}
+          {!menu.item.readOnly && <button onClick={async () => { const it = menu.item; setMenu(null); await del(it); }} className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-destructive hover:bg-raised"><Trash2 className="h-3.5 w-3.5" /> Delete</button>}
         </div>
       )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1910,6 +1910,7 @@ export interface SharedWithMeItem {
   object_id: string;
   name: string;
   owner_user_id: string;
+  owner_name: string;
   shared_by: string | null;
   permission: "read" | "write";
 }


### PR DESCRIPTION
## The problem

A teammate's sessions were unreachable from the sidebar Sessions tree, no matter what the share granted.

The tree was built from exactly two things (`explorer.tsx`):

- `listSessionFolders()` — owner-scoped, so it returns only your own folders
- `listMySessions(100).filter(s => !s.session_folder_id)` — unfiled sessions only

Every session is filed into a folder at upload (`session_service.create_session` drops it into `Default`), so a teammate's sessions were dropped by the unfiled filter — and the folders holding them were never in the tree to drill into. The tree never called `listSharedWithMe()` at all.

This is a navigation gap, not a permissions one. The backend hands the sessions over; only the full `/sessions` page surfaced them, in a separate shared-folder bucket.

## The change

- The tree lists shared session folders next to your own.
- Shared rows carry the owner's name, because folder names collide across people — everyone has a "Default".
- Drilling into a shared folder reads from `listSharedSessionFolderSessions`, since its sessions live in another scope.
- Shared rows are marked `readOnly`, so the row menu stops offering Rename and Delete on a folder you don't own. Both previously failed against the owner-only server check.

## Screenshots

Screenshots are pending — they need to be attached to this thread directly. Verified locally with a viewer ("Sam") and an owner ("Henry") who has shared his `Default` session folder:

- **Before** — the sidebar lists only Sam's own `Default`. Henry's folder and its sessions are unreachable, even though the shared-folder card is visible on the page body.
- **After** — `Default (Henry)` sits alongside Sam's own folder in the tree.
- **After, drilled in** — Henry's three sessions load under `Default (Henry)` from the share endpoint.

## Tests

`explorer.test.tsx` is new — 4 tests. 3 of them fail without this change; the fourth is the control that own folders keep Rename and Delete.

Full frontend suite: 55 files, 243 tests, passing. Lint clean. No new type errors (the one pre-existing `page.test.tsx` error is also on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)