### PR TITLE
fix: dedupe session events and un-strand end-only sessions

### DIFF
--- a/backend/migrations/versions/0167_event_source_uuid.py
+++ b/backend/migrations/versions/0167_event_source_uuid.py
@@ -1,0 +1,40 @@
+"""Give every history_events row a producer-assigned idempotency key.
+
+history_events had no uniqueness beyond its random PK, so the same event
+could land twice: a hook's 2s timeout fired while the backend commit was
+still in flight (the queued body replayed later), concurrent transcript
+uploads raced the count-then-insert guard, and re-imports re-inserted every
+line. source_uuid + a unique index makes every one of those a no-op at the
+database instead of a duplicate row.
+
+Existing rows are backfilled with random ids — pre-existing duplicates are
+left as-is (deliberate: content-based cleanup risks collapsing genuinely
+repeated messages); idempotency applies going forward.
+
+NULLS NOT DISTINCT keeps the index enforced for personal events, whose
+owner_user_id is NULL.
+"""
+
+from alembic import op
+
+revision = "0167"
+down_revision = "0166"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE history_events ADD COLUMN source_uuid TEXT")
+    op.execute(
+        "UPDATE history_events SET source_uuid = gen_random_uuid()::text WHERE source_uuid IS NULL"
+    )
+    op.execute("ALTER TABLE history_events ALTER COLUMN source_uuid SET NOT NULL")
+    op.execute(
+        "CREATE UNIQUE INDEX uq_history_events_source "
+        "ON history_events (owner_user_id, session_id, source_uuid) NULLS NOT DISTINCT"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX uq_history_events_source")
+    op.execute("ALTER TABLE history_events DROP COLUMN source_uuid")

--- a/backend/models.py
+++ b/backend/models.py
@@ -492,6 +492,11 @@ class HistoryEventCreateRequest(BaseModel):
     created_at: datetime | None = Field(
         None, description="ISO timestamp; defaults to now if omitted"
     )
+    source_uuid: str | None = Field(
+        None,
+        max_length=128,
+        description="Producer idempotency key; server generates one when absent",
+    )
 
 
 class HistoryEventBatchRequest(BaseModel):

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -64,6 +64,7 @@ async def push_event(
         metadata=req.metadata,
         attachments=attachments,
         created_at=req.created_at,
+        source_uuid=req.source_uuid,
     )
     if settings.ANTHROPIC_API_KEY and req.session_id and req.event_type in _TITLE_EVENT_TYPES:
         generate_session_title.delay(str(owner_user_id), req.session_id)

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -59,8 +59,15 @@ async def upload_transcript(
 ):
     """Parse the uploaded JSONL into history_events rows.
 
-    Existing sessions are left alone unless the caller explicitly asks to
-    replace them.
+    Sessions with renderable events are left alone unless the caller
+    explicitly asks to replace them: live-streamed rows carry random
+    source_uuids while imported rows carry line-derived ones, so merging the
+    two would double every turn. Bookkeeping rows (session_end) don't count —
+    the upload is the backstop for exactly the sessions where live streaming
+    failed and only session_end landed. The guard's check-then-insert race is
+    closed by the unique (owner_user_id, session_id, source_uuid) index:
+    concurrent imports of the same file compute identical ids and the loser
+    inserts nothing.
     """
     # Transcripts land in the active scope, matching where the session's
     # events were pushed (X-Stash-Scope header, personal when absent).
@@ -83,9 +90,11 @@ async def upload_transcript(
 
     pool = get_pool()
     existing = await pool.fetchval(
-        "SELECT COUNT(*) FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
+        "SELECT COUNT(*) FROM history_events "
+        "WHERE owner_user_id = $1 AND session_id = $2 AND event_type = ANY($3::text[])",
         owner_user_id,
         session_id,
+        list(memory_service.RENDERABLE_EVENT_TYPES),
     )
     if existing:
         if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
@@ -231,6 +240,7 @@ async def get_transcript_events(
 
     No ownership gate: can_read_session is enforced per scope below, so
     another user the session is shared with can read it."""
+    readable_but_empty = False
     for row in await session_service.list_sessions_for_session_id(session_id):
         owner_user_id = row["owner_user_id"]
         if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
@@ -250,6 +260,12 @@ async def get_transcript_events(
                 "total": total,
                 "has_more": offset + len(events) < total,
             }
+        readable_but_empty = True
+    if readable_but_empty:
+        # A session whose only rows are bookkeeping events (session_end) is a
+        # legitimate empty transcript, not a missing one — 404 is reserved for
+        # unknown/unauthorized sessions.
+        return {"events": [], "total": 0, "has_more": False}
     raise HTTPException(status_code=404, detail="Transcript not found")
 
 

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import logging
 from datetime import UTC, datetime
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import numpy as np
 
@@ -119,8 +119,14 @@ async def push_event(
     metadata: dict | None = None,
     attachments: list[dict] | None = None,
     created_at: datetime | None = None,
+    source_uuid: str | None = None,
 ) -> dict:
-    """Push a single event."""
+    """Push a single event.
+
+    source_uuid is the producer's idempotency key: a redelivery (hook retry
+    queue, client timeout that raced a successful commit) conflicts on the
+    unique index and returns the already-stored row instead of a duplicate.
+    """
     pool = get_pool()
     agent_name = _strip_nuls(agent_name)
     event_type = _strip_nuls(event_type)
@@ -129,14 +135,16 @@ async def push_event(
     tool_name = _strip_nuls(tool_name)
     attachments = _strip_nuls(attachments)
     meta = _strip_nuls(metadata or {})
+    source_uuid = _strip_nuls(source_uuid) or str(uuid4())
     if created_at is None:
         ts = datetime.now(UTC)
     else:
         ts = _normalize_ts(created_at)
     row = await pool.fetchrow(
         "INSERT INTO history_events "
-        "(owner_user_id, created_by, agent_name, event_type, content, session_id, tool_name, metadata, attachments, created_at) "
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10) "
+        "(owner_user_id, created_by, agent_name, event_type, content, session_id, tool_name, metadata, attachments, created_at, source_uuid) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11) "
+        "ON CONFLICT (owner_user_id, session_id, source_uuid) DO NOTHING "
         "RETURNING id, owner_user_id, created_by, agent_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at",
         owner_user_id,
@@ -149,7 +157,21 @@ async def push_event(
         meta,
         attachments,
         ts,
+        source_uuid,
     )
+    if row is None:
+        # Duplicate delivery: the first insert already ran the side effects
+        # (embed, session upsert, ticket/PR hints), so just return that row.
+        row = await pool.fetchrow(
+            "SELECT id, owner_user_id, created_by, agent_name, event_type, session_id, "
+            "tool_name, content, metadata, attachments, created_at "
+            "FROM history_events "
+            "WHERE owner_user_id IS NOT DISTINCT FROM $1 AND session_id = $2 AND source_uuid = $3",
+            owner_user_id,
+            session_id,
+            source_uuid,
+        )
+        return dict(row)
     event = dict(row)
     if embedding_service.is_configured():
         _schedule_event_embed(event["id"], content, _text_hash(content))
@@ -198,21 +220,26 @@ async def push_events_batch(
     metadatas = [json.dumps(e.get("metadata") or {}) for e in events]
     attachments = [json.dumps(e["attachments"]) if e.get("attachments") else None for e in events]
     timestamps = [_normalize_ts(e["created_at"]) if e.get("created_at") else now for e in events]
+    source_uuids = [e.get("source_uuid") or str(uuid4()) for e in events]
 
+    # ON CONFLICT DO NOTHING makes redeliveries (concurrent uploads of the
+    # same transcript, re-imports) no-ops; RETURNING yields only the rows
+    # actually inserted.
     rows = await pool.fetch(
         """
         INSERT INTO history_events
             (owner_user_id, created_by, agent_name, event_type, content,
-             session_id, tool_name, metadata, attachments, created_at)
+             session_id, tool_name, metadata, attachments, created_at, source_uuid)
         SELECT $1::uuid, $2::uuid, u.an, u.et, u.c,
                u.sid, u.tn, u.md::jsonb,
                CASE WHEN u.att IS NULL THEN NULL ELSE u.att::jsonb END,
-               u.ts
+               u.ts, u.su
         FROM UNNEST(
             $3::varchar[], $4::varchar[], $5::text[],
             $6::varchar[], $7::varchar[],
-            $8::text[], $9::text[], $10::timestamptz[]
-        ) AS u(an, et, c, sid, tn, md, att, ts)
+            $8::text[], $9::text[], $10::timestamptz[], $11::text[]
+        ) AS u(an, et, c, sid, tn, md, att, ts, su)
+        ON CONFLICT (owner_user_id, session_id, source_uuid) DO NOTHING
         RETURNING id, owner_user_id, created_by, agent_name, event_type,
                   session_id, tool_name, content, metadata, attachments, created_at
         """,
@@ -226,6 +253,7 @@ async def push_events_batch(
         metadatas,
         attachments,
         timestamps,
+        source_uuids,
     )
     results = [dict(r) for r in rows]
     await _upsert_sessions_for_events(owner_user_id, created_by, events)
@@ -576,7 +604,10 @@ async def search_scope_events(
     query: str,
     limit: int = 50,
 ) -> list[dict]:
-    """Full-text search on scope events."""
+    """Full-text search on scope events.
+
+    Restricted to renderable turns: bookkeeping rows like session_end would
+    otherwise surface sessions whose transcript has nothing to show."""
     pool = get_pool()
     limit = min(limit, 500)
     rows = await pool.fetch(
@@ -586,12 +617,14 @@ async def search_scope_events(
         "FROM history_events "
         "WHERE owner_user_id = $1 "
         f"AND {readable_session_event_condition('history_events', 4)} "
+        "AND event_type = ANY($5::text[]) "
         "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
         "ORDER BY rank DESC LIMIT $3",
         owner_user_id,
         query,
         limit,
         user_id,
+        list(RENDERABLE_EVENT_TYPES),
     )
     return [dict(r) for r in rows]
 
@@ -650,7 +683,9 @@ async def search_scope_events_vector(
     query_embedding: np.ndarray,
     limit: int = 20,
 ) -> list[dict]:
-    """Semantic vector search on scope events."""
+    """Semantic vector search on scope events.
+
+    Restricted to renderable turns, same as search_scope_events."""
     pool = get_pool()
     limit = min(limit, 200)
     rows = await pool.fetch(
@@ -660,12 +695,14 @@ async def search_scope_events_vector(
         "FROM history_events "
         "WHERE owner_user_id = $1 "
         f"AND {readable_session_event_condition('history_events', 4)} "
+        "AND event_type = ANY($5::text[]) "
         "AND embedding IS NOT NULL "
         "ORDER BY embedding <=> $2 LIMIT $3",
         owner_user_id,
         query_embedding,
         limit,
         user_id,
+        list(RENDERABLE_EVENT_TYPES),
     )
     return [dict(r) for r in rows]
 

--- a/backend/services/transcript_import.py
+++ b/backend/services/transcript_import.py
@@ -18,6 +18,7 @@ events.
 from __future__ import annotations
 
 import gzip
+import hashlib
 import json
 from datetime import UTC, datetime
 from typing import Any
@@ -145,13 +146,20 @@ def parse_jsonl_to_events(
     """Parse a transcript blob into event dicts ready for push_events_batch.
 
     Each event dict has: agent_name, event_type, content, session_id,
