### PR TITLE
fix: resolve .mcp.json sync path for local exec mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Scheduled agent runs no longer crash in local dev mode: the MCP registry's
+  `.mcp.json` is now written to the local simulated workdir instead of the
+  literal `/home/sprite/work` path, which is unwritable on dev machines.
 - Gong call documents now link back to the original call in Gong.
 - `stash vfs stat` once again shows the source-sharing command for connected
   source roots, including roots that do not have an app URL.

--- a/backend/services/mcp_server_service.py
+++ b/backend/services/mcp_server_service.py
@@ -115,8 +115,6 @@ async def sync_sprite_config(user_id: UUID, sprite: sprite_service.Sprite) -> No
     """
     servers = await list_servers(user_id)
     config = {"mcpServers": {s["name"]: claude_entry(s) for s in servers}}
-    await sprite_service.write_file(
-        sprite,
-        f"{sprite_service.SPRITE_WORKDIR}/.mcp.json",
-        json.dumps(config, indent=2) + "\n",
+    await sprite_service.write_workdir_file(
+        sprite, ".mcp.json", json.dumps(config, indent=2) + "\n"
     )

--- a/backend/services/sprite_service.py
+++ b/backend/services/sprite_service.py
@@ -484,6 +484,15 @@ async def write_file(sprite: Sprite, abs_path: str, contents: str) -> None:
         raise SpriteError(f"write_file failed for {abs_path}")
 
 
+async def write_workdir_file(sprite: Sprite, rel_path: str, contents: str) -> None:
+    """Write a workdir-relative file, resolved for the active exec mode.
+
+    Callers must not hardcode SPRITE_WORKDIR: in local mode the exec layer
+    translates the cwd but not argv, so an absolute /home/sprite path would be
+    written literally on the developer's machine."""
+    await write_file(sprite, _box_path(rel_path), contents)
+
+
 async def fs_list(sprite: Sprite, rel_path: str) -> list[dict]:
     """Directory entries at a workdir-relative path on the box."""
     output, code = await exec_collect(

--- a/backend/tests/test_sprite_agent_mapping.py
+++ b/backend/tests/test_sprite_agent_mapping.py
@@ -278,3 +278,26 @@ def test_box_path_rejects_escapes(monkeypatch):
     for bad in ("../etc/passwd", "../.ssh/id_rsa", "..", "a/../../.."):
         with pytest.raises(sprite_service.FsPathError):
             sprite_service._box_path(bad)
+
+
+@pytest.mark.asyncio
+async def test_write_workdir_file_resolves_per_exec_mode(monkeypatch):
+    from backend.services import sprite_service
+
+    written: list[str] = []
+
+    async def fake_write_file(sprite, abs_path, contents):
+        written.append(abs_path)
+
+    monkeypatch.setattr(sprite_service, "write_file", fake_write_file)
+    sprite = sprite_service.Sprite(name="test")
+
+    monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
+    await sprite_service.write_workdir_file(sprite, ".mcp.json", "{}")
+    assert written[-1] == "/home/sprite/work/.mcp.json"
+
+    # Local mode must land inside the simulated workdir, never the literal
+    # /home/sprite path — /home is root-owned on dev machines.
+    monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "local")
+    await sprite_service.write_workdir_file(sprite, ".mcp.json", "{}")
+    assert written[-1] == str(sprite_service._local_workdir() / ".mcp.json")


### PR DESCRIPTION
## Abbreviated Summary

When running locally, curator agents (and other schedule agents) would crash due to not having permission to write to home/sprite). This PR adds a check to switch to ~/.stash-dev-sprite instead if running locally.

## Summary (AI-generated below this line)

Every scheduled agent run in local dev mode (`AGENT_EXEC_MODE=local`, the default) crashed with `SpriteError('write_file failed for /home/sprite/work/.mcp.json')` before the agent even started.

`sync_sprite_config` (added in #884) hardcodes the Sprites-VM workdir path when writing the MCP registry as `.mcp.json`. The local exec layer translates only the **cwd** (`/home/sprite/work` → `~/.stash-dev-sprite/work`), not **argv**, so the write helper literally ran `os.makedirs('/home/sprite', ...)` on the developer's machine — `/home` is a root-owned read-only autofs mount on macOS, so the child exits 1 and the run dies.

## Changes

- New `sprite_service.write_workdir_file(sprite, rel_path, contents)`: writes a workdir-relative file, resolving the path with the existing mode-aware `_box_path` (Sprites → `/home/sprite/work`, local → the simulated workdir).
- `sync_sprite_config` uses it instead of hardcoding `SPRITE_WORKDIR`.
- Regression test asserting the resolved path in both exec modes.
- Sprites-mode behavior is unchanged (`/home/sprite/work/.mcp.json`, same as before).

The OAuth credential-file writes also hardcode `/home/sprite` paths, but local mode never injects credential files (`agent_auth` returns bare `RunAuth(harness=CLAUDE)`), so `sync_sprite_config` was the only local-mode caller affected.

## Verification

- `pytest backend/tests/test_sprite_agent_mapping.py`: passed, including the new `test_write_workdir_file_resolves_per_exec_mode`
- `pytest backend/tests/test_mcp_servers.py`: 11 passed; `test_registered_servers_reach_the_sprite_mcp_config` fails identically on clean `main` in this environment (pre-existing, unrelated)
- `ruff check` / `ruff format --check` on changed files: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)