### PR TITLE
Gzip client JSON bodies so the edge WAF can't eat agent shell text

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from . import integrations as _integrations  # noqa: F401 — registers provider
 from .config import settings
 from .database import close_db, init_db
 from .integrations.router import router as integrations_router
-from .middleware import limiter
+from .middleware import GzipRequestMiddleware, limiter
 from .routers import (
     admin,
     agent_chat,
@@ -108,6 +108,7 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_exception_handler(RowValidationError, _row_validation_handler)
 app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(GzipRequestMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,12 +1,70 @@
 """Shared middleware and rate-limiting configuration."""
 
+import gzip
 import os
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from starlette.responses import JSONResponse
 
 # Disable rate limiting when running under the test suite (TEST_DATABASE_URL is
 # set by conftest.py before any backend module is imported).
 _rate_limit_enabled = not bool(os.getenv("TEST_DATABASE_URL"))
 
 limiter = Limiter(key_func=get_remote_address, enabled=_rate_limit_enabled)
+
+
+class GzipRequestMiddleware:
+    """Decompress request bodies sent with `Content-Encoding: gzip`.
+
+    The Cloudflare WAF fronting Render pattern-matches raw request bodies and
+    403s agent-generated shell text as command injection — `stash share` and
+    ~1.5% of plugin bash events were eaten by the edge before reaching us
+    (measured in plugins commit eae5bdca). We cannot configure that WAF, so
+    clients gzip their JSON bodies and the edge has nothing to match. This
+    middleware restores the plaintext body before routing sees it.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        encoding = next((v for k, v in scope["headers"] if k == b"content-encoding"), b"")
+        if encoding.lower() != b"gzip":
+            await self.app(scope, receive, send)
+            return
+
+        chunks = []
+        while True:
+            message = await receive()
+            chunks.append(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        try:
+            body = gzip.decompress(b"".join(chunks))
+        except (OSError, EOFError):
+            response = JSONResponse(
+                {"detail": "Body does not match Content-Encoding: gzip"},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
+
+        scope = dict(scope)
+        scope["headers"] = [
+            (k, v) for k, v in scope["headers"] if k not in (b"content-encoding", b"content-length")
+        ] + [(b"content-length", str(len(body)).encode())]
+
+        replayed = False
+
+        async def receive_decompressed():
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {"type": "http.request", "body": body, "more_body": False}
+            return await receive()
+
+        await self.app(scope, receive_decompressed, send)

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,7 +1,7 @@
 """Shared middleware and rate-limiting configuration."""
 
-import gzip
 import os
+import zlib
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -13,6 +13,17 @@ _rate_limit_enabled = not bool(os.getenv("TEST_DATABASE_URL"))
 
 limiter = Limiter(key_func=get_remote_address, enabled=_rate_limit_enabled)
 
+# zlib speaks raw deflate by default; the +16 selects the gzip wrapper clients send.
+_GZIP_WINDOW = 16 + zlib.MAX_WBITS
+
+# Far above any real body (the largest is a shared session's Full Transcript
+# page, under a megabyte) and far below what a gzip bomb aims for.
+_MAX_DECOMPRESSED_BODY = 100 * 1024 * 1024
+
+
+async def _reject(scope, receive, send, status: int, detail: str) -> None:
+    await JSONResponse({"detail": detail}, status_code=status)(scope, receive, send)
+
 
 class GzipRequestMiddleware:
     """Decompress request bodies sent with `Content-Encoding: gzip`.
@@ -23,6 +34,11 @@ class GzipRequestMiddleware:
     (measured in plugins commit eae5bdca). We cannot configure that WAF, so
     clients gzip their JSON bodies and the edge has nothing to match. This
     middleware restores the plaintext body before routing sees it.
+
+    Inflating is incremental rather than one `gzip.decompress` of the buffered
+    body: compression is an amplifier, so a few hundred kilobytes on the wire
+    can inflate to gigabytes of our memory. Streaming lets us stop at the first
+    chunk that crosses the ceiling instead of after paying for all of it.
     """
 
     def __init__(self, app):
@@ -37,22 +53,35 @@ class GzipRequestMiddleware:
             await self.app(scope, receive, send)
             return
 
-        chunks = []
+        inflater = zlib.decompressobj(_GZIP_WINDOW)
+        body = bytearray()
         while True:
             message = await receive()
-            chunks.append(message.get("body", b""))
+            # Cap output at one byte past the limit: enough to notice the
+            # overflow, never enough to hold the bomb.
+            headroom = _MAX_DECOMPRESSED_BODY - len(body) + 1
+            try:
+                body += inflater.decompress(message.get("body", b""), headroom)
+            except zlib.error:
+                await _reject(
+                    scope, receive, send, 400, "Body does not match Content-Encoding: gzip"
+                )
+                return
+            if len(body) > _MAX_DECOMPRESSED_BODY:
+                await _reject(
+                    scope, receive, send, 413, "Gzipped body inflates past the size limit"
+                )
+                return
             if not message.get("more_body", False):
                 break
-        try:
-            body = gzip.decompress(b"".join(chunks))
-        except (OSError, EOFError):
-            response = JSONResponse(
-                {"detail": "Body does not match Content-Encoding: gzip"},
-                status_code=400,
-            )
-            await response(scope, receive, send)
+
+        # A body that stops mid-stream decompresses without error but is
+        # missing its tail; routing must never see a half-parsed request.
+        if not inflater.eof:
+            await _reject(scope, receive, send, 400, "Body does not match Content-Encoding: gzip")
             return
 
+        body = bytes(body)
         scope = dict(scope)
         scope["headers"] = [
             (k, v) for k, v in scope["headers"] if k not in (b"content-encoding", b"content-length")

--- a/backend/tests/test_gzip_requests.py
+++ b/backend/tests/test_gzip_requests.py
@@ -1,0 +1,93 @@
+"""Gzipped request bodies must be transparently decompressed.
+
+The Cloudflare WAF fronting Render 403s raw agent shell text as command
+injection ("stash share" was blocked entirely). Clients therefore gzip JSON
+bodies; GzipRequestMiddleware must restore them so routing sees plain JSON,
+and a body that lies about its encoding must fail loud with a 400.
+"""
+
+import gzip
+import json
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={
+            "name": unique_name("gzip"),
+            "display_name": "Gzip Tester",
+            "password": "securepassword1",
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+# Shell text that the edge WAF rejects when sent raw — the exact class of
+# content that motivated gzipping (command substitution + curl auth header).
+_WAF_HOSTILE = (
+    "```bash\n"
+    '$ TOKEN=$(gcloud auth print-access-token); curl -s -H "Authorization: '
+    'Bearer $TOKEN" https://example.com | python3 -c "import sys"\n'
+    "```"
+)
+
+
+@pytest.mark.asyncio
+async def test_gzipped_page_create_round_trips(client: AsyncClient):
+    api_key = await _register(client)
+
+    body = json.dumps({"name": "WAF-hostile page", "content": _WAF_HOSTILE}).encode()
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        content=gzip.compress(body),
+        headers={
+            **_auth(api_key),
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 201
+    page_id = resp.json()["id"]
+
+    read = await client.get(f"/api/v1/me/pages/{page_id}", headers=_auth(api_key))
+    assert read.status_code == 200
+    assert read.json()["content_markdown"] == _WAF_HOSTILE
+
+
+@pytest.mark.asyncio
+async def test_plain_requests_are_untouched(client: AsyncClient):
+    api_key = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Plain page", "content": "no encoding header"},
+        headers=_auth(api_key),
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_invalid_gzip_body_is_a_400(client: AsyncClient):
+    api_key = await _register(client)
+
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        content=b"this is not gzip",
+        headers={
+            **_auth(api_key),
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 400
+    assert "gzip" in resp.json()["detail"].lower()

--- a/backend/tests/test_gzip_requests.py
+++ b/backend/tests/test_gzip_requests.py
@@ -91,3 +91,50 @@ async def test_invalid_gzip_body_is_a_400(client: AsyncClient):
     )
     assert resp.status_code == 400
     assert "gzip" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_truncated_gzip_body_is_a_400(client: AsyncClient):
+    """A body cut off mid-stream inflates without error but is incomplete.
+
+    zlib returns the bytes it managed to inflate rather than raising, so
+    without an explicit end-of-stream check a half-received request would
+    reach routing as silently truncated JSON.
+    """
+    api_key = await _register(client)
+
+    whole = gzip.compress(json.dumps({"name": "Truncated", "content": _WAF_HOSTILE}).encode())
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        content=whole[: len(whole) // 2],
+        headers={
+            **_auth(api_key),
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_gzip_bomb_is_refused_before_it_is_buffered(client: AsyncClient):
+    """Compression amplifies, so an uncapped decompressor is a memory DoS.
+
+    A few hundred kilobytes on the wire inflate to gigabytes; the request must
+    be refused on size rather than accepted because it arrived small.
+    """
+    api_key = await _register(client)
+
+    bomb = gzip.compress(b"\0" * (200 * 1024 * 1024))
+    assert len(bomb) < 1024 * 1024, "the point of the test is a small body that inflates hugely"
+
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        content=bomb,
+        headers={
+            **_auth(api_key),
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 413

--- a/cli/client.py
+++ b/cli/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import json
 import mimetypes
 import os
@@ -101,6 +102,13 @@ class StashClient:
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
+        # The edge WAF pattern-matches raw bodies and 403s agent shell text as
+        # command injection. Gzip JSON bodies so the edge has nothing to match;
+        # the backend's GzipRequestMiddleware restores them.
+        if kwargs.get("json") is not None:
+            kwargs["content"] = gzip.compress(json.dumps(kwargs.pop("json")).encode())
+            headers["Content-Type"] = "application/json"
+            headers["Content-Encoding"] = "gzip"
         resp = self._http.request(method, path, headers=headers, **kwargs)
         release.note_latest(resp.headers.get(release.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:

--- a/cli/tests/test_gzip_json_bodies.py
+++ b/cli/tests/test_gzip_json_bodies.py
@@ -1,0 +1,51 @@
+"""JSON request bodies must leave the client gzipped.
+
+The Cloudflare WAF fronting the hosted API 403s raw agent shell text as
+command injection, which broke `stash share` outright. The client gzips every
+JSON body so the edge has nothing to pattern-match; the server decompresses.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+
+import httpx
+
+from cli.client import StashClient
+
+WAF_HOSTILE = '$ TOKEN=$(gcloud auth print-access-token); curl -H "Bearer $TOKEN" x'
+
+
+def _capture_client(captured: list) -> StashClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    c = StashClient("https://example.test", api_key="k")
+    c._http = httpx.Client(base_url="https://example.test", transport=httpx.MockTransport(handler))
+    return c
+
+
+def test_json_bodies_are_gzipped():
+    captured: list[httpx.Request] = []
+    c = _capture_client(captured)
+
+    c._post("/api/v1/me/pages/new", json={"name": "p", "content": WAF_HOSTILE})
+
+    req = captured[0]
+    assert req.headers["Content-Encoding"] == "gzip"
+    assert req.headers["Content-Type"] == "application/json"
+    assert json.loads(gzip.decompress(req.content)) == {
+        "name": "p",
+        "content": WAF_HOSTILE,
+    }
+
+
+def test_get_requests_are_untouched():
+    captured: list[httpx.Request] = []
+    c = _capture_client(captured)
+
+    c._get("/api/v1/users/me")
+
+    assert "content-encoding" not in captured[0].headers

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -13,6 +13,7 @@ flush daemon.
 
 from __future__ import annotations
 
+import gzip
 import json
 import time
 from pathlib import Path
@@ -117,6 +118,14 @@ class StashClient:
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
+        # The edge WAF pattern-matches raw bodies and 403s agent shell text as
+        # command injection (~1.5% of bash events; see StashError.from_api).
+        # Gzip JSON bodies so the edge has nothing to match; the backend's
+        # GzipRequestMiddleware restores them.
+        if kwargs.get("json") is not None:
+            kwargs["content"] = gzip.compress(json.dumps(kwargs.pop("json")).encode())
+            headers["Content-Type"] = "application/json"
+            headers["Content-Encoding"] = "gzip"
         resp = self._http.request(method, path, headers=headers, **kwargs)
         release.note_latest(resp.headers.get(release.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:


### PR DESCRIPTION
this is vibecoded and I think this may be an overzealous solution to a niche problem...

## Problem

Render fronts the API with a Cloudflare WAF we cannot configure. Its OWASP command-injection rules match agent-generated shell text in request bodies:

- **`stash share` is completely broken** for real sessions — the Full Transcript page POST 403s with an edge "Blocked" HTML page. Bisecting a real 724KB transcript showed triggers scattered through essentially every bash block (`$(gcloud auth print-access-token ...)`, `curl -H "Authorization: Bearer ..."`, `| python3 -c ...`). The CLI then crashes mid-flow, leaving orphan folders behind.
- **~1.5% of plugin bash events** (16% of session transcripts when sent as one body) are eaten by the same rules — measured in eae5bdca, which made those drops non-wedging but couldn't stop them.

Gzipped bodies pass the edge untouched: transcript uploads have gzipped since day one and have never been blocked. That commit already named the real fix: *"stop shipping raw shell text through a body the edge inspects."*

## Fix

- **`cli/client.py` + `stashai/plugin/stash_client.py`**: every JSON request body is serialized, gzipped, and sent with `Content-Encoding: gzip`. One codepath, no size threshold.
- **`backend/middleware.py`**: new `GzipRequestMiddleware` (pure ASGI) transparently decompresses `Content-Encoding: gzip` request bodies before routing, rewriting `Content-Length`. A body that lies about its encoding fails loud with a 400. Requests without the header are untouched.

Multipart file uploads are unchanged and remain WAF-exposed for shell-heavy text files (known limitation; the share flow's pages are JSON and are covered).

## Tests

- `backend/tests/test_gzip_requests.py` — gzipped page create with WAF-hostile shell content round-trips end-to-end; plain requests untouched; corrupt gzip → 400.
- `cli/tests/test_gzip_json_bodies.py` — client emits gzip + correct headers; GETs untouched.
- Full suite: **1356 passed** (backend + cli + plugins). `ruff check` and `ruff format --check` clean on CI scope.

## Deploy ordering

Merging deploys the backend middleware immediately; the CLI/plugin only reach users on the next version bump, so hosted ordering is automatic. **Self-hosters must update their server image before upgrading the CLI past the next release** — a new CLI against an old server will 4xx on every JSON POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the request pipeline for all gzip-encoded bodies (decompression DoS if the cap fails) and is a breaking client/server pairing for self-hosters. Not auth-critical, but a bad inflate path would affect availability.
> 
> **Overview**
> Stops Cloudflare WAF 403s on agent shell text by gzipping every JSON request from the CLI and plugin, then decompressing on the server before routing.
> 
> `stash share` and ~1.5% of plugin bash events were blocked because the edge pattern-matches raw bodies. Clients now send `Content-Encoding: gzip`; new `GzipRequestMiddleware` restores plaintext, rewrites `Content-Length`, and rejects invalid/truncated gzip (400) or inflation past 100MB (413). Plain requests are unchanged. Multipart uploads are still sent uncompressed.
> 
> **Compatibility:** hosted deploy is backend-first, so ordering is safe. Self-hosters must upgrade the server before a CLI that gzips, or every JSON POST will 4xx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebc079b898c3acfad2410078edbf219db9b60d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->