### PR TITLE
Instagram saves: keep the caption when media fails, and keep every carousel slide

### DIFF
--- a/backend/integrations/social_saves/indexer.py
+++ b/backend/integrations/social_saves/indexer.py
@@ -28,7 +28,12 @@ SC_TRANSCRIPT_URL = "https://api.scrapecreators.com/v2/instagram/media/transcrip
 
 # The transcript endpoint transcribes on demand (10-30s per reel).
 SC_TIMEOUT = 90
-MAX_MEDIA_BYTES = 50 * 1024 * 1024
+# Matches the X saves ceiling. 50 MB rejected ordinary reels, and because the
+# archive used to run before the document was written, an oversized video
+# discarded the caption and transcript along with it.
+MAX_MEDIA_BYTES = 100 * 1024 * 1024
+# A carousel holds up to 10 items.
+MAX_MEDIA_PER_POST = 10
 HYDRATION_BATCH = 25
 MAX_HYDRATION_ATTEMPTS = 3
 
@@ -93,8 +98,6 @@ async def _hydrate_one(
     if post["is_video"]:
         transcript = await _fetch_transcript(client, url)
 
-    media_key, media_content_type = await _archive_media(owner_user_id, shortcode, post)
-
     posted = post["posted_at"]
     parts = [
         f"# @{post['username']} — Instagram save",
@@ -119,14 +122,29 @@ async def _hydrate_one(
         external_ref=shortcode,
         external_updated_at=posted,
     )
+    # The document is written before any media is fetched, and archiving is
+    # best-effort from here. The caption and transcript are the part worth
+    # keeping and they are already in hand; losing them because a video was
+    # oversized or its CDN URL had expired is the wrong trade. A media failure
+    # is recorded on the row rather than swallowed.
+    media: list[dict] = []
+    media_error: str | None = None
+    try:
+        media = await _archive_media(owner_user_id, shortcode, _media_items(post))
+    except Exception as e:  # noqa: BLE001 — recorded below, never fatal to the save
+        media_error = f"media archive failed: {e}"
+        logger.warning("instagram media archive failed shortcode=%s error=%s", shortcode, e)
+
     await get_pool().execute(
-        "UPDATE instagram_save_docs SET media_storage_key = $3, media_content_type = $4, "
-        "hydration_status = 'done', hydration_error = NULL, updated_at = now() "
+        # The pool registers a jsonb codec, so the list goes across as-is —
+        # json.dumps here would double-encode it into a JSON string.
+        "UPDATE instagram_save_docs SET media = $3, "
+        "hydration_status = 'done', hydration_error = $4, updated_at = now() "
         "WHERE source_id = $1 AND path = $2",
         source_id,
         shortcode,
-        media_key,
-        media_content_type,
+        media,
+        media_error,
     )
 
 
@@ -141,8 +159,31 @@ async def _fetch_post(client: httpx.AsyncClient, url: str) -> dict:
         "caption": caption,
         "posted_at": datetime.fromtimestamp(media["taken_at_timestamp"], UTC),
         "is_video": bool(media.get("is_video")),
-        "media_url": media.get("video_url") or media.get("display_url"),
+        # Kept whole so _media_items can walk a carousel's children; the
+        # top-level video_url/display_url only describes the first slide.
+        "node": media,
     }
+
+
+def _media_items(post: dict) -> list[dict]:
+    """[{url, is_video}] for every image or video on the post.
+
+    A carousel puts its slides under `edge_sidecar_to_children`, and the
+    post's own `display_url` is just the first of them. Reading only the top
+    level archived slide one and silently dropped the other nine.
+    """
+
+    def _one(node: dict) -> dict | None:
+        url = node.get("video_url") or node.get("display_url")
+        return {"url": url, "is_video": bool(node.get("is_video"))} if url else None
+
+    node = post["node"]
+    children = (node.get("edge_sidecar_to_children") or {}).get("edges") or []
+    if children:
+        items = [_one(edge["node"]) for edge in children if edge.get("node")]
+    else:
+        items = [_one(node)]
+    return [item for item in items if item][:MAX_MEDIA_PER_POST]
 
 
 async def _fetch_transcript(client: httpx.AsyncClient, url: str) -> str:
@@ -156,26 +197,43 @@ async def _fetch_transcript(client: httpx.AsyncClient, url: str) -> str:
     return " ".join(t["text"] for t in (payload.get("transcripts") or []) if t.get("text")).strip()
 
 
-async def _archive_media(owner_user_id: UUID, shortcode: str, post: dict) -> tuple[str, str]:
-    """Download the post's video/image from Instagram's CDN (the signed URL
-    ScrapeCreators just returned is fresh) into object storage."""
-    media_url = post["media_url"]
-    if not media_url:
-        raise ValueError("Post has no media URL")
+async def _archive_media(owner_user_id: UUID, shortcode: str, items: list[dict]) -> list[dict]:
+    """Download each image/video from Instagram's CDN (the signed URLs
+    ScrapeCreators just returned are fresh) into object storage.
+
+    Returns [{storage_key, content_type}] — the same shape X saves use.
+    Streamed with the cap enforced *while* downloading, because buffering a
+    long 1080p video just to measure it is what OOM-killed the X worker.
+    An oversized item is skipped so the rest of a carousel still archives.
+    """
+    stored: list[dict] = []
+    if not items:
+        return stored
     async with httpx.AsyncClient(timeout=60, follow_redirects=True) as media_client:
-        response = await media_client.get(media_url)
-        response.raise_for_status()
-        content = response.content
-        if len(content) > MAX_MEDIA_BYTES:
-            raise ValueError(f"Media larger than {MAX_MEDIA_BYTES} bytes")
-        content_type = response.headers.get(
-            "content-type", "video/mp4" if post["is_video"] else "image/jpeg"
-        )
-    extension = "mp4" if post["is_video"] else "jpg"
-    storage_key = await storage_service.upload_file(
-        str(owner_user_id),
-        f"instagram-{shortcode}.{extension}",
-        content,
-        content_type,
-    )
-    return storage_key, content_type
+        for index, item in enumerate(items):
+            async with media_client.stream("GET", item["url"]) as response:
+                response.raise_for_status()
+                declared = response.headers.get("content-length")
+                if declared is not None and int(declared) > MAX_MEDIA_BYTES:
+                    continue
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes(64 * 1024):
+                    total += len(chunk)
+                    if total > MAX_MEDIA_BYTES:
+                        break
+                    chunks.append(chunk)
+                if total > MAX_MEDIA_BYTES:
+                    continue
+                content_type = response.headers.get(
+                    "content-type", "video/mp4" if item["is_video"] else "image/jpeg"
+                )
+            extension = "mp4" if item["is_video"] else "jpg"
+            storage_key = await storage_service.upload_file(
+                str(owner_user_id),
+                f"instagram-{shortcode}-{index}.{extension}",
+                b"".join(chunks),
+                content_type,
+            )
+            stored.append({"storage_key": storage_key, "content_type": content_type})
+    return stored

--- a/backend/migrations/versions/0177_instagram_media_array.py
+++ b/backend/migrations/versions/0177_instagram_media_array.py
@@ -1,0 +1,60 @@
+"""Instagram saves carry a media array, like X saves already do.
+
+A carousel post has up to ten images or videos; the single
+`media_storage_key` column could hold one, so the other nine were dropped
+silently. X solved this already — `x_save_docs.media` is a JSONB array of
+`{storage_key, content_type}` — so Instagram adopts the same shape rather
+than growing a second one.
+
+The two scalar columns are migrated into the array and then dropped: one
+column, one reader, no dual path. Rows whose media never archived get `[]`,
+which is what "no media stored" already meant.
+"""
+
+from alembic import op
+
+revision = "0177"
+down_revision = "0176"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE instagram_save_docs "
+        "ADD COLUMN IF NOT EXISTS media JSONB NOT NULL DEFAULT '[]'::jsonb"
+    )
+    op.execute(
+        """
+        UPDATE instagram_save_docs
+        SET media = jsonb_build_array(
+            jsonb_build_object(
+                'storage_key', media_storage_key,
+                'content_type', COALESCE(media_content_type, 'application/octet-stream')
+            )
+        )
+        WHERE media_storage_key IS NOT NULL AND media = '[]'::jsonb
+        """
+    )
+    op.execute(
+        "ALTER TABLE instagram_save_docs "
+        "DROP COLUMN IF EXISTS media_storage_key, "
+        "DROP COLUMN IF EXISTS media_content_type"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE instagram_save_docs "
+        "ADD COLUMN IF NOT EXISTS media_storage_key TEXT, "
+        "ADD COLUMN IF NOT EXISTS media_content_type TEXT"
+    )
+    op.execute(
+        """
+        UPDATE instagram_save_docs
+        SET media_storage_key = media->0->>'storage_key',
+            media_content_type = media->0->>'content_type'
+        WHERE jsonb_array_length(media) > 0
+        """
+    )
+    op.execute("ALTER TABLE instagram_save_docs DROP COLUMN IF EXISTS media")

