### PR TITLE
Paginate Slack conversations.list so DMs are not dropped

### DIFF
--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -43,11 +43,6 @@ router = APIRouter(prefix="/api/v1/integrations", tags=["integrations"])
 STATE_TTL = timedelta(minutes=10)
 
 
-SLACK_CONVERSATIONS_LIST_URL = "https://slack.com/api/conversations.list"
-SLACK_CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
-SLACK_CHANNEL_LIMIT = 100
-
-
 def _encode_state(
     user_id: UUID,
     provider: str,
@@ -609,18 +604,10 @@ async def slack_list_channels(current_user: dict = Depends(get_current_user)):
     access_token = await storage.get_valid_token(current_user["id"], "slack")
     headers = {"Authorization": f"Bearer {access_token}"}
     async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
-        resp = await client.get(
-            SLACK_CONVERSATIONS_LIST_URL,
-            params={"types": SLACK_CHANNEL_TYPES, "limit": SLACK_CHANNEL_LIMIT},
-        )
-        resp.raise_for_status()
-        payload = resp.json()
-
-        if not payload.get("ok"):
-            raise HTTPException(
-                status_code=502,
-                detail=f"Slack API error: {payload.get('error') or 'unknown_error'}",
-            )
+        try:
+            conversations = await slack_indexer.list_conversations(client)
+        except RuntimeError as e:
+            raise HTTPException(status_code=502, detail="Slack API error") from e
 
         # DMs carry no name in Slack's API — resolve them to the humans in the
         # conversation, exactly as the indexer names them, so the picker shows
@@ -628,7 +615,7 @@ async def slack_list_channels(current_user: dict = Depends(get_current_user)):
         self_user_id = await slack_indexer.authed_user_id(client)
         names: dict[str, str] = {}
         channels: list[SlackChannelSummary] = []
-        for channel in payload.get("channels", []):
+        for channel in conversations:
             channel_id = channel.get("id")
             if not channel_id:
                 continue

--- a/backend/integrations/slack/indexer.py
+++ b/backend/integrations/slack/indexer.py
@@ -11,6 +11,7 @@ attributed conversations instead of one-line files.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from uuid import UUID
@@ -31,8 +32,16 @@ USERS_INFO_URL = "https://slack.com/api/users.info"
 AUTH_TEST_URL = "https://slack.com/api/auth.test"
 
 CHANNEL_TYPES = "public_channel,private_channel,im,mpim"
-MAX_CHANNELS = 100
+# conversations.list accepts up to 1000 per page but Slack advises <= 200 —
+# larger pages time out on big workspaces. It returns every *public* channel
+# in the workspace, not just the ones the user belongs to, so on a workspace
+# with hundreds of channels a member's own DMs sort well past the first page.
+CHANNEL_PAGE_SIZE = 200
+MAX_CHANNEL_PAGES = 25
 MAX_MESSAGES_PER_CHANNEL = 200
+# Slack rate-limits conversations.list at tier 2 (~20 req/min), which paging a
+# large workspace will hit.
+SLACK_ATTEMPTS = 3
 
 # Sorts before any real YYYY-MM-DD transcript, so the cap disclosure is the
 # first entry an agent sees when listing a capped channel.
@@ -40,12 +49,46 @@ CAP_MARKER_LEAF = "0000-history-cap"
 
 
 async def _slack_get(client: httpx.AsyncClient, url: str, params: dict) -> dict:
-    resp = await client.get(url, params=params)
-    resp.raise_for_status()
-    payload = resp.json()
-    if not payload.get("ok"):
-        raise RuntimeError("Slack API returned ok=false")
-    return payload
+    # Every Web API method is rate limited by tier, and a 429 is a pacing
+    # signal carrying Retry-After rather than a failure — honor it a bounded
+    # number of times before failing the sync.
+    for attempt in range(SLACK_ATTEMPTS):
+        resp = await client.get(url, params=params)
+        if resp.status_code == 429 and attempt < SLACK_ATTEMPTS - 1:
+            await asyncio.sleep(float(resp.headers.get("Retry-After", "1")) + attempt)
+            continue
+        resp.raise_for_status()
+        payload = resp.json()
+        if not payload.get("ok"):
+            raise RuntimeError("Slack API returned ok=false")
+        return payload
+    raise AssertionError("unreachable")
+
+
+async def list_conversations(client: httpx.AsyncClient) -> list[dict]:
+    """Every conversation this token can see — channels, group DMs and 1:1
+    DMs. conversations.list is paginated: without following `next_cursor` we
+    only ever saw the first page, which silently dropped the conversations
+    that sorted past it (a member's own DMs, on any workspace with more than
+    a page of public channels)."""
+    conversations: list[dict] = []
+    cursor = ""
+    for _ in range(MAX_CHANNEL_PAGES):
+        params = {"types": CHANNEL_TYPES, "limit": CHANNEL_PAGE_SIZE}
+        if cursor:
+            params["cursor"] = cursor
+        payload = await _slack_get(client, CONVERSATIONS_LIST_URL, params)
+        conversations.extend(payload.get("channels", []))
+        cursor = (payload.get("response_metadata") or {}).get("next_cursor") or ""
+        if not cursor:
+            return conversations
+    logger.warning(
+        "slack: stopped paging conversations.list after %d pages (%d conversations) — "
+        "workspace has more, later conversations are not listed",
+        MAX_CHANNEL_PAGES,
+        len(conversations),
+    )
+    return conversations
 
 
 async def _author_of(
@@ -168,16 +211,12 @@ async def index_slack(source: dict) -> str | None:
     names: dict[str, str] = {}
 
     async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
-        channels_payload = await _slack_get(
-            client,
-            CONVERSATIONS_LIST_URL,
-            {"types": CHANNEL_TYPES, "limit": MAX_CHANNELS},
-        )
+        conversations = await list_conversations(client)
         self_user_id = await authed_user_id(client)
         named = _dedupe_channel_names(
             [
                 (channel, await channel_display_name(client, names, channel, self_user_id))
-                for channel in channels_payload.get("channels", [])
+                for channel in conversations
                 if channel["id"] in allowed_channel_ids
             ]
         )
@@ -248,11 +287,7 @@ async def fetch_history(source: dict, since, until, limit: int = 500) -> dict:
     refs: list[str] = []
     names: dict[str, str] = {}
     async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
-        channels = (
-            await _slack_get(
-                client, CONVERSATIONS_LIST_URL, {"types": CHANNEL_TYPES, "limit": MAX_CHANNELS}
-            )
-        ).get("channels", [])
+        channels = await list_conversations(client)
         self_user_id = await authed_user_id(client)
         named = _dedupe_channel_names(
             [

--- a/backend/tests/test_slack_security.py
+++ b/backend/tests/test_slack_security.py
@@ -7,6 +7,8 @@ from backend.integrations.slack import indexer
 
 
 class _SlackErrorResponse:
+    status_code = 200
+
     def raise_for_status(self):
         return None
 

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -447,6 +447,7 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
     class FakeSlackResponse:
         def __init__(self, payload):
             self._payload = payload
+            self.status_code = 200
 
         def raise_for_status(self):
             return None
@@ -466,19 +467,27 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
             return None
 
         async def get(self, url, params):
-            if url == integrations_router.SLACK_CONVERSATIONS_LIST_URL:
-                assert params == {
-                    "types": integrations_router.SLACK_CHANNEL_TYPES,
-                    "limit": integrations_router.SLACK_CHANNEL_LIMIT,
-                }
+            if url == indexer.CONVERSATIONS_LIST_URL:
+                assert params["types"] == indexer.CHANNEL_TYPES
+                assert params["limit"] == indexer.CHANNEL_PAGE_SIZE
+                # Slack pages conversations.list; a user's DMs routinely sort
+                # onto a later page than the workspace's public channels.
+                if params.get("cursor") != "page2":
+                    return FakeSlackResponse(
+                        {
+                            "ok": True,
+                            "channels": [
+                                {"id": "C1", "name": "general", "is_private": False},
+                                {"id": "G1", "name": "leadership", "is_private": True},
+                            ],
+                            "response_metadata": {"next_cursor": "page2"},
+                        }
+                    )
                 return FakeSlackResponse(
                     {
                         "ok": True,
-                        "channels": [
-                            {"id": "C1", "name": "general", "is_private": False},
-                            {"id": "G1", "name": "leadership", "is_private": True},
-                            {"id": "D1", "is_im": True, "user": "U1"},
-                        ],
+                        "channels": [{"id": "D1", "is_im": True, "user": "U1"}],
+                        "response_metadata": {"next_cursor": ""},
                     }
                 )
             if url == indexer.AUTH_TEST_URL:
@@ -494,12 +503,84 @@ async def test_slack_channel_picker_lists_conversations(client: AsyncClient, mon
     resp = await client.get("/api/v1/integrations/slack/channels", headers=_auth(api_key))
 
     assert resp.status_code == 200
-    # The DM surfaces as the human it's with — never the raw D…/U… id.
+    # The DM surfaces as the human it's with — never the raw D…/U… id — and a
+    # DM that only appears on page 2 must still reach the picker.
     assert resp.json() == [
         {"id": "C1", "name": "general", "is_private": False},
         {"id": "G1", "name": "leadership", "is_private": True},
         {"id": "D1", "name": "dm-sam-liu", "is_private": False},
     ]
+
+
+@pytest.mark.asyncio
+async def test_slack_list_conversations_follows_cursor_to_the_last_page():
+    """conversations.list returns every public channel in the workspace, not
+    just the user's own, so a member's DMs sort onto later pages. Stopping at
+    page 1 makes those conversations un-pickable and un-indexable."""
+    from backend.integrations.slack import indexer
+
+    requested_cursors = []
+
+    class FakePagedClient:
+        async def get(self, url, params):
+            assert url == indexer.CONVERSATIONS_LIST_URL
+            requested_cursors.append(params.get("cursor"))
+            page = len(requested_cursors)
+            return _FakeSlackHttpResponse(
+                {
+                    "ok": True,
+                    "channels": [{"id": f"C{page}"}],
+                    "response_metadata": {"next_cursor": "next" if page < 3 else ""},
+                }
+            )
+
+    conversations = await indexer.list_conversations(FakePagedClient())
+
+    assert [c["id"] for c in conversations] == ["C1", "C2", "C3"]
+    assert requested_cursors == [None, "next", "next"]
+
+
+@pytest.mark.asyncio
+async def test_slack_get_honors_retry_after_on_rate_limit(monkeypatch):
+    """Paging a large workspace runs into Slack's tier-2 limit; a 429 is a
+    pacing signal, not a failure, so the sync must wait rather than abort."""
+    import asyncio
+
+    from backend.integrations.slack import indexer
+
+    slept = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    responses = [
+        _FakeSlackHttpResponse({}, status_code=429, headers={"Retry-After": "2"}),
+        _FakeSlackHttpResponse({"ok": True, "channels": []}),
+    ]
+
+    class FakeRateLimitedClient:
+        async def get(self, url, params):
+            return responses.pop(0)
+
+    payload = await indexer._slack_get(FakeRateLimitedClient(), indexer.CONVERSATIONS_LIST_URL, {})
+
+    assert payload == {"ok": True, "channels": []}
+    assert slept == [2.0]
+
+
+class _FakeSlackHttpResponse:
+    def __init__(self, payload, status_code=200, headers=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
 
 
 # --- user-scoping (the access-control invariant) ----------------------------


### PR DESCRIPTION
## Problem

Slack DMs never reached the channel picker on any reasonably sized workspace. `dm-henry` — one of the most important conversations to index — simply wasn't listed.

The cause is not scope. 1:1 DMs were always in scope by design: the user token requests `im:read`/`im:history`, `CHANNEL_TYPES` includes `im`, and `channel_display_name` names an IM after its counterpart.

The cause is truncation. `conversations.list` is paginated, but all three call sites passed `limit=100` with no cursor:

- the `/slack/channels` picker endpoint
- `index_slack` (backfill)
- `fetch_history`

`conversations.list` also returns **every public channel in the workspace**, not just the ones the user belongs to. So on a workspace with more than a page of public channels, a member's own DMs sort past page 1 and were silently dropped — un-pickable, and therefore un-indexable.

## Fix

- **`list_conversations(client)`** in `slack/indexer.py` follows `response_metadata.next_cursor` to the last page. 200 per page (Slack's recommended max — larger pages time out on big workspaces), bounded at 25 pages with a `logger.warning` rather than silent truncation.
- **All three call sites** use it. The picker had its own duplicated `SLACK_CONVERSATIONS_LIST_URL`/`SLACK_CHANNEL_TYPES`/`SLACK_CHANNEL_LIMIT` constants; those are deleted, so there is now one definition of what a Slack conversation list is.
- **`_slack_get` honors `Retry-After` on 429**, up to 3 attempts. This is required for the pagination to work rather than optional polish: `conversations.list` is tier-2 rate limited (~20 req/min), so paging a large workspace provokes exactly the rate limit that would otherwise abort the sync. Matches the existing pattern in `gmail/indexer.py:129`.

## Tests

- The picker test now serves the DM on **page 2**, so it fails if pagination regresses.
- New unit tests for cursor-following to the last page, and for the 429 `Retry-After` backoff.
- One pre-existing fake response needed a `status_code` attribute now that `_slack_get` checks it.

142 passing across `test_slack_security.py`, `test_sources.py`, `test_integration_sources.py`; ruff clean.

## Screenshots

None — this is a backend-only change with no GUI diff. The user-visible effect (a DM appearing in the picker) requires a live Slack connection with a >100-conversation workspace, which can't be reproduced locally.

## Note for review

`conversations.list` returns all public channels workspace-wide, most of which the user isn't in. `users.conversations` returns only conversations they're actually a member of — smaller, faster, and closer to what the picker is for. That's a behavior change (public channels you're not in would disappear from the picker), so it's deliberately **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7sb9tiinFS4nY2aYT4gjq