### PR TITLE
Redesign CLI onboarding: opt-out recording, no git requirement, re-runnable wizard

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -88,7 +88,29 @@ async def upload_transcript(
         session_id,
     )
     if existing:
-        if not await memory_service.can_read_session(owner_user_id, session_id, current_user["id"]):
+        session_row = await session_service.get_session(owner_user_id, session_id)
+        if session_row is None:
+            # A session the user deleted keeps its events until purge; a
+            # re-upload (e.g. history import) must not resurrect it — and it
+            # isn't an error, so report a skip.
+            deleted = await pool.fetchval(
+                "SELECT 1 FROM sessions "
+                "WHERE owner_user_id = $1 AND session_id = $2 AND deleted_at IS NOT NULL",
+                owner_user_id,
+                session_id,
+            )
+            if deleted:
+                return {
+                    "session_id": session_id,
+                    "imported": 0,
+                    "skipped": True,
+                    "reason": "session was deleted",
+                }
+            # Events without any session row (legacy orphans): fall through —
+            # the no-replace branch below recreates the row and skips.
+        elif not await memory_service.can_read_session(
+            owner_user_id, session_id, current_user["id"]
+        ):
             raise HTTPException(status_code=404, detail="Transcript not found")
         if replace:
             await pool.execute(

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -939,3 +939,43 @@ async def test_live_session_is_dated_now(client: AsyncClient, pool):
         "live-now",
     )
     assert (datetime.now(UTC) - started_at).total_seconds() < 60
+
+
+@pytest.mark.asyncio
+async def test_reupload_to_deleted_session_skips_without_resurrecting(client: AsyncClient, pool):
+    """A history import that hits a session the user deleted must report a
+    skip, not an error — and must not undelete the session."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+    scope = await _scope(client, key)
+
+    up = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
+        data={"session_id": "sess-del", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert up.status_code == 201, up.text
+
+    row_id = await pool.fetchval(
+        "SELECT id FROM sessions WHERE owner_user_id = $1 AND session_id = $2",
+        UUID(scope),
+        "sess-del",
+    )
+    deleted = await client.delete(f"/api/v1/me/sessions/{row_id}", headers=headers)
+    assert deleted.status_code == 204
+
+    second = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(BODY), "application/jsonl")},
+        data={"session_id": "sess-del", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert second.status_code == 201, second.text
+    body = second.json()
+    assert body["skipped"] is True
+    assert body["reason"] == "session was deleted"
+
+    assert (
+        await pool.fetchval("SELECT deleted_at FROM sessions WHERE id = $1", row_id)
+    ) is not None

--- a/cli/import_history.py
+++ b/cli/import_history.py
@@ -602,6 +602,11 @@ def upload_conversation(
         if materialized:
             os.unlink(transcript_path)
 
+    # Skipped sessions (already streamed live, or deleted by the user) keep
+    # their real history — no import marker event.
+    if result.get("skipped"):
+        return result
+
     client.push_event(
         agent_name=conv.agent,
         event_type="session_end",

--- a/cli/main.py
+++ b/cli/main.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import httpx
 import questionary
-import questionary.prompts.common
 import typer
 from rich.align import Align
 from rich.panel import Panel
@@ -46,15 +45,6 @@ from .config import (
     write_manifest,
 )
 from .formatting import console, output_json, print_user
-
-# questionary's checkbox marks checked rows with ●/reverse-video, which reads
-# as a cursor highlight rather than "this agent is enabled". There is no
-# parameter for the tick marks — these module constants are the only knob.
-questionary.prompts.common.INDICATOR_SELECTED = "[x]"
-questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"
-
-# Checked rows: green instead of the default reverse-video block.
-CHECKBOX_STYLE = questionary.Style([("selected", "fg:#16a34a noreverse")])
 
 app = typer.Typer(
     name="stash",
@@ -4370,6 +4360,84 @@ _AGENT_LABEL = {
 }
 
 
+def _pick_agents(message: str, agents: list[str], checked: list[str]) -> list[str] | None:
+    """Agent multi-select where enter (or space) toggles the highlighted agent
+    and a Done row submits — enter never means "save" while pointing at an
+    agent. Custom prompt_toolkit widget because questionary's checkbox
+    hard-binds enter to submit. Returns None if dismissed with Ctrl-C."""
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.styles import Style
+
+    selected = set(checked)
+    row = 0
+    done_row = len(agents)
+
+    def fragments():
+        lines = [
+            ("class:qmark", "? "),
+            ("class:question", message),
+            ("class:instruction", "  (enter toggles an agent, Done saves)\n"),
+        ]
+        for i, agent in enumerate(agents):
+            box = "[x]" if agent in selected else "[ ]"
+            label = _AGENT_LABEL.get(agent, agent)
+            lines.append(("class:pointer", " » " if row == i else "   "))
+            lines.append(("class:checked" if agent in selected else "", f"{box} {label}\n"))
+        lines.append(("class:pointer", " » " if row == done_row else "   "))
+        lines.append(("bold", "Done"))
+        return lines
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    def _up(event):
+        nonlocal row
+        row = (row - 1) % (done_row + 1)
+
+    @kb.add("down")
+    def _down(event):
+        nonlocal row
+        row = (row + 1) % (done_row + 1)
+
+    @kb.add("enter")
+    @kb.add(" ")
+    def _toggle_or_submit(event):
+        if row == done_row:
+            event.app.exit(result=[a for a in agents if a in selected])
+            return
+        agent = agents[row]
+        if agent in selected:
+            selected.remove(agent)
+        else:
+            selected.add(agent)
+
+    @kb.add("c-c")
+    def _abort(event):
+        event.app.exit(result=None)
+
+    picker = Application(
+        layout=Layout(Window(FormattedTextControl(fragments), height=len(agents) + 2)),
+        key_bindings=kb,
+        erase_when_done=True,
+        style=Style(
+            [
+                ("qmark", "fg:#5f819d"),
+                ("question", "bold"),
+                ("instruction", "fg:#858585"),
+                ("checked", "fg:#16a34a"),
+            ]
+        ),
+    )
+    result = picker.run()
+    if result is not None:
+        labels = ", ".join(_AGENT_LABEL.get(a, a) for a in result) or "none"
+        console.print(f"[bold]?[/bold] {message}  [#FF9D00]{labels}[/#FF9D00]")
+    return result
+
+
 def _install_all_hooks(agents: list[str] | None = None) -> None:
     """Install/upgrade hooks for the given agents (defaults to all detected)."""
     detected = _detected_agents()
@@ -4541,19 +4609,9 @@ def _run_setup_wizard() -> None:
             default_enabled = enabled if enabled is not None else detected
 
             _reserve_bottom_padding(len(detected) + 4)
-            selected = questionary.checkbox(
-                "Which coding agents should Stash record?",
-                instruction="(space toggles an agent, enter saves the whole set)",
-                style=CHECKBOX_STYLE,
-                choices=[
-                    questionary.Choice(
-                        _AGENT_LABEL.get(a, a),
-                        value=a,
-                        checked=a in default_enabled,
-                    )
-                    for a in detected
-                ],
-            ).ask()
+            selected = _pick_agents(
+                "Which coding agents should Stash record?", detected, default_enabled
+            )
             if selected is None:
                 raise typer.Exit(1)
 
@@ -5090,19 +5148,9 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
 
         if picked == "enabled_agents":
             current_enabled = enabled if enabled is not None else detected
-            selected = questionary.checkbox(
-                "Which coding agents should stream to Stash?",
-                instruction="(space toggles an agent, enter saves the whole set)",
-                style=CHECKBOX_STYLE,
-                choices=[
-                    questionary.Choice(
-                        _AGENT_LABEL.get(a, a),
-                        value=a,
-                        checked=a in current_enabled,
-                    )
-                    for a in detected
-                ],
-            ).ask()
+            selected = _pick_agents(
+                "Which coding agents should stream to Stash?", detected, current_enabled
+            )
             if selected is not None:
                 save_enabled_agents(selected)
                 _install_all_hooks(selected)

--- a/cli/main.py
+++ b/cli/main.py
@@ -41,6 +41,7 @@ from .config import (
     start_streaming,
     stop_streaming,
     stored_base_url,
+    streaming_stopped,
     write_manifest,
 )
 from .formatting import console, output_json, print_user
@@ -432,15 +433,16 @@ def _ask_codex_network_access() -> bool:
     """Prompt the user to enable top-level `network_access` for codex's
     workspace-write sandbox."""
     console.print(
-        "For stash to work on codex specifically, we need to let bash ",
-        "commands make network requests so that we can upload session ",
-        "transcripts to the remote server.",
+        "For stash to work on codex specifically, we need to let bash "
+        "commands make network requests so that we can upload session "
+        "transcripts to the remote server."
     )
     answer = questionary.confirm(
         "Allow codex bash commands to make outbound network requests?",
         default=True,
     ).ask()
-    return True if answer is None else bool(answer)
+    # Dismissing the prompt (Esc/Ctrl-C) must not grant network access.
+    return bool(answer)
 
 
 def _merge_snippet_into_toml(existing: str, snippet: str) -> tuple[str, str]:
@@ -4226,36 +4228,6 @@ def _reserve_bottom_padding(lines: int = 4) -> None:
     sys.stdout.flush()
 
 
-def _self_host_walkthrough(cfg: dict) -> str:
-    """Walk the user through standing up a local Stash instance, then return its URL."""
-    console.print("\n[bold cyan]Self-hosting Stash[/bold cyan]\n")
-    console.print("You'll need [bold]Docker[/bold] installed.  https://docker.com/get-started\n")
-    console.print("Run these commands in a separate terminal:\n")
-    console.print(
-        "  [dim]1.[/dim] [cyan]git clone https://github.com/Fergana-Labs/stash.git[/cyan]"
-    )
-    console.print("  [dim]2.[/dim] [cyan]cd stash[/cyan]")
-    console.print("  [dim]3.[/dim] [cyan]cp .env.example .env[/cyan]")
-    console.print(
-        "  [dim]4.[/dim] edit [cyan].env[/cyan] and [cyan]Caddyfile[/cyan] for your domain"
-    )
-    console.print("  [dim]5.[/dim] [cyan]docker compose -f docker-compose.prod.yml up -d[/cyan]")
-    console.print("\n  [dim]Already running? Skip to the URL prompt below.[/dim]\n")
-
-    _reserve_bottom_padding(6)
-    ready = questionary.confirm("Is your instance running?", default=True).ask()
-    if ready is None or not ready:
-        console.print(
-            "\n[yellow]No problem — run [bold]stash connect[/bold] again when ready.[/yellow]"
-        )
-        raise typer.Exit(0)
-
-    current_url = cfg.get("base_url", "http://localhost:3456")
-    managed_hosts = ("https://joinstash.ai", "https://www.joinstash.ai", "https://api.joinstash.ai")
-    default_url = "http://localhost:3456" if current_url in managed_hosts else current_url
-    return typer.prompt("URL of your instance", default=default_url).rstrip("/")
-
-
 def _derive_display_name() -> str:
     """Pick a display name with zero interaction: git config → $USER → fallback."""
     import os
@@ -4286,7 +4258,10 @@ def _require_auth() -> dict:
 
 
 def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
-    """Connect a repo to Stash: write `.stash`, enable streaming, append CLAUDE.md."""
+    """Write `.stash` and append Stash context to CLAUDE.md in `repo_root`.
+
+    Works in any folder — a git repo is not required. Does not touch the
+    global streaming toggle; callers decide that."""
     manifest_path = repo_root / MANIFEST_FILE
 
     if manifest_path.is_file():
@@ -4302,14 +4277,13 @@ def _auto_connect_repo(repo_root: Path, cfg: dict) -> None:
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     console.print(f"  Wrote [cyan]{MANIFEST_FILE}[/cyan]")
 
-    start_streaming()
-
     _append_claude_md(repo_root)
 
-    console.print(
-        f"\n  Commit [cyan]{MANIFEST_FILE}[/cyan] and [cyan]CLAUDE.md[/cyan] and push. "
-        "Teammates will start streaming automatically."
-    )
+    if _git_toplevel(repo_root):
+        console.print(
+            f"\n  Commit [cyan]{MANIFEST_FILE}[/cyan] and [cyan]CLAUDE.md[/cyan] and push. "
+            "Teammates will start streaming automatically."
+        )
 
 
 def _append_claude_md(repo_root: Path) -> None:
@@ -4444,10 +4418,10 @@ def signin(
 ):
     """Sign in to Stash through the browser.
 
