### PR TITLE
CLI: promote page editing to top-level `stash edit`, paired with `upload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- `stash edit` is now a top-level command, sitting next to `stash upload` in
+  `--help` so agents can see that both creating and editing are supported.
+  It replaces `stash files edit-page` (same options), additionally accepts
+  the page's app URL (`…/p/<id>`) in place of an id, and gains `--append`
+  to add text to the end of a markdown page without resending the body.
+  `stash upload`'s help and output now say explicitly that uploads always
+  create new items and point at `stash edit` for changing existing pages —
+  the upload-vs-edit confusion that made agents conclude pages couldn't be
+  edited at all.
 - CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
   that can be re-run anytime with the new `stash setup` — no answer is final.
   Session recording is framed as private-by-default and on by default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ A Skill is a *special folder* — one containing a SKILL.md — holding related 
 A Skill is **not** a wrapper to slap on every single file you happen to share. One-item Skills clutter Discover and defeat the model. Pick the right tool:
 
 - Share a single file or a folder/project → `stash upload <path> --json`, hand over `app_url` (no Skill).
+- Change a page already in Stash → `stash edit <page_id> --content "..."` (`--append` adds to the end). Never re-upload to edit.
 - Publishing a curated bundle → `stash upload <path> --skill "<title>" --json`.
 - Creating a fresh skill → `stash skills create "<name>" --public --json`.
 - Share a coding session → `stash share <session_id>`.

--- a/cli/main.py
+++ b/cli/main.py
@@ -1397,12 +1397,16 @@ def upload(
     ),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Upload a local file or directory into your Files.
+    """Upload a local file or directory into your Files. Creates new items — `stash edit` changes a page that's already there.
 
     A single file lands directly in your Files (Markdown/HTML become
     editable pages, everything else a binary file). A directory becomes a folder, and
     every text file in it — Markdown, HTML, code, CSV, and friends —
     becomes an editable page. **No Skill is created.**
+
+    Uploading never overwrites anything already in your Stash — re-uploading
+    a file creates a second copy. To change a page you uploaded earlier, run
+    ``stash edit <page_id>`` with the id or app_url this command printed.
 
     Uploads are private. The returned ``app_url`` opens for you alone unless
     you pass ``--public-link``, which adds an "anyone with the link" grant —
@@ -1451,6 +1455,8 @@ def upload(
                 "[dim]Private — only you can open that link. "
                 "Re-run with --public-link to share it.[/dim]"
             )
+        if data.get("kind") == "page":
+            console.print(f"[dim]Change it later with: stash edit {data['id']}[/dim]")
         return
 
     files = _upload_file_list(target)
@@ -1561,6 +1567,126 @@ def upload(
             f"[dim]Folder: {root_folder['id']}  "
             f"(pass --skill <title> to turn the folder into a shareable Skill)[/dim]"
         )
+
+
+def _parse_page_ref(ref: str) -> str:
+    """A page id, or the app URL an upload prints (…/p/<id>)."""
+    match = re.fullmatch(r".*/p/([^/?#]+)/?", ref)
+    return match.group(1) if match else ref
+
+
+@app.command("edit")
+def edit(
+    page: str = typer.Argument(
+        ..., help="Page id, or the app URL `stash upload` printed (…/p/<id>)."
+    ),
+    content: str = typer.Option(
+        None, "--content", help="Replacement body. Reads stdin if omitted."
+    ),
+    append: str = typer.Option(
+        None, "--append", help="Add this text to the end of the page instead of replacing it."
+    ),
+    name: str = typer.Option(None, "--name", help="Rename the page."),
+    page_type: str = typer.Option(
+        None, "--type", help="Switch the page to this type: markdown or html.", case_sensitive=False
+    ),
+    html_file: str = typer.Option(
+        None, "--html-file", help="Local HTML file to load as content_html."
+    ),
+    layout: str = typer.Option(
+        None,
+        "--layout",
+        help="Switch HTML layout: 'responsive', 'full-width' (full-window web pages), "
+        "or 'fixed-aspect' (16:9 slide decks).",
+        case_sensitive=False,
+    ),
+    attach: list[str] = typer.Option(
+        None, "--attach", help="Local file path to upload and prepend (repeatable)."
+    ),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Edit a page already in your Stash — the counterpart to `stash upload`, which adds new items.
+
+    Every page in your Stash stays editable forever, including the ones
+    `stash upload` created from Markdown/HTML/code files. ``--content`` (or
+    stdin) replaces the body, ``--append`` adds to the end, ``--name``
+    renames. Binary files have no editable body — upload a new copy
+    instead."""
+    _require_auth()
+    telemetry.record("edit")
+    page_id = _parse_page_ref(page)
+    if append is not None and (content is not None or html_file is not None or page_type):
+        console.print(
+            "[red]--append can't be combined with --content, --html-file, or --type.[/red]"
+        )
+        raise typer.Exit(1)
+    html_body: str | None = None
+    if html_file:
+        if not Path(html_file).is_file():
+            console.print(f"[red]Not a file: {html_file}[/red]")
+            raise typer.Exit(1)
+        html_body = Path(html_file).read_text()
+    if content is None and append is None and not sys.stdin.isatty():
+        content = sys.stdin.read()
+    if page_type:
+        page_type = page_type.lower()
+        if page_type not in ("markdown", "html"):
+            console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
+            raise typer.Exit(1)
+    if layout is not None:
+        layout = layout.lower()
+        if layout not in ("responsive", "fixed-aspect", "full-width"):
+            console.print(
+                f"[red]--layout must be 'responsive', 'fixed-aspect', or 'full-width', "
+                f"got: {layout}[/red]"
+            )
+            raise typer.Exit(1)
+    if html_body is not None and page_type is None:
+        page_type = "html"
+    if page_type == "html" and html_body is None and content is not None:
+        html_body = content
+        content = None
+
+    with _client() as c:
+        try:
+            for p in attach or []:
+                if not Path(p).is_file():
+                    console.print(f"[red]Not a file: {p}[/red]")
+                    raise typer.Exit(1)
+            if append is not None:
+                current = c.get_page(page_id)
+                if (current.get("content_type") or "markdown") != "markdown":
+                    console.print("[red]--append only works on markdown pages.[/red]")
+                    raise typer.Exit(1)
+                base = current.get("content_markdown") or ""
+                content = f"{base.rstrip()}\n\n{append}" if base.strip() else append
+            if attach and page_type != "html":
+                base = (
+                    content
+                    if content is not None
+                    else c.get_page(page_id).get("content_markdown", "")
+                )
+                content = _prepend_attachments(c, base, attach)
+            elif attach:
+                console.print("[yellow]--attach is ignored for html pages[/yellow]")
+            kwargs: dict = {}
+            if content is not None:
+                kwargs["content"] = content
+            if name is not None:
+                kwargs["name"] = name
+            if page_type is not None:
+                kwargs["content_type"] = page_type
+            if html_body is not None:
+                kwargs["content_html"] = html_body
+            if layout is not None:
+                kwargs["html_layout"] = layout
+            data = c.update_page(page_id, **kwargs)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+    else:
+        console.print(f"[green]Page updated.[/green] {data['name']}  [dim]{data['id']}[/dim]")
 
 
 @app.command("export")
@@ -2489,92 +2615,6 @@ def files_add_page(
         )
 
 
-@files_app.command("edit-page")
-def files_edit_page(
-    page_id: str = typer.Argument(...),
-    content: str = typer.Option(None, "--content"),
-    name: str = typer.Option(None, "--name"),
-    page_type: str = typer.Option(
-        None, "--type", help="Switch the page to this type: markdown or html.", case_sensitive=False
-    ),
-    html_file: str = typer.Option(
-        None, "--html-file", help="Local HTML file to load as content_html."
-    ),
-    layout: str = typer.Option(
-        None,
-        "--layout",
-        help="Switch HTML layout: 'responsive', 'full-width' (full-window web pages), "
-        "or 'fixed-aspect' (16:9 slide decks).",
-        case_sensitive=False,
-    ),
-    attach: list[str] = typer.Option(
-        None, "--attach", help="Local file path to upload and prepend (repeatable)."
-    ),
-    as_json: bool = typer.Option(False, "--json"),
-):
-    """Update a page. Reads from stdin if --content not given."""
-    html_body: str | None = None
-    if html_file:
-        if not Path(html_file).is_file():
-            console.print(f"[red]Not a file: {html_file}[/red]")
-            raise typer.Exit(1)
-        html_body = Path(html_file).read_text()
-    if content is None and not sys.stdin.isatty():
-        content = sys.stdin.read()
-    if page_type:
-        page_type = page_type.lower()
-        if page_type not in ("markdown", "html"):
-            console.print(f"[red]--type must be 'markdown' or 'html', got: {page_type}[/red]")
-            raise typer.Exit(1)
-    if layout is not None:
-        layout = layout.lower()
-        if layout not in ("responsive", "fixed-aspect", "full-width"):
-            console.print(
-                f"[red]--layout must be 'responsive', 'fixed-aspect', or 'full-width', "
-                f"got: {layout}[/red]"
-            )
-            raise typer.Exit(1)
-    if html_body is not None and page_type is None:
-        page_type = "html"
-    if page_type == "html" and html_body is None and content is not None:
-        html_body = content
-        content = None
-
-    with _client() as c:
-        try:
-            for p in attach or []:
-                if not Path(p).is_file():
-                    console.print(f"[red]Not a file: {p}[/red]")
-                    raise typer.Exit(1)
-            if attach and page_type != "html":
-                base = (
-                    content
-                    if content is not None
-                    else c.get_page(page_id).get("content_markdown", "")
-                )
-                content = _prepend_attachments(c, base, attach)
-            elif attach:
-                console.print("[yellow]--attach is ignored for html pages[/yellow]")
-            kwargs: dict = {}
-            if content is not None:
-                kwargs["content"] = content
-            if name is not None:
-                kwargs["name"] = name
-            if page_type is not None:
-                kwargs["content_type"] = page_type
-            if html_body is not None:
-                kwargs["content_html"] = html_body
-            if layout is not None:
-                kwargs["html_layout"] = layout
-            data = c.update_page(page_id, **kwargs)
-        except StashError as e:
-            _err(e)
-    if _use_json(as_json):
-        output_json(data)
-    else:
-        console.print("[green]Page updated.[/green]")
-
-
 # ===========================================================================
 # Sessions
 # ===========================================================================
@@ -3333,7 +3373,7 @@ def _print_memory_tree(node: dict, indent: int) -> None:
 
 @memory_app.command("ls")
 def memory_ls(as_json: bool = typer.Option(False, "--json")):
-    """The Memory wiki tree with ids — page ids feed `stash files edit-page`
+    """The Memory wiki tree with ids — page ids feed `stash edit`
     and `stash rm page:<id>`."""
     with _client() as c:
         try:
@@ -4494,6 +4534,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 clutter Discover and defeat the model. Pick the right tool:
 
 - Share a single file or a folder/project → `stash upload <path> --json`, hand over `app_url` (no Skill).
+- Change a page already in Stash → `stash edit <page_id> --content "..."` (`--append` adds to the end). Never re-upload to edit.
 - Publishing a curated bundle → `stash upload <path> --skill "<title>" --json`.
 - Creating a fresh skill → `stash skills create "<name>" --public --json`.
 - Share a coding session → `stash share <session_id>`.
@@ -5695,6 +5736,10 @@ Commands to reach for
   everything else a binary file) or a folder, into your storage. Returns
   `app_url`. No Skill created. This is the default for "share this one
   file."
+- `stash edit <page_id> --content "…"` — change a page that's already in
+  your Stash (pass the id or app URL the upload printed). `--append "…"`
+  adds to the end instead of replacing. Upload creates, edit updates —
+  never re-upload a file to change it.
 - `stash upload <path> --skill "<title>" --json` — same as above AND
   publish the uploaded folder as a Skill with the given title. Use only
   when you're producing a shareable collection.

--- a/cli/tests/test_edit_cmd.py
+++ b/cli/tests/test_edit_cmd.py
@@ -1,0 +1,111 @@
+"""`stash edit` is the top-level counterpart to `stash upload`: upload creates
+new items, edit changes an existing page. These lock in the wiring — the right
+update_page call — plus the ergonomics that make it agent-friendly: accepting
+the app URL upload printed, and --append not clobbering the existing body."""
+
+import pytest
+import typer
+
+from cli import main
+from cli.main import _parse_page_ref
+
+
+class _FakeClient:
+    def __init__(self, calls: list, page: dict | None = None):
+        self._calls = calls
+        self._page = page or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def get_page(self, page_id):
+        self._calls.append(("get_page", page_id))
+        return self._page
+
+    def update_page(self, page_id, **kwargs):
+        self._calls.append(("update_page", page_id, kwargs))
+        return {"id": page_id, "name": kwargs.get("name", "Page")}
+
+
+def _wire(monkeypatch, page: dict | None = None) -> list:
+    calls: list = []
+    monkeypatch.setattr(main, "_require_auth", lambda: None)
+    monkeypatch.setattr(main, "_client", lambda: _FakeClient(calls, page))
+    monkeypatch.setattr(main.telemetry, "record", lambda *_a, **_k: None)
+    return calls
+
+
+def test_parse_page_ref_accepts_raw_id_and_app_url() -> None:
+    assert _parse_page_ref("abc-123") == "abc-123"
+    assert _parse_page_ref("https://app.joinstash.ai/p/abc-123") == "abc-123"
+    assert _parse_page_ref("https://app.joinstash.ai/p/abc-123/") == "abc-123"
+
+
+def test_edit_replaces_content(monkeypatch) -> None:
+    calls = _wire(monkeypatch)
+    main.edit(
+        "p1",
+        content="new body",
+        append=None,
+        name=None,
+        page_type=None,
+        html_file=None,
+        layout=None,
+        attach=None,
+        as_json=True,
+    )
+    assert calls == [("update_page", "p1", {"content": "new body"})]
+
+
+def test_edit_append_keeps_existing_body(monkeypatch) -> None:
+    calls = _wire(monkeypatch, page={"content_type": "markdown", "content_markdown": "# Notes\n"})
+    main.edit(
+        "https://app.joinstash.ai/p/p1",
+        content=None,
+        append="hello",
+        name=None,
+        page_type=None,
+        html_file=None,
+        layout=None,
+        attach=None,
+        as_json=True,
+    )
+    assert calls == [
+        ("get_page", "p1"),
+        ("update_page", "p1", {"content": "# Notes\n\nhello"}),
+    ]
+
+
+def test_edit_append_rejects_html_pages(monkeypatch) -> None:
+    _wire(monkeypatch, page={"content_type": "html", "content_markdown": ""})
+    with pytest.raises(typer.Exit):
+        main.edit(
+            "p1",
+            content=None,
+            append="hello",
+            name=None,
+            page_type=None,
+            html_file=None,
+            layout=None,
+            attach=None,
+            as_json=True,
+        )
+
+
+def test_edit_append_conflicts_with_content(monkeypatch) -> None:
+    _wire(monkeypatch)
+    with pytest.raises(typer.Exit):
+        main.edit(
+            "p1",
+            content="body",
+            append="hello",
+            name=None,
+            page_type=None,
+            html_file=None,
+            layout=None,
+            attach=None,
+            as_json=True,
+        )

--- a/frontend/src/lib/onboarding/collabIntro.test.ts
+++ b/frontend/src/lib/onboarding/collabIntro.test.ts
@@ -10,7 +10,7 @@ describe("generateCollabIntroMarkdown", () => {
     });
 
     expect(md).toContain("Authenticate: export STASH_API_KEY=self-hosted-key");
-    expect(md).toContain("stash files read-page page-1");
+    expect(md).toContain("stash edit page-1 --append");
   });
 
   it("points managed Auth0 users at the CLI sign-in flow instead of a key", () => {
@@ -22,6 +22,6 @@ describe("generateCollabIntroMarkdown", () => {
 
     expect(md).toContain("Authenticate: stash signin");
     expect(md).not.toContain("STASH_API_KEY");
-    expect(md).toContain("stash files read-page page-1");
+    expect(md).toContain("stash edit page-1 --append");
   });
 });

--- a/frontend/src/lib/onboarding/collabIntro.ts
+++ b/frontend/src/lib/onboarding/collabIntro.ts
@@ -30,9 +30,8 @@ Paste this into Claude Code, Codex, or Cursor — keep this tab open and watch t
 \`\`\`
 Install the Skill CLI: bash -c "$(curl -fsSL https://joinstash.ai/install)"
 Authenticate: ${authenticate}
-Read this page: stash files read-page ${pageId}
-Then append a short hello note at the bottom and save the full updated markdown with:
-stash files edit-page ${pageId} --content "<full updated markdown>"
+Then append a short hello note to the bottom of this page:
+stash edit ${pageId} --append "<your hello note>"
 \`\`\`
 
 ## What people keep here

--- a/plugins/claude-plugin/CLAUDE.md
+++ b/plugins/claude-plugin/CLAUDE.md
@@ -14,6 +14,7 @@ A Skill is **not** a wrapper around every single file you happen to share. One-i
 |---|---|---|
 | Share one file (publicly) | `stash upload <path> --json` | the returned `app_url` |
 | Upload a folder / project into your Stash | `stash upload <path> --json` | the returned `app_url` |
+| Change a page already in your Stash | `stash edit <page_id> --content "..."` | — (never re-upload to edit) |
 | Publish a curated bundle as one shareable thing | `stash upload <path> --skill "<title>" --json` | the returned `url` |
 | Create a fresh skill folder | `stash skills create "<name>" --public --json` | the returned folder |
 | Share a coding session (transcript + files) | `stash share <session_id>` | the returned `url` |
@@ -71,7 +72,7 @@ stash vfs "find /me -name '*.md'"                   # List your pages
 stash files create-folder "name"                    # Create a folder
 stash files add-page "title" --content "markdown content"
 stash vfs "cat '/me/files/<page>.md'"               # Read a page
-stash files edit-page <page_id> --content "new content"
+stash edit <page_id> --content "new content"        # Update any page (--append adds to the end)
 ```
 
 ### History (Agent Event Logs)

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -47,6 +47,11 @@ CONTEXT = (
     " - Using a public Skill locally → `stash skills install <slug>` "
     "writes it into ~/.claude/skills so it loads next session "
     "(`--project` for ./.claude/skills).\n\n"
+    "Everything uploaded stays editable: `stash edit <page_id> --content "
+    '"..."` changes a page already in Stash (`--append` adds to the end; '
+    "the id or app URL the upload printed both work). `stash upload` always "
+    "creates a NEW item — reach for `stash edit` to change an existing "
+    "one.\n\n"
     "Run `stash prompts agent-guidance` any time you want this guidance "
     "reprinted in full.\n\n"
     "`stash ls` shows everything Stash can reach as one filesystem — files, "

--- a/stashai/plugin/assets/claude/scripts/on_session_start.py
+++ b/stashai/plugin/assets/claude/scripts/on_session_start.py
@@ -47,6 +47,11 @@ CONTEXT = (
     " - Using a public Skill locally → `stash skills install <slug>` "
     "writes it into ~/.claude/skills so it loads next session "
     "(`--project` for ./.claude/skills).\n\n"
+    "Everything uploaded stays editable: `stash edit <page_id> --content "
+    '"..."` changes a page already in Stash (`--append` adds to the end; '
+    "the id or app URL the upload printed both work). `stash upload` always "
+    "creates a NEW item — reach for `stash edit` to change an existing "
+    "one.\n\n"
     "Run `stash prompts agent-guidance` any time you want this guidance "
     "reprinted in full.\n\n"
     "`stash ls` shows everything Stash can reach as one filesystem — files, "

--- a/stashai/plugin/assets/codex/AGENTS.md
+++ b/stashai/plugin/assets/codex/AGENTS.md
@@ -16,6 +16,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 - **A folder / project into your Stash** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.
+- **Changing a page already in your Stash** → `stash edit <page_id> --content "..."` (`--append` adds to the end; the page id or its app URL both work). `stash upload` always creates a NEW item — use `stash edit` to change an existing one.
 
 Run `stash prompts agent-guidance` any time you want this guidance reprinted in full.
 

--- a/stashai/plugin/assets/gemini/GEMINI.md
+++ b/stashai/plugin/assets/gemini/GEMINI.md
@@ -6,6 +6,8 @@ Your activity in this repo is streamed to your Stash, so your agents and you can
 
 When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
+`stash upload` always creates a NEW item. To change a page already in Stash, use `stash edit <page_id> --content "..."` (`--append` adds to the end; the page id or its app URL both work) — never re-upload to edit.
+
 Common reads (all support `--json`):
 - `stash search "<query>"` — full-text search across transcripts
 - `stash vfs "cat '/me/sessions/_index.jsonl'"` — recent events

--- a/stashai/plugin/assets/hermes/HERMES.md
+++ b/stashai/plugin/assets/hermes/HERMES.md
@@ -6,6 +6,8 @@ Your activity in this repo is streamed to your Stash, so your agents and you can
 
 When the user asks you to upload local files to Stash, use `stash upload <path> --json` and give the user the returned `url`. If you use `stash upload <path> --json` for a raw file upload, give the user the returned `app_url`.
 
+`stash upload` always creates a NEW item. To change a page already in Stash, use `stash edit <page_id> --content "..."` (`--append` adds to the end; the page id or its app URL both work) — never re-upload to edit.
+
 Common reads (all support `--json`):
 - `stash search "<query>"` — full-text search across transcripts
 - `stash vfs "cat '/me/sessions/_index.jsonl'"` — recent events

--- a/stashai/plugin/assets/opencode/AGENTS.md
+++ b/stashai/plugin/assets/opencode/AGENTS.md
@@ -16,6 +16,7 @@ A Skill is **not** a wrapper to slap on every single file you happen to share. O
 - **A folder / project into your Stash** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
 - **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
 - **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.
+- **Changing a page already in your Stash** → `stash edit <page_id> --content "..."` (`--append` adds to the end; the page id or its app URL both work). `stash upload` always creates a NEW item — use `stash edit` to change an existing one.
 
 Run `stash prompts agent-guidance` any time you want this guidance reprinted in full.
 

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -153,22 +153,20 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
         ]}
       />
 
