### PR TITLE
Celery: heavy queue for long-running tasks so cheap and cadence-sensitive work can't be starved

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -2,7 +2,9 @@
 
 One process model:
   - `backend` (uvicorn)         — HTTP API, dispatches tasks via `.delay()`.
-  - `worker`  (celery worker)   — executes tasks.
+  - `worker`  (celery worker)   — executes tasks (`-Q default`).
+  - `heartbeat worker`          — executes the cadence-sensitive beat tasks
+                                  (`-Q heartbeat`), see `task_routes`.
   - `beat`    (celery beat)     — fires the periodic tasks in `beat_schedule`.
 
 Each task module is added to `include` when it lands. Adding a module to
@@ -16,6 +18,7 @@ the same scheduled task multiple times.
 
 from celery import Celery
 from celery.schedules import crontab
+from kombu import Queue
 
 from .config import settings
 
@@ -46,6 +49,21 @@ celery = Celery(
 
 celery.conf.update(
     task_default_queue="default",
+    # Heavy tasks (Playwright renders, PDF extraction, zip exports) legally
+    # run up to 30 min each, so a saturated pool delays everything queued
+    # behind them. Beat tasks whose cadence is load-bearing — X token
+    # keep-fresh (the 45-min refresh_margin assumes a tick roughly every 30
+    # min) and the ticket reconcilers — run on the separate "heartbeat" queue
+    # so they can never sit behind heavy work. A worker started without -Q
+    # consumes every queue listed in task_queues, so a deploy whose worker
+    # command predates the split still executes heartbeat tasks; -Q flags
+    # (start.sh, docker-compose.prod.yml) give the real isolation.
+    task_queues=(Queue("default"), Queue("heartbeat")),
+    task_routes={
+        "backend.integrations.x_saves.keep_tokens_fresh": {"queue": "heartbeat"},
+        "backend.tasks.linear_tickets.reconcile": {"queue": "heartbeat"},
+        "backend.tasks.linear_tickets.reconcile_github_prs": {"queue": "heartbeat"},
+    },
     task_acks_late=True,
     task_reject_on_worker_lost=True,
     worker_prefetch_multiplier=1,

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -2,9 +2,9 @@
 
 One process model:
   - `backend` (uvicorn)         — HTTP API, dispatches tasks via `.delay()`.
-  - `worker`  (celery worker)   — executes tasks (`-Q default`).
-  - `heartbeat worker`          — executes the cadence-sensitive beat tasks
-                                  (`-Q heartbeat`), see `task_routes`.
+  - `worker`  (celery worker)   — executes cheap, bounded tasks (`-Q default`).
+  - `heavy worker`              — executes the long-running task families
+                                  (`-Q heavy`), see `task_routes`.
   - `beat`    (celery beat)     — fires the periodic tasks in `beat_schedule`.
 
 Each task module is added to `include` when it lands. Adding a module to
@@ -49,20 +49,30 @@ celery = Celery(
 
 celery.conf.update(
     task_default_queue="default",
-    # Heavy tasks (Playwright renders, PDF extraction, zip exports) legally
-    # run up to 30 min each, so a saturated pool delays everything queued
-    # behind them. Beat tasks whose cadence is load-bearing — X token
-    # keep-fresh (the 45-min refresh_margin assumes a tick roughly every 30
-    # min) and the ticket reconcilers — run on the separate "heartbeat" queue
-    # so they can never sit behind heavy work. A worker started without -Q
-    # consumes every queue listed in task_queues, so a deploy whose worker
-    # command predates the split still executes heartbeat tasks; -Q flags
-    # (start.sh, docker-compose.prod.yml) give the real isolation.
-    task_queues=(Queue("default"), Queue("heartbeat")),
+    # Two queues, split by task weight. Anything that can hold a worker slot
+    # for minutes — subprocess extractions, Playwright renders, exports,
+    # source crawls, bulk URL fetches, headless agent runs — routes to
+    # "heavy" and gets its own worker pool. Everything else (every beat
+    # sweep, every cheap bounded task) stays on "default", which therefore
+    # never stalls: cadence-sensitive tasks like X token keep-fresh (its
+    # 45-min refresh_margin assumes a tick roughly every 30 min) get their
+    # guarantee without being enumerated. Interactive agent replies
+    # (Slack/Telegram) also stay on "default" deliberately: a user is
+    # waiting, and "heavy" would queue them behind renders. A worker started
+    # without -Q consumes every queue listed in task_queues, so a deploy
+    # whose worker command predates the split still executes both queues;
+    # -Q flags (start.sh, docker-compose.prod.yml) give the real isolation.
+    task_queues=(Queue("default"), Queue("heavy")),
     task_routes={
-        "backend.integrations.x_saves.keep_tokens_fresh": {"queue": "heartbeat"},
-        "backend.tasks.linear_tickets.reconcile": {"queue": "heartbeat"},
-        "backend.tasks.linear_tickets.reconcile_github_prs": {"queue": "heartbeat"},
+        "backend.tasks.extraction.extract_file_text": {"queue": "heavy"},
+        "backend.tasks.drive_extraction.extract_drive_document": {"queue": "heavy"},
+        "backend.tasks.clips.process_url_imports": {"queue": "heavy"},
+        "backend.tasks.sources.sync_source": {"queue": "heavy"},
+        "backend.exports.pdf.export_pdf": {"queue": "heavy"},
+        "backend.exports.pptx.export_pptx": {"queue": "heavy"},
+        "backend.exports.gslides.export_to_google_slides": {"queue": "heavy"},
+        "backend.tasks.agent_schedules.run_scheduled_agent": {"queue": "heavy"},
+        "backend.tasks.agent_schedules.run_curator_now": {"queue": "heavy"},
     },
     task_acks_late=True,
     task_reject_on_worker_lost=True,

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -1,8 +1,11 @@
 """Run scheduled agents on their cron.
 
-The beat task fires every minute; for each scheduled agent it checks whether a
-cron tick is due since the agent's last run and, if so, runs it headless. The
-agent's own turn lock (Redis) prevents overlap with an in-flight run.
+The beat task fires every minute and is a pure dispatcher: it finds agents
+whose cron tick is due, consumes the tick, applies the cheap gates (credits,
+credential, pending changes), and hands each eligible run to
+`run_scheduled_agent` on the heavy queue — a headless agent turn runs for
+minutes and must not hold a default-queue slot. The agent's own turn lock
+(Redis) prevents overlap with an in-flight run.
 """
 
 from __future__ import annotations
@@ -36,6 +39,11 @@ def run_due() -> int:
     return run_async(_run_due())
 
 
+@celery.task(name="backend.tasks.agent_schedules.run_scheduled_agent")
+def run_scheduled_agent(agent_id: str, stamp: str) -> None:
+    run_async(_run_scheduled_agent(UUID(agent_id), stamp))
+
+
 @celery.task(name="backend.tasks.agent_schedules.run_curator_now")
 def run_curator_now(agent_id: str) -> None:
     run_async(_run_curator_now(UUID(agent_id)))
@@ -66,17 +74,11 @@ async def _run_curator_now(agent_id: UUID) -> None:
 async def _run_due() -> int:
     from ..config import settings
     from ..database import get_pool
-    from ..services import (
-        agent_auth,
-        agent_service,
-        alert_service,
-        curation_service,
-        sprite_agent_service,
-    )
+    from ..services import agent_auth, agent_service, curation_service
 
     now = datetime.now(UTC)
     stamp = now.strftime("%Y%m%d%H%M")
-    ran = 0
+    dispatched = 0
     for agent in await agent_service.list_scheduled():
         if not _is_due(agent["schedule_cron"], agent["last_run_at"], now):
             continue
@@ -107,26 +109,35 @@ async def _run_due() -> int:
             user_id, user_id, agent["curated_through"]
         ):
             continue
-        try:
-            await sprite_agent_service.run_scheduled(agent, stamp)
-            if agent["is_curator"]:
-                # `now` predates the run, so changes made during it stay ahead
-                # of the watermark and are picked up next time. If the delta
-                # overflowed the event cap, the watermark stops at the last
-                # event that fit — the overflow drains on subsequent runs.
-                through = await curation_service.complete_through(
-                    user_id, agent["curated_through"], now
-                )
-                await agent_service.mark_curated(agent["id"], through)
-            ran += 1
-        except Exception as e:
-            logger.exception("agent schedule: run failed for agent %s", agent["id"])
-            await agent_service.mark_run_failed(agent["id"], str(e))
-            email = await get_pool().fetchval("SELECT email FROM users WHERE id = $1", user_id)
-            await alert_service.send_alert(
-                f"Scheduled agent run failed: {agent['name']!r} for {email}: {str(e)[:300]}"
-            )
-    return ran
+        run_scheduled_agent.delay(str(agent["id"]), stamp)
+        dispatched += 1
+    return dispatched
+
+
+async def _run_scheduled_agent(agent_id: UUID, stamp: str) -> None:
+    from ..database import get_pool
+    from ..services import agent_service, alert_service, curation_service, sprite_agent_service
+
+    agent = await agent_service.get_agent_by_id(agent_id)
+    user_id = UUID(str(agent["user_id"]))
+    now = datetime.now(UTC)
+    try:
+        await sprite_agent_service.run_scheduled(agent, stamp)
+    except Exception as e:
+        logger.exception("agent schedule: run failed for agent %s", agent_id)
+        await agent_service.mark_run_failed(agent_id, str(e))
+        email = await get_pool().fetchval("SELECT email FROM users WHERE id = $1", user_id)
+        await alert_service.send_alert(
+            f"Scheduled agent run failed: {agent['name']!r} for {email}: {str(e)[:300]}"
+        )
+        return
+    if agent["is_curator"]:
+        # `now` predates the run, so changes made during it stay ahead of the
+        # watermark and are picked up next time. If the delta overflowed the
+        # event cap, the watermark stops at the last event that fit — the
+        # overflow drains on subsequent runs.
+        through = await curation_service.complete_through(user_id, agent["curated_through"], now)
+        await agent_service.mark_curated(agent_id, through)
 
 
 # A curator whose watermark is older than this while changes are pending has

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -118,11 +118,28 @@ async def _run_scheduled_agent(agent_id: UUID, stamp: str) -> None:
     from ..database import get_pool
     from ..services import agent_service, alert_service, curation_service, sprite_agent_service
 
-    agent = await agent_service.get_agent_by_id(agent_id)
+    try:
+        agent = await agent_service.get_agent_by_id(agent_id)
+    except ValueError:
+        # Deleted between the beat tick and this run — nothing to do, and no
+        # agent row left to record a failure on.
+        logger.info("agent schedule: agent %s deleted before its run", agent_id)
+        return
     user_id = UUID(str(agent["user_id"]))
     now = datetime.now(UTC)
     try:
         await sprite_agent_service.run_scheduled(agent, stamp)
+        if agent["is_curator"]:
+            # `now` predates the run, so changes made during it stay ahead of
+            # the watermark and are picked up next time. If the delta
+            # overflowed the event cap, the watermark stops at the last event
+            # that fit — the overflow drains on subsequent runs. Bookkeeping
+            # failures share the run's try so they also record last_run_error
+            # and alert, instead of dying as a bare task error.
+            through = await curation_service.complete_through(
+                user_id, agent["curated_through"], now
+            )
+            await agent_service.mark_curated(agent_id, through)
     except Exception as e:
         logger.exception("agent schedule: run failed for agent %s", agent_id)
         await agent_service.mark_run_failed(agent_id, str(e))
@@ -130,14 +147,6 @@ async def _run_scheduled_agent(agent_id: UUID, stamp: str) -> None:
         await alert_service.send_alert(
             f"Scheduled agent run failed: {agent['name']!r} for {email}: {str(e)[:300]}"
         )
-        return
-    if agent["is_curator"]:
-        # `now` predates the run, so changes made during it stay ahead of the
-        # watermark and are picked up next time. If the delta overflowed the
-        # event cap, the watermark stops at the last event that fit — the
-        # overflow drains on subsequent runs.
-        through = await curation_service.complete_through(user_id, agent["curated_through"], now)
-        await agent_service.mark_curated(agent_id, through)
 
 
 # A curator whose watermark is older than this while changes are pending has

--- a/backend/tasks/clips.py
+++ b/backend/tasks/clips.py
@@ -2,8 +2,8 @@
 
 Work arrives in batches of ids rather than one task per URL, and the
 dispatcher only keeps WINDOW_URLS in flight at once — a 40k bookmark
-import trickles through 2 of the worker's 4 slots instead of starving
-embeddings and syncs behind a flooded queue. Batches are interleaved
+import trickles through one heavy-queue slot instead of monopolizing the
+pool that renders, extractions, and source syncs share. Batches are interleaved
 across domains and fetches are capped per domain, because bookmark files
 cluster heavily (a quarter of a real export is youtube.com) and hammering
 one site from a datacenter IP is how imports get rate-limited.
@@ -43,8 +43,9 @@ logger = logging.getLogger(__name__)
 BATCH_SIZE = 100
 CONCURRENCY = 8
 PER_DOMAIN_CONCURRENCY = 2
-# 2 batches in flight leaves 2 of the worker's 4 slots free for other work.
-WINDOW_URLS = 2 * BATCH_SIZE
+# One batch in flight occupies one slot of the heavy pool, leaving the rest
+# for renders, extractions, and source syncs during a bulk import.
+WINDOW_URLS = BATCH_SIZE
 NEEDS_CLIENT_EXPIRY_HOURS = 24
 EXPIRY_SWEEP_LIMIT = 200
 

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -147,3 +147,42 @@ async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
         "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
     )
     assert error is not None and "opencode error" in error
+
+
+@pytest.mark.asyncio
+async def test_run_bookkeeping_failure_sends_alert(client: AsyncClient, monkeypatch):
+    """A run whose post-turn bookkeeping fails must record last_run_error and
+    alert, exactly like a failed turn — otherwise the watermark silently stops
+    advancing with no trace on the agent row."""
+    from backend.services import curation_service, sprite_agent_service
+
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+
+    async def fake_run_scheduled(agent, stamp):
+        return ""
+
+    async def boom(user_id, curated_through, now):
+        raise RuntimeError("watermark write failed")
+
+    monkeypatch.setattr(sprite_agent_service, "run_scheduled", fake_run_scheduled)
+    monkeypatch.setattr(curation_service, "complete_through", boom)
+    sent = _capture_alerts(monkeypatch)
+
+    await agent_schedules._run_scheduled_agent(uuid.UUID(agent["id"]), "202608091200")
+
+    assert len(sent) == 1 and "watermark write failed" in sent[0]
+    error = await get_pool().fetchval(
+        "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
+    )
+    assert error is not None and "watermark write failed" in error
+
+
+@pytest.mark.asyncio
+async def test_deleted_agent_run_is_a_quiet_no_op(client: AsyncClient, monkeypatch):
+    """An agent deleted between the beat tick and its dispatched run has
+    nothing to run and no row left to record a failure on — the task must
+    return quietly instead of dying as a bare task error."""
+    sent = _capture_alerts(monkeypatch)
+    await agent_schedules._run_scheduled_agent(uuid.uuid4(), "202608091200")
+    assert sent == []

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -133,7 +133,12 @@ async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", fake_run_scheduled)
     sent = _capture_alerts(monkeypatch)
 
-    assert await agent_schedules._run_due() == 0
+    dispatched = []
+    monkeypatch.setattr(
+        agent_schedules.run_scheduled_agent, "delay", lambda *args: dispatched.append(args)
+    )
+    assert await agent_schedules._run_due() == 1
+    await agent_schedules._run_scheduled_agent(uuid.UUID(dispatched[0][0]), dispatched[0][1])
     assert len(sent) == 1
     assert "Scheduled agent run failed" in sent[0] and "opencode error" in sent[0]
     # The failure is also stored on the agent, which is what the stale-curator

--- a/backend/tests/test_celery_routing.py
+++ b/backend/tests/test_celery_routing.py
@@ -1,0 +1,31 @@
+"""The heartbeat queue exists so cadence-sensitive beat tasks cannot sit
+behind heavy tasks that legally run 30 minutes each. X token keep-fresh is
+the sharpest case: the X provider's 45-min refresh_margin only rotates
+tokens pre-expiry if the keep-fresh tick actually runs ~every 30 minutes,
+so a starved queue silently reverts X to post-expiry reactive refresh."""
+
+from backend.celery_app import celery
+from backend.integrations.x_saves.tasks import keep_tokens_fresh
+from backend.tasks.linear_tickets import reconcile, reconcile_github_prs
+
+HEARTBEAT_TASKS = {
+    keep_tokens_fresh.name,
+    reconcile.name,
+    reconcile_github_prs.name,
+}
+
+
+def test_heartbeat_tasks_route_off_the_default_queue():
+    # Route keys are matched by name at dispatch time, so importing the real
+    # task objects above also pins the names against typos and renames.
+    routes = celery.conf.task_routes
+    assert set(routes) == HEARTBEAT_TASKS
+    for task_name in HEARTBEAT_TASKS:
+        assert routes[task_name] == {"queue": "heartbeat"}
+
+
+def test_bare_worker_consumes_both_queues():
+    # A worker started without -Q consumes exactly the queues declared in
+    # task_queues. If "heartbeat" is missing here, a worker whose command
+    # predates the split strands every routed task the moment routing ships.
+    assert {q.name for q in celery.conf.task_queues} == {"default", "heartbeat"}

--- a/backend/tests/test_celery_routing.py
+++ b/backend/tests/test_celery_routing.py
@@ -1,31 +1,52 @@
-"""The heartbeat queue exists so cadence-sensitive beat tasks cannot sit
-behind heavy tasks that legally run 30 minutes each. X token keep-fresh is
-the sharpest case: the X provider's 45-min refresh_margin only rotates
-tokens pre-expiry if the keep-fresh tick actually runs ~every 30 minutes,
-so a starved queue silently reverts X to post-expiry reactive refresh."""
+"""Two queues split by task weight: anything that can hold a worker slot for
+minutes routes to "heavy", so the beat sweeps and cheap tasks on "default"
+never queue behind it. The X token keep-fresh cadence is the sharpest thing
+this protects: its 45-min refresh_margin only rotates tokens pre-expiry if
+the keep-fresh tick actually runs ~every 30 minutes, and a starved queue
+silently reverts X to post-expiry reactive refresh."""
 
 from backend.celery_app import celery
-from backend.integrations.x_saves.tasks import keep_tokens_fresh
-from backend.tasks.linear_tickets import reconcile, reconcile_github_prs
+from backend.exports.pdf import export_pdf
+from backend.exports.pptx import export_pptx
+from backend.integrations.google.exporters.slides import export_to_google_slides
+from backend.tasks.agent_schedules import run_curator_now, run_scheduled_agent
+from backend.tasks.clips import process_url_imports
+from backend.tasks.drive_extraction import extract_drive_document
+from backend.tasks.extraction import extract_file_text
+from backend.tasks.sources import sync_source
 
-HEARTBEAT_TASKS = {
-    keep_tokens_fresh.name,
-    reconcile.name,
-    reconcile_github_prs.name,
+HEAVY_TASKS = {
+    extract_file_text.name,
+    extract_drive_document.name,
+    process_url_imports.name,
+    sync_source.name,
+    export_pdf.name,
+    export_pptx.name,
+    export_to_google_slides.name,
+    run_scheduled_agent.name,
+    run_curator_now.name,
 }
 
 
-def test_heartbeat_tasks_route_off_the_default_queue():
+def test_heavy_tasks_route_off_the_default_queue():
     # Route keys are matched by name at dispatch time, so importing the real
     # task objects above also pins the names against typos and renames.
     routes = celery.conf.task_routes
-    assert set(routes) == HEARTBEAT_TASKS
-    for task_name in HEARTBEAT_TASKS:
-        assert routes[task_name] == {"queue": "heartbeat"}
+    assert set(routes) == HEAVY_TASKS
+    for task_name in HEAVY_TASKS:
+        assert routes[task_name] == {"queue": "heavy"}
+
+
+def test_no_beat_task_is_heavy():
+    # The whole point of the split: every beat tick must stay cheap. A beat
+    # task routed to heavy (or doing heavy work inline, like run_due before
+    # it became a dispatcher) couples its cadence to long-running work.
+    beat_tasks = {entry["task"] for entry in celery.conf.beat_schedule.values()}
+    assert beat_tasks.isdisjoint(HEAVY_TASKS)
 
 
 def test_bare_worker_consumes_both_queues():
     # A worker started without -Q consumes exactly the queues declared in
-    # task_queues. If "heartbeat" is missing here, a worker whose command
+    # task_queues. If "heavy" is missing here, a worker whose command
     # predates the split strands every routed task the moment routing ships.
-    assert {q.name for q in celery.conf.task_queues} == {"default", "heartbeat"}
+    assert {q.name for q in celery.conf.task_queues} == {"default", "heavy"}

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -395,11 +395,13 @@ async def test_idle_curator_skipped_by_beat(client: AsyncClient, sprite_exec, _d
 
 
 @pytest.mark.asyncio
-async def test_curator_run_does_not_echo_loop(client: AsyncClient, sprite_exec, _db_pool):
+async def test_curator_run_does_not_echo_loop(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
     """A curator run writes its own transcript into history_events; that must
     not count as new changes, or the daily gate would fire forever."""
     from backend.services import curation_service
-    from backend.tasks.agent_schedules import _run_due
+    from backend.tasks.agent_schedules import _run_due, _run_scheduled_agent, run_scheduled_agent
 
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
@@ -408,8 +410,10 @@ async def test_curator_run_does_not_echo_loop(client: AsyncClient, sprite_exec, 
     )
     await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
 
-    ran = await _run_due()
-    assert ran == 1
+    dispatched = []
+    monkeypatch.setattr(run_scheduled_agent, "delay", lambda *args: dispatched.append(args))
+    assert await _run_due() == 1
+    await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
 
     after = await _db_pool.fetchval(
         "SELECT curated_through FROM agents WHERE id = $1", UUID(curator["id"])
@@ -422,10 +426,12 @@ async def test_curator_run_does_not_echo_loop(client: AsyncClient, sprite_exec, 
 
 
 @pytest.mark.asyncio
-async def test_curator_run_keeps_full_toolset(client: AsyncClient, sprite_exec, _db_pool):
+async def test_curator_run_keeps_full_toolset(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
     """The curator is a trusted headless run — it must NOT inherit the
     untrusted-channel tool restrictions (it needs to write the wiki)."""
-    from backend.tasks.agent_schedules import _run_due
+    from backend.tasks.agent_schedules import _run_due, _run_scheduled_agent, run_scheduled_agent
 
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
@@ -434,7 +440,10 @@ async def test_curator_run_keeps_full_toolset(client: AsyncClient, sprite_exec, 
     )
     await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
 
+    dispatched = []
+    monkeypatch.setattr(run_scheduled_agent, "delay", lambda *args: dispatched.append(args))
     await _run_due()
+    await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
 
     curator_argv = [a for a in sprite_exec.calls if "Memory Wiki Curation" in " ".join(a)]
     assert curator_argv and "--disallowedTools" not in curator_argv[0]
@@ -447,7 +456,7 @@ async def test_failed_curator_run_preserves_watermark(
     """A failed run consumes the cron tick but must not advance the watermark —
     the un-curated delta is re-covered on the next successful run."""
     from backend.services import sprite_agent_service
-    from backend.tasks.agent_schedules import _run_due
+    from backend.tasks.agent_schedules import _run_due, _run_scheduled_agent, run_scheduled_agent
 
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
@@ -461,8 +470,10 @@ async def test_failed_curator_run_preserves_watermark(
         raise RuntimeError("sprite exploded")
 
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", boom)
-    ran = await _run_due()
-    assert ran == 0
+    dispatched = []
+    monkeypatch.setattr(run_scheduled_agent, "delay", lambda *args: dispatched.append(args))
+    assert await _run_due() == 1
+    await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
 
     after = await _db_pool.fetchval(
         "SELECT curated_through FROM agents WHERE id = $1", UUID(curator["id"])
@@ -478,7 +489,7 @@ async def test_failed_run_records_error_and_refunds_credit(
     free monthly allowance — an infra outage would otherwise silently burn
     all credits."""
     from backend.services import sprite_agent_service
-    from backend.tasks.agent_schedules import _run_due
+    from backend.tasks.agent_schedules import _run_due, _run_scheduled_agent, run_scheduled_agent
 
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
@@ -492,7 +503,10 @@ async def test_failed_run_records_error_and_refunds_credit(
 
     real_run_scheduled = sprite_agent_service.run_scheduled
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", boom)
+    dispatched = []
+    monkeypatch.setattr(run_scheduled_agent, "delay", lambda *args: dispatched.append(args))
     await _run_due()
+    await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
 
     row = await _db_pool.fetchrow(
         "SELECT last_run_error, month_run_count FROM agents WHERE id = $1",
@@ -507,8 +521,8 @@ async def test_failed_run_records_error_and_refunds_credit(
     # would exec a real `claude` binary (passes on a dev machine, dies in CI).
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", real_run_scheduled)
     await _make_due(_db_pool, curator["id"], datetime.now(UTC) - timedelta(minutes=2))
-    ran = await _run_due()
-    assert ran == 1
+    assert await _run_due() == 1
+    await _run_scheduled_agent(UUID(dispatched[1][0]), dispatched[1][1])
     row = await _db_pool.fetchrow(
         "SELECT last_run_error, month_run_count FROM agents WHERE id = $1",
         UUID(curator["id"]),

--- a/backend/tests/test_plan_gate.py
+++ b/backend/tests/test_plan_gate.py
@@ -100,7 +100,7 @@ async def test_free_curator_credits_exhausted_skips_run(
 ):
     """Free accounts get a monthly curator allowance; past it the beat must not
     wake the sprite. Enterprise is unlimited — same state runs after the grant."""
-    from backend.tasks.agent_schedules import _run_due
+    from backend.tasks.agent_schedules import _run_due, _run_scheduled_agent, run_scheduled_agent
 
     key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
@@ -131,9 +131,10 @@ async def test_free_curator_credits_exhausted_skips_run(
     await _db_pool.execute("UPDATE users SET plan = 'enterprise' WHERE id = $1", uid)
     await _make_due(_db_pool, curator["id"], watermark)
 
-    ran = await _run_due()
-
-    assert ran == 1
+    dispatched = []
+    monkeypatch.setattr(run_scheduled_agent, "delay", lambda *args: dispatched.append(args))
+    assert await _run_due() == 1
+    await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
     assert sprite_exec.calls != []
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -98,7 +98,27 @@ services:
       REDIS_URL: redis://redis:6379/0
     volumes:
       - backend_secrets:/app/.secrets
-    command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
+    command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4", "-Q", "default"]
+
+  # Cadence-sensitive beat tasks (X token keep-fresh, ticket reconcilers)
+  # run in their own pool so 30-min heavy tasks can't delay them.
+  heartbeat-worker:
+    image: ghcr.io/fergana-labs/stash-backend:0.1.362
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - backend_secrets:/app/.secrets
+    command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heartbeat"]
 
   beat:
     image: ghcr.io/fergana-labs/stash-backend:0.1.362

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,9 +100,11 @@ services:
       - backend_secrets:/app/.secrets
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4", "-Q", "default"]
 
-  # Cadence-sensitive beat tasks (X token keep-fresh, ticket reconcilers)
-  # run in their own pool so 30-min heavy tasks can't delay them.
-  heartbeat-worker:
+  # Long-running tasks (renders, extractions, crawls, agent runs) get their
+  # own pool so beat sweeps and cheap tasks on "default" never queue behind
+  # a 30-min task. Concurrency 2 keeps 2 children x 800MB (see
+  # worker_max_memory_per_child) plus the parent inside a 2GB box.
+  heavy-worker:
     image: ghcr.io/fergana-labs/stash-backend:0.1.362
     restart: always
     depends_on:
@@ -118,7 +120,7 @@ services:
       REDIS_URL: redis://redis:6379/0
     volumes:
       - backend_secrets:/app/.secrets
-    command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heartbeat"]
+    command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heavy"]
 
   beat:
     image: ghcr.io/fergana-labs/stash-backend:0.1.362

--- a/start.sh
+++ b/start.sh
@@ -563,10 +563,16 @@ uvicorn backend.main:app --host 0.0.0.0 --port "$BACKEND_PORT" \
     --proxy-headers --forwarded-allow-ips '*' &
 PIDS+=($!)
 
-# --- Celery worker + beat ---
+# --- Celery workers + beat ---
 # Same commands as docker-compose.prod.yml; beat must run as exactly one instance.
-echo "[worker]   Starting celery worker..."
-celery -A backend.celery_app worker --loglevel=info --concurrency=4 &
+# Two workers: heavy tasks can hold the default pool for up to 30 min each, so
+# the cadence-sensitive beat tasks get their own pool (see task_routes).
+echo "[worker]   Starting celery worker (default queue)..."
+celery -A backend.celery_app worker --loglevel=info --concurrency=4 -Q default &
+PIDS+=($!)
+
+echo "[worker]   Starting celery heartbeat worker..."
+celery -A backend.celery_app worker --loglevel=info --concurrency=2 -Q heartbeat &
 PIDS+=($!)
 
 echo "[beat]     Starting celery beat..."

--- a/start.sh
+++ b/start.sh
@@ -565,14 +565,15 @@ PIDS+=($!)
 
 # --- Celery workers + beat ---
 # Same commands as docker-compose.prod.yml; beat must run as exactly one instance.
-# Two workers: heavy tasks can hold the default pool for up to 30 min each, so
-# the cadence-sensitive beat tasks get their own pool (see task_routes).
+# Two workers split by task weight: long-running tasks (renders, extractions,
+# crawls, agent runs) get their own "heavy" pool so every beat sweep and cheap
+# task on "default" stays snappy (see task_routes).
 echo "[worker]   Starting celery worker (default queue)..."
 celery -A backend.celery_app worker --loglevel=info --concurrency=4 -Q default &
 PIDS+=($!)
 
-echo "[worker]   Starting celery heartbeat worker..."
-celery -A backend.celery_app worker --loglevel=info --concurrency=2 -Q heartbeat &
+echo "[worker]   Starting celery heavy worker..."
+celery -A backend.celery_app worker --loglevel=info --concurrency=2 -Q heavy &
 PIDS+=($!)
 
 echo "[beat]     Starting celery beat..."


### PR DESCRIPTION
## Why

All Celery tasks share one queue and one prod worker (`--concurrency=2`, no `-Q`). Heavy tasks (Playwright renders, PDF extraction, zip exports) legally run up to 30 minutes each (`task_time_limit=1800`), so a burst of them delays everything queued behind them.

That was always mildly annoying; PR #971 makes it load-bearing. The X `refresh_margin=45min` hedge only rotates tokens *pre-expiry* if the keep-fresh tick actually runs roughly every 30 minutes. A starved queue silently reverts X to post-expiry reactive refresh — the exact behavior #971 hedges against.

## Changes

The split is by **task weight**, not by picking cadence-sensitive tasks: anything that can hold a worker slot for minutes routes to a **`heavy` queue** with its own pool. `default` then stays snappy for *every* beat sweep and cheap task — the cadence-sensitive ones (X keep-fresh, ticket reconcilers) get their guarantee without being enumerated, and so does every beat task added later.

- **`heavy` queue** for the long-running task families: subprocess extractions (`extraction.extract_file_text`, `drive_extraction.extract_drive_document`), bulk URL fetches (`clips.process_url_imports`), source crawls (`sources.sync_source`), exports (`exports.pdf`, `exports.pptx`, `exports.gslides`), and headless agent runs (`agent_schedules.run_scheduled_agent`, `run_curator_now`). Interactive agent replies (Slack/Telegram) stay on `default` deliberately — a user is waiting.
- **`run_due` becomes a pure dispatcher.** It previously executed scheduled agent runs *inline* — full headless turns, minutes each, serialized inside a beat task. Now the tick consumes the cron tick, applies the cheap gates (credits, credential, pending changes), and dispatches each run as its own `run_scheduled_agent` task on `heavy`. New routing-level test pins that no beat task is heavy.
- **Clips import window sized to one heavy slot** (`WINDOW_URLS = BATCH_SIZE`): a 40k bookmark import trickles through one slot of the heavy pool instead of monopolizing it.
- **Both queues declared in `task_queues`** — a worker started without `-Q` consumes every declared queue, so the merge is deploy-order-safe: prod's current `-Q`-less worker keeps executing both queues the moment this lands, just without isolation yet.
- **`start.sh`** and **`docker-compose.prod.yml`** run two workers: `-Q default` at concurrency 4, `-Q heavy` at concurrency 2 (2 children × `worker_max_memory_per_child` 800MB + parent fits a 2GB box).

## Hosted prod follow-up (Render dashboard, after merge)

Repo changes alone don't give prod isolation — the worker commands live in the Render dashboard:

1. `stash-celery-worker`: change docker command to `celery -A backend.celery_app worker --loglevel=info --concurrency=4 -Q default`
2. New background worker service (same repo/Dockerfile): `celery -A backend.celery_app worker --loglevel=info --concurrency=2 -Q heavy` — this one carries the real compute (renders, extractions, agent runs), so size it like today's worker; the default worker can be small.

Safe in either order relative to the merge; until step 1 adds `-Q default`, the existing worker consumes both queues as today.

## Validation

- Full backend suite: `pytest` — passes (routing tests rewritten; curator/plan-gate/alert tests updated for the dispatcher split: tick tests unchanged, execution tests drive `_run_scheduled_agent` directly)
- `ruff check` + `ruff format --check` clean; `bash -n start.sh` and `docker compose -f docker-compose.prod.yml config` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task routing and deploy topology (two workers); misconfigured `-Q` could strand heavy tasks, but undeclared workers still consume both queues per `task_queues`.
> 
> **Overview**
> Introduces **`default`** and **`heavy`** Celery queues so long-running work (extractions, URL import batches, source syncs, exports, headless scheduled/curator agent runs) cannot starve beat sweeps and other cheap, cadence-sensitive tasks on **`default`**.
> 
> **`run_due`** no longer runs headless agent turns inline: after gates (credits, credential, pending changes) it **`delay`s** `run_scheduled_agent` on **`heavy`**. Post-run curator bookkeeping failures are handled in the same try block as turn failures (`last_run_error` + alert); deleted agents between dispatch and run exit quietly.
> 
> **Clips** URL import concurrency is tightened to **one batch** in flight on the heavy pool (`WINDOW_URLS = BATCH_SIZE`).
> 
> **`start.sh`** and **`docker-compose.prod.yml`** run separate workers (`-Q default` concurrency 4, `-Q heavy` concurrency 2). **`test_celery_routing.py`** locks routing and asserts no beat task is heavy; curator/plan-gate/alert tests follow the dispatcher split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ed741df8b453144f528c77ccb3c46684729d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->