### PR TITLE
fix: trashed pages no longer occupy name uniqueness

### DIFF
--- a/backend/migrations/versions/0180_trash_exits_name_uniqueness.py
+++ b/backend/migrations/versions/0180_trash_exits_name_uniqueness.py
@@ -1,0 +1,50 @@
+"""Trashed pages leave name uniqueness.
+
+Folder deletion trashes the folder's pages, then the ON DELETE SET NULL FK
+moves them to the scope root. With uniqueness enforced over trashed rows too,
+the second same-named trashed page arriving at root violates
+idx_pages_unique_at_root — so deleting two skills back-to-back 500'd (each
+skill trashes a SKILL.md; found in prod on 2026-08-06). Uniqueness is a
+live-namespace concern: scope both indexes to deleted_at IS NULL so trash can
+hold any number of same-named pages.
+
+Revision ID: 0180
+Revises: 0179
+"""
+
+from alembic import op
+
+revision = "0180"
+down_revision = "0179"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_pages_unique_in_folder")
+    op.execute("DROP INDEX IF EXISTS idx_pages_unique_at_root")
+    op.execute("""
+CREATE UNIQUE INDEX idx_pages_unique_in_folder
+ON pages(owner_user_id, folder_id, name)
+WHERE folder_id IS NOT NULL AND deleted_at IS NULL
+""")
+    op.execute("""
+CREATE UNIQUE INDEX idx_pages_unique_at_root
+ON pages(owner_user_id, name)
+WHERE folder_id IS NULL AND deleted_at IS NULL
+""")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_pages_unique_in_folder")
+    op.execute("DROP INDEX IF EXISTS idx_pages_unique_at_root")
+    op.execute("""
+CREATE UNIQUE INDEX idx_pages_unique_in_folder
+ON pages(owner_user_id, folder_id, name)
+WHERE folder_id IS NOT NULL
+""")
+    op.execute("""
+CREATE UNIQUE INDEX idx_pages_unique_at_root
+ON pages(owner_user_id, name)
+WHERE folder_id IS NULL
+""")

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -477,12 +477,14 @@ async def _assert_not_protected(folder_id: UUID, owner_user_id: UUID) -> None:
     """Refuse rename/move/delete of a protected folder (Memory, Clips) by
     raising; the routers map the ValueError to a 400 with this message.
 
-    Protected folders are the ones product code resolves by identity and
-    writes into. Without this check the destructive act would SUCCEED with no
-    error, and the damage would surface later, silently: the next write
-    recreates an empty folder under the reserved name, and the user's wiki or
-    clips start landing somewhere they aren't looking. One check here in the
-    service covers every front door — UI, CLI, and agent tools."""
+    Protected folders are fixtures the product finds on its own — by reserved
+    marker (the is_memory flag, the root 'Clips' name), never by an id a
+    caller handed in — and the lookup is a get-or-create. So without this
+    check the destructive act would SUCCEED with no error, and the damage
+    would surface later, silently: the next write re-creates an empty
+    replacement under the marker, and the user's wiki or clips start landing
+    somewhere they aren't looking. One check here in the service covers every
+    front door — UI, CLI, and agent tools."""
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT name, is_protected FROM folders WHERE id = $1 AND owner_user_id = $2",

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1090,16 +1090,32 @@ async def delete_page(page_id: UUID, owner_user_id: UUID, deleted_by: UUID) -> b
 
 
 async def restore_page(page_id: UUID, owner_user_id: UUID, restored_by: UUID) -> bool:
+    """Restore a trashed page. Uniqueness only covers live pages, so the name
+    may have been retaken while this sat in trash — restore then lands on the
+    next free ' (2)', ' (3)', … name rather than failing."""
     pool = get_pool()
-    result = await pool.execute(
-        "UPDATE pages SET deleted_at = NULL, deleted_by = NULL "
-        "WHERE id = $1 AND owner_user_id = $2  "
-        "AND deleted_at IS NOT NULL",
+    row = await pool.fetchrow(
+        "SELECT name FROM pages WHERE id = $1 AND owner_user_id = $2 AND deleted_at IS NOT NULL",
         page_id,
         owner_user_id,
     )
-    if result != "UPDATE 1":
+    if not row:
         return False
+    name = row["name"]
+    n = 2
+    while True:
+        try:
+            await pool.execute(
+                "UPDATE pages SET deleted_at = NULL, deleted_by = NULL, name = $3 "
+                "WHERE id = $1 AND owner_user_id = $2",
+                page_id,
+                owner_user_id,
+                name,
+            )
+            break
+        except asyncpg.UniqueViolationError:
+            name = f"{row['name']} ({n})"
+            n += 1
     await security_audit_service.record_content_lifecycle_event(
         operation="restored",
         actor_user_id=restored_by,

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -474,11 +474,15 @@ async def memory_tree(owner_user_id: UUID, created_by: UUID) -> dict:
 
 
 async def _assert_not_protected(folder_id: UUID, owner_user_id: UUID) -> None:
-    """Protected folders are the ones code resolves by identity and writes into
-    — Memory and Clips. Renaming or moving one doesn't fail loudly, it fails
-    silently: the next write recreates the folder and the user's saves start
-    landing somewhere they aren't looking. Guarded in the service, so the CLI,
-    the agent's tools, and the UI are all covered by one check."""
+    """Refuse rename/move/delete of a protected folder (Memory, Clips) by
+    raising; the routers map the ValueError to a 400 with this message.
+
+    Protected folders are the ones product code resolves by identity and
+    writes into. Without this check the destructive act would SUCCEED with no
+    error, and the damage would surface later, silently: the next write
+    recreates an empty folder under the reserved name, and the user's wiki or
+    clips start landing somewhere they aren't looking. One check here in the
+    service covers every front door — UI, CLI, and agent tools."""
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT name, is_protected FROM folders WHERE id = $1 AND owner_user_id = $2",