-    Run interactively for guided first-run setup (endpoint, streaming agents,
-    repo). With --non-interactive — or whenever stdin isn't a terminal — it
-    skips the wizard and just authenticates, which is the path installers and
-    agents use. The browser opens automatically when one is available, and
+    Run interactively for guided first-run setup (session recording, agent
+    hooks, folder context) — re-runnable later via `stash setup`. With
+    --non-interactive — or whenever stdin isn't a terminal — it skips the
+    wizard and just authenticates, which is the path installers and agents use. The browser opens automatically when one is available, and
     otherwise a URL is printed to visit. For a fully unattended, browser-less
     machine, pass --api-key to store a pre-minted key directly (no handshake).
     """
@@ -4486,34 +4460,15 @@ def signin(
     cfg = load_config()
 
     # --- Step 1: API endpoint ---
-    prev_base = api or stored_base_url()
-    if prev_base:
-        base_url = prev_base
-        save_config(base_url=base_url)
-        console.print(f"  [green]✓[/green] Using endpoint: [bold]{base_url}[/bold]")
+    # Managed by default; self-hosters point at their instance with --api.
+    base_url = api or stored_base_url() or PRODUCTION_BASE_URL
+    save_config(base_url=base_url)
+    if base_url == PRODUCTION_BASE_URL:
+        console.print(
+            "  [dim]Self-hosting? Re-run with[/dim] stash signin --api <your-instance-url>"
+        )
     else:
-        mode_options = [
-            ("Managed", "hosted by Stash", "managed"),
-            ("Self-host", "run on your own machine", "self"),
-        ]
-        mode_label_w = max(len(label) for label, _, _ in mode_options)
-        _reserve_bottom_padding(8)
-        mode = questionary.select(
-            "Do you want to use managed Stash or self-host?",
-            choices=[
-                questionary.Choice(f"{label:<{mode_label_w}}   ({desc})", value=value)
-                for label, desc, value in mode_options
-            ],
-            use_shortcuts=True,
-        ).ask()
-        if mode is None:
-            raise typer.Exit(1)
-
-        if mode == "managed":
-            base_url = PRODUCTION_BASE_URL
-        else:
-            base_url = _self_host_walkthrough(cfg)
-        save_config(base_url=base_url)
+        console.print(f"  [green]✓[/green] Using endpoint: [bold]{base_url}[/bold]")
 
     # --- Step 2: Auth ---
     has_key = bool(cfg.get("api_key"))
@@ -4540,104 +4495,98 @@ def signin(
     # Returning user — just re-auth, no wizard
     if has_key:
         _install_all_hooks(load_enabled_agents())
-        console.print("\n  Run [cyan]stash settings[/cyan] to change agents or endpoint.")
+        console.print(
+            "\n  Run [cyan]stash setup[/cyan] to redo setup, or "
+            "[cyan]stash settings[/cyan] to change agents or endpoint."
+        )
         return
 
-    # --- Step 3: Share transcripts? ---
+    _run_setup_wizard()
+
+
+def _run_setup_wizard() -> None:
+    """First-run setup: session recording, agent hooks, folder context, history
+    import. Re-runnable anytime via `stash setup` — no answer here is final."""
+    cfg = load_config()
+
+    # --- Session recording ---
+    console.print(
+        "\nStash records your coding agent sessions to your private Stash so you\n"
+        "and your agents can search them later. Transcripts are visible only to\n"
+        "you unless you share them."
+    )
     _reserve_bottom_padding(4)
-    share_transcripts = questionary.confirm(
-        "Do you want to share your coding agent transcripts to Stash?",
+    record = questionary.confirm(
+        "Record your agent sessions? (pause anytime with `stash stop`)",
         default=True,
     ).ask()
-    if share_transcripts is None:
+    if record is None:
         raise typer.Exit(1)
 
-    if not share_transcripts:
-        _show_setup_complete_splash()
-        return
-
-    # --- Step 4: Agent detection + hook installation ---
     detected = _detected_agents()
-    if detected:
-        enabled = load_enabled_agents()
-        default_enabled = enabled if enabled is not None else detected
-
-        _reserve_bottom_padding(len(detected) + 4)
-        selected = questionary.checkbox(
-            "What coding agents do you want Stash to work on?",
-            choices=[
-                questionary.Choice(
-                    _AGENT_LABEL.get(a, a),
-                    value=a,
-                    checked=a in default_enabled,
-                )
-                for a in detected
-            ],
-        ).ask()
-        if selected is None:
-            raise typer.Exit(1)
-
-        save_enabled_agents(selected)
-        _install_all_hooks(selected)
-    else:
-        save_enabled_agents([])
-
-    # --- Step 5: Which repo? ---
-    # Outside a git repo, treat the current directory as the repo root: the
-    # .stash manifest lands there.
-    repo_root = _git_toplevel() or Path.cwd()
-
-    repo_choices = [
-        questionary.Choice(f"This repo ({repo_root.name})", value="this"),
-        questionary.Choice("Another repo", value="other"),
-        questionary.Choice("Done", value="done"),
-    ]
-    _reserve_bottom_padding(6)
-    answer = questionary.select(
-        "Which repo do you want to upload transcripts in?",
-        choices=repo_choices,
-        default=repo_choices[0],
-        use_shortcuts=True,
-    ).ask()
-    if answer is None:
-        raise typer.Exit(1)
-
-    if answer == "this":
-        try:
-            _auto_connect_repo(repo_root, cfg)
-        except StashError as e:
-            console.print(f"[red]Could not connect repo: {e.detail}[/red]")
-    elif answer == "other":
-        _reserve_bottom_padding(4)
-        repo_path = typer.prompt("Path to repo").strip()
-        target = Path(repo_path).expanduser().resolve()
-        target_root = _git_toplevel(target)
-        if not target_root:
-            console.print(f"[red]{repo_path} is not a git repo.[/red]")
+    if record:
+        start_streaming()
+        if detected:
+            save_enabled_agents(detected)
+            _install_all_hooks(detected)
+            labels = ", ".join(_AGENT_LABEL.get(a, a) for a in detected)
+            console.print(
+                f"  [green]✓[/green] Recording sessions from: [bold]{labels}[/bold]\n"
+                "    [dim]Change agents with stash settings[/dim]"
+            )
         else:
-            try:
-                _auto_connect_repo(target_root, cfg)
-            except StashError as e:
-                console.print(f"[red]Could not connect repo: {e.detail}[/red]")
+            save_enabled_agents([])
+            console.print(
+                "  [yellow]No coding agents found on this machine, so nothing will be\n"
+                "  recorded yet. Re-run [bold]stash setup[/bold] after installing one\n"
+                "  (Claude Code, Codex, Cursor, opencode, Gemini CLI…).[/yellow]"
+            )
+    else:
+        stop_streaming()
+        console.print(
+            "  Recording is off. Turn it on later with [cyan]stash setup[/cyan] "
+            "or [cyan]stash start[/cyan]."
+        )
 
-    # --- Step 6: Import historical conversations ---
-    _onboarding_import_history(detected)
+    # --- Folder context (any folder works — git repo not required) ---
+    repo_root = _git_toplevel() or Path.cwd()
+    _reserve_bottom_padding(4)
+    connect = questionary.confirm(
+        f"Point agents in this folder ({repo_root.name}) at Stash? "
+        "(writes .stash and a CLAUDE.md section)",
+        default=True,
+    ).ask()
+    if connect is None:
+        raise typer.Exit(1)
+    if connect:
+        _auto_connect_repo(repo_root, cfg)
+    else:
+        console.print("  [dim]Run stash connect from any project folder later.[/dim]")
+
+    # --- Import historical conversations ---
+    if record:
+        _onboarding_import_history(detected)
 
     _show_setup_complete_splash()
 
 
+@app.command("setup")
+def setup_cmd():
+    """Re-run the setup wizard: session recording, agent hooks, folder context."""
+    _require_auth()
+    telemetry.record("setup")
+    _run_setup_wizard()
+
+
 @app.command("connect")
 def connect_cmd():
-    """Connect this repo to Stash so its agent sessions stream to your scope."""
+    """Point agents in this folder at Stash and stream its sessions to your scope."""
     cfg = _require_auth()
     telemetry.record("connect")
 
-    repo_root = _git_toplevel()
-    if not repo_root:
-        console.print("[red]Not inside a git repo.[/red]")
-        raise typer.Exit(1)
-
+    repo_root = _git_toplevel() or Path.cwd()
     _auto_connect_repo(repo_root, cfg)
+    start_streaming()
 
 
 @app.command("start")
@@ -4657,7 +4606,7 @@ def stop_cmd():
 
 
 # ===========================================================================
-# Repo-level enablement: invoked from `stash connect`; toggled via enable/disable
+# Folder connection: `.stash` manifest + CLAUDE.md context, via `stash connect`
 # ===========================================================================
 
 
@@ -4849,40 +4798,36 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
                 last_error = str(e)
             progress.advance(task)
 
-    console.print(f"  [green]��[/green] Imported {imported} conversations")
+    console.print(f"  [green]✓[/green] Imported {imported} conversations")
     if errors:
         console.print(f"  [yellow]{errors} failed — {last_error}[/yellow]")
 
 
-def _setup_complete_intro(home_url: str, connected: bool) -> str:
-    home_link_section = (
-        "[bold]See your Stash[/bold]   [dim](transcripts and activity)[/dim]\n"
-        f"  [link={home_url}][bold #1e3a8a]{home_url}[/bold #1e3a8a][/link]\n"
-        "\n"
-        if connected
-        else ""
+def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> str:
+    recording_section = (
+        "[bold]You're recording[/bold]\n"
+        "This machine's agent sessions upload to your private Stash.\n"
+        "[dim]Pause with stash stop · exclude folders in stash settings[/dim]"
+        if recording
+        else "[bold]Recording is off[/bold]\n"
+        "Turn it on anytime with [cyan]stash start[/cyan] or [cyan]stash setup[/cyan]."
     )
-    memory_section = (
-        "It can read the transcripts your coding agents push to Stash — so it\n"
-        "knows what you've been working on.\n"
-        "\n"
+    connect_section = (
+        ""
         if connected
-        else "No repo is connected yet. Run [cyan]stash connect[/cyan] from a git repo when\n"
-        "you're ready to upload transcripts.\n"
-        "\n"
-    )
-    next_section = (
-        "[bold]You're streaming[/bold]\n"
-        "This repo's agent sessions now upload to your Stash automatically."
-        if connected
-        else "[bold]Connect a repo when ready[/bold]\n"
-        "Run [cyan]stash connect[/cyan] from the repo you want Stash to remember."
+        else "\n\n[bold]Point a project at Stash[/bold]\n"
+        "Run [cyan]stash connect[/cyan] from any project folder (git repo or not) so\n"
+        "agents working there know to use your Stash."
     )
     return (
         "[bold]What just happened[/bold]\n"
         "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
-        f"{memory_section}"
-        f"{home_link_section}"
+        "Recording transcripts is one part of Stash — your agents can also search,\n"
+        "browse, upload, and share files, sessions, and connected sources.\n"
+        "\n"
+        "[bold]See your Stash[/bold]\n"
+        f"  [link={home_url}][bold #1e3a8a]{home_url}[/bold #1e3a8a][/link]\n"
+        "\n"
         "[bold]Commands your agent can now use[/bold]\n"
         '  [#1e3a8a]stash vfs "find / -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
         '  [#1e3a8a]stash search "<query>"[/#1e3a8a]   full-text search across files, sessions, and sources\n'
@@ -4890,24 +4835,27 @@ def _setup_complete_intro(home_url: str, connected: bool) -> str:
         "\n"
         "Run [bold]stash --help[/bold] to see everything.\n"
         "\n"
-        f"{next_section}"
+        f"{recording_section}"
+        f"{connect_section}"
     )
 
 
 def _show_setup_complete_splash() -> None:
-    """Show a clean success splash after first-run login."""
-    console.clear()
+    """Show a success splash after first-run login. Never clears the screen —
+    errors printed by earlier steps must stay visible."""
     octopus = textwrap.dedent(STASH_OCTOPUS.strip("\n"))
     logo = textwrap.dedent(STASH_LOGO.strip("\n"))
+    console.print()
     console.print(Align.center(Text.from_markup(f"[bold #F97316]{octopus}[/bold #F97316]")))
     console.print()
     console.print(Align.center(Text.from_markup(f"[bold #1e3a8a]{logo}[/bold #1e3a8a]")))
     console.print("  [bold green]You're all set up.[/bold green]\n")
 
     connected = load_manifest() is not None
+    recording = not streaming_stopped()
     console.print(
         Panel(
-            Text.from_markup(_setup_complete_intro(_home_url(), connected)),
+            Text.from_markup(_setup_complete_intro(_home_url(), connected, recording)),
             title="[bold #1e3a8a]Your agent memory[/bold #1e3a8a]",
             border_style="#1e3a8a",
             padding=(1, 2),
@@ -5119,6 +5067,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             current_enabled = enabled if enabled is not None else detected
             selected = questionary.checkbox(
                 "Which coding agents should stream to Stash?",
+                instruction="(space toggles an agent, enter saves the whole set)",
                 choices=[
                     questionary.Choice(
                         _AGENT_LABEL.get(a, a),

--- a/cli/main.py
+++ b/cli/main.py
@@ -4773,11 +4773,6 @@ def _frontend_base_url() -> str:
     return base_url
 
 
-def _home_url() -> str:
-    """The user-facing link to the signed-in user's home on the configured frontend."""
-    return _frontend_base_url()
-
-
 def _install_claude_plugin() -> bool:
     """Install the stash plugin for Claude Code via the official marketplace.
 
@@ -4917,6 +4912,10 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
     if not ok:
         return
 
+    # Seed the status file so the setup-complete splash can show the import
+    # immediately; the spawned process takes over updating it.
+    _write_import_status(total=len(conversations), done=0, errors=0, finished=False)
+
     IMPORT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(IMPORT_LOG_FILE, "ab") as log:
         _sp.Popen(
@@ -4996,7 +4995,22 @@ def import_history_cmd(
         console.print(f"  [yellow]{errors} failed — last error: {last_error}[/yellow]")
 
 
-def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> str:
+def _active_import() -> dict | None:
+    """The in-flight history import's status, or None when there isn't one.
+
+    A status file that stopped updating an hour ago means the import process
+    died — don't claim it's still uploading."""
+    if not IMPORT_STATUS_FILE.exists():
+        return None
+    status = json.loads(IMPORT_STATUS_FILE.read_text())
+    if status["finished"] or time.time() - status["updated_at"] > 3600:
+        return None
+    return status
+
+
+def _setup_complete_intro(
+    memory_url: str, connected: bool, recording: bool, importing: dict | None
+) -> str:
     recording_section = (
         "[bold]You're recording[/bold]\n"
         "This machine's agent sessions upload to your private Stash.\n"
@@ -5004,6 +5018,14 @@ def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> st
         if recording
         else "[bold]Recording is off[/bold]\n"
         "Turn it on anytime with [cyan]stash start[/cyan] or [cyan]stash setup[/cyan]."
+    )
+    importing_section = (
+        ""
+        if importing is None
+        else "\n\n[bold]Your history is uploading right now[/bold]\n"
+        f"{importing['done']}/{importing['total']} past conversations imported so far, in the\n"
+        "background — watch your knowledge base fill up at the link above.\n"
+        "[dim]Progress: stash import-history --status[/dim]"
     )
     connect_section = (
         ""
@@ -5018,8 +5040,10 @@ def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> st
         "It can read the transcripts your coding agents push to Stash — so it\n"
         "knows what you've been working on.\n"
         "\n"
-        "[bold]See your Stash[/bold]\n"
-        f"  [link={home_url}][bold #1e3a8a]{home_url}[/bold #1e3a8a][/link]\n"
+        "[bold]See your knowledge base[/bold]\n"
+        f"  [link={memory_url}][bold #1e3a8a]{memory_url}[/bold #1e3a8a][/link]\n"
+        "Your command center: every session and memory in your Stash, embedded\n"
+        "and searchable by your agents.\n"
         "\n"
         "[bold]Commands your agent can now use[/bold]\n"
         '  [#1e3a8a]stash vfs "find / -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
@@ -5029,6 +5053,7 @@ def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> st
         "Run [bold]stash --help[/bold] to see everything.\n"
         "\n"
         f"{recording_section}"
+        f"{importing_section}"
         f"{connect_section}"
     )
 
@@ -5044,11 +5069,14 @@ def _show_setup_complete_splash() -> None:
     console.print(Align.center(Text.from_markup(f"[bold #1e3a8a]{logo}[/bold #1e3a8a]")))
     console.print("  [bold green]You're all set up.[/bold green]\n")
 
+    memory_url = f"{_frontend_base_url()}/memory"
     connected = load_manifest() is not None
     recording = not streaming_stopped()
     console.print(
         Panel(
-            Text.from_markup(_setup_complete_intro(_home_url(), connected, recording)),
+            Text.from_markup(
+                _setup_complete_intro(memory_url, connected, recording, _active_import())
+            ),
             title="[bold #1e3a8a]Your agent memory[/bold #1e3a8a]",
             border_style="#1e3a8a",
             padding=(1, 2),

--- a/cli/main.py
+++ b/cli/main.py
@@ -4868,8 +4868,13 @@ IMPORT_LOG_FILE = Path.home() / ".stash" / "import-history.log"
 
 
 def _write_import_status(total: int, done: int, errors: int, finished: bool) -> None:
+    import os
+
     IMPORT_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    IMPORT_STATUS_FILE.write_text(
+    # Atomic replace: `--status` follows this file live and must never read a
+    # half-written JSON.
+    tmp = IMPORT_STATUS_FILE.with_suffix(".json.tmp")
+    tmp.write_text(
         json.dumps(
             {
                 "total": total,
@@ -4881,6 +4886,7 @@ def _write_import_status(total: int, done: int, errors: int, finished: bool) -> 
         )
         + "\n"
     )
+    os.replace(tmp, IMPORT_STATUS_FILE)
 
 
 def _onboarding_import_history(detected_agents: list[str]) -> None:
@@ -4930,6 +4936,36 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
     )
 
 
+def _show_import_status() -> None:
+    """Follow a running import with a live progress bar; print a summary when
+    it's already finished or stalled. Ctrl-C detaches without stopping it."""
+    from rich.progress import Progress
+
+    if not IMPORT_STATUS_FILE.exists():
+        console.print("No import has run on this machine.")
+        return
+
+    s = json.loads(IMPORT_STATUS_FILE.read_text())
+    stalled = not s["finished"] and time.time() - s["updated_at"] > 3600
+    if s["finished"] or stalled:
+        state = "finished" if s["finished"] else "stalled — re-run stash import-history to resume"
+        console.print(f"  {s['done']}/{s['total']} conversations, {s['errors']} errors — {state}")
+        return
+
+    try:
+        with Progress(console=console) as progress:
+            task = progress.add_task("Importing…", total=s["total"])
+            while not s["finished"]:
+                s = json.loads(IMPORT_STATUS_FILE.read_text())
+                progress.update(task, completed=s["done"], total=s["total"])
+                time.sleep(0.5)
+    except KeyboardInterrupt:
+        console.print("  [dim]Detached — the import keeps running in the background.[/dim]")
+        return
+    if s["errors"]:
+        console.print(f"  [yellow]{s['errors']} conversations failed[/yellow]")
+
+
 @app.command("import-history")
 def import_history_cmd(
     status: bool = typer.Option(
@@ -4942,14 +4978,7 @@ def import_history_cmd(
     wizard launches this as a background process; run it directly to import
     in the foreground with a progress bar."""
     if status:
-        if not IMPORT_STATUS_FILE.exists():
-            console.print("No import has run on this machine.")
-            return
-        s = json.loads(IMPORT_STATUS_FILE.read_text())
-        state = (
-            "finished" if s["finished"] else f"running (last update {_format_age(s['updated_at'])})"
-        )
-        console.print(f"  {s['done']}/{s['total']} conversations, {s['errors']} errors — {state}")
+        _show_import_status()
         return
 
     _require_auth()
@@ -5012,7 +5041,6 @@ def _setup_complete_intro(
     frontend_url: str, connected: bool, recording: bool, importing: dict | None
 ) -> str:
     memory_url = f"{frontend_url}/memory"
-    integrations_url = f"{frontend_url}/integrations"
     recording_section = (
         "[bold]You're recording[/bold]\n"
         "This machine's agent sessions upload to your private Stash.\n"
@@ -5025,9 +5053,9 @@ def _setup_complete_intro(
         ""
         if importing is None
         else "\n\n[bold]Your history is uploading right now[/bold]\n"
-        f"{importing['done']}/{importing['total']} past conversations imported so far, in the\n"
-        "background — watch your knowledge base fill up.\n"
-        "[dim]Progress: stash import-history --status[/dim]"
+        f"{importing['total']} past conversations are importing in the background —\n"
+        "watch your knowledge base fill up.\n"
+        "[dim]Live progress: stash import-history --status[/dim]"
     )
     connect_section = (
         ""
@@ -5046,11 +5074,6 @@ def _setup_complete_intro(
         f"  [link={memory_url}][bold #1e3a8a]{memory_url}[/bold #1e3a8a][/link]\n"
         "Stash compiles your sessions into memory your agents check before they\n"
         "work. The more you use it, the better they get.\n"
-        "\n"
-        "[bold]Make it smarter: connect your tools[/bold]\n"
-        f"  [link={integrations_url}][bold #1e3a8a]{integrations_url}[/bold #1e3a8a][/link]\n"
-        "Connect Slack, Drive, Notion, GitHub and more — your agents will see\n"
-        "through your connectors and answer with your team's actual context.\n"
         "\n"
         f"{recording_section}"
         f"{importing_section}"

--- a/cli/main.py
+++ b/cli/main.py
@@ -4380,6 +4380,11 @@ def _pick_agents(message: str, agents: list[str], checked: list[str]) -> list[st
             ("class:qmark", "? "),
             ("class:question", message),
             ("class:instruction", "  (enter toggles an agent, Done saves)\n"),
+            (
+                "class:instruction",
+                "   [x] = uploads its sessions to your Stash. Unchecked agents upload "
+                "nothing\n   but can still use the stash CLI — anyone can use a CLI.\n",
+            ),
         ]
         for i, agent in enumerate(agents):
             box = "[x]" if agent in selected else "[ ]"
@@ -4419,7 +4424,7 @@ def _pick_agents(message: str, agents: list[str], checked: list[str]) -> list[st
         event.app.exit(result=None)
 
     picker = Application(
-        layout=Layout(Window(FormattedTextControl(fragments), height=len(agents) + 2)),
+        layout=Layout(Window(FormattedTextControl(fragments), height=len(agents) + 4)),
         key_bindings=kb,
         erase_when_done=True,
         style=Style(
@@ -4608,7 +4613,7 @@ def _run_setup_wizard() -> None:
             enabled = load_enabled_agents()
             default_enabled = enabled if enabled is not None else detected
 
-            _reserve_bottom_padding(len(detected) + 4)
+            _reserve_bottom_padding(len(detected) + 6)
             selected = _pick_agents(
                 "Which coding agents should Stash record?", detected, default_enabled
             )

--- a/cli/main.py
+++ b/cli/main.py
@@ -714,6 +714,9 @@ def _dir_content_matches(src: Path, dest: Path) -> bool:
     return True
 
 
+_OPENCLAW_MIN_VERSION = (2026, 4, 0)
+
+
 def _install_openclaw(force: bool) -> tuple[str, str]:
     import subprocess
 
@@ -721,6 +724,24 @@ def _install_openclaw(force: bool) -> tuple[str, str]:
     ext_dir = _openclaw_extension_dir()
     if ext_dir.is_dir() and _dir_content_matches(root, ext_dir):
         return ("skipped", f"{ext_dir}")
+
+    # The stash extension needs openclaw >= 2026.4.0 (its plugin-sdk layout
+    # and the install flags below). Older CLIs die with "unknown option
+    # '--force'", which tells the user nothing — name the real problem.
+    version_out = subprocess.run(
+        ["openclaw", "--version"], capture_output=True, text=True, timeout=30
+    )
+    match = re.search(r"\b(\d{4})\.(\d+)\.(\d+)\b", version_out.stdout)
+    if match:
+        version = tuple(int(g) for g in match.groups())
+        if version < _OPENCLAW_MIN_VERSION:
+            installed = ".".join(str(v) for v in version)
+            needed = ".".join(str(v) for v in _OPENCLAW_MIN_VERSION)
+            return (
+                "failed",
+                f"openclaw {installed} is older than {needed}, which the stash "
+                "extension needs — upgrade openclaw, then re-run stash setup",
+            )
 
     # --dangerously-force-unsafe-install: openclaw's code scanner blocks any
     # plugin that spawns processes, and piping hook events into the stashai

--- a/cli/main.py
+++ b/cli/main.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import httpx
 import questionary
+import questionary.prompts.common
 import typer
 from rich.align import Align
 from rich.panel import Panel
@@ -45,6 +46,15 @@ from .config import (
     write_manifest,
 )
 from .formatting import console, output_json, print_user
+
+# questionary's checkbox marks checked rows with ●/reverse-video, which reads
+# as a cursor highlight rather than "this agent is enabled". There is no
+# parameter for the tick marks — these module constants are the only knob.
+questionary.prompts.common.INDICATOR_SELECTED = "[x]"
+questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"
+
+# Checked rows: green instead of the default reverse-video block.
+CHECKBOX_STYLE = questionary.Style([("selected", "fg:#16a34a noreverse")])
 
 app = typer.Typer(
     name="stash",
@@ -4534,6 +4544,7 @@ def _run_setup_wizard() -> None:
             selected = questionary.checkbox(
                 "Which coding agents should Stash record?",
                 instruction="(space toggles an agent, enter saves the whole set)",
+                style=CHECKBOX_STYLE,
                 choices=[
                     questionary.Choice(
                         _AGENT_LABEL.get(a, a),
@@ -5082,6 +5093,7 @@ def settings_cmd(as_json: bool = typer.Option(False, "--json")):
             selected = questionary.checkbox(
                 "Which coding agents should stream to Stash?",
                 instruction="(space toggles an agent, enter saves the whole set)",
+                style=CHECKBOX_STYLE,
                 choices=[
                     questionary.Choice(
                         _AGENT_LABEL.get(a, a),

--- a/cli/main.py
+++ b/cli/main.py
@@ -4527,13 +4527,27 @@ def _run_setup_wizard() -> None:
     if record:
         start_streaming()
         if detected:
-            save_enabled_agents(detected)
-            _install_all_hooks(detected)
-            labels = ", ".join(_AGENT_LABEL.get(a, a) for a in detected)
-            console.print(
-                f"  [green]✓[/green] Recording sessions from: [bold]{labels}[/bold]\n"
-                "    [dim]Change agents with stash settings[/dim]"
-            )
+            enabled = load_enabled_agents()
+            default_enabled = enabled if enabled is not None else detected
+
+            _reserve_bottom_padding(len(detected) + 4)
+            selected = questionary.checkbox(
+                "Which coding agents should Stash record?",
+                instruction="(space toggles an agent, enter saves the whole set)",
+                choices=[
+                    questionary.Choice(
+                        _AGENT_LABEL.get(a, a),
+                        value=a,
+                        checked=a in default_enabled,
+                    )
+                    for a in detected
+                ],
+            ).ask()
+            if selected is None:
+                raise typer.Exit(1)
+
+            save_enabled_agents(selected)
+            _install_all_hooks(selected)
         else:
             save_enabled_agents([])
             console.print(

--- a/cli/main.py
+++ b/cli/main.py
@@ -4847,9 +4847,34 @@ def _enable_marketplace_autoupdate(settings_path: Path) -> bool:
     return True
 
 
+IMPORT_STATUS_FILE = Path.home() / ".stash" / "import-history.json"
+IMPORT_LOG_FILE = Path.home() / ".stash" / "import-history.log"
+
+
+def _write_import_status(total: int, done: int, errors: int, finished: bool) -> None:
+    IMPORT_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    IMPORT_STATUS_FILE.write_text(
+        json.dumps(
+            {
+                "total": total,
+                "done": done,
+                "errors": errors,
+                "finished": finished,
+                "updated_at": time.time(),
+            }
+        )
+        + "\n"
+    )
+
+
 def _onboarding_import_history(detected_agents: list[str]) -> None:
-    """Offer to import historical conversations during onboarding."""
-    from .import_history import discover_conversations, summarize_discovery, upload_conversation
+    """Offer to import historical conversations during onboarding.
+
+    The import itself runs as a detached `stash import-history` process —
+    thousands of uploads must not hold the wizard hostage."""
+    import subprocess as _sp
+
+    from .import_history import discover_conversations, summarize_discovery
 
     agents = detected_agents or None
     conversations = discover_conversations(agents)
@@ -4865,30 +4890,89 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
 
     _reserve_bottom_padding(4)
     ok = questionary.confirm(
-        f"Import {len(conversations)} historical conversations?", default=True
+        f"Import {len(conversations)} historical conversations? (runs in the background)",
+        default=True,
     ).ask()
     if not ok:
         return
 
+    IMPORT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(IMPORT_LOG_FILE, "ab") as log:
+        _sp.Popen(
+            [sys.argv[0], "import-history"],
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+    console.print(
+        f"  [green]✓[/green] Importing {len(conversations)} conversations in the background.\n"
+        "    [dim]Check on it anytime: stash import-history --status[/dim]"
+    )
+
+
+@app.command("import-history")
+def import_history_cmd(
+    status: bool = typer.Option(
+        False, "--status", help="Show progress of the running or last-finished import."
+    ),
+):
+    """Import all historical agent conversations into your Stash.
+
+    Safe to re-run: the server skips sessions that already exist. The setup
+    wizard launches this as a background process; run it directly to import
+    in the foreground with a progress bar."""
+    if status:
+        if not IMPORT_STATUS_FILE.exists():
+            console.print("No import has run on this machine.")
+            return
+        s = json.loads(IMPORT_STATUS_FILE.read_text())
+        state = (
+            "finished" if s["finished"] else f"running (last update {_format_age(s['updated_at'])})"
+        )
+        console.print(f"  {s['done']}/{s['total']} conversations, {s['errors']} errors — {state}")
+        return
+
+    _require_auth()
+    telemetry.record("import_history")
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     from rich.progress import Progress
 
-    imported = 0
+    from .import_history import discover_conversations, upload_conversation
+
+    conversations = discover_conversations(load_enabled_agents() or None)
+    if not conversations:
+        console.print("No historical conversations found.")
+        return
+
+    total = len(conversations)
+    done = 0
     errors = 0
     last_error = ""
+    _write_import_status(total=total, done=0, errors=0, finished=False)
+    # httpx.Client is thread-safe; sequential uploads were taking >1h for a
+    # machine with a few thousand conversations.
     with _client() as c, Progress(console=console) as progress:
-        task = progress.add_task("Importing…", total=len(conversations))
-        for conv in conversations:
-            try:
-                upload_conversation(c, conv)
-                imported += 1
-            except (StashError, httpx.HTTPError) as e:
-                errors += 1
-                last_error = str(e)
-            progress.advance(task)
+        task = progress.add_task("Importing…", total=total)
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(upload_conversation, c, conv) for conv in conversations]
+            for fut in as_completed(futures):
+                try:
+                    fut.result()
+                except (StashError, httpx.HTTPError) as e:
+                    errors += 1
+                    last_error = str(e)
+                done += 1
+                progress.advance(task)
+                if done % 25 == 0 or done == total:
+                    _write_import_status(
+                        total=total, done=done, errors=errors, finished=done == total
+                    )
 
-    console.print(f"  [green]✓[/green] Imported {imported} conversations")
+    console.print(f"  [green]✓[/green] Imported {done - errors} conversations")
     if errors:
-        console.print(f"  [yellow]{errors} failed — {last_error}[/yellow]")
+        console.print(f"  [yellow]{errors} failed — last error: {last_error}[/yellow]")
 
 
 def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> str:

--- a/cli/main.py
+++ b/cli/main.py
@@ -4640,8 +4640,8 @@ def _run_setup_wizard() -> None:
     repo_root = _git_toplevel() or Path.cwd()
     _reserve_bottom_padding(4)
     connect = questionary.confirm(
-        f"Point agents in this folder ({repo_root.name}) at Stash? "
-        "(writes .stash and a CLAUDE.md section)",
+        f"Add Stash instructions to CLAUDE.md in {repo_root.name}, so agents "
+        "working there know how to use Stash?",
         default=True,
     ).ask()
     if connect is None:
@@ -4668,7 +4668,7 @@ def setup_cmd():
 
 @app.command("connect")
 def connect_cmd():
-    """Point agents in this folder at Stash and stream its sessions to your scope."""
+    """Add Stash instructions to this folder's CLAUDE.md and enable session uploads."""
     cfg = _require_auth()
     telemetry.record("connect")
 
@@ -4903,9 +4903,9 @@ def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> st
     connect_section = (
         ""
         if connected
-        else "\n\n[bold]Point a project at Stash[/bold]\n"
-        "Run [cyan]stash connect[/cyan] from any project folder (git repo or not) so\n"
-        "agents working there know to use your Stash."
+        else "\n\n[bold]Set up a project[/bold]\n"
+        "Run [cyan]stash connect[/cyan] in a project folder to add Stash instructions\n"
+        "to its CLAUDE.md — agents working there will know how to use your Stash."
     )
     return (
         "[bold]What just happened[/bold]\n"

--- a/cli/main.py
+++ b/cli/main.py
@@ -4822,8 +4822,8 @@ def _setup_complete_intro(home_url: str, connected: bool, recording: bool) -> st
     return (
         "[bold]What just happened[/bold]\n"
         "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
-        "Recording transcripts is one part of Stash — your agents can also search,\n"
-        "browse, upload, and share files, sessions, and connected sources.\n"
+        "It can read the transcripts your coding agents push to Stash — so it\n"
+        "knows what you've been working on.\n"
         "\n"
         "[bold]See your Stash[/bold]\n"
         f"  [link={home_url}][bold #1e3a8a]{home_url}[/bold #1e3a8a][/link]\n"

--- a/cli/main.py
+++ b/cli/main.py
@@ -5009,8 +5009,10 @@ def _active_import() -> dict | None:
 
 
 def _setup_complete_intro(
-    memory_url: str, connected: bool, recording: bool, importing: dict | None
+    frontend_url: str, connected: bool, recording: bool, importing: dict | None
 ) -> str:
+    memory_url = f"{frontend_url}/memory"
+    integrations_url = f"{frontend_url}/integrations"
     recording_section = (
         "[bold]You're recording[/bold]\n"
         "This machine's agent sessions upload to your private Stash.\n"
@@ -5024,7 +5026,7 @@ def _setup_complete_intro(
         if importing is None
         else "\n\n[bold]Your history is uploading right now[/bold]\n"
         f"{importing['done']}/{importing['total']} past conversations imported so far, in the\n"
-        "background — watch your knowledge base fill up at the link above.\n"
+        "background — watch your knowledge base fill up.\n"
         "[dim]Progress: stash import-history --status[/dim]"
     )
     connect_section = (
@@ -5035,22 +5037,20 @@ def _setup_complete_intro(
         "to its CLAUDE.md — agents working there will know how to use your Stash."
     )
     return (
-        "[bold]What just happened[/bold]\n"
-        "Your coding agent now has the [bold #1e3a8a]stash[/bold #1e3a8a] CLI on its PATH.\n"
-        "It can read the transcripts your coding agents push to Stash — so it\n"
-        "knows what you've been working on.\n"
+        "[bold]Your agents just got a memory[/bold]\n"
+        "Every coding session on this machine now lands in your private Stash.\n"
+        "Your agents can draw on everything you've worked on before — past fixes,\n"
+        "decisions, dead ends — instead of starting every session from zero.\n"
         "\n"
-        "[bold]See your knowledge base[/bold]\n"
+        "[bold]Your knowledge base[/bold]\n"
         f"  [link={memory_url}][bold #1e3a8a]{memory_url}[/bold #1e3a8a][/link]\n"
-        "Your command center: every session and memory in your Stash, embedded\n"
-        "and searchable by your agents.\n"
+        "Stash compiles your sessions into memory your agents check before they\n"
+        "work. The more you use it, the better they get.\n"
         "\n"
-        "[bold]Commands your agent can now use[/bold]\n"
-        '  [#1e3a8a]stash vfs "find / -maxdepth 3 -type f"[/#1e3a8a]   browse Stash like a filesystem\n'
-        '  [#1e3a8a]stash search "<query>"[/#1e3a8a]   full-text search across files, sessions, and sources\n'
-        "  [#1e3a8a]stash sessions agents[/#1e3a8a]   see which agents have been active\n"
-        "\n"
-        "Run [bold]stash --help[/bold] to see everything.\n"
+        "[bold]Make it smarter: connect your tools[/bold]\n"
+        f"  [link={integrations_url}][bold #1e3a8a]{integrations_url}[/bold #1e3a8a][/link]\n"
+        "Connect Slack, Drive, Notion, GitHub and more — your agents will see\n"
+        "through your connectors and answer with your team's actual context.\n"
         "\n"
         f"{recording_section}"
         f"{importing_section}"
@@ -5069,13 +5069,12 @@ def _show_setup_complete_splash() -> None:
     console.print(Align.center(Text.from_markup(f"[bold #1e3a8a]{logo}[/bold #1e3a8a]")))
     console.print("  [bold green]You're all set up.[/bold green]\n")
 
-    memory_url = f"{_frontend_base_url()}/memory"
     connected = load_manifest() is not None
     recording = not streaming_stopped()
     console.print(
         Panel(
             Text.from_markup(
-                _setup_complete_intro(memory_url, connected, recording, _active_import())
+                _setup_complete_intro(_frontend_base_url(), connected, recording, _active_import())
             ),
             title="[bold #1e3a8a]Your agent memory[/bold #1e3a8a]",
             border_style="#1e3a8a",

--- a/cli/tests/test_install_openclaw.py
+++ b/cli/tests/test_install_openclaw.py
@@ -1,8 +1,8 @@
 """Tests for `_install_openclaw` — extension install via the openclaw CLI.
 
-The installer shells out to `openclaw plugins install --force <assets>`, so
-these tests stub subprocess.run and assert the skip/installed/failed
-contract around it.
+The installer checks `openclaw --version`, then shells out to
+`openclaw plugins install --force <assets>`, so these tests stub
+subprocess.run and assert the skip/installed/failed contract around it.
 """
 
 from __future__ import annotations
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from cli.main import _assets_dir, _install_openclaw
 
+CURRENT_VERSION_BANNER = "🦞 OpenClaw 2026.7.1 (abc1234)"
+
 
 def _patch_home(monkeypatch, tmp_path: Path) -> Path:
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -20,21 +22,26 @@ def _patch_home(monkeypatch, tmp_path: Path) -> Path:
     return tmp_path / ".openclaw" / "extensions" / "stash"
 
 
+def _fake_run(calls: list[list[str]], version_banner: str = CURRENT_VERSION_BANNER):
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        stdout = version_banner if "--version" in cmd else ""
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    return run
+
+
 def test_install_runs_openclaw_cli(monkeypatch, tmp_path: Path) -> None:
     _patch_home(monkeypatch, tmp_path)
     calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "run", _fake_run(calls))
 
     status, detail = _install_openclaw(False)
 
     assert status == "installed"
     assert "openclaw gateway restart" in detail
     assert calls == [
+        ["openclaw", "--version"],
         [
             "openclaw",
             "plugins",
@@ -42,8 +49,23 @@ def test_install_runs_openclaw_cli(monkeypatch, tmp_path: Path) -> None:
             "--force",
             "--dangerously-force-unsafe-install",
             str(_assets_dir("openclaw")),
-        ]
+        ],
     ]
+
+
+def test_outdated_openclaw_fails_with_upgrade_message(monkeypatch, tmp_path: Path) -> None:
+    _patch_home(monkeypatch, tmp_path)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess, "run", _fake_run(calls, version_banner="🦞 OpenClaw 2026.1.29 (6522de6)")
+    )
+
+    status, detail = _install_openclaw(False)
+
+    assert status == "failed"
+    assert "2026.1.29 is older than 2026.4.0" in detail
+    assert "upgrade openclaw" in detail
+    assert calls == [["openclaw", "--version"]]
 
 
 def test_up_to_date_extension_is_skipped_without_running_cli(monkeypatch, tmp_path: Path) -> None:
@@ -73,25 +95,24 @@ def test_stale_extension_is_reinstalled(monkeypatch, tmp_path: Path) -> None:
     )
     (ext_dir / "index.ts").write_text("// old version")
     calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "run", _fake_run(calls))
 
     status, _ = _install_openclaw(False)
 
     assert status == "installed"
-    assert len(calls) == 1
+    assert [c[:3] for c in calls] == [
+        ["openclaw", "--version"],
+        ["openclaw", "plugins", "install"],
+    ]
 
 
 def test_failed_cli_surfaces_error_tail(monkeypatch, tmp_path: Path) -> None:
     _patch_home(monkeypatch, tmp_path)
 
     def fake_run(cmd, **kwargs):
+        stdout = CURRENT_VERSION_BANNER if "--version" in cmd else ""
         return subprocess.CompletedProcess(
-            cmd, 1, stdout="", stderr="boom\nplugin rejected by gateway"
+            cmd, 1, stdout=stdout, stderr="boom\nplugin rejected by gateway"
         )
 
     monkeypatch.setattr(subprocess, "run", fake_run)

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -5,7 +5,7 @@ def test_setup_complete_intro_prompts_connect_when_not_connected() -> None:
     intro = main._setup_complete_intro("http://localhost:3457", connected=False, recording=True)
 
     assert "stash connect" in intro
-    assert "git repo or not" in intro
+    assert "CLAUDE.md" in intro
 
 
 def test_setup_complete_intro_omits_connect_prompt_when_connected() -> None:

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -2,17 +2,39 @@ from cli import main
 
 
 def test_setup_complete_intro_prompts_connect_when_not_connected() -> None:
-    intro = main._setup_complete_intro("", connected=False)
+    intro = main._setup_complete_intro("http://localhost:3457", connected=False, recording=True)
 
-    assert "No repo is connected yet" in intro
     assert "stash connect" in intro
-    assert "See your Stash" not in intro
+    assert "git repo or not" in intro
 
 
-def test_setup_complete_intro_includes_stash_link_when_connected() -> None:
-    intro = main._setup_complete_intro("http://localhost:3457/me", connected=True)
+def test_setup_complete_intro_omits_connect_prompt_when_connected() -> None:
+    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=True)
 
-    assert "See your Stash" in intro
-    assert "http://localhost:3457/me" in intro
-    assert "You're streaming" in intro
-    assert "No repo is connected yet" not in intro
+    assert "stash connect" not in intro
+
+
+def test_setup_complete_intro_always_links_home() -> None:
+    for connected in (False, True):
+        intro = main._setup_complete_intro(
+            "http://localhost:3457/me", connected=connected, recording=True
+        )
+        assert "See your Stash" in intro
+        assert "http://localhost:3457/me" in intro
+
+
+def test_setup_complete_intro_states_recording_on() -> None:
+    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=True)
+
+    assert "You're recording" in intro
+    assert "Recording is off" not in intro
+
+
+def test_setup_complete_intro_states_recording_off_with_way_back_in() -> None:
+    # Declining recording must never be a dead end: the splash has to name the
+    # commands that turn it back on.
+    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=False)
+
+    assert "Recording is off" in intro
+    assert "stash start" in intro
+    assert "stash setup" in intro

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -1,11 +1,11 @@
 from cli import main
 
-MEMORY_URL = "http://localhost:3457/memory"
+FRONTEND_URL = "http://localhost:3457"
 
 
 def _intro(connected=True, recording=True, importing=None):
     return main._setup_complete_intro(
-        MEMORY_URL, connected=connected, recording=recording, importing=importing
+        FRONTEND_URL, connected=connected, recording=recording, importing=importing
     )
 
 
@@ -20,11 +20,12 @@ def test_setup_complete_intro_omits_connect_prompt_when_connected() -> None:
     assert "stash connect" not in _intro(connected=True)
 
 
-def test_setup_complete_intro_always_links_memory() -> None:
+def test_setup_complete_intro_always_links_memory_and_integrations() -> None:
     for connected in (False, True):
         intro = _intro(connected=connected)
-        assert "See your knowledge base" in intro
-        assert MEMORY_URL in intro
+        assert "Your knowledge base" in intro
+        assert f"{FRONTEND_URL}/memory" in intro
+        assert f"{FRONTEND_URL}/integrations" in intro
 
 
 def test_setup_complete_intro_states_recording_on() -> None:

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -20,12 +20,11 @@ def test_setup_complete_intro_omits_connect_prompt_when_connected() -> None:
     assert "stash connect" not in _intro(connected=True)
 
 
-def test_setup_complete_intro_always_links_memory_and_integrations() -> None:
+def test_setup_complete_intro_always_links_memory() -> None:
     for connected in (False, True):
         intro = _intro(connected=connected)
         assert "Your knowledge base" in intro
         assert f"{FRONTEND_URL}/memory" in intro
-        assert f"{FRONTEND_URL}/integrations" in intro
 
 
 def test_setup_complete_intro_states_recording_on() -> None:
@@ -45,11 +44,11 @@ def test_setup_complete_intro_states_recording_off_with_way_back_in() -> None:
     assert "stash setup" in intro
 
 
-def test_setup_complete_intro_shows_running_import_with_counts() -> None:
+def test_setup_complete_intro_shows_running_import() -> None:
     intro = _intro(importing={"done": 120, "total": 6193})
 
     assert "Your history is uploading right now" in intro
-    assert "120/6193" in intro
+    assert "6193 past conversations" in intro
     assert "stash import-history --status" in intro
 
 

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -1,30 +1,34 @@
 from cli import main
 
+MEMORY_URL = "http://localhost:3457/memory"
+
+
+def _intro(connected=True, recording=True, importing=None):
+    return main._setup_complete_intro(
+        MEMORY_URL, connected=connected, recording=recording, importing=importing
+    )
+
 
 def test_setup_complete_intro_prompts_connect_when_not_connected() -> None:
-    intro = main._setup_complete_intro("http://localhost:3457", connected=False, recording=True)
+    intro = _intro(connected=False)
 
     assert "stash connect" in intro
     assert "CLAUDE.md" in intro
 
 
 def test_setup_complete_intro_omits_connect_prompt_when_connected() -> None:
-    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=True)
-
-    assert "stash connect" not in intro
+    assert "stash connect" not in _intro(connected=True)
 
 
-def test_setup_complete_intro_always_links_home() -> None:
+def test_setup_complete_intro_always_links_memory() -> None:
     for connected in (False, True):
-        intro = main._setup_complete_intro(
-            "http://localhost:3457/me", connected=connected, recording=True
-        )
-        assert "See your Stash" in intro
-        assert "http://localhost:3457/me" in intro
+        intro = _intro(connected=connected)
+        assert "See your knowledge base" in intro
+        assert MEMORY_URL in intro
 
 
 def test_setup_complete_intro_states_recording_on() -> None:
-    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=True)
+    intro = _intro(recording=True)
 
     assert "You're recording" in intro
     assert "Recording is off" not in intro
