### PR TITLE
PDF extraction via Gemini 3 Flash: markdown tables, figure descriptions, every PDF

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -340,6 +340,10 @@ class Settings:
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
     ANTHROPIC_FAST_MODEL: str = os.getenv("ANTHROPIC_FAST_MODEL", "claude-haiku-4-5")
 
+    # --- LLM (Gemini) — PDF vision transcription (services/pdf_ocr.py) ---
+    GEMINI_API_KEY: str | None = os.getenv("GEMINI_API_KEY")
+    GEMINI_EXTRACTION_MODEL: str = os.getenv("GEMINI_EXTRACTION_MODEL", "gemini-3-flash-preview")
+
     # --- Managed model keys (server-owned, for the cloud agent on paid tiers) ---
     # Each harness's default provider reads its key from here. A run on a paid
     # account is billed to us via these keys; free accounts are gated (until

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -346,7 +346,7 @@ async def extract_drive_text(
     - Google Doc       → markdown export
     - Google Sheet     → XLSX export, rendered as one TSV block per sheet
     - Google Slides    → text/plain export
-    - PDF              → with `transcribe_pdfs`, Claude vision grounded by the
+    - PDF              → with `transcribe_pdfs`, Gemini vision grounded by the
                          embedded text layer (structure from the page images,
                          characters from the layer; a scan just has no layer);
                          without it, the raw pypdf text layer

--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -1,20 +1,26 @@
-"""PDF transcription via Claude vision, grounded by the embedded text layer.
+"""PDF transcription via Gemini vision, grounded by the embedded text layer.
 
 pypdf reads a PDF's embedded text layer: exact characters, unreliable
 layout — a three-column parts table comes out as one undifferentiated
-stream. Claude vision reads the page images: reliable layout, but a
+stream. Vision reads the page images: reliable layout, but a
 transcribed character can be wrong, and a misread digit in a part
 number ships the wrong part. So each request carries both. The model
 is instructed to take structure from the images and characters from
 the text layer; a scanned PDF simply has no layer to attach and the
 same call degrades to pure OCR.
 
-Pages go up in chunks of PAGES_PER_REQUEST to the configured fast-tier
-model (`ANTHROPIC_FAST_MODEL`), at most OCR_CONCURRENCY chunks in
-flight at once, with vision capped at MAX_VISION_PAGES so one giant
-catalog can't burn unbounded API spend. Pages past the cap contribute
-their raw text layer under an explicit marker — the cap bounds spend,
-it must not discard text that pypdf reads for free.
+The model is `GEMINI_EXTRACTION_MODEL` (Gemini 3 Flash), picked by the
+Jul 2026 extraction benchmark on real truck-parts catalogs: it tied the
+frontier Claude models at 37/47 gold table rows with perfect digit
+fidelity, at fast-tier cost. Output is markdown — tables as markdown
+tables, figures described in place — so table structure and diagram
+content survive into the knowledge base.
+
+Pages go up in chunks of PAGES_PER_REQUEST, at most OCR_CONCURRENCY
+chunks in flight at once, with vision capped at MAX_VISION_PAGES so one
+giant catalog can't burn unbounded API spend. Pages past the cap
+contribute their raw text layer under an explicit marker — the cap
+bounds spend, it must not discard text that pypdf reads for free.
 
 Chunk slices are built lazily, one per in-flight request: the whole
 document held simultaneously as slices plus their base64 copies is what
@@ -32,8 +38,8 @@ import asyncio
 import base64
 import io
 
+import httpx
 import pypdf
-from anthropic import AsyncAnthropic
 
 from ..config import settings
 from .file_extraction import extract_text
@@ -47,11 +53,18 @@ MAX_OUTPUT_TOKENS = 16000
 # attempts on real customer catalogs.
 REQUEST_TIMEOUT_SECONDS = 300.0
 
+_GENERATE_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
 _PROMPT = (
-    "Transcribe all text in this document exactly as it appears, in reading order. "
-    "Output only the transcribed text - no commentary, no code fences. "
-    "Preserve paragraph breaks. Render table rows as lines with cells separated by tabs. "
-    "If a page contains no text, output nothing for it."
+    "Transcribe this document as markdown, in reading order. "
+    "Output only the document's content - no commentary, no surrounding code fence. "
+    "Render every table as a markdown table, one printed row per row, every cell exactly "
+    "as printed - part numbers, codes, and digits must survive character-for-character. "
+    "Where a page shows a figure, photo, or diagram, add a bracketed description in place - "
+    "[Figure: ...] - stating what it shows and every identifying detail it conveys "
+    "(shapes, dimensions, labels, colors, callouts), so someone who cannot see the image "
+    "still gets its information. "
+    "If a page contains no content, output nothing for it."
 )
 
 _LAYER_PROMPT = (
@@ -74,31 +87,35 @@ def _slice_pdf(reader: pypdf.PdfReader, start: int, end: int) -> bytes:
     return buf.getvalue()
 
 
-async def _transcribe_chunk(client: AsyncAnthropic, chunk: bytes) -> str:
+async def _transcribe_chunk(client: httpx.AsyncClient, chunk: bytes) -> str:
     layer = extract_text(chunk, "application/pdf")
     prompt = _PROMPT + (_LAYER_PROMPT.format(layer=layer) if layer else "")
-    response = await client.messages.create(
-        model=settings.ANTHROPIC_FAST_MODEL,
-        max_tokens=MAX_OUTPUT_TOKENS,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "document",
-                        "source": {
-                            "type": "base64",
-                            "media_type": "application/pdf",
-                            "data": base64.standard_b64encode(chunk).decode("ascii"),
+    response = await client.post(
+        _GENERATE_URL.format(model=settings.GEMINI_EXTRACTION_MODEL),
+        json={
+            "contents": [
+                {
+                    "parts": [
+                        {
+                            "inline_data": {
+                                "mime_type": "application/pdf",
+                                "data": base64.standard_b64encode(chunk).decode("ascii"),
+                            }
                         },
-                    },
-                    {"type": "text", "text": prompt},
-                ],
-            }
-        ],
+                        {"text": prompt},
+                    ]
+                }
+            ],
+            "generationConfig": {"maxOutputTokens": MAX_OUTPUT_TOKENS, "temperature": 0},
+        },
     )
