### PR TITLE
fix: X bookmarks import stranded at a fraction of users' bookmarks — page at 20, re-walk history

### DIFF
--- a/backend/integrations/x_saves/indexer.py
+++ b/backend/integrations/x_saves/indexer.py
@@ -59,13 +59,20 @@ MAX_USER_TWEET_PAGES = 5
 MAX_TIMELINE_BACKFILL_PAGES = 25
 # The X API bills per post returned (unlike twitterapi.io, which is cheap),
 # and most checks find no new bookmark — so bookmarks are checked at most
-# once a day, starting with one small probe page. Backlog and history pages
-# use the full size, capped per check. Posts/replies/articles are unaffected:
-# they ride twitterapi.io on the source's normal sync cadence.
+# once a day, starting with one small probe page. Posts/replies/articles are
+# unaffected: they ride twitterapi.io on the source's normal sync cadence.
 BOOKMARK_CHECK_INTERVAL = timedelta(days=1)
 BOOKMARK_PROBE_SIZE = 10
-BOOKMARK_PAGE_SIZE = 100
-MAX_BOOKMARK_PAGES = 5
+# X's bookmarks pagination silently drops next_token after a page or two at
+# max_results=100 even when thousands of bookmarks remain (confirmed on a
+# real account: 100/page ended at ~110 of 2,895; 20/page served all of them).
+# Small pages are the only size known to paginate to the true end.
+BOOKMARK_PAGE_SIZE = 20
+MAX_BOOKMARK_PROBE_PAGES = 5
+# Pages per daily check spent walking bookmark history. The endpoint allows
+# 180 requests / 15 min per user, so one check can walk ~3,000 bookmarks;
+# bigger archives resume from the stored cursor on later checks.
+MAX_BOOKMARK_WALK_PAGES = 150
 
 
 def tweet_url(tweet_id: str) -> str:
@@ -197,7 +204,7 @@ async def _backfill_bookmarks(
         timeout=30.0, headers={"Authorization": f"Bearer {token}"}
     ) as client:
         page_token: str | None = None
-        for page in range(MAX_BOOKMARK_PAGES):
+        for page in range(MAX_BOOKMARK_PROBE_PAGES):
             size = BOOKMARK_PROBE_SIZE if page == 0 else BOOKMARK_PAGE_SIZE
             payload = await _fetch_bookmarks_page(client, source_id, x_user_id, size, page_token)
             if payload is None:
