### PR TITLE
Drive extraction: surface the child's crash report instead of a bare exit 1

### DIFF
--- a/backend/tasks/drive_extraction.py
+++ b/backend/tasks/drive_extraction.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import subprocess
 import sys
+import tempfile
 from uuid import UUID
 
 from ..celery_app import celery
@@ -34,23 +36,42 @@ MAX_ATTEMPTS = 3
 # the sweep enqueues rows the claim then refuses.
 STALE_LOCK = "30 minutes"
 
+_CHILD_MODULE = "backend.workers.extract_drive_one"
 
-async def _run_child(row_id: UUID) -> int:
-    proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "backend.workers.extract_drive_one",
-        str(row_id),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    try:
-        await asyncio.wait_for(proc.communicate(), timeout=CHILD_TIMEOUT_SECONDS)
-    except TimeoutError:
-        proc.kill()
-        await proc.wait()
-        return -1
-    return proc.returncode or 0
+# Enough stderr to hold the child's crash report (a redacted traceback), small
+# enough that parser-library noise ahead of it can't bloat a log line.
+STDERR_TAIL_BYTES = 2000
+
+
+async def _run_child(row_id: UUID) -> tuple[int, str]:
+    """Run the child; return its exit code and the tail of its stderr.
+
+    stderr goes to a temp file, not a pipe: parser libraries can spew
+    megabytes of warnings, and a pipe would buffer all of it inside this
+    worker — the exact exposure the child process exists to avoid. Only the
+    tail comes back, which is where the child's own crash report lands.
+    stdout stays discarded (parser libraries print document content there).
+    """
+    with tempfile.TemporaryFile() as errf:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            _CHILD_MODULE,
+            str(row_id),
+            stdout=subprocess.DEVNULL,
+            stderr=errf,
+        )
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=CHILD_TIMEOUT_SECONDS)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return -1, ""
+        errf.seek(0, os.SEEK_END)
+        size = errf.tell()
+        errf.seek(max(0, size - STDERR_TAIL_BYTES))
+        tail = errf.read().decode(errors="replace").strip()
+    return proc.returncode or 0, tail
 
 
 async def _claim(row_id: UUID) -> bool:
@@ -101,14 +122,19 @@ async def _extract(row_id: UUID) -> str:
     if not await _claim(row_id):
         return "skipped"
 
-    code = await _run_child(row_id)
+    code, err_tail = await _run_child(row_id)
     if code == 0:
         return "ok"
 
     reason = "extraction ran out of memory" if code in (-9, 137) else f"extraction exited {code}"
     if code == -1:
         reason = "extraction timed out"
-    logger.warning("drive extraction child failed row=%s reason=%s", row_id, reason)
+    logger.warning(
+        "drive extraction child failed row=%s reason=%s stderr=%s",
+        row_id,
+        reason,
+        err_tail or "<empty>",
+    )
     await _mark_failed_externally(row_id, reason)
     return "failed"
 

