### PR TITLE
fix: every skill-creating surface marks the skill (CLI, shared list, feed)

### DIFF
--- a/backend/services/feed_service.py
+++ b/backend/services/feed_service.py
@@ -92,9 +92,7 @@ async def _resurface_items(user_id: UUID, cursor: int) -> list[dict]:
             WHERE raw_f.owner_user_id = $1 AND raw_f.name = $4
         ), skill_folders AS (
             SELECT f.id FROM folders f
-            WHERE f.owner_user_id = $1
-              AND EXISTS (SELECT 1 FROM pages sp WHERE sp.folder_id = f.id
-                          AND sp.name = 'SKILL.md' AND sp.deleted_at IS NULL)
+            WHERE f.owner_user_id = $1 AND f.is_skill
             UNION
             SELECT f.id FROM folders f
             JOIN skill_folders st ON f.parent_folder_id = st.id

--- a/backend/services/shared_skill_service.py
+++ b/backend/services/shared_skill_service.py
@@ -383,8 +383,8 @@ async def list_skills_shared_with_user(user_id: UUID) -> list[dict]:
                p.content_markdown AS skill_md,
                v.slug
         FROM shares sh
-        JOIN folders f ON f.id = sh.object_id AND sh.object_type = 'folder'
-        JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL
+        JOIN folders f ON f.id = sh.object_id AND sh.object_type = 'folder' AND f.is_skill
+        LEFT JOIN pages p ON p.folder_id = f.id AND p.name = 'SKILL.md' AND p.deleted_at IS NULL
         JOIN users ow ON ow.id = sh.owner_user_id
         LEFT JOIN users u ON u.id = sh.created_by
         LEFT JOIN skills v ON v.folder_id = f.id

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -136,3 +136,77 @@ async def test_convert_endpoint_leaves_a_loadable_skill(client, _db_pool):
     )
     assert kept == 1
     assert owner