@@ -216,18 +223,25 @@ async def _backfill_bookmarks(
         if source_settings.get("x_bookmarks_complete"):
             return
         page_token = source_settings.get("x_bookmarks_cursor")
-        for _ in range(MAX_BOOKMARK_PAGES):
+        for _ in range(MAX_BOOKMARK_WALK_PAGES):
             payload = await _fetch_bookmarks_page(
                 client, source_id, x_user_id, BOOKMARK_PAGE_SIZE, page_token
             )
             if payload is None:
-                return
+                return  # gate closed mid-walk; the stored cursor resumes next check
             await _insert_bookmarks_page(payload, source_id, owner_user_id)
-            page_token = (payload.get("meta") or {}).get("next_token")
-            if not page_token:
-                await _merge_source_settings(source_id, {"x_bookmarks_complete": True})
+            next_token = (payload.get("meta") or {}).get("next_token")
+            if not next_token:
+                if len(payload.get("data") or []) < BOOKMARK_PAGE_SIZE:
+                    await _merge_source_settings(source_id, {"x_bookmarks_complete": True})
+                # A FULL page with no next_token is X's truncation bug, not
+                # the end of the list — leave the cursor pointing at this page
+                # so the next daily check retries it instead of believing X.
                 return
-        await _merge_source_settings(source_id, {"x_bookmarks_cursor": page_token})
+            page_token = next_token
+            # Parked after every page so a mid-walk stop (page budget, rate
+            # limit, redeploy) never refetches — and re-bills — walked pages.
+            await _merge_source_settings(source_id, {"x_bookmarks_cursor": page_token})
 
 
 async def _fetch_bookmarks_page(

--- a/backend/migrations/versions/0179_rewalk_x_bookmarks.py
+++ b/backend/migrations/versions/0179_rewalk_x_bookmarks.py
@@ -1,0 +1,33 @@
+"""Re-walk X bookmark history for existing sources.
+
+The bookmarks history walk paged at max_results=100, where X's pagination
+silently drops next_token after a page or two even when thousands of
+bookmarks remain — so existing sources were stamped x_bookmarks_complete
+after ingesting a tiny newest-slice (one real account: 109 of 2,895). The
+indexer now pages at 20, which paginates to the true end.
+
+Clearing the completion stamp, the (100-sized) cursor, and the daily-check
+stamp makes the fixed walk re-run from the top on each source's next sync.
+Re-walking is idempotent per tweet (insert-or-ignore by path).
+"""
+
+from alembic import op
+
+revision = "0179"
+down_revision = "0178"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.get_bind().exec_driver_sql(
+        "UPDATE user_sources SET "
+        "settings = settings - 'x_bookmarks_complete' - 'x_bookmarks_cursor' "
+        "- 'x_bookmarks_checked_at', "
+        "updated_at = now() "
+        "WHERE source_type = 'x_saves' AND settings IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_x_saves.py
+++ b/backend/tests/test_x_saves.py
@@ -600,6 +600,87 @@ async def test_bookmark_probe_is_small_and_history_walk_runs_once(client, pool, 
     assert [c for c in _FakeApi.bookmarks_calls if c[0] == "b2"] == deep_fetches
 
 
+@pytest.mark.asyncio
+async def test_full_page_without_next_token_is_not_the_end(client, pool, fake_sync) -> None:
+    # X's pagination bug drops next_token on a FULL page with thousands of
+    # bookmarks still below. Believing it once stranded a user at 109 of
+    # 2,895 — a full page without a token must leave the walk incomplete so
+    # the next daily check retries the page.
+    full_page = [{"id": str(9000 + i)} for i in range(x_indexer.BOOKMARK_PAGE_SIZE)]
+    _FakeApi.bookmarks_pages = {None: {"data": full_page, "meta": {}}}
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+
+    await x_indexer.index_x_saves(source)
+
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert "x_bookmarks_complete" not in settings_
+
+    # Next day X paginates properly: the walk picks up the page below and a
+    # short final page marks the true end.
+    _FakeApi.bookmarks_pages = {
+        None: {"data": full_page, "meta": {"next_token": "b2"}},
+        "b2": {"data": [{"id": "9999"}], "meta": {}},
+    }
+    await _age_bookmark_check(pool, source["id"])
+    source = await source_service.get_source_for_sync(UUID(source["id"]))
+    await x_indexer.index_x_saves(source)
+
+    count = await pool.fetchval(
+        "SELECT count(*) FROM x_save_docs WHERE source_id = $1 AND path = 'Bookmarks/9999'",
+        UUID(source["id"]),
+    )
+    assert count == 1
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert settings_["x_bookmarks_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_bookmark_walk_pages_small_and_resumes_across_checks(
+    client, pool, fake_sync, monkeypatch
+) -> None:
+    # Deep archives outrun one check's page budget: the walk must park its
+    # cursor after every page and resume there next check — never refetching
+    # (re-billing) pages it already walked, and never at the 100-item page
+    # size whose pagination X silently truncates.
+    monkeypatch.setattr(x_indexer, "MAX_BOOKMARK_WALK_PAGES", 1)
+    _FakeApi.bookmarks_pages = {
+        None: {"data": [{"id": "910"}], "meta": {"next_token": "b2"}},
+        "b2": {"data": [{"id": "911"}], "meta": {}},
+    }
+    headers, owner_id = await _register(client)
+    source = await _x_source(pool, owner_id, x_user_id="999")
+    # 910 is already known so the probe stops at the top; only the walk digs.
+    await _insert_pending(pool, owner_id, source["id"], "Bookmarks/910", "Bookmark")
+
+    await x_indexer.index_x_saves(source)
+
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert settings_["x_bookmarks_cursor"] == "b2"
+    assert "x_bookmarks_complete" not in settings_
+
+    await _age_bookmark_check(pool, source["id"])
+    source = await source_service.get_source_for_sync(UUID(source["id"]))
+    await x_indexer.index_x_saves(source)
+
+    settings_ = await pool.fetchval(
+        "SELECT settings FROM user_sources WHERE id = $1", UUID(source["id"])
+    )
+    assert settings_["x_bookmarks_complete"] is True
+    walk_sizes = {size for token, size in _FakeApi.bookmarks_calls if token is not None}
+    assert walk_sizes == {x_indexer.BOOKMARK_PAGE_SIZE}
+    # The deep page was fetched exactly once across both checks.
+    assert [c for c in _FakeApi.bookmarks_calls if c[0] == "b2"] == [
+        ("b2", x_indexer.BOOKMARK_PAGE_SIZE)
+    ]
+
+
 async def _age_bookmark_check(pool, source_id: str) -> None:
     """Backdate x_bookmarks_checked_at so the daily gate lets the next
     check through."""


### PR DESCRIPTION
hotfix to our bookmark import feature. A silent bug in the X API was causing imports to fail. to fix this, we decrease page size (apparently this fixes the bug) and then also persist bookmarks after every page as we walk through the user's bookmarks

## Incident

A user reported publicly (X, Aug 5) that the bookmarks import "choked" partway through their X bookmarks.

## Root cause

X's `GET /2/users/:id/bookmarks` silently drops `meta.next_token` after 1–3 pages at `max_results=100` even when thousands of bookmarks remain — a [known X API bug](https://devcommunity.x.com/t/bookmarks-api-v2-stops-paginating-after-3-pages-no-next-token-returned/257339); the community workaround is smaller pages. Verified live against the affected account with its OAuth token (count-only probe): at 100/page pagination dies at ~110 items; at 20/page X serves all 2,895 across 145 pages and ends with a genuine short final page. The indexer's history walk treated the missing token as "all ingested" and stamped `x_bookmarks_complete`, so it never looked again.

## Fix (`backend/integrations/x_saves/indexer.py`)

- `BOOKMARK_PAGE_SIZE` 100 → **20** — the only size that demonstrably paginates to the end.
- History walk gets its own budget, `MAX_BOOKMARK_WALK_PAGES = 150` (~3,000 bookmarks/daily check; the endpoint allows 180 req/15 min per user, measured). Bigger archives resume next check.
- Cursor is persisted after **every** page, so a mid-walk stop (budget, rate limit, worker redeploy) resumes instead of refetching — and re-billing — walked pages.
- A missing `next_token` on a **full** page is treated as the truncation bug: the cursor stays put and the next daily check retries. Only a **short** final page stamps `x_bookmarks_complete`.

## Migration (`0179_rewalk_x_bookmarks.py`)

One-shot: strips `x_bookmarks_complete` / `x_bookmarks_cursor` / `x_bookmarks_checked_at` from existing `x_saves` sources, so each re-walks from the top on its next sync after deploy. Inserts are idempotent per tweet (`ON CONFLICT DO NOTHING`) — no duplicates. Note: the re-walk bills roughly 3,000–4,000 X API post-reads across the three accounts on day one; that is the point of the fix.

## Tests

Two new tests encode the failure mode: a full page without a `next_token` must not be believed (the 109-of-2,895 scenario, including recovery when X later paginates properly), and the walk must resume from its parked cursor at the small page size without refetching walked pages. Full backend suite: **1,284 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)