### PR TITLE
Filter unified search by a last-modified datetime range

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -155,6 +155,8 @@ async def search_sources(
     include_sources: list[str] | None = Query(None),
     exclude_sources: list[str] | None = Query(None),
     limit: int = Query(20, ge=1, le=500),
+    modified_after: datetime | None = Query(None),
+    modified_before: datetime | None = Query(None),
     current_user: dict = Depends(get_current_user),
     scope_user_id: UUID = Depends(get_scope),
 ):
@@ -164,7 +166,10 @@ async def search_sources(
     (files + sessions + its connected sources), or pass a handle to scope.
     Repeatable include_sources/exclude_sources params (native handles +
     provider names) filter which sources are searched:
-    (include or everything) - exclude."""
+    (include or everything) - exclude.
+    modified_after/modified_before (ISO-8601) restrict hits to those last
+    modified inside the range; hits with no known modification time are
+    excluded whenever a bound is set."""
     owner_user_id = scope_user_id
     await _require_member(owner_user_id, current_user["id"])
     try:
@@ -176,6 +181,8 @@ async def search_sources(
             include_sources=include_sources,
             exclude_sources=exclude_sources,
             limit=limit,
+            modified_after=modified_after,
+            modified_before=modified_before,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -9,6 +9,7 @@ import hashlib
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from uuid import UUID
 
 import asyncpg
@@ -1453,6 +1454,8 @@ async def search_pages_fts(
     query: str,
     limit: int = 10,
     user_id: UUID | None = None,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
 ) -> list[dict]:
     pool = get_pool()
     vec_expr = PAGES_FTS_VECTOR_EXPR
@@ -1466,6 +1469,12 @@ async def search_pages_fts(
     if user_id is not None:
         args.append(user_id)
         where += " AND " + permission_service.readable_content_condition("page", "p", 3)
+    if modified_after:
+        args.append(modified_after)
+        where += f" AND p.updated_at > ${len(args)}"
+    if modified_before:
+        args.append(modified_before)
+        where += f" AND p.updated_at < ${len(args)}"
     args.append(limit)
     rows = await pool.fetch(
         f"SELECT id, owner_user_id, folder_id, name, content_markdown, content_html, "

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -575,23 +575,33 @@ async def search_scope_events(
     user_id: UUID,
     query: str,
     limit: int = 50,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
 ) -> list[dict]:
-    """Full-text search on scope events."""
+    """Full-text search on scope events, optionally bounded to a created_at
+    range (strict bounds; naive datetimes read as UTC)."""
     pool = get_pool()
     limit = min(limit, 500)
+    args: list = [owner_user_id, query, user_id]
+    where = (
+        "owner_user_id = $1 "
+        f"AND {readable_session_event_condition('history_events', 3)} "
+        "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2)"
+    )
+    if modified_after:
+        args.append(_normalize_ts(modified_after))
+        where += f" AND created_at > ${len(args)}"
+    if modified_before:
+        args.append(_normalize_ts(modified_before))
+        where += f" AND created_at < ${len(args)}"
+    args.append(limit)
     rows = await pool.fetch(
         "SELECT id, owner_user_id, created_by, agent_name, event_type, session_id, "
         "tool_name, content, metadata, attachments, created_at, "
         "ts_rank(to_tsvector('english', content), websearch_to_tsquery('english', $2)) AS rank "
-        "FROM history_events "
-        "WHERE owner_user_id = $1 "
-        f"AND {readable_session_event_condition('history_events', 4)} "
-        "AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2) "
-        "ORDER BY rank DESC LIMIT $3",
-        owner_user_id,
-        query,
-        limit,
-        user_id,
+        f"FROM history_events WHERE {where} "
+        f"ORDER BY rank DESC LIMIT ${len(args)}",
+        *args,
     )
     return [dict(r) for r in rows]
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -1566,6 +1566,8 @@ async def search_documents(
     source: dict | None = None,
     providers: frozenset[str] | None = None,
     limit: int = 20,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
 ) -> list[dict]:
     """FTS over copied-content sources the user can read — their own or shared
     with them (github/slack/granola), UNIONed across their tables. Pass `source`
@@ -1615,9 +1617,14 @@ async def search_documents(
             )
         return ""
 
+    date_clause, date_args = _modified_range_clause(
+        "d.external_updated_at", 4, modified_after, modified_before
+    )
     # Each arm ranks on the stored vector and keeps only its own top `limit`
     # BEFORE the snippet expression runs: the 20KB substr detoasts the full
     # document, so it must touch the few returned rows, never every match.
+    # The date bound lives inside each arm too — outside it, the per-arm top-N
+    # would discard in-range rows in favor of out-of-range higher-ranked ones.
     parts = [
         f"""
         SELECT sub.source_id, sub.path, sub.name, sub.external_updated_at,
@@ -1634,7 +1641,7 @@ async def search_documents(
             JOIN user_sources s ON s.id = d.source_id
             WHERE d.source_id = ANY($1) AND d.deleted_at IS NULL
               AND d.content_tsv @@ websearch_to_tsquery('english', $2)
-              {visibility_clause(t)}
+              {visibility_clause(t)}{date_clause}
             ORDER BY rank DESC
             LIMIT $3
         ) sub
@@ -1650,6 +1657,7 @@ async def search_documents(
         readable_ids,
         query,
         limit,
+        *date_args,
     )
     return [
         {
@@ -2169,6 +2177,46 @@ def _parse_dt(value: str | None):
     return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
 
 
+def _normalize_ts(dt: datetime | None) -> datetime | None:
+    """Naive datetimes are treated as UTC (the columns are timestamptz)."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def _modified_range_clause(
+    column: str, first_index: int, modified_after: datetime | None, modified_before: datetime | None
+) -> tuple[str, list[datetime]]:
+    """SQL predicate bounding `column` to the range, with args numbered from
+    $first_index. NULL timestamps never satisfy a bound, so rows without a
+    modification time drop whenever a bound is set — by design."""
+    clause = ""
+    args: list[datetime] = []
+    if modified_after:
+        args.append(modified_after)
+        clause += f" AND {column} > ${first_index + len(args) - 1}"
+    if modified_before:
+        args.append(modified_before)
+        clause += f" AND {column} < ${first_index + len(args) - 1}"
+    return clause, args
+
+
+def _within_modified_range(
+    hit: dict, modified_after: datetime | None, modified_before: datetime | None
+) -> bool:
+    """Whether a federated hit's date_modified falls inside the bounds. Hits
+    with no timestamp are excluded whenever a bound is set (PostHog never
+    supplies one, so any bound excludes all PostHog hits)."""
+    if modified_after is None and modified_before is None:
+        return True
+    ts = _normalize_ts(hit.get("date_modified"))
+    if ts is None:
+        return False
+    if modified_after is not None and ts <= modified_after:
+        return False
+    return modified_before is None or ts < modified_before
+
+
 async def fetch_history(
     owner_user_id: UUID,
     user_id: UUID,
@@ -2226,23 +2274,36 @@ async def fetch_history(
     return result
 
 
-async def _external_ref_matches(sources: list[dict], query: str, limit: int) -> list[dict]:
+async def _external_ref_matches(
+    sources: list[dict],
+    query: str,
+    limit: int,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
+) -> list[dict]:
     """Documents whose provider id (`external_ref`) contains the query as a
     substring, across the given sources' document tables. These hits carry
     `exact_ref` so search_all pins them above everything else — an id match is
-    a lookup, not a relevance guess."""
+    a lookup, not a relevance guess. A modified bound excludes even exact-ref
+    hits whose external_updated_at is NULL: no timestamp means no proof the
+    document is in range."""
     query = query.strip()
     if not query:
         return []
+    date_clause, date_args = _modified_range_clause(
+        "external_updated_at", 4, modified_after, modified_before
+    )
 
     async def one_source(s: dict, table: str) -> list[dict]:
         rows = await get_pool().fetch(
             f"SELECT path, name, external_updated_at FROM {table} "
-            f"WHERE source_id = $1 AND strpos(external_ref, $2) > 0 AND deleted_at IS NULL "
+            f"WHERE source_id = $1 AND strpos(external_ref, $2) > 0 AND deleted_at IS NULL"
+            f"{date_clause} "
             f"LIMIT $3",
             UUID(s["id"]),
             query,
             limit,
+            *date_args,
         )
         return [
             {
@@ -2335,6 +2396,8 @@ async def _gather_search_candidates(
     source: str | None,
     allowed: frozenset[str],
     fetch_limit: int,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
 ) -> tuple[list[dict], list[dict], dict | None] | None:
     """Collect unranked hits from every sub-search: native sessions + pages,
     exact provider-id matches, copied-content FTS, and federated provider
@@ -2343,7 +2406,12 @@ async def _gather_search_candidates(
     docs 500, providers SEARCH_LIMIT) — asking for more than those yields
     has_more = False, not deeper results. The sub-searches are independent, so
     they run concurrently; a search's latency is its slowest sub-search, not
-    the sum of all of them."""
+    the sum of all of them.
+
+    A modified_after/modified_before bound is pushed into SQL for the stored
+    paths, but federated providers have no uniform date pushdown, so their live
+    hits are filtered here after the fact — their truncation markers may then
+    over-report, and hits without a timestamp (all of PostHog's) are excluded."""
     # Resolve a named connected source first: an unknown handle must return
     # None before any sub-search runs.
     connected: dict | None = None
@@ -2355,7 +2423,14 @@ async def _gather_search_candidates(
     async def session_hits() -> tuple[list[dict], list[dict]]:
         from .memory_service import search_scope_events
 
-        events = await search_scope_events(owner_user_id, user_id, query, limit=fetch_limit)
+        events = await search_scope_events(
+            owner_user_id,
+            user_id,
+            query,
+            limit=fetch_limit,
+            modified_after=modified_after,
+            modified_before=modified_before,
+        )
         return [
             {
                 "source": NATIVE_SESSIONS,
@@ -2369,7 +2444,14 @@ async def _gather_search_candidates(
     async def page_hits() -> tuple[list[dict], list[dict]]:
         from .files_tree_service import search_pages_fts
 
-        pages = await search_pages_fts(owner_user_id, query, limit=fetch_limit, user_id=user_id)
+        pages = await search_pages_fts(
+            owner_user_id,
+            query,
+            limit=fetch_limit,
+            user_id=user_id,
+            modified_after=modified_after,
+            modified_before=modified_before,
+        )
         return [
             {
                 "source": NATIVE_FILES,
@@ -2415,7 +2497,9 @@ async def _gather_search_candidates(
         # reads sources shared directly with the user, which searched_sources
         # never enumerates.
         ref_hits, docs, federated_results = await asyncio.gather(
-            _external_ref_matches(searched_sources, query, fetch_limit),
+            _external_ref_matches(
+                searched_sources, query, fetch_limit, modified_after, modified_before
+            ),
             search_documents(
                 user_id=user_id,
                 query=query,
@@ -2424,6 +2508,8 @@ async def _gather_search_candidates(
                 if connected is not None
                 else allowed - {NATIVE_FILES, NATIVE_SESSIONS},
                 limit=fetch_limit,
+                modified_after=modified_after,
+                modified_before=modified_before,
             ),
             asyncio.gather(
                 *(
@@ -2447,7 +2533,9 @@ async def _gather_search_candidates(
         ]
         markers: list[dict] = []
         for fed_hits, fed_markers in federated_results:
-            hits += fed_hits
+            hits += [
+                h for h in fed_hits if _within_modified_range(h, modified_after, modified_before)
+            ]
             markers += fed_markers
         return hits, markers
 
@@ -2475,6 +2563,8 @@ async def search_all(
     include_sources: list[str] | None = None,
     exclude_sources: list[str] | None = None,
     limit: int = 20,
+    modified_after: datetime | None = None,
+    modified_before: datetime | None = None,
 ) -> dict | None:
     """Search across sources. Omit `source` to search everything the user can
     see (native files + sessions + their connected sources), or pass a handle to
@@ -2485,6 +2575,12 @@ async def search_all(
     handles + provider names): searched = (include or everything) - exclude, so
     disjoint lists yield empty results. Unknown tokens, or combining either
     with `source`, raise ValueError.
+
+    modified_after/modified_before restrict hits to those last modified inside
+    the range (strict bounds, naive datetimes read as UTC); hits with no known
+    modification time are excluded whenever a bound is set. An inverted range
+    raises ValueError. Markers are never date-filtered, so federated truncation
+    markers and has_more may over-report when the bound drops live hits.
 
     Every candidate is re-scored on one uniform ts_rank scale over its display
     text, then the merged list is sorted and sliced to the first `limit` hits —
@@ -2506,10 +2602,21 @@ async def search_all(
     if source is not None and (include_sources or exclude_sources):
         raise ValueError("Pass either source or include_sources/exclude_sources, not both")
     allowed = resolve_search_source_filter(include_sources, exclude_sources)
+    modified_after = _normalize_ts(modified_after)
+    modified_before = _normalize_ts(modified_before)
+    if modified_after and modified_before and modified_after > modified_before:
+        raise ValueError("modified_after must be earlier than modified_before")
 
     # +1 sentinel: gathering exactly `limit` hits could never prove more exist.
     gathered = await _gather_search_candidates(
-        owner_user_id, user_id, query, source, allowed, fetch_limit=limit + 1
+        owner_user_id,
+        user_id,
+        query,
+        source,
+        allowed,
+        fetch_limit=limit + 1,
+        modified_after=modified_after,
+        modified_before=modified_before,
     )
     if gathered is None:
         return None

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -2680,6 +2680,233 @@ async def test_search_excluded_provider_is_never_called(client: AsyncClient, mon
     assert not any(r.get("error") for r in results["results"])
 
 
+async def _github_doc(ws: UUID, src: dict, path: str, content: str, **kwargs) -> None:
+    await source_service.upsert_content_document(
+        table="github_documents",
+        source_id=UUID(src["id"]),
+        owner_user_id=ws,
+        path=path,
+        name=path,
+        content=content,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_modified_range_filters_docs_and_pages(client: AsyncClient):
+    """modified_after/modified_before bound every stored path — the
+    copied-content FTS and native pages both honor the range."""
+    from backend.database import get_pool
+
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await _github_source_with_docs(ws, owner_id, {})
+    await _github_doc(
+        ws, src, "old.md", "kumquat pruning", external_updated_at=datetime(2026, 1, 15, tzinfo=UTC)
+    )
+    await _github_doc(
+        ws, src, "new.md", "kumquat harvest", external_updated_at=datetime(2026, 3, 15, tzinfo=UTC)
+    )
+    page = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Kumquat runbook", "content": "kumquat watering notes"},
+        headers=_auth(api_key),
+    )
+    assert page.status_code == 201
+    page_id = page.json()["id"]
+    await get_pool().execute(
+        "UPDATE pages SET updated_at = $1 WHERE id = $2",
+        datetime(2026, 1, 10, tzinfo=UTC),
+        UUID(page_id),
+    )
+
+    recent = await source_service.search_all(
+        ws, owner_id, "kumquat", modified_after=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+    assert [r["ref"] for r in recent["results"]] == ["new.md"]
+
+    older = await source_service.search_all(
+        ws, owner_id, "kumquat", modified_before=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+    assert sorted(r["ref"] for r in older["results"]) == sorted(["old.md", page_id])
+
+    window = await source_service.search_all(
+        ws,
+        owner_id,
+        "kumquat",
+        modified_after=datetime(2026, 1, 12, tzinfo=UTC),
+        modified_before=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+    assert [r["ref"] for r in window["results"]] == ["old.md"]
+
+
+@pytest.mark.asyncio
+async def test_search_modified_range_excludes_null_timestamps(client: AsyncClient):
+    """A doc with no provider modification time can't prove it's inside the
+    range, so any bound excludes it — a hit filtered by recency must never
+    smuggle in undated content."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    await _github_source_with_docs(ws, owner_id, {"a.md": "kumquat pruning notes"})
+
+    unbounded = await source_service.search_all(ws, owner_id, "kumquat")
+    assert [r["ref"] for r in unbounded["results"]] == ["a.md"]
+
+    for bound in (
+        {"modified_after": datetime(2020, 1, 1, tzinfo=UTC)},
+        {"modified_before": datetime(2030, 1, 1, tzinfo=UTC)},
+    ):
+        results = await source_service.search_all(ws, owner_id, "kumquat", **bound)
+        assert results["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_exact_ref_null_timestamp_excluded_when_bounded(client: AsyncClient):
+    """exact_ref hits pin above everything, but a bound still excludes them
+    when their external_updated_at is NULL — no timestamp, no range proof."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await _github_source_with_docs(ws, owner_id, {})
+    await _github_doc(ws, src, "doc.md", "release checklist", external_ref="DRV-12345")
+
+    unbounded = await source_service.search_all(ws, owner_id, "DRV-12345")
+    assert [r.get("exact_ref") for r in unbounded["results"]] == [True]
+
+    bounded = await source_service.search_all(
+        ws, owner_id, "DRV-12345", modified_after=datetime(2020, 1, 1, tzinfo=UTC)
+    )
+    assert bounded["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_modified_range_filters_session_hits(client: AsyncClient):
+    """Session hits filter on their event's created_at — the only modification
+    time an event has."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    for month, session_id in ((1, "sess-jan"), (3, "sess-mar")):
+        resp = await client.post(
+            "/api/v1/me/sessions/events",
+            json={
+                "agent_name": "tester",
+                "event_type": "note",
+                "content": "kumquat espalier techniques",
+                "session_id": session_id,
+                "created_at": f"2026-0{month}-01T00:00:00Z",
+            },
+            headers=_auth(api_key),
+        )
+        assert resp.status_code == 201
+
+    results = await source_service.search_all(
+        ws, owner_id, "kumquat espalier", modified_after=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    assert [r["ref"] for r in results["results"]] == ["sess-mar"]
+
+
+@pytest.mark.asyncio
+async def test_search_modified_range_filters_federated_hits_and_keeps_markers(
+    client: AsyncClient, monkeypatch
+):
+    """Federated providers have no date pushdown, so their live hits are
+    filtered after the fact: out-of-range and undated hits drop, while the
+    provider's truncation marker still trails the response."""
+    from backend.integrations.gmail import indexer
+
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="gmail",
+        external_ref="henry@ferganalabs.com",
+        display_name="Gmail (henry@ferganalabs.com)",
+    )
+
+    async def dated_search(source, query, limit):
+        return {
+            "hits": [
+                {
+                    "ref": "m-recent",
+                    "name": "recent",
+                    "snippet": "",
+                    "date_modified": datetime(2026, 3, 1, tzinfo=UTC),
+                },
+                {
+                    "ref": "m-old",
+                    "name": "old",
+                    "snippet": "",
+                    "date_modified": datetime(2026, 1, 1, tzinfo=UTC),
+                },
+                {"ref": "m-undated", "name": "undated", "snippet": ""},
+            ],
+            "truncated": True,
+            "estimated_total": 7,
+        }
+
+    monkeypatch.setattr(indexer, "search_gmail", dated_search)
+
+    results = await source_service.search_all(
+        ws, owner_id, "anything", modified_after=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    hits = [r for r in results["results"] if r.get("ref")]
+    assert [h["ref"] for h in hits] == ["m-recent"]
+    assert results["results"][-1]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_modified_after_later_than_before_is_400(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    resp = await client.get(
+        "/api/v1/me/sources/search",
+        params={
+            "q": "anything",
+            "modified_after": "2026-02-01T00:00:00Z",
+            "modified_before": "2026-01-01T00:00:00Z",
+        },
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 400
+    assert "modified_after" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_search_modified_garbage_is_422(client: AsyncClient):
+    api_key, _ = await _register(client)
+
+    for param in ("modified_after", "modified_before"):
+        resp = await client.get(
+            "/api/v1/me/sources/search",
+            params={"q": "anything", param: "notadate"},
+            headers=_auth(api_key),
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_search_modified_naive_datetime_is_treated_as_utc(client: AsyncClient):
+    """A bound without a timezone must mean UTC, not crash asyncpg — clients
+    (the CLI) send plain ISO strings like 2026-02-01."""
+    api_key, owner_id = await _register(client)
+    ws = await _user_scope(client, api_key)
+    src = await _github_source_with_docs(ws, owner_id, {})
+    await _github_doc(
+        ws, src, "a.md", "kumquat harvest", external_updated_at=datetime(2026, 3, 15, tzinfo=UTC)
+    )
+
+    resp = await client.get(
+        "/api/v1/me/sources/search",
+        params={"q": "kumquat", "modified_after": "2026-02-01T00:00:00"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 200
+    assert [r["ref"] for r in resp.json()["results"]] == ["a.md"]
+
+
 @pytest.mark.asyncio
 async def test_search_gmail_reports_truncation_from_next_page_token(monkeypatch):
     """search_gmail maps Gmail's nextPageToken to truncated and surfaces the

--- a/cli/client.py
+++ b/cli/client.py
@@ -727,10 +727,13 @@ class StashClient:
         include_sources: list[str] | None = None,
         exclude_sources: list[str] | None = None,
         limit: int = 20,
+        modified_after: str | None = None,
+        modified_before: str | None = None,
     ) -> dict:
         """Returns the search envelope: {"results": [...], "has_more": bool}.
         List params reach the server as repeated query params (httpx does this
-        natively), matching the endpoint's list[str] Query params."""
+        natively), matching the endpoint's list[str] Query params. The modified
+        bounds are raw ISO-8601 strings — the server parses and validates."""
         params: dict = {"q": query, "limit": limit}
         if source:
             params["source"] = source
@@ -738,6 +741,10 @@ class StashClient:
             params["include_sources"] = include_sources
         if exclude_sources:
             params["exclude_sources"] = exclude_sources
+        if modified_after:
+            params["modified_after"] = modified_after
+        if modified_before:
+            params["modified_before"] = modified_before
         return self._get("/api/v1/me/sources/search", **params)
 
     # --- Tables ---

--- a/cli/main.py
+++ b/cli/main.py
@@ -2981,6 +2981,8 @@ def _print_search(
     exclude_sources: str,
     limit: int,
     as_json: bool,
+    modified_after: str = "",
+    modified_before: str = "",
 ) -> None:
     """Shared body for `stash search`."""
     telemetry.record("sources.search")
@@ -2992,6 +2994,8 @@ def _print_search(
                 include_sources=split_source_tokens(include_sources),
                 exclude_sources=split_source_tokens(exclude_sources),
                 limit=limit,
+                modified_after=modified_after or None,
+                modified_before=modified_before or None,
             )
         except StashError as e:
             _err(e)
@@ -3043,11 +3047,32 @@ def search(
         "--exclude-sources",
         help="Comma-separated sources to skip. Not combinable with --source.",
     ),
+    modified_after: str = typer.Option(
+        "",
+        "--modified-after",
+        help="Only results last modified after this ISO timestamp (e.g. 2026-01-01). "
+        "Results with no known modification time are excluded.",
+    ),
+    modified_before: str = typer.Option(
+        "",
+        "--modified-before",
+        help="Only results last modified before this ISO timestamp. "
+        "Results with no known modification time are excluded.",
+    ),
     limit: int = typer.Option(20, "-n", "--limit"),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Search everything you can see — files, sessions, and connected sources."""
-    _print_search(query, source, include_sources, exclude_sources, limit, as_json)
+    _print_search(
+        query,
+        source,
+        include_sources,
+        exclude_sources,
+        limit,
+        as_json,
+        modified_after=modified_after,
+        modified_before=modified_before,
+    )
 
 
 def _poll_recompute_outcome(

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -29,6 +29,8 @@ def stash_search(
     include_sources: str = "",
     exclude_sources: str = "",
     limit: int = 20,
+    modified_after: str = "",
+    modified_before: str = "",
 ) -> str:
     """Search across all your sources — native files + session transcripts +
     connected sources (GitHub/Drive/Gmail/Notion/Slack/Granola) — merged onto
@@ -39,6 +41,9 @@ def stash_search(
     'sessions', or a connected-source id); omit it to search everything.
     Or filter with comma-separated `include_sources`/`exclude_sources` (native
     handles + provider names, e.g. "files,gmail"); not combinable with `source`.
+    Pass `modified_after`/`modified_before` (ISO-8601) to restrict to a
+    last-modified window; results with no known modification time are excluded
+    whenever a bound is set.
     """
     return _json(
         _client().search_sources(
@@ -47,6 +52,8 @@ def stash_search(
             include_sources=split_source_tokens(include_sources),
             exclude_sources=split_source_tokens(exclude_sources),
             limit=limit,
+            modified_after=modified_after or None,
+            modified_before=modified_before or None,
         )
     )
 

--- a/cli/tests/test_sources_cli.py
+++ b/cli/tests/test_sources_cli.py
@@ -18,9 +18,27 @@ class _FakeClient:
         return None
 
     def search_sources(
-        self, query, source=None, include_sources=None, exclude_sources=None, limit=20
+        self,
+        query,
+        source=None,
+        include_sources=None,
+        exclude_sources=None,
+        limit=20,
+        modified_after=None,
+        modified_before=None,
     ):
-        self._calls.append(("search", query, source, include_sources, exclude_sources, limit))
+        self._calls.append(
+            (
+                "search",
+                query,
+                source,
+                include_sources,
+                exclude_sources,
+                limit,
+                modified_after,
+                modified_before,
+            )
+        )
         return {
             "results": [{"source": "files", "ref": "p1", "name": "Runbook", "snippet": "deploy"}],
             "has_more": False,
@@ -56,17 +74,31 @@ def _wire(monkeypatch) -> list:
 def test_search_everything_passes_no_source(monkeypatch) -> None:
     calls = _wire(monkeypatch)
     main.search(
-        "migration", source="", include_sources="", exclude_sources="", limit=20, as_json=True
+        "migration",
+        source="",
+        include_sources="",
+        exclude_sources="",
+        modified_after="",
+        modified_before="",
+        limit=20,
+        as_json=True,
     )
-    assert calls == [("search", "migration", None, None, None, 20)]
+    assert calls == [("search", "migration", None, None, None, 20, None, None)]
 
 
 def test_search_scoped_passes_the_source(monkeypatch) -> None:
     calls = _wire(monkeypatch)
     main.search(
-        "rotate", source="src-9", include_sources="", exclude_sources="", limit=5, as_json=True
+        "rotate",
+        source="src-9",
+        include_sources="",
+        exclude_sources="",
+        modified_after="",
+        modified_before="",
+        limit=5,
+        as_json=True,
     )
-    assert calls == [("search", "rotate", "src-9", None, None, 5)]
+    assert calls == [("search", "rotate", "src-9", None, None, 5, None, None)]
 
 
 def test_search_splits_comma_separated_source_filters(monkeypatch) -> None:
@@ -76,10 +108,33 @@ def test_search_splits_comma_separated_source_filters(monkeypatch) -> None:
         source="",
         include_sources="files, gmail,,jira",
         exclude_sources="slack",
+        modified_after="",
+        modified_before="",
         limit=20,
         as_json=True,
     )
-    assert calls == [("search", "migration", None, ["files", "gmail", "jira"], ["slack"], 20)]
+    assert calls == [
+        ("search", "migration", None, ["files", "gmail", "jira"], ["slack"], 20, None, None)
+    ]
+
+
+def test_search_forwards_modified_range(monkeypatch) -> None:
+    """The bounds are raw ISO strings passed through untouched — the server
+    parses and validates, so the CLI must not reformat or reject them."""
+    calls = _wire(monkeypatch)
+    main.search(
+        "migration",
+        source="",
+        include_sources="",
+        exclude_sources="",
+        modified_after="2026-01-01",
+        modified_before="2026-02-01T00:00:00Z",
+        limit=20,
+        as_json=True,
+    )
+    assert calls == [
+        ("search", "migration", None, None, None, 20, "2026-01-01", "2026-02-01T00:00:00Z")
+    ]
 
 
 def test_split_source_tokens() -> None:
@@ -120,6 +175,27 @@ def test_search_sends_source_filters_as_repeated_query_params(monkeypatch) -> No
     ]
 
 
+def test_search_sends_modified_bounds_only_when_set(monkeypatch) -> None:
+    """Blank bounds must stay off the wire entirely (the repeated-params test
+    above shows they're absent by default); set bounds ride as query params."""
+    requests: list = []
+
+    class _Resp:
+        def json(self):
+            return {"results": [], "has_more": False}
+
+    def fake_request(method, url, **kwargs):
+        requests.append(kwargs.get("params"))
+        return _Resp()
+
+    client = StashClient("http://test")
+    monkeypatch.setattr(client, "_request", fake_request)
+    client.search_sources("q", modified_after="2026-01-01", modified_before="2026-02-01")
+    assert requests == [
+        {"q": "q", "limit": 20, "modified_after": "2026-01-01", "modified_before": "2026-02-01"}
+    ]
+
+
 def test_list_source_entries_sends_path_as_query_param(monkeypatch) -> None:
     """The entries endpoint takes a query param literally named "path". The real
     client method must not collide with the helpers' URL argument (it did once:
@@ -153,9 +229,7 @@ def test_search_renders_error_and_truncation_markers(monkeypatch, capsys) -> Non
         def __exit__(self, *_args):
             return None
 
-        def search_sources(
-            self, query, source=None, include_sources=None, exclude_sources=None, limit=20
-        ):
+        def search_sources(self, query, **kwargs):
             return {
                 "results": [
                     {
@@ -181,7 +255,16 @@ def test_search_renders_error_and_truncation_markers(monkeypatch, capsys) -> Non
 
     monkeypatch.setattr(main, "_require_auth", lambda: None)
     monkeypatch.setattr(main, "_client", lambda: _MarkerClient())
-    main.search("q", source="", include_sources="", exclude_sources="", limit=30, as_json=False)
+    main.search(
+        "q",
+        source="",
+        include_sources="",
+        exclude_sources="",
+        modified_after="",
+        modified_before="",
+        limit=30,
+        as_json=False,
+    )
 
     out = capsys.readouterr().out
     assert "Hello" in out
@@ -204,9 +287,7 @@ def test_search_prints_the_server_snippet_whole(monkeypatch, capsys) -> None:
         def __exit__(self, *_args):
             return None
 
-        def search_sources(
-            self, query, source=None, include_sources=None, exclude_sources=None, limit=20
-        ):
+        def search_sources(self, query, **kwargs):
             return {
                 "results": [{"source": "files", "ref": "p1", "name": "Notes", "snippet": snippet}],
                 "has_more": False,
@@ -214,6 +295,15 @@ def test_search_prints_the_server_snippet_whole(monkeypatch, capsys) -> None:
 
     monkeypatch.setattr(main, "_require_auth", lambda: None)
     monkeypatch.setattr(main, "_client", lambda: _SnippetClient())
-    main.search("match", source="", include_sources="", exclude_sources="", limit=20, as_json=False)
+    main.search(
+        "match",
+        source="",
+        include_sources="",
+        exclude_sources="",
+        modified_after="",
+        modified_before="",
+        limit=20,
+        as_json=False,
+    )
 
     assert "ZFINALZ" in capsys.readouterr().out

--- a/frontend/src/app/search/modified-range.test.ts
+++ b/frontend/src/app/search/modified-range.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODIFIED_RANGE,
+  modifiedRangeLabel,
+  modifiedRangeParams,
+  withinModifiedRange,
+  type ModifiedRange,
+} from "./modified-range";
+
+const NOW = new Date("2026-07-24T12:00:00Z");
+
+function custom(from: string, to: string): ModifiedRange {
+  return { preset: "custom", from, to };
+}
+
+describe("modifiedRangeParams", () => {
+  it("sends nothing for the default range", () => {
+    expect(modifiedRangeParams(DEFAULT_MODIFIED_RANGE, NOW)).toEqual({});
+  });
+
+  it("anchors each relative preset to now, with no upper bound", () => {
+    const cases: Array<[ModifiedRange["preset"], string]> = [
+      ["24h", "2026-07-23T12:00:00.000Z"],
+      ["week", "2026-07-17T12:00:00.000Z"],
+      ["month", "2026-06-24T12:00:00.000Z"],
+      ["year", "2025-07-24T12:00:00.000Z"],
+    ];
+    for (const [preset, expected] of cases) {
+      expect(modifiedRangeParams({ preset, from: "", to: "" }, NOW)).toEqual({
+        modifiedAfter: expected,
+      });
+    }
+  });
+
+  it("converts custom datetime-local values from local time to UTC ISO", () => {
+    const bounds = modifiedRangeParams(custom("2026-07-01T09:30", "2026-07-20T18:00"), NOW);
+    // new Date(value) parses datetime-local strings as local time, so the
+    // expected ISO is whatever that conversion yields in this environment.
+    expect(bounds).toEqual({
+      modifiedAfter: new Date("2026-07-01T09:30").toISOString(),
+      modifiedBefore: new Date("2026-07-20T18:00").toISOString(),
+    });
+  });
+
+  it("sends only the bound that is filled in", () => {
+    expect(modifiedRangeParams(custom("2026-07-01T09:30", ""), NOW)).toEqual({
+      modifiedAfter: new Date("2026-07-01T09:30").toISOString(),
+    });
+    expect(modifiedRangeParams(custom("", "2026-07-20T18:00"), NOW)).toEqual({
+      modifiedBefore: new Date("2026-07-20T18:00").toISOString(),
+    });
+    expect(modifiedRangeParams(custom("", ""), NOW)).toEqual({});
+  });
+});
+
+describe("withinModifiedRange", () => {
+  const bounds = {
+    modifiedAfter: "2026-02-01T00:00:00Z",
+    modifiedBefore: "2026-03-01T00:00:00Z",
+  };
+
+  it("keeps everything when no bounds are set", () => {
+    expect(withinModifiedRange(null, {})).toBe(true);
+    expect(withinModifiedRange("2020-01-01T00:00:00Z", {})).toBe(true);
+  });
+
+  it("excludes results with no timestamp whenever a bound is set", () => {
+    expect(withinModifiedRange(null, { modifiedAfter: bounds.modifiedAfter })).toBe(false);
+    expect(withinModifiedRange(undefined, { modifiedBefore: bounds.modifiedBefore })).toBe(false);
+  });
+
+  it("applies strict bounds, matching the server", () => {
+    expect(withinModifiedRange("2026-02-15T00:00:00Z", bounds)).toBe(true);
+    expect(withinModifiedRange("2026-01-15T00:00:00Z", bounds)).toBe(false);
+    expect(withinModifiedRange("2026-03-15T00:00:00Z", bounds)).toBe(false);
+    expect(withinModifiedRange(bounds.modifiedAfter, bounds)).toBe(false);
+    expect(withinModifiedRange(bounds.modifiedBefore, bounds)).toBe(false);
+  });
+});
+
+describe("modifiedRangeLabel", () => {
+  it("labels each preset for the chip", () => {
+    expect(modifiedRangeLabel(DEFAULT_MODIFIED_RANGE)).toBe("Any time");
+    expect(modifiedRangeLabel({ preset: "24h", from: "", to: "" })).toBe("Past 24 hours");
+    expect(modifiedRangeLabel({ preset: "week", from: "", to: "" })).toBe("Past week");
+    expect(modifiedRangeLabel(custom("2026-07-01T09:30", ""))).toBe("Custom range");
+  });
+});

--- a/frontend/src/app/search/modified-range.ts
+++ b/frontend/src/app/search/modified-range.ts
@@ -1,0 +1,66 @@
+// The last-modified chip stores user intent (a preset id, or custom
+// datetime-local bounds); concrete ISO bounds are computed at query time so
+// relative presets like "Past 24 hours" re-anchor to now on every fetch.
+export type ModifiedPreset = "any" | "24h" | "week" | "month" | "year" | "custom";
+
+export interface ModifiedRange {
+  preset: ModifiedPreset;
+  // datetime-local input values ("2026-07-01T09:30"); "" means unset.
+  from: string;
+  to: string;
+}
+
+export interface ModifiedBounds {
+  modifiedAfter?: string;
+  modifiedBefore?: string;
+}
+
+export const DEFAULT_MODIFIED_RANGE: ModifiedRange = { preset: "any", from: "", to: "" };
+
+const PRESET_LABELS: Record<ModifiedPreset, string> = {
+  any: "Any time",
+  "24h": "Past 24 hours",
+  week: "Past week",
+  month: "Past month",
+  year: "Past year",
+  custom: "Custom range",
+};
+
+const PRESET_MS: Partial<Record<ModifiedPreset, number>> = {
+  "24h": 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000,
+  year: 365 * 24 * 60 * 60 * 1000,
+};
+
+export function modifiedRangeLabel(range: ModifiedRange): string {
+  return PRESET_LABELS[range.preset];
+}
+
+// The ISO bounds the search request should carry. Custom values come from
+// datetime-local inputs, which parse as local time — new Date().toISOString()
+// is the local→UTC conversion the server expects.
+export function modifiedRangeParams(range: ModifiedRange, now: Date): ModifiedBounds {
+  const ms = PRESET_MS[range.preset];
+  if (ms) return { modifiedAfter: new Date(now.getTime() - ms).toISOString() };
+  if (range.preset !== "custom") return {};
+  const bounds: ModifiedBounds = {};
+  if (range.from) bounds.modifiedAfter = new Date(range.from).toISOString();
+  if (range.to) bounds.modifiedBefore = new Date(range.to).toISOString();
+  return bounds;
+}
+
+// Client-side counterpart of the server filter, for the kinds searched in the
+// browser (skills, tables): strict bounds, and a result with no timestamp is
+// excluded whenever any bound is set.
+export function withinModifiedRange(
+  updatedAt: string | null | undefined,
+  bounds: ModifiedBounds
+): boolean {
+  if (!bounds.modifiedAfter && !bounds.modifiedBefore) return true;
+  if (!updatedAt) return false;
+  const ts = new Date(updatedAt).getTime();
+  if (bounds.modifiedAfter && ts <= new Date(bounds.modifiedAfter).getTime()) return false;
+  if (bounds.modifiedBefore && ts >= new Date(bounds.modifiedBefore).getTime()) return false;
+  return true;
+}

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -6,8 +6,15 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type React
 import WorkspaceShell from "@/components/workspace/workspace-shell";
 import CustomSelect from "../../components/CustomSelect";
 import SearchSourceFilter from "../../components/SearchSourceFilter";
+import SearchModifiedFilter from "../../components/SearchModifiedFilter";
 import { providerForSourceType } from "../../components/integrations/connectors";
 import { CLIENT_SIDE_TOKENS, unifiedSearchTokens } from "./unified-tokens";
+import {
+  DEFAULT_MODIFIED_RANGE,
+  modifiedRangeParams,
+  withinModifiedRange,
+  type ModifiedRange,
+} from "./modified-range";
 import { BasicPageSkeleton, SearchResultsSkeleton, SearchSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import { track } from "../../lib/analytics";
@@ -91,6 +98,7 @@ function SearchPageInner() {
   // The chip stores what's UNCHECKED, so "all selected" is the default even
   // before the connected providers load, and the default sends no filter.
   const [deselectedSources, setDeselectedSources] = useState<Set<string>>(new Set());
+  const [modifiedRange, setModifiedRange] = useState<ModifiedRange>(DEFAULT_MODIFIED_RANGE);
   const [results, setResults] = useState<SearchResult[]>([]);
   const [sourceNotices, setSourceNotices] = useState<string[]>([]);
   const [hasMore, setHasMore] = useState(false);
@@ -121,6 +129,7 @@ function SearchPageInner() {
     selectedPageId,
     selectedProductSkillId,
     selectedProductSkillSlug,
+    modifiedRange,
   ]);
   const [prevSearchKey, setPrevSearchKey] = useState(searchKey);
   if (prevSearchKey !== searchKey) {
@@ -234,6 +243,10 @@ function SearchPageInner() {
       const includePages = selected.includes("files");
       const includeTables = selected.includes("tables");
       const includeSkills = selected.includes("skills");
+      // Computed per fetch so relative presets ("Past 24 hours") anchor to
+      // now. The scoped modes below (single session, public skill) are
+      // explicit navigation targets, not the unified surface — unfiltered.
+      const modifiedBounds = modifiedRangeParams(modifiedRange, new Date());
 
       if (selectedSessionId) {
         const events = await getSessionEvents(selectedSessionId);
@@ -259,7 +272,11 @@ function SearchPageInner() {
       }
 
       if (includeSkills && !selectedFolderId && !selectedPageId) {
-        nextResults.push(...searchSkills(skills, q, sourceName));
+        nextResults.push(
+          ...searchSkills(skills, q, sourceName).filter((r) =>
+            withinModifiedRange(r.updatedAt, modifiedBounds)
+          )
+        );
       }
 
       // One unified call covers sessions + pages + connected sources, merged
@@ -275,6 +292,8 @@ function SearchPageInner() {
         const { results: hits, has_more } = await searchSource(q, {
           includeSources: tokens.length === allApiTokenCount ? undefined : tokens,
           limit,
+          modifiedAfter: modifiedBounds.modifiedAfter,
+          modifiedBefore: modifiedBounds.modifiedBefore,
         });
         if (searchSeq.current !== seq) return;
         const folderIds = sidebar
@@ -295,7 +314,9 @@ function SearchPageInner() {
       }
 
       if (includeTables && !selectedFolderId && !selectedPageId) {
-        nextResults.push(...searchTables(tables, q));
+        nextResults.push(
+          ...searchTables(tables, q).filter((r) => withinModifiedRange(r.updatedAt, modifiedBounds))
+        );
       }
 
       setResults(sortResults(nextResults));
@@ -316,6 +337,7 @@ function SearchPageInner() {
   }, [
     allSourceTokens,
     deselectedSources,
+    modifiedRange,
     skills,
     selectedFolderId,
     selectedPageId,
@@ -424,6 +446,8 @@ function SearchPageInner() {
                 })
               }
             />
+
+            <SearchModifiedFilter range={modifiedRange} onChange={setModifiedRange} />
           </div>
 
           <main className="min-w-0">

--- a/frontend/src/components/SearchModifiedFilter.test.tsx
+++ b/frontend/src/components/SearchModifiedFilter.test.tsx
@@ -1,0 +1,65 @@
+/** The last-modified chip defaults to "Any time", swaps its label to the
+ * active preset, and flips to a custom range as soon as either datetime input
+ * is edited — the preset list and the custom inputs are one control. */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MODIFIED_RANGE, type ModifiedRange } from "@/app/search/modified-range";
+import SearchModifiedFilter from "./SearchModifiedFilter";
+
+function Harness({ initial = DEFAULT_MODIFIED_RANGE }: { initial?: ModifiedRange }) {
+  const [range, setRange] = useState(initial);
+  return <SearchModifiedFilter range={range} onChange={setRange} />;
+}
+
+function openMenu(): HTMLElement {
+  // Radix triggers open on pointer/keyboard events, not jsdom's synthetic
+  // click — Enter is the reliable way to open the menu in tests. The open
+  // menu is modal (the trigger goes aria-hidden), so later assertions must
+  // use the element captured here, not a fresh role query.
+  const trigger = screen.getByRole("button", { name: "Last modified" });
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  return trigger;
+}
+
+describe("SearchModifiedFilter", () => {
+  it("labels the trigger 'Any time' by default", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: "Last modified" })).toHaveTextContent("Any time");
+  });
+
+  it("selects a preset, relabels the trigger, and keeps the menu open", () => {
+    render(<Harness />);
+    const trigger = openMenu();
+
+    const items = screen.getAllByRole("menuitemcheckbox");
+    expect(items.map((i) => i.textContent)).toEqual([
+      "Any time",
+      "Past 24 hours",
+      "Past week",
+      "Past month",
+      "Past year",
+    ]);
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Past week" }));
+    expect(trigger).toHaveTextContent("Past week");
+    // The item is still queryable — the menu did not close on selection.
+    expect(screen.getByRole("menuitemcheckbox", { name: "Past week" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("switches to a custom range when a datetime input is edited", () => {
+    render(<Harness initial={{ preset: "week", from: "", to: "" }} />);
+    const trigger = openMenu();
+
+    fireEvent.change(screen.getByLabelText("From"), { target: { value: "2026-07-01T09:30" } });
+    expect(trigger).toHaveTextContent("Custom range");
+    expect(screen.getByLabelText("From")).toHaveValue("2026-07-01T09:30");
+
+    fireEvent.change(screen.getByLabelText("To"), { target: { value: "2026-07-20T18:00" } });
+    expect(screen.getByLabelText("From")).toHaveValue("2026-07-01T09:30");
+    expect(screen.getByLabelText("To")).toHaveValue("2026-07-20T18:00");
+  });
+});

--- a/frontend/src/components/SearchModifiedFilter.tsx
+++ b/frontend/src/components/SearchModifiedFilter.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  modifiedRangeLabel,
+  type ModifiedPreset,
+  type ModifiedRange,
+} from "@/app/search/modified-range";
+
+const PRESETS: ModifiedPreset[] = ["any", "24h", "week", "month", "year"];
+
+export default function SearchModifiedFilter({
+  range,
+  onChange,
+}: {
+  range: ModifiedRange;
+  onChange: (range: ModifiedRange) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Last modified"
+        className="flex h-7 items-center gap-1.5 rounded-full border border-border bg-surface px-3 text-[12.5px] text-foreground hover:border-[var(--color-brand-300)]"
+      >
+        {modifiedRangeLabel(range)}
+        <ChevronDown className="size-3.5 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56 text-[12.5px]">
+        {PRESETS.map((preset) => (
+          <DropdownMenuCheckboxItem
+            key={preset}
+            checked={range.preset === preset}
+            onCheckedChange={() => onChange({ preset, from: "", to: "" })}
+            // Keep the menu open — picking a range is often a two-step gesture.
+            onSelect={(e) => e.preventDefault()}
+          >
+            {modifiedRangeLabel({ preset, from: "", to: "" })}
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        {/* Typing dates must not trigger Radix's menu typeahead. */}
+        <div className="flex flex-col gap-2 px-2 py-1.5" onKeyDown={(e) => e.stopPropagation()}>
+          <label className="flex flex-col gap-1 text-muted-foreground">
+            From
+            <input
+              type="datetime-local"
+              value={range.from}
+              onChange={(e) => onChange({ preset: "custom", from: e.target.value, to: range.to })}
+              className="rounded-md border border-border bg-surface px-2 py-1 text-foreground"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-muted-foreground">
+            To
+            <input
+              type="datetime-local"
+              value={range.to}
+              onChange={(e) => onChange({ preset: "custom", from: range.from, to: e.target.value })}
+              className="rounded-md border border-border bg-surface px-2 py-1 text-foreground"
+            />
+          </label>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -431,13 +431,21 @@ export interface SourceSearchResponse {
 
 export async function searchSource(
   query: string,
-  opts: { source?: string; includeSources?: string[]; limit?: number } = {},
+  opts: {
+    source?: string;
+    includeSources?: string[];
+    limit?: number;
+    modifiedAfter?: string;
+    modifiedBefore?: string;
+  } = {},
 ): Promise<SourceSearchResponse> {
   const params = new URLSearchParams({ q: query });
   if (opts.source) params.set("source", opts.source);
   // Repeated params — the endpoint declares include_sources as a list.
   for (const token of opts.includeSources ?? []) params.append("include_sources", token);
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.modifiedAfter) params.set("modified_after", opts.modifiedAfter);
+  if (opts.modifiedBefore) params.set("modified_before", opts.modifiedBefore);
   return apiFetch<SourceSearchResponse>(`${ME}/sources/search?${params.toString()}`);
 }
 

--- a/www/app/docs/cli/page.tsx
+++ b/www/app/docs/cli/page.tsx
@@ -292,6 +292,8 @@ stash vfs --cwd "/me/sources" "rg 'incident' ."`}</CodeBlock>
         params={[
           { name: "<query>", type: "string", desc: "Search query.", required: true },
           { name: "--source", type: "string", desc: "Scope to one source handle (from stash sources ls). Omit to search everything." },
+          { name: "--modified-after", type: "string", desc: "Only results last modified after this ISO timestamp (e.g. 2026-01-01). Results with no known modification time are excluded." },
+          { name: "--modified-before", type: "string", desc: "Only results last modified before this ISO timestamp. Results with no known modification time are excluded." },
           { name: "-n, --limit", type: "number", desc: "Maximum number of results. Defaults to 20." },
         ]}
       />


### PR DESCRIPTION
## Changes

Allows the user to sort by date when searching stash. This is accomplished by adding the --modified-after and --modified-before CLI options, and similarly allowing the user to select from a datetime range in the web UI. The UI is a bit vibecoded at the moment, but works.

Default behavior remains the same as before, changes only occur if the user decides to sort by date.

Finally, some integrations don't actually give us a date of last modification, and hits from those are only included if the user doesn't sort by date.

## What (Claude-generated below this point)

Adds `modified_after` / `modified_before` bounds to unified search, applied on every result path:

- Sessions, pages, and exact-ref matches are bounded in-SQL, as is the copied-content FTS path.
- Federated (connected-source) hits are post-filtered.
- Results with no last-modified date are excluded whenever either bound is set.

## Surfaces

- **CLI**: `stash search --modified-after / --modified-before`
- **MCP**: same parameters on the search tool
- **Search page**: a fourth filter chip with presets plus a custom range (`SearchModifiedFilter`)
- **Docs**: CLI docs page updated

## Tests

Backend (`test_sources.py`), CLI (`test_sources_cli.py`), and frontend (`modified-range.test.ts`, `SearchModifiedFilter.test.tsx`) coverage included.

## Notes

- Branch predates ~77 commits of main but merges cleanly (verified with `git merge-tree`).
- Screenshots of the new search-page chip to follow: the local stack's backend port is currently held by a benchmarking run, so I couldn't capture the UI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)