### PR TITLE
fix: Convert to Skill actually converts (and lands on a real page)

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -60,8 +60,15 @@ async def convert_folder_to_skill(
 ):
     """Promote a plain folder to a skill. Membership is explicit — this verb
     and skill creation are the only ways in; a SKILL.md appearing inside a
-    folder no longer promotes it."""
-    return await _set_is_skill(folder_id, owner_user_id, current_user["id"], True)
+    folder no longer promotes it.
+
+    The folder also gets a starter SKILL.md if it has none, so converting
+    leaves a skill an agent can actually load rather than a draft."""
+    result = await _set_is_skill(folder_id, owner_user_id, current_user["id"], True)
+    await shared_skill_service.ensure_skill_md(
+        owner_user_id, folder_id, current_user["id"], result["name"]
+    )
+    return result
 
 
 @me_router.post("/folders/{folder_id}/convert-to-folder", status_code=200)

--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -121,7 +121,7 @@ def skill_md_template(name: str, description: str = "") -> str:
     return f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n"
 
 
-async def _ensure_skill_md(owner_user_id: UUID, folder_id: UUID, user_id: UUID, title: str) -> None:
+async def ensure_skill_md(owner_user_id: UUID, folder_id: UUID, user_id: UUID, title: str) -> None:
     """Give the folder instructions if it has none, and mark it a skill.
 
     Publishing/forking/installing a skill is an explicit "this is a skill"
@@ -187,7 +187,7 @@ async def publish_folder(
         title = meta.get("name") or folder["name"]
         description = description or meta.get("description", "")
 
-    await _ensure_skill_md(owner_user_id, folder_id, owner_id, title)
+    await ensure_skill_md(owner_user_id, folder_id, owner_id, title)
     try:
         inserted = await pool.fetchrow(
             "INSERT INTO skills (owner_user_id, folder_id, slug, title, description, owner_id, "

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -7,7 +7,7 @@ stray SKILL.md could promote Memory into a wipeable "skill". Membership now
 changes only through deliberate verbs.
 """
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
@@ -100,3 +100,39 @@ async def test_bulk_write_carrying_a_skill_md_promotes_explicitly(scope, _db_poo
     assert [s["folder_id"] for s in await skill_service.list_skills(scope, scope)] == [
         str(folder["id"])
     ]
+
+
+@pytest.mark.asyncio
+async def test_convert_endpoint_leaves_a_loadable_skill(client, _db_pool):
+    """The Convert-to-Skill button's contract: one call promotes the folder
+    AND leaves instructions, so the user lands on a skill an agent can load —
+    not a draft, and not (as before) a SKILL.md write that no longer promotes
+    anything."""
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"conv_{uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    body = reg.json()
+    headers = {"Authorization": f"Bearer {body['api_key']}"}
+    owner = UUID(body["id"])
+
+    folder = await client.post("/api/v1/me/folders", json={"name": "Runbooks"}, headers=headers)
+    folder_id = folder.json()["id"]
+
+    resp = await client.post(f"/api/v1/me/folders/{folder_id}/convert-to-skill", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["is_skill"] is True
+
+    listed = (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"]
+    [skill] = [s for s in listed if s["folder_id"] == folder_id]
+    assert skill["has_instructions"] is True
+
+    # And back again: demotion is equally explicit, contents untouched.
+    back = await client.post(f"/api/v1/me/folders/{folder_id}/convert-to-folder", headers=headers)
+    assert back.status_code == 200
+    assert (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"] == []
+    kept = await _db_pool.fetchval(
+        "SELECT count(*) FROM pages WHERE folder_id = $1 AND deleted_at IS NULL", UUID(folder_id)
+    )
+    assert kept == 1
+    assert owner

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -11,18 +11,14 @@ import FileBrowser from "@/components/content/file-browser/FileBrowser";
 import { useAuth } from "@/hooks/useAuth";
 import {
   ApiError,
-  createPage,
+  convertFolderToSkill,
   getFolderContents,
   getPublicSkill,
   type FolderBreadcrumb,
   type PublicSkillContents,
   type PublicSkillSubfolder,
 } from "@/lib/api";
-import {
-  findInSkillContents,
-  SKILL_MD,
-  skillMdTemplate,
-} from "@/lib/localSkill";
+import { findInSkillContents } from "@/lib/localSkill";
 import { loginPathWithNext } from "@/lib/loginRedirect";
 import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
@@ -136,9 +132,13 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
     if (!folderName || !user) return;
     setConverting(true);
     try {
-      await createPage(SKILL_MD, folderId, skillMdTemplate(folderName));
+      // The explicit verb — writing a SKILL.md hasn't promoted a folder
+      // since membership became a stored flag.
+      await convertFolderToSkill(folderId);
       await refreshSidebar().catch(() => {});
-      router.push(`/skills/${folderId}`);
+      // /skills/<x> is the published-slug route; a folder id there renders
+      // "Skill not found". The skill's own page is /skills/folder/<id>.
+      router.push(`/skills/folder/${folderId}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Convert failed");
     } finally {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -593,6 +593,15 @@ export async function createSkill(name?: string): Promise<{ folder_id: string; n
   });
 }
 
+// Promote a plain folder to a skill (and give it starter instructions if it
+// has none). Membership is a stored flag now — writing a SKILL.md into a
+// folder no longer promotes it.
+export async function convertFolderToSkill(
+  folderId: string
+): Promise<{ folder_id: string; name: string; is_skill: boolean }> {
+  return apiFetch(`${ME}/folders/${folderId}/convert-to-skill`, { method: "POST" });
+}
+
 export async function updateFolder(
   folderId: string,
   data: { name?: string; parent_folder_id?: string | null; move_to_root?: boolean }


### PR DESCRIPTION
Update out button so that it creates skills the new way, not by creating a SKILL.md.

Found while reviewing what to tell the customer. **Two bugs in one button**, both live in prod right now:

1. **It doesn't convert.** The button promoted a folder by writing a `SKILL.md` — which stopped promoting anything when membership became a stored flag (#985). It wrote a stub file and silently failed to create a skill. My regression: I removed the derivation rule without updating its one UI consumer.
2. **It routes to a dead page.** It pushed `/skills/<folder_id>` — the *published-slug* route — which renders "Skill not found" for a folder id. That's the same dead end the customer's agent hit yesterday from a hallucinated URL. This one is pre-existing, and means the button has been broken for longer than #985 has existed.

## The fix

One call to the convert verb, which sets membership **and** gives the folder starter instructions if it has none (so you land on a skill an agent can load, not a draft), then routes to the skill's real page — `/skills/folder/<id>`.

## Verified live

Folder → click **Convert to Skill** → lands on `/skills/folder/<id>`, sidebar shows it under Skills with the skill icon, header offers **Convert to folder** for the way back, API reports `has_instructions: true`. [Screenshot](https://app.joinstash.ai/f/7e55c0ad-c62d-498c-a489-eb9139376c9a)

New backend test pins the round trip: convert promotes and leaves instructions; convert back demotes and leaves contents untouched. Backend skills suites 18 passed; frontend 276 passed; tsc + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)