### PR TITLE
stash setup: headless mode driven by flags, for coding agents

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4833,11 +4833,109 @@ def _run_setup_wizard() -> None:
 
 
 @app.command("setup")
-def setup_cmd():
-    """Re-run the setup wizard: session recording, agent hooks, folder context."""
+def setup_cmd(
+    record: bool | None = typer.Option(
+        None,
+        "--record/--no-record",
+        help="Record agent sessions on this machine (headless mode).",
+    ),
+    agents: str | None = typer.Option(
+        None,
+        "--agents",
+        help="Comma-separated agents to record, e.g. claude,codex. Requires --record.",
+    ),
+    connect: bool | None = typer.Option(
+        None,
+        "--connect/--no-connect",
+        help="Add Stash instructions to CLAUDE.md in the current folder (headless mode).",
+    ),
+    import_history: bool | None = typer.Option(
+        None,
+        "--import-history/--no-import-history",
+        help="Import historical conversations in the background. Requires --record.",
+    ),
+):
+    """Run the setup wizard: session recording, agent hooks, folder context.
+
+    Interactive in a terminal. With any flag — or whenever stdin isn't a
+    TTY — it runs headless instead, and every decision must arrive as a
+    flag. That is the path coding agents drive: ask the setup questions in
+    conversation, then run one deterministic command.
+    """
     _require_auth()
     telemetry.record("setup")
-    _run_setup_wizard()
+
+    headless = (
+        any(v is not None for v in (record, agents, connect, import_history))
+        or not sys.stdin.isatty()
+    )
+    if not headless:
+        _run_setup_wizard()
+        return
+
+    missing = []
+    if record is None:
+        missing.append("--record/--no-record")
+    if connect is None:
+        missing.append("--connect/--no-connect")
+    if record:
+        if agents is None:
+            missing.append("--agents")
+        if import_history is None:
+            missing.append("--import-history/--no-import-history")
+    if missing:
+        console.print(
+            "[red]Headless setup needs every decision as an explicit flag. "
+            f"Missing: {', '.join(missing)}[/red]"
+        )
+        raise typer.Exit(1)
+    if not record and (agents is not None or import_history):
+        console.print("[red]--agents and --import-history require --record.[/red]")
+        raise typer.Exit(1)
+
+    _run_setup_headless(record, agents, connect, import_history)
+
+
+def _run_setup_headless(
+    record: bool, agents_csv: str | None, connect: bool, import_history: bool | None
+) -> None:
+    """Non-interactive setup: every wizard decision arrives pre-answered.
+
+    Terse ✓-per-step output and no splash — the caller is a coding agent
+    relaying to a user, not a person at a terminal."""
+    cfg = load_config()
+
+    if record:
+        detected = _detected_agents()
+        selected = [a.strip() for a in agents_csv.split(",") if a.strip()]
+        unknown = sorted(set(selected) - set(detected))
+        if not selected or unknown:
+            what = f"not detected on this machine: {', '.join(unknown)}" if unknown else "empty"
+            console.print(
+                f"[red]--agents is {what}. Detected agents: {', '.join(detected) or 'none'}.[/red]"
+            )
+            raise typer.Exit(1)
+        start_streaming()
+        save_enabled_agents(selected)
+        _install_all_hooks(selected)
+        console.print(f"  [green]✓[/green] Recording on for: {', '.join(selected)}")
+    else:
+        stop_streaming()
+        console.print("  [green]✓[/green] Recording off")
+
+    if connect:
+        _auto_connect_repo(_git_toplevel() or Path.cwd(), cfg)
+    else:
+        console.print("  [green]✓[/green] Folder context skipped")
+
+    if import_history:
+        from .import_history import discover_conversations
+
+        conversations = discover_conversations(selected)
+        if conversations:
+            _spawn_history_import(len(conversations))
+        else:
+            console.print("  No historical conversations found.")
 
 
 @app.command("connect")
@@ -5042,13 +5140,31 @@ def _write_import_status(total: int, done: int, errors: int, finished: bool) -> 
     os.replace(tmp, IMPORT_STATUS_FILE)
 
 