+
+
+@pytest.mark.asyncio
+async def test_folder_plus_skill_md_plus_convert_is_the_cli_recipe(client, _db_pool):
+    """What every CLI skill-creating command does: make a folder, write its
+    SKILL.md, then say "this is a skill". The middle step alone used to be
+    enough, which is why `stash skills create` broke silently when membership
+    became a flag — this pins the sequence the CLI depends on."""
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"cli_{uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    headers = {"Authorization": f"Bearer {reg.json()['api_key']}"}
+
+    folder_id = (
+        await client.post("/api/v1/me/folders", json={"name": "cli-skill"}, headers=headers)
+    ).json()["id"]
+    await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "SKILL.md", "folder_id": folder_id, "content": "---\nname: cli-skill\n---\n"},
+        headers=headers,
+    )
+
+    # Writing the file is not enough — that is the whole point of the flag.
+    assert (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"] == []
+
+    convert = await client.post(f"/api/v1/me/folders/{folder_id}/convert-to-skill", headers=headers)
+    assert convert.status_code == 200
+    listed = (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"]
+    assert [s["folder_id"] for s in listed] == [folder_id]
+    # Converting did not clobber the instructions the caller just wrote.
+    kept = await _db_pool.fetchval(
+        "SELECT content_markdown FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'",
+        UUID(folder_id),
+    )
+    assert "name: cli-skill" in kept
+
+
+@pytest.mark.asyncio
+async def test_shared_skill_without_instructions_still_lists(client, _db_pool):
+    """A skill shared with you shows up even as a draft. The listing used to
+    inner-join SKILL.md, so a shared skill missing instructions vanished
+    instead of appearing with has_instructions false."""
+    owner = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"own_{uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    owner_h = {"Authorization": f"Bearer {owner.json()['api_key']}"}
+    friend = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"fr_{uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    friend_h = {"Authorization": f"Bearer {friend.json()['api_key']}"}
+
+    made = await client.post(
+        "/api/v1/me/skills/new", json={"name": "Shared draft"}, headers=owner_h
+    )
+    folder_id = made.json()["folder_id"]
+    # Force the draft state (the delete route refuses, by design).
+    await _db_pool.execute(
+        "UPDATE pages SET deleted_at = now() WHERE folder_id = $1 AND name = 'SKILL.md'",
+        UUID(folder_id),
+    )
+    await _db_pool.execute(
+        "INSERT INTO shares (owner_user_id, object_type, object_id, principal_type, "
+        "                    principal_id, permission, created_by) "
+        "VALUES ($1, 'folder', $2, 'user', $3, 'read', $1)",
+        UUID(owner.json()["id"]),
+        UUID(folder_id),
+        UUID(friend.json()["id"]),
+    )
+
+    listed = (await client.get("/api/v1/me/shared-skills", headers=friend_h)).json()
+    assert folder_id in [s["folder_id"] for s in listed["skills"]]

--- a/cli/client.py
+++ b/cli/client.py
@@ -339,6 +339,12 @@ class StashClient:
             body["parent_folder_id"] = parent_folder_id
         return self._post("/api/v1/me/folders", json=body)
 
+    def convert_folder_to_skill(self, folder_id: str) -> dict:
+        """Mark a folder as a skill (and give it starter instructions if it has
+        none). Skill membership is a stored flag server-side — writing a
+        SKILL.md into a folder does not make it a skill."""
+        return self._post(f"/api/v1/me/folders/{folder_id}/convert-to-skill")
+
     def delete_folder(self, folder_id: str) -> None:
         self._delete(f"/api/v1/me/folders/{folder_id}")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1519,7 +1519,8 @@ def upload(
             result["public_link"] = True
 
         if create_skill:
-            # A skill is a folder with a SKILL.md; publishing makes it public.
+            # Skill membership is a stored flag: writing a SKILL.md does not
+            # make a folder a skill, the convert verb does.
             try:
                 c.create_page(
                     name="SKILL.md",
@@ -1530,6 +1531,7 @@ def upload(
             except StashError as e:
                 if e.status_code != 409:
                     raise
+            c.convert_folder_to_skill(root_folder["id"])
             if public:
                 skill_row = c.publish_skill_folder(
                     root_folder["id"],
@@ -1643,7 +1645,8 @@ def skills_add(
     folder_name = src.name
     with _client() as c:
         try:
-            # Skills are represented as folders containing markdown pages.
+            # A skill is a folder marked as one; its markdown pages (SKILL.md
+            # plus siblings) are its content.
             new_folder = c.create_folder(folder_name)
             folder_id = new_folder["id"]
             for md_file in sorted(src.glob("*.md")):
@@ -1653,6 +1656,7 @@ def skills_add(
                     folder_id=folder_id,
                     content_type="markdown",
                 )
+            c.convert_folder_to_skill(folder_id)
         except StashError as e:
             _err(e)
     console.print(f"[green]Added skill '{folder_name}' to your Files.[/green]")
@@ -1680,6 +1684,9 @@ def skills_create(
                 folder_id=folder["id"],
                 content_type="markdown",
             )
+            # Membership is a stored flag; the SKILL.md above is the skill's
+            # instructions, not what makes the folder a skill.
+            c.convert_folder_to_skill(folder["id"])
             skill = None
             if public:
                 skill = c.publish_skill_folder(

--- a/cli/tests/test_share_and_upload_helpers.py
+++ b/cli/tests/test_share_and_upload_helpers.py
@@ -38,6 +38,7 @@ def test_upload_with_skill_flag_publishes_the_folder(monkeypatch, tmp_path) -> N
     uploaded.write_bytes(b"png")
     published: dict = {}
     created_pages: list[str] = []
+    converted: list[str] = []
 
     class FakeClient:
         def __enter__(self):
@@ -58,6 +59,10 @@ def test_upload_with_skill_flag_publishes_the_folder(monkeypatch, tmp_path) -> N
             created_pages.append(name)
             return {"id": f"page-{len(created_pages)}"}
 
+        def convert_folder_to_skill(self, folder_id):
+            converted.append(folder_id)
+            return {"folder_id": folder_id, "name": "shot", "is_skill": True}
+
         def publish_skill_folder(self, folder_id, **kwargs):
             published["folder_id"] = folder_id
             published["kwargs"] = kwargs
@@ -68,8 +73,10 @@ def test_upload_with_skill_flag_publishes_the_folder(monkeypatch, tmp_path) -> N
 
     main.upload(str(uploaded), name="", skill="shot", public=True, as_json=False)
 
-    # --skill makes the folder a skill (SKILL.md) and --public publishes it.
+    # --skill writes the instructions AND marks the folder a skill — writing
+    # SKILL.md alone stopped conferring membership when it became a stored flag.
     assert "SKILL.md" in created_pages
+    assert converted == ["folder-1"]
     assert published["folder_id"] == "folder-1"
 
 
@@ -78,6 +85,7 @@ def test_upload_with_skill_flag_private_skips_publish(monkeypatch, tmp_path) -> 
     uploaded.write_text("# Notes")
     published: dict = {}
     created_pages: list[str] = []
+    converted: list[str] = []
 
     class FakeClient:
         def __enter__(self):
@@ -95,6 +103,10 @@ def test_upload_with_skill_flag_private_skips_publish(monkeypatch, tmp_path) -> 
             assert folder_id == "folder-1"
             return {"id": f"page-{len(created_pages)}"}
 
+        def convert_folder_to_skill(self, folder_id):
+            converted.append(folder_id)
+            return {"folder_id": folder_id, "name": "notes", "is_skill": True}
+
         def publish_skill_folder(self, folder_id, **kwargs):
             published["folder_id"] = folder_id
             return {"id": "skill-1", "slug": "notes", "title": "notes"}
@@ -104,6 +116,8 @@ def test_upload_with_skill_flag_private_skips_publish(monkeypatch, tmp_path) -> 
 
     main.upload(str(uploaded), name="", skill="notes", public=False, as_json=False)
 
-    # Private: the folder becomes a skill (SKILL.md) but nothing is published.
+    # Private: the folder becomes a skill (instructions + explicit convert)
+    # but nothing is published.
     assert "SKILL.md" in created_pages
+    assert converted == ["folder-1"]
     assert published == {}


### PR DESCRIPTION
Some more cleanup from a number of big changes tonight to get Skills UX to a stable state. We forgot some consumers to update.

Follow-up sweep after #985. That PR made skill membership a stored flag, but I only updated the consumers the test suite happened to cover. Enumerating the rest found three more — **one of them a live regression on the CLI**, which is the surface agents actually use.

## What was broken

**1. The whole CLI skill surface (live regression, my fault).**
`stash skills create`, `stash skills upload <dir>`, and `stash upload <path> --skill "title"` each created skills the old way — make a folder, write a `SKILL.md` — which stopped conferring membership in #985. Result: a CLI-created "skill" was an invisible plain folder. Reproduced against the new model before fixing, exactly the failure mode the customer hit in the GUI. All three now call the convert verb after writing the instructions.

**2. Shared-skills listing** inner-joined `SKILL.md`, so a skill shared with you that lacks instructions vanished from the list instead of showing as a draft. Now joins on the flag, left-joins the file.

**3. Home feed** still derived membership for its skill-subtree filter, classifying folders by their contents rather than by the flag.

## Tests

- The API sequence the CLI depends on, pinned: folder + `SKILL.md` alone is **not** a skill; convert makes it one and doesn't clobber the instructions the caller just wrote.
- A shared skill without instructions still lists.
- The CLI's own upload tests now assert the **conversion call**, not just the `SKILL.md` write — the assertion that would have caught this in the first place.

Backend suite: **1,301 passed**. CLI suite: **210 passed**. Ruff clean.

## Method note

This came from asking "what else consumed the rule I deleted?" instead of waiting to trip over each consumer. The remaining known-unfixed items from that sweep are unrelated to skills: a second Granola source failing token refresh (400), 3 high Dependabot alerts, and a test referencing `auth0_sub` (dropped in migration 0006) that passes only by test-ordering luck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)