### PR TITLE
Make scheduled-agent skips legible: record last_run_outcome per tick

### DIFF
--- a/backend/migrations/versions/0174_agent_last_run_outcome.py
+++ b/backend/migrations/versions/0174_agent_last_run_outcome.py
@@ -1,0 +1,30 @@
+"""Record how each scheduled-agent tick resolved.
+
+mark_run consumes the cron tick up front (last_run_at), after which a run
+either executes, fails, or is skipped by one of three designed gates (credit
+allowance, missing credential, no changes since the watermark). Only failures
+left a trace (last_run_error), so from the outside a healthy skip was
+indistinguishable from a run that died mid-flight — the confusion behind the
+July 2026 "curator silently stopped" incident, and again on Aug 2 when a
+correct no-changes skip for an enterprise customer read as a silent death.
+
+last_run_outcome makes every tick legible: mark_run stamps 'started', which
+then resolves to 'ran', 'failed', or 'skipped_<reason>'. A row still at
+'started' means the run died without resolving — the stale-curator watchdog
+pages on that. NULL means no tick since this column shipped.
+"""
+
+from alembic import op
+
+revision = "0174"
+down_revision = "0173"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN last_run_outcome text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS last_run_outcome")

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -18,7 +18,7 @@ from ..database import get_pool
 _COLUMNS = (
     "id, user_id, name, model_provider, system_prompt, run_mode, "
     "schedule_cron, schedule_prompt, is_default, is_curator, slack_bound, "
-    "telegram_bound, last_run_at, last_run_error, curated_through, "
+    "telegram_bound, last_run_at, last_run_error, last_run_outcome, curated_through, "
     "month_run_count, month_run_anchor, created_at"
 )
 
@@ -263,12 +263,17 @@ async def mark_run(agent_id: UUID) -> int:
     the free-tier curator credit gate reads it.
 
     Also clears last_run_error, so after last_run_at advances the error state
