### PR TITLE
Fix shared upload links, and HTML uploads that lost their images

### DIFF
--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -58,11 +58,38 @@ _SVG_TAGS = {
     "polygon",
     "text",
     "tspan",
+    "textPath",
     "linearGradient",
     "radialGradient",
     "stop",
     "clipPath",
+    # Exporters lean on these constantly, and dropping a container is worse
+    # than dropping a leaf: nh3 keeps a stripped tag's CHILDREN, so a missing
+    # <mask> turned its shapes into visible ones painted over the diagram.
+    "symbol",
+    "use",
+    "mask",
+    "pattern",
+    "image",
+    "filter",
+    "feGaussianBlur",
+    "feOffset",
+    "feFlood",
+    "feComposite",
+    "feBlend",
+    "feMerge",
+    "feMergeNode",
+    "feDropShadow",
+    "feColorMatrix",
+    # <desc> renders nothing in a browser, but stripping the tag used to spill
+    # its text into the diagram as stray words.
+    "desc",
 }
+# Deliberately absent: <script> and <foreignObject>. foreignObject re-opens the
+# HTML namespace inside SVG, which is exactly the escape hatch this allowlist
+# exists to close. SVG <title> (a tooltip) is dropped with its text by
+# clean_content_tags below — nh3 can't tell it apart from a document <title>,
+# and letting document titles through leaks them into the body as bare text.
 _SVG_ATTRS = {
     "viewBox",
     "xmlns",
@@ -115,6 +142,32 @@ _SVG_ATTRS = {
     "stop-opacity",
     "clip-path",
     "clip-rule",
+    # References into <defs>: `href` for <use>/<textPath>/<image>, and the
+    # url(#id) attributes that point at a mask/pattern/filter.
+    "href",
+    "xlink:href",
+    "mask",
+    "filter",
+    "maskUnits",
+    "maskContentUnits",
+    "patternUnits",
+    "patternContentUnits",
+    "patternTransform",
+    "clipPathUnits",
+    "filterUnits",
+    "primitiveUnits",
+    "result",
+    "in",
+    "in2",
+    "mode",
+    "stdDeviation",
+    "flood-color",
+    "flood-opacity",
+    "values",
+    "type",
+    "operator",
+    "spreadMethod",
+    "startOffset",
 }
 _SANITIZE_TAGS = (
     nh3.ALLOWED_TAGS

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -88,6 +88,62 @@ async def test_inline_svg_keeps_geometry(scope, _db_pool):
 
 
 @pytest.mark.asyncio
+async def test_inline_svg_keeps_defs_referenced_by_url(scope, _db_pool):
+    """Real exporters lean on <mask>, <pattern>, <filter>, <use>/<symbol> and
+    <image>. Dropping a container is worse than dropping a leaf: nh3 keeps a
+    stripped tag's CHILDREN, so a discarded <mask> repainted its shapes on top
+    of the diagram, and a discarded <symbol> duplicated every icon."""
+    scope_id, user_id = scope
+    diagram = (
+        '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">'
+        "<defs>"
+        '<symbol id="ic"><path d="M0 0 L4 4"/></symbol>'
+        '<mask id="m"><rect width="10" height="10" fill="#fff"/></mask>'
+        '<pattern id="p" patternUnits="userSpaceOnUse"><rect width="2" height="2"/></pattern>'
+        '<filter id="f"><feGaussianBlur stdDeviation="2"/></filter>'
+        "</defs>"
+        '<use href="#ic"/>'
+        '<rect width="50" height="50" mask="url(#m)" fill="url(#p)" filter="url(#f)"/>'
+        '<image href="https://cdn.example/chart.png" width="20" height="20"/>'
+        "</svg>"
+    )
+    page = await files_tree_service.create_page(
+        owner_user_id=scope_id,
+        name="Rich diagram",
+        created_by=user_id,
+        content_type="html",
+        content_html=diagram,
+    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
+    for tag in ("<symbol", "<use", "<mask", "<pattern", "<filter", "<feGaussianBlur", "<image"):
+        assert tag in stored, f"{tag} was stripped — its children would paint over the diagram"
+    for attr in ('mask="url(#m)"', 'fill="url(#p)"', 'filter="url(#f)"', 'stdDeviation="2"'):
+        assert attr in stored
+
+
+@pytest.mark.asyncio
+async def test_foreign_object_is_never_allowed(scope, _db_pool):
+    """<foreignObject> re-opens the HTML namespace inside SVG — the exact
+    escape hatch the SVG allowlist exists to close. Widening the allowlist for
+    diagram fidelity must never let it back in."""
+    scope_id, user_id = scope
+    page = await files_tree_service.create_page(
+        owner_user_id=scope_id,
+        name="Hostile diagram",
+        created_by=user_id,
+        content_type="html",
+        content_html=(
+            '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject>'
+            '<use href="javascript:alert(1)"/></svg>'
+        ),
+    )
+    stored = await _db_pool.fetchval("SELECT content_html FROM pages WHERE id = $1", page["id"])
+    assert "foreignObject" not in stored
+    assert "onerror" not in stored
+    assert "javascript:" not in stored
+
+
+@pytest.mark.asyncio
 async def test_title_text_does_not_leak_into_body(scope, _db_pool):
     """A full HTML document carries a <title>. nh3 drops the (disallowed) tag,
     but without clean_content_tags it would keep the title's text and render it

--- a/cli/client.py
+++ b/cli/client.py
@@ -291,6 +291,19 @@ class StashClient:
     def list_object_shares(self, object_type: str, object_id: str) -> list:
         return self._list("/api/v1/share", "shares", object_type=object_type, object_id=object_id)
 
+    def set_general_access(self, object_type: str, object_id: str, public_permission: str) -> dict:
+        """The "anyone with the link" level for a page/file/folder/table.
+        Uploads are private until this is set, so the app_url an upload returns
+        opens only for its owner."""
+        return self._patch(
+            "/api/v1/share/general-access",
+            json={
+                "object_type": object_type,
+                "object_id": object_id,
+                "public_permission": public_permission,
+            },
+        )
+
     # --- Session folders (shareable grouping for sessions) ---
 
     def list_session_folders(self) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -7,6 +7,7 @@ import json
 import re
 import shutil
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
@@ -1282,6 +1283,11 @@ _UPLOAD_TEXT_EXTENSIONS = {
 }
 
 
+# Mirrors backend files_tree_service.HTML_EXTS — these become HTML pages
+# server-side, so the CLI must not pre-empt that by posting them as markdown.
+_HTML_UPLOAD_EXTENSIONS = {".html", ".htm"}
+
+
 def _is_upload_text_file(path: Path) -> bool:
     return path.suffix.lower() in _UPLOAD_TEXT_EXTENSIONS
 
@@ -1335,15 +1341,27 @@ def upload(
         "--public/--private",
         help="Skill visibility (only meaningful with --skill).",
     ),
+    public_link: bool = typer.Option(
+        False,
+        "--public-link",
+        help=(
+            "Give the upload an 'anyone with the link' grant, so the returned "
+            "app_url opens for people you send it to. Without this an upload "
+            "is private and its link works only for you."
+        ),
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Upload a local file or directory into your Files.
 
     A single file lands directly in your Files (Markdown/HTML become
-    editable pages, everything else a binary file) and the returned
-    ``app_url`` is the share link. A directory becomes a folder, and
+    editable pages, everything else a binary file). A directory becomes a folder, and
     every text file in it — Markdown, HTML, code, CSV, and friends —
     becomes an editable page. **No Skill is created.**
+
+    Uploads are private. The returned ``app_url`` opens for you alone unless
+    you pass ``--public-link``, which adds an "anyone with the link" grant —
+    that is what makes the URL worth handing to someone else.
 
     Pass ``--skill <title>`` to *also* bundle the upload into a shareable
     Skill. Use a Skill when you're publishing a folder of related
@@ -1352,6 +1370,11 @@ def upload(
     upload."""
     _require_auth()
     telemetry.record("upload")
+    # Callers that invoke this function directly bypass Typer's default
+    # resolution, so an unset flag arrives as a (truthy) OptionInfo. Publishing
+    # someone's upload to anyone-with-the-link is not a mistake we can make by
+    # accident, so nothing short of a literal True counts.
+    public_link = public_link is True
     target = Path(path)
     if not target.exists():
         console.print(f"[red]Not found: {path}[/red]")
@@ -1363,14 +1386,26 @@ def upload(
         with _client() as c:
             try:
                 data = _upload_path(c, str(target))
+                if public_link:
+                    c.set_general_access(data["kind"], data["id"], "read")
+                    # An HTML page's pictures are separate file rows; without
+                    # their own grant the shared page shows broken images.
+                    for asset_id in data.get("asset_file_ids") or []:
+                        c.set_general_access("file", asset_id, "read")
             except StashError as e:
                 _err(e)
+        data["public_link"] = public_link
         if _use_json(as_json):
             output_json(data)
             return
         label = "Uploaded as page" if data.get("kind") == "page" else "Uploaded"
         console.print(f"[green]{label}[/green] {data['name']}  [dim]{data['id']}[/dim]")
         console.print(data["app_url"])
+        if not public_link:
+            console.print(
+                "[dim]Private — only you can open that link. "
+                "Re-run with --public-link to share it.[/dim]"
+            )
         return
 
     files = _upload_file_list(target)
@@ -1387,7 +1422,12 @@ def upload(
         root_folder = c.create_folder(root_name)
         folder_cache: dict[tuple[str, str], str] = {}
 
-        for file_path in files:
+        # HTML last: by then every sibling picture has been uploaded, so the
+        # markup can be rewritten to point at those files instead of re-
+        # uploading them.
+        asset_urls: dict[Path, str] = {}
+        html_files = [f for f in files if f.suffix.lower() in _HTML_UPLOAD_EXTENSIONS]
+        for file_path in [f for f in files if f not in html_files] + html_files:
             relative_path = (
                 file_path.relative_to(target) if target.is_dir() else Path(file_path.name)
             )
@@ -1398,6 +1438,16 @@ def upload(
                 relative_path,
             )
 
+            # HTML goes through the server's ingest, which files it as an HTML
+            # page. Reading it here and posting it as `content` would store the
+            # markup in the markdown field, where it renders as escaped source
+            # instead of a page — the same file uploaded on its own renders
+            # correctly, and that inconsistency is the bug.
+            if file_path in html_files:
+                _upload_html_with_assets(c, file_path, folder_id, asset_urls)
+                console.print(f"  [dim]Page: {relative_path}[/dim]")
+                continue
+
             if _is_upload_text_file(file_path):
                 content = file_path.read_text(errors="replace")
                 c.create_page(file_path.name, content=content, folder_id=folder_id)
@@ -1407,6 +1457,7 @@ def upload(
             # Creating the stub page embeds the binary: the server claims any
             # root file whose download link appears in a saved page body.
             uploaded = c.upload_file(str(file_path))
+            asset_urls[file_path.resolve()] = f"/api/v1/me/files/{uploaded['id']}/download"
             c.create_page(
                 file_path.name,
                 content=_markdown_snippet(uploaded),
@@ -1416,6 +1467,11 @@ def upload(
 
         folder_url = f"{_web_app_url()}/folders/{root_folder['id']}"
         result: dict = {"folder": root_folder, "app_url": folder_url}
+        if public_link:
+            # Folder shares cascade to their contents at read time, so one
+            # grant on the root covers every page and file just uploaded.
+            c.set_general_access("folder", root_folder["id"], "read")
+            result["public_link"] = True
 
         if create_skill:
             # A skill is a folder with a SKILL.md; publishing makes it public.
@@ -3994,7 +4050,89 @@ def _upload_path(c: StashClient, path: str) -> dict:
     if not Path(path).is_file():
         console.print(f"[red]Not a file: {path}[/red]")
         raise typer.Exit(1)
+    if Path(path).suffix.lower() in _HTML_UPLOAD_EXTENSIONS:
+        return _upload_html_with_assets(c, Path(path))
     return c.upload_file(path)
+
+
+# src="chart.png" / href="logo.svg" / poster="…" / url(bg.png) — the forms an
+# exported HTML file uses to point at a picture sitting next to it.
+_HTML_ASSET_REF = re.compile(
+    r"""(?P<prefix>(?:src|href|poster)\s*=\s*["']|url\(\s*["']?)(?P<url>[^"')]+)""",
+    re.IGNORECASE,
+)
+_HTML_ASSET_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".svg",
+    ".avif",
+    ".bmp",
+    ".ico",
+    ".mp4",
+    ".webm",
+    ".ogg",
+    ".mp3",
+    ".wav",
+}
+
+
+def _upload_html_with_assets(
+    c: StashClient,
+    html_path: Path,
+    folder_id: str | None = None,
+    known_assets: dict[Path, str] | None = None,
+) -> dict:
+    """Upload an HTML file along with the pictures it points at.
+
+    An exported report references its images by relative path. Uploading only
+    the markup leaves every one of them pointing at a path that doesn't exist
+    on the server, so the page renders with broken images. Each referenced file
+    that exists on disk is uploaded and its reference rewritten to the file's
+    permanent download route — the one route that also serves viewers holding a
+    public link. Anything already uploaded by the caller (`known_assets`) is
+    reused rather than uploaded twice.
+    """
+    html = html_path.read_text(errors="replace")
+    uploaded: dict[Path, str] = dict(known_assets or {})
+    rewritten: dict[str, str] = {}
+    # Assets uploaded here sit at the root with no parent folder, so they
+    # inherit no visibility. A public page whose pictures stay private renders
+    # with broken images, so the caller has to grant them too.
+    asset_file_ids: list[str] = []
+
+    for match in _HTML_ASSET_REF.finditer(html):
+        ref = match.group("url").strip()
+        if ref in rewritten or not ref:
+            continue
+        # Absolute URLs, data: payloads, and in-page anchors are already fine.
+        if ref.startswith(("http://", "https://", "//", "data:", "#", "mailto:", "/")):
+            continue
+        asset = (html_path.parent / ref.split("?")[0].split("#")[0]).resolve()
+        if asset.suffix.lower() not in _HTML_ASSET_EXTENSIONS or not asset.is_file():
+            continue
+        if asset not in uploaded:
+            asset_id = c.upload_file(str(asset))["id"]
+            uploaded[asset] = f"/api/v1/me/files/{asset_id}/download"
+            asset_file_ids.append(asset_id)
+            console.print(f"  [dim]Asset: {asset.name}[/dim]")
+        rewritten[ref] = uploaded[asset]
+
+    if rewritten:
+        for ref, url in rewritten.items():
+            html = html.replace(ref, url)
+        # The server names the page from the filename, so the rewritten copy
+        # has to keep it.
+        with tempfile.TemporaryDirectory() as tmp:
+            staged = Path(tmp) / html_path.name
+            staged.write_text(html)
+            page = c.upload_file(str(staged), folder_id)
+    else:
+        page = c.upload_file(str(html_path), folder_id)
+    page["asset_file_ids"] = asset_file_ids
+    return page
 
 
 def _get_file_meta(c: StashClient, file_id: str) -> dict:

--- a/cli/tests/test_upload_html_assets.py
+++ b/cli/tests/test_upload_html_assets.py
@@ -1,0 +1,108 @@
+"""Uploading an HTML file has to bring its pictures with it.
+
+An exported report points at its images by relative path. Uploading only the
+markup leaves each one pointing at a path that exists on the author's disk and
+nowhere else, so the page renders with broken images. The upload rewrites those
+references to the files' permanent download route — the one route that also
+serves a viewer holding a public link.
+"""
+
+from pathlib import Path
+
+from cli.main import _upload_html_with_assets
+
+
+class FakeClient:
+    """Records uploads and hands back predictable file ids."""
+
+    def __init__(self):
+        self.uploads: list[tuple[str, str | None]] = []
+        self.sent_html = ""
+        self._next = 0
+
+    def upload_file(self, path: str, folder_id: str | None = None) -> dict:
+        name = Path(path).name
+        self.uploads.append((name, folder_id))
+        if name.endswith(".html"):
+            self.sent_html = Path(path).read_text()
+        self._next += 1
+        return {"id": f"file-{self._next}", "name": name, "kind": "file"}
+
+
+def _write(tmp_path: Path, html: str) -> Path:
+    (tmp_path / "chart.png").write_bytes(b"\x89PNG fake")
+    report = tmp_path / "report.html"
+    report.write_text(html)
+    return report
+
+
+def test_relative_image_is_uploaded_and_rewritten(tmp_path: Path) -> None:
+    report = _write(tmp_path, '<img src="chart.png">')
+    client = FakeClient()
+
+    page = _upload_html_with_assets(client, report)
+
+    # The picture went up, and the markup now points at it rather than at a
+    # path that only exists on the author's machine.
+    assert ("chart.png", None) in client.uploads
+    assert page["asset_file_ids"] == ["file-1"]
+    assert client.sent_html == '<img src="/api/v1/me/files/file-1/download">'
+    # The page is named from the filename, so the rewritten copy keeps it.
+    assert ("report.html", None) in client.uploads
+
+
+def test_svg_and_css_references_are_followed(tmp_path: Path) -> None:
+    (tmp_path / "logo.svg").write_text("<svg/>")
+    report = tmp_path / "report.html"
+    report.write_text(
+        '<svg><image href="logo.svg"/></svg><div style="background: url(logo.svg)"></div>'
+    )
+    client = FakeClient()
+
+    page = _upload_html_with_assets(client, report)
+
+    # One upload for the one file, even though it's referenced twice and
+    # through two different syntaxes.
+    assert [n for n, _ in client.uploads if n == "logo.svg"] == ["logo.svg"]
+    assert page["asset_file_ids"] == ["file-1"]
+
+
+def test_remote_and_data_urls_are_left_alone(tmp_path: Path) -> None:
+    report = _write(
+        tmp_path,
+        '<img src="https://cdn.example/a.png">'
+        '<img src="data:image/png;base64,AAAA">'
+        '<a href="#section">jump</a>',
+    )
+    client = FakeClient()
+
+    page = _upload_html_with_assets(client, report)
+
+    assert page["asset_file_ids"] == []
+    assert [n for n, _ in client.uploads] == ["report.html"]
+
+
+def test_missing_asset_does_not_fail_the_upload(tmp_path: Path) -> None:
+    """A reference to a file the author didn't ship is their problem to fix —
+    it must not cost them the upload."""
+    report = tmp_path / "report.html"
+    report.write_text('<img src="nope.png">')
+    client = FakeClient()
+
+    page = _upload_html_with_assets(client, report)
+
+    assert page["asset_file_ids"] == []
+    assert [n for n, _ in client.uploads] == ["report.html"]
+
+
+def test_assets_already_uploaded_are_reused(tmp_path: Path) -> None:
+    """A directory upload sends the pictures first; the HTML pass must point at
+    those rows instead of uploading a second copy of every image."""
+    report = _write(tmp_path, '<img src="chart.png">')
+    client = FakeClient()
+    known = {(tmp_path / "chart.png").resolve(): "/api/v1/me/files/existing/download"}
+
+    page = _upload_html_with_assets(client, report, folder_id="folder-1", known_assets=known)
+
+    assert [n for n, _ in client.uploads] == ["report.html"]
+    assert page["asset_file_ids"] == []

--- a/frontend/managed/auth0/ExchangeAndRedirect.tsx
+++ b/frontend/managed/auth0/ExchangeAndRedirect.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { API_BASE, getAuth0AccessToken, revokeStoredApiKey } from "@/lib/api";
 import { auth0LogoutUrl } from "@/lib/authLogout";
+import { localNextPath } from "@/lib/loginRedirect";
 
 type Props = {
   cliSession?: string | null;
@@ -13,6 +14,11 @@ type Props = {
 
 export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Someone who clicked a link they couldn't read yet arrives with ?next=.
+  // Without honoring it, signing in dumps them on the home page and the link
+  // they were trying to open is lost.
+  const nextPath = localNextPath(searchParams.get("next"));
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -62,13 +68,13 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
         router.push("/onboarding");
         return;
       }
-      // Returning user: land on their home.
-      if (!cancelled) router.push("/");
+      // Returning user: back to whatever they were opening, else their home.
+      if (!cancelled) router.push(nextPath || "/");
     })();
     return () => {
       cancelled = true;
     };
-  }, [cliSession, provisionBrowserSession, router]);
+  }, [cliSession, provisionBrowserSession, router, nextPath]);
 
   async function handleAuthorizeCli() {
     if (!cliSession) return;
@@ -116,12 +122,24 @@ export default function ExchangeAndRedirect({ cliSession, onCliApproved }: Props
   }
 
   if (error) {
+    // This branch is reached *while already signed in to Auth0* — the session
+    // exists but couldn't produce a usable token. "Try again" re-runs the same
+    // silent auth and fails identically, so signing out is the only real way
+    // out and has to be offered here.
     return (
       <div className="text-center space-y-3">
         <p className="text-sm text-red-400">{error}</p>
-        <a href="/auth/login" className="text-sm text-brand hover:underline">
-          Try again
-        </a>
+        <p className="text-xs text-muted">
+          Your sign-in session has expired. Signing out and back in will fix it.
+        </p>
+        <div className="flex flex-col items-center gap-2">
+          <a href={auth0LogoutUrl()} className="text-sm text-brand hover:underline">
+            Sign out and start over
+          </a>
+          <a href="/auth/login" className="text-[11px] text-muted hover:text-foreground">
+            Try again
+          </a>
+        </div>
       </div>
     );
   }

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.test.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.test.tsx
@@ -1,0 +1,110 @@
+/** A file link handed to someone else must open, not bounce.
+ *
+ * `stash upload` hands back /f/<id>, and files can carry an "anyone with the
+ * link" grant — so the viewer has to attempt the read before deciding anyone
+ * is signed out. Redirecting first made every public file link unreachable,
+ * and sent people who were signed in elsewhere into a login they didn't need.
+ */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FileViewerPage from "./FileClient";
+
+const api = vi.hoisted(() => {
+  class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = "ApiError";
+    }
+  }
+  return {
+    ApiError,
+    getFile: vi.fn(),
+    getFolderContents: vi.fn(),
+    getPublicSkill: vi.fn(),
+    ingestCsvFile: vi.fn(),
+    ingestXlsxFile: vi.fn(),
+    trashItem: vi.fn(),
+    updateFile: vi.fn(),
+  };
+});
+
+const route = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn(), search: "" }));
+const auth = vi.hoisted(() => ({ user: null as unknown, loading: false }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: route.push, replace: route.replace }),
+  useSearchParams: () => new URLSearchParams(route.search),
+}));
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => auth }));
+vi.mock("@/lib/api", () => api);
+vi.mock("@/components/BreadcrumbContext", () => ({ useBreadcrumbs: vi.fn() }));
+vi.mock("@/components/ShellChromeContext", () => ({ useShareAction: vi.fn() }));
+vi.mock("@/components/ConfirmDialog", () => ({ useConfirm: () => vi.fn() }));
+vi.mock("@/lib/pins", () => ({ recordRecent: vi.fn() }));
+vi.mock("@/lib/memory-folder", () => ({
+  sectionCrumbs: () => [],
+  useMemoryFolderId: () => null,
+}));
+vi.mock("@/components/SkeletonStates", () => ({
+  FileViewerSkeleton: () => <div>Loading file</div>,
+}));
+vi.mock("@/components/share/ResourceShareButton", () => ({ default: () => null }));
+vi.mock("@/components/content/FileViewerHeader", () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/content/FileContentRenderer", () => ({
+  default: () => <div>file contents</div>,
+  isImage: () => false,
+  isMarkdown: () => false,
+  isPdf: () => false,
+  isText: () => true,
+}));
+
+const PUBLIC_FILE = {
+  id: "file-1",
+  owner_user_id: "someone-else",
+  folder_id: null,
+  name: "report.png",
+  content_type: "image/png",
+  size_bytes: 10,
+  url: "https://blob.example/report.png",
+  app_url: "/f/file-1",
+  uploaded_by: "someone-else",
+  created_at: "2026-07-24T00:00:00Z",
+};
+
+beforeEach(() => {
+  route.push.mockClear();
+  route.search = "";
+  auth.user = null;
+  auth.loading = false;
+  api.getFile.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("signed-out visitor with a file link", () => {
+  it("sees a file that has a public link instead of a login redirect", async () => {
+    api.getFile.mockResolvedValue(PUBLIC_FILE);
+
+    render(<FileViewerPage fileId="file-1" />);
+
+    await waitFor(() => expect(screen.getByText("file contents")).toBeTruthy());
+    expect(route.push).not.toHaveBeenCalled();
+  });
+
+  it("is sent to sign in carrying the file link when the read is refused", async () => {
+    api.getFile.mockRejectedValue(new api.ApiError(404, "Not found"));
+
+    render(<FileViewerPage fileId="file-1" />);
+
+    // Without `next` a successful sign-in would land them on the home page,
+    // silently losing the link they clicked.
+    await waitFor(() =>
+      expect(route.push).toHaveBeenCalledWith("/login?next=%2Ff%2Ffile-1"),
+    );
+  });
+});

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -5,6 +5,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { useShareAction } from "@/components/ShellChromeContext";
+import { loginPathWithNext } from "@/lib/loginRedirect";
 import { recordRecent } from "@/lib/pins";
 import { FileViewerSkeleton } from "@/components/SkeletonStates";
 import { useAuth } from "@/hooks/useAuth";
@@ -183,18 +184,26 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
       ) {
         if (await loadSkillFallback()) return;
       }
+      // Only a signed-out visitor who genuinely can't read this file is sent
+      // to sign in. Redirecting before the read would make every "anyone with
+      // the link" file unreachable — and bounce signed-in-elsewhere visitors
+      // into a login they don't need. `next` carries them back here after,
+      // instead of dropping them on the home page.
+      if (!user) {
+        router.push(loginPathWithNext(`/f/${fileId}`));
+        return;
+      }
       setError(e instanceof Error ? e.message : "Failed to load file");
     }
