### PR TITLE
Per-folder session-upload controls, surfaced in Stash Desktop

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -37,6 +37,26 @@
         <p class="error" id="health-error" hidden></p>
       </section>
 
+      <section class="card" id="uploads-card">
+        <h2>Session uploads</h2>
+        <p class="muted">
+          Sessions from every folder upload to your Stash unless you exclude
+          the folder here.
+        </p>
+        <div class="actions">
+          <label class="toggle">
+            <input type="checkbox" id="streaming-toggle" />
+            Upload sessions
+          </label>
+          <button id="exclude-folder-btn" class="btn btn-ghost">Exclude a folder…</button>
+        </div>
+        <h3>Recently uploading</h3>
+        <ul class="statuslist" id="recent-dirs"></ul>
+        <h3>Excluded — never upload</h3>
+        <ul class="statuslist" id="excluded-dirs"></ul>
+        <p class="error" id="uploads-error" hidden></p>
+      </section>
+
       <section class="card" id="memory-card">
         <h2>Memory curator <span class="muted">(Stash cloud)</span></h2>
         <div id="memory-status"></div>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",
+        "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2"
       },
       "devDependencies": {
@@ -1044,6 +1045,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.2.tgz",
+      "integrity": "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2"
   },
   "devDependencies": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2283,6 +2283,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2933,6 +2934,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3439,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
 ]
 
@@ -3727,6 +3753,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "toml 1.1.3+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4823,6 +4891,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4854,11 +4931,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4892,6 +4986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +5002,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4916,10 +5022,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4934,6 +5052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4944,6 +5068,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4958,6 +5088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,6 +5104,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -22,3 +22,4 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
 gethostname = "1"