-    is unambiguous: non-null means THIS run failed (clients poll on that)."""
+    is unambiguous: non-null means THIS run failed (clients poll on that).
+
+    Stamps last_run_outcome 'started'; the tick must then resolve it to 'ran',
+    'failed', or 'skipped_<reason>'. A row still at 'started' means the run
+    died mid-flight — the stale-curator watchdog pages on that."""
     return await get_pool().fetchval(
         """
         UPDATE agents SET
             last_run_at = now(),
             last_run_error = NULL,
+            last_run_outcome = 'started',
             month_run_count = CASE
                 WHEN month_run_anchor = date_trunc('month', now())::date
                 THEN month_run_count + 1 ELSE 1 END,
@@ -288,11 +293,32 @@ async def mark_run_failed(agent_id: UUID, error: str) -> None:
         """
         UPDATE agents SET
             last_run_error = left($2, 500),
+            last_run_outcome = 'failed',
             month_run_count = greatest(month_run_count - 1, 0)
         WHERE id = $1
         """,
         agent_id,
         error,
+    )
+
+
+async def mark_run_skipped(agent_id: UUID, reason: str) -> None:
+    """Resolve a consumed tick as a designed skip (credit allowance, missing
+    credential, no changes since the watermark) so it can't be mistaken for a
+    run that died mid-flight. Skips keep last_run_error NULL — they are not
+    failures, and the failure surfaces must stay quiet for them."""
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = $2 WHERE id = $1",
+        agent_id,
+        f"skipped_{reason}",
+    )
+
+
+async def mark_run_succeeded(agent_id: UUID) -> None:
+    """Resolve a consumed tick as a completed run."""
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'ran' WHERE id = $1",
+        agent_id,
     )
 
 

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -57,6 +57,7 @@ async def _run_curator_now(agent_id: UUID) -> None:
     except Exception as e:
         await agent_service.mark_run_failed(agent_id, str(e))
         raise
+    await agent_service.mark_run_succeeded(agent_id)
     through = await curation_service.complete_through(
         UUID(str(agent["user_id"])), agent["curated_through"], now
     )
@@ -94,21 +95,25 @@ async def _run_due() -> int:
                 logger.info(
                     "agent schedule: curator credits exhausted for user %s — skipping", user_id
                 )
+                await agent_service.mark_run_skipped(agent["id"], "credits")
                 continue
         # No runnable credential (unconnected free user) → nothing can run.
         try:
             await agent_auth.resolve(user_id, agent["model_provider"])
         except (agent_auth.NeedsAuth, agent_auth.ProviderNotConfigured):
             logger.info("agent schedule: no credential for agent %s — skipping", agent["id"])
+            await agent_service.mark_run_skipped(agent["id"], "no_credential")
             continue
         # Cost gate: skip the curator (and the sprite wake) when nothing changed
         # since its watermark. Idle users cost one EXISTS per day.
         if agent["is_curator"] and not await curation_service.has_changes_since(
             user_id, user_id, agent["curated_through"]
         ):
+            await agent_service.mark_run_skipped(agent["id"], "no_changes")
             continue
         try:
             await sprite_agent_service.run_scheduled(agent, stamp)
+            await agent_service.mark_run_succeeded(agent["id"])
             if agent["is_curator"]:
                 # `now` predates the run, so changes made during it stay ahead
                 # of the watermark and are picked up next time. If the delta
@@ -143,9 +148,11 @@ async def _alert_stale_curators() -> int:
     """Alert on curators whose watermark stopped advancing despite pending
     changes. Alerting on the stale *outcome* catches every cause — dead
     provider keys, harness bugs, a wedged beat — where per-run failure alerts
-    only catch runs that started. `last_run_error IS NOT NULL` scopes this to
-    curators whose last attempted run actually failed; curators skipped by
-    design (credit allowance, no credential) keep a NULL error and stay quiet.
+    only catch runs that started. Two shapes qualify: the last attempted run
+    failed (last_run_error), or it stamped 'started' and never resolved — a
+    run that died mid-flight without reaching the failure path. Curators
+    skipped by design (credit allowance, no credential, no changes) resolve
+    to 'skipped_<reason>' with a NULL error and stay quiet.
     """
     from ..database import get_pool
     from ..services import alert_service, curation_service
@@ -157,7 +164,7 @@ async def _alert_stale_curators() -> int:
         FROM agents a JOIN users u ON u.id = a.user_id
         WHERE a.is_curator AND a.run_mode = 'scheduled'
           AND a.curated_through IS NOT NULL AND a.curated_through < $1
-          AND a.last_run_error IS NOT NULL
+          AND (a.last_run_error IS NOT NULL OR a.last_run_outcome = 'started')
         """,
         cutoff,
     )