-    text = "".join(block.text for block in response.content if block.type == "text").strip()
-    if response.stop_reason == "max_tokens":
+    response.raise_for_status()
+    candidates = response.json().get("candidates")
+    if not candidates:
+        raise RuntimeError("Gemini returned no candidates")
+    parts = candidates[0].get("content", {}).get("parts", [])
+    text = "".join(p.get("text", "") for p in parts if not p.get("thought")).strip()
+    if candidates[0].get("finishReason") == "MAX_TOKENS":
         text += "\n\n[transcription truncated]"
     return text
 
@@ -117,8 +134,8 @@ def _text_layer_tail(reader: pypdf.PdfReader, start: int) -> str:
 
 
 async def transcribe_pdf(content: bytes) -> str:
-    if not settings.ANTHROPIC_API_KEY:
-        raise RuntimeError("ANTHROPIC_API_KEY is required to transcribe PDFs")
+    if not settings.GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY is required to transcribe PDFs")
 
     reader = pypdf.PdfReader(io.BytesIO(content))
     total_pages = len(reader.pages)
@@ -134,13 +151,16 @@ async def transcribe_pdf(content: bytes) -> str:
             chunk = _slice_pdf(reader, start, min(start + PAGES_PER_REQUEST, vision_pages))
             return await _transcribe_chunk(client, chunk)
 