+tauri-plugin-dialog = "2.7.2"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:allow-open",
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled"

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -48,6 +48,15 @@ pub fn load() -> Result<StashConfig, String> {
 /// Merge key/value pairs into the config file, preserving every key we don't
 /// own — the CLI stores its own settings (enabled_agents, scope, …) here too.
 pub fn save_keys(pairs: &[(&str, &str)]) -> Result<(), String> {
+    let values: Vec<(&str, Value)> = pairs
+        .iter()
+        .map(|(k, v)| (*k, Value::String(v.to_string())))
+        .collect();
+    save_values(&values)
+}
+
+/// Same merge semantics for non-string values (lists, booleans).
+pub fn save_values(pairs: &[(&str, Value)]) -> Result<(), String> {
     let path = config_path();
     let mut root: Value = match std::fs::read_to_string(&path) {
         Ok(raw) => serde_json::from_str(&raw)
@@ -58,10 +67,19 @@ pub fn save_keys(pairs: &[(&str, &str)]) -> Result<(), String> {
         .as_object_mut()
         .ok_or_else(|| format!("{} is not a JSON object", path.display()))?;
     for (key, value) in pairs {
-        obj.insert(key.to_string(), Value::String(value.to_string()));
+        obj.insert(key.to_string(), value.clone());
     }
     let parent = path.parent().expect("config path has a parent");
     std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     let pretty = serde_json::to_string_pretty(&root).expect("serialize config");
     std::fs::write(&path, pretty + "\n").map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+pub fn raw() -> Result<Value, String> {
+    let path = config_path();
+    if !path.exists() {
+        return Ok(Value::Object(Default::default()));
+    }
+    let text = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod curator;
 mod install;
 mod signin;
+mod uploads;
 
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconBuilder;
@@ -12,6 +13,7 @@ use tauri::Manager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
@@ -28,6 +30,10 @@ pub fn run() {
             signin::signin_poll,
             install::install_cli,
             install::install_plugin,
+            uploads::upload_settings,
+            uploads::set_streaming,
+            uploads::exclude_path,
+            uploads::include_path,
             curator::curator_local_status,
             curator::curator_run_now,
             curator::curator_set_enabled,

--- a/desktop/src-tauri/src/uploads.rs
+++ b/desktop/src-tauri/src/uploads.rs
@@ -1,0 +1,96 @@
+//! The "Session uploads" card: which folders stream sessions to Stash.
+//!
+//! Streaming is on globally once signed in; `excluded_paths` in
+//! ~/.stash/config.json is the per-folder opt-out the plugin hooks enforce
+//! (stashai/plugin/scope.py::cwd_in_scope). The plugins also keep a rolling
+//! `recent_cwds` list in their state files, which is what makes "these
+//! folders have been uploading" visible here.
+
+use crate::config;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+fn state_files() -> Vec<(String, PathBuf)> {
+    let home = dirs::home_dir().expect("no home directory");
+    let mut files = vec![(
+        "claude".to_string(),
+        home.join(".claude/plugins/data/stash-stash-plugins/state.json"),
+    )];
+    let others = home.join(".stash/plugins");
+    if let Ok(entries) = std::fs::read_dir(others) {
+        for entry in entries.flatten() {
+            let agent = entry.file_name().to_string_lossy().into_owned();
+            files.push((agent, entry.path().join("state.json")));
+        }
+    }
+    files
+}
+
+/// Folders that have streamed sessions recently, newest-ish first, deduped
+/// across agents.
+fn recent_dirs() -> Vec<String> {
+    let mut seen = Vec::new();
+    for (_agent, path) in state_files() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(state) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        if let Some(list) = state["recent_cwds"].as_array() {
+            for c in list.iter().filter_map(Value::as_str) {
+                if !c.is_empty() && !seen.iter().any(|s| s == c) {
+                    seen.push(c.to_string());
+                }
+            }
+        }
+    }
+    seen
+}
+
+fn excluded_paths(cfg: &Value) -> Vec<String> {
+    cfg["excluded_paths"]
+        .as_array()
+        .map(|l| {
+            l.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn upload_settings() -> Result<Value, String> {
+    let cfg = config::raw()?;
+    Ok(json!({
+        "streaming": cfg["stopped_streaming"] != true,
+        "excluded_paths": excluded_paths(&cfg),
+        "recent_dirs": recent_dirs(),
+    }))
+}
+
+#[tauri::command]
+pub fn set_streaming(enabled: bool) -> Result<(), String> {
+    config::save_values(&[("stopped_streaming", Value::Bool(!enabled))])
+}
+
+#[tauri::command]
+pub fn exclude_path(path: String) -> Result<(), String> {
+    if path.trim().is_empty() {
+        return Err("empty path".into());
+    }
+    let cfg = config::raw()?;
+    let mut paths = excluded_paths(&cfg);
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+    config::save_values(&[("excluded_paths", json!(paths))])
+}
+
+#[tauri::command]
+pub fn include_path(path: String) -> Result<(), String> {
+    let cfg = config::raw()?;
+    let paths: Vec<String> = excluded_paths(&cfg).into_iter().filter(|p| p != &path).collect();
+    config::save_values(&[("excluded_paths", json!(paths))])
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 
 interface Checks {
   signed_in: boolean;
@@ -211,6 +212,74 @@ async function renderHealth() {
 }
 
 // ---------------------------------------------------------------------------
+// Session uploads
+// ---------------------------------------------------------------------------
+
+interface UploadSettings {
+  streaming: boolean;
+  excluded_paths: string[];
+  recent_dirs: string[];
+}
+
+function pathButton(label: string, command: string, path: string): HTMLButtonElement {
+  const btn = el("button", "btn btn-ghost", label) as HTMLButtonElement;
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    try {
+      await invoke(command, { path });
+    } catch (e) {
+      showError("uploads-error", String(e));
+    }
+    await renderUploads();
+  });
+  return btn;
+}
+
+async function renderUploads() {
+  showError("uploads-error", null);
+  try {
+    const s = await invoke<UploadSettings>("upload_settings");
+    ($("streaming-toggle") as HTMLInputElement).checked = s.streaming;
+
+    const recent = $("recent-dirs");
+    recent.replaceChildren();
+    const uploading = s.recent_dirs.filter((d) => !s.excluded_paths.includes(d));
+    if (uploading.length === 0) {
+      recent.append(statusItem("off", "No sessions streamed yet", ""));
+    }
+    for (const dir of uploading) {
+      const li = statusItem(s.streaming ? "ok" : "off", dir, "");
+      li.append(pathButton("Exclude", "exclude_path", dir));
+      recent.append(li);
+    }
+
+    const excluded = $("excluded-dirs");
+    excluded.replaceChildren();
+    if (s.excluded_paths.length === 0) {
+      excluded.append(statusItem("off", "Nothing excluded", ""));
+    }
+    for (const dir of s.excluded_paths) {
+      const li = statusItem("bad", dir, "");
+      li.append(pathButton("Resume uploads", "include_path", dir));
+      excluded.append(li);
+    }
+  } catch (e) {
+    showError("uploads-error", String(e));
+  }
+}
+
+async function excludeFolderViaPicker() {
+  const dir = await openDialog({ directory: true, multiple: false });
+  if (typeof dir !== "string" || !dir) return;
+  try {
+    await invoke("exclude_path", { path: dir });
+  } catch (e) {
+    showError("uploads-error", String(e));
+  }
+  await renderUploads();
+}
+
+// ---------------------------------------------------------------------------
 // Memory curator (server-side)
 // ---------------------------------------------------------------------------
 
@@ -326,13 +395,30 @@ async function renderAutostart() {
 // ---------------------------------------------------------------------------
 
 async function refreshAll() {
-  await Promise.all([renderChecklist(), renderHealth(), renderMemory(), renderLocal()]);
+  await Promise.all([
+    renderChecklist(),
+    renderHealth(),
+    renderUploads(),
+    renderMemory(),
+    renderLocal(),
+  ]);
 }
 
 window.addEventListener("DOMContentLoaded", () => {
   $("refresh-btn").addEventListener("click", refreshAll);
   $("recompute-btn").addEventListener("click", recomputeMemory);
   $("local-run-btn").addEventListener("click", runLocalNow);
+
+  $("streaming-toggle").addEventListener("change", async (e) => {
+    const enabled = (e.target as HTMLInputElement).checked;
+    try {
+      await invoke("set_streaming", { enabled });
+    } catch (err) {
+      showError("uploads-error", String(err));
+    }
+    await renderUploads();
+  });
+  $("exclude-folder-btn").addEventListener("click", excludeFolderViaPicker);
 
   $("local-enabled").addEventListener("change", async (e) => {
     const enabled = (e.target as HTMLInputElement).checked;

--- a/plugins/tests/conftest.py
+++ b/plugins/tests/conftest.py
@@ -12,4 +12,4 @@ def _scope_wide_open(monkeypatch):
     # tests exercise the real gate directly.
     from stashai.plugin import hooks
 
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -1,11 +1,13 @@
-"""Scope gate — global, single-player streaming switch.
+"""Scope gate — global switch plus per-folder exclusions.
 
-There is no `.stash` manifest and no cwd/path-based scope. A session streams
-iff the plugin is configured (an `api_key` is present in the user CLI config)
-AND streaming has not been globally stopped (`stopped_streaming` flag). The
-`cwd` argument is kept only for call-site compatibility.
+A session streams iff the plugin is configured (an `api_key` is present in
+the user CLI config), streaming has not been globally stopped
+(`stopped_streaming` flag), and the session's cwd is not inside any
+`excluded_paths` entry — the per-folder opt-out Stash Desktop manages. The
+exclusion must be path-boundary-safe: excluding /repo must not silence
+/repo2, or an unrelated project goes dark without the user ever choosing it.
 
-Regression test: when the global gate is off, no event reaches the transport.
+Regression test: when the gate is off, no event reaches the transport.
 """
 
 from __future__ import annotations
@@ -49,12 +51,33 @@ def test_missing_config_does_not_stream(tmp_path, monkeypatch):
     assert not scope_mod.cwd_in_scope("/anywhere")
 
 
-def test_cwd_is_ignored(tmp_path, monkeypatch):
+def test_no_exclusions_streams_everywhere(tmp_path, monkeypatch):
     cfg = _write_config(tmp_path, {"api_key": "k"})
     monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
     assert scope_mod.cwd_in_scope("")
     assert scope_mod.cwd_in_scope(None)
     assert scope_mod.cwd_in_scope("/some/deep/path")
+
+
+def test_excluded_folder_blocks_itself_and_children(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "excluded_paths": ["/w/secret"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert not scope_mod.cwd_in_scope("/w/secret")
+    assert not scope_mod.cwd_in_scope("/w/secret/sub/dir")
+    assert scope_mod.cwd_in_scope("/w/other")
+
+
+def test_exclusion_is_path_boundary_safe(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "excluded_paths": ["/w/repo"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert not scope_mod.cwd_in_scope("/w/repo")
+    assert scope_mod.cwd_in_scope("/w/repo2")
+
+
+def test_empty_cwd_cannot_match_an_exclusion(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "excluded_paths": ["/w/secret"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert scope_mod.cwd_in_scope("")
 
 
 # --- Regression: the global gate must short-circuit live events ------------
@@ -73,7 +96,7 @@ def test_gate_off_blocks_live_events(monkeypatch):
     from stashai.plugin import hooks
     from stashai.plugin.hooks import stream_user_message
 
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: False)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: False)
 
     c = _RecordingClient()
     stream_user_message(
@@ -90,7 +113,7 @@ def test_gate_on_allows_live_events(monkeypatch):
     from stashai.plugin import hooks
     from stashai.plugin.hooks import stream_user_message
 
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)
 
     c = _RecordingClient()
     stream_user_message(

--- a/plugins/tests/test_upload_health_warning.py
+++ b/plugins/tests/test_upload_health_warning.py
@@ -25,7 +25,7 @@ def _event(session_id: str) -> HookEvent:
 
 
 def _enable_streaming(monkeypatch):
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)
     monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
 
 
@@ -81,7 +81,7 @@ def test_uploads_enabled_requires_auth_and_streaming(monkeypatch):
 
 def test_uploads_disabled_warning_is_once_per_session(monkeypatch, tmp_path):
     monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)
     monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
     state = {}
     cfg = {**_cfg(), "api_key": ""}
@@ -101,7 +101,7 @@ def test_uploads_disabled_warning_is_once_per_session(monkeypatch, tmp_path):
 
 def test_uploads_disabled_warning_skips_disabled_agent(monkeypatch, tmp_path):
     monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)
     monkeypatch.setattr(hooks, "_read_user_config", lambda: {"enabled_agents": ["claude"]})
 
     warning = uploads_disabled_warning(_cfg(), {}, _event("s1"), tmp_path)
@@ -111,7 +111,7 @@ def test_uploads_disabled_warning_skips_disabled_agent(monkeypatch, tmp_path):
 
 def test_uploads_disabled_warning_skips_when_streaming_stopped(monkeypatch, tmp_path):
     monkeypatch.setattr(hooks.shutil, "which", lambda name: "/usr/local/bin/stash")
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: False)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: False)
     monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
 
     warning = uploads_disabled_warning(_cfg(), {}, _event("s1"), tmp_path)
@@ -121,7 +121,7 @@ def test_uploads_disabled_warning_skips_when_streaming_stopped(monkeypatch, tmp_
 
 def test_uploads_disabled_warning_requires_stash_cli(monkeypatch, tmp_path):
     monkeypatch.setattr(hooks.shutil, "which", lambda name: None)
-    monkeypatch.setattr(hooks, "streaming_enabled", lambda: True)
+    monkeypatch.setattr(hooks, "cwd_in_scope", lambda *a, **k: True)
     monkeypatch.setattr(hooks, "_read_user_config", lambda: {})
 
     warning = uploads_disabled_warning({**_cfg(), "api_key": ""}, {}, _event("s1"), tmp_path)

--- a/stashai/plugin/hooks.py
+++ b/stashai/plugin/hooks.py
@@ -23,7 +23,7 @@ import shutil
 from pathlib import Path
 
 from stashai.plugin.event import HookEvent
-from stashai.plugin.scope import streaming_enabled
+from stashai.plugin.scope import cwd_in_scope
 from stashai.plugin.session_upload import spawn_session_upload
 from stashai.plugin.stash_client import StashClient
 from stashai.plugin.state import read_stats, record_tool_use, save_state
@@ -106,18 +106,23 @@ def _is_agent_enabled(cfg: dict) -> bool:
     return canonical in enabled
 
 
-def _short_circuit(cfg: dict) -> bool:
+def _cwd_of(event: HookEvent | None, state: dict) -> str:
+    return (event.cwd if event else "") or state.get("cwd", "")
+
+
+def _short_circuit(cfg: dict, cwd: str = "") -> bool:
     """Return True when this session should NOT stream.
 
     Streams by default whenever the plugin is configured and streaming hasn't
-    been globally stopped. Only skips when the agent is disabled, the plugin is
-    unconfigured, or the user ran `stash stop`.
+    been globally stopped. Skips when the agent is disabled, the plugin is
+    unconfigured, the user ran `stash stop`, or the session's directory is
+    inside an excluded folder (`excluded_paths` in the user config).
     """
     if not _is_agent_enabled(cfg):
         return True
     if not cfg.get("agent_name"):
         return True
-    return not streaming_enabled()
+    return not cwd_in_scope(cwd)
 
 
 def _event_metadata(event: HookEvent | None, base: dict | None = None) -> dict:
@@ -205,7 +210,7 @@ def create_session_record(
     The hook must stay best-effort: backend/network failures should never
     interrupt the user's coding agent.
     """
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return None
 
     sid = event.session_id or state.get("session_id", "")
@@ -213,6 +218,10 @@ def create_session_record(
         return None
     if event.cwd:
         state["cwd"] = event.cwd
+        # Rolling list of folders that have streamed sessions — Stash
+        # Desktop's "Session uploads" card shows it so uploading is visible.
+        recents = [c for c in state.get("recent_cwds", []) if c != event.cwd]
+        state["recent_cwds"] = [event.cwd, *recents][:20]
 
     if state.get("session_row_id") and state.get("uploaded_session_id") == sid:
         return state.get("session_url")
@@ -254,7 +263,7 @@ def finalize_session_upload(
     if not event.cwd and state.get("cwd"):
         event.cwd = state["cwd"]
 
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return False
 
     sid = event.session_id or state.get("session_id", "")
@@ -302,7 +311,7 @@ def stream_user_message(
     prompt_text: str,
     event: HookEvent | None = None,
 ) -> None:
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return
     if not prompt_text or not prompt_text.strip():
         return
@@ -333,7 +342,7 @@ def stream_tool_use(
     event: HookEvent,
     data_dir: Path | None = None,
 ) -> None:
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return
     if not event.tool_name:
         return
@@ -379,7 +388,7 @@ def stream_assistant_message(
     """Push the final assistant text for a turn. Call from per-turn Stop /
     afterAgentResponse / AfterAgent hooks. Never emits session_end — the
     session is still live."""
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return
     if not event.last_assistant_message:
         return
@@ -407,7 +416,7 @@ def upload_health_warning(
     data_dir: Path,
 ) -> str | None:
     """Return the once-per-session local upload failure warning, if needed."""
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return None
 
     session_id = event.session_id or state.get("session_id", "")
@@ -445,7 +454,7 @@ def stream_session_end(
     if not event.cwd and state.get("cwd"):
         event.cwd = state["cwd"]
 
-    if _short_circuit(cfg):
+    if _short_circuit(cfg, _cwd_of(event, state)):
         return None
 
     sid = event.session_id or state.get("session_id", "")

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -1,10 +1,10 @@
-"""Global streaming gate for the plugin.
+"""Streaming gate for the plugin.
 
-There is no `.stash` manifest and no cwd/path-based scope anymore. A session
-streams iff the plugin is configured (an api_key is present in the user CLI
-config) and streaming has not been globally stopped (`stopped_streaming` in the
-user config). The `cwd` argument is kept only for call-site compatibility; it
-does not affect the result.
+A session streams iff the plugin is configured (an api_key is present in the
+user CLI config), streaming has not been globally stopped (`stopped_streaming`
+in the user config), and the session's working directory is not under any
+entry in `excluded_paths` — the per-folder opt-out that Stash Desktop's
+"Session uploads" card manages.
 """
 
 from __future__ import annotations
@@ -32,6 +32,23 @@ def streaming_enabled() -> bool:
     return not cfg.get("stopped_streaming")
 
 
+def _under(cwd: Path, excluded: Path) -> bool:
+    return cwd == excluded or excluded in cwd.parents
+
+
 def cwd_in_scope(cwd: str | None = None) -> bool:
-    """True if streaming is globally enabled. `cwd` is ignored."""
-    return streaming_enabled()
+    """True if a session in `cwd` should stream.
+
+    Globally enabled AND cwd is not inside an excluded folder. An empty cwd
+    (some per-turn events carry none) can't match an exclusion and streams.
+    """
+    if not streaming_enabled():
+        return False
+    if not cwd:
+        return True
+    cfg = _read_user_config()
+    cwd_path = Path(cwd).resolve()
+    for entry in cfg.get("excluded_paths") or []:
+        if isinstance(entry, str) and entry and _under(cwd_path, Path(entry).resolve()):
+            return False
+    return True


### PR DESCRIPTION
Follow-up to #928. Sessions streamed globally with no per-folder control and no visibility into which folders were uploading.

## What changed

- **Enforcement (shared hook gate, all agent plugins):** `cwd_in_scope()` in `stashai/plugin/scope.py` now honors `excluded_paths` in `~/.stash/config.json` — a session whose cwd is inside an excluded folder never streams. Path-boundary-safe (excluding `/w/repo` does not silence `/w/repo2`); an empty cwd can't match an exclusion. The per-event gate threads the session cwd through `_short_circuit`.
- **Visibility:** the session-start hook keeps a rolling `recent_cwds` (cap 20) in each agent's plugin state, so "these folders have been uploading" is knowable locally.
- **Stash Desktop — new "Session uploads" card:** global upload toggle (`stopped_streaming`), the recently-uploading folder list with one-click **Exclude**, the excluded list with **Resume uploads**, and an "Exclude a folder…" native picker (tauri-plugin-dialog).

## Tests

- `plugins/tests/test_scope.py`: exclusion blocks the folder and children, boundary safety (`/repo` vs `/repo2`), empty-cwd behavior; gate-off blocks live events (fixtures updated to the new gate name).
- Full plugin + CLI suites: 351 passed. tsc + cargo clean.

## Notes

- The exclusion takes effect fleet-wide when this releases through the normal CLI train (`stashai/**` triggers the version bump).
- "Recently uploading" populates as sessions run under the new plugin; fresh installs show an empty state until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)