--- a/backend/tests/test_folder_delete.py
+++ b/backend/tests/test_folder_delete.py
@@ -118,3 +118,43 @@ async def test_delete_folder_still_refuses_memory(scope, _db_pool):
     memory = await files_tree_service.get_or_create_memory_folder(scope_id, user_id)
     with pytest.raises(ValueError):
         await files_tree_service.delete_folder(memory["id"], scope_id, user_id)
+
+
+@pytest.mark.asyncio
+async def test_deleting_two_skill_folders_back_to_back(scope, _db_pool):
+    """Each skill folder trashes a SKILL.md to the scope root on delete. With
+    uniqueness enforced over trash too, the second delete blew up on the root
+    name index (prod, 2026-08-06) — trash must accept repeated names."""
+    scope_id, user_id = scope
+    for _ in range(2):
+        folder = await files_tree_service.create_skill(scope_id, user_id, "New skill")
+        assert await files_tree_service.delete_folder(folder["id"], scope_id, user_id) is True
+
+    trashed = await _db_pool.fetchval(
+        "SELECT count(*) FROM pages WHERE owner_user_id = $1 AND name = 'SKILL.md' "
+        "AND folder_id IS NULL AND deleted_at IS NOT NULL",
+        scope_id,
+    )
+    assert trashed == 2
+
+
+@pytest.mark.asyncio
+async def test_restore_uniquifies_when_the_name_was_retaken(scope, _db_pool):
+    """Trash no longer holds names, so a live page may take a trashed page's
+    name. Restore must land on the next free name, not die on the index."""
+    scope_id, user_id = scope
+    old = await files_tree_service.create_page(
+        owner_user_id=scope_id, name="Doc", created_by=user_id, content="v1"
+    )
+    assert await files_tree_service.delete_page(old["id"], scope_id, user_id) is True
+    await files_tree_service.create_page(
+        owner_user_id=scope_id, name="Doc", created_by=user_id, content="v2"
+    )
+
+    assert await files_tree_service.restore_page(old["id"], scope_id, user_id) is True
+
+    restored = await _db_pool.fetchrow(
+        "SELECT name, deleted_at FROM pages WHERE id = $1", old["id"]
+    )
+    assert restored["deleted_at"] is None
+    assert restored["name"] == "Doc (2)"


### PR DESCRIPTION
part of the resolution of an incident around our skills UX misbehaving today.

We were enforcing uniqueness of page names for names at every scope, including *pages in the trash*! So whenever we tried to delete a skill folder (excluding the first ever skill folder deletion per user), the transaction would try to move a new page to root (bc trash'd pages are impliticly in root) with the same name as an existing page (SKILL.md) and would therefore abort, two separate pages in the trash named SKILL.md isn't allowed. But actually, we should allow this, and now we do. Oops.

## What happened

Found while QA-verifying #974 against prod: deleting two skills back-to-back returns a 500. Reproduced directly against the prod DB — `duplicate key value violates unique constraint "idx_pages_unique_at_root"`.

Chain: `delete_folder` soft-deletes the folder's pages into trash, then `DELETE FROM folders` fires the `ON DELETE SET NULL` FK, which moves those trashed pages to the scope root. The root-level unique name index covered trashed rows too, so the *second* trashed `SKILL.md` arriving at root violates it. Every skill contains a SKILL.md, so any user bulk-deleting ≥2 skills (a button the Skills page ships) hits this.

## The fix

- Migration `0180` recreates `idx_pages_unique_in_folder` and `idx_pages_unique_at_root` scoped to `deleted_at IS NULL` — name uniqueness is a live-namespace concern; trash accepts any number of repeated names. (Safe on existing data: the old indexes were strictly wider, so no live duplicates can exist.)
- Handled consequence: a live page can now retake a name while its predecessor sits in trash, so `restore_page` uniquifies on collision (" (2)", " (3)", …) instead of dying on the index — same convention as `create_page_unique`.

`files` have no unique name index and `tables` are hard-deleted with their folder, so pages are the only affected table.

## Tests

- `test_deleting_two_skill_folders_back_to_back` — the prod incident, pinned.
- `test_restore_uniquifies_when_the_name_was_retaken` — the restore consequence.
- Full backend suite passes (1,290 tests), ruff clean. No GUI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)