### PR TITLE
Extension page copy, in the voice that sells browser extensions

### DIFF
--- a/frontend/src/app/(app)/extension/page.tsx
+++ b/frontend/src/app/(app)/extension/page.tsx
@@ -12,22 +12,22 @@ const FEATURES = [
   {
     icon: Globe,
     title: "Clip any page",
-    body: "Save the page you're reading — or every open tab — as a clean, readable copy in your Stash. PDFs included.",
+    body: "Articles, PDFs, and every open tab. Saved clean and readable.",
   },
   {
     icon: BookMarked,
-    title: "Import your bookmarks",
-    body: "Bring your whole bookmarks file. Stash fetches every page's content in the background and files them under Clips.",
+    title: "Bring your bookmarks",
+    body: "Import the whole file. We fetch what's behind every link.",
   },
   {
     icon: Camera,
     title: "Instagram saves",
-    body: "Your saved posts sync automatically — captions, images, and video archived so they outlive the post.",
+    body: "Your saved posts, synced. Captions, images, and video kept.",
   },
   {
     icon: MessagesSquare,
     title: "AI chats",
-    body: "ChatGPT and Claude conversations stream into your Stash as transcripts, searchable like everything else.",
+    body: "ChatGPT and Claude, streamed in. Searchable like everything else.",
   },
 ];
 
@@ -36,10 +36,10 @@ export default function ExtensionPage() {
     <div className="scroll-thin flex-1 overflow-y-auto">
       <div className="mx-auto max-w-2xl px-8 py-12">
         <h1 className="font-display text-[30px] font-bold tracking-tight text-foreground">
-          The Stash browser extension
+          Save anything from the web
         </h1>
         <p className="mt-2 max-w-lg text-[14px] leading-relaxed text-dim">
-          Everything you read, save, and discuss — captured into your Stash while you browse.
+          Automatic. Searchable. Read by your agents.
         </p>
 
         <div className="mt-7">
@@ -64,11 +64,11 @@ export default function ExtensionPage() {
         </div>
 
         <div className="mt-9 rounded-xl border border-border bg-base p-5">
-          <div className="text-[13.5px] font-semibold text-foreground">How it connects</div>
+          <div className="text-[13.5px] font-semibold text-foreground">One click to connect</div>
           <p className="mt-1.5 text-[12.5px] leading-relaxed text-muted-foreground">
-            After installing, click the extension icon and hit <span className="font-medium text-foreground">Connect</span>.
-            You&apos;ll sign in to Stash once in a normal tab — no tokens to copy. The extension
-            gets its own key you can revoke any time from Settings.
+            Click the icon and hit <span className="font-medium text-foreground">Connect</span>. You
+            sign in once, in a normal tab. No tokens to copy. The extension gets its own key, and
+            you can revoke it any time in Settings.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Rewrites `/extension` copy against how Raindrop pitches their extension: a headline that says what you *get* rather than what the thing is *called*, a three-beat subhead, and feature bodies cut to one short sentence each. Second person, no em-dash subclauses, parallel construction.

**Copy only** — no markup, styling, or behaviour changes. The diff is 11 lines, all strings.

| | Before | After |
|---|---|---|
| Headline | The Stash browser extension | Save anything from the web |
| Subhead | Everything you read, save, and discuss — captured into your Stash while you browse. | Automatic. Searchable. Read by your agents. |
| Clip | Save the page you're reading — or every open tab — as a clean, readable copy in your Stash. PDFs included. | Articles, PDFs, and every open tab. Saved clean and readable. |
| Bookmarks | Bring your whole bookmarks file. Stash fetches every page's content in the background and files them under Clips. | Import the whole file. We fetch what's behind every link. |
| Instagram | Your saved posts sync automatically — captions, images, and video archived so they outlive the post. | Your saved posts, synced. Captions, images, and video kept. |
| AI chats | ChatGPT and Claude conversations stream into your Stash as transcripts, searchable like everything else. | ChatGPT and Claude, streamed in. Searchable like everything else. |
| Connect | How it connects | One click to connect |

Raindrop's pattern for reference: headline "All-in-one bookmark manager", subhead "Intuitive. Powerful. Runs everywhere", section headers 2–3 words, bodies 4–10 words.

Screenshot of the rendered page is in the PR thread.

Verified: `eslint` clean, `tsc --noEmit` reports nothing for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ivyhVft6t3VUzWfUGUcHX