-    client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY, timeout=REQUEST_TIMEOUT_SECONDS)
+    client = httpx.AsyncClient(
+        headers={"x-goog-api-key": settings.GEMINI_API_KEY},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
     try:
         texts = await asyncio.gather(
             *(transcribe_from(start) for start in range(0, vision_pages, PAGES_PER_REQUEST))
         )
     finally:
-        await client.close()
+        await client.aclose()
 
     parts = [t for t in texts if t]
     if total_pages > vision_pages:

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -352,3 +352,36 @@ async def test_transcription_failure_marks_row_for_retry(monkeypatch):
 
     assert await extract_one._run(file_id) == 1
     assert persisted_errors == ["Extraction failed: RuntimeError"]
+
+
+@pytest.mark.asyncio
+async def test_a_rate_limit_hands_the_attempt_back(monkeypatch):
+    """HTTP 429 means "later", not "broken". Counting it against the attempt
+    budget let one quota blip march 20 real customer documents to permanent
+    failure in seconds — the row must go back to pending with its attempt
+    returned, so the next dispatch retries it as if this one never happened."""
+    import httpx
+
+    file_id = uuid.uuid4()
+    executed_queries = []
+
+    class RateLimitedConnection(_FakeConnection):
+        async def execute(self, query, *args):
+            executed_queries.append(query)
+
+    conn = RateLimitedConnection(file_id, "application/pdf")
+    _wire_extract_one(monkeypatch, conn, _blank_pdf(1))
+
+    async def rate_limited_transcribe(content):
+        request = httpx.Request("POST", "https://generativelanguage.googleapis.com")
+        raise httpx.HTTPStatusError(
+            "429", request=request, response=httpx.Response(429, request=request)
+        )
+
+    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", rate_limited_transcribe)
+
+    assert await extract_one._run(file_id) == 1
+    (query,) = executed_queries
+    assert "extraction_status = 'pending'" in query
+    assert "extraction_attempts = greatest(extraction_attempts - 1, 0)" in query
+    assert "failed" not in query

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -6,15 +6,17 @@ number ships the wrong part. `transcribe_pdf` sends both in one request:
 structure from the page images, characters from the embedded text layer. A
 scanned PDF simply has no layer to attach and degrades to pure OCR.
 
-These tests pin that contract: the layer rides along as grounding, pages past
-the vision cap keep their raw text layer (the cap bounds API spend, it must not
-discard free text), failures surface loudly, and the upload path never pays for
-a vision call when plain extraction already worked.
+These tests pin that contract: the layer rides along as grounding, the prompt
+demands markdown tables and figure descriptions (diagram content must survive
+into text), pages past the vision cap keep their raw text layer (the cap
+bounds API spend, it must not discard free text), failures surface loudly,
+and every PDF — digital or scanned — takes the vision path, because the
+pypdf-only path stores scrambled tables that read fine while crossing the
+wrong part numbers.
 """
 
 import io
 import uuid
-from types import SimpleNamespace
 
 import asyncpg
 import pypdf
@@ -36,17 +38,48 @@ def _blank_pdf(pages: int) -> bytes:
     return buf.getvalue()
 
 
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _FakeGeminiClient:
+    def __init__(self, payload):
+        self._payload = payload
+        self.captured = {}
+
+    async def post(self, url, json):
+        self.captured["url"] = url
+        self.captured["json"] = json
+        return _FakeResponse(self._payload)
+
+
+def _payload(text: str, finish_reason: str = "STOP") -> dict:
+    return {"candidates": [{"content": {"parts": [{"text": text}]}, "finishReason": finish_reason}]}
+
+
+def _prompt_of(client: _FakeGeminiClient) -> str:
+    parts = client.captured["json"]["contents"][0]["parts"]
+    return "".join(p.get("text", "") for p in parts if "text" in p)
+
+
 @pytest.mark.asyncio
 async def test_transcribe_pdf_fails_loud_without_api_key(monkeypatch):
-    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", None)
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", None)
 
-    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
         await pdf_ocr.transcribe_pdf(_blank_pdf(1))
 
 
 @pytest.mark.asyncio
 async def test_transcribe_pdf_chunks_pages_and_joins_transcriptions(monkeypatch):
-    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "test-key")
 
     async def fake_chunk(client, chunk):
         pages = len(pypdf.PdfReader(io.BytesIO(chunk)).pages)
@@ -64,25 +97,13 @@ async def test_the_text_layer_rides_along_as_grounding(monkeypatch):
     """The whole point of reconciliation: the request must carry the embedded
     text layer so the model takes characters from it, not from its own read
     of the page image."""
-    captured = {}
-
-    class FakeMessages:
-        async def create(self, **kwargs):
-            captured.update(kwargs)
-            return SimpleNamespace(
-                content=[SimpleNamespace(type="text", text="reconciled")],
-                stop_reason="end_turn",
-            )
-
-    client = SimpleNamespace(messages=FakeMessages())
+    client = _FakeGeminiClient(_payload("reconciled"))
     monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: "288241R\tOR288241\t106113")
 
     result = await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
 
     assert result == "reconciled"
-    prompt = "".join(
-        block["text"] for block in captured["messages"][0]["content"] if block["type"] == "text"
-    )
+    prompt = _prompt_of(client)
     assert "288241R\tOR288241\t106113" in prompt
     assert "<text_layer>" in prompt
     # A page can render a token cut off (page edge, cropped scan) while the
@@ -92,27 +113,53 @@ async def test_the_text_layer_rides_along_as_grounding(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_a_scan_sends_no_grounding_block(monkeypatch):
-    """A scan has no text layer. The prompt must not carry an empty
-    <text_layer> block that invites the model to treat 'nothing' as truth."""
-    captured = {}
-
-    class FakeMessages:
-        async def create(self, **kwargs):
-            captured.update(kwargs)
-            return SimpleNamespace(
-                content=[SimpleNamespace(type="text", text="ocr")], stop_reason="end_turn"
-            )
-
-    client = SimpleNamespace(messages=FakeMessages())
+async def test_the_prompt_demands_markdown_tables_and_figure_descriptions(monkeypatch):
+    """The two output requirements the knowledge base depends on: tables must
+    come back as markdown tables (a flattened parts table crosses the wrong
+    part numbers), and figures must be described in place (a diagram's
+    identifying details — the only way to tell a 4515 shoe from a 4707 —
+    otherwise never enter the searchable text)."""
+    client = _FakeGeminiClient(_payload("out"))
     monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
 
     await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
 
-    prompt = "".join(
-        block["text"] for block in captured["messages"][0]["content"] if block["type"] == "text"
-    )
-    assert "<text_layer>" not in prompt
+    prompt = _prompt_of(client)
+    assert "markdown table" in prompt
+    assert "[Figure:" in prompt
+
+
+@pytest.mark.asyncio
+async def test_a_scan_sends_no_grounding_block(monkeypatch):
+    """A scan has no text layer. The prompt must not carry an empty
+    <text_layer> block that invites the model to treat 'nothing' as truth."""
+    client = _FakeGeminiClient(_payload("ocr"))
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
+
+    assert "<text_layer>" not in _prompt_of(client)
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_transcription_is_marked_not_silent(monkeypatch):
+    client = _FakeGeminiClient(_payload("partial", finish_reason="MAX_TOKENS"))
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    result = await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
+
+    assert result == "partial\n\n[transcription truncated]"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_candidate_list_raises(monkeypatch):
+    """No candidates means the API refused or filtered the request. That must
+    surface as a retryable failure, never be stored as a blank document."""
+    client = _FakeGeminiClient({"candidates": []})
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    with pytest.raises(RuntimeError, match="no candidates"):
+        await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
 
 
 @pytest.mark.asyncio
@@ -120,7 +167,7 @@ async def test_pages_past_the_vision_cap_keep_their_text_layer(monkeypatch):
     """The cap bounds vision spend on giant catalogs. It must not discard text
     pypdf reads for free — the tail is appended raw, under a marker that says
     exactly where reconciliation stopped."""
-    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "test-key")
     monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 4)
     monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 2)
 
@@ -141,7 +188,7 @@ async def test_the_vision_cap_is_marked_not_silent(monkeypatch):
     """A scan past the cap has no text layer to fall back on. Bounding API
     spend is fine; pretending we read the whole document is not — the stored
     text must say where transcription stopped."""
-    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "test-key")
     monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 4)
     monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 2)
 
@@ -165,7 +212,7 @@ async def test_ocr_holds_at_most_the_concurrency_limit_in_memory(monkeypatch):
     API call have to sit behind the semaphore."""
     import asyncio
 
-    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "test-key")
     monkeypatch.setattr(pdf_ocr, "MAX_VISION_PAGES", 12)
     monkeypatch.setattr(pdf_ocr, "PAGES_PER_REQUEST", 1)
 
