### PR TITLE
Workspace members can share workspace content; share dialog shows the true owner

### DIFF
--- a/backend/routers/shares.py
+++ b/backend/routers/shares.py
@@ -52,7 +52,7 @@ async def create_share(req: ShareRequest, current_user: dict = Depends(get_curre
         object_id=req.object_id,
         email=req.email,
         permission=req.permission,
-        owner_id=current_user["id"],
+        actor_id=current_user["id"],
         expires_at=req.expires_at,
     )
 
@@ -64,7 +64,7 @@ async def delete_share(req: UnshareRequest, current_user: dict = Depends(get_cur
         object_id=req.object_id,
         principal_type=req.principal_type,
         principal_id=req.principal_id,
-        owner_id=current_user["id"],
+        actor_id=current_user["id"],
     )
     return {"ok": True}
 
@@ -78,7 +78,7 @@ async def delete_pending_invite(
         object_type=req.object_type,
         object_id=req.object_id,
         email=req.email,
-        owner_id=current_user["id"],
+        actor_id=current_user["id"],
     )
     return {"ok": True}
 
@@ -121,11 +121,4 @@ async def list_shares(
     object_id: UUID,
     current_user: dict = Depends(get_current_user),
 ):
-    return {
-        "shares": await share_service.list_object_shares(
-            object_type, object_id, current_user["id"]
-        ),
-        "general_access": await share_service.get_general_access(
-            object_type, object_id, current_user["id"]
-        ),
-    }
+    return await share_service.object_access(object_type, object_id, current_user["id"])

--- a/backend/services/share_service.py
+++ b/backend/services/share_service.py
@@ -1,7 +1,8 @@
 """Sharing: grant a principal (user or skill) access to an object.
 
-Primary path is sharing a folder/file/session with a person by email. Only the
-object's owner may share it. Folder/session-folder shares
+Primary path is sharing a folder/file/session with a person by email. The
+object's scope owner may share it, and for workspace-scoped content so may any
+workspace member — see `_require_share_access`. Folder/session-folder shares
 cascade to contents — that's handled at read time by permission_service, not here.
 
 Sharing with an email that isn't a Stash user yet records a pending invite
@@ -28,12 +29,22 @@ _GENERAL_ACCESS_TABLE = {"page": "pages", "file": "files", "folder": "folders", 
 _PUBLIC_PERMISSIONS = {"none", "read", "comment", "write"}
 
 
-async def _require_owner(object_type: str, object_id: UUID, user_id: UUID) -> UUID:
-    """The caller must be an owner of the object's scope."""
+async def _require_share_access(object_type: str, object_id: UUID, user_id: UUID) -> UUID:
+    """The caller must be the object's scope owner or, for content in a
+    workspace scope, a workspace member — a member can already read and copy
+    workspace content, so sharing it grants nothing they couldn't leak by hand.
+    Sources stay owner-only: a shared source delegates reads through the
+    scope's OAuth token, which members don't otherwise hold."""
     owner_user_id = await permission_service.resolve_owner_user_id(object_type, object_id)
-    if owner_user_id is None or not await user_scope_service.is_owner(owner_user_id, user_id):
+    if owner_user_id is None:
         raise HTTPException(status_code=404, detail="Not found")
-    return owner_user_id
+    if await user_scope_service.is_owner(owner_user_id, user_id):
+        return owner_user_id
+    if object_type != "source" and await permission_service.is_workspace_member(
+        owner_user_id, user_id
+    ):
+        return owner_user_id
+    raise HTTPException(status_code=404, detail="Not found")
 
 
 async def _record_share_event(
@@ -61,7 +72,7 @@ async def share_with_user_by_email(
     object_id: UUID,
     email: str,
     permission: str,
-    owner_id: UUID,
+    actor_id: UUID,
     expires_at: datetime | None = None,
 ) -> dict:
     if object_type not in _SHAREABLE:
@@ -72,7 +83,7 @@ async def share_with_user_by_email(
     # read (delegated). Management/sync/write stay owner-only by design.
     if object_type == "source" and permission != "read":
         raise HTTPException(status_code=400, detail="a source can only be shared read-only")
-    owner_user_id = await _require_owner(object_type, object_id, owner_id)
+    owner_user_id = await _require_share_access(object_type, object_id, actor_id)
     normalized_email = email.strip().lower()
 
     pool = get_pool()
@@ -102,21 +113,21 @@ async def share_with_user_by_email(
             object_id,
             normalized_email,
             permission,
-            owner_id,
+            actor_id,
             expires_at,
         )
         # Email only on the FIRST invite for this object+address — re-sharing to
         # tweak permission must not re-spam the recipient.
         if newly_invited:
             sharer_name = await pool.fetchval(
-                "SELECT COALESCE(display_name, name) FROM users WHERE id = $1", owner_id
+                "SELECT COALESCE(display_name, name) FROM users WHERE id = $1", actor_id
             )
             email_service.send_share_invite_email(
                 normalized_email, sharer_name, object_type.replace("_", " ")
             )
         await _record_share_event(
             action="share.invited",
-            actor_user_id=owner_id,
+            actor_user_id=actor_id,
             owner_user_id=owner_user_id,
             object_type=object_type,
             object_id=object_id,
@@ -126,8 +137,8 @@ async def share_with_user_by_email(
             },
         )
         return {"ok": True, "email": normalized_email}
-    if user["id"] == owner_id:
-        raise HTTPException(status_code=400, detail="You already own this")
+    if user["id"] == actor_id:
+        raise HTTPException(status_code=400, detail="You already have access")
     await pool.execute(
         """
         INSERT INTO shares (owner_user_id, object_type, object_id, principal_type,
@@ -141,12 +152,12 @@ async def share_with_user_by_email(
         object_id,
         user["id"],
         permission,
-        owner_id,
+        actor_id,
         expires_at,
     )
     await _record_share_event(
         action="share.granted",
-        actor_user_id=owner_id,
+        actor_user_id=actor_id,
         owner_user_id=owner_user_id,
         object_type=object_type,
         object_id=object_id,
@@ -219,9 +230,9 @@ async def convert_pending_invites(user_id: UUID, email: str | None) -> int:
 
 
 async def unshare(
-    *, object_type: str, object_id: UUID, principal_type: str, principal_id: UUID, owner_id: UUID
+    *, object_type: str, object_id: UUID, principal_type: str, principal_id: UUID, actor_id: UUID
 ) -> None:
-    owner_user_id = await _require_owner(object_type, object_id, owner_id)
+    owner_user_id = await _require_share_access(object_type, object_id, actor_id)
     removed = await get_pool().fetchrow(
         "DELETE FROM shares WHERE object_type = $1 AND object_id = $2 "
         "AND principal_type = $3 AND principal_id = $4 "
@@ -235,7 +246,7 @@ async def unshare(
         hash_key = "recipient_user_hash" if principal_type == "user" else "principal_id_hash"
         await _record_share_event(
             action="share.revoked",
-            actor_user_id=owner_id,
+            actor_user_id=actor_id,
             owner_user_id=owner_user_id,
             object_type=object_type,
             object_id=object_id,
@@ -252,9 +263,9 @@ async def revoke_pending_invite_by_email(
     object_type: str,
     object_id: UUID,
     email: str,
-    owner_id: UUID,
+    actor_id: UUID,
 ) -> None:
-    owner_user_id = await _require_owner(object_type, object_id, owner_id)
+    owner_user_id = await _require_share_access(object_type, object_id, actor_id)
     normalized_email = email.strip().lower()
     removed = await get_pool().fetchrow(
         "DELETE FROM share_invites "
@@ -267,7 +278,7 @@ async def revoke_pending_invite_by_email(
     if removed:
         await _record_share_event(
             action="share.invite_revoked",
-            actor_user_id=owner_id,
+            actor_user_id=actor_id,
             owner_user_id=owner_user_id,
             object_type=object_type,
             object_id=object_id,
@@ -278,8 +289,14 @@ async def revoke_pending_invite_by_email(
         )
 
 
-async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) -> list[dict]:
-    await _require_owner(object_type, object_id, owner_id)
+async def object_access(object_type: str, object_id: UUID, actor_id: UUID) -> dict:
+    """Everything the share dialog needs in one gated read: the object's true
+    owner (which may be a workspace scope user, not the caller), the named
+    shares and pending invites, and the public-link level."""
+    owner_user_id = await _require_share_access(object_type, object_id, actor_id)
+    owner = await get_pool().fetchrow(
+        "SELECT name, display_name, email FROM users WHERE id = $1", owner_user_id
+    )
     rows = await get_pool().fetch(
         """
         SELECT s.principal_type, s.principal_id, s.permission, s.expires_at,
@@ -330,32 +347,39 @@ async def list_object_shares(object_type: str, object_id: UUID, owner_id: UUID) 
         }
         for inv in invites
     )
-    return shares
 
+    general_access = "none"
+    if object_type in _GENERAL_ACCESS_TABLE:
+        table = _GENERAL_ACCESS_TABLE[object_type]
+        general_access = (
+            await get_pool().fetchval(
+                f"SELECT public_permission FROM {table} WHERE id = $1", object_id
+            )
+            or "none"
+        )
 
-async def get_general_access(object_type: str, object_id: UUID, user_id: UUID) -> str:
-    """The object's current public link level ('none' when only owner/shares can
-    reach it). Owner-only, so it sits behind the same gate as the share list."""
-    if object_type not in _GENERAL_ACCESS_TABLE:
-        return "none"
-    await _require_owner(object_type, object_id, user_id)
-    table = _GENERAL_ACCESS_TABLE[object_type]
-    value = await get_pool().fetchval(
-        f"SELECT public_permission FROM {table} WHERE id = $1", object_id
-    )
-    return value or "none"
+    return {
+        "owner": {
+            "user_id": str(owner_user_id),
+            "label": owner["display_name"] or owner["name"],
+            "email": owner["email"],
+            "is_you": owner_user_id == actor_id,
+        },
+        "shares": shares,
+        "general_access": general_access,
+    }
 
 
 async def set_general_access(
     *, object_type: str, object_id: UUID, public_permission: str, user_id: UUID
 ) -> str:
-    """Set the "anyone with the link" level for a page/file/folder/table. Only the
-    scope owner may change publicity, mirroring session-folder general access."""
+    """Set the "anyone with the link" level for a page/file/folder/table.
+    Same gate as sharing: scope owner, or workspace member for workspace content."""
     if object_type not in _GENERAL_ACCESS_TABLE:
         raise HTTPException(status_code=400, detail=f"{object_type} has no general access link")
     if public_permission not in _PUBLIC_PERMISSIONS:
         raise HTTPException(status_code=400, detail="invalid public_permission")
-    owner_user_id = await _require_owner(object_type, object_id, user_id)
+    owner_user_id = await _require_share_access(object_type, object_id, user_id)
     table = _GENERAL_ACCESS_TABLE[object_type]
     await get_pool().execute(
         f"UPDATE {table} SET public_permission = $1 WHERE id = $2",

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -336,7 +336,7 @@ async def test_table_share_by_email_grants_direct_read(pool):
         object_id=table,
         email="friend@example.com",
         permission="read",
-        owner_id=owner,
+        actor_id=owner,
     )
 
     assert await permission_service.check_access("table", table, friend)

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -3766,7 +3766,7 @@ async def test_connected_source_is_shareable_read_only(client: AsyncClient, pool
         object_id=source_id,
         email="invitee@example.com",
         permission="read",
-        owner_id=owner_id,
+        actor_id=owner_id,
     )
     # Only the owner may share it.
     with pytest.raises(Exception):
@@ -3775,7 +3775,7 @@ async def test_connected_source_is_shareable_read_only(client: AsyncClient, pool
             object_id=source_id,
             email="invitee@example.com",
             permission="read",
-            owner_id=friend_id,
+            actor_id=friend_id,
         )
 
     # Before a share lands: friend can't read, list, or manage.
@@ -3983,7 +3983,7 @@ async def test_source_recipient_cannot_reshare_or_share_write(client: AsyncClien
             object_id=source_id,
             email="third@example.com",
             permission="read",
-            owner_id=friend_id,
+            actor_id=friend_id,
         )
     # Even the owner cannot grant above read on a source.
     with pytest.raises(Exception):
@@ -3992,5 +3992,5 @@ async def test_source_recipient_cannot_reshare_or_share_write(client: AsyncClien
             object_id=source_id,
             email="third@example.com",
             permission="write",
-            owner_id=owner_id,
+            actor_id=owner_id,
         )

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -8,7 +8,8 @@ What matters here:
 - `workspace_members` rows are off-domain-only (explicit admin adds), so
   admin removal always sticks — a login can never re-derive a removed row.
 - The X-Stash-Scope header re-roots content routes for members only.
-- Owner-only powers (sharing, key minting) never leak to members.
+- Sharing workspace content extends to members (they can already copy it out);
+  key minting and source management stay owner-only.
 - A read-access workspace key can feed the KB (transcripts) but not destroy it.
 """
 
@@ -221,13 +222,46 @@ async def test_member_can_edit_workspace_page(client: AsyncClient, pool):
 
 
 @pytest.mark.asyncio
-async def test_member_cannot_manage_workspace_shares(client: AsyncClient, pool):
-    """Sharing is an owner power: a member must not be able to share (leak)
-    the org KB to outsiders."""
+async def test_member_shares_workspace_page(client: AsyncClient, pool):
+    """Members get share powers on workspace content: they can already read
+    and copy it, so sharing grants nothing they couldn't leak by hand. The
+    access listing names the workspace — not the caller — as owner, so the
+    share dialog renders the true owner instead of assuming the viewer."""
     domain = _domain()
     key, body = await _register_with_email(client, f"editor@{domain}")
     await _verify_email(pool, uuid.UUID(body["id"]))
     ws = await _create_workspace(client, domain)
+    page_id = await _workspace_page(pool, ws["scope_user_id"])
+    invited = f"{unique_name('s')}@other.io"
+
+    resp = await client.post(
+        "/api/v1/share",
+        json={
+            "object_type": "page",
+            "object_id": str(page_id),
+            "email": invited,
+            "permission": "read",
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200
+
+    listing = await client.get(
+        f"/api/v1/share?object_type=page&object_id={page_id}", headers=_auth(key)
+    )
+    assert listing.status_code == 200
+    access = listing.json()
+    assert access["owner"]["label"] == "Acme"
+    assert access["owner"]["is_you"] is False
+    assert [s["email"] for s in access["shares"] if s["pending"]] == [invited]
+
+
+@pytest.mark.asyncio
+async def test_outsider_cannot_manage_workspace_shares(client: AsyncClient, pool):
+    """Share powers stop at membership: an off-domain user gets the same 404
+    as for any object they can't see."""
+    outsider_key, _ = await _register_with_email(client, f"{unique_name('o')}@other.io")
+    ws = await _create_workspace(client, _domain())
     page_id = await _workspace_page(pool, ws["scope_user_id"])
 
     resp = await client.post(
@@ -235,6 +269,36 @@ async def test_member_cannot_manage_workspace_shares(client: AsyncClient, pool):
         json={
             "object_type": "page",
             "object_id": str(page_id),
+            "email": f"{unique_name('s')}@other.io",
+            "permission": "read",
+        },
+        headers=_auth(outsider_key),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_share_workspace_source(client: AsyncClient, pool):
+    """Sources stay owner-only even for members: a shared source delegates
+    reads through the scope's OAuth token, which members don't otherwise hold."""
+    from backend.services import source_service
+
+    domain = _domain()
+    key, body = await _register_with_email(client, f"editor@{domain}")
+    await _verify_email(pool, uuid.UUID(body["id"]))
+    ws = await _create_workspace(client, domain)
+    source = await source_service.create_source(
+        owner_user_id=uuid.UUID(ws["scope_user_id"]),
+        source_type="google_drive_folder",
+        external_ref=f"folder-{unique_name('gd')}",
+        display_name="Org KB",
+    )
+
+    resp = await client.post(
+        "/api/v1/share",
+        json={
+            "object_type": "source",
+            "object_id": str(source["id"]),
             "email": f"{unique_name('s')}@other.io",
             "permission": "read",
         },

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -213,7 +213,6 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
         objectId={file.id}
         resourceName={file.name}
         resourceUrlPath={`/f/${file.id}`}
-        currentUser={user}
       />
     );
   }, [file, readOnly, user]);

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -163,7 +163,6 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
           objectId={folderId}
           resourceName={folderName}
           resourceUrlPath={`/folders/${folderId}`}
-          currentUser={user}
         />
       </div>
     );

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -47,7 +47,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { User } from "@/lib/types";
 import { routes } from "@/lib/workspace-routes";
 
 // How often a row re-checks a source that is mid-sync, and how many times before
@@ -557,7 +556,6 @@ export function IntegrationDetail({ provider }: { provider: string }) {
                 <SourceRow
                   key={source.source}
                   source={source}
-                  currentUser={user}
                   highlighted={source.source === highlightSourceId}
                   open={source.source === openSourceId}
                   busySync={busy === `sync:${source.source}`}
@@ -666,7 +664,6 @@ function shortRef(source: Source): string | null {
 
 function SourceRow({
   source,
-  currentUser,
   highlighted,
   open,
   busySync,
@@ -676,7 +673,6 @@ function SourceRow({
   onRemove,
 }: {
   source: Source;
-  currentUser: User;
   highlighted: boolean;
   open: boolean;
   busySync: boolean;
@@ -841,7 +837,6 @@ function SourceRow({
               objectId={source.source}
               resourceName={source.display_name}
               resourceUrlPath={`/integrations/${providerForSourceType[source.type]}?source=${source.source}`}
-              currentUser={currentUser}
               boundaryRef={menuBoundaryRef}
               onClose={() => setShareOpen(false)}
             />

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -235,7 +235,6 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
         objectId={page.id}
         resourceName={title}
         resourceUrlPath={`/p/${page.id}`}
-        currentUser={user}
       />
     );
   }, [page, skillSlug, user]);

--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -166,7 +166,6 @@ export default function SessionViewerPage({ sessionId }: { sessionId: string }) 
           objectId={sessionDetail.id}
           resourceName={sessionHeading(sessionDetail, sessionId)}
           resourceUrlPath={`/sessions/${encodeURIComponent(sessionId)}`}
-          currentUser={user}
         />
         <DownloadMenu
           options={[

--- a/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/SkillPageClient.test.tsx
@@ -15,9 +15,8 @@ import {
 } from "@/components/ShellChromeContext";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 import {
-  getGeneralAccess,
+  getObjectAccess,
   getPublicSkill,
-  listObjectShares,
   shareObjectByEmail,
   unpublishSkill,
   updateSkill,
@@ -62,8 +61,7 @@ vi.mock("../../../../lib/api", () => ({
   getPublicSkill: vi.fn(),
   githubOwner: (url: string) =>
     url.replace("https://github.com/", "").split("/")[0],
-  listObjectShares: vi.fn(),
-  getGeneralAccess: vi.fn(),
+  getObjectAccess: vi.fn(),
   updateGeneralAccess: vi.fn(),
   publishSkillFolder: vi.fn(),
   shareObjectByEmail: vi.fn(),
@@ -158,8 +156,16 @@ describe("SkillPageClient", () => {
       ...skillDetail(),
       can_write: true,
     });
-    vi.mocked(listObjectShares).mockResolvedValue([]);
-    vi.mocked(getGeneralAccess).mockResolvedValue("none");
+    vi.mocked(getObjectAccess).mockResolvedValue({
+      owner: {
+        user_id: "user-1",
+        label: "Henry",
+        email: "henry@example.com",
+        is_you: true,
+      },
+      shares: [],
+      general_access: "none",
+    });
     vi.mocked(updateSkill).mockImplementation(async (_skillId, updates) => ({
       ...skillDetail().skill,
       ...updates,
@@ -248,7 +254,7 @@ describe("SkillPageClient", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "Share Shared Skill",
     });
-    expect(listObjectShares).toHaveBeenCalledWith("folder", "folder-1");
+    expect(getObjectAccess).toHaveBeenCalledWith("folder", "folder-1");
 
     fireEvent.change(within(dialog).getByPlaceholderText("Add people by email"), {
       target: { value: "sam@example.com" },

--- a/frontend/src/app/(app)/skills/[slug]/SkillPageClient.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/SkillPageClient.tsx
@@ -95,7 +95,6 @@ export default function SkillPageClient({ slug }: { slug: string }) {
             objectId={skill.folder_id}
             resourceName={skill.title}
             resourceUrlPath={`/skills/folder/${skill.folder_id}`}
-            currentUser={user}
           />
         )}
         <SkillShareButton

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
@@ -145,7 +145,6 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
           objectId={folderId}
           resourceName={folderName}
           resourceUrlPath={`/skills/${folderId}`}
-          currentUser={user}
         />
         <SkillShareButton
           folderId={folderId}

--- a/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
@@ -383,7 +383,6 @@ function TableEditorPageInner({
         objectId={table.id}
         resourceName={table.name}
         resourceUrlPath={`/tables/${table.id}`}
-        currentUser={user}
       />
     );
   }, [readOnly, table, user]);

--- a/frontend/src/components/share/ResourceShareButton.test.tsx
+++ b/frontend/src/components/share/ResourceShareButton.test.tsx
@@ -3,30 +3,42 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ResourceShareButton from "./ResourceShareButton";
 import {
-  getGeneralAccess,
-  listObjectShares,
+  ApiError,
+  getObjectAccess,
   shareObjectByEmail,
   unshareObject,
   updateGeneralAccess,
+  type ObjectAccess,
+  type ObjectShare,
 } from "../../lib/api";
 
-vi.mock("../../lib/api", () => ({
-  listObjectShares: vi.fn(),
+vi.mock("../../lib/api", async () => ({
+  ...(await vi.importActual<typeof import("../../lib/api")>("../../lib/api")),
+  getObjectAccess: vi.fn(),
   shareObjectByEmail: vi.fn(),
   unshareObject: vi.fn(),
-  getGeneralAccess: vi.fn(),
   updateGeneralAccess: vi.fn(),
 }));
 
-const currentUser = {
-  id: "user-1",
-  name: "henry",
-  display_name: "Henry Dowling",
+const owner = {
+  user_id: "user-1",
+  label: "Henry Dowling",
   email: "henry@example.com",
-  description: "",
-  created_at: "2026-05-11T00:00:00Z",
-  last_seen: "2026-05-11T00:00:00Z",
+  is_you: true,
 };
+
+const adaShare: ObjectShare = {
+  principal_type: "user",
+  principal_id: "user-2",
+  label: "Ada Lovelace",
+  email: "ada@example.com",
+  permission: "read",
+  pending: false,
+};
+
+function access(overrides: Partial<ObjectAccess> = {}): ObjectAccess {
+  return { owner, shares: [adaShare], general_access: "none", ...overrides };
+}
 
 describe("ResourceShareButton", () => {
   beforeEach(() => {
@@ -35,19 +47,9 @@ describe("ResourceShareButton", () => {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
-    vi.mocked(listObjectShares).mockResolvedValue([
-      {
-        principal_type: "user",
-        principal_id: "user-2",
-        label: "Ada Lovelace",
-        email: "ada@example.com",
-        permission: "read",
-        pending: false,
-      },
-    ]);
+    vi.mocked(getObjectAccess).mockResolvedValue(access());
     vi.mocked(shareObjectByEmail).mockResolvedValue(undefined);
     vi.mocked(unshareObject).mockResolvedValue(undefined);
-    vi.mocked(getGeneralAccess).mockResolvedValue("none");
     vi.mocked(updateGeneralAccess).mockImplementation(
       async (_type, _id, permission) => permission,
     );
@@ -64,7 +66,6 @@ describe("ResourceShareButton", () => {
         objectId="file-1"
         resourceName="launch.png"
         resourceUrlPath="/f/file-1"
-        currentUser={currentUser}
       />,
     );
 
@@ -73,7 +74,7 @@ describe("ResourceShareButton", () => {
     expect(
       await screen.findByRole("dialog", { name: "Share launch.png" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Henry Dowling (you)")).toBeInTheDocument();
+    expect(await screen.findByText("Henry Dowling (you)")).toBeInTheDocument();
     expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByText("Restricted")).toBeInTheDocument();
 
@@ -85,19 +86,78 @@ describe("ResourceShareButton", () => {
     expect(await screen.findByText("Link copied.")).toBeInTheDocument();
   });
 
-  it("invites people directly to the resource", async () => {
-    vi.mocked(listObjectShares)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          principal_type: "user",
-          principal_id: null,
-          label: "ada@example.com",
-          email: "ada@example.com",
-          permission: "write",
-          pending: true,
+  it("shows the true owner, not the viewer, when they differ", async () => {
+    // Workspace content is owned by the workspace's scope user; the dialog
+    // must render that owner instead of assuming the logged-in user owns it.
+    vi.mocked(getObjectAccess).mockResolvedValue(
+      access({
+        owner: {
+          user_id: "ws-1",
+          label: "Fergana Labs",
+          email: null,
+          is_you: false,
         },
-      ]);
+      }),
+    );
+
+    render(
+      <ResourceShareButton
+        objectType="page"
+        objectId="page-1"
+        resourceName="Org page"
+        resourceUrlPath="/p/page-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(await screen.findByText("Fergana Labs")).toBeInTheDocument();
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+    expect(screen.queryByText(/\(you\)/)).toBeNull();
+  });
+
+  it("explains instead of offering controls when the viewer cannot share", async () => {
+    // A share/public-link recipient can open the dialog but the access
+    // listing 404s; dead invite controls must not render.
+    vi.mocked(getObjectAccess).mockRejectedValue(new ApiError(404, "Not found"));
+
+    render(
+      <ResourceShareButton
+        objectType="page"
+        objectId="page-1"
+        resourceName="Someone else's page"
+        resourceUrlPath="/p/page-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(
+      await screen.findByText(
+        "You can view this item, but only its owner can manage sharing.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Add people")).toBeNull();
+    expect(screen.queryByText("General access")).toBeNull();
+  });
+
+  it("invites people directly to the resource", async () => {
+    vi.mocked(getObjectAccess)
+      .mockResolvedValueOnce(access({ shares: [] }))
+      .mockResolvedValueOnce(
+        access({
+          shares: [
+            {
+              principal_type: "user",
+              principal_id: null,
+              label: "ada@example.com",
+              email: "ada@example.com",
+              permission: "write",
+              pending: true,
+            },
+          ],
+        }),
+      );
 
     render(
       <ResourceShareButton
@@ -105,7 +165,6 @@ describe("ResourceShareButton", () => {
         objectId="table-1"
         resourceName="Prospects"
         resourceUrlPath="/tables/table-1"
-        currentUser={currentUser}
       />,
     );
 
@@ -139,7 +198,6 @@ describe("ResourceShareButton", () => {
         objectId="page-1"
         resourceName="Blog post outline"
         resourceUrlPath="/p/page-1"
-        currentUser={currentUser}
       />,
     );
 
@@ -170,7 +228,6 @@ describe("ResourceShareButton", () => {
         objectId="src-1"
         resourceName="Team Drive"
         resourceUrlPath="/integrations/google?source=src-1"
-        currentUser={currentUser}
       />,
     );
 

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -11,16 +11,16 @@ import {
 
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import {
-  getGeneralAccess,
-  listObjectShares,
+  ApiError,
+  getObjectAccess,
   shareObjectByEmail,
   unshareObject,
   updateGeneralAccess,
   type GeneralPermission,
   type ObjectShare,
+  type ShareOwner,
   type SharedObjectType,
 } from "../../lib/api";
-import type { User } from "../../lib/types";
 
 type SharePermission = Extract<GeneralPermission, "read" | "comment" | "write">;
 
@@ -46,13 +46,11 @@ export default function ResourceShareButton({
   objectId,
   resourceName,
   resourceUrlPath,
-  currentUser,
 }: {
   objectType: SharedObjectType;
   objectId: string;
   resourceName: string;
   resourceUrlPath: string;
-  currentUser: User;
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -75,7 +73,6 @@ export default function ResourceShareButton({
           objectId={objectId}
           resourceName={resourceName}
           resourceUrlPath={resourceUrlPath}
-          currentUser={currentUser}
           boundaryRef={containerRef}
           onClose={() => setOpen(false)}
         />
@@ -94,7 +91,6 @@ export function ResourceShareDialog({
   objectId,
   resourceName,
   resourceUrlPath,
-  currentUser,
   boundaryRef,
   onClose,
 }: {
@@ -102,11 +98,15 @@ export function ResourceShareDialog({
   objectId: string;
   resourceName: string;
   resourceUrlPath: string;
-  currentUser: User;
   boundaryRef: RefObject<HTMLDivElement | null>;
   onClose: () => void;
 }) {
+  const [owner, setOwner] = useState<ShareOwner | null>(null);
   const [shares, setShares] = useState<ObjectShare[]>([]);
+  // False once the access listing 404s: the viewer reached this object through
+  // a share or public link, and only the owner (or workspace members, for
+  // workspace content) may manage sharing.
+  const [canShare, setCanShare] = useState(true);
   const [email, setEmail] = useState("");
   const [permission, setPermission] = useState<SharePermission>("read");
   const [busy, setBusy] = useState(false);
@@ -134,20 +134,21 @@ export function ResourceShareDialog({
     setLoadingShares(true);
     setMessage("");
     try {
-      const [shareRows, access] = await Promise.all([
-        listObjectShares(objectType, objectId),
-        supportsGeneralAccess
-          ? getGeneralAccess(objectType, objectId)
-          : Promise.resolve<GeneralPermission>("none"),
-      ]);
-      setShares(shareRows);
-      setGeneralAccess(access);
+      const access = await getObjectAccess(objectType, objectId);
+      setOwner(access.owner);
+      setShares(access.shares);
+      setGeneralAccess(access.general_access);
+      setCanShare(true);
     } catch (e) {
-      setMessage(e instanceof Error ? e.message : "Could not load access.");
+      if (e instanceof ApiError && e.status === 404) {
+        setCanShare(false);
+      } else {
+        setMessage(e instanceof Error ? e.message : "Could not load access.");
+      }
     } finally {
       setLoadingShares(false);
     }
-  }, [objectId, objectType, supportsGeneralAccess]);
+  }, [objectId, objectType]);
 
   async function changeGeneralAccess(next: GeneralPermission) {
     const previous = generalAccess;
@@ -277,6 +278,17 @@ export function ResourceShareDialog({
         </button>
       </div>
 
+      {!canShare && !loadingShares && (
+        <div
+          className="mt-4 rounded-md border border-border bg-surface px-3 py-3 text-[12.5px] text-muted-foreground"
+          role="status"
+        >
+          You can view this item, but only its owner can manage sharing.
+        </div>
+      )}
+
+      {canShare && (
+      <>
       <form onSubmit={addPerson} className="mt-4">
         <label className="sr-only" htmlFor="resource-share-email">
           Add people
@@ -326,11 +338,13 @@ export function ResourceShareDialog({
           People with access
         </h3>
         <div className="mt-2 flex flex-col gap-2">
-          <AccessRow
-            label={`${currentUser.display_name || currentUser.name} (you)`}
-            sublabel={currentUser.email ?? `@${currentUser.name}`}
-            permissionLabel="Owner"
-          />
+          {owner && (
+            <AccessRow
+              label={owner.is_you ? `${owner.label} (you)` : owner.label}
+              sublabel={owner.email ?? "Workspace"}
+              permissionLabel="Owner"
+            />
+          )}
 
           {loadingShares && (
             <div className="rounded-md border border-border bg-surface px-3 py-2 text-[12.5px] text-muted-foreground">
@@ -455,6 +469,8 @@ export function ResourceShareDialog({
           )}
         </div>
       </section>
+      </>
+      )}
 
       <div className="mt-5 flex items-center justify-between gap-3">
         <button

--- a/frontend/src/components/share/SessionFolderShareModal.test.tsx
+++ b/frontend/src/components/share/SessionFolderShareModal.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SessionFolderShareModal from "./SessionFolderShareModal";
 import {
-  listObjectShares,
+  getObjectAccess,
   revokePendingShareInvite,
   shareObjectByEmail,
   unshareObject,
@@ -11,7 +11,7 @@ import {
 import type { SessionFolder } from "../../lib/api";
 
 vi.mock("../../lib/api", () => ({
-  listObjectShares: vi.fn(),
+  getObjectAccess: vi.fn(),
   revokePendingShareInvite: vi.fn(),
   shareObjectByEmail: vi.fn(),
   unshareObject: vi.fn(),
@@ -47,18 +47,28 @@ describe("SessionFolderShareModal", () => {
   });
 
   it("revokes pending email invites instead of treating them as user shares", async () => {
-    vi.mocked(listObjectShares)
-      .mockResolvedValueOnce([
-        {
-          principal_type: "user",
-          principal_id: null,
-          label: "pending@example.com",
-          email: "pending@example.com",
-          permission: "read",
-          pending: true,
-        },
-      ])
-      .mockResolvedValueOnce([]);
+    const owner = {
+      user_id: "user-1",
+      label: "Henry",
+      email: "henry@example.com",
+      is_you: true,
+    };
+    vi.mocked(getObjectAccess)
+      .mockResolvedValueOnce({
+        owner,
+        shares: [
+          {
+            principal_type: "user",
+            principal_id: null,
+            label: "pending@example.com",
+            email: "pending@example.com",
+            permission: "read",
+            pending: true,
+          },
+        ],
+        general_access: "none",
+      })
+      .mockResolvedValueOnce({ owner, shares: [], general_access: "none" });
 
     render(
       <SessionFolderShareModal
@@ -79,6 +89,6 @@ describe("SessionFolderShareModal", () => {
       )
     );
     expect(unshareObject).not.toHaveBeenCalled();
-    await waitFor(() => expect(listObjectShares).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getObjectAccess).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/components/share/SessionFolderShareModal.tsx
+++ b/frontend/src/components/share/SessionFolderShareModal.tsx
@@ -7,7 +7,7 @@ import {
   type ObjectShare,
   type SessionFolder,
   type SessionFolderVisibility,
-  listObjectShares,
+  getObjectAccess,
   revokePendingShareInvite,
   shareObjectByEmail,
   unshareObject,
@@ -51,7 +51,7 @@ export default function SessionFolderShareModal({
 
   const loadShares = useCallback(async () => {
     try {
-      setShares(await listObjectShares("session_folder", folder.id));
+      setShares((await getObjectAccess("session_folder", folder.id)).shares);
     } catch {
       /* owner-only; ignore on shared views */
     }

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -469,7 +469,6 @@ export default function FilesExplorer({
               objectId={sharing.item.id}
               resourceName={sharing.item.name}
               resourceUrlPath={shareUrlPath(sharing.item)}
-              currentUser={user}
               boundaryRef={shareRef}
               onClose={() => setSharing(null)}
             />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1944,26 +1944,28 @@ export interface ObjectShare {
   pending: boolean;
 }
 
-export async function listObjectShares(
-  objectType: SharedObjectType,
-  objectId: string,
-): Promise<ObjectShare[]> {
-  const res = await apiFetch<{ shares: ObjectShare[] }>(
-    `/api/v1/share?object_type=${objectType}&object_id=${objectId}`,
-  );
-  return res.shares;
+export interface ShareOwner {
+  user_id: string;
+  label: string;
+  email: string | null;
+  is_you: boolean;
 }
 
-// The object's current "anyone with the link" level ('none' when it's only
-// reachable by the owner and named shares).
-export async function getGeneralAccess(
+// The object's true owner (which may be a workspace scope user, not the
+// caller), its named shares/invites, and its "anyone with the link" level.
+export interface ObjectAccess {
+  owner: ShareOwner;
+  shares: ObjectShare[];
+  general_access: GeneralPermission;
+}
+
+export async function getObjectAccess(
   objectType: SharedObjectType,
   objectId: string,
-): Promise<GeneralPermission> {
-  const res = await apiFetch<{ general_access: GeneralPermission }>(
+): Promise<ObjectAccess> {
+  return apiFetch<ObjectAccess>(
     `/api/v1/share?object_type=${objectType}&object_id=${objectId}`,
   );
-  return res.general_access;
 }
 
 export async function updateGeneralAccess(


### PR DESCRIPTION
## Problem

Sharing was gated on `is_owner`, and a workspace's scope user is a login-less account that nobody is — so workspace-scoped content was unshareable by **anyone**: no user could invite an outside email or turn on a public link. The dialog made it worse by rendering the logged-in viewer as "Owner" (hardcoded, never checked) and offering invite/general-access controls whose every action 404'd with a bare "Not found" footer.

Hit in prod: inviting an external email to a workspace-scoped page failed with "Not found" while the dialog claimed the viewer was the owner.

## Changes

**Backend**
- `_require_owner` → `_require_share_access`: share, unshare, invite-revoke, and public-link changes on content types now accept workspace members as well as the scope owner. A member can already read and copy workspace content, so sharing grants nothing they couldn't leak by hand. **Sources stay owner-only** — a shared source delegates reads through the scope's OAuth token.
- `GET /api/v1/share` now returns a single `object_access` payload — true owner (`label`, `email`, `is_you`), shares/invites, and public-link level — replacing the double fetch of shares + general access.
- "You already own this" → "You already have access" (the actor may now be a member, not the owner).

**Frontend**
- The dialog renders the owner row from the API (e.g. "Fergana Labs — Workspace") instead of hardcoding the current user as "Owner".
- When the access listing 404s (viewer reached the object via a share or public link), the dialog shows "You can view this item, but only its owner can manage sharing." instead of dead controls.
- Removed the now-unused `currentUser` prop from the dialog and all nine callers.

**Note for review:** this deliberately reverses a documented decision — `user_scope_service.py` said owner-only powers (including sharing) "never leak to members" by design. Since membership is flat (no admin role), that design left workspace content unshareable by anyone, which can't have been the intent. Docstrings and the old test asserting "a member must not be able to share" are updated to encode the new policy.

## Screenshots

Member viewing a workspace page — dialog shows the workspace as the true owner:

![share dialog showing workspace as owner](https://api.joinstash.ai/api/v1/me/files/2c00f813-3661-4fd6-be18-7c622dfe1b85/download)

Member invites an external email to that page — the exact case that 404'd before:

![member invite succeeds with pending invite row](https://api.joinstash.ai/api/v1/me/files/48db5f6c-2d04-4fe7-9cee-4cc2c669b6be/download)

Share recipients get no Share button at all (unchanged), and the dialog's no-access state is additionally covered by a unit test.

## Verification

- backend: 1023 passed (full suite, rebased on main)
- frontend: 251 passed; eslint 0 errors; tsc clean apart from a pre-existing error in `page.test.tsx` untouched by this PR
- ruff check + format clean
- Manual E2E on the local stack: member invite to workspace page succeeds (screenshots above); new tests cover member-share, outsider-404, and source-exclusion boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)