### PR TITLE
fix: convert-to-folder, MCP skill creation, and write-path page responses

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -349,7 +349,7 @@ async def snapshot_source(
             "skill_id": str(skill_id),
         },
     )
-    return PageResponse(**page)
+    return PageResponse(**{**page, "can_write": True})
 
 
 class MaterializeSessionRequest(BaseModel):
@@ -376,7 +376,7 @@ async def materialize_session(
     )
     if page is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    return PageResponse(**page)
+    return PageResponse(**{**page, "can_write": True})
 
 
 @public_router.patch("/{skill_id}", response_model=SkillResponse)

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -210,3 +210,44 @@ async def test_shared_skill_without_instructions_still_lists(client, _db_pool):
 
     listed = (await client.get("/api/v1/me/shared-skills", headers=friend_h)).json()
     assert folder_id in [s["folder_id"] for s in listed["skills"]]
+
+
+@pytest.mark.asyncio
+async def test_convert_to_folder_keeps_the_files_and_needs_no_deletion(client, _db_pool):
+    """The Convert-to-folder button used to demote by deleting SKILL.md. That
+    stopped demoting anything (membership is a flag) and is now refused
+    outright — so the button errored with 'convert the skill to a folder
+    first', which is what it was. Demotion is the verb; files stay put."""
+    reg = await client.post(
+        "/api/v1/users/register",
+        json={"name": f"dem_{uuid4().hex[:8]}", "password": "securepassword1"},
+    )
+    headers = {"Authorization": f"Bearer {reg.json()['api_key']}"}
+    folder_id = (
+        await client.post("/api/v1/me/skills/new", json={"name": "Demote me"}, headers=headers)
+    ).json()["folder_id"]
+
+    # The old mechanism is refused, and says so.
+    page_id = await _db_pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'", UUID(folder_id)
+    )
+    refused = await client.delete(f"/api/v1/me/pages/{page_id}", headers=headers)
+    assert refused.status_code == 400
+
+    # The verb works, and keeps the instructions.
+    demoted = await client.post(
+        f"/api/v1/me/folders/{folder_id}/convert-to-folder", headers=headers
+    )
+    assert demoted.status_code == 200
+    assert demoted.json()["is_skill"] is False
+    assert (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"] == []
+    still_there = await _db_pool.fetchval(
+        "SELECT count(*) FROM pages WHERE folder_id = $1 AND deleted_at IS NULL", UUID(folder_id)
+    )
+    assert still_there == 1
+
+    # And it round-trips: promote again without re-uploading anything.
+    again = await client.post(f"/api/v1/me/folders/{folder_id}/convert-to-skill", headers=headers)
+    assert again.status_code == 200
+    listed = (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"]
+    assert [s["folder_id"] for s in listed] == [folder_id]

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -518,6 +518,9 @@ def stash_create_skill(
     client.create_page(
         name="SKILL.md", content=content, folder_id=folder["id"], content_type="markdown"
     )
+    # Membership is a stored flag server-side: writing SKILL.md is the skill's
+    # instructions, the convert verb is what makes the folder a skill.
+    client.convert_folder_to_skill(folder["id"])
     return _json({"folder_id": folder["id"], "name": name})
 
 

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
@@ -11,13 +11,12 @@ import SkillShareButton from "@/components/skill/SkillShareButton";
 import FileBrowser from "@/components/content/file-browser/FileBrowser";
 import { useAuth } from "@/hooks/useAuth";
 import {
+  convertSkillToFolder,
   getFolderContents,
   listSkills,
-  trashItem,
   type FolderContents,
   type SkillPublishInfo,
 } from "@/lib/api";
-import { SKILL_MD } from "@/lib/localSkill";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
 
 // Browse a skill folder (or a subfolder inside one). Same file browser as
@@ -107,17 +106,15 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
       : "";
     const yes = await confirm({
       title: `Convert "${contents.folder.name}" back to a plain folder?`,
-      body: `This deletes its SKILL.md.${publishedWarning}`,
+      body: `It stops appearing under Skills and agents stop loading it. Its files, including SKILL.md, are kept.${publishedWarning}`,
       confirmLabel: "Convert",
     });
     if (!yes) return;
-    const skillMd = contents.pages.find((p) => p.name === SKILL_MD);
-    if (!skillMd) {
-      setError("SKILL.md not found in this folder.");
-      return;
-    }
     try {
-      await trashItem("page", skillMd.id);
+      // Demotion is the explicit verb. It used to delete SKILL.md — which
+      // no longer demotes anything (membership is a stored flag) and is now
+      // refused outright, so this button errored on itself.
+      await convertSkillToFolder(folderId);
       await refreshSidebar().catch(() => {});
       router.push(`/folders/${folderId}`);
     } catch (e) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -602,6 +602,14 @@ export async function convertFolderToSkill(
   return apiFetch(`${ME}/folders/${folderId}/convert-to-skill`, { method: "POST" });
 }
 
+// Demote a skill back to a plain folder. Contents are untouched — it simply
+// stops appearing under Skills and stops loading for agents.
+export async function convertSkillToFolder(
+  folderId: string
+): Promise<{ folder_id: string; name: string; is_skill: boolean }> {
+  return apiFetch(`${ME}/folders/${folderId}/convert-to-folder`, { method: "POST" });
+}
+
 export async function updateFolder(
   folderId: string,
   data: { name?: string; parent_folder_id?: string | null; move_to_root?: boolean }


### PR DESCRIPTION
Second consumer sweep after #985 — prompted by "you find bugs every time you look, so look again." Three more, one of them live in prod and darkly funny.

## 1. "Convert to folder" tells you to press itself (live)

The button on a skill page demoted a skill by **deleting its SKILL.md**. Since #985 that neither demotes anything (membership is a flag) nor succeeds — the guard refuses it with *"SKILL.md holds this skill's instructions and can't be deleted or renamed. Convert the skill to a folder first."* Which is the button the user just pressed.

Now it calls the demote verb, keeps every file, and the confirm dialog says so instead of promising to delete SKILL.md.

**Browser-verified round trip:** promote → demote → promote. Dialog reads "Its files, including SKILL.md, are kept", demotion lands on the folder page, SKILL.md survives, skill disappears from the Skills list and comes back on re-promote. [Screenshot](https://app.joinstash.ai/f/c87489ed-492d-492d-aefd-fc41a67b5f16)

## 2. MCP server skill creation (live)

`stash_create_skill` — the tool other agent harnesses call — created a folder + SKILL.md and produced a **non-skill**, exactly like the three CLI commands fixed in #988. I swept the CLI and missed its sibling one file over.

## 3. Write-path page responses missing `can_write`

Snapshot-source-into-skill and materialize-session-page returned pages without the flag, so a client using the response would open a read-only editor. Same class as the duplicate-kwarg bug CI caught earlier.

## Tests

New: the demotion round trip through the routes — the old mechanism is refused, the verb works, files stay, and re-promotion needs no re-upload. Backend **1,302 passed**, CLI **210 passed**, frontend **276 passed**; ruff + tsc + ESLint clean.

## Method note

Both convert buttons broke the same way and I fixed them in separate passes — the first only because I happened to review a Slack draft. The generalization now applied: when a rule is deleted, grep for **every** consumer, including the mirror-image verb of the one you just fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)