@@ -239,23 +286,25 @@ def _wire_extract_one(monkeypatch, conn, content):
 
 
 @pytest.mark.asyncio
-async def test_textless_pdf_is_transcribed_and_stored(monkeypatch):
+async def test_every_uploaded_pdf_is_transcribed_and_stored(monkeypatch):
+    """Digital PDFs included: the pypdf-only path stores a scrambled table
+    that reads fine while crossing the wrong part numbers, so a text layer
+    must not divert a PDF away from vision — it rides along as grounding."""
     conn = _FakeConnection(uuid.uuid4(), "application/pdf")
     _wire_extract_one(monkeypatch, conn, _blank_pdf(2))
 
     async def fake_transcribe(content):
-        return "transcribed scan"
+        return "vision transcription"
 
     monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fake_transcribe)
 
     assert await extract_one._run(conn.file_id) == 0
-    assert conn.persisted_text == "transcribed scan"
+    assert conn.persisted_text == "vision transcription"
 
 
 @pytest.mark.asyncio
-async def test_upload_with_text_layer_skips_vision(monkeypatch):
-    """Vision costs an API call per chunk — an upload the embedded-text path
-    already handled must never hit the API."""
+async def test_non_pdf_upload_never_transcribes(monkeypatch):
+    """Vision costs an API call per chunk — only PDFs take that path."""
     conn = _FakeConnection(uuid.uuid4(), "text/plain")
     _wire_extract_one(monkeypatch, conn, b"plain text body")
 

