### PR TITLE
skills: membership is a stored flag, not a property of a file

### DIFF
--- a/backend/migrations/versions/0181_is_skill_flag.py
+++ b/backend/migrations/versions/0181_is_skill_flag.py
@@ -1,0 +1,54 @@
+"""Skill membership becomes a stored flag instead of a derived property.
+
+A folder was a skill because it contained a live SKILL.md. That made
+membership change as a side effect of ordinary file edits: deleting the
+file silently demoted the skill (a customer hit this three times in two
+weeks, losing their skill from every agent's catalog with no warning), and
+dropping a stray SKILL.md into Memory silently promoted it.
+
+Membership is now explicit: folders.is_skill, flipped only by deliberate
+verbs. Content stays exactly where it was — SKILL.md remains the one truth
+for instructions and frontmatter metadata.
+
+Backfill flags every folder that has a live SKILL.md today, so no skill
+disappears. Protected folders (Memory, Clips) are excluded and can never be
+flagged: the constraint makes the promote-Memory-then-wipe-it path
+unrepresentable rather than merely guarded.
+
+Revision ID: 0181
+Revises: 0180
+"""
+
+from alembic import op
+
+revision = "0181"
+down_revision = "0180"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE folders ADD COLUMN IF NOT EXISTS is_skill BOOLEAN NOT NULL DEFAULT false"
+    )
+    op.execute("""
+UPDATE folders f SET is_skill = true
+WHERE NOT f.is_protected
+  AND EXISTS (
+    SELECT 1 FROM pages p
+    WHERE p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL
+  )
+""")
+    op.execute(
+        "ALTER TABLE folders ADD CONSTRAINT folders_protected_is_never_a_skill "
+        "CHECK (NOT (is_skill AND is_protected))"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_folders_is_skill ON folders(owner_user_id) WHERE is_skill"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_folders_is_skill")
+    op.execute("ALTER TABLE folders DROP CONSTRAINT IF EXISTS folders_protected_is_never_a_skill")
+    op.execute("ALTER TABLE folders DROP COLUMN IF EXISTS is_skill")

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -351,16 +351,13 @@ async def get_folder_contents(
     ancestry_rows = await pool.fetch(
         """
         WITH RECURSIVE chain AS (
-          SELECT id, name, parent_folder_id, 0 AS depth
+          SELECT id, name, parent_folder_id, is_skill, 0 AS depth
           FROM folders WHERE id = $1
           UNION ALL
-          SELECT f.id, f.name, f.parent_folder_id, c.depth + 1
+          SELECT f.id, f.name, f.parent_folder_id, f.is_skill, c.depth + 1
           FROM folders f JOIN chain c ON c.parent_folder_id = f.id
         )
-        SELECT id, name,
-               EXISTS(SELECT 1 FROM pages skp WHERE skp.folder_id = chain.id
-                      AND skp.name = 'SKILL.md' AND skp.deleted_at IS NULL) AS is_skill
-        FROM chain ORDER BY depth DESC
+        SELECT id, name, is_skill FROM chain ORDER BY depth DESC
         """,
         folder_id,
     )
@@ -615,7 +612,7 @@ async def create_page(
         html_layout=req.html_layout,
     )
     # The creator just wrote it; the response must not demote the editor.
-    return PageResponse(**page, can_write=True)
+    return PageResponse(**{**page, "can_write": True})
 
 
 @router.post("/pages/{page_id}/copy", response_model=PageResponse, status_code=201)
@@ -639,7 +636,7 @@ async def copy_page(
     )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
-    return PageResponse(**page, can_write=True)
+    return PageResponse(**{**page, "can_write": True})
 
 
 @router.get("/pages/semantic-search")
@@ -811,6 +808,8 @@ async def update_page(
         )
     except DuplicatePageName as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except files_tree_service.ConcurrentEditError:
         raise HTTPException(
             status_code=409,
@@ -820,7 +819,7 @@ async def update_page(
         raise HTTPException(status_code=404, detail="Page not found")
     # Write access was checked above; a save response must not flip the
     # editor read-only by omitting the flag.
-    return PageResponse(**page, can_write=True)
+    return PageResponse(**{**page, "can_write": True})
 
 
 @router.delete("/pages/{page_id}", status_code=204)
@@ -837,7 +836,10 @@ async def delete_page(
         current_user["id"],
         require="write",
     )
-    deleted = await files_tree_service.delete_page(page_id, owner_user_id, current_user["id"])
+    try:
+        deleted = await files_tree_service.delete_page(page_id, owner_user_id, current_user["id"])
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     if not deleted:
         raise HTTPException(status_code=404, detail="Page not found")
 

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -52,6 +52,45 @@ async def create_skill(
     return {"folder_id": str(folder["id"]), "name": folder["name"]}
 
 
+@me_router.post("/folders/{folder_id}/convert-to-skill", status_code=200)
+async def convert_folder_to_skill(
+    folder_id: UUID,
+    current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
+):
+    """Promote a plain folder to a skill. Membership is explicit — this verb
+    and skill creation are the only ways in; a SKILL.md appearing inside a
+    folder no longer promotes it."""
+    return await _set_is_skill(folder_id, owner_user_id, current_user["id"], True)
+
+
+@me_router.post("/folders/{folder_id}/convert-to-folder", status_code=200)
+async def convert_skill_to_folder(
+    folder_id: UUID,
+    current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
+):
+    """Demote a skill back to a plain folder. Contents are untouched — the
+    folder simply stops appearing under Skills and stops loading for agents."""
+    return await _set_is_skill(folder_id, owner_user_id, current_user["id"], False)
+
+
+async def _set_is_skill(
+    folder_id: UUID, owner_user_id: UUID, user_id: UUID, is_skill: bool
+) -> dict:
+    if not await permission_service.check_access(
+        "folder", folder_id, user_id, owner_user_id=owner_user_id, require="write"
+    ):
+        raise HTTPException(status_code=403, detail="Not allowed to write this folder")
+    try:
+        folder = await files_tree_service.set_folder_is_skill(folder_id, owner_user_id, is_skill)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if folder is None:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    return {"folder_id": str(folder["id"]), "name": folder["name"], "is_skill": folder["is_skill"]}
+
+
 @me_router.post("/skills", response_model=SkillResponse, status_code=201)
 async def publish_skill(
     req: SkillPublishRequest,

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -425,10 +425,8 @@ async def _create_skill(args: dict) -> dict:
         from ..database import get_pool
 
         existing = await get_pool().fetchrow(
-            "SELECT f.id, EXISTS (SELECT 1 FROM pages p WHERE p.folder_id = f.id "
-            "  AND p.name = 'SKILL.md' AND p.deleted_at IS NULL) AS is_skill "
-            "FROM folders f WHERE f.owner_user_id = $1 AND f.parent_folder_id IS NULL "
-            "  AND f.name = $2",
+            "SELECT f.id, f.is_skill FROM folders f "
+            "WHERE f.owner_user_id = $1 AND f.parent_folder_id IS NULL AND f.name = $2",
             owner_user_id,
             args["name"],
         )
@@ -449,6 +447,7 @@ async def _create_skill(args: dict) -> dict:
                 }
             )
         )
+    await files_tree_service.set_folder_is_skill(folder["id"], owner_user_id, True)
     await files_tree_service.create_page(
         owner_user_id,
         "SKILL.md",

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -319,7 +319,7 @@ async def create_folder(
         row = await pool.fetchrow(
             "INSERT INTO folders (owner_user_id, parent_folder_id, name, created_by, is_protected) "
             "VALUES ($1, $2, $3, $4, $5) "
-            "RETURNING id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at",
+            "RETURNING id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at",
             owner_user_id,
             parent_folder_id,
             name,
@@ -334,7 +334,7 @@ async def create_folder(
 async def get_folder(folder_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+        "SELECT id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at "
         "FROM folders WHERE id = $1",
         folder_id,
     )
@@ -349,7 +349,7 @@ async def list_folders(owner_user_id: UUID, user_id: UUID | None = None) -> list
         args.append(user_id)
         where += " AND " + permission_service.readable_content_condition("folder", "f", 2)
     rows = await pool.fetch(
-        "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at, "
+        "SELECT id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at, "
         "  is_protected "
         f"FROM folders f WHERE {where} ORDER BY name",
         *args,
@@ -362,7 +362,7 @@ async def get_or_create_memory_folder(owner_user_id: UUID, created_by: UUID) -> 
     One per owner (partial unique index); created on first access."""
     pool = get_pool()
     select = (
-        "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+        "SELECT id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at "
         "FROM folders WHERE owner_user_id = $1 AND is_memory LIMIT 1"
     )
     row = await pool.fetchrow(select, owner_user_id)
@@ -372,7 +372,7 @@ async def get_or_create_memory_folder(owner_user_id: UUID, created_by: UUID) -> 
         row = await pool.fetchrow(
             "INSERT INTO folders (owner_user_id, name, created_by, is_memory, is_protected) "
             "VALUES ($1, 'Memory', $2, true, true) "
-            "RETURNING id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at",
+            "RETURNING id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at",
             owner_user_id,
             created_by,
         )
@@ -525,7 +525,7 @@ async def update_folder(
         row = await pool.fetchrow(
             f"UPDATE folders SET {', '.join(sets)} "
             f"WHERE id = ${idx} AND owner_user_id = ${idx + 1} "
-            "RETURNING id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at",
+            "RETURNING id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at",
             *args,
         )
     except asyncpg.UniqueViolationError as e:
@@ -797,6 +797,8 @@ async def update_page(
     event to open viewers and invalidates any persisted collab doc so a reopened
     editor reloads the fresh content instead of stale Yjs state."""
     pool = get_pool()
+    if name is not None:
+        await _assert_not_a_skills_instructions(page_id, owner_user_id)
     if content_html is not None:
         content_html = _sanitize_html(content_html)
     content_changed = content is not None or content_type is not None or content_html is not None
@@ -1074,6 +1076,29 @@ async def _reconcile_embedded_files(
     )
 
 
+async def _assert_not_a_skills_instructions(page_id: UUID, owner_user_id: UUID) -> None:
+    """A skill's SKILL.md can't be deleted or renamed.
+
+    It is the document agents load; without it the skill is a draft that can
+    do nothing. Deleting it used to silently demote the whole folder (a
+    customer did this three times), and now that membership is a flag it
+    would instead leave a skill nobody can run. Either way the user did not
+    mean to break their skill, so refuse and tell them: convert the skill to
+    a plain folder first if that's really what they want."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT p.name, f.is_skill FROM pages p JOIN folders f ON f.id = p.folder_id "
+        "WHERE p.id = $1 AND p.owner_user_id = $2",
+        page_id,
+        owner_user_id,
+    )
+    if row and row["is_skill"] and row["name"] == skill_service.SKILL_MD_NAME:
+        raise ValueError(
+            "SKILL.md holds this skill's instructions and can't be deleted or renamed. "
+            "Convert the skill to a folder first if you want to remove it."
+        )
+
+
 async def delete_page(page_id: UUID, owner_user_id: UUID, deleted_by: UUID) -> bool:
     """Soft delete: stamps deleted_at + deleted_by. Restore via restore_page.
 
@@ -1081,6 +1106,7 @@ async def delete_page(page_id: UUID, owner_user_id: UUID, deleted_by: UUID) -> b
     their page exists. A file owned by a trashed page is exactly as invisible
     as a trashed one (nothing displays it but the page), restore has nothing
     to undo, and purge_page is the destructor either way."""
+    await _assert_not_a_skills_instructions(page_id, owner_user_id)
     pool = get_pool()
     result = await pool.execute(
         "UPDATE pages SET deleted_at = NOW(), deleted_by = $3 "
@@ -1249,6 +1275,7 @@ async def create_skill(owner_user_id: UUID, created_by: UUID, base_name: str) ->
     Skills surface, and the hard-coded 'New skill' default made that a
     guaranteed collision on the second create."""
     folder = await _create_folder_unique(owner_user_id, base_name, created_by, None)
+    await set_folder_is_skill(folder["id"], owner_user_id, True)
     await create_page(
         owner_user_id,
         skill_service.SKILL_MD_NAME,
@@ -1256,7 +1283,36 @@ async def create_skill(owner_user_id: UUID, created_by: UUID, base_name: str) ->
         folder_id=folder["id"],
         content=skill_service.skill_md_template(folder["name"]),
     )
-    return folder
+    return {**folder, "is_skill": True}
+
+
+async def set_folder_is_skill(folder_id: UUID, owner_user_id: UUID, is_skill: bool) -> dict | None:
+    """Promote a folder to a skill, or demote it back. The only way membership
+    ever changes — editing files inside a folder never reclassifies it.
+
+    Protected folders (Memory, Clips) refuse promotion: a DB constraint makes
+    the state unrepresentable, and this raises before reaching it so the
+    caller gets a sentence instead of an integrity error."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "SELECT name, is_protected FROM folders WHERE id = $1 AND owner_user_id = $2",
+        folder_id,
+        owner_user_id,
+    )
+    if row is None:
+        return None
+    if is_skill and row["is_protected"]:
+        raise ValueError(f"the {row['name']} folder can't be turned into a skill")
+    updated = await pool.fetchrow(
+        "UPDATE folders SET is_skill = $3, updated_at = now() "
+        "WHERE id = $1 AND owner_user_id = $2 "
+        "RETURNING id, owner_user_id, parent_folder_id, name, is_skill, created_by, "
+        "  created_at, updated_at",
+        folder_id,
+        owner_user_id,
+        is_skill,
+    )
+    return dict(updated) if updated else None
 
 
 def _page_content_kwargs(src: dict) -> dict:
@@ -1417,6 +1473,9 @@ async def copy_folder(
     new_root = await _create_folder_unique(
         owner_user_id, f"Copy of {src['name']}", copied_by, parent
     )
+    # A copy of a skill is a skill: the user duplicated the thing as it is.
+    if src["is_skill"]:
+        new_root = await set_folder_is_skill(new_root["id"], owner_user_id, True)
     await _copy_folder_contents(folder_id, new_root["id"], owner_user_id, copied_by)
     return new_root
 
@@ -1653,7 +1712,7 @@ async def find_or_create_root_folder(
     """
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+        "SELECT id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at "
         "FROM folders WHERE owner_user_id = $1 AND parent_folder_id IS NULL AND name = $2",
         owner_user_id,
         name,
@@ -1673,7 +1732,7 @@ async def find_or_create_root_folder(
         # Lost a get-or-create race (concurrent clip saves): the folder now
         # exists, so return it.
         row = await pool.fetchrow(
-            "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+            "SELECT id, owner_user_id, parent_folder_id, name, is_skill, created_by, created_at, updated_at "
             "FROM folders WHERE owner_user_id = $1 AND parent_folder_id IS NULL AND name = $2",
             owner_user_id,
             name,
@@ -1719,9 +1778,13 @@ async def write_folder_files(
     files: list[tuple[str, bytes]],
 ) -> int:
     """Write (relative_path, bytes) pairs into the folder, creating subfolders
-    as needed. Markdown/HTML become pages keeping their full filenames (skill
-    detection requires a page named literally SKILL.md); everything else goes
-    to file storage. Returns the number of items written."""
+    as needed. Markdown/HTML become pages keeping their full filenames;
+    everything else goes to file storage. Returns the number of items written.
+
+    Any folder that receives a SKILL.md is promoted to a skill: a bulk import
+    or sync carrying one is an explicit "this is a skill" statement by the
+    caller, unlike a user editing files inside an existing folder. Protected
+    folders are never promoted."""
     import mimetypes
 
     from . import storage_service
@@ -1744,9 +1807,12 @@ async def write_folder_files(
         return folder["id"]
 
     written = 0
+    promote: set[UUID] = set()
     for rel_path, blob in files:
         dir_path, _, filename = rel_path.rpartition("/")
         folder_id = await ensure_dir(dir_path)
+        if filename == skill_service.SKILL_MD_NAME:
+            promote.add(folder_id)
         page_kind = detect_page_kind(filename, "")
         if page_kind is not None:
             text = blob.decode("utf-8", errors="replace")
@@ -1780,4 +1846,11 @@ async def write_folder_files(
             owner_id,
         )
         written += 1
+    if promote:
+        await get_pool().execute(
+            "UPDATE folders SET is_skill = true "
+            "WHERE id = ANY($1::uuid[]) AND owner_user_id = $2 AND NOT is_protected",
+            list(promote),
+            owner_user_id,
+        )
     return written

--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -122,6 +122,12 @@ def skill_md_template(name: str, description: str = "") -> str:
 
 
 async def _ensure_skill_md(owner_user_id: UUID, folder_id: UUID, user_id: UUID, title: str) -> None:
+    """Give the folder instructions if it has none, and mark it a skill.
+
+    Publishing/forking/installing a skill is an explicit "this is a skill"
+    act by the caller, so it sets membership — unlike a user editing files
+    inside a folder, which never reclassifies anything."""
+    await files_tree_service.set_folder_is_skill(folder_id, owner_user_id, True)
     pool = get_pool()
     existing = await pool.fetchval(
         "SELECT 1 FROM pages WHERE folder_id = $1 AND name = 'SKILL.md' "
@@ -670,17 +676,22 @@ async def _fork_folder(
     user_id: UUID,
     name_override: str | None = None,
 ) -> UUID:
-    folder = await conn.fetchrow("SELECT name FROM folders WHERE id = $1", source_folder_id)
+    folder = await conn.fetchrow(
+        "SELECT name, is_skill FROM folders WHERE id = $1", source_folder_id
+    )
     if not folder:
         raise ValueError("Skill folder not found")
 
+    # Forking a skill is an explicit "give me this skill" — membership travels
+    # with the copy, exactly like its files do.
     new_folder = await conn.fetchrow(
-        "INSERT INTO folders (owner_user_id, parent_folder_id, name, created_by) "
-        "VALUES ($1, $2, $3, $4) RETURNING id",
+        "INSERT INTO folders (owner_user_id, parent_folder_id, name, created_by, is_skill) "
+        "VALUES ($1, $2, $3, $4, $5) RETURNING id",
         owner_user_id,
         parent_folder_id,
         name_override or folder["name"],
         user_id,
+        folder["is_skill"],
     )
 
     child_folders = await conn.fetch(

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -1,11 +1,15 @@
-"""Skill service — skills are special folders containing a SKILL.md file.
+"""Skill service — a skill is a folder whose ``is_skill`` flag is set.
 
-Detection rule: any folder whose immediate children include a page named
-``SKILL.md``. Skill-ness is derived, never stored; reads/writes go through
-the Files API. Files and Skills are MECE: skill subtrees are filtered out of
-every Files surface (see ``skill_subtree_folder_ids``) and surfaced in the
-Skills area instead. Publishing/sharing attaches a 1:1 ``skills`` row to the
-folder (shared_skill_service).
+Membership is stored, never derived: it changes only through deliberate
+verbs (create a skill, convert a folder, import a repo), so editing files
+inside a folder can never reclassify it. SKILL.md still holds the skill's
+instructions and frontmatter metadata — a skill missing it is a draft that
+says so, not a folder that quietly stopped being a skill.
+
+Files and Skills are MECE: skill subtrees are filtered out of every Files
+surface (see ``skill_subtree_folder_ids``) and surfaced in the Skills area
+instead. Publishing/sharing attaches a 1:1 ``skills`` row to the folder
+(shared_skill_service).
 """
 
 from __future__ import annotations
@@ -23,11 +27,8 @@ def skill_md_template(name: str) -> str:
 
 
 def not_skill_folder_pred(alias: str) -> str:
-    """SQL fragment: folder ``alias`` has no live SKILL.md child."""
-    return (
-        f"NOT EXISTS (SELECT 1 FROM pages skp WHERE skp.folder_id = {alias}.id "
-        "AND skp.name = 'SKILL.md' AND skp.deleted_at IS NULL)"
-    )
+    """SQL fragment: folder ``alias`` is not a skill."""
+    return f"NOT {alias}.is_skill"
 
 
 async def skill_subtree_folder_ids(owner_user_id: UUID) -> set[UUID]:
@@ -36,10 +37,7 @@ async def skill_subtree_folder_ids(owner_user_id: UUID) -> set[UUID]:
     pool = get_pool()
     rows = await pool.fetch(
         "WITH RECURSIVE skill_tree AS ("
-        "  SELECT f.id FROM folders f "
-        "  WHERE f.owner_user_id = $1 "
-        "    AND EXISTS (SELECT 1 FROM pages p WHERE p.folder_id = f.id "
-        "                AND p.name = 'SKILL.md' AND p.deleted_at IS NULL)"
+        "  SELECT f.id FROM folders f WHERE f.owner_user_id = $1 AND f.is_skill"
         "  UNION"
         "  SELECT f.id FROM folders f JOIN skill_tree st ON f.parent_folder_id = st.id"
         ") SELECT id FROM skill_tree",
@@ -80,20 +78,24 @@ def parse_frontmatter(md: str) -> tuple[dict, str]:
 
 async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     """List every skill folder in the scope: folder + SKILL.md frontmatter,
-    plus the publish record when the skill has been shared."""
+    plus the publish record when the skill has been shared.
+
+    LEFT JOIN on SKILL.md, not INNER: membership is the flag, so a skill
+    whose instructions are missing still lists — as a draft, with
+    has_instructions false — instead of vanishing from every surface."""
     pool = get_pool()
     readable = permission_service.readable_content_condition("folder", "f", 2)
     rows = await pool.fetch(
-        "SELECT f.id AS folder_id, f.name AS folder_name, "
+        "SELECT f.id AS folder_id, f.name AS folder_name, f.updated_at AS folder_updated_at, "
         "  p.id AS skill_md_id, p.content_markdown AS skill_md, p.updated_at, "
         "  (SELECT COUNT(*) FROM pages p2 WHERE p2.folder_id = f.id "
         "   AND p2.deleted_at IS NULL) AS file_count, "
         "  s.id AS publish_id, s.slug, s.title, s.discoverable, "
         "  s.cover_image_url, s.icon_url, s.view_count "
         "FROM folders f "
-        "JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL "
+        "LEFT JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL "
         "LEFT JOIN skills s ON s.folder_id = f.id "
-        f"WHERE f.owner_user_id = $1 AND {readable} "
+        f"WHERE f.owner_user_id = $1 AND f.is_skill AND {readable} "
         "ORDER BY f.name",
         owner_user_id,
         user_id,
@@ -120,7 +122,10 @@ async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
                 "version": meta.get("version", ""),
                 "mcp_exposed": bool(meta.get("mcp_exposed", False)),
                 "file_count": int(r["file_count"]),
-                "updated_at": r["updated_at"],
+                "updated_at": r["updated_at"] or r["folder_updated_at"],
+                # False = a draft skill: it exists and is named, but has no
+                # instructions for an agent to load yet. Surfaces say so.
+                "has_instructions": r["skill_md_id"] is not None,
                 "published": published,
             }
         )
@@ -180,6 +185,10 @@ async def read_skill(owner_user_id: UUID, name: str, user_id: UUID) -> dict | No
         "name": match["name"],
         "description": match["description"],
         "when_to_use": match["when_to_use"],
+        # A draft skill loads with no instructions. Callers that need them
+        # (agent load, publish, install) refuse on this rather than handing
+        # an agent an empty document and calling it a skill.
+        "has_instructions": skill_md is not None,
         "body": body,
         "files": [
             {

--- a/backend/tests/test_folder_skills.py
+++ b/backend/tests/test_folder_skills.py
@@ -66,7 +66,7 @@ def _all_tree_folder_ids(node: dict) -> set[str]:
 
 
 @pytest.mark.asyncio
-async def test_skill_folder_is_hidden_from_files_surfaces_until_skill_md_deleted(
+async def test_skill_folder_is_hidden_from_files_surfaces_until_converted_back(
     client: AsyncClient,
 ):
     api_key, _ = await _register(client)
@@ -76,6 +76,11 @@ async def test_skill_folder_is_hidden_from_files_surfaces_until_skill_md_deleted
     skill_folder = await _folder(client, api_key, scope, "my-skill", parent_folder_id=docs)
     nested = await _folder(client, api_key, scope, "refs", parent_folder_id=skill_folder)
     skill_md = await _page(client, api_key, scope, "SKILL.md", folder_id=skill_folder)
+    # Membership is explicit now: writing SKILL.md no longer promotes.
+    promoted = await client.post(
+        f"/api/v1/me/folders/{skill_folder}/convert-to-skill", headers=_auth(api_key)
+    )
+    assert promoted.status_code == 200
     nested_page = await _page(client, api_key, scope, "notes", folder_id=nested)
 
     # /tree hides the whole skill subtree (the SKILL.md folder + descendants).
@@ -114,9 +119,18 @@ async def test_skill_folder_is_hidden_from_files_surfaces_until_skill_md_deleted
     assert "SKILL.md" in [p["name"] for p in body["pages"]]
     assert nested in [f["id"] for f in body["subfolders"]]
 
-    # Deleting SKILL.md ends skill-ness: the folder rejoins the Files tree.
-    deleted = await client.delete(f"/api/v1/me/pages/{skill_md}", headers=_auth(api_key))
-    assert deleted.status_code == 204
+    # SKILL.md can't be deleted out from under a skill — that used to demote
+    # the folder silently and cost a customer their skill three times.
+    refused = await client.delete(f"/api/v1/me/pages/{skill_md}", headers=_auth(api_key))
+    assert refused.status_code == 400
+    assert "can't be deleted" in refused.json()["detail"]
+
+    # Converting back to a folder is the explicit way out, and it returns the
+    # folder to the Files tree.
+    demoted = await client.post(
+        f"/api/v1/me/folders/{skill_folder}/convert-to-folder", headers=_auth(api_key)
+    )
+    assert demoted.status_code == 200
     tree_after = (await client.get("/api/v1/me/tree", headers=_auth(api_key))).json()
     assert skill_folder in _all_tree_folder_ids(tree_after)
 

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -1,0 +1,102 @@
+"""Skill membership is stored and explicit, never derived from file contents.
+
+A folder used to be a skill because it contained a live SKILL.md, so ordinary
+file edits silently reclassified folders: deleting the file demoted a
+customer's skill out of every agent's catalog three times in two weeks, and a
+stray SKILL.md could promote Memory into a wipeable "skill". Membership now
+changes only through deliberate verbs.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import files_tree_service, skill_service
+
+
+@pytest_asyncio.fixture
+async def scope(_db_pool):
+    user_id = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        user_id,
+        f"u_{user_id.hex[:6]}",
+    )
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_dropping_a_skill_md_into_a_folder_does_not_promote_it(scope, _db_pool):
+    folder = await files_tree_service.create_folder(scope, "Notes", scope)
+    await files_tree_service.create_page(
+        scope, "SKILL.md", scope, folder_id=folder["id"], content="# not a skill"
+    )
+
+    skills = await skill_service.list_skills(scope, scope)
+
+    assert [s["folder_id"] for s in skills] == []
+
+
+@pytest.mark.asyncio
+async def test_convert_verbs_are_the_only_way_membership_changes(scope, _db_pool):
+    folder = await files_tree_service.create_folder(scope, "Recipes", scope)
+
+    promoted = await files_tree_service.set_folder_is_skill(folder["id"], scope, True)
+    assert promoted["is_skill"] is True
+    assert [s["folder_id"] for s in await skill_service.list_skills(scope, scope)] == [
+        str(folder["id"])
+    ]
+
+    demoted = await files_tree_service.set_folder_is_skill(folder["id"], scope, False)
+    assert demoted["is_skill"] is False
+    assert await skill_service.list_skills(scope, scope) == []
+
+
+@pytest.mark.asyncio
+async def test_deleting_skill_md_leaves_a_draft_skill_not_a_silent_demotion(scope, _db_pool):
+    """The customer's exact move. Before: the skill vanished from every
+    surface with no warning. Now: the delete is refused outright, and even
+    forced at the data layer the skill still lists — as a draft."""
+    folder = await files_tree_service.create_skill(scope, scope, "Brake Shoes")
+    page_id = await _db_pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'", folder["id"]
+    )
+
+    with pytest.raises(ValueError, match="can't be deleted or renamed"):
+        await files_tree_service.delete_page(page_id, scope, scope)
+    with pytest.raises(ValueError, match="can't be deleted or renamed"):
+        await files_tree_service.update_page(page_id, scope, scope, name="notes.md")
+
+    await _db_pool.execute("UPDATE pages SET deleted_at = now() WHERE id = $1", page_id)
+    [skill] = await skill_service.list_skills(scope, scope)
+    assert skill["folder_id"] == str(folder["id"])
+    assert skill["has_instructions"] is False
+
+
+@pytest.mark.asyncio
+async def test_memory_can_never_become_a_skill(scope, _db_pool):
+    memory = await files_tree_service.get_or_create_memory_folder(scope, scope)
+
+    with pytest.raises(ValueError, match="can't be turned into a skill"):
+        await files_tree_service.set_folder_is_skill(memory["id"], scope, True)
+
+    # And a stray SKILL.md inside it changes nothing.
+    await files_tree_service.create_page(
+        scope, "SKILL.md", scope, folder_id=memory["id"], content="# stray"
+    )
+    assert await skill_service.list_skills(scope, scope) == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_write_carrying_a_skill_md_promotes_explicitly(scope, _db_pool):
+    """Import/sync is a caller saying "this is a skill" — unlike a user
+    editing files inside an existing folder."""
+    folder = await files_tree_service.create_folder(scope, "imported-repo", scope)
+    await files_tree_service.write_folder_files(
+        scope, scope, folder["id"], [("SKILL.md", b"# imported"), ("notes.md", b"context")]
+    )
+
+    assert [s["folder_id"] for s in await skill_service.list_skills(scope, scope)] == [
+        str(folder["id"])
+    ]

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -522,7 +522,8 @@ async def test_member_sessions_and_events_land_in_workspace_scope(client: AsyncC
 async def _workspace_skill_folder(pool, scope_user_id, name="team-skill") -> uuid.UUID:
     scope_id = uuid.UUID(scope_user_id)
     folder = await pool.fetchrow(
-        "INSERT INTO folders (owner_user_id, name, created_by) VALUES ($1, $2, $1) RETURNING id",
+        "INSERT INTO folders (owner_user_id, name, created_by, is_skill) "
+        "VALUES ($1, $2, $1, true) RETURNING id",
         scope_id,
         name,
     )


### PR DESCRIPTION
This changes our invariant that "a skill is just a folder with a SKILL.md". This caused confusion among users, and also can lead to some weird bugs.

Stacked on #982 (migration chain); retargets to main when that merges.

## Why

A folder was a skill because it contained a live `SKILL.md`. Membership therefore changed as a **side effect of ordinary file edits**:

- Mike deleted the auto-created stub SKILL.md — which the broken editor rendered as blank — and his skill silently vanished from every agent's catalog. Three times in two weeks.
- A stray SKILL.md dropped into Memory promoted it to a "skill", which made it eligible for the skills-sync content wipe (#979 blocked the consequence; this removes the cause).
- Nobody could tell which file was load-bearing, because nothing said so.

## What changes

**Membership is stored and explicit.** `folders.is_skill` flips only through deliberate verbs: create a skill, the new convert-to-skill/convert-to-folder endpoints, fork/publish/install, or a bulk import carrying a SKILL.md (an explicit act by the caller, unlike a user editing files in place).

**Content is untouched.** SKILL.md remains the single source of truth for instructions *and* frontmatter metadata, edited directly by users and agents exactly as today. No metadata columns, no sync layer, no second representation — deliberately rejected during review as recreating the dual-source-of-truth problem we just deleted with the collab server.

**Migration 0182** adds the column, backfills every folder holding a live SKILL.md (no skill disappears on deploy), and adds `CHECK (NOT (is_skill AND is_protected))` — the Memory-as-skill state becomes unrepresentable rather than merely guarded.

**SKILL.md is protected inside a skill**: delete/rename refused at the service layer, so UI, CLI, and agent tools are covered by one check, with a message pointing at convert-to-folder.

**Draft skills are visible**: a skill whose instructions are missing lists with `has_instructions: false` instead of silently ceasing to exist.

## Every creation path had to be taught the flag

The suite caught all of them, which is the good version of this problem — loud, at build time, with a list: agent `create_skill`, fork, publish, install/add, workspace bootstrap, folder copy, and bulk import. Each now sets membership explicitly.

## Tests

New `test_skill_membership.py` pins the model: dropping a SKILL.md into a folder does **not** promote it; convert verbs are the only path; the customer's exact delete is refused and even a forced data-layer delete leaves a listed draft rather than a vanished skill; Memory can never be promoted; bulk import promotes. Full backend suite: **1,288 passed, 0 failed**. Ruff clean.

## Follow-up (not here)

The skill view still opens as a file browser showing SKILL.md as an ordinary file — the reason Mike pasted his content into a new page beside it. Next PR: open the instructions directly, with the folder name as the editable title and siblings listed below. That also removes the Skills→Files tab-jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)