### PR TITLE
Refocus the terminal after CLI browser auth completes

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -139,6 +139,27 @@ def _default_signin_page(api: str) -> str:
     return api + "/connect-token"
 
 
+def _refocus_terminal() -> None:
+    """Bring the user's terminal app back to the foreground after browser auth.
+
+    The browser steals focus during sign-in, so after clicking Authorize the
+    user is left staring at the done page while onboarding continues in a
+    hidden terminal. On macOS every GUI terminal stamps __CFBundleIdentifier
+    into its children's env, so `open -b` re-activates whichever app this CLI
+    is actually running in. Elsewhere (Linux, SSH) there's no reliable way to
+    grab focus, so we leave the user where they are.
+    """
+    import os
+    import subprocess
+
+    if sys.platform != "darwin":
+        return
+    bundle_id = os.environ.get("__CFBundleIdentifier")
+    if not bundle_id:
+        return
+    subprocess.run(["open", "-b", bundle_id], check=False, capture_output=True)
+
+
 def _browser_auth_flow(
     api: str,
     page: str | None = None,
@@ -194,6 +215,7 @@ def _browser_auth_flow(
                 console.print(f"[red]Polling failed: {e}[/red]")
                 raise typer.Exit(1)
             if data.get("status") == "complete":
+                _refocus_terminal()
                 return data["api_key"], data["username"]
             time.sleep(1)
 

--- a/www/app/connect-token/ConnectTokenClient.tsx
+++ b/www/app/connect-token/ConnectTokenClient.tsx
@@ -71,8 +71,8 @@ export default function ConnectTokenClient({ apiUrl, sessionId, device, userName
             <>{device} now has its token. You can close this tab.</>
           ) : (
             <>
-              Head back to your terminal — the <code>stash</code> CLI has the token and will
-              finish wiring up your Stash. You can close this tab.
+              Sending you back to your terminal — the <code>stash</code> CLI has the token
+              and is finishing wiring up your Stash. You can close this tab.
             </>
           )}
         </p>


### PR DESCRIPTION
## Problem

After clicking **Authorize** on `/connect-token`, seemingly nothing happens: the browser keeps focus, the done page just sits there, and onboarding continues in a terminal hidden behind the browser window.

## Fix

The browser can't focus another app, but the CLI knows the exact moment authorization lands — it polls the auth session every second. When `_browser_auth_flow` sees `status == "complete"`, a new `_refocus_terminal()` runs `open -b $__CFBundleIdentifier`. On macOS every GUI terminal (iTerm2, Terminal.app, Ghostty, VS Code/Cursor, WezTerm, kitty) stamps its bundle id into its children's env, so this re-activates exactly the app the CLI is running in — no per-terminal mapping. Within ~1s of clicking Authorize, the terminal jumps back to the front with the onboarding flow in view.

- Covers both `stash signin` and the onboarding wizard (both go through `_browser_auth_flow`).
- Linux/SSH unchanged: no reliable way to grab focus there (and over SSH we don't auto-open the browser anyway).

## UI copy

The post-authorize page copy now matches what actually happens (one-line change in `ConnectTokenClient.tsx`, CLI case only — the Chrome-extension variant keeps "close this tab"):

> ~~Head back to your terminal~~ → **Sending you back to your terminal** — the `stash` CLI has the token and is finishing wiring up your Stash. You can close this tab.

## Verification

- `ruff check` / `ruff format --check` pass on `cli/`; `www` lint: 0 errors.
- Mechanism verified live on this machine: the shell env carries `__CFBundleIdentifier=com.googlecode.iterm2`, and `open -b` on it pulls iTerm to the front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)