### PR TITLE
fix: link Gong documents to original calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Gong call documents now link back to the original call in Gong.
 - `stash vfs stat` once again shows the source-sharing command for connected
   source roots, including roots that do not have an app URL.
 - OAuth reconnects now require a stable provider account identity. Slack,

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -2101,7 +2101,7 @@ def source_document_url(
         return f"https://www.instagram.com/p/{path}/"
     if source_type == "gong_calls":
         return f"https://app.gong.io/call?id={quote(path, safe='')}"
-    # Slack and Granola need provider metadata that we do not store yet.
+    # TODO - Slack and Granola need provider metadata that we do not store yet.
     return None
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -2099,7 +2099,9 @@ def source_document_url(
         return f"https://x.com/i/status/{path.rsplit('/', 1)[-1]}"
     if source_type == "instagram_saves":
         return f"https://www.instagram.com/p/{path}/"
-    # slack, granola, gong_calls: deep link TODO — needs team domain / note url / gong subdomain.
+    if source_type == "gong_calls":
+        return f"https://app.gong.io/call?id={quote(path, safe='')}"
+    # Slack and Granola need provider metadata that we do not store yet.
     return None
 
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1376,6 +1376,12 @@ async def test_gong_visibility_requires_account_allowlist(client: AsyncClient):
     blocked_hits = await source_service.search_documents(user_id=owner_id, query="blocked revenue")
     assert len(allowed_hits) == 1
     assert blocked_hits == []
+    source_ok, allowed_call = await source_service.source_document(
+        ws, owner_id, configured["id"], "call-1"
+    )
+    assert source_ok is True
+    assert allowed_call is not None
+    assert allowed_call["url"] == "https://app.gong.io/call?id=call-1"
 
 
 @pytest.mark.asyncio
@@ -3126,7 +3132,7 @@ async def test_read_source_rejects_unowned_connected_source(client: AsyncClient)
 
 def test_source_document_url_builds_provider_deep_links():
     """source_document_url derives a canonical provider URL from stored refs, and
-    returns None for sources we can't deep-link yet (Slack/Gong/Granola)."""
+    returns None for sources we can't deep-link yet (Slack/Granola)."""
     # GitHub: source external_ref is owner/repo, path is the file.
     assert (
         source_service.source_document_url("github_repo", "acme/widgets", "src/app.py")
@@ -3147,6 +3153,11 @@ def test_source_document_url_builds_provider_deep_links():
     assert (
         source_service.source_document_url("notion", None, "abc-def")
         == "https://www.notion.so/abcdef"
+    )
+    # Gong stores the call id as the document path.
+    assert (
+        source_service.source_document_url("gong_calls", "calls", "7782342274025937895")
+        == "https://app.gong.io/call?id=7782342274025937895"
     )
     # Slack has no deep link yet → None.
     assert source_service.source_document_url("slack", "T123", "#eng/1.ts") is None


### PR DESCRIPTION
## Summary

- add canonical Gong call URLs to connected-source documents
- return the link only after existing ownership and workspace-allowlist checks pass
- cover both URL construction and the authorized document-read path

## Why

Gong calls were indexed with their stable call IDs, but Stash returned no provider URL for them. Users could read and search a call in Stash without a direct way to open the original in Gong. Gong documents the call page format as `https://app.gong.io/call?id={id}`, so the existing stored path is sufficient and no schema change is needed.

## Impact

Gong source documents now include a canonical link back to the original call. Other source providers are unchanged.

## Validation

- `python -m pytest backend/tests/test_sources.py::test_gong_visibility_requires_account_allowlist backend/tests/test_sources.py::test_source_document_url_builds_provider_deep_links -q --no-cov` (2 passed)
- `python -m pytest backend/tests/test_sources.py -q --no-cov` (104 passed)
- `ruff check backend/ cli/`
- `ruff format --check backend/ cli/`
- independent review: no findings