### PR TITLE
docs: record that prod embeds via OpenAI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,16 @@ Two model tiers, configured in `backend/.env`:
   ask-the-stash.
 - `ANTHROPIC_FAST_MODEL` — fast tier (default `claude-haiku-4-5`).
 
+**Embeddings: prod uses OpenAI.** Hosted prod (joinstash.ai) embeds with
+OpenAI `text-embedding-3-small` truncated to 384 dims (matching the
+`vector(384)` columns), selected because `OPENAI_API_KEY` is set in the Render
+environment. The provider is resolved by auto-detection in
+`backend/services/embeddings/` (openai → huggingface → local, in that order —
+a self-hosting affordance, deliberately added in 96ee3b6f); do not add
+`HF_TOKEN` or change embedding env vars in prod without understanding this
+chain, and never infer the prod provider from the code alone — it is a
+deployment fact (verified via prod worker logs, 2026-08-05).
+
 ## Project layout
 
 - `backend/` — FastAPI app (Python 3.12), runs on port `3456`. Migrations via Alembic.

--- a/backend/services/embeddings/auto.py
+++ b/backend/services/embeddings/auto.py
@@ -1,4 +1,11 @@
-"""Auto-detection and global singleton for the active embedding provider."""
+"""Auto-detection and global singleton for the active embedding provider.
+
+Hosted prod (joinstash.ai) resolves to the **openai** provider — OpenAI
+text-embedding-3-small truncated to 384 dims — because OPENAI_API_KEY is set
+in the Render environment. The other providers are self-hosting affordances.
+Which provider runs is a deployment fact, not a code fact: check the
+"Embedding provider: <name>" line in worker logs, not this file.
+"""
 
 import logging
 import os


### PR DESCRIPTION
## What

Documentation only — no behavior change.

- `CLAUDE.md` (LLM configuration section): notes that hosted prod embeds with OpenAI `text-embedding-3-small` @ 384 dims, selected by the auto-detection chain because `OPENAI_API_KEY` is set on Render; warns against adding `HF_TOKEN`/changing embedding env vars in prod without understanding the chain.
- `backend/services/embeddings/auto.py` docstring: same fact at the point of auto-detection, plus how to verify (the "Embedding provider: <name>" worker log line).

## Why

The provider is resolved from env vars at runtime, so prod's provider cannot be determined from the code. We re-derived it empirically today (prod worker logs) while doing SOC 2 vendor accounting. The pluggable providers are a deliberate self-hosting feature (96ee3b6f), so they stay — this just records which branch prod takes.

Replaces #967, which removed the other providers; closed in favor of keeping the self-host flexibility and documenting instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)