### PR TITLE
Unbreak the deploy, uncap the Instagram sync, restore the bookmark drawer links

### DIFF
--- a/backend/migrations/versions/0175_protected_folders.py
+++ b/backend/migrations/versions/0175_protected_folders.py
@@ -15,8 +15,8 @@ Revises: 0173
 
 from alembic import op
 
-revision = "0174"
-down_revision = "0173"
+revision = "0175"
+down_revision = "0174"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/0176_bookmark_row_at_import.py
+++ b/backend/migrations/versions/0176_bookmark_row_at_import.py
@@ -20,8 +20,8 @@ Revises: 0174
 
 from alembic import op
 
-revision = "0175"
-down_revision = "0174"
+revision = "0176"
+down_revision = "0175"
 branch_labels = None
 depends_on = None
 

--- a/backend/tests/test_migration_chain.py
+++ b/backend/tests/test_migration_chain.py
@@ -1,0 +1,65 @@
+"""The migration graph must have exactly one head.
+
+Two PRs merged the same day each added a `0174`, both parented on `0173`.
+Alembic could not resolve the graph, so `alembic upgrade head` — which
+`database.py` runs at boot — failed, and the backend exited with status 3 on
+every deploy. Prod sat on the previous release until someone noticed.
+
+Nothing in the test suite caught it because each PR's migrations were fine in
+isolation; only the merge was broken. So this asserts a property of the
+directory rather than of any one file.
+"""
+
+import re
+from collections import Counter
+from pathlib import Path
+
+VERSIONS = Path(__file__).resolve().parents[1] / "migrations" / "versions"
+_REVISION = re.compile(r'^revision = "([^"]+)"', re.M)
+_DOWN = re.compile(r'^down_revision = (?:"([^"]+)"|None)', re.M)
+
+
+def _graph() -> dict[str, str | None]:
+    graph: dict[str, str | None] = {}
+    for path in VERSIONS.glob("*.py"):
+        text = path.read_text()
+        rev = _REVISION.search(text)
+        if not rev:
+            continue
+        down = _DOWN.search(text)
+        graph[rev.group(1)] = down.group(1) if down else None
+    return graph
+
+
+def test_no_duplicate_revision_ids():
+    """Two files claiming the same revision is the failure mode that took
+    prod down; alembic only warns about it, then errors later."""
+    revisions = []
+    for path in VERSIONS.glob("*.py"):
+        match = _REVISION.search(path.read_text())
+        if match:
+            revisions.append(match.group(1))
+
+    duplicates = [rev for rev, count in Counter(revisions).items() if count > 1]
+    assert not duplicates, (
+        f"revision id(s) used by more than one migration: {duplicates}. "
+        "Two branches picked the same number — renumber the later one and "
+        "re-chain its down_revision."
+    )
+
+
+def test_exactly_one_head():
+    """A head is a revision nothing points at. More than one means the graph
+    forked and `upgrade head` is ambiguous."""
+    graph = _graph()
+    parents = {down for down in graph.values() if down}
+    heads = sorted(set(graph) - parents)
+    assert len(heads) == 1, f"expected one head, found {heads}"
+
+
+def test_every_parent_exists():
+    """A down_revision pointing at a deleted or renamed migration breaks the
+    chain just as hard, and is the easy mistake when renumbering."""
+    graph = _graph()
+    missing = {rev: down for rev, down in graph.items() if down is not None and down not in graph}
+    assert not missing, f"down_revision points at a revision that doesn't exist: {missing}"

--- a/chrome_extension/src/content/instagram.ts
+++ b/chrome_extension/src/content/instagram.ts
@@ -8,7 +8,21 @@
 const SAVED_FEED_PATH = '/api/v1/feed/saved/posts/';
 // Instagram's public web-app id, required on internal API calls.
 const IG_APP_ID = '936619743392459';
