### PR TITLE
fix: skill creation can never 409 on a name collision

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -33,6 +33,25 @@ public_router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 _PUBLIC_ITEM_TYPES = {"page", "file", "table", "folder"}
 
 
+class SkillCreateRequest(BaseModel):
+    name: str = "New skill"
+
+
+@me_router.post("/skills/new", status_code=201)
+async def create_skill(
+    req: SkillCreateRequest,
+    current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
+):
+    """Create a skill (root folder + SKILL.md) in one server-side call. The
+    name is uniquified against existing root folders, so this never 409s."""
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name must not be blank")
+    folder = await files_tree_service.create_skill(owner_user_id, current_user["id"], name)
+    return {"folder_id": str(folder["id"]), "name": folder["name"]}
+
+
 @me_router.post("/skills", response_model=SkillResponse, status_code=201)
 async def publish_skill(
     req: SkillPublishRequest,

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1212,6 +1212,23 @@ async def _create_folder_unique(
             n += 1
 
 
+async def create_skill(owner_user_id: UUID, created_by: UUID, base_name: str) -> dict:
+    """Create a skill: a root folder plus its SKILL.md, in one server-side call.
+    The folder name is uniquified (' (2)', ' (3)', …) so creation never 409s —
+    a plain root folder can hold the wanted name without being visible on the
+    Skills surface, and the hard-coded 'New skill' default made that a
+    guaranteed collision on the second create."""
+    folder = await _create_folder_unique(owner_user_id, base_name, created_by, None)
+    await create_page(
+        owner_user_id,
+        skill_service.SKILL_MD_NAME,
+        created_by,
+        folder_id=folder["id"],
+        content=skill_service.skill_md_template(folder["name"]),
+    )
+    return folder
+
+
 def _page_content_kwargs(src: dict) -> dict:
     return {
         "content": src["content_markdown"] or "",

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -18,6 +18,10 @@ from . import permission_service
 SKILL_MD_NAME = "SKILL.md"
 
 
+def skill_md_template(name: str) -> str:
+    return f"---\nname: {name}\ndescription: \n---\n\n# {name}\n"
+
+
 def not_skill_folder_pred(alias: str) -> str:
     """SQL fragment: folder ``alias`` has no live SKILL.md child."""
     return (

--- a/backend/tests/test_folder_skills.py
+++ b/backend/tests/test_folder_skills.py
@@ -429,3 +429,40 @@ async def test_install_ping_counts_adoption_separately_from_views(client: AsyncC
     assert detail.json()["skill"]["install_count"] == 2
 
     assert (await client.post("/api/v1/skills/not-a-real-slug/installs")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_skill_makes_a_folder_with_a_skill_md(client: AsyncClient):
+    key, _ = await _register(client)
+
+    resp = await client.post("/api/v1/me/skills/new", json={}, headers=_auth(key))
+
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "New skill"
+    held = await client.get("/api/v1/me/skills", headers=_auth(key))
+    assert [s["folder_id"] for s in held.json()["skills"]] == [resp.json()["folder_id"]]
+
+
+@pytest.mark.asyncio
+async def test_create_skill_never_collides_with_a_name_squatting_folder(client: AsyncClient):
+    """A plain root folder can hold the wanted name while being invisible on
+    the Skills surface (e.g. a skill whose SKILL.md was deleted). Creation must
+    pick the next free name instead of 409ing on something the user can't see."""
+    key, _ = await _register(client)
+    scope = await _scope(client, key)
+    await _folder(client, key, scope, "New skill")
+
+    first = await client.post("/api/v1/me/skills/new", json={}, headers=_auth(key))
+    second = await client.post("/api/v1/me/skills/new", json={}, headers=_auth(key))
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json()["name"] == "New skill (2)"
+    assert second.json()["name"] == "New skill (3)"
+
+
+@pytest.mark.asyncio
+async def test_create_skill_rejects_a_blank_name(client: AsyncClient):
+    key, _ = await _register(client)
+    resp = await client.post("/api/v1/me/skills/new", json={"name": "  "}, headers=_auth(key))
+    assert resp.status_code == 400

--- a/frontend/src/app/(app)/skills/page.test.tsx
+++ b/frontend/src/app/(app)/skills/page.test.tsx
@@ -8,14 +8,7 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SkillsPage from "./page";
-import {
-  createFolder,
-  createPage,
-  listSkills,
-  type Skill,
-} from "@/lib/api";
-import type { Page } from "@/lib/types";
-import { skillMdTemplate } from "@/lib/localSkill";
+import { createSkill, listSkills, type Skill } from "@/lib/api";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 
 function render(ui: ReactNode) {
@@ -54,8 +47,7 @@ vi.mock("@/lib/api", () => ({
       this.status = status;
     }
   },
-  createFolder: vi.fn(),
-  createPage: vi.fn(),
+  createSkill: vi.fn(),
   deleteFolder: vi.fn(),
   forkSkill: vi.fn(),
   listSkills: vi.fn(),
@@ -159,29 +151,15 @@ describe("SkillsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("creates a New Skill folder with a SKILL.md and navigates to it", async () => {
+  it("creates the skill server-side and navigates to it", async () => {
     vi.stubGlobal("prompt", vi.fn(() => "My Skill"));
-    vi.mocked(createFolder).mockResolvedValue({
-      id: "folder-9",
-      owner_user_id: "user-1",
-      name: "My Skill",
-      parent_folder_id: null,
-      created_by: "user-1",
-      created_at: "",
-      updated_at: "",
-    });
-    vi.mocked(createPage).mockResolvedValue({ id: "page-9" } as unknown as Page);
+    vi.mocked(createSkill).mockResolvedValue({ folder_id: "folder-9", name: "My Skill" });
 
     render(<SkillsPage />);
 
     fireEvent.click(await screen.findByRole("button", { name: /New Skill/ }));
 
-    await waitFor(() => expect(createFolder).toHaveBeenCalledWith("My Skill"));
-    expect(createPage).toHaveBeenCalledWith(
-      "SKILL.md",
-      "folder-9",
-      skillMdTemplate("My Skill"),
-    );
+    await waitFor(() => expect(createSkill).toHaveBeenCalledWith("My Skill"));
     await waitFor(() =>
       expect(router.push).toHaveBeenCalledWith("/skills/folder/folder-9"),
     );

--- a/frontend/src/app/(app)/skills/page.tsx
+++ b/frontend/src/app/(app)/skills/page.tsx
@@ -21,8 +21,7 @@ import {
   forkSkill,
   ApiError,
   API_BASE,
-  createFolder,
-  createPage,
+  createSkill,
   deleteFolder,
   listSkills,
   type Skill,
@@ -30,7 +29,6 @@ import {
 } from "@/lib/api";
 import { useAuth } from "@/hooks/useAuth";
 import type { LaunchableSkill } from "@/lib/types";
-import { SKILL_MD, skillMdTemplate } from "@/lib/localSkill";
 import { usePins } from "@/lib/pins";
 import { skillSlugFromInput } from "@/lib/skillLinks";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
@@ -122,10 +120,9 @@ export default function SkillsPage() {
     const name = window.prompt("Skill name?");
     if (!name?.trim()) return;
     try {
-      const folder = await createFolder(name.trim());
-      await createPage(SKILL_MD, folder.id, skillMdTemplate(name.trim()));
+      const created = await createSkill(name.trim());
       if (user) await refreshSidebar().catch(() => {});
-      router.push(`/skills/folder/${folder.id}`);
+      router.push(`/skills/folder/${created.folder_id}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create skill");
     }

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -4,9 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bot, ChevronRight, File, Folder, Loader2, MessagesSquare, GraduationCap, Monitor, Plus, Settings, FolderTree, Brain, Plug, Sparkles, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
-import { ApiError, listMySessions, listSessionFolders, listSharedWithMe, listSkillsSharedWithMe, listSharedSessionFolderSessions, createSessionFolder, listSkills, listSources, createFolder, createPage, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
+import { ApiError, listMySessions, listSessionFolders, listSharedWithMe, listSkillsSharedWithMe, listSharedSessionFolderSessions, createSessionFolder, listSkills, listSources, createSkill as createSkillApi, machineFsList, listAgents, createAgent, type Agent as AgentRow, type MachineEntry, type SessionSummary, type Source } from "@/lib/api";
 import { useMemoryFolderId } from "@/lib/memory-folder";
-import { SKILL_MD, skillMdTemplate } from "@/lib/localSkill";
 import { requestAgentConfigView, requestCuratorRun } from "@/lib/agent-tab-view";
 import { cn } from "@/lib/utils";
 import { useWorkspace, type TabKind } from "@/lib/workspace-store";
@@ -320,8 +319,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
   }, []);
   // A skill is a folder + SKILL.md — the Skills root's "create native item" action.
   const createSkill = useCallback(async () => {
-    const folder = await createFolder("New skill", null);
-    await createPage(SKILL_MD, folder.id, skillMdTemplate("New skill"));
+    await createSkillApi();
   }, []);
 
   // Sessions are their own tree: session folders + loose sessions at the root,

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -297,7 +297,16 @@ export default function FilesExplorer({
     openAsTab({ kind: "table", id: t.id, name: t.name });
   }
   async function newFolder(folder: string | null) { await createFolder("New folder", folder); await load(); }
-  async function runNewRootItem() { if (!newRootItem) return; await newRootItem.run(); await load(); }
+  async function runNewRootItem() {
+    if (!newRootItem) return;
+    try {
+      await newRootItem.run();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : `${newRootItem.label} failed`);
+      return;
+    }
+    await load();
+  }
   async function uploadFiles(files: File[], folder: string | null) {
     const label = files.length === 1 ? files[0].name : `${files.length} files`;
     const toastId = toast.loading(`Uploading ${label}…`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -584,6 +584,15 @@ export async function createFolder(
   });
 }
 
+// Create a skill (folder + SKILL.md) server-side. The name is uniquified
+// against existing root folders, so this never fails on a name collision.
+export async function createSkill(name?: string): Promise<{ folder_id: string; name: string }> {
+  return apiFetch(`${ME}/skills/new`, {
+    method: "POST",
+    body: JSON.stringify(name ? { name } : {}),
+  });
+}
+
 export async function updateFolder(
   folderId: string,
   data: { name?: string; parent_folder_id?: string | null; move_to_root?: boolean }


### PR DESCRIPTION
Fix our horrible naming collision default with our "new skill" button, hotfix merging to main to unblock our friends at heavi.


## What happened

Heavi hit this on 8/6: clicking **New skill** silently did nothing, with an uncaught `409 Folder 'New skill' already exists in the root of the scope` in the console — while Home/Skills showed an empty list.

Root cause: skill creation was two client-side calls with a hard-coded folder name — `createFolder("New skill")` then `createPage("SKILL.md", …)`. Any root folder holding that exact name blocks the button forever. In Heavi's case a skill whose SKILL.md had been deleted had become a plain folder: invisible on the Skills surface, but still squatting the name. And even without debris, the button could never create a second skill without the user renaming the first — the collision is manufactured by the client on every click.

## The fix

- New `POST /api/v1/me/skills/new` creates the folder + SKILL.md in one server-side call and uniquifies the name ("New skill (2)", "New skill (3)", …) against existing root folders, so a collision is impossible. Blank names 400.
- Both frontend create sites (sidebar explorer's New-skill button, Skills page's name dialog) now call it instead of the two-call sequence.
- The explorer's new-item button surfaces failures as an error toast instead of an uncaught promise rejection.

## Tests

- New backend test encodes the incident: a plain root folder squatting "New skill", then two creates → both 201 as "New skill (2)" / "New skill (3)". Plus happy-path and blank-name tests.
- Frontend test updated for the server-side create. Full frontend suite (273 tests), 74 backend skill/permission tests, ruff, and ESLint all pass.

## Screenshots

The only visual change is an error toast on the explorer's new-item button failure path; local stack ports were occupied by another session, so no capture — happy to add one from prod post-deploy if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)