### PR TITLE
Reframe the reading page: find, remember, act — not just bookmarks

### DIFF
--- a/www/app/_components/SiteHeader.tsx
+++ b/www/app/_components/SiteHeader.tsx
@@ -71,12 +71,11 @@ function NavLink({
 const FOR_FIRMS = [
   ["Company Brain", "/company-brain", "All your tools as one agent-native source of truth"],
   ["Memory & Observability", "/memory", "Retrieval that doesn't miss, plus every agent session"],
-  ["For SMBs", "/smb", "Find the hours AI can give back"],
 ];
 
 const FOR_USERS = [
   ["AI-native Drive", "/drive", "Your files and folders, in a Drive your AI can read"],
-  ["Bookmark manager", "/bookmarks", "Clip pages and keep what's behind every link"],
+  ["Everything you've read", "/bookmarks", "Your reading, in one place your agent can act on"],
 ];
 
 // CSS-only dropdown (no client JS): opens on hover and on keyboard focus of

--- a/www/app/bookmarks/page.tsx
+++ b/www/app/bookmarks/page.tsx
@@ -6,10 +6,27 @@ import SiteHeader from "../_components/SiteHeader";
 import Texture from "../_components/Texture";
 
 export const metadata: Metadata = {
-  title: "A bookmark manager that read the bookmarks · Stash",
+  title: "Everything you've read, in one place your agent can use · Stash",
   description:
-    "Clip any page, import your whole bookmarks file, and sync your X bookmarks. Stash keeps the page itself — text, images, PDFs — so you can ask what it said months later.",
+    "Stash captures what you read — articles, bookmarks, X threads, PDFs, AI chats — and what you saved and never got to. So your agent can find it, remember it, and act on it.",
 };
+
+// The three things having your reading in one place actually buys you. This is
+// the spine of the page: capture is the mechanism, not the pitch.
+const VERBS = [
+  [
+    "Find it",
+    "“Which article had the bit about migration locks?” You read it, you can't name it, and search engines only know the open web. Stash answers from the thing you actually read, and links back to it.",
+  ],
+  [
+    "Remember it",
+    "You shouldn't have to remember that you read something in order to use it. Ask a question and what you read eight months ago comes back at the moment it's relevant — not when you happen to think of it.",
+  ],
+  [
+    "Act on it",
+    "Draft the reply, compare the two vendors, plan the trip — grounded in your own reading instead of a generic answer scraped off the web this morning.",
+  ],
+];
 
 const SAVES = [
   [
@@ -30,38 +47,6 @@ const SAVES = [
   ],
 ];
 
-const KEEPS = [
-  [
-    "It keeps the page, not the link",
-    "A saved link is a promise the site will still be up. Stash stores the whole text, the images, and the PDF, so a dead URL still has the article behind it.",
-  ],
-  [
-    "Ask, don't dig",
-    "Search by meaning, not title. Ask what you saved about a topic six months ago and get the answer with links back to the source.",
-  ],
-  [
-    "It organizes itself",
-    "Saved pages get titles, summaries, and tags on the way in. The pile stays browsable without you filing anything.",
-  ],
-  [
-    "Your AI reads it too",
-    "Everything you save lands in the same Drive your agents work from — so the answer comes from what you actually read, not from the open web.",
-  ],
-];
-
-function Shot({ src, caption }: { src: string; caption: string }) {
-  return (
-    <figure>
-      <img
-        src={src}
-        alt={caption}
-        className="w-full rounded-xl border border-border shadow-[var(--shadow-card)]"
-      />
-      <figcaption className="mt-3 text-[13.5px] leading-[1.55] text-dim">{caption}</figcaption>
-    </figure>
-  );
-}
-
 export default function BookmarksPage() {
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -78,16 +63,16 @@ export default function BookmarksPage() {
           }}
         />
         <div className="relative z-10 mx-auto max-w-[1200px] px-7">
-          <p className="kicker rise-in mb-6">Bookmark.manager</p>
+          <p className="kicker rise-in mb-6">Everything.you.read</p>
           <h1 className="max-w-[920px] text-balance font-display text-[clamp(40px,5.4vw,72px)] font-bold leading-[1.02] tracking-[-0.035em] text-ink">
-            A bookmark manager{" "}
-            <span className="text-brand">that read the bookmarks.</span>
+            Your agent should know{" "}
+            <span className="text-brand">everything you&apos;ve read.</span>
           </h1>
-          <p className="mt-7 max-w-[620px] text-[18px] leading-[1.55] text-foreground">
-            You save things all day — tabs, bookmarks, X threads — into places
-            you never look at again. Stash keeps the page itself, so months
-            later you can ask what it said instead of hoping the site is still
-            up.
+          <p className="mt-7 max-w-[640px] text-[18px] leading-[1.55] text-foreground">
+            You&apos;ve read thousands of articles, threads, and PDFs this year.
+            Your AI has read none of them. Stash captures what you read — and
+            the pile you saved and never got to — so your agent can find it,
+            remember it, and act on it.
           </p>
           <div className="mt-9">
             <CtaPair />
@@ -95,13 +80,47 @@ export default function BookmarksPage() {
         </div>
       </section>
 
-      <section className="border-b border-border-subtle py-16 md:py-20">
+      <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
         <div className="mx-auto max-w-[1200px] px-7">
-          <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-            <Shot
-              src="/screens/save-page.jpg"
-              caption="One click from the browser extension, on any page you're reading."
-            />
+          <h2 className="max-w-[760px] text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            Saving was never the point.
+          </h2>
+          <p className="mt-5 max-w-[620px] text-[16px] leading-[1.6] text-dim">
+            Every bookmark manager ends the story at &ldquo;saved.&rdquo; That&apos;s
+            where this one starts.
+          </p>
+          <div className="mt-12 grid grid-cols-1 gap-4 md:grid-cols-3">
+            {VERBS.map(([name, blurb]) => (
+              <div
+                key={name}
+                className="rounded-[12px] border border-border bg-background p-6 transition-colors hover:border-brand"
+              >
+                <div className="font-display text-[19px] font-bold tracking-[-0.01em] text-ink">
+                  {name}
+                </div>
+                <p className="mt-2 text-[14.5px] leading-[1.55] text-dim">{blurb}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border-subtle py-20 md:py-28">
+        <div className="mx-auto max-w-[1200px] px-7">
+          <div className="grid grid-cols-1 gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-16">
+            <div>
+              <p className="kicker">The.unread.pile</p>
+              <h2 className="mt-5 text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+                And the things you haven&apos;t read.
+              </h2>
+              <p className="mt-5 text-[16px] leading-[1.6] text-foreground">
+                The 200 links you saved and never opened are read on the way in
+                anyway — the whole page, not the title. So the pile stops being
+                a guilt trip and starts being a corpus: ask which of the forty
+                things you saved this month actually answer your question, and
+                skip the thirty-seven that don&apos;t.
+              </p>
+            </div>
             <Shot
               src="/screens/bookmarks-library.jpg"
               caption="Everything you've saved in one library — filterable, sortable, kept in full."
@@ -113,8 +132,12 @@ export default function BookmarksPage() {
       <section className="border-b border-border-subtle bg-surface py-20 md:py-28">
         <div className="mx-auto max-w-[1200px] px-7">
           <h2 className="max-w-[760px] text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
-            Saving to it takes one click. Usually zero.
+            Getting it in takes one click. Usually zero.
           </h2>
+          <p className="mt-5 max-w-[620px] text-[16px] leading-[1.6] text-dim">
+            A library only works if filling it is free. Nothing here asks you to
+            file, tag, or tidy.
+          </p>
           <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
             {SAVES.map(([name, blurb]) => (
               <div
@@ -128,27 +151,35 @@ export default function BookmarksPage() {
               </div>
             ))}
           </div>
+          <div className="mt-12 max-w-[900px]">
+            <Shot
+              src="/screens/save-page.jpg"
+              caption="One click from the browser extension, on any page you're reading."
+            />
+          </div>
         </div>
       </section>
 
       <section className="border-b border-border-subtle py-20 md:py-28">
         <div className="mx-auto max-w-[1200px] px-7">
-          <h2 className="max-w-[760px] text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
-            Then it does what a folder of links can&apos;t.
+          <p className="kicker">Not.a.notebook</p>
+          <h2 className="mt-5 max-w-[820px] text-balance font-display text-[clamp(28px,3.4vw,44px)] font-bold leading-[1.1] tracking-[-0.02em] text-ink">
+            A library that fills itself, not a notebook you fill by hand.
           </h2>
-          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {KEEPS.map(([name, blurb]) => (
-              <div
-                key={name}
-                className="rounded-[12px] border border-border bg-background p-5 transition-colors hover:border-brand"
-              >
-                <div className="font-display text-[17px] font-bold tracking-[-0.01em] text-ink">
-                  {name}
-                </div>
-                <p className="mt-1.5 text-[14px] leading-[1.55] text-dim">{blurb}</p>
-              </div>
-            ))}
-          </div>
+          <p className="mt-6 max-w-[680px] text-[16px] leading-[1.6] text-foreground">
+            Gemini Notebook — the tool formerly called NotebookLM — is grounded
+            in sources you hand it, one notebook at a time, capped at 50 sources
+            per notebook on the free plan, with no way to ask across notebooks.
+            That&apos;s a good way to study a stack of documents you&apos;ve
+            already gathered. It isn&apos;t a way to know everything you read
+            this year.
+          </p>
+          <p className="mt-4 max-w-[680px] text-[16px] leading-[1.6] text-foreground">
+            Stash collects in the background instead: one library with no
+            notebook walls around it, and a CLI, MCP server, and API so any
+            agent you already use — Claude, ChatGPT, Cursor — can read the whole
+            thing.
+          </p>
         </div>
       </section>
 
@@ -156,7 +187,7 @@ export default function BookmarksPage() {
         <Texture className="opacity-70" fade="center" />
         <div className="relative z-10 mx-auto max-w-[1200px] px-7">
           <h2 className="text-balance font-display text-[clamp(36px,4.6vw,64px)] font-bold leading-[1.0] tracking-[-0.035em] text-ink">
-            Stop saving things you&apos;ll never find again.
+            You did the reading. Get to keep it.
           </h2>
           <div className="mt-8 flex justify-center">
             <CtaPair align="center" />
@@ -170,5 +201,18 @@ export default function BookmarksPage() {
         </div>
       </section>
     </main>
+  );
+}
+
+function Shot({ src, caption }: { src: string; caption: string }) {
+  return (
+    <figure>
+      <img
+        src={src}
+        alt={caption}
+        className="w-full rounded-xl border border-border shadow-[var(--shadow-card)]"
+      />
+      <figcaption className="mt-3 text-[13.5px] leading-[1.55] text-dim">{caption}</figcaption>
+    </figure>
   );
 }


### PR DESCRIPTION
The page sold a bookmark manager. The interesting product is the one where **your agent knows everything you've read** — so it can find it, remember it, and act on it. Saving is the mechanism, not the pitch.

## What changed on `/bookmarks`

- **Hero**: "Your agent should know everything you've read." You've read thousands of articles this year; your AI has read none of them.
- **Find it / Remember it / Act on it** — the three things the library actually buys you, now the spine of the page.
- **"And the things you haven't read"** — the links you saved and never opened get read on the way in, so the unread pile becomes a corpus you can query instead of a guilt trip.
- **Capture** (clipper, bookmarks import, X, AI chats) demoted to a "getting it in takes one click, usually zero" section.
- **One comparison section**, factual and non-disparaging: Gemini Notebook (formerly NotebookLM) is grounded in sources you hand it, one notebook at a time, capped at 50 sources per notebook on the free plan, with no cross-notebook querying. Good for studying a stack you've already gathered; not a way to know everything you read this year.

## Also

Removed **For SMBs** from the For-firms menu. The `/smb` page stays live — ad traffic points at it — it's just out of the nav.

## Sourcing for the comparison claims

- Source/notebook caps: Google's own [Gemini Notebook plan limits](https://support.google.com/notebooklm/answer/16213268) — 50 sources/notebook Standard, up to 600 on Ultra
- Rename: [Google's announcement](https://blog.google/innovation-and-ai/products/gemini-notebook/notebooklm-gemini-notebook/), 16 July 2026, and [TechCrunch](https://techcrunch.com/2026/07/16/google-continues-its-renaming-streak-by-turning-notebooklm-to-gemini-notebook/)
- Notebook isolation / no API: [NotebookLM limits writeups](https://elephas.app/blog/notebooklm-source-limits) — third-party, so the page only claims what Google's docs also support

**If you'd rather not name a Google product on a landing page, cut the "Not.a.notebook" section — nothing else depends on it.**

## Verification

`npm run build` green in `www`; page and both nav menus rendered and eyeballed at 1440×950.