-const MAX_ITEMS = 200;
+
+// The saved feed returns ~18 posts per page, so the old MAX_ITEMS = 200 cap
+// stopped after a dozen requests and reported ~210 saves to anyone with more
+// — silently, because a truncated harvest looks identical to a complete one.
+// These bounds exist to stop a runaway loop, not to cap a real library:
+// PAGE_LIMIT is what actually ends the walk, and MAX_ITEMS is a backstop in
+// case Instagram keeps setting more_available forever.
+const MAX_ITEMS = 20000;
+const PAGE_LIMIT = 400;
+// Instagram rate-limits the saved feed aggressively. A short pause between
+// pages is the difference between walking a large library and getting a 429
+// partway through, which would truncate just as silently as the old cap.
+const PAGE_DELAY_MS = 350;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function harvest(): Promise<void> {
   const check = await chrome.runtime.sendMessage({
@@ -28,8 +42,17 @@ async function harvest(): Promise<void> {
   }
 
   const items: { url: string }[] = [];
+  const seen = new Set<string>();
   let maxId = '';
-  while (items.length < MAX_ITEMS) {
+  let truncated = false;
+
+  for (let page = 0; ; page += 1) {
+    if (page >= PAGE_LIMIT || items.length >= MAX_ITEMS) {
+      truncated = true;
+      break;
+    }
+    if (page > 0) await sleep(PAGE_DELAY_MS);
+
     const query = maxId ? `?max_id=${encodeURIComponent(maxId)}` : '';
     const res = await fetch(`${SAVED_FEED_PATH}${query}`, {
       headers: {
@@ -39,20 +62,36 @@ async function harvest(): Promise<void> {
       },
     });
     if (!res.ok) {
+      // Partway through a long walk, a failure means the harvest is
+      // incomplete. Keeping what we have and saying so beats discarding
+      // hundreds of good URLs, and beats reporting it as a clean pass.
       void chrome.runtime.sendMessage({
         type: 'SAVED_ITEMS_FAILED',
         platform: 'instagram',
-        error: `saved-posts API returned ${res.status}`,
+        error: `saved-posts API returned ${res.status} after ${items.length} saves`,
       });
       return;
     }
     const data = await res.json();
     for (const wrapper of data.items || []) {
       const media = wrapper?.media || wrapper;
-      if (media?.code) items.push({ url: `https://www.instagram.com/p/${media.code}/` });
+      // Instagram repeats posts across page boundaries when the list changes
+      // mid-walk; without this a long harvest inflates its own count.
+      if (media?.code && !seen.has(media.code)) {
+        seen.add(media.code);
+        items.push({ url: `https://www.instagram.com/p/${media.code}/` });
+      }
     }
     if (!data.more_available || !data.next_max_id) break;
     maxId = data.next_max_id;
+  }
+
+  if (truncated) {
+    void chrome.runtime.sendMessage({
+      type: 'SAVED_ITEMS_FAILED',
+      platform: 'instagram',
+      error: `stopped at ${items.length} saves — hit the safety limit, re-run to continue`,
+    });
   }
 
   // Empty is a valid harvest (no saves yet) — the background still records

--- a/frontend/src/components/apps/AppDetail.tsx
+++ b/frontend/src/components/apps/AppDetail.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Plus, X } from "lucide-react";
+import { ExternalLink, FileText, Plus, X } from "lucide-react";
 
 import { setRowTopics, updateTableRow } from "@/lib/api";
 import type { MiniProgramManifest, Table, TableColumn, TableRow } from "@/lib/types";
 
 import TopicInput from "./TopicInput";
-import { cellLabels, cellText } from "./cells";
+import { cellLabels, cellText, internalPath } from "./cells";
 
 function inputValue(row: TableRow, column: TableColumn): string {
   const value = row.data[column.id];
@@ -118,6 +118,12 @@ export default function AppDetail({
   const labels = cellLabels(row, labelColumnId);
   const title = cellText(row, manifest.detail.title) || "Untitled";
 
+  // The two things a saved item is *for*: the copy we captured, and where it
+  // came from. The Clip cell holds an absolute app URL, which may point at a
+  // different origin than the one being browsed, so it's reduced to a path.
+  const archivedPath = internalPath(cellText(row, manifest.detail.content));
+  const originalUrl = cellText(row, manifest.detail.link);
+
   useEffect(() => {
     setValues(
       Object.fromEntries(columns.map((column) => [column.id, inputValue(row, column)]))
@@ -179,6 +185,36 @@ export default function AppDetail({
           <X className="h-4 w-4" />
         </button>
       </div>
+
+      {(archivedPath || originalUrl) && (
+        <div
+          data-testid="detail-links"
+          className="flex flex-wrap gap-2 border-b border-border px-4 py-2.5"
+        >
+          {archivedPath && (
+            <a
+              href={archivedPath}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1.5 text-[12px] text-foreground hover:bg-raised"
+            >
+              <FileText className="h-3.5 w-3.5 text-brand" />
+              Open saved copy
+            </a>
+          )}
+          {originalUrl && (
+            <a
+              href={originalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1.5 text-[12px] text-foreground hover:bg-raised"
+            >
+              <ExternalLink className="h-3.5 w-3.5 text-brand" />
+              Open original
+            </a>
+          )}
+        </div>
+      )}
 
       <div className="scroll-thin flex-1 space-y-4 overflow-y-auto px-4 py-4">
         {columns.map((column) => {

--- a/frontend/src/components/apps/AppView.test.tsx
+++ b/frontend/src/components/apps/AppView.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import AppView from "./AppView";
@@ -76,6 +76,7 @@ const manifest = {
     body: "summary",
     labels: "topics",
     link: "url",
+    content: "clip",
   },
   enriched_columns: ["summary", "topics"],
 };
@@ -86,6 +87,10 @@ const rows = ["First", "Second", "Third"].map((title, index) => ({
   data: {
     title,
     url: `https://example.com/${index + 1}`,
+    // The Clip cell holds an absolute app URL — possibly on a different
+    // origin than the one being viewed, which is why the drawer reduces it
+    // to a path rather than linking it verbatim.
+    clip: `https://app.example.test/p/0000000${index + 1}-0000-4000-8000-000000000000`,
     summary: `Summary ${index + 1}`,
     topics: index === 0 ? ["AI"] : [],
   },
@@ -194,7 +199,7 @@ describe("Bookmarks app", () => {
   it("opens an editable field drawer and saves changed row values", async () => {
     render(<AppView slug="bookmarks" />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "First" }));
+    fireEvent.click((await screen.findByText("First")).closest("tr")!);
     const title = screen.getByLabelText("Title");
     fireEvent.change(title, { target: { value: "Updated title" } });
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
@@ -209,7 +214,7 @@ describe("Bookmarks app", () => {
   it("keeps generated topics visible and editable", async () => {
     render(<AppView slug="bookmarks" />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "First" }));
+    fireEvent.click((await screen.findByText("First")).closest("tr")!);
     expect(screen.getAllByText("AI").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByTestId("add-topic"));
     fireEvent.change(screen.getByPlaceholderText("Add a topic…"), {
@@ -223,5 +228,41 @@ describe("Bookmarks app", () => {
         "Research",
       ])
     );
+  });
+
+  it("opens the drawer from anywhere in the row, not just the title", async () => {
+    render(<AppView slug="bookmarks" />);
+
+    // A non-title cell. The row highlights on hover across its whole width,
+    // so responding only on the title reads as a broken row.
+    const titleCell = (await screen.findByText("First")).closest("td")!;
+    const otherCell = titleCell.nextElementSibling as HTMLElement;
+    fireEvent.click(otherCell);
+
+    expect(await screen.findByTestId("app-detail")).toBeTruthy();
+  });
+
+  it("does not open the drawer when ticking the row's checkbox", async () => {
+    render(<AppView slug="bookmarks" />);
+
+    const row = (await screen.findByText("First")).closest("tr")!;
+    fireEvent.mouseDown(row.querySelector('input[type="checkbox"]')!);
+
+    expect(screen.getByText("1 selected")).toBeTruthy();
+    expect(screen.queryByTestId("app-detail")).toBeNull();
+  });
+
+  it("keeps links to the saved copy and the original in the drawer", async () => {
+    render(<AppView slug="bookmarks" />);
+
+    fireEvent.click((await screen.findByText("First")).closest("tr")!);
+
+    // The two things a bookmark is for. A drawer that can edit fields but
+    // can't reach either is a spreadsheet cell with extra steps.
+    const links = within(screen.getByTestId("detail-links")).getAllByRole("link");
+    const hrefs = links.map((link) => link.getAttribute("href"));
+    expect(hrefs).toContain("https://example.com/1");
+    expect(hrefs.some((href) => href?.startsWith("/p/"))).toBe(true);
+    expect(links.every((link) => link.getAttribute("target") === "_blank")).toBe(true);
   });
 });

--- a/frontend/src/components/apps/AppView.tsx
+++ b/frontend/src/components/apps/AppView.tsx
@@ -482,9 +482,19 @@ export default function AppView({ slug }: { slug: string }) {
                 {rows.map((row, index) => (
                   <tr
                     key={row.id}
-                    className={row.id === openRowId ? "bg-brand/5" : "hover:bg-raised/60"}
+                    // The whole row opens the detail pane, not just the title
+                    // cell — a row that highlights on hover but only responds
+                    // on one word reads as broken. The checkbox cell stops
+                    // propagation so selecting still works.
+                    onClick={() => setOpenRowId(row.id === openRowId ? null : row.id)}
+                    className={`cursor-pointer ${
+                      row.id === openRowId ? "bg-brand/5" : "hover:bg-raised/60"
+                    }`}
                   >
-                    <td className="border-b border-r border-border px-3 py-2">
+                    <td
+                      className="border-b border-r border-border px-3 py-2"
+                      onClick={(event) => event.stopPropagation()}
+                    >
                       <input
                         type="checkbox"
                         checked={selected.has(row.id)}
@@ -503,13 +513,9 @@ export default function AppView({ slug }: { slug: string }) {
                         className="border-b border-r border-border px-3 py-2 text-foreground last:border-r-0"
                       >
                         {column.id === manifest.detail.title ? (
-                          <button
-                            type="button"
-                            onClick={() => setOpenRowId(row.id === openRowId ? null : row.id)}
-                            className="block max-w-80 truncate text-left font-medium hover:text-brand"
-                          >
+                          <span className="block max-w-80 truncate font-medium">
                             {cellText(row, column.id) || "Untitled"}
-                          </button>
+                          </span>
                         ) : (
                           <CellValue row={row} column={column} />
                         )}


### PR DESCRIPTION
## Summary

Unblocks the hosted backend deploy, which has been failing since two PRs merged the same day. Also fixes the Instagram sync silently capping at ~210 saves, and restores the bookmark drawer's links.

## Changes

**The deploy is broken on `main` right now.** Two PRs each added a migration numbered `0174`, both parented on `0173`. `database.py` runs `alembic upgrade head` at boot, so the backend exits with status 3 on every deploy — prod has been sitting on **0.1.355** while main moved on. The only clue in the log is a `UserWarning: Revision 0174 is present more than once` before `==> Exited with status 3`.

- `0174_email_verifications` **keeps** its number — prod's database is already stamped at it, since it shipped in the last deploy that went live. `0174_protected_folders` → `0175`, `0175_bookmark_row_at_import` → `0176`, re-chained. An already-migrated database picks up from 0174; a fresh one walks the same chain.
- `test_migration_chain.py` asserts one head, no duplicate revision ids, and no dangling `down_revision`. It checks a property of the *directory*, because each PR's migrations were individually fine — only the merge was broken, which is why nothing caught it.

**Instagram was capping at ~210 saves.** `MAX_ITEMS = 200` in the content script stopped the walk after a dozen pages; the loop overshoots on the last page, which is where 210 comes from. A truncated harvest reported success identically to a complete one.

- The remaining bounds are runaway guards, not a cap on a real library, and hitting one now says so. A mid-walk HTTP failure reports how far it got.
- Added a pause between pages (Instagram rate-limits the saved feed — a 429 halfway would truncate just as quietly) and dedup by shortcode (the feed repeats posts across page boundaries when the list changes underneath it).

**Bookmark drawer.**
- Clicking anywhere in a row opens it, not just the title cell. The row already highlighted across its full width, so responding on one word read as broken. The checkbox cell stops propagation so selecting still works.
- The rewrite that made drawer fields editable dropped the links to the saved copy and the original — the two things a bookmark is for. Both are back, opening in a new tab. The archived copy is reduced to a path because the Clip cell stores an absolute URL that may not match the origin being browsed.

## Related issues

<!-- none -->

## Test plan

- [x] Existing tests pass — **1252 backend**, **273 frontend**. The 4 `test_activity.py` failures are pre-existing and unrelated.
- [x] New tests added — migration-chain guards (verified they error when the collision is reintroduced, pass when fixed); three frontend tests for row-click, checkbox-doesn't-open-drawer, and the drawer links.
- [x] Migration chain verified end to end: `alembic heads` reports a single `0176`, and a fresh database walks `0167 → 0176` with no duplicate-revision warning.
- [x] Extension typechecks and builds (`npm run typecheck`, `npm run build`).
- [x] Checked the failing deploy on Render directly — confirmed `update_failed` on the last two, `live` on 0.1.355, and read the boot log to find the cause.

## Checklist

- [x] No hardcoded secrets or credentials
- [ ] Documentation updated if behaviour changed
- [ ] CHANGELOG.md updated (for user-facing changes)

## Not in this PR

- **Instagram collections/lists are not captured at all.** The content script reads `/api/v1/feed/saved/posts/` (the all-saved feed), which does include posts that live in collections — but the collection each post belongs to is dropped. Capturing it means a second endpoint (`/api/v1/collections/list/` plus per-collection posts) and a place to put the membership. I did not build it because I can't verify Instagram's internal API against a live session from here, and shipping untested API integration seemed worse than reporting it.
- **Instagram/X UI parity.** The two already share the provider page, the connector list, and the source-doc renderer; the only code-level differences are the URL builder and the label. Whatever looks different is likely downstream of the data (X threads carry more text/media than an Instagram caption), so I'd want to know specifically what looks wrong before changing rendering.
- **Hydration failures.** The worker is throwing per-post `HTTPStatusError` from ScrapeCreators' transcript endpoint — expected for posts with no video, and non-fatal (the save still lands without a transcript), but worth confirming that's all it is.
