### PR TITLE
Curator nightly cloud run gets an off switch

### DIFF
--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -168,6 +168,15 @@ async def create_agent(user_id: UUID, fields: dict) -> dict:
 
 async def update_agent(user_id: UUID, agent_id: UUID, fields: dict) -> dict:
     current = await get_agent(user_id, agent_id)
+    # The curator is a reserved system agent — its name, prompt, and staggered
+    # cron are managed by Stash. The one user decision is whether the nightly
+    # cloud run happens at all: run_mode 'scheduled' (on) or 'chat' (off, e.g.
+    # when curating locally). Off keeps on-demand runs working.
+    if current["is_curator"] and set(fields) - {"run_mode"}:
+        raise HTTPException(
+            status_code=400,
+            detail="only run_mode can change on the Memory curator (its schedule on/off switch)",
+        )
     merged = {**current, **fields}
     _validate(
         merged.get("model_provider"), merged.get("run_mode", "chat"), merged.get("schedule_cron")

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -47,6 +47,52 @@ async def test_curator_cannot_be_deleted(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_curator_schedule_turns_off_and_back_on(client: AsyncClient, _db_pool):
+    """The off switch for users who curate locally (e.g. Chainbase): run_mode
+    'chat' takes the curator out of the beat's pickup so the nightly cloud run
+    can't fire mid-work, while the watermark survives so nothing un-curated is
+    lost when the schedule comes back on."""
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+
+    r = await client.patch(
+        f"/api/v1/me/agents/{curator['id']}", json={"run_mode": "chat"}, headers=_auth(key)
+    )
+    assert r.status_code == 200
+    off = r.json()
+    assert off["run_mode"] == "chat"
+    # The cron baseline clears; the delta watermark stays.
+    assert off["last_run_at"] is None
+    assert datetime.fromisoformat(off["curated_through"]) == curator["curated_through"]
+    assert curator["id"] not in {a["id"] for a in await agent_service.list_scheduled()}
+
+    r = await client.patch(
+        f"/api/v1/me/agents/{curator['id']}", json={"run_mode": "scheduled"}, headers=_auth(key)
+    )
+    assert r.status_code == 200
+    on = r.json()
+    assert on["run_mode"] == "scheduled"
+    # Baseline re-seeds to now, so the schedule resumes at the next cron tick
+    # rather than firing immediately for the paused window.
+    assert on["last_run_at"] is not None
+    assert curator["id"] in {a["id"] for a in await agent_service.list_scheduled()}
+
+
+@pytest.mark.asyncio
+async def test_curator_only_run_mode_is_editable(client: AsyncClient):
+    """The curator is reserved: its staggered cron, name, and prompt are
+    Stash-managed. A PATCH touching anything but run_mode is refused."""
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+    r = await client.patch(
+        f"/api/v1/me/agents/{curator['id']}",
+        json={"schedule_cron": "0 9 * * *"},
+        headers=_auth(key),
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_curator_provisioned_at_signup(client: AsyncClient):
     """Every account gets sleep-time curation from day one — including
     API-key-only production integrations that never touch chat or channels."""
@@ -483,6 +529,13 @@ async def test_recompute_runs_curator_now(client: AsyncClient, sprite_exec, _db_
     key, uid = await _register(client)
     await client.post(
         "/api/v1/me/pages/new", json={"name": "N", "content": "x"}, headers=_auth(key)
+    )
+
+    # On-demand runs are independent of the nightly switch: a user who turned
+    # the schedule off (curating locally) can still trigger a cloud pass.
+    curator = await agent_service.get_or_create_curator(uid)
+    await client.patch(
+        f"/api/v1/me/agents/{curator['id']}", json={"run_mode": "chat"}, headers=_auth(key)
     )
 
     started = []

--- a/cli/client.py
+++ b/cli/client.py
@@ -386,6 +386,12 @@ class StashClient:
         agents = self._get("/api/v1/me/agents")["agents"]
         return next((a for a in agents if a["is_curator"]), None)
 
+    def set_curator_scheduled(self, agent_id: str, scheduled: bool) -> dict:
+        """Turn the curator's nightly cloud run on or off. Off keeps on-demand
+        runs (--recompute) working — it only stops the schedule."""
+        run_mode = "scheduled" if scheduled else "chat"
+        return self._patch(f"/api/v1/me/agents/{agent_id}", json={"run_mode": run_mode})
+
     # --- Pages (user-scoped) ---
 
     def create_page(

--- a/cli/main.py
+++ b/cli/main.py
@@ -3143,12 +3143,39 @@ def memory_default(
         "--recompute",
         help="Run the Memory curator now instead of waiting for the daily pass.",
     ),
+    curator: str = typer.Option(
+        None,
+        "--curator",
+        help="Turn the curator's nightly cloud run 'on' or 'off'. Turn it off when "
+        "you curate locally; --recompute still works while it's off.",
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Show your reserved Memory folder (its id is where the wiki lives)."""
     if ctx.invoked_subcommand is not None:
         return
+    if curator is not None and curator not in ("on", "off"):
+        console.print("[red]--curator takes 'on' or 'off'.[/red]")
+        raise typer.Exit(1)
     with _client() as c:
+        if curator is not None:
+            row = c.get_curator()
+            if not row:
+                console.print("[red]No Memory curator found for this account.[/red]")
+                raise typer.Exit(1)
+            updated = c.set_curator_scheduled(row["id"], curator == "on")
+            if _use_json(as_json):
+                output_json(updated)
+            elif curator == "on":
+                console.print(
+                    "Curator nightly cloud run: [green]on[/green] — resumes at the next daily tick."
+                )
+            else:
+                console.print(
+                    "Curator nightly cloud run: [yellow]off[/yellow] — "
+                    "run it yourself with `stash memory --recompute` or locally."
+                )
+            return
         if recompute:
             before = c.get_curator()
             data = c.recompute_memory()
@@ -3171,16 +3198,18 @@ def memory_default(
                 raise typer.Exit(1)
             return
         folder = c.get_memory_folder()
-        curator = c.get_curator()
+        row = c.get_curator()
     if _use_json(as_json):
-        output_json({**folder, "curator": curator})
+        output_json({**folder, "curator": row})
         return
     console.print(f"Memory folder: [cyan]{folder['name']}[/cyan] (id {folder['id']})")
-    if curator:
-        last_run = curator["last_run_at"] or "never"
+    if row:
+        schedule = "nightly (cloud)" if row["run_mode"] == "scheduled" else "off — on-demand only"
+        console.print(f"Curator schedule: {schedule}")
+        last_run = row["last_run_at"] or "never"
         console.print(f"Curator last run: {last_run}")
-        if curator["last_run_error"]:
-            console.print(f"[red]Curator last run failed:[/red] {curator['last_run_error']}")
+        if row["last_run_error"]:
+            console.print(f"[red]Curator last run failed:[/red] {row['last_run_error']}")
 
 
 def _resolve_memory_target(c: StashClient, path: str) -> tuple[dict | None, str, str]:

--- a/frontend/src/components/agents/AgentConfigPanel.tsx
+++ b/frontend/src/components/agents/AgentConfigPanel.tsx
@@ -92,6 +92,24 @@ export default function AgentConfigPanel({
     }
   }
 
+  // The curator's one user-facing setting: whether the nightly cloud run
+  // happens at all. Off is for users who curate locally (Stash Desktop or the
+  // stash CLI on their own machine) — "Run now" keeps working either way.
+  async function setCuratorSchedule(on: boolean) {
+    if (!agent) return;
+    setSaving(true);
+    setMsg(null);
+    try {
+      const updated = await updateAgent(agent.id, { run_mode: on ? "scheduled" : "chat" });
+      setAgent(updated);
+      window.dispatchEvent(new Event("agents-changed"));
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : "Could not save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   async function remove() {
     if (!agent) return;
     await deleteAgent(agent.id);
@@ -195,8 +213,28 @@ export default function AgentConfigPanel({
           </p>
         </div>
 
-        <Field label="Schedule">
-          <div className="text-[13px] text-foreground">Daily · automatic</div>
+        <Field
+          label="Nightly cloud run"
+          hint={
+            agent.run_mode === "scheduled"
+              ? "Runs once a night on your cloud computer. Turn it off if you curate locally — Run now keeps working."
+              : "Off — nothing runs on a schedule. Use Run now below, or curate locally with the stash CLI."
+          }
+        >
+          <div className="flex items-center justify-between rounded-md border border-border bg-base px-3 py-2">
+            <span className="text-[13px] text-foreground">
+              {agent.run_mode === "scheduled" ? "On · daily, automatic" : "Off"}
+            </span>
+            <button
+              type="button"
+              onClick={() => void setCuratorSchedule(agent.run_mode !== "scheduled")}
+              disabled={saving}
+              className="rounded-md border border-border px-3 py-1.5 text-[12.5px] font-medium text-foreground hover:bg-raised disabled:opacity-60"
+            >
+              {saving ? "Saving…" : agent.run_mode === "scheduled" ? "Turn off" : "Turn on"}
+            </button>
+          </div>
+          {msg && <div className="mt-1.5 text-[12px] text-error">{msg}</div>}
         </Field>
 
         <RunOnDemand isCurator run={run} onRun={runNow} />


### PR DESCRIPTION
## Why

Users who curate locally need the scheduled cloud curator to *not* fire mid-work. Concretely: the Chainbase onboarding flow has each employee build their memory wiki on their own laptop (via the `stash-onboarding` skills) against their own MCP connections — and prod curator crons stagger across 08:00–11:59 UTC, which is 16:00–19:59 in Beijing, right in the middle of the workday. With the cloud run left on, two curators with different prompts would write the same Memory wiki.

Today there is no off switch: the curator panel is read-only, and `delete_agent` refuses with "turn it off instead" — which didn't exist.

## What

`run_mode` already gates the beat's pickup (`list_scheduled` filters `run_mode = 'scheduled'`), so flipping the curator to `'chat'` is a complete, zero-migration off state:

- the nightly run can't fire, and stale-curator alerts stay quiet (same filter)
- on-demand runs (`POST /me/memory/recompute`, "Run now", `stash memory --recompute`) keep working
- the `curated_through` watermark is untouched, so nothing un-curated is lost; turning back on re-seeds the cron baseline and resumes at the next nightly tick

Changes:
- **backend** — the reserved curator now accepts PATCH, but only `run_mode`; its Stash-managed cron/name/prompt are rejected with a 400
- **CLI** — `stash memory --curator on|off`, plus the schedule state in plain `stash memory` output
- **web** — the curator panel's read-only "Schedule: Daily · automatic" field is now a "Nightly cloud run" control with a Turn off/on button

The uncommitted `stash-hooks` prototype (run_mode `local` + lease/complete endpoints) composes with this: no new run_mode value, no schema change.

## Tests

- `test_curator_schedule_turns_off_and_back_on` — off ⇒ out of `list_scheduled`, baseline cleared, watermark preserved; on ⇒ baseline re-seeded
- `test_curator_only_run_mode_is_editable` — reserved fields stay locked
- `test_recompute_runs_curator_now` now flips the schedule off first, proving on-demand runs are independent of the switch
- Full suite: backend 1218 passed, frontend 250 passed, ruff + eslint clean, `next build` clean

## Screenshots

Pending — the machine's one allowed local stack (ports 3456/3457) is currently held by another worktree's session, so I couldn't capture the changed curator panel yet. Will add them to this thread as soon as the stack frees up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)