--- a/backend/services/feed_service.py
+++ b/backend/services/feed_service.py
@@ -108,7 +108,7 @@ async def _resurface_items(user_id: UUID, cursor: int) -> list[dict]:
               AND created_at < now() - interval '{RESURFACE_MIN_AGE_DAYS} days'
             UNION ALL
             SELECT 'instagram', id::text, name, content,
-                   created_at, external_ref, media_storage_key
+                   created_at, external_ref, media->0->>'storage_key'
             FROM instagram_save_docs
             WHERE owner_user_id = $1 AND hydration_status = 'done'
               AND deleted_at IS NULL AND content IS NOT NULL

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -439,12 +439,15 @@ async def _cleanup_source_data(source_ids: list[UUID]) -> None:
         for item in row["media"]:
             await storage_service.delete_file(item["storage_key"])
     ig_rows = await pool.fetch(
-        "SELECT media_storage_key FROM instagram_save_docs "
-        "WHERE source_id = ANY($1::uuid[]) AND media_storage_key IS NOT NULL",
+        "SELECT media FROM instagram_save_docs "
+        "WHERE source_id = ANY($1::uuid[]) AND media <> '[]'::jsonb",
         source_ids,
     )
     for row in ig_rows:
-        await storage_service.delete_file(row["media_storage_key"])
+        # A carousel stores one blob per slide, so disconnecting has to walk
+        # the array or it orphans every slide but the first.
+        for item in row["media"]:
+            await storage_service.delete_file(item["storage_key"])
     await pool.execute(
         "DELETE FROM shares WHERE object_type = 'source' AND object_id = ANY($1::uuid[])",
         source_ids,
@@ -1324,8 +1327,8 @@ async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
     from . import storage_service
 
     row = await get_pool().fetchrow(
-        "SELECT path, name, kind, content, external_ref, media_storage_key, "
-        "media_content_type, hydration_status, hydration_error "
+        "SELECT path, name, kind, content, external_ref, media, "
+        "hydration_status, hydration_error "
         "FROM instagram_save_docs WHERE source_id = $1 AND path = $2 AND deleted_at IS NULL",
         source_id,
         path,
@@ -1348,9 +1351,17 @@ async def _read_instagram_save(source_id: UUID, path: str) -> dict | None:
         "content": row["content"],
         "external_ref": row["external_ref"],
     }
-    if row["media_storage_key"]:
-        doc["media_url"] = await storage_service.get_file_url(row["media_storage_key"])
-        doc["media_content_type"] = row["media_content_type"]
+    # Same shape as a saved tweet: a carousel is many slides, so the reader
+    # returns a list rather than a single media_url.
+    media = row["media"] or []
+    if media:
+        doc["media"] = [
+            {
+                "url": await storage_service.get_file_url(m["storage_key"]),
+                "content_type": m.get("content_type"),
+            }
+            for m in media
+        ]
     return doc
 
 

--- a/backend/tests/test_instagram_saves.py
+++ b/backend/tests/test_instagram_saves.py
@@ -51,10 +51,33 @@ class _FakeResponse:
         return self._payload
 
 
+class _FakeStream:
+    """Media is downloaded with `stream()` so the size cap can hold while the
+    bytes arrive, rather than after buffering a whole video."""
+
+    def __init__(self, content: bytes, content_type: str = "video/mp4"):
+        self._content = content
+        self.headers = {"content-type": content_type, "content-length": str(len(content))}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self, chunk_size=65536):
+        for start in range(0, len(self._content), chunk_size):
+            yield self._content[start : start + chunk_size]
+
+
 class _FakeScrapeCreators:
-    """Answers the SC post + transcript endpoints and the CDN media URL."""
+    """Answers the SC post + transcript endpoints and the CDN media URLs."""
 
     media_bytes = b"fake video bytes"
+    post_payload = _POST_PAYLOAD
 
     def __init__(self, **kwargs):
         pass
@@ -67,12 +90,15 @@ class _FakeScrapeCreators:
 
     async def get(self, url, params=None):
         if url == ig_indexer.SC_POST_URL:
-            return _FakeResponse(payload=_POST_PAYLOAD)
+            return _FakeResponse(payload=type(self).post_payload)
         if url == ig_indexer.SC_TRANSCRIPT_URL:
             return _FakeResponse(payload=_TRANSCRIPT_PAYLOAD)
-        if url == "https://cdn.example/reel.mp4":
-            return _FakeResponse(content=type(self).media_bytes)
         raise AssertionError(f"unexpected URL {url}")
+
+    def stream(self, method, url):
+        if url.startswith("https://cdn.example/"):
+            return _FakeStream(type(self).media_bytes)
+        raise AssertionError(f"unexpected media URL {url}")
 
 
 @pytest.fixture
@@ -281,17 +307,24 @@ async def test_indexer_hydrates_content_transcript_and_media(
     assert row["name"] == "@chefkim - 2025-07-01"
     assert "60-second focaccia" in row["content"]
     assert "mix the flour and water" in row["content"]
-    assert row["media_storage_key"] == "store/instagram-ABC123xyz.mp4"
-    assert row["media_content_type"] == "video/mp4"
+    assert row["media"] == [
+        {"storage_key": "store/instagram-ABC123xyz-0.mp4", "content_type": "video/mp4"}
+    ]
     assert row["embed_stale"] is True
-    assert fake_hydration == [("instagram-ABC123xyz.mp4", "video/mp4")]
+    assert fake_hydration == [("instagram-ABC123xyz-0.mp4", "video/mp4")]
     assert row["external_updated_at"] == datetime.fromtimestamp(1751371200, UTC)
 
-    # The doc read serves a fresh presigned media URL.
+    # The doc read serves fresh presigned media URLs.
     ok, doc = await source_service.source_document(
         UUID(owner_id), UUID(owner_id), str(source["id"]), "ABC123xyz"
     )
-    assert ok and doc["media_url"] == "https://blob.example/store/instagram-ABC123xyz.mp4"
+    assert ok
+    assert doc["media"] == [
+        {
+            "url": "https://blob.example/store/instagram-ABC123xyz-0.mp4",
+            "content_type": "video/mp4",
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -336,3 +369,149 @@ async def test_hydration_failure_lands_on_the_row(
     assert ok and doc["http_status"] == 422
     assert "couldn't be archived" in doc["error"]
     assert "scrapecreators exploded" not in doc["error"]
+
+
+_CAROUSEL_PAYLOAD = {
+    "data": {
+        "xdt_shortcode_media": {
+            "owner": {"username": "chefkim"},
+            "edge_media_to_caption": {"edges": [{"node": {"text": "three ways with dough"}}]},
+            "taken_at_timestamp": 1751371200,
+            "is_video": False,
+            "display_url": "https://cdn.example/slide-1.jpg",
+            "edge_sidecar_to_children": {
+                "edges": [
+                    {"node": {"is_video": False, "display_url": "https://cdn.example/slide-1.jpg"}},
+                    {"node": {"is_video": False, "display_url": "https://cdn.example/slide-2.jpg"}},
+                    {
+                        "node": {
+                            "is_video": True,
+                            "video_url": "https://cdn.example/slide-3.mp4",
+                            "display_url": "https://cdn.example/slide-3.jpg",
+                        }
+                    },
+                ]
+            },
+        }
+    }
+}
+
+
+def test_carousel_yields_every_slide():
+    """A carousel's slides live under edge_sidecar_to_children; the post's own
+    display_url is only the first. Reading the top level archived one image
+    and silently dropped the rest."""
+    post = {"node": _CAROUSEL_PAYLOAD["data"]["xdt_shortcode_media"]}
+
+    items = ig_indexer._media_items(post)
+
+    assert [item["url"] for item in items] == [
+        "https://cdn.example/slide-1.jpg",
+        "https://cdn.example/slide-2.jpg",
+        "https://cdn.example/slide-3.mp4",
+    ]
+    # The video slide keeps its video URL, not its poster frame.
+    assert [item["is_video"] for item in items] == [False, False, True]
+
+
+def test_single_post_still_yields_its_one_item():
+    post = {"node": _POST_PAYLOAD["data"]["xdt_shortcode_media"]}
+    assert ig_indexer._media_items(post) == [
+        {"url": "https://cdn.example/reel.mp4", "is_video": True}
+    ]
+
+
+async def test_carousel_archives_every_slide(
+    client: AsyncClient, pool, fake_hydration, monkeypatch
+):
+    monkeypatch.setattr(_FakeScrapeCreators, "post_payload", _CAROUSEL_PAYLOAD)
+    headers, owner_id = await _register(client)
+    await client.post(
+        "/api/v1/me/saved-items",
+        json={"platform": "instagram", "items": [{"url": "https://www.instagram.com/p/CARO123/"}]},
+        headers=headers,
+    )
+    source = await pool.fetchrow(
+        "SELECT id FROM user_sources WHERE owner_user_id = $1 AND source_type = 'instagram_saves'",
+        UUID(owner_id),
+    )
+    await ig_indexer.index_instagram_saves(await source_service.get_source_for_sync(source["id"]))
+
+    row = await pool.fetchrow(
+        "SELECT media, hydration_status FROM instagram_save_docs WHERE source_id = $1", source["id"]
+    )
+    assert row["hydration_status"] == "done"
+    assert [m["storage_key"] for m in row["media"]] == [
+        "store/instagram-CARO123-0.jpg",
+        "store/instagram-CARO123-1.jpg",
+        "store/instagram-CARO123-2.mp4",
+    ]
+
+
+async def test_media_failure_keeps_the_caption_and_transcript(
+    client: AsyncClient, pool, fake_hydration, monkeypatch
+):
+    """The archive used to run before the document was written, so an
+    oversized video or an expired CDN URL discarded the caption and
+    transcript too — the parts already fetched and worth keeping."""
+
+    async def _explode(*args, **kwargs):
+        raise RuntimeError("CDN url expired")
+
+    monkeypatch.setattr(ig_indexer, "_archive_media", _explode)
+    headers, owner_id = await _register(client)
+    await client.post(
+        "/api/v1/me/saved-items",
+        json={
+            "platform": "instagram",
+            "items": [{"url": "https://www.instagram.com/p/ABC123xyz/"}],
+        },
+        headers=headers,
+    )
+    source = await pool.fetchrow(
+        "SELECT id FROM user_sources WHERE owner_user_id = $1 AND source_type = 'instagram_saves'",
+        UUID(owner_id),
+    )
+    await ig_indexer.index_instagram_saves(await source_service.get_source_for_sync(source["id"]))
+
+    row = await pool.fetchrow(
+        "SELECT content, media, hydration_status, hydration_error "
+        "FROM instagram_save_docs WHERE source_id = $1",
+        source["id"],
+    )
+    assert row["hydration_status"] == "done"
+    assert "60-second focaccia" in row["content"], "the caption must survive a media failure"
+    assert "mix the flour and water" in row["content"]
+    assert row["media"] == []
+    # Recorded, not swallowed.
+    assert "CDN url expired" in row["hydration_error"]
+
+
+async def test_oversized_media_is_skipped_without_losing_the_save(
+    client: AsyncClient, pool, fake_hydration, monkeypatch
+):
+    """The cap holds while streaming, and one oversized blob skips itself
+    rather than failing the post."""
+    monkeypatch.setattr(ig_indexer, "MAX_MEDIA_BYTES", 4)
+    headers, owner_id = await _register(client)
+    await client.post(
+        "/api/v1/me/saved-items",
+        json={
+            "platform": "instagram",
+            "items": [{"url": "https://www.instagram.com/p/ABC123xyz/"}],
+        },
+        headers=headers,
+    )
+    source = await pool.fetchrow(
+        "SELECT id FROM user_sources WHERE owner_user_id = $1 AND source_type = 'instagram_saves'",
+        UUID(owner_id),
+    )
+    await ig_indexer.index_instagram_saves(await source_service.get_source_for_sync(source["id"]))
+
+    row = await pool.fetchrow(
+        "SELECT content, media, hydration_status FROM instagram_save_docs WHERE source_id = $1",
+        source["id"],
+    )
+    assert row["hydration_status"] == "done"
+    assert row["media"] == []
+    assert "60-second focaccia" in row["content"]

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -952,11 +952,10 @@ function DocViewer({
         if (cancelled) return;
         setContent(doc.content ?? "");
         setUrl(doc.url ?? null);
-        // X carries up to 4 media items (media[]); Instagram a single blob.
+        // Both X and Instagram carry a media array now — a tweet's up-to-four
+        // attachments and a carousel's up-to-ten slides render the same way.
         if (doc.media?.length) {
           setMedia(doc.media.map((m) => ({ url: m.url, contentType: m.content_type ?? "" })));
-        } else if (doc.media_url) {
-          setMedia([{ url: doc.media_url, contentType: doc.media_content_type ?? "" }]);
         }
         if (doc.name) setTitle(doc.name);
       })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -398,10 +398,8 @@ export async function readSourceDoc(
   name?: string;
   content?: string;
   url?: string | null;
-  // Archived save media served via fresh presigned URLs. Instagram carries a
-  // single blob (media_url); X can carry up to 4 (media[]).
-  media_url?: string | null;
-  media_content_type?: string | null;
+  // Archived save media served via fresh presigned URLs — a tweet's
+  // attachments or a carousel's slides, same shape for both.
   media?: { url: string; content_type?: string | null }[] | null;
 }> {
   return apiFetch(`${ME}/sources/${source}/doc?ref=${encodeURIComponent(ref)}`);


### PR DESCRIPTION
## Summary

Three fixes to Instagram save hydration, all in the same few lines: a media failure no longer discards the caption, the size cap no longer rejects ordinary reels, and a carousel no longer loses nine of its ten slides.

## Changes

**A media failure used to discard the caption and transcript.** `_archive_media` ran at line 96, `upsert_content_document` at line 111 — so a video over the cap threw before the document was ever written, and the caption, transcript, author and date went with it. A long reel became a save with no content at all.

The document is now written first, and archiving is best-effort behind it. A failure is recorded on the row (`hydration_error`) rather than swallowed, and the save still lands with everything that was already fetched.

**The 50 MB cap rejected ordinary reels.** It matches the X ceiling (100 MB) now, and — like X — is enforced *while streaming* rather than after buffering the whole file. X learned that one by OOM-killing a celery worker on a long 1080p video. An oversized item skips itself so the rest of a carousel still archives.

**Carousels lost nine of ten slides.** A carousel's items live under `edge_sidecar_to_children`; the post's own `display_url` is just the first. `instagram_save_docs` now carries the same `media` JSONB array `x_save_docs` already had — migrated from the two scalar columns, which are then dropped. One shape, one reader.

That last change also deletes the client's `media_url` branch: both providers return the same array, so a tweet's attachments and a carousel's slides render through identical code. **That's a real step toward the Instagram/X UI parity we discussed** — the viewer no longer has a single-blob path for Instagram.

## Related issues

<!-- none -->

## Test plan

- [x] Existing tests pass — **1258 backend**, **273 frontend**. The 4 `test_activity.py` failures and one `page.test.tsx` type error are pre-existing on main; confirmed by stashing.
- [x] New tests added — five, covering: a carousel yielding every slide with the video slide keeping its video URL (not its poster); a single post still yielding one item; a carousel archiving all three blobs under distinct keys; **a media failure preserving the caption and transcript** with the error recorded; and an oversized blob skipping itself without failing the save.
- [x] Updated the existing hydration test for the array shape, and taught the test double to `stream()` since the archiver no longer buffers.
- [x] Migration applied locally; `instagram_save_docs.media` is `jsonb NOT NULL DEFAULT '[]'`, and every reader (`source_service` disconnect + doc read, `feed_service` resurface) moved across with no references to the old columns left outside migrations.

## Checklist

- [x] No hardcoded secrets or credentials
- [ ] Documentation updated if behaviour changed
- [ ] CHANGELOG.md updated (for user-facing changes)

## Worth knowing

- **Existing saves are not re-archived.** The migration carries the one stored blob per row into the array, but a carousel saved before this only ever had slide one downloaded — the rest are gone from our side and would need a re-hydration pass to recover. I did not add one, since it means re-fetching from ScrapeCreators for every existing save; say the word if it's worth the spend.
- **Collections are still not captured.** The all-saved feed includes posts that live in collections, but not which collection. Unchanged by this PR.