-      <CommandRef
-        command="stash files read-page"
-        args="<page_id>"
-        description="Read a page."
-        params={[
-          { name: "<page_id>", type: "string", desc: "ID of the page.", required: true },
-        ]}
-      />
+      <Callout type="tip">
+        Reading pages goes through the VFS:{" "}
+        <Code>{`stash vfs "cat '/me/files/<page>.md'"`}</Code>.
+      </Callout>
 
       <CommandRef
-        command="stash files edit-page"
-        args="<page_id> --content '...'"
-        description="Update a page. Reads from stdin if --content is not given."
+        command="stash edit"
+        args="<page_id> [--content '...'] [--append '...']"
+        description="Edit a page already in your Stash — the counterpart to stash upload, which creates new items. Accepts the page id or the app URL upload printed."
         params={[
-          { name: "<page_id>", type: "string", desc: "ID of the page.", required: true },
-          { name: "--content", type: "string", desc: "New page content. Reads from stdin if omitted." },
+          { name: "<page_id>", type: "string", desc: "Page id, or its app URL (…/p/<id>).", required: true },
+          { name: "--content", type: "string", desc: "Replacement body. Reads from stdin if omitted." },
+          { name: "--append", type: "string", desc: "Add text to the end of the page instead of replacing it." },
+          { name: "--name", type: "string", desc: "Rename the page." },
         ]}
       />
 