--- a/backend/tests/test_drive_extraction_pipeline.py
+++ b/backend/tests/test_drive_extraction_pipeline.py
@@ -7,6 +7,7 @@ child process's status transitions. Without this the read-side tests only prove
 that a correctly populated table reads correctly — never that anything fills it.
 """
 
+import sys
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from uuid import UUID, uuid4
@@ -357,11 +358,11 @@ async def test_a_row_is_claimed_once(client: AsyncClient, monkeypatch):
 
 
 async def _child_ok(_row_id):
-    return 0
+    return 0, ""
 
 
 async def _child_oom(_row_id):
-    return 137
+    return 137, ""
 
 
 async def test_a_child_killed_by_the_oom_killer_is_recorded(client: AsyncClient, monkeypatch):
@@ -378,6 +379,40 @@ async def test_a_child_killed_by_the_oom_killer_is_recorded(client: AsyncClient,
     )
     assert row["extraction_status"] == "pending"  # retryable, attempts = 1
     assert "out of memory" in row["extraction_error"]
+
+
+async def test_a_startup_crash_reaches_the_parents_log(monkeypatch):
+    """A child that dies before it can write its own reason — an import
+    failure, a refused DB connection — must not vanish into a bare 'exited 1'.
+    The parent captures the stderr tail, which carries the failure."""
+    monkeypatch.setattr(drive_extraction, "_CHILD_MODULE", "backend.no_such_module")
+
+    code, tail = await drive_extraction._run_child(uuid4())
+
+    assert code == 1
+    assert "No module named" in tail
+
+
+def test_a_child_crash_report_names_the_class_but_never_the_message(monkeypatch, capsys):
+    """The stderr crash report follows the same redaction rule as the row's
+    persisted error: frames locate the failure, the message stays out — it can
+    embed document text or provider responses, and this reaches the logs."""
+    monkeypatch.setattr(extract_drive_one, "_apply_memory_limit", lambda: None)
+
+    async def _boom(_row_id):
+        raise RuntimeError("token abc123 leaked into the message")
+
+    monkeypatch.setattr(extract_drive_one, "_run", _boom)
+    monkeypatch.setattr(sys, "argv", ["extract_drive_one", str(uuid4())])
+
+    with pytest.raises(SystemExit) as exc:
+        extract_drive_one.main()
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "RuntimeError" in err
+    assert "_boom" in err  # the frames locate the failure
+    assert "abc123" not in err
 
 
 async def test_a_file_removed_from_drive_stops_being_readable(client: AsyncClient, monkeypatch):

--- a/backend/workers/extract_drive_one.py
+++ b/backend/workers/extract_drive_one.py
@@ -8,13 +8,16 @@ Isolated in its own OS process so pypdf on a 180 MB parts catalog OOMs this
 child rather than the Celery worker. RLIMIT_AS is applied before any heavy
 library loads, exactly as `extract_one` does for uploads.
 
-The dispatcher discards stdout/stderr (parser libraries print document content),
-so the child never logs: its only output channels are the exit code and the row
-it updates.
+The dispatcher discards stdout (parser libraries print document content there)
+but keeps the tail of stderr: a crash that happens before the row can record
+its own reason — an import failure, a refused DB connection, a MemoryError in
+startup — used to vanish into an unexplained exit 1. On any crash the child
+now writes a redacted traceback to stderr (frames and exception class only;
+messages can embed document text or provider responses) for the parent to log.
 
 Exit codes:
     0  success (the row carries the text, or a loud reason it has none)
-    1  failure (the row records a redacted error)
+    1  failure (the row records a redacted error; stderr carries the frames)
     137 SIGKILL — typically the OOM killer. The parent records it.
 """
 
@@ -24,6 +27,7 @@ import asyncio
 import os
 import resource
 import sys
+import traceback
 from uuid import UUID
 
 _MEM_LIMIT_BYTES = int(os.getenv("EXTRACTION_MEMORY_LIMIT_MB", "1024")) * 1024 * 1024
@@ -134,7 +138,16 @@ def main() -> None:
         print("invalid uuid", file=sys.stderr)
         sys.exit(2)
     _apply_memory_limit()
-    sys.exit(asyncio.run(_run(row_id)))
+    try:
+        code = asyncio.run(_run(row_id))
+    except Exception as e:
+        # Frame locations only — no source lines and no message. Either can
+        # embed document text, and this report reaches the parent's logs.
+        for filename, lineno, name, _line in traceback.extract_tb(e.__traceback__):
+            sys.stderr.write(f'  File "{filename}", line {lineno}, in {name}\n')
+        sys.stderr.write(f"{type(e).__name__}\n")
+        sys.exit(1)
+    sys.exit(code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The drive-extraction child (`extract_drive_one`) runs with stdout AND stderr discarded, and its imports + DB connect sit outside its error-recording try/except. Any startup failure — import error, refused DB connection, MemoryError before the row is loaded — is an unrecorded `exit 1`, indistinguishable from every other failure.

This is not hypothetical: on 7/25 a ~90-minute storm of sub-200ms child deaths (starting one minute after an instance replacement, across multiple users, with zero successful extractions globally in the window) burned all 3 retry attempts on two Heavi brake-shoe documents. The docs then rested permanently as `failed / "extraction exited 1"`. Root cause is unknowable in hindsight — nothing was captured. Both files extracted fine on first attempt once revived today, proving the failure was environmental, not the documents.

## Fix

- **Child** (`backend/workers/extract_drive_one.py`): `main()` wraps the run; on any crash it writes a redacted crash report to stderr — frame locations only (`File "...", line N, in fn`), no source lines and no exception message, either of which can embed document text. Same redaction rule as the row's persisted error.
- **Parent** (`backend/tasks/drive_extraction.py`): `_run_child` captures the stderr tail (last 2000 bytes) via a temp file — never a pipe, since parser libraries can spew megabytes of warnings and buffering that inside the celery worker is the exact exposure the child process exists to avoid. The tail is logged with the existing failure warning. stdout stays discarded (document content).

## Testing

- New test: a child that dies at startup (unimportable module) returns exit 1 **with** the failure visible in the captured tail — the exact 7/25 class.
- New test: the crash report names the exception class and frames but never the message (this test caught a real leak in the first implementation — `format_tb` includes source lines, which can embed the message).
- Extraction + drive-documents suites: 29 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)