-  }, [fileId, router, skillSlug, loadSkillFallback]);
+  }, [fileId, router, skillSlug, loadSkillFallback, user]);
 
+  // Anonymous visitors attempt the read too: getFile is the authorization
+  // gate, and it succeeds for a file with a public link.
   useEffect(() => {
-    if (user) load();
-    else if (!loading && skillSlug) void loadSkillFallback();
+    if (loading) return;
+    if (user || !skillSlug) load();
+    else void loadSkillFallback();
   }, [user, loading, load, loadSkillFallback, skillSlug]);
-
-  useEffect(() => {
-    if (!loading && !user && !skillSlug) router.push("/login");
-  }, [user, loading, router, skillSlug]);
 
   const shareAction = useMemo(() => {
     if (!file || readOnly || !user) return null;
@@ -211,7 +220,8 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
   useShareAction(shareAction);
 
   if (loading) return <FileViewerSkeleton />;
-  if (!user && !skillSlug) return null;
+  // No `user` check here: a signed-out visitor holding a public link gets the
+  // file. One who can't read it was already redirected to sign in.
   if (!file && !error) return <FileViewerSkeleton />;
 
   const fileKindLabel = file ? kindLabel(file.content_type, file.name) : "";

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -23,6 +23,7 @@ import {
   SKILL_MD,
   skillMdTemplate,
 } from "@/lib/localSkill";
+import { loginPathWithNext } from "@/lib/loginRedirect";
 import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
 
@@ -85,9 +86,13 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
     }
   }, [skillSlug, folderId]);
 