@@ -497,7 +495,7 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
       <CommandRef
         command="stash upload"
         args="<path> [--skill TITLE]"
-        description="Upload a single file (Markdown/HTML become pages, everything else a binary file) or a folder into your Stash. Pass --skill to also bundle it into a shareable Skill."
+        description="Upload a single file (Markdown/HTML become pages, everything else a binary file) or a folder into your Stash. Always creates a new item — use stash edit to change a page that's already there. Pass --skill to also bundle it into a shareable Skill."
         params={[
           { name: "<path>", type: "path", desc: "File or directory to upload.", required: true },
           { name: "--skill", type: "string", desc: "Also publish the upload as a Skill with this title." },


### PR DESCRIPTION
## Problem

Agents kept concluding Stash pages couldn't be edited (Slack report: "agent got confused on upload vs edit and thought we could not edit files"). `stash upload` was top-level and prominent while editing hid behind `stash files edit-page`, and no help text or agent guidance surface mentioned that both creating and editing exist. Reading `stash --help` + `upload --help`, "we only support upload" was a reasonable inference.

## Fix

**`stash edit <page>` is now top-level, listed right under `upload`, and the two cross-reference each other:**

```
│ upload   Upload a local file or directory into your Files. Creates new items │
│          — `stash edit` changes a page that's already there.                 │
│ edit     Edit a page already in your Stash — the counterpart to              │
│          `stash upload`, which adds new items.                               │
```

- Replaces `stash files edit-page` (same options, moved — no alias kept).
- Accepts the app URL upload prints (`…/p/<id>`) as well as a raw page id.
- New `--append "text"` adds to the end of a markdown page without resending the whole body (errors on HTML pages).
- Uploading a page now prints `Change it later with: stash edit <id>`, and upload's docstring states uploads never overwrite — re-uploading creates a copy.
- Every agent guidance surface now states the rule ("upload creates, edit updates — never re-upload to edit"): SessionStart hook context (both copies), `stash prompts agent-guidance`, plugin CLAUDE.md, the `stash connect` CLAUDE.md block, repo CLAUDE.md, and the Codex/OpenCode/Gemini/Hermes assets.

## Docs & onboarding

- www CLI docs document `stash edit` beside `upload`, and drop the stale `stash files read-page` entry (command removed in #644) in favor of a VFS-read callout.
- The onboarding welcome page's "watch your agent edit this page" demo depended on that dead `read-page` command; it's now a single working step: `stash edit <id> --append "<hello note>"`.

![stash edit in the CLI docs](https://api.joinstash.ai/api/v1/me/files/4497349d-fdc9-458f-9c77-984653614d3e/download)

## Testing

- 207 CLI tests pass, including 5 new ones (`cli/tests/test_edit_cmd.py`): URL/id parsing, content replace, append preserving the existing body, append rejecting HTML pages, append/content conflict.
- `frontend` collabIntro vitest passes; ruff check + format clean; www lint has no errors in touched files.
- Smoke-ran `stash --help` / `stash edit --help` and rendered the docs page (screenshot above).

Not in scope: binary files still have no in-place content update (server only PATCHes metadata); `edit` covers pages and its help says to upload a fresh copy for binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)