### PR TITLE
Extension 0.5.1

### DIFF
--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stash Sync",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Saves webpages, PDFs, and your ChatGPT/Claude conversations to Stash.",
   "permissions": [
     "storage",

--- a/chrome_extension/package.json
+++ b/chrome_extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stash-chat-sync",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Chrome extension that clips webpages/PDFs and syncs ChatGPT and Claude.ai conversations into Stash",
   "scripts": {


### PR DESCRIPTION
Version bump for the Chrome Web Store submission that carries the Instagram saved-feed fix from #950.

The store rejects a resubmission at an existing version, so 0.5.0 could not be uploaded again. `package.json` moves with the manifest so the two don't drift.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run package` builds and zips; verified the bundle carries the new bounds (`MAX_ITEMS = 2e4`, `PAGE_LIMIT = 400`, `PAGE_DELAY_MS = 350`) and that the old 200 cap is gone
- [x] Zip contains 13 files, manifest reads 0.5.1, permissions unchanged