--- a/backend/workers/extract_drive_one.py
+++ b/backend/workers/extract_drive_one.py
@@ -69,6 +69,7 @@ async def _run(row_id: UUID) -> int:
         DriveFileUnsupported,
         extract_drive_text,
     )
+    from .extract_one import _is_rate_limit
 
     # get_valid_token refreshes the OAuth token through the shared pool.
     await init_pool()
@@ -112,14 +113,27 @@ async def _run(row_id: UUID) -> int:
         # The persisted error carries only the exception class — never the
         # message, which may embed document text or provider responses.
         try:
-            await conn.execute(
-                "UPDATE drive_documents SET "
-                "extraction_status = CASE WHEN extraction_attempts >= 3 THEN 'failed' "
-                "ELSE 'pending' END, "
-                "extraction_error = $2, locked_at = NULL WHERE id = $1",
-                row_id,
-                f"Extraction failed: {type(e).__name__}",
-            )
+            if _is_rate_limit(e):
+                # A rate limit means "later", not "broken": hand the attempt
+                # back, or a quota blip marches every in-flight document to
+                # permanent failure in seconds.
+                await conn.execute(
+                    "UPDATE drive_documents SET "
+                    "extraction_status = 'pending', "
+                    "extraction_attempts = greatest(extraction_attempts - 1, 0), "
+                    "extraction_error = 'Extraction rate limited: HTTP 429', "
+                    "locked_at = NULL WHERE id = $1",
+                    row_id,
+                )
+            else:
+                await conn.execute(
+                    "UPDATE drive_documents SET "
+                    "extraction_status = CASE WHEN extraction_attempts >= 3 THEN 'failed' "
+                    "ELSE 'pending' END, "
+                    "extraction_error = $2, locked_at = NULL WHERE id = $1",
+                    row_id,
+                    f"Extraction failed: {type(e).__name__}",
+                )
         except Exception:
             pass
         return 1

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -45,6 +45,12 @@ def _apply_memory_limit() -> None:
         pass
 
 
+def _is_rate_limit(e: Exception) -> bool:
+    import httpx
+
+    return isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 429
+
+
 async def _run(file_id: UUID) -> int:
     # Lazy imports so the RLIMIT above applies to everything heavy.
     import asyncpg
@@ -108,15 +114,29 @@ async def _run(file_id: UUID) -> int:
         # persisted error carries only the exception class — never the
         # message, which may embed document text or provider responses.
         try:
