### PR TITLE
Extension 0.5.2: a sync switch per source

### DIFF
--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stash Sync",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Saves webpages, PDFs, and your ChatGPT/Claude conversations to Stash.",
   "permissions": [
     "storage",

--- a/chrome_extension/package-lock.json
+++ b/chrome_extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stash-chat-sync",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stash-chat-sync",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@mozilla/readability": "^0.6.0"
       },

--- a/chrome_extension/package.json
+++ b/chrome_extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stash-chat-sync",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "Chrome extension that clips webpages/PDFs and syncs ChatGPT and Claude.ai conversations into Stash",
   "scripts": {

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -4,7 +4,9 @@
   <meta charset="utf-8" />
   <style>
     body {
-      width: 320px;
+      /* Wide enough that a source row fits its name, status, Sync now, and
+         the switch on one line. */
+      width: 352px;
       margin: 0;
       padding: 16px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -120,6 +122,31 @@
       flex: none;
     }
     button.sync-now:disabled { opacity: 0.5; cursor: default; }
+    .source-row.off .source-name { color: #9ca3af; }
+    input.switch {
+      appearance: none;
+      width: 30px;
+      height: 18px;
+      flex: none;
+      margin: 0;
+      padding: 0;
+      border-radius: 9px;
+      background: #d1d5db;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    input.switch:checked { background: #F97316; }
+    input.switch::after {
+      content: '';
+      display: block;
+      width: 14px;
+      height: 14px;
+      margin: 2px;
+      border-radius: 50%;
+      background: white;
+      transition: transform 0.15s;
+    }
+    input.switch:checked::after { transform: translateX(12px); }
   </style>
 </head>
 <body>

--- a/chrome_extension/src/background.ts
+++ b/chrome_extension/src/background.ts
@@ -24,6 +24,7 @@ import {
   shouldFetchSaves,
 } from './background/instagram';
 import { platformStatus, syncNow } from './background/status';
+import { setSyncEnabled, isSyncEnabled } from './background/sync_settings';
 import type { ConversationSnapshot } from './content/sync';
 
 const DEFAULT_API_BASE = 'https://api.joinstash.ai';
@@ -80,6 +81,9 @@ async function handle(message: any, sender: chrome.runtime.MessageSender): Promi
       return platformStatus();
     case 'SYNC_NOW':
       return syncNow(message.platform);
+    case 'SET_SYNC_ENABLED':
+      await setSyncEnabled(message.platform, message.enabled);
+      return { ok: true };
     case 'CONNECT':
       return connect();
     case 'DISCONNECT':
@@ -106,6 +110,11 @@ async function handle(message: any, sender: chrome.runtime.MessageSender): Promi
 // ---------------------------------------------------------------------------
 
 async function syncConversation(snapshot: ConversationSnapshot): Promise<any> {
+  // The content scripts keep pushing from an open tab regardless; the switch
+  // is enforced here so turning ChatGPT or Claude off stops that too.
+  const platform = snapshot.platform === 'claude-web' ? 'claude' : 'chatgpt';
+  if (!(await isSyncEnabled(platform))) return { ok: true, skipped: true };
+
   const cfg = await chrome.storage.local.get(['apiBase', 'apiKey', 'folderId']);
   if (!cfg.apiKey) {
     await setBadge('!', 'Not connected to Stash — click to sign in');

--- a/chrome_extension/src/background/chat_poll.ts
+++ b/chrome_extension/src/background/chat_poll.ts
@@ -15,6 +15,7 @@ import {
 } from '../lib/chat_apis';
 import type { ConversationSnapshot } from '../content/sync';
 import { setBadge } from '../lib/stash';
+import { isSyncEnabled } from './sync_settings';
 
 const ALARM_NAME = 'chat-poll';
 const POLL_PERIOD_MINUTES = 24 * 60;
@@ -46,7 +47,10 @@ function schedule(): void {
 async function pollAll(): Promise<void> {
   const { apiKey } = await chrome.storage.local.get(['apiKey']);
   if (!apiKey) return;
-  const results = await Promise.all([syncChat('chatgpt'), syncChat('claude')]);
+  const results = [];
+  for (const platform of ['chatgpt', 'claude'] as ChatPlatform[]) {
+    if (await isSyncEnabled(platform)) results.push(await syncChat(platform));
+  }
   const errors = results.filter((r) => !r.ok);
   if (errors.length > 0) {
     // No notification — a logged-out site would nag daily. Badge + popup error.

--- a/chrome_extension/src/background/instagram.ts
+++ b/chrome_extension/src/background/instagram.ts
@@ -9,6 +9,7 @@
 
 import { clearSurfaceError, setSurfaceError } from '../lib/errors';
 import { setBadge, stashConfig } from '../lib/stash';
+import { isSyncEnabled } from './sync_settings';
 
 const VISIT_ALARM = 'instagram-saves-visit';
 const VISIT_TIMEOUT_ALARM = 'instagram-saves-visit-timeout';
@@ -30,6 +31,7 @@ function schedule(): void {
 export async function shouldFetchSaves(): Promise<any> {
   const { apiKey } = await chrome.storage.local.get(['apiKey']);
   if (!apiKey) return { fetch: false };
+  if (!(await isSyncEnabled('instagram'))) return { fetch: false };
   const { igFetchedAt } = await chrome.storage.local.get(['igFetchedAt']);
   return { fetch: !igFetchedAt || Date.now() - igFetchedAt > HARVEST_INTERVAL_MS };
 }

--- a/chrome_extension/src/background/status.ts
+++ b/chrome_extension/src/background/status.ts
@@ -1,16 +1,19 @@
 // Per-platform status + "Sync now" for the background pollers the popup shows:
 // ChatGPT, Claude, Instagram. "Connected" means the user is signed in to that
 // site (so a sync would actually work) — checked live via a session fetch
-// (chat) or the site's login cookie (Instagram). X is handled server-side over
-// OAuth now, so it isn't an extension platform.
+// (chat) or the site's login cookie (Instagram). "Enabled" is the user's own
+// switch for the platform. X is handled server-side over OAuth now, so it
+// isn't an extension platform.
 
 import { chatLastSyncAt, chatSignedIn, syncChat } from './chat_poll';
 import { instagramLastSyncAt, syncInstagramNow } from './instagram';
+import { PLATFORMS, type Platform, syncEnabled } from './sync_settings';
 
-export type Platform = 'chatgpt' | 'claude' | 'instagram';
+export type { Platform };
 
 export interface PlatformState {
   connected: boolean;
+  enabled: boolean;
   lastSyncAt: number | null;
 }
 
@@ -33,11 +36,14 @@ async function lastSyncAt(p: Platform): Promise<number | null> {
 }
 
 export async function platformStatus(): Promise<Record<Platform, PlatformState>> {
-  const platforms: Platform[] = ['chatgpt', 'claude', 'instagram'];
+  const enabled = await syncEnabled();
   const entries = await Promise.all(
-    platforms.map(
+    PLATFORMS.map(
       async (p) =>
-        [p, { connected: await connected(p), lastSyncAt: await lastSyncAt(p) }] as const
+        [
+          p,
+          { connected: await connected(p), enabled: enabled[p], lastSyncAt: await lastSyncAt(p) },
+        ] as const
     )
   );
   return Object.fromEntries(entries) as Record<Platform, PlatformState>;

--- a/chrome_extension/src/background/sync_settings.ts
+++ b/chrome_extension/src/background/sync_settings.ts
@@ -1,0 +1,32 @@
+// Per-platform sync switch, toggled from the popup.
+//
+// Every path that would send data for a platform checks this first — the
+// daily alarms, the content scripts pushing from an open tab, and the
+// popup's "Sync now" — so turning a source off actually stops it rather
+// than just hiding the button.
+
+export type Platform = 'chatgpt' | 'claude' | 'instagram';
+
+export const PLATFORMS: Platform[] = ['chatgpt', 'claude', 'instagram'];
+
+const KEY = 'syncEnabled';
+
+const DEFAULTS: Record<Platform, boolean> = { chatgpt: true, claude: true, instagram: true };
+
+/** The switch map, writing the defaults the first time anything asks for it.
+ * Every reader goes through here, so no caller has to know what an absent
+ * key means. */
+export async function syncEnabled(): Promise<Record<Platform, boolean>> {
+  const stored = await chrome.storage.local.get([KEY]);
+  if (stored[KEY]) return stored[KEY];
+  await chrome.storage.local.set({ [KEY]: DEFAULTS });
+  return DEFAULTS;
+}
+
+export async function isSyncEnabled(platform: Platform): Promise<boolean> {
+  return (await syncEnabled())[platform];
+}
+
+export async function setSyncEnabled(platform: Platform, on: boolean): Promise<void> {
+  await chrome.storage.local.set({ [KEY]: { ...(await syncEnabled()), [platform]: on } });
+}

--- a/chrome_extension/src/popup/popup.ts
+++ b/chrome_extension/src/popup/popup.ts
@@ -231,7 +231,8 @@ async function render(): Promise<void> {
 }
 
 // The background pollers: each shows whether you're signed in to the site and
-// when it last synced, with a Sync-now button.
+// when it last synced, with a switch that turns its syncing off entirely and
+// a Sync-now button.
 async function renderSources(): Promise<HTMLElement> {
   const section = el('div', { className: 'sources' }, [
     el('div', { className: 'section-label' }, ['Sources']),
@@ -239,17 +240,19 @@ async function renderSources(): Promise<HTMLElement> {
   const statuses = await send({ type: 'PLATFORM_STATUS' });
 
   for (const { key, label } of PLATFORMS) {
-    const s = statuses?.[key] || { connected: false, lastSyncAt: null };
-    const detail = !s.connected
-      ? 'Not connected — sign in on the site'
-      : s.lastSyncAt
-        ? `Synced ${timeAgo(s.lastSyncAt)}`
-        : 'Connected';
+    const s = statuses[key];
+    const detail = !s.enabled
+      ? 'Sync off'
+      : !s.connected
+        ? 'Not connected — sign in on the site'
+        : s.lastSyncAt
+          ? `Synced ${timeAgo(s.lastSyncAt)}`
+          : 'Connected';
 
     const syncBtn = el('button', {
       className: 'secondary sync-now',
       textContent: 'Sync now',
-      disabled: !s.connected,
+      disabled: !s.connected || !s.enabled,
       onclick: async () => {
         syncBtn.textContent = 'Syncing…';
         syncBtn.disabled = true;
@@ -258,14 +261,27 @@ async function renderSources(): Promise<HTMLElement> {
       },
     });
 
+    const toggle = el('input', {
+      type: 'checkbox',
+      className: 'switch',
+      checked: s.enabled,
+      title: `Sync ${label}`,
+      onchange: async () => {
+        await send({ type: 'SET_SYNC_ENABLED', platform: key, enabled: toggle.checked });
+        await render();
+      },
+    });
+    toggle.setAttribute('aria-label', `Sync ${label}`);
+
     section.append(
-      el('div', { className: 'source-row' }, [
-        el('span', { className: `dot ${s.connected ? 'on' : 'off'}` }),
+      el('div', { className: s.enabled ? 'source-row' : 'source-row off' }, [
+        el('span', { className: `dot ${s.enabled && s.connected ? 'on' : 'off'}` }),
         el('div', { className: 'source-meta' }, [
           el('div', { className: 'source-name' }, [label]),
           el('div', { className: 'source-detail muted' }, [detail]),
         ]),
         syncBtn,
+        toggle,
       ])
     );
   }


### PR DESCRIPTION
Each source in the popup — ChatGPT, Claude, Instagram — gets its own on/off switch. Before this, the only way to stop one of them was to disconnect the extension entirely or sign out of the site.

**Off is enforced in the background, not just hidden in the UI.** Every path that would send data for a platform checks the switch:

| Path | Behaviour when off |
| --- | --- |
| Daily chat alarm (`pollAll`) | platform skipped |
| Content script pushing from an open ChatGPT/Claude tab | `SYNC_CONVERSATION` dropped, returns `skipped` |
| Instagram harvest (`shouldFetchSaves`) and daily auto-visit | `{fetch: false}`, no tab opened |
| Sync now | button disabled |

The switch map lives in one module (`background/sync_settings.ts`) that writes its defaults the first time anything reads it, so no caller has to interpret an absent key.

Popup widens 320 → 352px so a source row still fits name, status, Sync now, and the switch on one line.

## QA (real, against a live local stack)

Loaded unpacked into Chrome, connected to a local backend as a seeded user:

- Toggle ChatGPT off → `syncEnabled` becomes `{chatgpt: false, …}`, row greys out and reads "Sync off", Sync now disabled
- With ChatGPT off, pushing a `SYNC_CONVERSATION` snapshot → `{ok: true, skipped: true}` and **no session in the database**
- Same push for Claude (still on) → uploaded, `claude-web-qa-on-1` present in `sessions`
- Instagram on → `SHOULD_FETCH_SAVES` returns `{fetch: true}`; off → `{fetch: false}`
- Settings survive a popup reload; re-enabling ChatGPT syncs again (`chatgpt-qa-on-2` lands)
- Clipping is unaffected — "Save this tab" still saved a page end to end

`npm run typecheck` clean.

## Version

0.5.1 → **0.5.2** (manifest, package.json, lockfile) since 0.5.1 is what's on the Web Store — a resubmission needs a higher version.