### PR TITLE
fix: opening a file inside a skill keeps you in the Skills tab

### DIFF
--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -395,7 +395,10 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
           rootLabel={LABEL[section]}
           rootFolderId={section === "memory" ? memoryFolderId : null}
           hideFolderId={section === "files" ? memoryFolderId : null}
-          tabSection={section === "memory" ? "memory" : undefined}
+          // Stamp the section on opened tabs so the shell keeps you where you
+          // are. Without it every folder/page route reads as Files, and opening
+          // a file inside a skill teleported you to the Files tab.
+          tabSection={section === "memory" || section === "skills" ? section : undefined}
           loadRoot={section === "skills" ? skillsRoot : isSessions ? sessionsRoot : undefined}
           loadFolder={isSessions ? sessionsFolder : undefined}
           // Sessions already merges shared folders into its root, and Memory is


### PR DESCRIPTION
The explorer stamped `?section=` on opened tabs only for Memory. Every other section fell back to path-derived section — and every folder/page route is Files-shaped — so clicking a file inside a skill teleported you to **Files**. Flagged by the customer on the 8/6 call; one of the last open items from that incident.

One line: Skills stamps its section like Memory already did.

**Verified on the live stack** — create skill → open it → click SKILL.md: editor opens, rail stays on **Skills**, URL carries `?section=skills`. [Screenshot](https://app.joinstash.ai/f/2abeed76-802a-467c-b269-366222f1a6b5)

Known leftover, not this PR: the page header's own breadcrumb still reads "Files / …" — a different component, part of the skill-view rework (open the instructions directly, folder name as editable title, siblings below).

Frontend-only, no migration. Full frontend suite 276 passed; tsc + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)