### PR TITLE
Email verification for password signups; loud pending-workspace state

### DIFF
--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from backend.database import get_pool
-from backend.services import share_service, user_scope_service
+from backend.services import email_verification_service, share_service, user_scope_service
 from backend.services.email_service import send_welcome_email
 
 logger = logging.getLogger(__name__)
@@ -58,9 +58,15 @@ async def get_or_create_user_row_from_auth0(
     if row:
         if email:
             # email_verified is the trust anchor for derived workspace
-            # membership — persisting it here IS the enrollment.
+            # membership — persisting it here IS the enrollment. OR-ing with
+            # the stored value means a sparse /userinfo payload (or our own
+            # emailed-link verification) is never downgraded by a later
+            # login; email changes still reset it via the email inequality.
             await pool.execute(
-                "UPDATE users SET last_seen = now(), email = $2, email_verified = $3 WHERE id = $1",
+                "UPDATE users SET last_seen = now(), "
+                "email_verified = (users.email = $2 AND users.email_verified) OR $3, "
+                "email = $2 "
+                "WHERE id = $1",
                 row["id"],
                 email,
                 email_verified,
@@ -101,6 +107,12 @@ async def get_or_create_user_row_from_auth0(
     await user_scope_service.seed_user_scope(user["id"])
 
     await share_service.convert_pending_invites(user["id"], email)
+
+    # Password signups arrive unverified and Auth0 is not guaranteed to get
+    # them verified — send our own link so the account can still join its
+    # domain workspace. OAuth signups are already verified and skip this.
+    if email and not email_verified:
+        await email_verification_service.start(user["id"], email)
 
     if email:
         try:

--- a/backend/managed/auth0/users.py
+++ b/backend/managed/auth0/users.py
@@ -111,8 +111,13 @@ async def get_or_create_user_row_from_auth0(
     # Password signups arrive unverified and Auth0 is not guaranteed to get
     # them verified — send our own link so the account can still join its
     # domain workspace. OAuth signups are already verified and skip this.
+    # Guarded like the welcome email: a mail-provider outage must not fail
+    # the signup exchange, and the resend endpoint recovers later.
     if email and not email_verified:
-        await email_verification_service.start(user["id"], email)
+        try:
+            await email_verification_service.start(user["id"], email)
+        except Exception as exc:
+            logger.warning("verification email failed exception_type=%s", type(exc).__name__)
 
     if email:
         try:

--- a/backend/migrations/versions/0174_email_verifications.py
+++ b/backend/migrations/versions/0174_email_verifications.py
@@ -1,0 +1,33 @@
+"""Single-use email verification tokens.
+
+`users.email_verified` is the trust anchor for derived workspace membership,
+but until now only an OAuth provider could set it — a password signup
+(Auth0 database connection on hosted, /users/register on self-host) had no
+way to verify and was silently locked out of its domain workspace forever.
+This table backs a plain email-a-link flow: one live token per user,
+consumed on click.
+"""
+
+from alembic import op
+
+revision = "0174"
+down_revision = "0173"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE email_verifications (
+            user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+            token text NOT NULL UNIQUE,
+            email text NOT NULL,
+            expires_at timestamptz NOT NULL
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE email_verifications")

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -381,8 +381,15 @@ async def _check_overview_access(owner_user_id: UUID, user_id: UUID) -> None:
 @router.get("/workspaces")
 async def list_my_workspaces(current_user: dict = Depends(get_current_user)):
     """Workspaces the caller belongs to. Powers the frontend scope switcher;
-    an empty list hides it."""
-    return {"workspaces": await workspace_service.list_for_user(current_user["id"])}
+    an empty list hides it. `pending_domain_workspaces` names workspaces on
+    the caller's email domain that stay locked until the email is verified
+    (i.e. sign in with OAuth) — loud, instead of silently absent."""
+    return {
+        "workspaces": await workspace_service.list_for_user(current_user["id"]),
+        "pending_domain_workspaces": await workspace_service.list_pending_for_user(
+            current_user["id"]
+        ),
+    }
 
 
 async def _sidebar_etag(owner_user_id: UUID, user_id: UUID) -> str:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -17,7 +17,7 @@ from ..models import (
     UserRegisterResponse,
     UserUpdateRequest,
 )
-from ..services import user_service
+from ..services import email_verification_service, user_service
 from ..services.email_service import send_enterprise_lead_email
 
 logger = logging.getLogger(__name__)
@@ -49,12 +49,50 @@ async def register(request: Request, req: UserRegisterRequest):
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    if req.email:
+        await email_verification_service.start(user["id"], req.email)
     return UserRegisterResponse(
         id=user["id"],
         name=user["name"],
         display_name=user["display_name"],
         api_key=api_key,
     )
+
+
+@router.post("/verify-email")
+@limiter.limit("10/minute")
+async def verify_email(request: Request, body: dict):
+    """Consume an emailed verification token. Unauthenticated — the link is
+    clicked from any browser. Sets `users.email_verified`, the trust anchor
+    for derived workspace membership."""
+    token = str(body.get("token") or "")
+    if not token:
+        raise HTTPException(status_code=400, detail="token is required")
+    if not await email_verification_service.confirm(token):
+        raise HTTPException(
+            status_code=400,
+            detail="This verification link is invalid, expired, or superseded — "
+            "request a new one and use the latest email.",
+        )
+    return {"verified": True}
+
+
+@router.post("/me/verify-email", status_code=202)
+@limiter.limit("5/minute")
+async def resend_verification_email(
+    request: Request, current_user: dict = Depends(get_current_user)
+):
+    """Send (or re-send) the caller's verification email."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT email, email_verified FROM users WHERE id = $1", current_user["id"]
+    )
+    if not row["email"]:
+        raise HTTPException(status_code=400, detail="No email on this account to verify.")
+    if row["email_verified"]:
+        raise HTTPException(status_code=400, detail="Email is already verified.")
+    await email_verification_service.start(current_user["id"], row["email"])
+    return {"sent_to": row["email"]}
 
 
 @router.post("/login", response_model=UserRegisterResponse)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -50,7 +50,12 @@ async def register(request: Request, req: UserRegisterRequest):
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     if req.email:
-        await email_verification_service.start(user["id"], req.email)
+        # Guarded like the welcome email: a mail-provider outage must not
+        # fail signup — the token row still lands, and resend recovers.
+        try:
+            await email_verification_service.start(user["id"], req.email)
+        except Exception as exc:
+            logger.warning("verification email failed exception_type=%s", type(exc).__name__)
     return UserRegisterResponse(
         id=user["id"],
         name=user["name"],

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -76,6 +76,26 @@ def send_share_invite_email(to_email: str, owner_name: str, object_type: str) ->
     )
 
 
+def send_verification_email(to_email: str, token: str) -> None:
+    """One click sets `users.email_verified` — the trust anchor for joining
+    the workspace on the email's domain."""
+    app_url = settings.PUBLIC_URL.rstrip("/")
+    _send(
+        {
+            "From": DEFAULT_FROM,
+            "To": to_email,
+            "Subject": "Verify your email for Stash",
+            "HtmlBody": (
+                "<p>Click to verify this email address for your Stash account:</p>"
+                f'<p><a href="{app_url}/verify-email?token={token}">Verify my email</a></p>'
+                "<p>Verifying connects you to your company's workspace if one exists "
+                "for your email domain. The link works for 7 days; requesting a new "
+                "one replaces it.</p>"
+            ),
+        }
+    )
+
+
 def send_welcome_email(user_email: str, first_name: str | None = None) -> None:
     if not user_email:
         return

--- a/backend/services/email_verification_service.py
+++ b/backend/services/email_verification_service.py
@@ -1,0 +1,51 @@
+"""Verify a user's email address with a single-use emailed link.
+
+`users.email_verified` gates derived workspace membership. OAuth sign-ins
+verify implicitly (the provider vouches for the address); this service is
+the path for everyone else — password signups on either auth stack. One
+live token per user; requesting a new one replaces the old.
+"""
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from ..database import get_pool
+from . import email_service
+
+TOKEN_TTL = timedelta(days=7)
+
+
+async def start(user_id: UUID, email: str) -> None:
+    """Issue the user's verification token and email them the link."""
+    token = secrets.token_urlsafe(32)
+    pool = get_pool()
+    await pool.execute(
+        "INSERT INTO email_verifications (user_id, token, email, expires_at) "
+        "VALUES ($1, $2, $3, $4) "
+        "ON CONFLICT (user_id) DO UPDATE SET token = $2, email = $3, expires_at = $4",
+        user_id,
+        token,
+        email,
+        datetime.now(UTC) + TOKEN_TTL,
+    )
+    email_service.send_verification_email(email, token)
+
+
+async def confirm(token: str) -> bool:
+    """Consume a token. True when it verified the user's current email;
+    False for unknown, expired, or stale (email since changed) tokens."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "DELETE FROM email_verifications WHERE token = $1 AND expires_at > now() "
+        "RETURNING user_id, email",
+        token,
+    )
+    if not row:
+        return False
+    result = await pool.execute(
+        "UPDATE users SET email_verified = true WHERE id = $1 AND email = $2",
+        row["user_id"],
+        row["email"],
+    )
+    return result.endswith("1")

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -109,6 +109,21 @@ async def remove_member(workspace_id: UUID, user_id: UUID) -> bool:
     return result.endswith(" 1")
 
 
+async def list_pending_for_user(user_id: UUID) -> list[dict]:
+    """Workspaces on the caller's email domain that they are NOT a member of
+    because their email is unverified. Exists so the product can say WHY a
+    teammate is locked out of their company workspace instead of silently
+    hiding it — the remedy is an OAuth sign-in, which verifies the address."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT w.id, w.name, w.domain FROM workspaces w "
+        "JOIN users u ON lower(split_part(u.email, '@', 2)) = w.domain "
+        "WHERE u.id = $1 AND NOT u.email_verified",
+        user_id,
+    )
+    return [dict(row) for row in rows]
+
+
 async def list_for_user(user_id: UUID) -> list[dict]:
     from . import permission_service
 

--- a/backend/tests/test_auth0_provision.py
+++ b/backend/tests/test_auth0_provision.py
@@ -424,3 +424,37 @@ async def test_returning_login_grants_membership_once_verified(pool):
         auth0_sub=sub, email=email, name="Late", email_verified=True
     )
     assert await permission_service.is_workspace_member(ws["scope_user_id"], user["id"])
+
+
+@pytest.mark.asyncio
+async def test_returning_db_login_never_downgrades_verified_email(pool):
+    """A database-connection user who verified (via our emailed link or
+    Auth0's) must STAY verified when a later login's /userinfo omits the
+    claim — the claim-absent update used to write email_verified=false."""
+    sub = f"auth0|{unique_name()}"
+    email = f"{unique_name('pw')}@example.com"
+    user, _created = await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=email, name="Password Person", email_verified=False
+    )
+    await pool.execute("UPDATE users SET email_verified = true WHERE id = $1", user["id"])
+
+    await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=email, name="Password Person", email_verified=False
+    )
+    assert await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"])
+
+
+@pytest.mark.asyncio
+async def test_changed_email_resets_verification(pool):
+    """Verification vouches for one address. When a login arrives with a
+    different email, the flag must reset until the new address is verified."""
+    sub = f"auth0|{unique_name()}"
+    user, _created = await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=f"{unique_name('a')}@example.com", name="P", email_verified=False
+    )
+    await pool.execute("UPDATE users SET email_verified = true WHERE id = $1", user["id"])
+
+    await get_or_create_user_row_from_auth0(
+        auth0_sub=sub, email=f"{unique_name('b')}@example.com", name="P", email_verified=False
+    )
+    assert not await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user["id"])

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -1,0 +1,89 @@
+"""Email-a-link verification — the path for password signups to reach
+`email_verified = true`, the trust anchor for derived workspace membership.
+Without it a password account can never join its domain workspace."""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient, email: str) -> tuple[str, str]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1", "email": email},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], body["id"]
+
+
+def _auth(key: str) -> dict:
+    return {"Authorization": f"Bearer {key}"}
+
+
+async def _stored_token(pool, user_id: str) -> str | None:
+    return await pool.fetchval("SELECT token FROM email_verifications WHERE user_id = $1", user_id)
+
+
+@pytest.mark.asyncio
+async def test_register_issues_token_and_confirm_verifies(client: AsyncClient, pool):
+    _key, user_id = await _register(client, f"{unique_name()}@example.com")
+
+    token = await _stored_token(pool, user_id)
+    assert token
+
+    resp = await client.post("/api/v1/users/verify-email", json={"token": token})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"verified": True}
+    assert await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user_id)
+
+    # Single-use: the same token is gone after consumption.
+    resp = await client.post("/api/v1/users/verify-email", json={"token": token})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_resend_replaces_token(client: AsyncClient, pool):
+    key, user_id = await _register(client, f"{unique_name()}@example.com")
+    first = await _stored_token(pool, user_id)
+
+    resp = await client.post("/api/v1/users/me/verify-email", headers=_auth(key))
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["sent_to"].endswith("@example.com")
+
+    second = await _stored_token(pool, user_id)
+    assert second and second != first
+
+    # The replaced token is dead; the fresh one works.
+    assert (
+        await client.post("/api/v1/users/verify-email", json={"token": first})
+    ).status_code == 400
+    assert (
+        await client.post("/api/v1/users/verify-email", json={"token": second})
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_resend_rejects_already_verified(client: AsyncClient, pool):
+    key, user_id = await _register(client, f"{unique_name()}@example.com")
+    await pool.execute("UPDATE users SET email_verified = true WHERE id = $1", user_id)
+
+    resp = await client.post("/api/v1/users/me/verify-email", headers=_auth(key))
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_token_for_changed_email_does_not_verify(client: AsyncClient, pool):
+    """A token proves control of the address it was mailed to. If the account's
+    email changed since, consuming the token must not verify the new address."""
+    _key, user_id = await _register(client, f"{unique_name()}@example.com")
+    token = await _stored_token(pool, user_id)
+
+    await pool.execute(
+        "UPDATE users SET email = $2 WHERE id = $1", user_id, f"{unique_name()}@other.com"
+    )
+
+    resp = await client.post("/api/v1/users/verify-email", json={"token": token})
+    assert resp.status_code == 400
+    assert not await pool.fetchval("SELECT email_verified FROM users WHERE id = $1", user_id)

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -635,3 +635,29 @@ async def test_member_forks_public_skill_into_workspace(client: AsyncClient, poo
         headers=_auth(outsider_key),
     )
     assert denied.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unverified_on_domain_user_sees_pending_workspace(client: AsyncClient, pool):
+    """A password signup on a workspace domain is locked out of membership
+    until the email is verified — and the lockout must be LOUD: the
+    workspace appears under pending_domain_workspaces with the reason
+    surface, not silently absent."""
+    domain = _domain()
+    ws = await _create_workspace(client, domain, name="Chainbase")
+    key, body = await _register_with_email(client, f"lewis@{domain}")
+
+    resp = await client.get("/api/v1/me/workspaces", headers=_auth(key))
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["workspaces"] == []
+    assert [w["name"] for w in payload["pending_domain_workspaces"]] == ["Chainbase"]
+    assert payload["pending_domain_workspaces"][0]["domain"] == domain
+
+    await _verify_email(pool, body["id"])
+
+    resp = await client.get("/api/v1/me/workspaces", headers=_auth(key))
+    payload = resp.json()
+    assert [w["name"] for w in payload["workspaces"]] == ["Chainbase"]
+    assert payload["pending_domain_workspaces"] == []
+    assert ws["workspace_id"] in [str(w["id"]) for w in payload["workspaces"]]

--- a/cli/client.py
+++ b/cli/client.py
@@ -160,6 +160,9 @@ class StashClient:
     def whoami(self) -> dict:
         return self._get("/api/v1/users/me")
 
+    def resend_verification_email(self) -> dict:
+        return self._post("/api/v1/users/me/verify-email")
+
     def list_workspaces(self) -> dict:
         """Full /me/workspaces payload: `workspaces` plus
         `pending_domain_workspaces` (on-domain but email unverified)."""

--- a/cli/client.py
+++ b/cli/client.py
@@ -160,8 +160,10 @@ class StashClient:
     def whoami(self) -> dict:
         return self._get("/api/v1/users/me")
 
-    def list_workspaces(self) -> list:
-        return self._list("/api/v1/me/workspaces", "workspaces")
+    def list_workspaces(self) -> dict:
+        """Full /me/workspaces payload: `workspaces` plus
+        `pending_domain_workspaces` (on-domain but email unverified)."""
+        return self._get("/api/v1/me/workspaces")
 
     def list_api_keys(self) -> list:
         return self._get("/api/v1/users/me/keys")

--- a/cli/main.py
+++ b/cli/main.py
@@ -4818,6 +4818,22 @@ def setup_cmd():
     _run_setup_wizard()
 
 
+@app.command("verify-email")
+def verify_email_cmd():
+    """Email yourself a verification link. Verifying your email is what joins
+    you to your company's workspace, if one exists for your email domain."""
+    _require_auth()
+    with _client() as c:
+        try:
+            result = c.resend_verification_email()
+        except StashError as e:
+            _err(e)
+    console.print(
+        f"  [green]✓[/green] Verification link sent to [bold]{result['sent_to']}[/bold] — "
+        "click it and you're done."
+    )
+
+
 @app.command("connect")
 def connect_cmd():
     """Add Stash instructions to this folder's CLAUDE.md and enable session uploads."""
@@ -5490,8 +5506,8 @@ def workspace_list(as_json: bool = typer.Option(False, "--json")):
     for ws in pending:
         console.print(
             f"  [yellow]{ws['name']}[/yellow]  [dim]{ws['domain']}[/dim]  "
-            "[yellow]— locked until your email is verified: sign in with Google/OAuth "
-            "([cyan]stash signin[/cyan] after signing out on the website)[/yellow]"
+            "[yellow]— joins once your email is verified: run "
+            "[cyan]stash verify-email[/cyan] and click the link we send[/yellow]"
         )
     if not workspaces and not pending:
         console.print(
@@ -5535,9 +5551,9 @@ def workspace_switch(
         )
         if pending:
             console.print(
-                f"[red]Error:[/red] '{pending['name']}' matches your email domain, but your "
-                "email isn't verified, so membership is locked. Sign in with Google/OAuth "
-                "to verify it, then try again."
+                f"[red]Error:[/red] '{pending['name']}' matches your email domain — you'll "
+                "join it as soon as your email is verified. Run [cyan]stash verify-email[/cyan], "
+                "click the link we send, then try again."
             )
             raise typer.Exit(1)
         known = ", ".join(ws["name"] for ws in workspaces) or "(none)"

--- a/cli/main.py
+++ b/cli/main.py
@@ -5468,18 +5468,32 @@ def workspace_list(as_json: bool = typer.Option(False, "--json")):
     active = load_config().get("scope", "")
     with _client() as c:
         try:
-            workspaces = c.list_workspaces()
+            data = c.list_workspaces()
         except StashError as e:
             _err(e)
+    workspaces = data["workspaces"]
+    pending = data.get("pending_domain_workspaces", [])
     if _use_json(as_json):
-        output_json({"workspaces": workspaces, "active_scope": active or None})
+        output_json(
+            {
+                "workspaces": workspaces,
+                "pending_domain_workspaces": pending,
+                "active_scope": active or None,
+            }
+        )
         return
     marker = " [green]*[/green]" if not active else ""
     console.print(f"  [bold]personal[/bold]{marker}")
     for ws in workspaces:
         marker = " [green]*[/green]" if ws["scope_user_id"] == active else ""
         console.print(f"  [bold]{ws['name']}[/bold]  [dim]{ws['domain']}[/dim]{marker}")
-    if not workspaces:
+    for ws in pending:
+        console.print(
+            f"  [yellow]{ws['name']}[/yellow]  [dim]{ws['domain']}[/dim]  "
+            "[yellow]— locked until your email is verified: sign in with Google/OAuth "
+            "([cyan]stash signin[/cyan] after signing out on the website)[/yellow]"
+        )
+    if not workspaces and not pending:
         console.print(
             "[dim]Team workspaces are set up for you — email sam@joinstash.ai "
             "and we'll get your team going.[/dim]"
@@ -5502,14 +5516,30 @@ def workspace_switch(
 
     with _client() as c:
         try:
-            workspaces = c.list_workspaces()
+            data = c.list_workspaces()
         except StashError as e:
             _err(e)
+    workspaces = data["workspaces"]
     match = next(
         (ws for ws in workspaces if name in (ws["name"], ws["domain"])),
         None,
     )
     if match is None:
+        pending = next(
+            (
+                ws
+                for ws in data.get("pending_domain_workspaces", [])
+                if name in (ws["name"], ws["domain"])
+            ),
+            None,
+        )
+        if pending:
+            console.print(
+                f"[red]Error:[/red] '{pending['name']}' matches your email domain, but your "
+                "email isn't verified, so membership is locked. Sign in with Google/OAuth "
+                "to verify it, then try again."
+            )
+            raise typer.Exit(1)
         known = ", ".join(ws["name"] for ws in workspaces) or "(none)"
         console.print(f"[red]Error:[/red] no workspace named '{name}'. You belong to: {known}")
         raise typer.Exit(1)

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -74,9 +74,11 @@ def stash_list_workspaces() -> str:
     """Workspaces you belong to, plus which scope is active. The active scope
     is where sessions/events/searches read and write ('' = personal)."""
     cfg = load_config()
+    data = _client().list_workspaces()
     return _json(
         {
-            "workspaces": _client().list_workspaces(),
+            "workspaces": data["workspaces"],
+            "pending_domain_workspaces": data.get("pending_domain_workspaces", []),
             "active_scope": cfg.get("scope", "") or None,
         }
     )
@@ -91,7 +93,7 @@ def stash_switch_workspace(name: str) -> str:
     if name == "personal":
         save_scope(None)
         return _json({"active_scope": None})
-    workspaces = _client().list_workspaces()
+    workspaces = _client().list_workspaces()["workspaces"]
     match = next((ws for ws in workspaces if name in (ws["name"], ws["domain"])), None)
     if match is None:
         known = [ws["name"] for ws in workspaces]

--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+// Landing page for the emailed verification link. Unauthenticated on purpose:
+// the click can come from any browser, and the token alone is the proof.
+function VerifyEmailInner() {
+  const token = useSearchParams().get("token") ?? "";
+  const [state, setState] = useState<"working" | "verified" | "failed">("working");
+
+  useEffect(() => {
+    if (!token) {
+      setState("failed");
+      return;
+    }
+    fetch("/api/v1/users/verify-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    }).then(
+      (res) => setState(res.ok ? "verified" : "failed"),
+      () => setState("failed"),
+    );
+  }, [token]);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-[680px] px-6 pb-24 pt-20">
+        {state === "working" && <h1 className="text-2xl font-bold">Verifying your email…</h1>}
+        {state === "verified" && (
+          <>
+            <h1 className="text-2xl font-bold">Email verified</h1>
+            <p className="mt-4 text-[16px] leading-[1.6]">
+              You&apos;re all set. If your company has a Stash workspace on this email&apos;s
+              domain, you&apos;re now a member of it.
+            </p>
+            <Link href="/" className="mt-6 inline-block underline">
+              Go to your Stash
+            </Link>
+          </>
+        )}
+        {state === "failed" && (
+          <>
+            <h1 className="text-2xl font-bold">This link didn&apos;t work</h1>
+            <p className="mt-4 text-[16px] leading-[1.6]">
+              It may have expired or been replaced by a newer email. Request a fresh link
+              from your account and use the most recent one.
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense>
+      <VerifyEmailInner />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
The real fix for the Chainbase-prep "OAuth required" item — reframed per Henry: **don't force OAuth; let password signups verify their email and get everything.** Two layers, one branch:

## 1. Email verification (the fix)

`users.email_verified` gates derived workspace membership (that part was always sound), but only OAuth sign-ins could ever set it — a password signup was silently locked out of its domain workspace *forever*, on both auth stacks. Now:

- Signup with an email → we send a verification link automatically (Postmark), from both `/users/register` (self-host) and Auth0 database-connection provisioning (hosted).
- Click → frontend `/verify-email` page → `POST /users/verify-email` consumes the single-use token (7-day TTL; reissue replaces; a token whose email has since changed verifies nothing).
- `stash verify-email` / `POST /users/me/verify-email` resends anytime — self-serve path for the 22 existing unverified password accounts.
- **Dormant-bug fix that makes it stick:** Auth0 provisioning wrote `email_verified = <claim>` on every returning login, and returning `/userinfo` payloads can omit the claim — so any verification (Auth0's own included) was silently undone at next sign-in; the Google special-case existed precisely to dodge this. Now it never downgrades on the same email; changing email still resets verification.

## 2. The pending state is visible (kept from the first commit, copy softened)

`/me/workspaces` returns `pending_domain_workspaces`; `stash workspace list` shows the workspace with "joins once your email is verified: run `stash verify-email`", and `workspace switch` explains instead of "no workspace named X". No OAuth admonitions anywhere.

Migration: `0174_email_verifications` (new table only; applies at deploy boot).

## Testing

- New `test_email_verification.py`: token issue on register, confirm flips the flag, single-use, resend replaces, already-verified 400s, changed-email token rejected.
- `test_unverified_on_domain_user_sees_pending_workspace`: pending → member flip on verification.
- Full suites: backend 1203 passed (+ the 4 new + 22 workspace; one pre-existing env-specific failure in `test_admin_creates_workspace_with_working_bootstrap_key`, fails on clean main here), CLI 202, frontend 250, ruff + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)