### PR TITLE
refactor: reads span every scope you own (scope as a place, not a mode)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,9 +46,19 @@ S3-backed binary, vs. an in-app-editable page, vs. a folder).
   integrations keyring. The cloud agent's sprite gets the registry written
   into its `.mcp.json` every turn.
 - A workspace is an org-owned, login-less scope (`workspaces.domain`,
-  membership derived from verified email domain). Content routes select the
-  scope via the `X-Stash-Scope` header — including the plugin's session,
-  event, transcript, and artifact writes — and non-members are hard-403'd.
+  membership derived from verified email domain). Non-members are hard-403'd.
+- **Scope is a place, not a mode.** A caller owns one scope per membership —
+  themselves, plus each workspace — and those are the roots a client renders
+  (/personal, /workspace/&lt;domain&gt;). Reads span all of them
+  (`auth.get_read_scopes` → `permission_service.read_scope_ids`) and tag each row
+  with its `owner_user_id`, so what a GET returns never depends on ambient state.
+  Writes still resolve to exactly one scope (`auth.get_scope`, selected by the
+  `X-Stash-Scope` header) because a new object has to land somewhere: that is the
+  plugin's session, event, transcript, and artifact destination.
+  - Three read shapes, by pagination: paginated lists span in SQL
+    (`accessible_scope_ids_sql`, since merging separate pages is not one list);
+    unpaginated listings fan out per scope and sort in Python; by-id reads
+    resolve which owned scope holds the id rather than being told.
 
 Object-level privacy tables and page-link graph tables are intentionally not part
 of the current architecture. Privacy is mediated by Skills.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -264,6 +264,23 @@ async def get_scope(
     return scope_user_id
 
 
+async def get_read_scopes(
+    current_user: dict = Depends(get_current_user),
+) -> list[UUID]:
+    """Every scope a read spans: the caller's own, then each workspace they
+    belong to.
+
+    Reads ignore `X-Stash-Scope` on purpose. Scope is a place, not a mode: a
+    read returns everything the caller owns, each row tagged with the scope it
+    came from, and the client renders those scopes as roots. Only writes still
+    resolve to a single scope (`get_scope`) — a new object has to land
+    somewhere, and that somewhere is the one thing a caller must choose.
+    """
+    from .services import permission_service
+
+    return await permission_service.read_scope_ids(current_user["id"])
+
+
 async def get_current_user_optional(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
 
-from ..auth import get_current_user, get_scope
+from ..auth import get_current_user, get_read_scopes, get_scope
 from ..config import settings
 from ..database import get_pool
 from ..services import (
@@ -94,19 +94,19 @@ async def list_my_sessions(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     current_user: dict = Depends(get_current_user),
-    scope_user_id: UUID = Depends(get_scope),
 ):
     """Recent sessions across the user's accessible scopes, grouped by
     session_id. Each row carries the agent name, event count, first & last
-    timestamps, and a preview of the first prompt.
+    timestamps, a preview of the first prompt, and the `owner_user_id` of the
+    scope it belongs to — that is what buckets a row under /personal or a
+    /workspace root.
 
-    Pass `session_folder_id` to scope to one folder — without it the list is a
-    global recent window, so a folder's older sessions would never appear.
-    `offset` pages through the (last_event_at DESC) order for infinite scroll."""
-    # The personal view spans every accessible scope (own + shared + workspace);
-    # switching into a workspace narrows the window to that scope's sessions.
-    if owner_user_id is None and scope_user_id != current_user["id"]:
-        owner_user_id = scope_user_id
+    The window always spans every accessible scope. Pass `owner_user_id` to
+    look at one scope on its own; that is a filter the caller asks for, never
+    ambient state. Pass `session_folder_id` to scope to one folder — without it
+    the list is a global recent window, so a folder's older sessions would never
+    appear. `offset` pages through the (last_event_at DESC) order for infinite
+    scroll."""
     pool = get_pool()
     args: list = [current_user["id"]]
     accessible_ws = permission_service.accessible_scope_ids_sql(1)
@@ -287,13 +287,24 @@ async def get_session_canonical(
 async def get_my_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
-    scope_user_id: UUID = Depends(get_scope),
+    read_scopes: list[UUID] = Depends(get_read_scopes),
 ):
-    owner_user_id = scope_user_id
-    payload = await _session_detail_payload(owner_user_id, session_id, current_user["id"])
-    if not payload:
-        raise HTTPException(status_code=404, detail="Session not found")
-    return payload
+    """A session in one of the caller's own scopes, newest first when the same
+    session_id exists in several of them (a session streamed personally before
+    the machine was pointed at a workspace exists in both).
+
+    session_id is unique per scope, so the scope has to be resolved rather than
+    supplied: the caller addresses a session by id, not by first selecting where
+    to look."""
+    for row in await session_service.list_sessions_for_session_id(session_id):
+        if row["owner_user_id"] not in read_scopes:
+            continue
+        payload = await _session_detail_payload(
+            row["owner_user_id"], session_id, current_user["id"]
+        )
+        if payload:
+            return payload
+    raise HTTPException(status_code=404, detail="Session not found")
 
 
 class SessionTitleRequest(BaseModel):

--- a/backend/routers/trash.py
+++ b/backend/routers/trash.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from ..auth import get_scope
+from ..auth import get_read_scopes
 from ..database import get_pool
 from ..services import (
     files_service,
@@ -15,20 +15,37 @@ from ..services import (
 router = APIRouter(prefix="/api/v1/me", tags=["trash"])
 
 
+async def _fan_out(list_for_scope, read_scopes: list[UUID]) -> list[dict]:
+    """Run a single-scope listing across every scope the caller reads, tagging
+    each row with the scope it came from.
+
+    Trash is unpaginated, so gathering per scope and sorting in Python is exact.
+    A spanning SQL predicate is the right tool once LIMIT/OFFSET is involved —
+    merging pages of separate queries is not the same list.
+    """
+    rows: list[dict] = []
+    for owner_user_id in read_scopes:
+        for row in await list_for_scope(owner_user_id):
+            rows.append({**row, "owner_user_id": owner_user_id})
+    rows.sort(key=lambda row: row["deleted_at"], reverse=True)
+    return rows
+
+
 @router.get("/trash")
 async def list_trash(
-    scope_user_id: UUID = Depends(get_scope),
+    read_scopes: list[UUID] = Depends(get_read_scopes),
 ):
     """Trash listing: pages + files + sessions, each sorted by deleted_at DESC.
 
-    Includes deleted_by display name so the UI can show "Deleted by Alice"
-    without a second round-trip.
+    Spans every scope the caller reads — deleting something from a workspace
+    then hunting for it in a scope switcher is the exact confusion this model
+    removes. Each row carries `owner_user_id` so the UI can say which place it
+    came from, and `deleted_by`'s display name so it can say who did it without
+    a second round-trip.
     """
-    owner_user_id = scope_user_id
-
-    pages = await files_tree_service.list_trashed_pages(owner_user_id)
-    files = await files_service.list_trashed_files(owner_user_id)
-    sessions = await session_service.list_trashed_sessions(owner_user_id)
+    pages = await _fan_out(files_tree_service.list_trashed_pages, read_scopes)
+    files = await _fan_out(files_service.list_trashed_files, read_scopes)
+    sessions = await _fan_out(session_service.list_trashed_sessions, read_scopes)
 
     actor_ids = {row["deleted_by"] for row in pages + files + sessions if row.get("deleted_by")}
     actors: dict[UUID, dict] = {}
@@ -47,6 +64,7 @@ async def list_trash(
         return {
             "id": str(row["id"]),
             "name": row[name_key],
+            "owner_user_id": str(row["owner_user_id"]),
             "deleted_at": row["deleted_at"],
             "deleted_by": str(row["deleted_by"]) if row.get("deleted_by") else None,
             "deleted_by_name": (actor["display_name"] or actor["name"] if actor else None),

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -243,6 +243,25 @@ def accessible_scope_ids_sql(user_arg: int) -> str:
     )"""
 
 
+async def read_scope_ids(user_id: UUID) -> list[UUID]:
+    """Every scope the user reads as their own: themselves, then each workspace
+    they belong to (membership order by workspace name).
+
+    These are the *places* a client renders — /personal plus one /workspace per
+    membership — and the owner set a spanning read filters on. Shares are
+    deliberately excluded: shared-in content lives in somebody else's scope and
+    surfaces per-object through `readable_content_condition`, so it is never a
+    root of your own. The caller's own id always comes first.
+    """
+    pool = get_pool()
+    rows = await pool.fetch(
+        f"SELECT w.scope_user_id FROM workspaces w "
+        f"WHERE {workspace_member_condition('w', 1)} ORDER BY w.name",
+        user_id,
+    )
+    return [user_id] + [row["scope_user_id"] for row in rows]
+
+
 async def resolve_owner_user_id(object_type: str, object_id: UUID) -> UUID | None:
     pool = get_pool()
     if object_type not in _OWNER_LOOKUP:

--- a/backend/tests/test_read_scopes.py
+++ b/backend/tests/test_read_scopes.py
@@ -1,0 +1,253 @@
+"""Scope as a place, not a mode: reads span every scope the caller owns.
+
+Why this matters:
+- A read must not depend on ambient state. Before this, the same GET returned
+  different content depending on a header the user set days earlier on a
+  different machine, which is how sessions "disappeared" after switching.
+- Spanning must not widen access by one row. The owner set comes from the same
+  derived-membership predicate as everything else, so an unverified on-domain
+  signup — the case that must never see a customer's KB — gains nothing.
+- Writes stay single-scope on purpose: a new object has to land somewhere, and
+  that destination is the one thing a caller still chooses.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import permission_service
+
+from .conftest import unique_name
+from .test_permissions import _auth, _register_with_email
+from .test_workspaces import (
+    ADMIN,
+    _create_workspace,
+    _domain,
+    _verify_email,
+    _workspace_page,
+)
+
+
+@pytest.fixture(autouse=True)
+def _admin_token(monkeypatch):
+    """Workspaces are created through the admin API, same as test_workspaces."""
+    monkeypatch.setattr("backend.routers.admin.settings.ADMIN_PASSWORD", ADMIN["X-Admin-Token"])
+
+
+async def _member_of_new_workspace(client: AsyncClient, pool) -> tuple[str, dict, dict]:
+    """A verified on-domain user plus the workspace they derive membership in."""
+    domain = _domain()
+    key, body = await _register_with_email(client, f"{unique_name('m')}@{domain}")
+    await _verify_email(pool, uuid.UUID(body["id"]))
+    workspace = await _create_workspace(client, domain)
+    return key, body, workspace
+
+
+# --- The owner set itself ---
+
+
+@pytest.mark.asyncio
+async def test_read_scopes_are_just_yourself_without_a_workspace(client: AsyncClient):
+    key, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
+    assert key
+    scopes = await permission_service.read_scope_ids(uuid.UUID(body["id"]))
+    assert scopes == [uuid.UUID(body["id"])]
+
+
+@pytest.mark.asyncio
+async def test_read_scopes_put_yourself_first_then_workspaces(client: AsyncClient, pool):
+    _, body, workspace = await _member_of_new_workspace(client, pool)
+    scopes = await permission_service.read_scope_ids(uuid.UUID(body["id"]))
+    assert scopes == [uuid.UUID(body["id"]), uuid.UUID(workspace["scope_user_id"])]
+
+
+@pytest.mark.asyncio
+async def test_unverified_on_domain_signup_gets_no_workspace_scope(client: AsyncClient, pool):
+    """The trust anchor. An unverified `fake@customer.com` must not read the
+    customer's KB just because reads now span — membership is still derived from
+    a *verified* email, and spanning reuses that one predicate.
+    """
+    domain = _domain()
+    _, body = await _register_with_email(client, f"{unique_name('imposter')}@{domain}")
+    workspace = await _create_workspace(client, domain)
+
+    scopes = await permission_service.read_scope_ids(uuid.UUID(body["id"]))
+    assert scopes == [uuid.UUID(body["id"])]
+    assert uuid.UUID(workspace["scope_user_id"]) not in scopes
+
+
+@pytest.mark.asyncio
+async def test_read_scopes_exclude_workspaces_you_do_not_belong_to(client: AsyncClient, pool):
+    _, outsider = await _register_with_email(client, f"{unique_name('out')}@elsewhere.io")
+    _, _, workspace = await _member_of_new_workspace(client, pool)
+
+    scopes = await permission_service.read_scope_ids(uuid.UUID(outsider["id"]))
+    assert scopes == [uuid.UUID(outsider["id"])]
+    assert uuid.UUID(workspace["scope_user_id"]) not in scopes
+
+
+# --- Reads span without being told to ---
+
+
+@pytest.mark.asyncio
+async def test_trash_spans_scopes_and_says_which_place_each_row_came_from(
+    client: AsyncClient, pool
+):
+    """Deleting something from the workspace and then hunting for it in a scope
+    switcher is the confusion this model removes: one trash, rows labelled."""
+    key, body, workspace = await _member_of_new_workspace(client, pool)
+    org_page = await _workspace_page(pool, workspace["scope_user_id"], name="org-page")
+    await pool.execute("UPDATE pages SET deleted_at = now() WHERE id = $1", org_page)
+
+    mine = await client.post("/api/v1/me/pages/new", json={"name": "my-page"}, headers=_auth(key))
+    assert mine.status_code in (200, 201), mine.text
+    await client.delete(f"/api/v1/me/pages/{mine.json()['id']}", headers=_auth(key))
+
+    resp = await client.get("/api/v1/me/trash", headers=_auth(key))
+    assert resp.status_code == 200, resp.text
+    pages = resp.json()["pages"]
+    by_name = {page["name"]: page for page in pages}
+    assert {"org-page", "my-page"} <= set(by_name)
+    assert by_name["org-page"]["owner_user_id"] == workspace["scope_user_id"]
+    assert by_name["my-page"]["owner_user_id"] == body["id"]
+
+
+@pytest.mark.asyncio
+async def test_trash_still_hides_other_scopes(client: AsyncClient, pool):
+    """Spanning is "every scope you own", not "every scope"."""
+    _, _, workspace = await _member_of_new_workspace(client, pool)
+    org_page = await _workspace_page(pool, workspace["scope_user_id"], name="secret-org-page")
+    await pool.execute("UPDATE pages SET deleted_at = now() WHERE id = $1", org_page)
+
+    outsider_key, _ = await _register_with_email(client, f"{unique_name('out')}@elsewhere.io")
+    resp = await client.get("/api/v1/me/trash", headers=_auth(outsider_key))
+    assert resp.status_code == 200
+    assert "secret-org-page" not in [page["name"] for page in resp.json()["pages"]]
+
+
+@pytest.mark.asyncio
+async def test_session_detail_resolves_the_scope_instead_of_being_told_it(
+    client: AsyncClient, pool
+):
+    """A session streamed into the workspace is addressable by id alone. Under
+    the old model this 404'd unless the caller re-sent the header that was set
+    when the session was uploaded."""
+    key, _, workspace = await _member_of_new_workspace(client, pool)
+    session_id = str(uuid.uuid4())
+    scoped = {**_auth(key), "X-Stash-Scope": workspace["scope_user_id"]}
+
+    pushed = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": "work session in the org scope",
+            "session_id": session_id,
+        },
+        headers=scoped,
+    )
+    assert pushed.status_code == 201, pushed.text
+
+    resp = await client.get(f"/api/v1/me/sessions/{session_id}", headers=_auth(key))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["owner_user_id"] == workspace["scope_user_id"]
+
+
+@pytest.mark.asyncio
+async def test_session_detail_denies_scopes_you_do_not_own(client: AsyncClient, pool):
+    key, _, workspace = await _member_of_new_workspace(client, pool)
+    session_id = str(uuid.uuid4())
+    await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": "org-only",
+            "session_id": session_id,
+        },
+        headers={**_auth(key), "X-Stash-Scope": workspace["scope_user_id"]},
+    )
+
+    outsider_key, _ = await _register_with_email(client, f"{unique_name('out')}@elsewhere.io")
+    resp = await client.get(f"/api/v1/me/sessions/{session_id}", headers=_auth(outsider_key))
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_session_list_spans_scopes_with_no_header(client: AsyncClient, pool):
+    key, body, workspace = await _member_of_new_workspace(client, pool)
+    personal_session, org_session = str(uuid.uuid4()), str(uuid.uuid4())
+
+    for session_id, headers in (
+        (personal_session, _auth(key)),
+        (org_session, {**_auth(key), "X-Stash-Scope": workspace["scope_user_id"]}),
+    ):
+        resp = await client.post(
+            "/api/v1/me/sessions/events",
+            json={
+                "agent_name": "claude",
+                "event_type": "user_message",
+                "content": f"prompt for {session_id}",
+                "session_id": session_id,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    resp = await client.get("/api/v1/me/sessions", headers=_auth(key))
+    assert resp.status_code == 200, resp.text
+    owners = {row["session_id"]: row["owner_user_id"] for row in resp.json()["sessions"]}
+    assert owners.get(personal_session) == body["id"]
+    assert owners.get(org_session) == workspace["scope_user_id"]
+
+
+@pytest.mark.asyncio
+async def test_session_list_header_no_longer_narrows_the_window(client: AsyncClient, pool):
+    """The header is a write destination now. Sending it must not silently
+    change what a read returns — that ambient narrowing is the bug."""
+    key, _, workspace = await _member_of_new_workspace(client, pool)
+    personal_session = str(uuid.uuid4())
+    await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": "personal work",
+            "session_id": personal_session,
+        },
+        headers=_auth(key),
+    )
+
+    scoped = await client.get(
+        "/api/v1/me/sessions",
+        headers={**_auth(key), "X-Stash-Scope": workspace["scope_user_id"]},
+    )
+    assert scoped.status_code == 200, scoped.text
+    assert personal_session in [row["session_id"] for row in scoped.json()["sessions"]]
+
+
+@pytest.mark.asyncio
+async def test_owner_filter_still_narrows_when_asked_explicitly(client: AsyncClient, pool):
+    """Narrowing is fine as a query the caller writes down; it just stops being
+    ambient state."""
+    key, body, workspace = await _member_of_new_workspace(client, pool)
+    org_session = str(uuid.uuid4())
+    await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": "org work",
+            "session_id": org_session,
+        },
+        headers={**_auth(key), "X-Stash-Scope": workspace["scope_user_id"]},
+    )
+
+    resp = await client.get(
+        "/api/v1/me/sessions",
+        params={"owner_user_id": body["id"]},
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200, resp.text
+    assert org_session not in [row["session_id"] for row in resp.json()["sessions"]]


### PR DESCRIPTION
## Why

`X-Stash-Scope` is a **mode**, not a place. One key in `~/.stash/config.json` silently re-roots what every read returns, so the same `GET` answers differently depending on a header someone set days ago on another machine. Two concrete consequences:

- A session streamed into a workspace becomes unfindable from a personal scope, even though you own both.
- The CLI cannot search the team KB while streaming personally — the single `scope` key drives reads *and* writes (`cli/client.py:88`), so they can never diverge.

The fix is to stop treating scope as ambient state. **You own one scope per membership — yourself, plus each workspace — and those are places.** Reads span all of them and tag each row with the scope it came from; the client renders those as roots (`/personal`, `/workspace/<domain>`). Only writes still choose a single scope, because a new object has to land somewhere.

## Scope of this PR — please read

This is **increment 1 of 4**. The full read-side conversion is ~1,700 `owner_user_id` sites across 11 routers and 8 service modules; that is not one reviewable PR, and a half-converted read path is a broken app. This PR lands the primitive plus one reference conversion per read shape, so the pattern is settled before the bulk lands.

Converted here (3 of 43 read routes):

| Route | Shape | Change |
|---|---|---|
| `GET /me/sessions` | paginated span | Drops the ambient narrowing; already spanned via `accessible_scope_ids_sql` |
| `GET /me/sessions/{session_id}` | by-id | Resolves which owned scope holds the id instead of being told |
| `GET /me/trash` | unpaginated fan-out | Per-scope listing, merged and sorted, rows tagged |

The three shapes exist because **pagination decides the technique**: paginated lists must span in SQL (merging pages of separate queries is not one list), unpaginated listings can fan out and sort in Python, and by-id reads resolve the owner. Every follow-up route falls into one of these.

Remaining increments, for sequencing — not started:

2. The other 40 read routes: `files_tree` (24), `tables` (10), `files` (3), `memory` (4), `sources` (4), `skills` (3), `user_knowledge` (2). Tree endpoints (`/tree`, `/sidebar`, `/overview`) fan out per scope and nest under two roots — a two-root tree is literally two trees.
3. The 64 mutating routes: resolve the owner from the object id (`resolve_owner_user_id` already exists) rather than from the header, so editing a workspace page doesn't require pre-selecting the workspace. Creation keeps `get_scope`.
4. Clients: `/personal` + `/workspace/<domain>` roots in the VFS (`stashvfs/model.py` roots are already synthesized, so they slot in), frontend switcher becomes navigation rather than a mode, and the CLI's read/write coupling disappears. Documented paths (`CLAUDE.md`, `stash prompts agent-guidance`, README) change in one shot — no aliases.

## What is deliberately unchanged

- **Ownership and permissions.** `owner_user_id` stays the security boundary. Spanning reuses `workspace_member_condition`, so it cannot widen access by one row — an unverified on-domain signup still gets nothing, which is covered by a test.
- **Writes.** `get_scope` and the plugin's streaming path are untouched, so the workspace stays the durable owner of what a member streams into it.
- **Shares.** Excluded from the owner set on purpose: shared-in content is somebody else's scope, surfaced per object by `readable_content_condition`, not a root of your own.

## Testing

`backend/tests/test_read_scopes.py` — 11 new tests, all passing:

- the owner set: no workspace, member ordering, **unverified on-domain signup gets nothing**, non-member gets nothing
- spanning reads: trash spans and labels rows, trash still hides other scopes, session detail resolves the scope, session detail 404s for scopes you don't own, session list spans with no header, the header no longer narrows, an explicit `owner_user_id` filter still narrows

Regression run across the 12 suites that touch these routes or `X-Stash-Scope`: **172 passed, 1 failed**. The failure is `test_workspaces.py::test_admin_creates_workspace_with_working_bootstrap_key` (`column "auth0_sub" does not exist`) and is **pre-existing** — it fails identically on a clean tree, verified by stashing this branch's changes. `ruff check` and `ruff format --check` clean.

No GUI changes in this increment, so no screenshots — the frontend still renders the switcher as it does today. Increment 4 is where screenshots will matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
