### PR TITLE
Minting a key during onboarding no longer eats the whole analytics batch

### DIFF
--- a/backend/services/analytics_events_service.py
+++ b/backend/services/analytics_events_service.py
@@ -26,6 +26,7 @@ ALLOWED_EVENT_NAMES = {
     "onboarding.about_submitted",
     "onboarding.source_selected",
     "onboarding.collab_path_chosen",
+    "onboarding.api_key_minted",
     "onboarding.skipped",
     "onboarding.completed",
     # Web actions

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -87,6 +87,38 @@ async def test_ingest_rejects_unknown_event(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_ingest_accepts_every_onboarding_event_the_web_app_fires(client: AsyncClient):
+    """A call site the allowlist doesn't know about costs more than its own row.
+
+    The endpoint rejects the whole batch on one unrecognised name, and the web
+    client's flush is fire-and-forget — so an unlisted event silently takes up
+    to 19 legitimate events down with it. `onboarding.api_key_minted` shipped
+    that way and recorded zero rows. Every name below has a live `track()` call
+    in frontend/src/app/onboarding/page.tsx; adding one there means adding it
+    here too.
+    """
+    key = await _register(client)
+    fired_by_onboarding_page = [
+        "onboarding.viewed",
+        "onboarding.step_viewed",
+        "onboarding.about_submitted",
+        "onboarding.collab_path_chosen",
+        "onboarding.api_key_minted",
+        "onboarding.skipped",
+        "onboarding.completed",
+    ]
+    resp = await client.post(
+        "/api/v1/analytics/events",
+        json={
+            "events": [{"surface": "web", "event_name": name} for name in fired_by_onboarding_page]
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"recorded": len(fired_by_onboarding_page)}
+
+
+@pytest.mark.asyncio
 async def test_ingest_accepts_round_2_event_names(client: AsyncClient):
     """The second batch of events (file_uploaded, stash_created, page_edited,
     search_query, signed_up, plus CLI history.*) must all pass the allowlist."""


### PR DESCRIPTION
## The bug

`onboarding.api_key_minted` has a live `track()` call in the onboarding page (`frontend/src/app/onboarding/page.tsx:541`) but was never added to `ALLOWED_EVENT_NAMES`. It has recorded **zero rows since it shipped** — confirmed against the dev DB after two successful key mints:

```
          event_name           | count
-------------------------------+-------
 onboarding.step_viewed        |    12
 onboarding.viewed             |     8
 onboarding.about_submitted    |     2
 onboarding.collab_path_chosen |     1
 onboarding.completed          |     1
```

The cost isn't just its own row. `backend/routers/analytics.py:46` rejects the **entire batch** on one unrecognised name, and the web client's `flush()` has already `splice`d the events off the queue and ends in `.catch(() => {})`. So an unlisted event silently takes up to 19 legitimate events down with it:

```
$ curl … -d '{"events":[{"event_name":"onboarding.completed"},{"event_name":"onboarding.api_key_minted"}]}'
{"detail":"unknown event_name: onboarding.api_key_minted"}   HTTP 400
```

That valid `onboarding.completed` died with it.

## The fix

One allowlist row, plus a regression test listing every event the onboarding page fires — so wiring a new `track()` call without an allowlist row fails loudly in CI instead of quietly draining the funnel.

## Verification

- New test **fails without** the allowlist entry and **passes with** it.
- `backend/tests/test_analytics.py` — 16 passed, against current `main`.
- `ruff check` + `ruff format --check` — clean.
- Against a live server, the same batch that previously 400'd now returns `{"recorded":2}`, with the sibling event surviving.

No GUI changes in this PR.

## Noted, not fixed

`onboarding.source_selected` is in the allowlist but nothing in the frontend fires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ivyhVft6t3VUzWfUGUcHX