### PR TITLE
Curator: include changed Drive-folder documents in the change feed

### DIFF
--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -2,10 +2,11 @@
 
 `changes_since` is the incremental delta since the curator's watermark: new
 history events (excluding the curator's own run sessions), changed pages
-(excluding the Memory subtree), new files, and the user's connected sources as
-pointers (the agent pulls source specifics with `stash search`) — the curator
-never sees its own output. `has_changes_since` is the cheap EXISTS the beat
-task uses to skip idle users without waking a sprite.
+(excluding the Memory subtree), new files, changed Drive-folder documents,
+and the user's connected sources as pointers (the agent pulls source
+specifics with `stash search`) — the curator never sees its own output.
+`has_changes_since` is the cheap EXISTS the beat task uses to skip idle users
+without waking a sprite.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ _MAX_EVENTS = 500
 _MAX_PAGES = 100
 _MAX_FILES = 100
 _MAX_SAVES = 100
+_MAX_SOURCE_DOCS = 100
 _SNIPPET = 280
 
 
@@ -46,6 +48,9 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
                             OR folder_id <> ALL($3)))
           OR EXISTS (SELECT 1 FROM files
                      WHERE owner_user_id = $1 AND created_at > $2)
+          OR EXISTS (SELECT 1 FROM drive_documents
+                     WHERE owner_user_id = $1 AND updated_at > $2
+                       AND extraction_status = 'done' AND deleted_at IS NULL)
           OR EXISTS (SELECT 1 FROM x_save_docs
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND hydration_status = 'done' AND deleted_at IS NULL)
@@ -63,7 +68,8 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
 
 async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> dict:
     """The delta the curator reads: history events, changed pages (excl. Memory),
-    new files, newly hydrated X/Instagram saves, and connected-source pointers."""
+    new files, changed Drive-folder documents, newly hydrated X/Instagram
+    saves, and connected-source pointers."""
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
     exclude = list(memory_ids) or None
@@ -130,6 +136,36 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         for r in file_rows
     ]
 
+    # Changed Drive-folder documents, as items rather than source pointers — a
+    # picked Drive folder is the user's curated document set (edited outside
+    # Stash), so an edit there is curation input the same way an upload is.
+    # `updated_at` moves only on a real change: the sync upsert bumps it when
+    # Drive's modifiedTime differs, and extraction bumps it when the new body
+    # lands. Gating on 'done' presents a doc only once its text is readable.
+    source_doc_rows = await pool.fetch(
+        """
+        SELECT path, name, updated_at, left(coalesce(content, ''), $4) AS snippet
+        FROM drive_documents
+        WHERE owner_user_id = $1
+          AND ($2::timestamptz IS NULL OR updated_at > $2)
+          AND extraction_status = 'done' AND deleted_at IS NULL
+        ORDER BY updated_at DESC LIMIT $3
+        """,
+        owner_user_id,
+        since,
+        _MAX_SOURCE_DOCS,
+        _SNIPPET,
+    )
+    source_docs = [
+        {
+            "path": r["path"],
+            "name": r["name"],
+            "updated_at": _iso(r["updated_at"]),
+            "snippet": r["snippet"],
+        }
+        for r in source_doc_rows
+    ]
+
     # Newly hydrated X/Instagram saves, as items rather than source pointers —
     # a save the user made is deliberate curation input, like an upload.
     save_rows = await pool.fetch(
@@ -183,6 +219,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "history": len(history),
             "pages": len(pages),
             "files": len(files),
+            "source_docs": len(source_docs),
             "saves": len(saves),
             "sources": len(sources),
         },
@@ -190,6 +227,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         "history_has_more": history_has_more,
         "pages": pages,
         "files": files,
+        "source_docs": source_docs,
         "saves": saves,
         "sources": sources,
     }

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -196,7 +196,8 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 
 ## Read the inputs
 - `{changes_cmd}` — the delta to curate: recent
-  history/chats, changed pages, new files, new saves (clips and X/Instagram
+  history/chats, changed pages, new files, changed source documents (docs
+  edited in a connected Drive folder), new saves (clips and X/Instagram
   saves), and connected sources. This IS your work set; do not re-scan the
   whole corpus.
 - `history_has_more: true` means the history overflowed this run's cap. The
@@ -249,10 +250,13 @@ pages themselves.
 - **Category-first, pages-second.** A concept from chat history gets its own
   page only when it appears in >=2 distinct events; one-shot mentions stay as
   bullets on the category index page.
-- **Uploaded documents are content, not context.** The changed pages and new
-  files in the delta are material the user deliberately added — represent every
-  distinct document or document set in the wiki: a topic page, or bullets under
-  the best-fit category, adding a new category when none fits. The >=2 rule
+- **Uploaded documents are content, not context.** The changed pages, new
+  files, and changed source documents in the delta are material the user
+  deliberately added — represent every distinct document or document set in
+  the wiki: a topic page, or bullets under the best-fit category, adding a new
+  category when none fits. A changed source document whose topic already has a
+  wiki page supersedes what that page took from the old version — fold the new
+  version in (`stash search` its path for the full body). The >=2 rule
   above is for chat mentions and never applies to documents. After curation,
   each upload must be findable by searching the wiki.
 - **Saved content becomes topic list pages.** Clips and X/Instagram saves in

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -115,6 +115,40 @@ async def test_hydrated_saves_flow_through_the_feed(client: AsyncClient, _db_poo
     assert save["snippet"] == "a saved thread"
 
 
+@pytest.mark.asyncio
+async def test_changed_drive_docs_flow_through_the_feed(client: AsyncClient, _db_pool):
+    """A doc edited in a connected Drive folder is curation input like an
+    upload: once its new body is extracted it must trip the cheap gate and
+    appear in the delta. A doc still mid-extraction or deleted must do
+    neither — the curator only sees documents whose text is readable."""
+    from backend.services import source_service
+
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    source = await source_service.create_source(
+        owner_user_id=str(uid),
+        source_type="google_drive_folder",
+        external_ref=unique_name("folder"),
+        display_name="Part Cheat Sheets",
+    )
+    await _db_pool.execute(
+        "INSERT INTO drive_documents (owner_user_id, source_id, path, name, kind, "
+        "external_ref, content, extraction_status, deleted_at) VALUES "
+        "($1, $2, 'Sheets/Brakes', 'Brakes', 'file', 'g1', 'the final recipe', 'done', NULL), "
+        "($1, $2, 'Sheets/Hubs', 'Hubs', 'file', 'g2', NULL, 'pending', NULL), "
+        "($1, $2, 'Sheets/Old', 'Old', 'file', 'g3', 'stale', 'done', now())",
+        uid,
+        UUID(source["id"]),
+    )
+
+    assert await curation_service.has_changes_since(uid, uid, old) is True
+    feed = await curation_service.changes_since(uid, uid, old)
+    assert feed["counts"]["source_docs"] == 1
+    doc = feed["source_docs"][0]
+    assert doc["path"] == "Sheets/Brakes"
+    assert doc["snippet"] == "the final recipe"
+
+
 async def _push_events(client: AsyncClient, key: str, events: list[dict]) -> None:
     r = await client.post(
         "/api/v1/me/sessions/events/batch", json={"events": events}, headers=_auth(key)


### PR DESCRIPTION
## Problem

The nightly Memory curator was blind to Google Drive changes. Its delta (`changes_since`) covered history events, changed pages, new files, and X/Instagram saves — but docs edited in a connected Drive folder never appeared. The sync pipeline tracked them precisely (`drive_documents.updated_at` moves only on a real Drive `modifiedTime` change or a completed extraction), but that delta dead-ended in the table: connected sources reached the curator only as name pointers, and the prompt explicitly told it not to re-scan the corpus. Worst case, if a Drive edit was the *only* change since the watermark, `has_changes_since` returned false and the run was skipped entirely — no error, no alert.

Observed in prod on the Heavi account: cheat-sheet docs overhauled in Drive on 7/23 were ignored by three consecutive successful curator runs; their wiki pages still reflect the pre-7/23 versions.

## Fix

Changed Drive-folder docs are now curation input on the same footing as uploads:

- `curation_service.changes_since` gains a `source_docs` section — path, name, updated_at, content snippet; `extraction_status = 'done'` and not deleted; same 100-row cap as pages/files.
- `curation_service.has_changes_since` gains the matching EXISTS, so a Drive-only day wakes the curator.
- The curator prompt names changed source documents in its work set, and the documents ingest principle now states a changed source doc supersedes what its wiki page took from the old version.

Scoped to `drive_documents` deliberately: it's the one source where a customer curates documents *outside* Stash and expects the wiki to follow. Other content tables (gong, github, notion) share the structural gap but have no live use case yet.

## Testing

- New test: an extracted Drive doc trips the gate and appears in the feed; mid-extraction and deleted docs do neither.
- Full suite: 1008 passed. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)