### PR TITLE
Let agents edit the Memory wiki directly from the CLI

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -181,14 +181,16 @@ async def get_memory_folder(
 @router.get("/memory-tree", response_model=ScopeTreeResponse)
 async def get_memory_tree(
     current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
 ):
     """The Memory wiki as a nested file-system tree (folders + pages), rooted
-    at the caller's Memory folder. Drives the wiki browser page."""
-    tree = await files_tree_service.memory_tree(current_user["id"], current_user["id"])
+    at the scope's Memory folder. Drives the wiki browser page and `stash
+    memory ls`/`write`."""
+    tree = await files_tree_service.memory_tree(scope_user_id, current_user["id"])
     await security_audit_service.record_entries_listed(
         target_type="memory_tree",
         actor_user_id=current_user["id"],
-        owner_user_id=current_user["id"],
+        owner_user_id=scope_user_id,
         metadata={"result_count": len(tree["folders"]) + len(tree["pages"])},
     )
     return ScopeTreeResponse(**tree)

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -136,10 +136,9 @@ personal Stash scope and is not shared with their team.
 
 ## Steps
 
-1. Find the wiki. `stash memory --json` prints the reserved Memory folder id
-   — every page you create belongs under it. Read the current structure with
-   `stash vfs "ls /memory"` and read any page that might overlap this run's
-   topics with `stash vfs "cat '/memory/<page>.md'"`.
+1. Find the wiki. `stash memory ls --json` prints its full tree with ids.
+   Read any page that might overlap this run's topics with
+   `stash vfs "cat '/memory/<page>.md'"`.
 2. Gather what's new since your last successful run (the timestamp is in the
    Runtime context section appended to this prompt):
    - Recent agent activity: `stash sessions agents`, recent entries in
@@ -149,9 +148,9 @@ personal Stash scope and is not shared with their team.
      each connector's time-filtered search/list tools; where a connector can
      only list, read newest-first and stop as soon as items are older than
      the timestamp.
-3. Decide, per durable topic: update an existing page (`stash files
-   edit-page`), or create a new one (`stash files add-page --folder
-   <memory_folder_id>`). If the wiki is empty, this is a bootstrap: cluster
+3. Write, per durable topic: `stash memory write "<Category>/<Page>"
+   --content "<markdown>"` creates or updates the page at that path (missing
+   subfolders are created). If the wiki is empty, this is a bootstrap: cluster
    the material into a handful of themes and create a small page per theme —
    structure first, completeness later.
 4. Keep runs small: fold in the handful of things that mattered, cross-link
@@ -268,9 +267,9 @@ pages themselves.
   claim, and which supersedes, with a one-line reason.
 
 ## Write the wiki (under the Memory folder)
-- Category subfolder: `stash files create-folder "<Category>" --parent {memory_folder_id} --json`.
-- New page: `stash files add-page "<Title>" --folder <category_folder_id> --content "<markdown>" --json`.
-- Update page: `stash files edit-page <page_id> --content "<markdown>" --json`.
+- Create or update a page: `stash memory write "<Category>/<Title>" --content "<markdown>" --json`
+  — the path is relative to the Memory folder and missing category subfolders
+  are created for you. Long bodies pipe on stdin instead of --content.
 - Every page: a one-sentence summary; a markdown link up to its category;
   sideways links to related pages; confidence tags; date new content
   `<!-- added YYYY-MM-DD -->`.

--- a/backend/tests/test_local_curator_prompt.py
+++ b/backend/tests/test_local_curator_prompt.py
@@ -22,5 +22,4 @@ async def test_serves_the_curation_prompt(client: AsyncClient):
     # it must ground the run in the stash CLI and include the page-update
     # loop, or runs regenerate instead of maintaining.
     assert "stash" in prompt
-    assert "edit-page" in prompt
-    assert "add-page" in prompt
+    assert "memory write" in prompt

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -276,6 +276,43 @@ async def test_scope_header_reroots_overview_for_members_only(client: AsyncClien
 
 
 @pytest.mark.asyncio
+async def test_scope_header_reroots_memory_tree(client: AsyncClient, pool):
+    """memory-folder, memory-tree, and the page/folder writes must all follow
+    the scope header together: `stash memory write` resolves its path against
+    the tree and writes into the folder, so a tree rooted in a different scope
+    than the folder makes every scoped upsert re-create existing pages."""
+    domain = _domain()
+    member_key, member = await _register_with_email(client, f"m@{domain}")
+    await _verify_email(pool, uuid.UUID(member["id"]))
+    ws = await _create_workspace(client, domain)
+    scoped = {**_auth(member_key), "X-Stash-Scope": ws["scope_user_id"]}
+
+    mem = (await client.get("/api/v1/me/memory-folder", headers=scoped)).json()
+    assert mem["owner_user_id"] == ws["scope_user_id"]
+    sub = (
+        await client.post(
+            "/api/v1/me/folders",
+            json={"name": "Customers", "parent_folder_id": mem["id"]},
+            headers=scoped,
+        )
+    ).json()
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Chainbase", "content": "x", "folder_id": sub["id"]},
+        headers=scoped,
+    )
+    assert resp.status_code == 201, resp.text
+
+    tree = (await client.get("/api/v1/me/memory-tree", headers=scoped)).json()
+    assert [f["name"] for f in tree["folders"]] == ["Customers"]
+    assert [p["name"] for p in tree["folders"][0]["pages"]] == ["Chainbase"]
+
+    # The member's personal wiki stays untouched.
+    personal = (await client.get("/api/v1/me/memory-tree", headers=_auth(member_key))).json()
+    assert personal["folders"] == []
+
+
+@pytest.mark.asyncio
 async def test_member_creates_page_owned_by_workspace(client: AsyncClient, pool):
     domain = _domain()
     key, body = await _register_with_email(client, f"m@{domain}")

--- a/cli/main.py
+++ b/cli/main.py
@@ -3128,8 +3128,16 @@ def _poll_recompute_outcome(
     return "queued", None
 
 
-@app.command("memory")
-def memory(
+memory_app = typer.Typer(
+    help="Your Memory wiki — status, recompute, and direct page writes.",
+    invoke_without_command=True,
+)
+app.add_typer(memory_app, name="memory")
+
+
+@memory_app.callback()
+def memory_default(
+    ctx: typer.Context,
     recompute: bool = typer.Option(
         False,
         "--recompute",
@@ -3138,6 +3146,8 @@ def memory(
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Show your reserved Memory folder (its id is where the wiki lives)."""
+    if ctx.invoked_subcommand is not None:
+        return
     with _client() as c:
         if recompute:
             before = c.get_curator()
@@ -3171,6 +3181,97 @@ def memory(
         console.print(f"Curator last run: {last_run}")
         if curator["last_run_error"]:
             console.print(f"[red]Curator last run failed:[/red] {curator['last_run_error']}")
+
+
+def _resolve_memory_target(c: StashClient, path: str) -> tuple[dict | None, str, str]:
+    """Walk `path` (relative to the Memory folder) to its page slot.
+
+    Returns (existing_page | None, folder_id, page_name), creating missing
+    intermediate folders along the way. A trailing `.md` on the page segment
+    is stripped — the VFS shows page names with that suffix."""
+    segments = [s for s in path.split("/") if s]
+    page_name = segments[-1].removesuffix(".md") if segments else ""
+    if not page_name:
+        raise ValueError(f"not a page path: {path!r}")
+    folder_id = c.get_memory_folder()["id"]
+    node: dict | None = c.get_memory_tree()
+    for segment in segments[:-1]:
+        child = next((f for f in node["folders"] if f["name"] == segment), None) if node else None
+        if child is None:
+            folder_id = c.create_folder(segment, parent_folder_id=folder_id)["id"]
+            node = None
+        else:
+            folder_id = child["id"]
+            node = child
+    pages = node["pages"] if node else []
+    page = next((p for p in pages if p["name"] == page_name), None)
+    return page, folder_id, page_name
+
+
+@memory_app.command("write")
+def memory_write(
+    path: str = typer.Argument(
+        ...,
+        help="Page path under the Memory folder, e.g. 'Product/Chainbase'. "
+        "Missing subfolders are created; a trailing .md is stripped.",
+    ),
+    content: str = typer.Option(None, "--content", help="Page body. Reads stdin if omitted."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Create or update a Memory wiki page at a path — the direct write
+    surface for agents that maintain the wiki themselves."""
+    if content is None and not sys.stdin.isatty():
+        content = sys.stdin.read()
+    if content is None:
+        console.print("[red]No content: pass --content or pipe the body on stdin.[/red]")
+        raise typer.Exit(1)
+    with _client() as c:
+        try:
+            page, folder_id, page_name = _resolve_memory_target(c, path)
+        except ValueError as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1)
+        except StashError as e:
+            _err(e)
+        try:
+            if page is None:
+                data = c.create_page(page_name, content=content, folder_id=folder_id)
+                action = "created"
+            else:
+                data = c.update_page(page["id"], content=content)
+                action = "updated"
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json({**data, "action": action})
+    else:
+        console.print(f"[green]Page '{data['name']}' {action}.[/green]  ID: {data['id']}")
+
+
+def _print_memory_tree(node: dict, indent: int) -> None:
+    pad = "  " * indent
+    for f in node["folders"]:
+        console.print(f"{pad}[cyan]{f['name']}/[/cyan]  [dim]{f['id']}[/dim]")
+        _print_memory_tree(f, indent + 1)
+    for p in node["pages"]:
+        console.print(f"{pad}{p['name']}  [dim]{p['id']}[/dim]")
+
+
+@memory_app.command("ls")
+def memory_ls(as_json: bool = typer.Option(False, "--json")):
+    """The Memory wiki tree with ids — page ids feed `stash files edit-page`
+    and `stash rm page:<id>`."""
+    with _client() as c:
+        try:
+            folder = c.get_memory_folder()
+            tree = c.get_memory_tree()
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json({"id": folder["id"], "name": folder["name"], **tree})
+        return
+    console.print(f"[cyan]{folder['name']}/[/cyan]  [dim]{folder['id']}[/dim]")
+    _print_memory_tree(tree, indent=1)
 
 
 @app.command("changes")

--- a/cli/tests/test_memory_write.py
+++ b/cli/tests/test_memory_write.py
@@ -1,0 +1,74 @@
+"""`stash memory write` resolves a path under the Memory folder to a page
+slot: existing pages are found by name (so the command updates instead of
+duplicating), and missing intermediate folders are created on the way down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cli.main import _resolve_memory_target
+
+MEMORY_FOLDER = {"id": "mem-root"}
+
+
+class _FakeClient:
+    def __init__(self, tree: dict):
+        self._tree = tree
+        self.created_folders: list[tuple[str, str]] = []
+
+    def get_memory_folder(self) -> dict:
+        return MEMORY_FOLDER
+
+    def get_memory_tree(self) -> dict:
+        return self._tree
+
+    def create_folder(self, name: str, parent_folder_id: str | None = None) -> dict:
+        self.created_folders.append((name, parent_folder_id))
+        return {"id": f"new-{name}"}
+
+
+def _tree(folders: list | None = None, pages: list | None = None) -> dict:
+    return {"folders": folders or [], "pages": pages or []}
+
+
+def test_existing_root_page_is_found():
+    client = _FakeClient(_tree(pages=[{"id": "p1", "name": "Log"}]))
+    page, folder_id, name = _resolve_memory_target(client, "Log")
+    assert page["id"] == "p1"
+    assert folder_id == "mem-root"
+    assert name == "Log"
+    assert client.created_folders == []
+
+
+def test_md_suffix_matches_the_vfs_rendering():
+    """The VFS shows pages as `<name>.md`, so agents naturally pass that back."""
+    client = _FakeClient(_tree(pages=[{"id": "p1", "name": "Log"}]))
+    page, _, name = _resolve_memory_target(client, "Log.md")
+    assert page["id"] == "p1"
+    assert name == "Log"
+
+
+def test_new_page_in_existing_category():
+    category = _tree(pages=[{"id": "p2", "name": "Other"}]) | {"id": "f1", "name": "Product"}
+    client = _FakeClient(_tree(folders=[category]))
+    page, folder_id, name = _resolve_memory_target(client, "Product/Chainbase")
+    assert page is None
+    assert folder_id == "f1"
+    assert name == "Chainbase"
+    assert client.created_folders == []
+
+
+def test_missing_folders_are_created_down_the_path():
+    client = _FakeClient(_tree())
+    page, folder_id, name = _resolve_memory_target(client, "Customers/Chainbase/Notes")
+    assert page is None
+    assert client.created_folders == [("Customers", "mem-root"), ("Chainbase", "new-Customers")]
+    assert folder_id == "new-Chainbase"
+    assert name == "Notes"
+
+
+def test_pathless_input_is_rejected():
+    client = _FakeClient(_tree())
+    with pytest.raises(ValueError):
+        _resolve_memory_target(client, "/")


### PR DESCRIPTION
## What

Agents with the `stash` CLI can now maintain the Memory wiki themselves — built for the Chainbase demo, where Yuxing's curator runs locally on his laptop (pairs with the cancelable-curator work) and any Claude Code / Kimi / Codex session folds what it learned into memory with one command.

`stash memory` becomes a command group; bare `stash memory` and `--recompute` are unchanged.

```bash
# Create or update a page by path — missing subfolders are created
stash memory write "Customers/Chainbase" --content "..."

# Long bodies pipe on stdin; the .md the VFS shows is accepted
cat notes.md | stash memory write "Customers/Chainbase.md"

# The wiki tree with folder/page ids
stash memory ls [--json]
```

## Bug fixed along the way

`GET /me/memory-tree` was the one memory route that ignored `X-Stash-Scope` while `/me/memory-folder`, `/me/memory-graph`, and all page/folder writes honored it. In a workspace scope the tree came from a different wiki than the writes targeted, so path-based upserts re-created existing pages (409s on folders) and the web wiki browser showed the workspace graph next to the personal tree. The endpoint is now scope-aware like its siblings; regression test `test_scope_header_reroots_memory_tree` covers the loop.

Discovered live: raw writes into the Memory folder already worked (`stash files add-page --folder <id>`), but this scope mismatch made any path-based agent loop break for workspace users.

## Prompts

Both curator prompts — the cloud curator and the local-curator prompt Stash Desktop fetches fresh before every run — now instruct `stash memory write` instead of the add-page/edit-page/folder-id dance. Note: an installed CLI needs its self-update to gain `memory write`, so there is a brief skew window after this deploys.

## Testing

- New `cli/tests/test_memory_write.py`: path resolution, upsert-by-name, `.md` stripping, intermediate-folder creation.
- New `test_scope_header_reroots_memory_tree` in `test_workspaces.py`.
- `test_local_curator_prompt.py` updated to assert the new write surface.
- Full suites green: backend 1216 passed, CLI 196 passed, frontend 250 passed; ruff clean.
- Live E2E against prod with this checkout's CLI: created, updated (stdin), read back, and cleaned up real memory pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)