### PR TITLE
fix: let VFS grep survive the read budget and accept BRE escapes

### DIFF
--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -23,10 +23,12 @@ import anyio
 import anyio.to_thread
 import httpx
 
-from stashvfs import SkillAppVfsShell, StashVfsModel, VfsClientError
+from stashvfs import SkillAppVfsShell, StashVfsModel, VfsClientError, VfsScanBudget
 
 # A `grep -r /` loads every document it walks, one nested request each. Past this
-# many the caller has asked for a scan, not a search — fail loud rather than sit
+# many the budget is spent: a grep stops its sweep and returns partial results
+# with a loud truncation warning (VfsScanBudget), while direct reads — a `cat`
+# over hundreds of files — abort the command (VfsBudgetExceeded) rather than sit
 # on an open connection until the client's own timeout fires.
 MAX_DOCUMENT_READS = 400
 
@@ -34,9 +36,10 @@ SOURCE_ENTRIES_PAGE = 1000
 
 
 class VfsBudgetExceeded(Exception):
-    """More document reads than one shell invocation is allowed. Deliberately not
-    a VfsClientError: the shell downgrades those to per-file warnings, and this
-    must abort the whole command."""
+    """More direct document reads than one shell invocation is allowed.
+    Deliberately not a VfsClientError: the shell downgrades those to per-file
+    warnings, and this must abort the whole command. Reads inside a grep sweep
+    raise VfsScanBudget instead, which the shell turns into a partial result."""
 
 
 class InProcessVfsClient:
@@ -122,6 +125,8 @@ class InProcessVfsClient:
             self._document_reads += 1
             over_budget = self._document_reads > MAX_DOCUMENT_READS
         if over_budget:
+            if self._scan:
+                raise VfsScanBudget(f"scan budget of {MAX_DOCUMENT_READS} documents spent")
             raise VfsBudgetExceeded(
                 f"command read more than {MAX_DOCUMENT_READS} documents; "
                 "scope it to a subdirectory or use search"

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -184,16 +184,33 @@ async def test_unknown_cwd_is_a_client_error(client: AsyncClient):
     assert resp.status_code == 400
 
 
-async def test_document_read_budget_aborts_the_command(client: AsyncClient, monkeypatch):
-    """An unscoped `grep -r /` would walk every document in every source. The
-    ceiling must abort the command, not degrade into a per-file warning that the
-    caller reads as 'no matches'."""
+async def test_scan_budget_makes_grep_partial_and_loud(client: AsyncClient, monkeypatch):
+    """An org-wide grep that outruns the read budget must return whatever it
+    found so far with an explicit truncation warning — not abort with 413
+    (Heavi's agent lost entire per-VIN sweeps to that), and never a clean
+    no-match exit that reads as 'searched everything, found nothing'."""
     monkeypatch.setattr("backend.services.vfs_service.MAX_DOCUMENT_READS", 1)
     api_key, _ = await _register(client)
     await _make_page(client, api_key, "One", "alpha")
     await _make_page(client, api_key, "Two", "beta")
 
     resp = await _vfs(client, api_key, "grep -ri 'alpha' /files")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "of 2 files" in body["stderr"]
+    assert "partial" in body["stderr"]
+
+
+async def test_document_read_budget_still_aborts_direct_reads(client: AsyncClient, monkeypatch):
+    """Outside a grep sweep there are no partial results to salvage: a `cat`
+    over more documents than the budget allows must abort the command."""
+    monkeypatch.setattr("backend.services.vfs_service.MAX_DOCUMENT_READS", 1)
+    api_key, _ = await _register(client)
+    await _make_page(client, api_key, "One", "alpha")
+    await _make_page(client, api_key, "Two", "beta")
+
+    resp = await _vfs(client, api_key, "cat '/files/One.md' '/files/Two.md'")
 
     assert resp.status_code == 413
 

--- a/cli/tests/test_app_vfs.py
+++ b/cli/tests/test_app_vfs.py
@@ -190,20 +190,21 @@ def test_app_vfs_grep_no_match_stops_and_chain():
     assert result.stderr == ""
 
 
-def test_app_vfs_grep_rejects_bre_escapes_loudly():
-    """Patterns compile as extended regex, where BRE's `\\|` means a literal pipe —
-    a default-grep caller writing `foo\\|bar` would silently match nothing (this
-    burned Heavi's agent in prod). The shell must refuse with a correction, never
-    return a clean no-match exit 1."""
+def test_app_vfs_grep_accepts_bre_operator_escapes():
+    """Patterns compile as extended regex, but default-grep callers write BRE —
+    `foo\\|bar` (this burned Heavi's agent in prod, twice: first as a silent
+    no-match, then as a hard refusal that cost the agent its search). Both
+    dialects intend an operator there, so the escape must just work; `-F` stays
+    the literal-match path."""
     shell, _client = _shell()
 
-    result = shell.run("grep -ri 'hello\\|missing' /")
+    assert shell.run("grep -ri 'hello\\|missing' /").exit_code == 0
 
-    assert result.exit_code == 2
-    assert "extended" in result.stderr
-
-    # The same intent written as extended regex works.
+    # The same intent written as extended regex still works.
     assert shell.run("grep -ri 'hello|missing' /").exit_code == 0
+
+    # A literal backslash escape that is not a BRE operator is left alone.
+    assert shell.run("grep -ri 'hello\\d' /").exit_code == 1
 
 
 def test_app_vfs_grep_accepts_extended_and_fixed_string_flags():

--- a/stashvfs/__init__.py
+++ b/stashvfs/__init__.py
@@ -2,7 +2,7 @@
 contract that backs them. Shared by the `stash vfs` CLI command and the
 `/api/v1/me/vfs` endpoint."""
 
-from .client import MachineVfsClient, VfsClient, VfsClientError
+from .client import MachineVfsClient, VfsClient, VfsClientError, VfsScanBudget
 from .model import MountError, StashVfsModel
 from .shell import SkillAppVfsShell, VfsCommandResult
 
@@ -14,4 +14,5 @@ __all__ = [
     "VfsClient",
     "VfsClientError",
     "VfsCommandResult",
+    "VfsScanBudget",
 ]

--- a/stashvfs/client.py
+++ b/stashvfs/client.py
@@ -25,6 +25,16 @@ class VfsClientError(Exception):
         super().__init__(str(detail))
 
 
+class VfsScanBudget(Exception):
+    """A document read was refused because the command's scan budget ran out.
+
+    Raised by clients that meter reads (the server-side VFS) for reads issued
+    inside `scan_calls`. The shell stops the grep sweep at this point and
+    reports the results so far with a loud truncation warning — an org-wide
+    sweep degrades to a partial answer instead of an aborted command.
+    """
+
+
 class VfsClient(Protocol):
     """Everything `StashVfsModel` reads. Listing calls run during `refresh()`;
     the rest are lazy loaders fired when a file's bytes are first read."""

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from .client import MachineVfsClient, VfsClient, VfsClientError
+from .client import MachineVfsClient, VfsClient, VfsClientError, VfsScanBudget
 
 BytesLoader = Callable[[], bytes]
 
@@ -57,7 +57,7 @@ class VfsNode:
     # Set when `prefetch` already tried this loader and it failed. `read_file`
     # re-raises it rather than fetching again — a second fetch would hit the
     # provider twice and, server-side, spend the document budget twice.
-    error: VfsClientError | None = None
+    error: VfsClientError | VfsScanBudget | None = None
 
     @property
     def is_dir(self) -> bool:
@@ -180,16 +180,16 @@ class StashVfsModel:
         if len(pending) < 2:
             return
 
-        def load(node: VfsNode) -> tuple[VfsNode, bytes | VfsClientError]:
+        def load(node: VfsNode) -> tuple[VfsNode, bytes | VfsClientError | VfsScanBudget]:
             try:
                 return node, node.loader()
-            except VfsClientError as e:
+            except (VfsClientError, VfsScanBudget) as e:
                 return node, e
 
         workers = min(PREFETCH_CONCURRENCY, len(pending))
         with ThreadPoolExecutor(max_workers=workers) as pool:
             for node, result in pool.map(load, pending):
-                if isinstance(result, VfsClientError):
+                if isinstance(result, (VfsClientError, VfsScanBudget)):
                     node.error = result
                     continue
                 node.content = result

--- a/stashvfs/shell.py
+++ b/stashvfs/shell.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 
-from .client import VfsClientError
+from .client import VfsClientError, VfsScanBudget
 from .model import MountError, StashVfsModel
 
 
@@ -435,9 +435,8 @@ class SkillAppVfsShell:
         if fixed_strings:
             regex = re.compile(re.escape(pattern), flags)
         else:
-            _reject_bre_escapes(pattern)
             try:
-                regex = re.compile(pattern, flags)
+                regex = re.compile(_translate_bre_escapes(pattern), flags)
             except re.error as e:
                 raise VfsShellError(str(e)) from e
 
@@ -459,27 +458,44 @@ class SkillAppVfsShell:
             paths = ["."]
         matches = []
         roots = []
+        # Resolve every root before reading anything (listings are unbudgeted),
+        # so a budget stop can say how much of the sweep went unsearched.
+        sweep: list[list[str]] = []
+        total_files = 0
+        for raw_path in paths:
+            path = self._resolve_path(raw_path)
+            roots.append(path)
+            node = self.model._get_node(path)
+            file_paths = [path] if node.is_file else self._file_paths(path) if recursive else []
+            if node.is_dir and not recursive:
+                raise VfsShellError(f"{raw_path}: is a directory")
+            sweep.append(file_paths)
+            total_files += len(file_paths)
         docs_scanned = 0
+        budget_hit = False
         # The per-document reads below are the mechanics of one search, not
         # documents the user asked to see — scan_calls tags them so analytics
         # skip them, and record_search writes the single search event that
         # stands in for the whole sweep.
         with self.model.client.scan_calls():
-            for raw_path in paths:
-                path = self._resolve_path(raw_path)
-                roots.append(path)
-                node = self.model._get_node(path)
-                file_paths = [path] if node.is_file else self._file_paths(path) if recursive else []
-                if node.is_dir and not recursive:
-                    raise VfsShellError(f"{raw_path}: is a directory")
+            for file_paths in sweep:
+                if budget_hit:
+                    break
                 self.model.prefetch(file_paths)
                 for file_path in file_paths:
-                    docs_scanned += 1
                     try:
                         text = self._read_text(file_path)
+                    except VfsScanBudget:
+                        # Out of reads mid-sweep: report what was found rather
+                        # than aborting, but never silently — the warning below
+                        # marks the results partial.
+                        budget_hit = True
+                        break
                     except VfsClientError as e:
+                        docs_scanned += 1
                         self._warn(f"{name}: {file_path}: {e.detail}")
                         continue
+                    docs_scanned += 1
                     matches.append(
                         _grep_text(
                             regex,
@@ -492,6 +508,12 @@ class SkillAppVfsShell:
                         )
                     )
         self.model.client.record_search(pattern, roots, docs_scanned)
+        if budget_hit:
+            self._warn(
+                f"{name}: stopped after reading {docs_scanned} of {total_files} files "
+                "(server scan budget); matches shown are partial — narrow the paths to "
+                "search the rest"
+            )
         output = "".join(matches)
         if not output:
             raise VfsShellExit(1)
@@ -860,23 +882,28 @@ def _render_printf_template(template: str, values: list[str]) -> tuple[str, int]
     return "".join(output), used
 
 
-def _reject_bre_escapes(pattern: str) -> None:
+def _translate_bre_escapes(pattern: str) -> str:
     """Patterns compile as Python (extended) regex, where BRE's operator escapes
-    `\\|` `\\(` `\\)` mean the *literal* character — so a caller writing default-grep
-    syntax like `foo\\|bar` would silently match nothing. Refuse loudly instead."""
+    `\\|` `\\(` `\\)` would mean the *literal* character — so a caller writing
+    default-grep syntax like `foo\\|bar` would silently match nothing. Both
+    dialects intend an operator there, so treat the escape as the operator;
+    `-F` remains the way to match the character literally."""
+    output: list[str] = []
     index = 0
-    while index < len(pattern) - 1:
-        if pattern[index] != "\\":
-            index += 1
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\" and index + 1 < len(pattern):
+            escaped = pattern[index + 1]
+            if escaped in "|()":
+                output.append(escaped)
+            else:
+                output.append(char)
+                output.append(escaped)
+            index += 2
             continue
-        escaped = pattern[index + 1]
-        if escaped in "|()":
-            raise VfsShellError(
-                f"pattern escape \\{escaped} is BRE syntax; patterns here are extended "
-                f"regex — use {escaped} as the operator, or -F to match text literally",
-                exit_code=2,
-            )
-        index += 2
+        output.append(char)
+        index += 1
+    return "".join(output)
 
 
 def _grep_text(


### PR DESCRIPTION
## What

Two fixes to the VFS shell's `grep`, both hit by Heavi's production agent while running org-wide per-VIN sweeps (`grep -rni '3HTNUAPT3GN749198\|DF677' /sources /files /sessions /memory`):

1. **BRE operator escapes now work.** `'a\|b'` (default-grep syntax) previously exited 2 with a correction. That refusal was itself the fix for an earlier silent-no-match bug — but agents write BRE reflexively and burn a turn (or the whole search) on the error. Since `\|` `\(` `\)` mean the operator in BRE and callers wanting literals have `-F` (which the old error already pointed to), the shell now translates the escape to the operator. Other escapes (`\d`, `\\`) are untouched.

2. **The read budget no longer vaporizes a sweep's results.** Past `MAX_DOCUMENT_READS` (400), the whole command aborted with 413 — a grep that had already found matches returned nothing, and the agent's correct instinct ("search the whole org for this VIN") was unusable. Document reads inside a grep sweep now raise `VfsScanBudget`; the shell stops the sweep, returns the matches found so far, and warns loudly on stderr: `grep: stopped after reading N of M files (server scan budget); matches shown are partial — narrow the paths to search the rest`. Never silent: partial results always carry the warning, and a budget-stopped no-match exits 1 *with* the warning rather than looking like a clean miss.

**Direct reads keep the hard 413** — a `cat` over hundreds of files has no partial result worth salvaging, so `VfsBudgetExceeded` behavior there is unchanged.

## How

- `stashvfs/client.py`: new `VfsScanBudget` exception — the contract for budget-metered clients to signal "scan budget spent" distinctly from a per-node failure.
- `backend/services/vfs_service.py`: `_read_document` raises `VfsScanBudget` when over budget inside `scan_calls`, `VfsBudgetExceeded` (→413) otherwise.
- `stashvfs/shell.py`: grep resolves all roots up front (listings are unbudgeted) so the truncation warning can say how much went unsearched; the sweep catches `VfsScanBudget`, stops, and reports partials. `_reject_bre_escapes` → `_translate_bre_escapes`.
- `stashvfs/model.py`: `prefetch` parks `VfsScanBudget` on the node like a `VfsClientError`, so budget trips inside the pool surface at the sequential read that hits the node.

## Tests

- `test_scan_budget_makes_grep_partial_and_loud` — budget-limited grep returns 200 with "of 2 files"/"partial" on stderr (assertions are prefetch-race-proof).
- `test_document_read_budget_still_aborts_direct_reads` — multi-file `cat` over budget still 413s.
- `test_app_vfs_grep_accepts_bre_operator_escapes` — `'hello\|missing'` matches; non-operator escapes (`\d`) unaffected; replaces the rejection test.
- Full `cli/tests/test_app_vfs.py` + `test_mount_vfs.py` (56) and `backend/tests/test_vfs.py` (14) pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)