### PR TITLE
Read-only view with one-click scope switch for wrong-scope pages

### DIFF
--- a/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.test.tsx
@@ -1,12 +1,21 @@
-import { cleanup, render as renderBase, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render as renderBase, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SkillPageView from "./PageClient";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
+import { getScope, setScope } from "@/lib/scope-store";
 
 function render(ui: ReactNode) {
   return renderBase(ui, { wrapper: ConfirmDialogProvider });
 }
+
+// jsdom's location.reload throws "Not implemented"; the scope-switch flow
+// calls it, so swap in a spy.
+const reloadSpy = vi.fn();
+Object.defineProperty(window, "location", {
+  value: { ...window.location, reload: reloadSpy },
+  writable: true,
+});
 
 const api = vi.hoisted(() => {
   class ApiError extends Error {
@@ -29,6 +38,7 @@ const api = vi.hoisted(() => {
     getPage: vi.fn(),
     getPublicSkill: vi.fn(),
     listCommentThreads: vi.fn(),
+    listMyWorkspaces: vi.fn().mockResolvedValue([]),
     reconcileCommentAnchors: vi.fn(),
     replyToCommentThread: vi.fn(),
     setCommentResolved: vi.fn(),
@@ -183,6 +193,86 @@ describe("SkillPageView HTML page width", () => {
     expect(wrapper.className).not.toContain("max-w-[1200px]");
     // The comment rail stays — only the cap goes.
     expect(wrapper.className).toContain("lg:grid-cols-[minmax(0,1fr)_240px]");
+  });
+});
+
+describe("SkillPageView scope mismatch", () => {
+  // A markdown page owned by a workspace scope, not the signed-in user.
+  const workspacePage = {
+    id: "page-1",
+    owner_user_id: "ws-scope-1",
+    folder_id: null,
+    name: "Chainbase plan.md",
+    content_markdown: "# Plan",
+    content_type: "markdown",
+    content_html: "",
+    html_layout: "responsive",
+    updated_at: "2026-06-08T00:00:00Z",
+  };
+  const workspace = {
+    id: "workspace-1",
+    name: "Fergana Labs",
+    domain: "ferganalabs.com",
+    scope_user_id: "ws-scope-1",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    route.search = "";
+    setScope(null);
+    api.getPage.mockResolvedValue(workspacePage);
+    api.listCommentThreads.mockResolvedValue({ threads: [] });
+    api.listMyWorkspaces.mockResolvedValue([workspace]);
+  });
+
+  afterEach(() => {
+    setScope(null);
+    cleanup();
+  });
+
+  it("renders a workspace page read-only with a switch banner instead of the editor", async () => {
+    render(<SkillPageView pageId="page-1" />);
+
+    expect(
+      await screen.findByRole("button", { name: "Switch to Fergana Labs" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/read-only here/)).toBeInTheDocument();
+    expect(screen.getByText("Skill page body")).toBeInTheDocument();
+    // The editor must never mount in the wrong scope: its autosave PATCH is
+    // scope-bound and would 404 with a baffling "Page not found".
+    expect(screen.queryByText("Markdown editor")).not.toBeInTheDocument();
+  });
+
+  it("switching persists the owning workspace as the active scope", async () => {
+    render(<SkillPageView pageId="page-1" />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Switch to Fergana Labs" }),
+    );
+
+    expect(getScope()).toEqual({ scope_user_id: "ws-scope-1", name: "Fergana Labs" });
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+
+  it("offers a switch back to Personal when viewing an own page from a workspace scope", async () => {
+    setScope({ scope_user_id: "ws-scope-1", name: "Fergana Labs" });
+    api.getPage.mockResolvedValue({ ...workspacePage, owner_user_id: "user-1" });
+
+    render(<SkillPageView pageId="page-1" />);
+
+    expect(
+      await screen.findByRole("button", { name: "Switch to Personal" }),
+    ).toBeInTheDocument();
+    expect(api.listMyWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("shows the editor as usual when the active scope owns the page", async () => {
+    setScope({ scope_user_id: "ws-scope-1", name: "Fergana Labs" });
+
+    render(<SkillPageView pageId="page-1" />);
+
+    expect(await screen.findByText("Markdown editor")).toBeInTheDocument();
+    expect(screen.queryByText(/read-only here/)).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -34,7 +34,6 @@ import { useAuth } from "@/hooks/useAuth";
 import {
   ApiError,
   createCommentThread,
-  createPage,
   deleteCommentMessage,
   deleteCommentThread,
   getFolderContents,
@@ -54,7 +53,6 @@ import { findInSkillContents } from "@/lib/localSkill";
 import { getScope, getScopeUserId, setScope } from "@/lib/scope-store";
 import type { CommentThread, Page, Scope, Workspace } from "@/lib/types";
 import { subscribePageEvents } from "@/lib/pageEvents";
-import { refreshSidebar } from "@/lib/skillNavigationCache";
 
 function wrapHtml(title: string, body: string): string {
   // HTML pages can be stored as a full document (when imported from .html

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -41,6 +41,7 @@ import {
   getPage,
   getPublicSkill,
   listCommentThreads,
+  listMyWorkspaces,
   reconcileCommentAnchors,
   replyToCommentThread,
   setCommentResolved,
@@ -50,7 +51,8 @@ import {
   type PublicSkillPage,
 } from "@/lib/api";
 import { findInSkillContents } from "@/lib/localSkill";
-import type { CommentThread, Page } from "@/lib/types";
+import { getScope, getScopeUserId, setScope } from "@/lib/scope-store";
+import type { CommentThread, Page, Scope, Workspace } from "@/lib/types";
 import { subscribePageEvents } from "@/lib/pageEvents";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
 
@@ -115,6 +117,14 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
   const [skillAccessDenied, setSkillAccessDenied] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
   const [error, setError] = useState("");
+  // Every write route is scope-bound, so a page owned by a scope other than
+  // the active one renders read-only (saves from the wrong scope 404 with a
+  // baffling "Page not found"). We resolve the owning workspace to name it in
+  // the banner and offer a one-click switch. undefined = still resolving.
+  const [ownerWorkspace, setOwnerWorkspace] = useState<Workspace | null | undefined>(undefined);
+  const pageOwnerId = page?.owner_user_id ?? null;
+  const scopeMismatch =
+    !!page && !!user && !skillSlug && pageOwnerId !== (getScopeUserId() ?? user.id);
   // Save responses can arrive out of order if a fast save fires while a
   // slow save is still in flight. Treat the most-recently-issued seq as
   // the source of truth so older responses can't roll back the page.
@@ -164,6 +174,22 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
     setCommentAnchorTops({});
     setExternalEdit(null);
   }, [pageId]);
+
+  useEffect(() => {
+    setOwnerWorkspace(undefined);
+    if (!scopeMismatch || !pageOwnerId) return;
+    // A page from the viewer's own personal stash needs no lookup — the
+    // switch target is Personal.
+    if (pageOwnerId === user?.id) {
+      setOwnerWorkspace(null);
+      return;
+    }
+    listMyWorkspaces()
+      .then((ws) => setOwnerWorkspace(ws.find((w) => w.scope_user_id === pageOwnerId) ?? null))
+      // Can't resolve the owner — the read-only view still stands, just
+      // without a named switch target.
+      .catch(() => setOwnerWorkspace(null));
+  }, [scopeMismatch, pageOwnerId, user?.id]);
 
   // Live updates: when an agent or another user edits this page on the backend,
   // refresh a passive view in place (HTML / read-only), or — when the user is
@@ -539,6 +565,15 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       </div>
     );
   }
+  if (page && scopeMismatch) {
+    return (
+      <WrongScopePageView
+        page={page}
+        ownerWorkspace={ownerWorkspace}
+        isPersonalPage={page.owner_user_id === user.id}
+      />
+    );
+  }
   if (!page && !error) return <DocumentPageSkeleton />;
 
   const isHtml = page?.content_type === "html";
@@ -901,6 +936,102 @@ function HtmlGlyph() {
       <circle cx="6" cy="6.5" r="0.6" fill="currentColor" />
       <circle cx="8.2" cy="6.5" r="0.6" fill="currentColor" />
     </svg>
+  );
+}
+
+// The active scope doesn't own this page: reads resolve the real owner, but
+// every write route runs against the active scope and would 404. So the page
+// renders read-only with a banner naming the owning scope and — when the
+// viewer can get there — a one-click switch (same mechanics as the scope
+// switcher: persist, then reload so every scoped fetch re-runs).
+function WrongScopePageView({
+  page,
+  ownerWorkspace,
+  isPersonalPage,
+}: {
+  page: Page;
+  ownerWorkspace: Workspace | null | undefined;
+  isPersonalPage: boolean;
+}) {
+  const activeScopeName = getScope()?.name ?? "Personal";
+
+  function switchTo(scope: Scope | null) {
+    setScope(scope);
+    window.location.reload();
+  }
+
+  let notice: ReactNode;
+  if (isPersonalPage) {
+    notice = (
+      <>
+        <span>
+          This page lives in your <strong>personal stash</strong> — you&apos;re
+          viewing it from the <strong>{activeScopeName}</strong>{" "}
+          workspace, so it&apos;s read-only here.
+        </span>
+        <button
+          type="button"
+          onClick={() => switchTo(null)}
+          className="shrink-0 cursor-pointer font-medium text-[var(--color-brand-600)] hover:underline"
+        >
+          Switch to Personal
+        </button>
+      </>
+    );
+  } else if (ownerWorkspace) {
+    notice = (
+      <>
+        <span>
+          This page belongs to the <strong>{ownerWorkspace.name}</strong>{" "}
+          workspace — you&apos;re in <strong>{activeScopeName}</strong>, so
+          it&apos;s read-only here.
+        </span>
+        <button
+          type="button"
+          onClick={() =>
+            switchTo({ scope_user_id: ownerWorkspace.scope_user_id, name: ownerWorkspace.name })
+          }
+          className="shrink-0 cursor-pointer font-medium text-[var(--color-brand-600)] hover:underline"
+        >
+          Switch to {ownerWorkspace.name}
+        </button>
+      </>
+    );
+  } else if (ownerWorkspace === null) {
+    notice = (
+      <span>This page was shared from another account — it&apos;s read-only here.</span>
+    );
+  } else {
+    // Owner lookup still in flight: state the read-only fact without yet
+    // claiming who owns the page.
+    notice = <span>This page belongs to a different scope — it&apos;s read-only here.</span>;
+  }
+
+  return (
+    <div className="scroll-thin flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-[920px] px-12 pb-20 pt-6">
+        <div className="mb-6 flex items-center justify-between gap-3 rounded-lg border border-[var(--color-brand-600)]/40 bg-[var(--color-brand-600)]/10 px-4 py-2 text-[13px]">
+          {notice}
+        </div>
+        <h1 className="m-0 font-display text-[22px] font-bold leading-tight tracking-[-0.015em] text-foreground">
+          {page.name.replace(/\.(md|html)$/i, "") || "(untitled)"}
+        </h1>
+        <div className="mt-6">
+          <PageBody
+            page={{
+              id: page.id,
+              name: page.name,
+              content_type: page.content_type,
+              content_markdown: page.content_markdown,
+              content_html: page.content_html,
+              html_layout: page.html_layout,
+              updated_at: page.updated_at,
+              folder_path: [],
+            }}
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem

Opening a page owned by a different scope than the active one (e.g. a workspace page while in Personal) rendered the full editor and then showed a red **"Page not found"** error over perfectly visible content.

Root cause: reads and writes are asymmetric. `getPage` uses the canonical `/api/v1/pages/{id}` route, which resolves the page's real owner and honors workspace membership — so the content loads. But the editor's autosave `PATCH /api/v1/me/pages/{id}` is scope-bound: run from the wrong scope, `update_page` matches no row and 404s with "Page not found". The autosave can fire on mere open (the initial Yjs sync triggers `onUpdate` whenever the collab doc's serialization differs from the DB projection), so the page looked broken without the user touching anything.

## Change

When the loaded page's `owner_user_id` doesn't match the active scope, `PageClient` now renders a read-only `WrongScopePageView` instead of the editor:

- Banner names the owning workspace (resolved via `listMyWorkspaces()`) and offers a one-click **Switch to {workspace}** — same mechanics as the scope switcher (`setScope` + reload).
- Mirror case: viewing your own personal page from a workspace scope offers **Switch to Personal**.
- A page reachable by no switchable scope (shared from another account) gets a plain read-only note.
- The editor never mounts in the wrong scope, so the confusing save-404 is gone entirely.

## Screenshots

Workspace page opened while in Personal scope:

![wrong-scope banner](https://api.joinstash.ai/api/v1/me/files/9df7dea4-fb2c-448d-9c21-1961a7681c3e/download)

After clicking "Switch to Example Corp" — workspace scope active, full editor, saves working:

![after switch](https://api.joinstash.ai/api/v1/me/files/a1382cd4-e403-4e36-8bf6-5785c65ed023/download)

## Verification

- 4 new vitest cases: banner + editor suppression, switch persists scope and reloads, personal-page mirror case, no banner when the active scope owns the page. Full frontend suite 249/249.
- Live E2E on the local stack with a hand-seeded workspace + workspace-owned page: banner renders, one click lands in the writable editor under the right scope.

Not changed here: the backend write routes are still scope-bound. Making `PATCH` resolve the real owner like the canonical `GET` does would let cross-scope saves just work; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)