@@ -172,7 +179,7 @@ async def _alert_stale_curators() -> int:
         return 0
     lines = [
         f"- {r['email']}: last curated {r['curated_through']:%Y-%m-%d %H:%M} UTC "
-        f"({r['last_run_error'][:200]})"
+        f"({(r['last_run_error'] or 'run died mid-flight — started, never resolved')[:200]})"
         for r in stale
     ]
     await alert_service.send_alert(

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -69,10 +69,14 @@ async def test_stale_failing_curator_alerts(client: AsyncClient, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_skipped_by_design_curator_stays_quiet(client: AsyncClient, monkeypatch):
-    # Curators skipped on purpose (credit allowance, no credential) never run,
-    # so their error stays NULL — a stalled watermark there is not a failure.
+    # Curators skipped on purpose (credit allowance, no credential, no
+    # changes) resolve to 'skipped_<reason>' with a NULL error — a stalled
+    # watermark there is not a failure.
     user_id = await _register(client)
-    await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'skipped_no_changes' WHERE id = $1", agent["id"]
+    )
     await memory_service.push_event(
         user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
     )
@@ -80,6 +84,26 @@ async def test_skipped_by_design_curator_stays_quiet(client: AsyncClient, monkey
 
     assert await agent_schedules._alert_stale_curators() == 0
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_stale_curator_died_mid_run_alerts(client: AsyncClient, monkeypatch):
+    # A run that stamps 'started' and never resolves died mid-flight — no
+    # last_run_error exists, which is exactly why the watchdog must not key
+    # off the error alone (the July 2026 silent-stop shape).
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'started' WHERE id = $1", agent["id"]
+    )
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 1
+    assert len(sent) == 1
+    assert "died mid-flight" in sent[0]
 
 
 @pytest.mark.asyncio
@@ -138,7 +162,43 @@ async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
     assert "Scheduled agent run failed" in sent[0] and "opencode error" in sent[0]
     # The failure is also stored on the agent, which is what the stale-curator
     # watchdog keys off — the two alert paths must stay connected.
-    error = await get_pool().fetchval(
-        "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
+    row = await get_pool().fetchrow(
+        "SELECT last_run_error, last_run_outcome FROM agents WHERE id = $1", agent["id"]
     )
-    assert error is not None and "opencode error" in error
+    assert row["last_run_error"] is not None and "opencode error" in row["last_run_error"]
+    assert row["last_run_outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_run_due_records_skip_outcome(client: AsyncClient, monkeypatch):
+    from backend.services import agent_auth, curation_service, sprite_agent_service
+
+    # A due curator with nothing to curate: the cost gate skips the run, and
+    # the consumed tick must resolve to a legible skip — not linger at
+    # 'started', where it reads as a run that died mid-flight.
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=1, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET schedule_cron = '* * * * *', last_run_at = $2 WHERE id = $1",
+        agent["id"],
+        datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+    async def fake_resolve(user_id, prefer_provider=None):
+        return None
+
+    async def no_changes(owner_user_id, user_id, since):
+        return False
+
+    async def must_not_run(agent, stamp):
+        raise AssertionError("run_scheduled must not fire when the cost gate skips")
+
+    monkeypatch.setattr(agent_auth, "resolve", fake_resolve)
+    monkeypatch.setattr(curation_service, "has_changes_since", no_changes)
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", must_not_run)
+
+    assert await agent_schedules._run_due() == 0
+    outcome = await get_pool().fetchval(
+        "SELECT last_run_outcome FROM agents WHERE id = $1", agent["id"]
+    )
+    assert outcome == "skipped_no_changes"


### PR DESCRIPTION
This is a small change to our logging- we explicitly log the performance of our nightly curator agent so we can continuously monitor the health of our system.


# Slop
## Why

The nightly curator's beat task consumes the cron tick up front (`mark_run` stamps `last_run_at`), after which a run either executes, fails, or is skipped by one of three designed gates: credit allowance, missing credential, or the no-changes cost gate. Only failures left a trace (`last_run_error`), so from the database a healthy skip was indistinguishable from a run that died mid-flight.

This has now caused two false alarms for the same customer: the July "curator silently stopped" incident, and Aug 2, when Heavi's curator stamped `last_run_at` and then went dark — hours of diagnosis later, it turned out to be the no-changes gate correctly skipping an idle weekend account.

Worse, the stale-curator watchdog keyed off `last_run_error IS NOT NULL` — precisely the field a mid-flight death never sets — so the one failure shape with no other trace was also the one the watchdog couldn't see.

## What

- **Migration 0174**: `agents.last_run_outcome text`.
- `mark_run` stamps `'started'`; the tick must then resolve it:
  - `mark_run_succeeded` → `'ran'`
  - `mark_run_failed` → `'failed'` (alongside the existing error text)
  - new `mark_run_skipped` → `'skipped_credits' | 'skipped_no_credential' | 'skipped_no_changes'`
  - a row stuck at `'started'` now means exactly one thing: the run died without resolving.
- All three skip gates in `_run_due` record their reason; the beat path and the manual-run path (`_run_curator_now`) both record success.
- `alert_stale_curators` now also pages on `last_run_outcome = 'started'` (stale watermark + pending changes + a tick that began and never resolved). Designed skips stay quiet, as before.

No metering changes: skips still consume the month credit exactly as they did.

## Tests

- New: silent-death shape alerts (`'started'`, no error); designed skip stays quiet; `_run_due` records `skipped_no_changes` (with `run_scheduled` rigged to fail loudly if the gate leaks).
- Extended: the run-failure test asserts `outcome='failed'`.
- Full backend suite: **1223 passed**, coverage 80.32%, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)