-def _onboarding_import_history(detected_agents: list[str]) -> None:
-    """Offer to import historical conversations during onboarding.
-
-    The import itself runs as a detached `stash import-history` process —
-    thousands of uploads must not hold the wizard hostage."""
+def _spawn_history_import(count: int) -> None:
+    """Kick off the history import as a detached `stash import-history`
+    process — thousands of uploads must not hold setup hostage."""
     import subprocess as _sp
 
+    # Seed the status file so the setup-complete splash can show the import
+    # immediately; the spawned process takes over updating it.
+    _write_import_status(total=count, done=0, errors=0, finished=False)
+
+    IMPORT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(IMPORT_LOG_FILE, "ab") as log:
+        _sp.Popen(
+            [sys.argv[0], "import-history"],
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+    console.print(
+        f"  [green]✓[/green] Importing {count} conversations in the background.\n"
+        "    [dim]Check on it anytime: stash import-history --status[/dim]"
+    )
+
+
+def _onboarding_import_history(detected_agents: list[str]) -> None:
+    """Offer to import historical conversations during onboarding."""
     from .import_history import discover_conversations, summarize_discovery
 
     agents = detected_agents or None
@@ -5071,22 +5187,7 @@ def _onboarding_import_history(detected_agents: list[str]) -> None:
     if not ok:
         return
 
-    # Seed the status file so the setup-complete splash can show the import
-    # immediately; the spawned process takes over updating it.
-    _write_import_status(total=len(conversations), done=0, errors=0, finished=False)
-
-    IMPORT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(IMPORT_LOG_FILE, "ab") as log:
-        _sp.Popen(
-            [sys.argv[0], "import-history"],
-            stdout=log,
-            stderr=log,
-            start_new_session=True,
-        )
-    console.print(
-        f"  [green]✓[/green] Importing {len(conversations)} conversations in the background.\n"
-        "    [dim]Check on it anytime: stash import-history --status[/dim]"
-    )
+    _spawn_history_import(len(conversations))
 
 
 def _show_import_status() -> None:

--- a/cli/tests/test_setup_headless.py
+++ b/cli/tests/test_setup_headless.py
@@ -1,0 +1,146 @@
+"""Headless `stash setup`: inside a coding agent session there is no TTY, so
+setup must be fully drivable by flags — the agent asks the wizard's questions
+in conversation, then runs one deterministic command. A missing decision must
+fail loud naming the flag to pass, never abort with a bare TTY error (the
+pre-flag behavior) and never silently assume a default."""
+
+import sys
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import cli.import_history as import_history_mod
+from cli import main
+
+
+class _Stdin:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Stub every side effect and record what setup decided to do."""
+    calls = {
+        "start_streaming": 0,
+        "stop_streaming": 0,
+        "saved_agents": None,
+        "hooks_installed": None,
+        "connected": 0,
+        "import_spawned": None,
+        "wizard_runs": 0,
+    }
+    monkeypatch.setattr(main, "_require_auth", lambda: {"api_key": "k"})
+    monkeypatch.setattr(main.telemetry, "record", lambda *a, **kw: None)
+    monkeypatch.setattr(main, "load_config", lambda: {"api_key": "k"})
+    monkeypatch.setattr(main, "_detected_agents", lambda: ["claude", "codex"])
+    monkeypatch.setattr(main, "start_streaming", lambda: calls.__setitem__("start_streaming", 1))
+    monkeypatch.setattr(main, "stop_streaming", lambda: calls.__setitem__("stop_streaming", 1))
+    monkeypatch.setattr(main, "save_enabled_agents", lambda a: calls.__setitem__("saved_agents", a))
+    monkeypatch.setattr(
+        main, "_install_all_hooks", lambda a: calls.__setitem__("hooks_installed", a)
+    )
+    monkeypatch.setattr(
+        main, "_auto_connect_repo", lambda root, cfg: calls.__setitem__("connected", 1)
+    )
+    monkeypatch.setattr(
+        main, "_spawn_history_import", lambda n: calls.__setitem__("import_spawned", n)
+    )
+    monkeypatch.setattr(main, "_run_setup_wizard", lambda: calls.__setitem__("wizard_runs", 1))
+    monkeypatch.setattr(
+        import_history_mod, "discover_conversations", lambda agents: ["c1", "c2", "c3"]
+    )
+    return calls
+
+
+def _setup(record=None, agents=None, connect=None, import_history=None):
+    main.setup_cmd(record=record, agents=agents, connect=connect, import_history=import_history)
+
+
+def test_no_tty_without_flags_fails_naming_the_missing_flags(calls, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+
+    with pytest.raises(typer.Exit):
+        _setup()
+
+    out = capsys.readouterr().out
+    assert "--record/--no-record" in out
+    assert "--connect/--no-connect" in out
+    assert calls["wizard_runs"] == 0
+
+
+def test_tty_without_flags_runs_the_interactive_wizard(calls, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=True))
+
+    _setup()
+
+    assert calls["wizard_runs"] == 1
+
+
+def test_any_flag_forces_headless_even_on_a_tty(calls, monkeypatch):
+    # An agent that passes flags wants determinism — never drop into prompts.
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=True))
+
+    with pytest.raises(typer.Exit):
+        _setup(record=False)
+
+    assert calls["wizard_runs"] == 0
+
+
+def test_full_flags_drive_every_setup_step(calls, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+
+    _setup(record=True, agents="claude,codex", connect=True, import_history=True)
+
+    assert calls["start_streaming"] == 1
+    assert calls["saved_agents"] == ["claude", "codex"]
+    assert calls["hooks_installed"] == ["claude", "codex"]
+    assert calls["connected"] == 1
+    assert calls["import_spawned"] == 3
+
+
+def test_no_record_needs_no_agents_or_import_decision(calls, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+
+    _setup(record=False, connect=False)
+
+    assert calls["stop_streaming"] == 1
+    assert calls["start_streaming"] == 0
+    assert calls["connected"] == 0
+    assert calls["import_spawned"] is None
+
+
+def test_unknown_agent_fails_and_names_the_detected_ones(calls, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+
+    with pytest.raises(typer.Exit):
+        _setup(record=True, agents="cursor", connect=False, import_history=False)
+
+    out = capsys.readouterr().out
+    assert "cursor" in out
+    assert "claude" in out
+    assert calls["start_streaming"] == 0
+
+
+def test_import_history_without_record_is_an_error(calls, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+
+    with pytest.raises(typer.Exit):
+        _setup(record=False, connect=False, import_history=True)
+
+    assert "--record" in capsys.readouterr().out
+
+
+def test_flags_parse_end_to_end_through_the_cli(calls):
+    result = CliRunner().invoke(
+        main.app,
+        ["setup", "--record", "--agents", "claude", "--connect", "--import-history"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["saved_agents"] == ["claude"]
+    assert calls["import_spawned"] == 3


### PR DESCRIPTION
## Problem

The onboarding skill has the coding agent (or the user via `!`) run `stash setup`, but under Claude Code stdin is not a TTY, so the questionary wizard aborts with **"Warning: Input is not a terminal (fd=0). Aborted."** The canonical onboarding path failed in the exact environment onboarding runs in; the only workaround was a second terminal tab.

## Change

`stash setup` now has a headless mode where every wizard decision arrives as a flag:

```
stash setup --record --agents claude,codex --connect --import-history
```

- **Routing:** a real terminal with no flags gets the interactive wizard, exactly as before. Any flag — or a non-TTY stdin — selects headless mode.
- **Fail loud, no defaults:** in headless mode, missing decisions are an error that names the flags to pass (`--record/--no-record`, `--connect/--no-connect`, and with `--record` also `--agents` and `--import-history/--no-import-history`). This replaces the bare TTY abort with an actionable message.
- **Validation:** `--agents` must be a non-empty subset of the detected agents; `--agents`/`--import-history` without `--record` are errors.
- **Terse output:** headless mode prints one ✓ per step and skips the splash — the caller is an agent relaying to a user.
- The detached history-import spawn is extracted into `_spawn_history_import` and shared between the wizard and headless paths.

The intended onboarding flow becomes: agent runs `stash signin` handoff (already non-TTY-safe), asks the setup questions **conversationally**, then runs one deterministic `stash setup <flags>` itself. Companion skill change: Fergana-Labs/stash-onboarding#2.

## Tests

`cli/tests/test_setup_headless.py` — 8 tests covering routing (TTY→wizard, non-TTY/flags→headless), the missing-flag error naming flags, full-flag end-to-end behavior, unknown-agent validation, and flag parsing through the CLI. Full `cli/tests` suite: 210 passed. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)