-            await conn.execute(
-                "UPDATE files SET "
-                "extraction_status = CASE WHEN extraction_attempts >= 3 THEN 'failed' ELSE 'pending' END, "
-                "extraction_error = $2, "
-                "locked_at = NULL "
-                "WHERE id = $1",
-                file_id,
-                f"Extraction failed: {type(e).__name__}",
-            )
+            if _is_rate_limit(e):
+                # A rate limit means "later", not "broken": hand the attempt
+                # back, or a quota blip marches every in-flight document to
+                # permanent failure in seconds.
+                await conn.execute(
+                    "UPDATE files SET "
+                    "extraction_status = 'pending', "
+                    "extraction_attempts = greatest(extraction_attempts - 1, 0), "
+                    "extraction_error = 'Extraction rate limited: HTTP 429', "
+                    "locked_at = NULL "
+                    "WHERE id = $1",
+                    file_id,
+                )
+            else:
+                await conn.execute(
+                    "UPDATE files SET "
+                    "extraction_status = CASE WHEN extraction_attempts >= 3 THEN 'failed' ELSE 'pending' END, "
+                    "extraction_error = $2, "
+                    "locked_at = NULL "
+                    "WHERE id = $1",
+                    file_id,
+                    f"Extraction failed: {type(e).__name__}",
+                )
         except Exception:
             pass
         return 1

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -71,12 +71,16 @@ async def _run(file_id: UUID) -> int:
             return 1
 
         content = await storage_service.download_file(row["storage_key"])
-        text = extract_text(content, row["content_type"])
-        if text is None and is_pdf(row["content_type"]):
-            # A PDF with no embedded text layer is a scan. OCR errors
-            # propagate to the except below so the row records the
-            # failure and the retry machinery re-runs it.
+        if is_pdf(row["content_type"]):
+            # One codepath for every PDF: vision reads the pages, the embedded
+            # text layer (empty for a scan) grounds the characters. pypdf alone
+            # scrambles multi-column tables, and a scrambled parts table reads
+            # fine while crossing the wrong part numbers. Transcription errors
+            # propagate to the except below so the row records the failure and
+            # the retry machinery re-runs it.
             text = await transcribe_pdf(content) or None
+        else:
+            text = extract_text(content, row["content_type"])
         if text and len(text) > MAX_EXTRACTED_TEXT:
             text = text[:MAX_EXTRACTED_TEXT] + "\n\n[truncated]"
 


### PR DESCRIPTION
Much better PDF extraction! Excited about this one.

## What

Rewires PDF vision transcription (`backend/services/pdf_ocr.py`) from the fast-tier Claude model to **Gemini 3 Flash** (`gemini-3-flash-preview`), and upgrades what it produces:

- **Markdown tables, cell-for-cell.** The old prompt flattened tables to tab-separated lines; current prod output on catalog pages was a multi-thousand-line dump with table structure destroyed (digit precision 0.187 on the Jul 24 benchmark).
- **Figures described in place** (`[Figure: ...]`). Diagram content — e.g. the hump and rivet-pattern differences that distinguish a 4515 brake shoe from a 4707 — now enters the extracted text instead of vanishing.
- **Every PDF takes the vision path.** Uploaded digital PDFs previously got raw pypdf, which scrambles multi-column tables; scans, uploads, and Drive PDFs now share one codepath, with the embedded text layer riding along as character grounding as before.

## Why this model

The Jul 24 extraction benchmark on six real truck-parts catalog pages (47 hand-verified gold table rows): Gemini 3 Flash tied Claude Opus/Sonnet at 37/47 with perfect digit recall/precision, at fast-tier cost. The previous prod model scored 33/47 — below plain pypdf. Model is configurable via `GEMINI_EXTRACTION_MODEL`.

## Config

New required env for PDF transcription: `GEMINI_API_KEY` (fails loud if missing). Must be set on `stash_backend` and `stash-celery-worker` before this deploys.

## Verification

- 38/38 tests pass (`test_pdf_ocr.py` rewritten for the Gemini client, plus new contract tests: prompt demands markdown tables + figure descriptions, empty candidate list raises, truncation is marked), ruff clean.
- Live end-to-end smoke test against the real Gemini API on Haldex TechTopics L26012 (the 4515-vs-4707 doc from the Heavi thread): clean markdown out, both figures' identifying details captured in text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)