+  // Signed-out visitors attempt the read too — getFolderContents is the
+  // authorization gate and succeeds for a folder with a public link. Only a
+  // failed read sends them to sign in (below).
   useEffect(() => {
-    if (!user) {
-      if (!loading && skillSlug) void loadSkillFallback();
+    if (loading) return;
+    if (!user && skillSlug) {
+      void loadSkillFallback();
       return;
     }
     let cancelled = false;
@@ -113,7 +118,9 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
           (e.status === 401 || e.status === 403 || e.status === 404)
         ) {
           await loadSkillFallback();
+          return;
         }
+        if (!user) router.push(loginPathWithNext(`/folders/${folderId}`));
       });
     return () => {
       cancelled = true;
@@ -163,16 +170,13 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
   }, [folderId, folderName, skillSlug, user, convertToSkill, converting]);
   useShareAction(shareAction);
 
-  useEffect(() => {
-    if (!loading && !user && !skillSlug) router.push("/login");
-  }, [user, loading, router, skillSlug]);
-
   if (loading) return <FileBrowserSkeleton />;
   if (skillFallback) {
     return <SkillFallbackFolderView {...skillFallback} />;
   }
-  if (!user) {
-    if (!skillSlug) return null;
+  // A signed-out visitor whose read succeeded is holding a public link — show
+  // them the folder. One whose read failed is already on their way to sign in.
+  if (!user && !folderName) {
     if (!error) return <FileBrowserSkeleton />;
     return (
       <div className="mx-auto max-w-md py-24 text-center">

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { ReactNode } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { loginPathWithNext } from "@/lib/loginRedirect";
 import { recordRecent } from "@/lib/pins";
 import { PageBody } from "../../skills/[slug]/SkillItemBodies";
 import {
@@ -266,7 +267,7 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       // A logged-out visitor who can't read this page (it has no public link)
       // is sent to sign in rather than shown a raw error.
       if (!user) {
-        router.push("/login");
+        router.push(loginPathWithNext(`/p/${pageId}`));
         return;
       }
       setError(e instanceof Error ? e.message : "Failed to load page");

--- a/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
@@ -21,6 +21,7 @@ import CustomSelect from "../../../../components/CustomSelect";
 import { downloadBlob } from "../../../../components/DownloadMenu";
 import { useShareAction } from "../../../../components/ShellChromeContext";
 import ResourceShareButton from "../../../../components/share/ResourceShareButton";
+import { loginPathWithNext } from "../../../../lib/loginRedirect";
 import { useAuth } from "../../../../hooks/useAuth";
 import { useConfirm } from "../../../../components/ConfirmDialog";
 import { useEscapeKey } from "../../../../hooks/useEscapeKey";
@@ -1166,7 +1167,7 @@ function TableEditorPageInner({
 
   // Skill-scoped readers can be anonymous when the skill is public; only
   // redirect to /login when not in skill mode.
-  useEffect(() => { if (!readOnly && !loading && !user) router.push("/login"); }, [readOnly, user, loading, router]);
+  useEffect(() => { if (!readOnly && !loading && !user) router.push(loginPathWithNext(`/tables/${tableId}`)); }, [readOnly, user, loading, router, tableId]);
   if (loading && !readOnly) return <TableEditorSkeleton />;
   if (!user && !readOnly) return null;
   if (!table && !error) {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
 import { API_BASE, getToken, setToken } from "../../lib/api";
 import { consumeManualAuth0Logout } from "../../lib/authLogout";
+import { localNextPath } from "../../lib/loginRedirect";
 import { hasSignedInBefore } from "../../lib/returningUser";
 
 const AUTH0_ENABLED = process.env.NEXT_PUBLIC_AUTH0_ENABLED === "true";
@@ -230,12 +231,6 @@ function LoginPageInner() {
 // loading gate, so this only runs client-side after mount.
 function signInTitle(): string {
   return hasSignedInBefore() ? "Welcome back" : "Welcome";
-}
-
-function localNextPath(value: string | null): string {
-  if (!value) return "";
-  if (!value.startsWith("/") || value.startsWith("//")) return "";
-  return value;
 }
 
 // --- Authorize CLI (already signed-in) ---------------------------------------

--- a/frontend/src/lib/loginRedirect.ts
+++ b/frontend/src/lib/loginRedirect.ts
@@ -1,0 +1,20 @@
+/** Where to send a viewer who has to sign in, and how to get them back.
+ *
+ * Viewers reach a page/file/folder link before we know whether they can read
+ * it. When the read fails and they're signed out, they go to /login carrying
+ * `next` — without it a successful sign-in drops them on the home page and the
+ * link they clicked is lost.
+ */
+
+/** Same-origin absolute paths only: a `next` from the query string is
+ * attacker-controlled, and "//evil.com" is a protocol-relative URL that would
+ * bounce the user off-site after login. */
+export function localNextPath(value: string | null): string {
+  if (!value) return "";
+  if (!value.startsWith("/") || value.startsWith("//")) return "";
+  return value;
+}
+
+export function loginPathWithNext(path: string): string {
+  return `/login?next=${encodeURIComponent(path)}`;
+}


### PR DESCRIPTION
Started from "the link the CLI gave me made me log in, and then I couldn't because I was already logged in." That one path had five separate faults.

## 1. The link was private all along

`stash upload` prints `app_url` and its own help calls it *"the share link"* — but nothing grants public access. The URL opens for its owner and renders **"Not found"** for everyone else. Verified against a real screenshot uploaded earlier: HTTP 200, then "Not found".

New `--public-link` sets the anyone-with-the-link grant. Uploads stay private by default; the non-JSON output now says so instead of implying the link is shareable.

## 2. Signed-out viewers were bounced before the read

`FileClient` and `FolderClient` redirected to `/login` the moment they saw an anonymous visitor — *before* attempting the read. So a file that genuinely had a public link could never be opened. This directly contradicted the app layout, which deliberately lets `/f/` and `/p/` through **so the viewer's own read can be the gate**:

> Page and file viewers may hold content with an "anyone with the link" public grant, so anonymous visitors must reach the viewer instead of being bounced to /login.

They now attempt the read and redirect only when it's refused.

## 3. Signing in lost what you clicked

The redirects carried no `next`, and `ExchangeAndRedirect` ignored `next` regardless — it always pushed `/`. So even a *successful* sign-in dropped you on the home page. Both fixed; `localNextPath` (same-origin only) is now shared instead of duplicated in the login page.

## 4. Already signed in = dead end

This is the error you hit. When Auth0 holds a session that can't mint an access token, the exchange fails and offers only **"Try again"** → `/auth/login` → same silent auth → same error, forever. There was no way to sign out. It now offers that, since it's the only thing that resolves it.

## 5. HTML lost its images, and rendered inconsistently

Uploading `report.html` stored `src="chart.png"` **verbatim** — a path that resolves against the app domain and 404s. Referenced images are now uploaded and rewritten to their permanent download route (the one that also serves public-link viewers), reusing anything a directory upload already sent rather than uploading twice.

Separately: `.html` inside a *directory* upload was posted as `content=` with the default `content_type="markdown"`, so the markup landed in the markdown field and rendered as escaped source — while the same file uploaded alone rendered correctly. `rehype-raw` is installed but never imported, so raw HTML in a markdown page is escaped. Directory uploads now take the same server ingest.

## 6. SVGs were quietly mangled

The allowlist covered basic shapes but dropped `mask`, `pattern`, `filter`/`fe*`, `use`/`symbol`, `image`, `textPath`. Worse than dropping them: **nh3 keeps a stripped tag's children**, so a discarded `<mask>` repainted its shapes on top of the diagram and a discarded `<symbol>` duplicated every icon. Widened to what real exporters emit.

`foreignObject` and `script` stay out — foreignObject re-opens the HTML namespace inside SVG, which is the exact hole the allowlist exists to close. SVG `<title>` is still dropped with its text (nh3 can't distinguish it from a document `<title>`, and letting those through leaks them into the body).

## Verification

End-to-end against prod with the patched CLI, then cleaned up:

```
anon page   -> 200
anon image  -> 200  (content-type: image/png)
```

Both were failing before (401 / 404). Also confirmed the frontend viewers call the canonical `/api/v1/pages/{id}` and `/api/v1/files/{id}` routes, which honor public grants anonymously — so the viewer fix has something to succeed at.

1190 backend + CLI tests and 245 frontend tests pass; ruff and eslint clean. New coverage: public file renders for a signed-out visitor and a refused read redirects carrying `next`; asset upload/rewrite incl. dedupe, remote/data URLs left alone, and a missing asset not costing the upload; SVG defs survive and foreignObject never does.

One guard worth noting: `--public-link` defaults to a Typer `OptionInfo` when `upload()` is called directly (as tests do), and that object is **truthy** — which would have published uploads by accident. The flag now requires a literal `True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdacdeuYJ4PrPRRK84kS5E