-    tool_name, metadata, created_at. Caller supplies owner_user_id and
-    created_by when calling push_events_batch.
+    tool_name, metadata, created_at, source_uuid. Caller supplies
+    owner_user_id and created_by when calling push_events_batch.
+
+    source_uuid is deterministic per line (the line's own uuid when present,
+    a hash of the line otherwise) so re-uploading the same transcript
+    conflicts on the unique index instead of duplicating rows. A message
+    Claude re-serializes under a *new* uuid after compaction still gets a
+    new id — content-based dedup is deliberately not attempted, since it
+    can't match across the live/import representations and would collapse
+    genuinely repeated messages.
     """
     text = _decompress(blob)
     events: list[dict] = []
-    fallback_idx = 0
-    for line in text.splitlines():
+    for line_idx, line in enumerate(text.splitlines()):
         line = line.strip()
         if not line:
             continue
@@ -162,52 +170,63 @@ def parse_jsonl_to_events(
         if not isinstance(obj, dict):
             continue
 
+        line_events: list[dict] = []
         entry_type = obj.get("type")
         if entry_type == "response_item":
-            events.extend(
-                _parse_codex_response_item(obj, session_id=session_id, agent_name=agent_name)
+            line_events = _parse_codex_response_item(
+                obj, session_id=session_id, agent_name=agent_name
             )
+        elif entry_type in ("user", "assistant"):
+            message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+            content_raw = message.get("content", "")
+            text_content = _text_from_content(content_raw)
+            created_at = _parse_ts(obj.get("timestamp")) or _parse_ts(message.get("timestamp"))
+
+            if text_content.strip():
+                line_events.append(
+                    {
+                        "agent_name": agent_name,
+                        "event_type": "user_message"
+                        if entry_type == "user"
+                        else "assistant_message",
+                        "content": text_content,
+                        "session_id": session_id,
+                        "tool_name": None,
+                        "metadata": {"source": "transcript_import"},
+                        "created_at": created_at,
+                    }
+                )
+
+            # Surface tool_use blocks (assistant side) as their own events so
+            # the timeline shows tool calls alongside messages — mirrors what
+            # the live hook does.
+            for tu in _tool_blocks(content_raw):
+                tool_name = tu.get("name") or ""
+                tool_input = tu.get("input")
+                line_events.append(
+                    {
+                        "agent_name": agent_name,
+                        "event_type": "tool_use",
+                        "content": _content_repr(tool_input),
+                        "session_id": session_id,
+                        "tool_name": tool_name or None,
+                        "metadata": {"source": "transcript_import"},
+                        "created_at": created_at,
+                    }
+                )
+
+        if not line_events:
             continue
 
-        if entry_type not in ("user", "assistant"):
-            continue
-
-        message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
-        content_raw = message.get("content", "")
-        text_content = _text_from_content(content_raw)
-        created_at = _parse_ts(obj.get("timestamp")) or _parse_ts(message.get("timestamp"))
-
-        if text_content.strip():
-            events.append(
-                {
-                    "agent_name": agent_name,
-                    "event_type": "user_message" if entry_type == "user" else "assistant_message",
-                    "content": text_content,
-                    "session_id": session_id,
-                    "tool_name": None,
-                    "metadata": {"source": "transcript_import"},
-                    "created_at": created_at,
-                }
-            )
-
-        # Surface tool_use blocks (assistant side) as their own events so
-        # the timeline shows tool calls alongside messages — mirrors what
-        # the live hook does.
-        for tu in _tool_blocks(content_raw):
-            tool_name = tu.get("name") or ""
-            tool_input = tu.get("input")
-            events.append(
-                {
-                    "agent_name": agent_name,
-                    "event_type": "tool_use",
-                    "content": _content_repr(tool_input),
-                    "session_id": session_id,
-                    "tool_name": tool_name or None,
-                    "metadata": {"source": "transcript_import"},
-                    "created_at": created_at,
-                }
-            )
-
-        fallback_idx += 1
+        raw_uuid = obj.get("uuid")
+        if isinstance(raw_uuid, str) and raw_uuid:
+            base = raw_uuid
+        else:
+            # Codex lines carry no per-line id; transcript files are
+            # append-only, so the line index is stable across re-uploads.
+            base = hashlib.sha256(f"{session_id}:{line_idx}:{line}".encode()).hexdigest()
+        for j, ev in enumerate(line_events):
+            ev["source_uuid"] = f"{base}:{j}"
+        events.extend(line_events)
 
     return events

--- a/backend/tests/test_cohorts.py
+++ b/backend/tests/test_cohorts.py
@@ -40,11 +40,12 @@ async def _insert_history_event(pool, user_id: UUID, created_at: datetime, metad
     await pool.execute(
         "INSERT INTO history_events "
         "(owner_user_id, created_by, agent_name, event_type, content, metadata, "
-        " created_at, session_id) "
+        " created_at, session_id, source_uuid) "
         # $2 goes over the wire as text and is cast in SQL: the pool's jsonb
         # codec would otherwise re-encode the string into a double-encoded
         # JSON string, breaking ->> lookups.
-        "VALUES ($1, $1, 'agent', 'message', 'hello', (($2)::text)::jsonb, $3, gen_random_uuid())",
+        "VALUES ($1, $1, 'agent', 'message', 'hello', (($2)::text)::jsonb, $3, gen_random_uuid(), "
+        "gen_random_uuid()::text)",
         user_id,
         metadata,
         created_at,

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -136,8 +136,8 @@ async def _make_history_event(
 ):
     return await pool.fetchval(
         "INSERT INTO history_events "
-        "(owner_user_id, created_by, agent_name, event_type, content, session_id) "
-        "VALUES ($1, $2, 'agent', $3, $4, $5) RETURNING id",
+        "(owner_user_id, created_by, agent_name, event_type, content, session_id, source_uuid) "
+        "VALUES ($1, $2, 'agent', $3, $4, $5, gen_random_uuid()::text) RETURNING id",
         owner_user_id,
         created_by,
         event_type,

--- a/backend/tests/test_session_rename.py
+++ b/backend/tests/test_session_rename.py
@@ -137,8 +137,8 @@ async def test_user_set_title_survives_auto_regeneration(client: AsyncClient, po
     # Seed an event so the generator sees content to work with.
     await pool.execute(
         "INSERT INTO history_events "
-        "(owner_user_id, session_id, agent_name, event_type, content, created_at) "
-        "VALUES ($1, $2, 'claude', 'user_message', 'first prompt', now())",
+        "(owner_user_id, session_id, agent_name, event_type, content, created_at, source_uuid) "
+        "VALUES ($1, $2, 'claude', 'user_message', 'first prompt', now(), gen_random_uuid()::text)",
         scope["id"],
         "sess-rename-6",
     )

--- a/backend/tests/test_transcript_import.py
+++ b/backend/tests/test_transcript_import.py
@@ -145,3 +145,55 @@ def test_empty_input_returns_empty_list():
 def test_skips_empty_content():
     body = (_line(type="user", message={"content": ""}) + "\n").encode()
     assert parse_jsonl_to_events(body, session_id="s6", agent_name="claude") == []
+
+
+def test_source_uuids_are_deterministic():
+    """source_uuid is the import idempotency key: re-uploading the same file
+    must produce identical ids so the unique index dedups instead of
+    duplicating rows."""
+    body = (
+        "\n".join(
+            [
+                _line(
+                    type="user",
+                    uuid="line-uuid-1",
+                    message={"content": "hi"},
+                ),
+                _line(
+                    type="assistant",
+                    uuid="line-uuid-2",
+                    message={
+                        "content": [
+                            {"type": "text", "text": "reading"},
+                            {"type": "tool_use", "name": "Read", "input": {"file": "x.py"}},
+                        ]
+                    },
+                ),
+                # Codex lines carry no uuid — id falls back to a line hash.
+                _line(
+                    type="response_item",
+                    payload={
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "fix it"}],
+                    },
+                ),
+            ]
+        )
+        + "\n"
+    ).encode()
+
+    first = parse_jsonl_to_events(body, session_id="s7", agent_name="claude")
+    second = parse_jsonl_to_events(body, session_id="s7", agent_name="claude")
+
+    ids = [e["source_uuid"] for e in first]
+    assert ids == [e["source_uuid"] for e in second]
+    assert len(set(ids)) == len(ids)
+    assert ids[0] == "line-uuid-1:0"
+    # Two events from one line get distinct suffixes.
+    assert ids[1] == "line-uuid-2:0"
+    assert ids[2] == "line-uuid-2:1"
+    # The hash id is scoped to the session so identical lines in different
+    # sessions never collide.
+    other_session = parse_jsonl_to_events(body, session_id="s8", agent_name="claude")
+    assert other_session[3]["source_uuid"] != first[3]["source_uuid"]

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -812,6 +812,135 @@ async def test_transcript_viewer_includes_streamed_legacy_event_types(client: As
 
 
 @pytest.mark.asyncio
+async def test_transcript_backstop_imports_after_session_end_only(client: AsyncClient):
+    """When live streaming failed and only the session_end event landed, the
+    transcript upload is the repair path — a lone bookkeeping row must not
+    trip the 'session already has events' guard."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    ended = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "session_end",
+            "content": "Session ended. 2 tool uses.",
+            "session_id": "sess-end-only",
+        },
+        headers=headers,
+    )
+    assert ended.status_code == 201
+
+    up = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
+        data={"session_id": "sess-end-only", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert up.status_code == 201, up.text
+    assert up.json()["skipped"] is False
+    assert up.json()["imported"] == 2
+
+    events_resp = await client.get(
+        "/api/v1/me/transcripts/sess-end-only/events",
+        headers=headers,
+    )
+    assert events_resp.status_code == 200
+    assert [e["content"] for e in events_resp.json()["events"]] == ["hi", "hello"]
+
+
+@pytest.mark.asyncio
+async def test_end_only_session_hidden_from_search_and_viewable(client: AsyncClient):
+    """A session holding only a session_end row must not surface in event
+    search (its boilerplate isn't a turn), and opening its transcript must
+    return an empty page, not 404 — it's a legitimate empty session."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    ended = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "session_end",
+            "content": "Session ended. 3 tool uses.",
+            "session_id": "sess-end-search",
+        },
+        headers=headers,
+    )
+    assert ended.status_code == 201
+
+    search = await client.get(
+        "/api/v1/me/sessions/events/search",
+        params={"q": "Session ended"},
+        headers=headers,
+    )
+    assert search.status_code == 200
+    assert search.json()["events"] == []
+
+    events_resp = await client.get(
+        "/api/v1/me/transcripts/sess-end-search/events",
+        headers=headers,
+    )
+    assert events_resp.status_code == 200
+    assert events_resp.json() == {"events": [], "total": 0, "has_more": False}
+
+
+@pytest.mark.asyncio
+async def test_push_event_is_idempotent(client: AsyncClient, pool):
+    """A redelivered event (hook timeout that raced a successful commit, queue
+    replay) carries the same source_uuid and must not create a second row."""
+    key = await _register(client)
+    scope = await _scope(client, key)
+    headers = {"Authorization": f"Bearer {key}"}
+    event = {
+        "agent_name": "claude",
+        "event_type": "user_message",
+        "content": "please fix the build",
+        "session_id": "sess-idem",
+        "source_uuid": "hook-generated-id",
+    }
+
+    first = await client.post("/api/v1/me/sessions/events", json=event, headers=headers)
+    assert first.status_code == 201
+    second = await client.post("/api/v1/me/sessions/events", json=event, headers=headers)
+    assert second.status_code == 201
+    assert second.json()["id"] == first.json()["id"]
+
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
+        UUID(scope),
+        "sess-idem",
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_double_import_is_idempotent(client: AsyncClient, pool):
+    """Stand-in for two concurrent uploads racing the guard: the parser emits
+    deterministic source_uuids, so inserting the same parsed transcript twice
+    lands every event exactly once."""
+    from backend.services import memory_service, transcript_import
+
+    key, user_id = await _register_user(client)
+    scope = await _scope(client, key)
+
+    events = transcript_import.parse_jsonl_to_events(
+        BODY, session_id="sess-race", agent_name="claude"
+    )
+    first = await memory_service.push_events_batch(UUID(scope), UUID(user_id), events)
+    assert len(first) == len(events)
+    second = await memory_service.push_events_batch(UUID(scope), UUID(user_id), events)
+    assert second == []
+
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
+        UUID(scope),
+        "sess-race",
+    )
+    assert count == len(events)
+
+
+@pytest.mark.asyncio
 async def test_oversize_rejected(client: AsyncClient):
     key = await _register(client)
     big = b"x" * (50 * 1024 * 1024 + 1)

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -176,6 +178,12 @@ class StashClient:
             merged_meta["client"] = client
         if merged_meta:
             body["metadata"] = merged_meta
+        # Set identity and time before the first POST so a queued retry
+        # resends the exact same event: the server dedups on source_uuid (a
+        # timeout that raced a successful commit becomes a no-op) and a
+        # genuinely queued event keeps its real time instead of drain time.
+        body["source_uuid"] = str(uuid.uuid4())
+        body["created_at"] = datetime.now(UTC).isoformat()
 
         path = self._EVENTS_PATH
         record_upload_attempt(self._data_dir, "event")


### PR DESCRIPTION
## Problem

Two adjacent transcript-pipeline bugs:

1. **Sessions containing only a `session_end` event 404 when opened from search.** The plugin hook pushes `session_end` *before* the transcript backstop upload, and the upload guard counted **all** event types — so the just-pushed bookkeeping row blocked the exact repair path for sessions whose live streaming failed (2s client timeouts, queued events, edge 403 drops). `session_end` isn't renderable, so the viewer 404ed while event search still surfaced the session.

2. **Duplicated human messages.** `history_events` had no idempotency key or unique constraint. Duplicates came from: the plugin's 2.0s timeout firing while the backend commit actually succeeded (the queued body replayed later — hits user prompts hardest), concurrent transcript uploads racing the count-then-insert guard, and re-imports ignoring the per-line JSONL `uuid`.

## Fix

- **Migration 0167**: `history_events.source_uuid TEXT NOT NULL` + `UNIQUE (owner_user_id, session_id, source_uuid) NULLS NOT DISTINCT` (pg15+; Neon prod, self-host compose, and CI are all pg16). Existing rows backfilled with random ids; pre-existing duplicates deliberately left in place — content-based cleanup risks collapsing genuinely repeated messages.
- **`memory_service.push_event` / `push_events_batch`**: insert with `ON CONFLICT DO NOTHING`. Redeliveries and concurrent imports become no-ops; a duplicate single push returns the already-stored row and skips side effects.
- **Plugin `stash_client.push_event`**: generates `source_uuid` + `created_at` once, *before* POST/enqueue, so queue replays resend the identical event and the server drops it. Queued events also keep their real timestamp instead of drain time.
- **`transcript_import`**: each parsed event gets a deterministic `source_uuid` (the line's `uuid`, or a session-scoped line hash for Codex lines), so re-uploads dedupe at the index.
- **Upload guard**: counts only `RENDERABLE_EVENT_TYPES` — a lone `session_end` no longer blocks the backstop, so stranded sessions self-heal on the next upload. Its check-then-insert race is closed by the unique index.
- **Search/viewer**: event FTS + vector search skip bookkeeping rows; a readable session with zero renderable events returns an empty page instead of 404.

Known limitation (documented in the parser): a message Claude re-serializes under a *new* uuid after compaction still duplicates — content-based dedup can't match across live/import representations and would collapse legitimate repeats.

## Testing

- Full backend suite: 1009 passed (test setup runs migrations, exercising 0167). Plugin suite: 147 passed. `ruff check` + `ruff format --check` clean.
- New regression tests:
  - backstop imports after an end-only `session_end` (`test_transcript_backstop_imports_after_session_end_only`)
  - same `source_uuid` pushed twice → one row, same id (`test_push_event_is_idempotent`)
  - same parsed transcript batch-inserted twice → second inserts nothing (`test_double_import_is_idempotent`)
  - end-only session absent from search, empty 200 from the viewer (`test_end_only_session_hidden_from_search_and_viewable`)
  - parser `source_uuid`s deterministic and session-scoped (`test_source_uuids_are_deterministic`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)