@@ -33,8 +37,20 @@ def test_setup_complete_intro_states_recording_on() -> None:
 def test_setup_complete_intro_states_recording_off_with_way_back_in() -> None:
     # Declining recording must never be a dead end: the splash has to name the
     # commands that turn it back on.
-    intro = main._setup_complete_intro("http://localhost:3457", connected=True, recording=False)
+    intro = _intro(recording=False)
 
     assert "Recording is off" in intro
     assert "stash start" in intro
     assert "stash setup" in intro
+
+
+def test_setup_complete_intro_shows_running_import_with_counts() -> None:
+    intro = _intro(importing={"done": 120, "total": 6193})
+
+    assert "Your history is uploading right now" in intro
+    assert "120/6193" in intro
+    assert "stash import-history --status" in intro
+
+
+def test_setup_complete_intro_omits_import_section_when_no_import() -> None:
+    assert "uploading right now" not in _intro(importing=None)

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # joinstash.ai/install — install the stashai CLI and run the interactive
-# `stash signin` setup wizard (managed-vs-self-host, browser auth,
-# upload-vs-read, agent hooks, repo connection).
+# `stash signin` setup wizard (browser auth, session recording, agent
+# hooks, folder connection).
 #
 # Recommended invocation (keeps stdin attached to your terminal so the
 # questionnaire's interactive picker works):
