### PR TITLE
feat: New-skill button gives real feedback and lands you on the skill

### DIFF
--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -317,9 +317,11 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
         readOnly: true,
       }));
   }, []);
-  // A skill is a folder + SKILL.md — the Skills root's "create native item" action.
-  const createSkill = useCallback(async () => {
-    await createSkillApi();
+  // A skill is a folder + SKILL.md — the Skills root's "create native item"
+  // action. Returns the created Item so the explorer opens and highlights it.
+  const createSkill = useCallback(async (): Promise<Item> => {
+    const created = await createSkillApi();
+    return { kind: "skill", id: created.folder_id, name: created.name };
   }, []);
 
   // Sessions are their own tree: session folders + loose sessions at the root,

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -108,8 +108,10 @@ export default function FilesExplorer({
    *  explorer's root; omitted, the section has no shared surface at all. */
   loadShared?: () => Promise<Item[]>;
   /** At a virtual root (loadRoot), the "create" action for that root's native item
-   *  (e.g. New skill) — replaces new-file/folder/upload, which need a real folder. */
-  newRootItem?: { label: string; run: () => Promise<void> };
+   *  (e.g. New skill) — replaces new-file/folder/upload, which need a real folder.
+   *  Returning the created Item makes the explorer open it and highlight its
+   *  row; returning void leaves the list refresh as the only effect. */
+  newRootItem?: { label: string; run: () => Promise<Item | void> };
   /** Double-clicking the root crumb can open a native overview tab. */
   openRootTab?: () => void;
   /** Show the GitHub import button. Default true. */
@@ -145,6 +147,10 @@ export default function FilesExplorer({
   const [menu, setMenu] = useState<Menu>(null);
   const [renaming, setRenaming] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const [creatingRoot, setCreatingRoot] = useState(false);
+  // Row to visually call out after a create, so the new item is findable in a
+  // long list. Cleared on a timer.
+  const [highlightId, setHighlightId] = useState<string | null>(null);
   const [sort, setSort] = useState<Sort>("name");
   const [importOpen, setImportOpen] = useState(false);
   const [repoUrl, setRepoUrl] = useState("");
@@ -298,14 +304,27 @@ export default function FilesExplorer({
   }
   async function newFolder(folder: string | null) { await createFolder("New folder", folder); await load(); }
   async function runNewRootItem() {
-    if (!newRootItem) return;
+    if (!newRootItem || creatingRoot) return;
+    setCreatingRoot(true);
+    let created: Item | void;
     try {
-      await newRootItem.run();
+      created = await newRootItem.run();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : `${newRootItem.label} failed`);
       return;
+    } finally {
+      setCreatingRoot(false);
     }
     await load();
+    if (!created) return;
+    const item = created;
+    toast.success(`Created ${item.name}`);
+    // Land the user on the new item: its row is highlighted (and scrolled to —
+    // an alphabetical list files "New skill" below the fold) and it opens as a
+    // tab, ready to rename. Without this the click reads as a no-op.
+    setHighlightId(item.id);
+    setTimeout(() => setHighlightId((h) => (h === item.id ? null : h)), 3000);
+    openAsTab(item);
   }
   async function uploadFiles(files: File[], folder: string | null) {
     const label = files.length === 1 ? files[0].name : `${files.length} files`;
@@ -408,8 +427,8 @@ export default function FilesExplorer({
         <div className="ml-auto flex shrink-0 items-center gap-0.5">
           {inSharedIndex ? null : atVirtualRoot ? (
             newRootItem && (
-              <button title={newRootItem.label} aria-label={newRootItem.label} onClick={runNewRootItem} className="flex h-7 items-center gap-1 rounded px-1.5 text-[12px] text-sidebar-foreground hover:bg-sidebar-accent">
-                <FolderPlus className="h-4 w-4" /><Plus className="h-2.5 w-2.5" />
+              <button title={newRootItem.label} aria-label={newRootItem.label} onClick={runNewRootItem} disabled={creatingRoot} className="flex h-7 cursor-pointer items-center gap-1 rounded px-1.5 text-[12px] text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground disabled:cursor-default disabled:opacity-50">
+                {creatingRoot ? <Loader2 className="h-4 w-4 animate-spin" /> : <><FolderPlus className="h-4 w-4" /><Plus className="h-2.5 w-2.5" /></>}
               </button>
             )
           ) : vfsWritable ? (
@@ -480,9 +499,11 @@ export default function FilesExplorer({
               onClick={() => onRowClick(item)}
               onDoubleClick={() => onRowDoubleClick(item)}
               onContextMenu={(e) => { e.preventDefault(); setMenu({ x: e.clientX, y: e.clientY, item }); }}
+              ref={item.id === highlightId ? (el) => el?.scrollIntoView({ block: "nearest" }) : undefined}
               className={cn(
-                "group flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[13px] text-sidebar-foreground hover:bg-sidebar-accent",
+                "group flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[13px] text-sidebar-foreground transition-colors hover:bg-sidebar-accent",
                 dropTarget === item.id && "ring-1 ring-brand-400",
+                item.id === highlightId && "bg-brand-400/15 ring-1 ring-brand-400",
               )}
               title={item.name}
             >


### PR DESCRIPTION
## What happened

The New-skill button worked but read as a total no-op: no pointer cursor (Tailwind preflight defaults buttons to `cursor: default`), no in-flight state, silent success, and the created skill filed alphabetically below the fold of a long list. A user clicked it seven times today and concluded it was broken — it had created seven skills.

## The fix

`newRootItem.run` may now return the created `Item`. When it does, the explorer:

- shows a **success toast** naming what was created,
- **opens the new skill as a tab**, ready to rename,
- **highlights + scrolls to its row** in the list for a few seconds.

The button itself gets `cursor-pointer`, a hover state, and a **spinner while creating** — which also disables it mid-flight, so an impatient double-click can't create two skills. Sessions' "New folder" returns void and keeps its existing behavior.

## Screenshots (captured on the live local stack)

- [Skills root, before click](https://app.joinstash.ai/f/8bc53d32-5fe6-4411-8836-a524f2b3ec68)
- [After click: skill opened as a tab + "Created New skill" toast](https://app.joinstash.ai/f/0f94dc76-2bc4-4829-b530-97654ab4e830)
- [Second click: "New skill (2)" created, row highlighted + scrolled to, uniquifier visible](https://app.joinstash.ai/f/20bc144f-cd92-47c6-acca-9e36029ab381)

(Linked via Stash rather than inlined — no CLI path for GitHub image attachment.)

## Tests

Full frontend suite passes (273 tests), tsc and ESLint clean (two pre-existing warnings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)