### PR TITLE
Sprite exec: give the WebSocket handshake time to wake a sleeping VM

### DIFF
--- a/backend/services/sprite_service.py
+++ b/backend/services/sprite_service.py
@@ -56,6 +56,13 @@ OPENCODE_VERSION = "1.17.18"
 
 # A first-ever provision creates the VM and seeds it (~10-30s).
 PROVISION_TIMEOUT_S = 180
+
+# Sprites auto-sleep when idle, and connecting is what wakes them — so the
+# WebSocket opening handshake must absorb a cold boot. The websockets default
+# (10s) is too tight for a box that sleeps between nightly curator runs: it
+# cost Heavi's curator two consecutive mornings ("timed out during opening
+# handshake") because nothing else touches their sprite during the day.
+WS_OPEN_TIMEOUT_S = 60
 # A provisioning row older than this is presumed crashed and retried.
 STALE_PROVISION_S = 300
 
@@ -359,7 +366,9 @@ async def _sprites_exec_stream(
     url = f"{ws_base}/v1/sprites/{sprite.name}/exec?{urlencode(params)}"
     headers = {"Authorization": f"Bearer {settings.SPRITES_TOKEN}"}
 
-    async with websockets.connect(url, additional_headers=headers, max_size=None) as ws:
+    async with websockets.connect(
+        url, additional_headers=headers, max_size=None, open_timeout=WS_OPEN_TIMEOUT_S
+    ) as ws:
         async for frame in ws:
             if not isinstance(frame, bytes):
                 continue  # JSON control messages (resize, session info)
@@ -589,6 +598,7 @@ class _SpriteTerminal(Terminal):
             url,
             additional_headers={"Authorization": f"Bearer {settings.SPRITES_TOKEN}"},
             max_size=None,
+            open_timeout=WS_OPEN_TIMEOUT_S,
         )
         return cls(ws)
 


### PR DESCRIPTION
## Problem

Heavi's Memory curator failed two consecutive mornings (7/27: `no close frame received or sent` 40s into the run; 7/28: `timed out during opening handshake` 10s in), while 41 other curators succeeded each morning. Their sprite is unique in being touched by nothing but the nightly curator — heavi-chat runs through the API tool loop, not sprites — so it cold-wakes from auto-sleep every single morning.

Both sprite exec WebSocket connects use the `websockets` library default `open_timeout` of **10 seconds**, and connecting is itself the wake trigger. A wake slower than 10s kills the scheduled run before the agent starts. The failure is invisible until the stale-curator alert fires 48h later.

## Fix

`open_timeout=60` on both connect sites (`_sprites_exec_stream` and the terminal opener), via a named constant documenting why the default is too tight.

## Testing

Sprite + curator suites: 54 passed. ruff clean. (The wake-latency path itself needs a real sleeping Fly VM — tonight's re-triggered Heavi run is the live test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)