### PR TITLE
Docs sync: onboarding redesign, stash memory group, curator switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
+  that can be re-run anytime with the new `stash setup` — no answer is final.
+  Session recording is framed as private-by-default and on by default
+  (`stash stop` pauses). The agent picker uses `[x]` checkboxes where enter
+  toggles and a `Done` row saves. `stash connect` works in any folder — a git
+  repo is no longer required. History import runs in the background via the
+  new `stash import-history` (parallel uploads; `--status` attaches a live
+  progress bar). Re-uploading a transcript for a deleted session now reports
+  a clean skip instead of a 404 error, and no longer pollutes plugin upload
+  health.
+- `stash memory` is now a command group (#941): `stash memory write "<Path>"`
+  creates or updates a Memory wiki page (stdin for long bodies) and
+  `stash memory ls` prints the wiki tree — the direct write surface for
+  agents that maintain the wiki themselves. Bare `stash memory` and
+  `--recompute` are unchanged.
+- The nightly cloud Memory curator has an off switch (#942):
+  `stash memory --curator off|on`, also surfaced in the web curator panel.
+  On-demand recomputes keep working while it's off.
 - Scheduled agent run history now reports each run's status, error, duration,
   event count, and tool count while preserving the chronological transcript
   feed used by the agent workspace.
@@ -25,9 +43,6 @@ everything before it is captured in git history (`git log`), not here.
 - Added a committed `docker-compose.local.yml` override for laptop
   self-hosting dry runs. It exposes backend, frontend, and collab on
   localhost ports and disables Caddy.
-- CLI onboarding now says to run `stash connect` when setup finishes
-  without connecting a repo, instead of telling users to commit a
-  `.stash` file that was never created.
 - Self-hosting now uses a prebuilt `ghcr.io/fergana-labs/stash-frontend`
   image alongside the backend and collab images, so
   `docker-compose.prod.yml` no longer builds application containers on the

--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ uv tool install stashai
 stash signin
 ```
 
-`stash signin` authenticates you in the browser, asks whether you want to
-share your agent transcripts, then finds the coding agents installed on your
-machine and installs hooks for the ones you pick. It offers to connect the
-repo you're standing in and to import conversations you've already had. Use
-`stash connect` later when you're already signed in and only need to bind
-another repo.
+`stash signin` authenticates you in the browser, then walks first-run setup:
+session recording (on by default — pause anytime with `stash stop`), which
+coding agents to record, Stash instructions for the folder you're standing in
+(any folder — a git repo isn't required), and a background import of the
+conversations you've already had (`stash import-history --status` follows it
+live). Re-run the wizard anytime with `stash setup`; use `stash connect` from
+any other project folder to set it up for Stash.
 
 <details>
 <summary>Prefer a one-liner?</summary>
@@ -202,12 +203,11 @@ Then install the CLI:
 
 ```bash
 uv tool install stashai
-cd /path/to/the/repo/you/want/to/connect
-stash signin   # choose "Self-host" and enter http://localhost:3456
+stash signin --api http://localhost:3456
 ```
 
-When connecting to a domain-backed install, enter your public URL (e.g.
-`https://app.example.com`) at the same prompt. To change the endpoint later,
+For a domain-backed install, pass your public URL instead (e.g.
+`stash signin --api https://app.example.com`). To change the endpoint later,
 run `stash settings`.
 
 Finally see it in action:
@@ -223,7 +223,7 @@ Stash is built for engineering teams working in private repos.
 
 - **LLM calls are optional and scoped.** An Anthropic key powers ask-the-stash, session titles, and OCR for scanned PDFs; the chat agent runs on Anthropic, OpenAI, or OpenRouter with your own key. Without any of them, the rest of Stash works — those features are simply unavailable.
 - **Private by default.** Your Stash is yours alone. Content becomes public only when you make it so: publishing a Skill, creating a public link to a page, file, folder, or table, or posting to the pastebin.
-- **Transcripts are opt-in.** If you don't want to upload your agent transcripts, you can give your agent *read* access to your Stash without uploading any of your own session data.
+- **Recording is yours to control.** Session recording is on by default during setup, and every control is one command away: decline it in the wizard, pause globally with `stash stop`, pick which agents record, or exclude folders in `stash settings`. Saying no still gives your agent *read* access to your Stash — nothing about using Stash requires uploading your own sessions.
   
 ## FAQ
 
@@ -231,7 +231,7 @@ Stash is built for engineering teams working in private repos.
 An Anthropic key covers ask-the-stash, session titles, and scanned-PDF OCR. The chat agent is separate and runs whichever harness you point it at — Claude Code, Codex, or opencode — against your own Anthropic, OpenAI, or OpenRouter credentials. Embeddings are a third, independent choice (OpenAI, HuggingFace, or a local model). All of it is optional; without any keys the rest of Stash works and those features are disabled.
 
 **What writes to my Stash on its own?**
-One thing by default: the Memory curator, a scheduled agent that compiles your Memory wiki from new sessions and files. It only writes inside the reserved Memory folder, and it only reads what's new since its last run. Beyond that, nothing runs unless you create it — any agent you give a cron to becomes a scheduled agent, and those have the same reach you do.
+One thing by default: the Memory curator, a scheduled agent that compiles your Memory wiki from new sessions and files. It only writes inside the reserved Memory folder, and it only reads what's new since its last run. Turn the nightly run off or on with `stash memory --curator off|on` (on-demand runs keep working). Beyond that, nothing runs unless you create it — any agent you give a cron to becomes a scheduled agent, and those have the same reach you do.
 
 **Can I use this without Claude Code?**
 Yes. You can use the CLI with anything, and Stash has native plugins for Cursor, Codex, Opencode, Gemini CLI, and more.

--- a/cli/main.py
+++ b/cli/main.py
@@ -4493,6 +4493,7 @@ Common reads:
 - `stash sessions agents` — who's been active
 
 Common writes:
+- `stash memory write "<Topic>/<Page>" --content "..."` — fold what you learned into the Memory wiki
 - `stash share --title "..."` — share this session as a public Skill
 - `stash read <url>` — read a public Skill URL
 """

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -14,7 +14,7 @@ A Tauri app that makes the local-curator setup feel stable and real:
   user's own credentials and MCP connectors, on a schedule, from the tray.
   Off by default; enabled with one switch. Each run maintains the user's
   **personal** knowledge base — the wiki in their personal scope's Memory
-  folder — directly (`stash files add-page` / `edit-page`), pinned to the
+  folder — directly (`stash memory write "<Path>"`), pinned to the
   personal scope via `STASH_SCOPE=""` regardless of workspace config. One
   curator per person; nothing is shared with the team. The curation prompt
   is served by the backend (`GET /api/v1/me/local-curator-prompt`, defined
@@ -23,8 +23,9 @@ A Tauri app that makes the local-curator setup feel stable and real:
   run history, logs) lives in `~/.stash/curator/`.
 
   Onboarding note: accounts using the local curator should have the
-  server-side Memory curator turned off — one agent maintains the wiki, not
-  two.
+  server-side Memory curator's nightly run turned off (`stash memory
+  --curator off`) — one agent maintains the wiki, not two. On-demand
+  recomputes keep working either way.
 
 Closing the window hides to the tray; the scheduler keeps running. "Launch at
 login" is a toggle in the app. The interval is measured from the last

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -48,9 +48,17 @@ stash vfs "cat '/me/README.md'"
 
 ### Plugin control
 ```bash
-stash signin                       # Interactive setup (auth + hook install)
+stash signin                       # Sign in + first-run setup (auth, recording, hooks)
+stash setup                        # Re-run the setup wizard anytime
 stash settings                     # Interactive settings page (streaming, scope, endpoint, …)
-stash disconnect                   # Pause event streaming across every plugin
+stash stop                         # Pause session recording across every plugin (stash start resumes)
+```
+
+### Memory
+```bash
+stash memory ls                                # The Memory wiki tree with ids
+stash memory write "Topic/Page" --content "…"  # Create or update a wiki page (stdin for long bodies)
+stash memory --curator off                     # Turn the nightly cloud curator off (on to resume)
 ```
 
 ### Files, history, tables

--- a/plugins/claude-plugin/README.md
+++ b/plugins/claude-plugin/README.md
@@ -65,9 +65,9 @@ Everything is a `stash` CLI subcommand — there are no slash commands.
 
 | Command | Description |
 |---------|-------------|
-| `stash signin` | Onboarding wizard — auth + hook install |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause activity streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 The plugin also gives Claude access to the rest of the `stash` CLI. Key commands:
 

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -8,7 +8,7 @@ Streams Codex CLI sessions to Stash using Codex's native `hooks` system.
 - Codex CLI with `features.hooks = true` enabled for hook-based streaming
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`). There is
+(`stash signin`) and haven't stopped recording (`stash stop`). There is
 no per-repo manifest.
 
 ## Install
@@ -42,9 +42,9 @@ Everything is a plain `stash` CLI subcommand — no slash commands or skills:
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Launching: use the `stash` profile
 

--- a/plugins/cursor-plugin/README.md
+++ b/plugins/cursor-plugin/README.md
@@ -8,7 +8,7 @@ plugin's event coverage.
 - `stash` CLI installed (on PATH) and signed in (`uv tool install stashai && stash signin`)
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`).
+(`stash signin`) and haven't stopped recording (`stash stop`).
 
 ## Install
 
@@ -19,8 +19,8 @@ machine-independent and never changes across upgrades.
 
 For agent context (so Cursor knows the `stash` CLI is available), Cursor
 only auto-loads `.mdc` rules from project-level `.cursor/rules/` — there
-is no global file location for user rules. Run `stash init` inside a repo
-and the installer will drop a `.cursor/rules/stash.mdc` into that repo.
+is no global file location for user rules. Run `stash connect` in the project folder
+and the installer will drop a `.cursor/rules/stash.mdc` there.
 Commit it so teammates' Cursor agents pick it up too.
 
 Or, for per-project use, drop `hooks.json` into `<project>/.cursor/hooks.json`
@@ -60,9 +60,9 @@ Everything is a plain `stash` CLI subcommand — no Cursor-specific slash comman
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps vs Claude plugin
 

--- a/plugins/gemini-plugin/README.md
+++ b/plugins/gemini-plugin/README.md
@@ -36,7 +36,7 @@ Everything is a plain `stash` CLI subcommand — no Gemini-specific slash comman
 |---------|-------------|
 | `stash signin` | Interactive setup (auth + hook install) |
 | `stash settings` | Interactive settings page (streaming, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps
 

--- a/plugins/hermes-plugin/README.md
+++ b/plugins/hermes-plugin/README.md
@@ -62,7 +62,7 @@ Everything is a plain `stash` CLI subcommand — no Hermes-specific commands:
 |---------|-------------|
 | `stash signin` | Interactive setup (auth + hook install) |
 | `stash settings` | Interactive settings page (streaming, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Retrieval
 

--- a/plugins/openclaw-plugin/README.md
+++ b/plugins/openclaw-plugin/README.md
@@ -68,8 +68,7 @@ plugin captures tool history at higher fidelity.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash signin` + `stash
-config …`). Overrides:
+Reads from `~/.stash/config.json` (populated by `stash signin`; change it later with `stash settings`). Overrides:
 
 - `STASH_OPENCLAW_DATA=<path>` — custom state dir (default `~/.stash/plugins/openclaw`)
 

--- a/plugins/opencode-plugin/README.md
+++ b/plugins/opencode-plugin/README.md
@@ -8,7 +8,7 @@ Streams opencode sessions to your Stash.
 - opencode installed (Bun-based runtime — opencode transpiles TS directly, no build step needed)
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`).
+(`stash signin`) and haven't stopped recording (`stash stop`).
 
 ## Install
 
@@ -51,9 +51,9 @@ Everything is a plain `stash` CLI subcommand — no opencode-specific slash comm
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps
 

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -8,7 +8,7 @@ Streams Codex CLI sessions to Stash using Codex's native `hooks` system.
 - Codex CLI with `features.hooks = true` enabled for hook-based streaming
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`). There is
+(`stash signin`) and haven't stopped recording (`stash stop`). There is
 no per-repo manifest.
 
 ## Install
@@ -42,9 +42,9 @@ Everything is a plain `stash` CLI subcommand — no slash commands or skills:
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Launching: use the `stash` profile
 

--- a/stashai/plugin/assets/cursor/README.md
+++ b/stashai/plugin/assets/cursor/README.md
@@ -8,7 +8,7 @@ plugin's event coverage.
 - `stash` CLI installed (on PATH) and signed in (`uv tool install stashai && stash signin`)
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`).
+(`stash signin`) and haven't stopped recording (`stash stop`).
 
 ## Install
 
@@ -19,8 +19,8 @@ machine-independent and never changes across upgrades.
 
 For agent context (so Cursor knows the `stash` CLI is available), Cursor
 only auto-loads `.mdc` rules from project-level `.cursor/rules/` — there
-is no global file location for user rules. Run `stash init` inside a repo
-and the installer will drop a `.cursor/rules/stash.mdc` into that repo.
+is no global file location for user rules. Run `stash connect` in the project folder
+and the installer will drop a `.cursor/rules/stash.mdc` there.
 Commit it so teammates' Cursor agents pick it up too.
 
 Or, for per-project use, drop `hooks.json` into `<project>/.cursor/hooks.json`
@@ -60,9 +60,9 @@ Everything is a plain `stash` CLI subcommand — no Cursor-specific slash comman
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps vs Claude plugin
 

--- a/stashai/plugin/assets/gemini/README.md
+++ b/stashai/plugin/assets/gemini/README.md
@@ -36,7 +36,7 @@ Everything is a plain `stash` CLI subcommand — no Gemini-specific slash comman
 |---------|-------------|
 | `stash signin` | Interactive setup (auth + hook install) |
 | `stash settings` | Interactive settings page (streaming, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps
 

--- a/stashai/plugin/assets/hermes/README.md
+++ b/stashai/plugin/assets/hermes/README.md
@@ -62,7 +62,7 @@ Everything is a plain `stash` CLI subcommand — no Hermes-specific commands:
 |---------|-------------|
 | `stash signin` | Interactive setup (auth + hook install) |
 | `stash settings` | Interactive settings page (streaming, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Retrieval
 

--- a/stashai/plugin/assets/openclaw/README.md
+++ b/stashai/plugin/assets/openclaw/README.md
@@ -68,8 +68,7 @@ plugin captures tool history at higher fidelity.
 
 ## Config
 
-Reads from `~/.stash/config.json` (populated by `stash signin` + `stash
-config …`). Overrides:
+Reads from `~/.stash/config.json` (populated by `stash signin`; change it later with `stash settings`). Overrides:
 
 - `STASH_OPENCLAW_DATA=<path>` — custom state dir (default `~/.stash/plugins/openclaw`)
 

--- a/stashai/plugin/assets/opencode/README.md
+++ b/stashai/plugin/assets/opencode/README.md
@@ -8,7 +8,7 @@ Streams opencode sessions to your Stash.
 - opencode installed (Bun-based runtime — opencode transpiles TS directly, no build step needed)
 
 Streaming is gated globally: it is on whenever you are signed in
-(`stash signin`) and haven't stopped streaming (`stash disconnect`).
+(`stash signin`) and haven't stopped recording (`stash stop`).
 
 ## Install
 
@@ -51,9 +51,9 @@ Everything is a plain `stash` CLI subcommand — no opencode-specific slash comm
 
 | Command | Description |
 |---------|-------------|
-| `stash connect` | Interactive setup (auth + store) |
+| `stash signin` | Sign in + first-run setup (re-run the wizard anytime: `stash setup`) |
 | `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
-| `stash disconnect` | Pause event streaming across every installed plugin |
+| `stash stop` | Pause session recording across every installed plugin (`stash start` resumes) |
 
 ## Known gaps
 

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -18,15 +18,33 @@ export default function CLIPage() {
 
       <H2>First-time setup</H2>
       <P>
-        Run the interactive setup wizard. It configures the API endpoint, authenticates you
-        through the browser, and sets up your Stash — all in one shot. No manual config
-        editing required.
+        Run the setup wizard. It authenticates you through the browser, turns on session
+        recording (pause anytime with <Code>stash stop</Code>), lets you pick which coding
+        agents to record, sets up the folder you&apos;re standing in, and imports your
+        conversation history in the background. No manual config editing required.
       </P>
-      <CodeBlock>{`stash connect`}</CodeBlock>
+      <CodeBlock>{`stash signin`}</CodeBlock>
       <P>
-        The wizard saves everything to <Code>~/.stash/config.json</Code>. Once complete,
-        commands like <Code>stash sessions push</Code> work without extra flags.
+        The wizard saves everything to <Code>~/.stash/config.json</Code>. Re-run it anytime
+        with <Code>stash setup</Code> — no answer is final. Self-hosting? Point the CLI at
+        your instance with <Code>stash signin --api &lt;url&gt;</Code>.
       </P>
+      <CommandRef
+        command="stash setup"
+        description="Re-run the setup wizard: session recording, agent hooks, folder context, and history import. Safe to repeat."
+      />
+      <CommandRef
+        command="stash connect"
+        description="Set up the current folder for Stash: writes .stash and adds Stash instructions to CLAUDE.md so agents working there use your Stash. Works in any folder — a git repo is not required."
+      />
+      <CommandRef
+        command="stash import-history"
+        args="[--status]"
+        description="Import your historical agent conversations (Claude Code, Codex, Cursor) into Stash with parallel uploads. Safe to re-run — the server skips sessions that already exist. The wizard launches this in the background; --status attaches a live progress bar (Ctrl-C detaches)."
+        params={[
+          { name: "--status", type: "flag", desc: "Follow the running or last-finished import with a live progress bar." },
+        ]}
+      />
 
       <H2>Virtual filesystem</H2>
       <P>
@@ -56,7 +74,7 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
       <CommandRef
         command="stash signin"
         args="[--api <base_url>] [--api-key <key>] [--non-interactive]"
-        description="Authenticate this machine. With no flags it runs the browser flow: on first run it also picks the endpoint (managed or self-host) and offers to install streaming hooks for your coding agents. On SSH/headless it prints a URL to open instead of launching a browser. Pass --api-key to store a pre-minted key directly (no browser) on an unattended, browser-less machine — typically a self-hosted CI runner; get the key from your self-hosted instance's API-key page."
+        description="Authenticate this machine. With no flags it runs the browser flow against managed Stash and, on first run, continues into the setup wizard (recording, agent hooks, folder context, history import). Self-hosters pass --api with their instance URL. On SSH/headless it prints a URL to open instead of launching a browser. Pass --api-key to store a pre-minted key directly (no browser) on an unattended, browser-less machine — typically a self-hosted CI runner; get the key from your self-hosted instance's API-key page."
         params={[
           { name: "--api", type: "string", desc: "Base URL of the Stash server. Override for self-hosted deployments.", required: false },
           { name: "--api-key", type: "string", desc: "A pre-minted key to store directly, skipping the browser. For unattended, browser-less machines.", required: false },
@@ -80,7 +98,7 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
 
       <CommandRef
         command="stash disconnect"
-        description="Sign out and clear all stored credentials so the next stash connect re-onboards."
+        description="Sign out and clear all stored credentials so the next stash signin starts fresh."
       />
 
       <CommandRef
@@ -93,7 +111,7 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
       />
 
       <Callout>
-        After <Code>stash connect</Code>, your defaults are stored. Change the endpoint
+        After <Code>stash signin</Code>, your defaults are stored. Change the endpoint
         any time from <Code>stash settings</Code>, or set <Code>STASH_API_KEY</Code> /{" "}
         <Code>STASH_URL</Code> as environment variables for CI and scripts.
       </Callout>
@@ -218,6 +236,42 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
         params={[
           { name: "<session_id>", type: "string", desc: "ID of the session.", required: true },
           { name: "--save", type: "path", desc: "Save the transcript to a file instead of printing." },
+        ]}
+      />
+
+      <H2>Memory</H2>
+      <P>
+        Your Memory wiki lives in a reserved folder that the Memory curator — and, since{" "}
+        <Code>stash memory write</Code>, any agent — maintains. Pages are addressed by path.
+      </P>
+
+      <CommandRef
+        command="stash memory"
+        args="[--recompute] [--curator on|off] [--json]"
+        description="Show your reserved Memory folder and the nightly curator's schedule state. --recompute runs the curator now; --curator off|on toggles the nightly cloud run (on-demand runs keep working)."
+        params={[
+          { name: "--recompute", type: "flag", desc: "Run the Memory curator now." },
+          { name: "--curator", type: "string", desc: "Turn the nightly cloud curator run off or on." },
+          { name: "--json", type: "flag", desc: "Machine-readable output." },
+        ]}
+      />
+
+      <CommandRef
+        command="stash memory write"
+        args='"<Path>" [--content TEXT] [--json]'
+        description="Create or update a Memory wiki page at a path (e.g. 'Customers/Chainbase'). Missing subfolders are created; a trailing .md is stripped. Long bodies pipe on stdin."
+        params={[
+          { name: "--content", type: "string", desc: "Page body. Reads stdin if omitted." },
+          { name: "--json", type: "flag", desc: "Machine-readable output." },
+        ]}
+      />
+
+      <CommandRef
+        command="stash memory ls"
+        args="[--json]"
+        description="Print the Memory wiki tree with folder and page ids."
+        params={[
+          { name: "--json", type: "flag", desc: "Machine-readable output." },
         ]}
       />
 

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Callout, H3, P, Title, Subtitle } from "./components";
+import { Callout, Code, H3, P, Title, Subtitle } from "./components";
 
 export default function DocsOverview() {
   return (
@@ -230,8 +230,10 @@ export default function DocsOverview() {
       <H3>FAQ</H3>
       <p className="text-[15px] font-semibold text-foreground leading-7 mb-2">Do I have to upload my transcripts?</p>
       <P>
-        Transcript upload is opt-in. If you want, you can choose to give your coding agent shared
-        access to the repository memory without uploading anything.
+        No. Session recording is on by default during setup, but it&apos;s entirely yours to
+        control: decline it in the wizard, pause globally with <Code>stash stop</Code>, pick
+        which agents record, or exclude folders in <Code>stash settings</Code>. Your coding
+        agent keeps read access to your Stash either way.
       </P>
 
       <H3>Quick links</H3>

--- a/www/app/docs/quickstart/page.tsx
+++ b/www/app/docs/quickstart/page.tsx
@@ -17,10 +17,11 @@ export default function QuickstartPage() {
 stash signin`}</CodeBlock>
       <P>
         <Code>stash signin</Code> opens your browser to create an account (or sign in) and
-        hands the CLI a key automatically — nothing to copy. It then detects the coding
-        agents installed on your machine — Claude Code, Cursor, Codex, OpenCode, Gemini
-        CLI, Openclaw — and installs their hooks, so sessions start streaming to your
-        Stash right away.
+        hands the CLI a key automatically — nothing to copy. It then walks setup: session
+        recording (on by default; pause anytime with <Code>stash stop</Code>), which of
+        your installed coding agents to record — Claude Code, Cursor, Codex, OpenCode,
+        Gemini CLI, Openclaw — and a background import of your existing conversation
+        history. Re-run the wizard anytime with <Code>stash setup</Code>.
       </P>
       <Callout>
         On an unattended, browser-less machine (a CI runner, a headless box), use{" "}

--- a/www/app/docs/self-hosting/page.tsx
+++ b/www/app/docs/self-hosting/page.tsx
@@ -32,13 +32,12 @@ docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 curl https://app.example.com/health   # wait for {"status":"ok"}`}</CodeBlock>
       <P>
-        Then install the CLI and connect a repo:
+        Then install the CLI and point it at your instance:
       </P>
       <CodeBlock>{`uv tool install stashai
-cd /path/to/your/repo
-stash signin   # choose "Self-host" and enter http://localhost:3456`}</CodeBlock>
+stash signin --api http://localhost:3456`}</CodeBlock>
       <P>
-        Enter your public URL instead of <Code>http://localhost:3456</Code> for a
+        Pass your public URL instead of <Code>http://localhost:3456</Code> for a
         Caddy-backed install. <Code>stash signin</Code> opens it to register and
         authorize the CLI; change the endpoint later from <Code>stash settings</Code>.
       </P>


### PR DESCRIPTION
Post-merge docs sweep for #940 (onboarding redesign), #941 (`stash memory write`/`ls`), and #942 (`stash memory --curator on|off`). Every doc that describes the CLI surface is brought back to true; no behavior changes except the CLAUDE.md template block `stash connect` writes (gains a `stash memory write` line).

Highlights:
- **Inverted privacy claim fixed in two public places**: README and the www docs FAQ said "transcripts are opt-in" — recording is now on by default with explicit controls (`stash stop`, per-agent picker, excluded folders). Reworded honestly rather than deleted.
- **Self-host instructions** taught a wizard prompt that no longer exists → `stash signin --api <url>` everywhere.
- **www CLI reference** gains `stash setup`, `stash connect` (as it actually behaves), `stash import-history [--status]`, and a Memory section documenting the #941/#942 surface (verified against merged `cli/main.py`).
- **Plugin READMEs** (both `plugins/` and packaged `stashai/plugin/assets/` copies, all seven agents): `stash connect | Interactive setup (auth + store)` rows replaced; `stash disconnect` was documented as the pause-streaming command (it signs you out) → `stash stop`; cursor's README told users to run `stash init`, which has never existed → `stash connect`.
- **Agent instruction surfaces** now teach the memory write path: claude-plugin CLAUDE.md gets a Memory section; the repo CLAUDE.md block written by `stash connect` adds `stash memory write` under Common writes. (The served curator prompt in `backend/services/prompts.py` was already updated by #941 — verified, untouched.)
- **desktop/README** names `stash memory --curator off` as the mechanism its onboarding note previously left mechanism-less.
- **CHANGELOG**: Unreleased entries for all three PRs; removed a now-superseded entry describing the pre-#940 connect copy.

Testing: 202 CLI tests pass (the template block lives in `cli/main.py`), ruff clean, `www` lint and `tsc --noEmit` clean on the edited pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)