@@ -76,7 +76,6 @@ MSG
   exit 0
 fi
 
-# Stdin is a real terminal; launch the questionnaire. `stash signin`
-# asks scope, managed-vs-self-host, browser sign-in, workspace, and the
-# Claude Code plugin install (when detected).
+# Stdin is a real terminal; launch the wizard. `stash signin` does browser
+# sign-in, then session recording, agent hooks, and folder connection.
 exec "$STASH_BIN" signin


### PR DESCRIPTION
Redesign of `stash signin`/CLI onboarding, from a full audit of the flow plus a live walkthrough on a real machine. Context: prep for the Chainbase single-player setup — the wizard is the first 15 minutes of their experience.

## The wizard

| Problem | Fix |
|---|---|
| Answering "No" to transcripts was a **permanent dead end** — `signin` skips the wizard forever on re-auth | New `stash setup` re-runs the wizard anytime; every answer is reversible |
| Scary opt-in gate ("Do you want to **share** your coding agent transcripts?") that skipped all remaining setup when declined | Private-by-default framing: "Record your agent sessions? (pause anytime with `stash stop`)"; declining no longer aborts the rest |
| Select vs. multi-select prompts indistinguishable; enter-vs-space confusion; checked rows rendered like cursor highlights | Custom agent picker: `[x]`/`[ ]` tick marks, **enter toggles the highlighted agent**, explicit `Done` row submits, legend spelling out that `[x]` = session uploads (every agent can use the CLI regardless) |
| "You must be in a git repo" — `stash connect` hard-failed outside git while the streaming hooks never cared | `connect` and the wizard's folder step work in any folder |
| "Which repo do you want to upload transcripts in?" implied per-repo streaming (it's global); leaked `.stash` jargon | One honest confirm: "Add Stash instructions to CLAUDE.md in <folder>, so agents working there know how to use Stash?" |
| Managed-vs-self-host jargon as the first question | Managed by default; dim hint points self-hosters at `--api`; docker walkthrough deleted |
| No-agents-detected: silently saved empty list, still asked about uploads | Explicit notice naming supported agents and `stash setup` to re-run |

## History import

- **Import no longer holds the wizard hostage** (6k conversations = 1h18m sequential): the wizard spawns a detached `stash import-history` and finishes immediately.
- New `stash import-history` command: 8-wide parallel uploads (~8× faster), atomic progress file, safe to re-run (server skips existing sessions).
- `stash import-history --status`: live progress bar following the import; Ctrl-C detaches.
- **Server fix:** re-uploading a transcript for a session the user had deleted returned `404 Transcript not found` — a real import hit 3,333 of these and reported them all as errors. Now returns `skipped: "session was deleted"` without resurrecting; orphaned events (rows in `history_events` with no `sessions` row) recreate the row and skip; the client stops pushing import-marker events onto skipped sessions.

## The ending

- Splash never clears the screen (it was erasing errors printed seconds earlier), states the true recording state, and shows an in-flight import.
- Benefit-led copy replacing the CLI command tour: "Your agents just got a memory", knowledge-base link to **/memory**. (Integrations pitch drafted then removed — one message for now.)
- Codex network-access prompt: Esc/Ctrl-C now declines instead of granting.
- Openclaw installer: version pre-check — outdated openclaw (< 2026.4.0, the extension's floor) fails with an upgrade instruction instead of `unknown option '--force'`.
- Fixed mojibake checkmark, wrong-command message in the self-host bailout, stale comments in `main.py` and `install.sh`.

## Testing

- `pytest cli/tests/` 197 passed; `pytest backend/tests/test_transcripts.py` 21 passed (incl. new deleted-session skip test); ruff clean.
- Live-tested end to end on a real machine: fresh `stash signin`, `stash setup` re-runs, picker toggling in a pty, background import of 6,195 real conversations, `--status` attach/detach.

## Notes for review

- Backend change deploys to prod on merge (Render autodeploy); the import fix only takes effect for CLI users then.
- Shipping to CLI users additionally needs a `stashai` version bump (PyPI publish) — not included here.
- Possible overlap with `session-upload-controls` (per-folder upload controls) and the `onboarding-10` worktree's wizard exploration — flagging so we pick one direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)