### PR TITLE
fix: editor is read-only until the collab doc has synced

### DIFF
--- a/frontend/src/components/content/MarkdownEditor.tsx
+++ b/frontend/src/components/content/MarkdownEditor.tsx
@@ -94,6 +94,9 @@ export default function MarkdownEditor({
   const lastSaved = useRef<string>(file.content_markdown);
   const [collabError, setCollabError] = useState("");
   const [readOnly, setReadOnly] = useState(false);
+  // True once the collab provider has delivered the server doc (see onSynced).
+  const [synced, setSynced] = useState(false);
+  const syncedRef = useRef(false);
   // Refs that closures inside `useEditor` / window listeners can call
   // without re-creating the editor every render.
   const saveMarkdownRef = useRef<(md: string) => void>(() => {});
@@ -124,6 +127,8 @@ export default function MarkdownEditor({
     let active = true;
     setCollabError("");
     setReadOnly(false);
+    setSynced(false);
+    syncedRef.current = false;
 
     const document = new Y.Doc();
     const provider = new HocuspocusProvider({
@@ -138,6 +143,18 @@ export default function MarkdownEditor({
         if (!active) return;
         setReadOnly(scope === "readonly");
         setCollabError("");
+      },
+      // The collab doc is the content's source of truth, seeded server-side.
+      // Until it has synced down, the editor holds an empty local doc —
+      // letting the user edit then would autosave that empty doc over the
+      // real page (silent total data loss when collab is down; hit by a
+      // customer 2026-08-06). Synced flips once per mount and stays true
+      // through reconnect blips: after first sync the local doc is real, so
+      // offline edits are safe to keep.
+      onSynced: () => {
+        if (!active) return;
+        syncedRef.current = true;
+        setSynced(true);
       },
       onAuthenticationFailed: ({ reason }) => {
         if (!active) return;
@@ -162,7 +179,7 @@ export default function MarkdownEditor({
     () => colorFromId(collaborationUser.id),
     [collaborationUser.id],
   );
-  const canEdit = !!collaboration && !readOnly;
+  const canEdit = !!collaboration && !readOnly && synced;
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -321,7 +338,7 @@ export default function MarkdownEditor({
       },
     },
     onUpdate: ({ editor }) => {
-      if (readOnly) return;
+      if (readOnly || !syncedRef.current) return;
       const md = serializeMarkdown(editor.getJSON(), lastSaved.current);
       if (md === lastSaved.current) return;
       setDirty(true);


### PR DESCRIPTION
This is a hotfix to out collaboration server behavior. Previously, if the collab server was down, we treated that the same as "page is empty" and allowed editing -> overwriting whatever was supposed to be there.

@samzliu I will slack you about this but I recommend we remove the collab server altogether

## What happened

`canEdit` only checked that a HocuspocusProvider *object* existed — not that it ever authenticated or synced. When the collab connection fails (server down, auth rejection, network), the editor renders an **empty local doc but stays editable**. Typing then autosaves that empty-plus-typed doc over the real page content. Silent, total data loss.

This is not theoretical: it destroyed a customer's SKILL.md on 2026-08-06 — their console screenshot showed the collab websocket failing (`wss://stash-collab.onrender.com` closed before established), they saw an "empty" page, pasted their content in, and the save wiped what the page previously held.

Verified live before the fix: stop the collab server, open a page containing `---\nname: roundtrip-test\ndescription: precious content\n---\n\n# Do not lose me\n`, type one line → the entire stored markdown became `'typed while collab was broken'`.

## The fix

The editor stays read-only until the provider's first `onSynced`, and the autosave path is gated on the same flag. Synced flips once per mount and stays true through reconnect blips — after first sync the local doc holds the real content, so offline edits during a blip remain safe (that's collab working as intended).

Verified after the fix, same scenario: editor shows the connection-error banner and refuses input; stored content byte-for-byte untouched. Healthy-collab editing verified unaffected (load → edit → save works).

[Screenshot: guarded editor with collab down](https://app.joinstash.ai/f/f9d2bcbf-9d7c-45c2-b516-aa67b90e7303)

## Related but NOT fixed here

The same investigation proved a second editor bug: the collab bootstrap renders page markdown through markdown-it, which parses `---` frontmatter fences as a **setext H2 heading** — so any GUI edit of a SKILL.md rewrites `---\nname: x\n---` into `## name: x` in the body, silently destroying skill metadata (this is exactly the state the customer's file was found in, and they'd hit it repeatedly since July 30). Needs a design decision on where frontmatter lives during editing — kept out of this PR.

## Tests

Editor-adjacent vitest suites pass (29 tests), tsc and ESLint clean (pre-existing warnings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)