### PR TITLE
fix: protected folders refuse the skills-sync content wipe

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -209,7 +209,10 @@ async def replace_skill_contents(
     if not any(path == "SKILL.md" for path, _blob in payload):
         raise HTTPException(status_code=400, detail="A skill must include a SKILL.md")
 
-    await files_tree_service.clear_folder_contents(folder_id)
+    try:
+        await files_tree_service.clear_folder_contents(folder_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     written = await files_tree_service.write_folder_files(
         owner_user_id, current_user["id"], folder_id, payload
     )

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1689,10 +1689,22 @@ async def clear_folder_contents(root_folder_id: UUID) -> None:
     folders, skills.folder_id cascades on folder delete, so dropping the root
     would unpublish the skill. Pages/files folder FKs are ON DELETE SET NULL,
     so their rows must be deleted explicitly or they'd orphan into the
-    scope root."""
+    scope root.
+
+    Protected folders (Memory, Clips) refuse this like every other destructive
+    verb. Skill-ness is derived, so a stray SKILL.md inside Memory makes it
+    pass ``_require_skill_folder`` — and this is the one destructive path with
+    no trash to recover from, so it must not trust that derivation."""
     from . import storage_service
 
     pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT name, is_protected FROM folders WHERE id = $1", root_folder_id
+    )
+    if row is None:
+        raise ValueError("folder not found")
+    if row["is_protected"]:
+        raise ValueError(f"the {row['name']} folder can't be emptied or replaced")
     if storage_service.is_configured():
         rows = await pool.fetch(
             f"SELECT storage_key FROM files WHERE folder_id IN ({_SUBTREE})", root_folder_id

--- a/backend/tests/test_protected_folders.py
+++ b/backend/tests/test_protected_folders.py
@@ -121,3 +121,37 @@ async def test_the_api_reports_which_folders_are_protected(client):
     by_name = {f["name"]: f for f in tree.json()["folders"]}
     assert by_name["Clips"]["is_protected"] is True
     assert by_name["Notes"]["is_protected"] is False
+
+
+async def test_memory_refuses_content_wipe_even_disguised_as_a_skill(client, pool):
+    """Skill-ness is derived (folder with a live SKILL.md), so a stray SKILL.md
+    inside Memory makes it pass the skills sync gate — and skills sync empties
+    the folder with a hard delete, no trash. The wipe must refuse protected
+    folders no matter what the derivation claims."""
+    user = await _user(client)
+    owner = user["id"]
+    memory = await files_tree_service.get_or_create_memory_folder(owner, owner)
+    wiki_page = await files_tree_service.create_page(
+        owner, "Wiki Index", owner, folder_id=memory["id"], content="precious"
+    )
+    await files_tree_service.create_page(
+        owner, "SKILL.md", owner, folder_id=memory["id"], content="# stray"
+    )
+
+    with pytest.raises(ValueError, match="can't be emptied"):
+        await files_tree_service.clear_folder_contents(memory["id"])
+
+    response = await client.put(
+        f"/api/v1/me/skills/{memory['id']}/contents",
+        files=[("files", ("SKILL.md", b"# replacement", "text/markdown"))],
+        headers=user["headers"],
+    )
+    assert response.status_code == 400
+    assert "can't be emptied" in response.json()["detail"]
+
+    # The wiki survived both attempts, live and in place.
+    row = await pool.fetchrow(
+        "SELECT folder_id, deleted_at FROM pages WHERE id = $1", wiki_page["id"]
+    )
+    assert row["folder_id"] == memory["id"]
+    assert row["deleted_at"] is None


### PR DESCRIPTION
We have a skill sync mechanism that allows us to silently and destructively overwrite folders in the name of syncing remote skills to local skills. So, if we have a local skill folder named `youtube`, we will silently attempt to overwrite the remote skill folder named `youtube` whenever the local version changes. However, we never structurally prevent this update mechanism from deleting folders that *are not* skill! So anything could be deleted if a caller is irresponsible, including memory! We now explicitly check that a folder is not a "protected folder" (Memory or Clips (browser extension saves)) before overwriting it in the name of "syncing".

More broadly, this indicates to me that we should either remove or seriously revamp our "skill sync" feature. @samzliu I'm gonna make a proposal here later this weekend. As far as I know nobody is using it, it's not part of our core story, and it's very jank right now. There's also no conflict resolution, so as soon as a skill is concurrently written to both locally and on remote, sync just silently stops working. Finally, the way we identify which skill to sync is literally just through skill name which is obviously very brittle and not even uniquely identifying. 

## The hole

`clear_folder_contents` hard-deletes everything inside a folder — pages, files, storage blobs — with **no trash**. It's reached by `PUT /me/skills/{folder_id}/contents` (the `stash skills sync` push) and GitHub re-import, and its only gate was `_require_skill_folder`: "the target must be a skill folder."

Skill-ness is *derived* — any folder containing a live `SKILL.md`. So a stray SKILL.md inside Memory (an agent's `create_page`, a user paste — agents mint SKILL.md files constantly, and Memory is a folder agents write into by design) makes Memory pass that gate. Worse, the system then *advertises* Memory as a skill in every skills listing, so good-faith automation ("sync all my skills") targets it legitimately. One call later the wiki is gone, unrecoverably — the only destructive path in the product with no trash, reachable on the most valuable folder in the account, with the protection guard never consulted.

Found during the 2026-08-06 incident review of every folder-deletion surface.

## The fix

`clear_folder_contents` now refuses protected folders (Memory, Clips) in the service layer — same choke-point style as rename/move/delete — and the sync route maps the refusal to a 400. Both callers are covered; GitHub re-import already maps ValueError to 400.

## Tests

New regression in `test_protected_folders.py`: plant a stray SKILL.md in Memory, attempt the wipe both at service level and through the sync endpoint — service raises, route 400s, and the wiki page is verified live and in place afterwards. Full protected-folders + skills + import suites pass (35 tests); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)