### PR TITLE
fix: two live bugs in the skills UI, plus three hardenings

### DIFF
--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -380,6 +380,19 @@ async def _read_skill(args: dict) -> dict:
     skill = await skill_service.read_skill(owner_user_id, args.get("name", ""), user_id)
     if not skill:
         return _text_result(json.dumps({"error": "not found"}))
+    if not skill["has_instructions"]:
+        # A draft skill exists and is named but has no SKILL.md. Handing back
+        # an empty document would let the model act as if it had guidance.
+        return _text_result(
+            json.dumps(
+                {
+                    "error": "no_instructions",
+                    "name": skill["name"],
+                    "folder_id": skill["folder_id"],
+                    "hint": "This skill has no SKILL.md yet, so there is nothing to follow.",
+                }
+            )
+        )
     return _text_result(json.dumps({"name": skill["name"], "combined": skill["combined"]}))
 
 

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -799,6 +799,10 @@ async def update_page(
     pool = get_pool()
     if name is not None:
         await _assert_not_a_skills_instructions(page_id, owner_user_id)
+    if folder_id is not None or move_to_root:
+        await _assert_not_a_skills_instructions(
+            page_id, owner_user_id, moving=True, moving_to=None if move_to_root else folder_id
+        )
     if content_html is not None:
         content_html = _sanitize_html(content_html)
     content_changed = content is not None or content_type is not None or content_html is not None
@@ -1076,8 +1080,10 @@ async def _reconcile_embedded_files(
     )
 
 
-async def _assert_not_a_skills_instructions(page_id: UUID, owner_user_id: UUID) -> None:
-    """A skill's SKILL.md can't be deleted or renamed.
+async def _assert_not_a_skills_instructions(
+    page_id: UUID, owner_user_id: UUID, *, moving_to: UUID | None = None, moving: bool = False
+) -> None:
+    """A skill's SKILL.md can't be deleted, renamed, or moved out.
 
     It is the document agents load; without it the skill is a draft that can
     do nothing. Deleting it used to silently demote the whole folder (a
@@ -1087,16 +1093,20 @@ async def _assert_not_a_skills_instructions(page_id: UUID, owner_user_id: UUID) 
     a plain folder first if that's really what they want."""
     pool = get_pool()
     row = await pool.fetchrow(
-        "SELECT p.name, f.is_skill FROM pages p JOIN folders f ON f.id = p.folder_id "
+        "SELECT p.name, p.folder_id, f.is_skill FROM pages p JOIN folders f ON f.id = p.folder_id "
         "WHERE p.id = $1 AND p.owner_user_id = $2",
         page_id,
         owner_user_id,
     )
-    if row and row["is_skill"] and row["name"] == skill_service.SKILL_MD_NAME:
-        raise ValueError(
-            "SKILL.md holds this skill's instructions and can't be deleted or renamed. "
-            "Convert the skill to a folder first if you want to remove it."
-        )
+    if not (row and row["is_skill"] and row["name"] == skill_service.SKILL_MD_NAME):
+        return
+    # A move only matters when it actually leaves the skill folder.
+    if moving and moving_to == row["folder_id"]:
+        return
+    raise ValueError(
+        "SKILL.md holds this skill's instructions and can't be deleted, renamed, or moved "
+        "out. Convert the skill to a folder first if you want to remove it."
+    )
 
 
 async def delete_page(page_id: UUID, owner_user_id: UUID, deleted_by: UUID) -> bool:
@@ -1303,6 +1313,17 @@ async def set_folder_is_skill(folder_id: UUID, owner_user_id: UUID, is_skill: bo
         return None
     if is_skill and row["is_protected"]:
         raise ValueError(f"the {row['name']} folder can't be turned into a skill")
+    if not is_skill:
+        published = await pool.fetchval("SELECT slug FROM skills WHERE folder_id = $1", folder_id)
+        if published:
+            # Demoting used to leave the publish record live: the folder
+            # stopped being a skill while its public URL kept serving it, and
+            # the confirm dialog told the user the link would stop working.
+            # Refuse instead of silently disagreeing with ourselves.
+            raise ValueError(
+                f"'{row['name']}' is published at /skills/{published}. Unpublish it first, "
+                "then convert it back to a folder."
+            )
     updated = await pool.fetchrow(
         "UPDATE folders SET is_skill = $3, updated_at = now() "
         "WHERE id = $1 AND owner_user_id = $2 "

--- a/backend/tests/test_skill_lifecycle_surfaces.py
+++ b/backend/tests/test_skill_lifecycle_surfaces.py
@@ -1,0 +1,96 @@
+"""Skill lifecycle surfaces under the stored-membership model.
+
+Publishing, forking, and deleting used to confer or revoke skill-ness as a
+side effect of writing or removing a SKILL.md. These pin the behaviour now
+that membership is a flag: each path carries it deliberately, protected
+folders can never acquire it, and a deleted skill does not return when one of
+its trashed pages is restored.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from backend.services import files_tree_service, shared_skill_service, skill_service
+
+
+@pytest_asyncio.fixture
+async def scope(_db_pool):
+    uid = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)", uid, f"u_{uid.hex[:6]}"
+    )
+    return uid
+
+
+async def _draft_skill(scope, pool, name):
+    """A skill whose instructions are missing — the draft state the flag makes
+    representable. Forced at the data layer, since the routes refuse it."""
+    folder = await files_tree_service.create_skill(scope, scope, name)
+    await pool.execute(
+        "UPDATE pages SET deleted_at = now() WHERE folder_id = $1 AND name = 'SKILL.md'",
+        folder["id"],
+    )
+    return folder
+
+
+@pytest.mark.asyncio
+async def test_publishing_a_draft_gives_it_instructions(scope, _db_pool):
+    folder = await _draft_skill(scope, _db_pool, "Draft to publish")
+
+    await shared_skill_service.publish_folder(
+        scope, scope, folder["id"], title="Draft to publish", description="d"
+    )
+
+    [published] = await skill_service.list_skills(scope, scope)
+    assert published["has_instructions"] is True
+
+
+@pytest.mark.asyncio
+async def test_forking_carries_membership_into_the_new_scope(scope, _db_pool):
+    folder = await _draft_skill(scope, _db_pool, "Draft to fork")
+    pub = await shared_skill_service.publish_folder(
+        scope, scope, folder["id"], title="Draft to fork", description="d"
+    )
+    other = uuid4()
+    await _db_pool.execute(
+        "INSERT INTO users (id, name, display_name) VALUES ($1, $2, $2)",
+        other,
+        f"o_{other.hex[:6]}",
+    )
+
+    forked = await shared_skill_service.fork_skill(other, pub["slug"], other)
+
+    assert forked is not None
+    listed = await skill_service.list_skills(other, other)
+    assert [s["folder_id"] for s in listed] == [forked["folder_id"]]
+
+
+@pytest.mark.asyncio
+async def test_publishing_cannot_turn_memory_into_a_skill(scope, _db_pool):
+    """Publish sets membership, so it is another door onto the protected
+    folders — it must refuse them like every other promotion path."""
+    memory = await files_tree_service.get_or_create_memory_folder(scope, scope)
+
+    with pytest.raises(ValueError, match="can't be turned into a skill"):
+        await shared_skill_service.publish_folder(
+            scope, scope, memory["id"], title="Memory", description="d"
+        )
+
+    assert await skill_service.list_skills(scope, scope) == []
+
+
+@pytest.mark.asyncio
+async def test_restoring_a_page_does_not_resurrect_a_deleted_skill(scope, _db_pool):
+    """Deleting a skill hard-deletes the folder row; its pages land in trash
+    with a null folder. Restoring one must not bring the skill back."""
+    folder = await files_tree_service.create_skill(scope, scope, "Doomed")
+    page_id = await _db_pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'", folder["id"]
+    )
+
+    assert await files_tree_service.delete_folder(folder["id"], scope, scope) is True
+    assert await files_tree_service.restore_page(page_id, scope, scope) is True
+
+    assert await skill_service.list_skills(scope, scope) == []

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -7,6 +7,7 @@ stray SKILL.md could promote Memory into a wipeable "skill". Membership now
 changes only through deliberate verbs.
 """
 
+import json
 from uuid import UUID, uuid4
 
 import pytest
@@ -251,3 +252,30 @@ async def test_convert_to_folder_keeps_the_files_and_needs_no_deletion(client, _
     assert again.status_code == 200
     listed = (await client.get("/api/v1/me/skills", headers=headers)).json()["skills"]
     assert [s["folder_id"] for s in listed] == [folder_id]
+
+
+@pytest.mark.asyncio
+async def test_agent_read_skill_refuses_a_draft_rather_than_returning_emptiness(scope, _db_pool):
+    """A skill with no SKILL.md is a draft. Returning its (empty) document to
+    an agent would let the model act as though it had guidance; the boundary
+    says so instead."""
+    from backend.services import agent_runtime
+
+    folder = await files_tree_service.create_skill(scope, scope, "Draft skill")
+    await _db_pool.execute(
+        "UPDATE pages SET deleted_at = now() WHERE folder_id = $1 AND name = 'SKILL.md'",
+        folder["id"],
+    )
+
+    scope_token = agent_runtime._scope_ctx.set(scope)
+    user_token = agent_runtime._user_ctx.set(scope)
+    try:
+        result = json.loads(
+            (await agent_runtime._read_skill.handler({"name": "Draft skill"}))["content"][0]["text"]
+        )
+    finally:
+        agent_runtime._user_ctx.reset(user_token)
+        agent_runtime._scope_ctx.reset(scope_token)
+
+    assert result["error"] == "no_instructions"
+    assert result["name"] == "Draft skill"

--- a/backend/tests/test_skill_membership.py
+++ b/backend/tests/test_skill_membership.py
@@ -13,7 +13,7 @@ from uuid import UUID, uuid4
 import pytest
 import pytest_asyncio
 
-from backend.services import files_tree_service, skill_service
+from backend.services import files_tree_service, shared_skill_service, skill_service
 
 
 @pytest_asyncio.fixture
@@ -64,9 +64,9 @@ async def test_deleting_skill_md_leaves_a_draft_skill_not_a_silent_demotion(scop
         "SELECT id FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'", folder["id"]
     )
 
-    with pytest.raises(ValueError, match="can't be deleted or renamed"):
+    with pytest.raises(ValueError, match="can't be deleted, renamed, or moved"):
         await files_tree_service.delete_page(page_id, scope, scope)
-    with pytest.raises(ValueError, match="can't be deleted or renamed"):
+    with pytest.raises(ValueError, match="can't be deleted, renamed, or moved"):
         await files_tree_service.update_page(page_id, scope, scope, name="notes.md")
 
     await _db_pool.execute("UPDATE pages SET deleted_at = now() WHERE id = $1", page_id)
@@ -279,3 +279,48 @@ async def test_agent_read_skill_refuses_a_draft_rather_than_returning_emptiness(
 
     assert result["error"] == "no_instructions"
     assert result["name"] == "Draft skill"
+
+
+@pytest.mark.asyncio
+async def test_skill_md_cannot_be_moved_out_of_its_skill(scope, _db_pool):
+    """The guard blocked rename and delete but not moves, so dragging SKILL.md
+    into another folder still demoted a skill silently — the same hole through
+    a different door."""
+    folder = await files_tree_service.create_skill(scope, scope, "Movable")
+    elsewhere = await files_tree_service.create_folder(scope, "Elsewhere", scope)
+    page_id = await _db_pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = 'SKILL.md'", folder["id"]
+    )
+
+    with pytest.raises(ValueError, match="can't be deleted, renamed, or moved"):
+        await files_tree_service.update_page(page_id, scope, scope, folder_id=elsewhere["id"])
+    with pytest.raises(ValueError, match="can't be deleted, renamed, or moved"):
+        await files_tree_service.update_page(page_id, scope, scope, move_to_root=True)
+
+    # Editing its content is untouched — only leaving the skill is refused.
+    edited = await files_tree_service.update_page(page_id, scope, scope, content="# new body")
+    assert edited is not None
+    [skill] = await skill_service.list_skills(scope, scope)
+    assert skill["has_instructions"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_published_skill_refuses_demotion_until_unpublished(scope, _db_pool):
+    """Demotion left the publish record live: the folder stopped being a skill
+    while its public URL kept serving it — and the confirm dialog told the
+    user the share link would stop working. Refuse rather than lie."""
+    folder = await files_tree_service.create_skill(scope, scope, "Public thing")
+    published = await shared_skill_service.publish_folder(
+        scope, scope, folder["id"], title="Public thing", description="d"
+    )
+
+    with pytest.raises(ValueError, match="Unpublish it first"):
+        await files_tree_service.set_folder_is_skill(folder["id"], scope, False)
+    assert [s["folder_id"] for s in await skill_service.list_skills(scope, scope)] == [
+        str(folder["id"])
+    ]
+
+    # Unpublish, and demotion proceeds.
+    await shared_skill_service.unpublish_skill(UUID(str(published["id"])), scope)
+    demoted = await files_tree_service.set_folder_is_skill(folder["id"], scope, False)
+    assert demoted["is_skill"] is False

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
@@ -102,7 +102,7 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
   const convertToFolder = useCallback(async () => {
     if (!contents || !user) return;
     const publishedWarning = publish
-      ? " Its share link will stop working."
+      ? " It's published, so you'll need to unpublish it first — the convert will be refused until you do."
       : "";
     const yes = await confirm({
       title: `Convert "${contents.folder.name}" back to a plain folder?`,

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -262,15 +262,23 @@ export default function FilesExplorer({
     await load();
   }
 
+  // Rename and delete can be refused with an explanation the user needs to
+  // read (a skill's SKILL.md can't be renamed or deleted; Memory can't be
+  // touched at all). Swallowing those rejections is how "I click and nothing
+  // happens" bugs are born — surface them.
   async function rename(item: Item, name: string) {
     setRenaming(null);
     if (!name.trim() || name === item.name) return;
-    if (item.kind === "folder" || item.kind === "skill") await updateFolder(item.id, { name });
-    else if (item.kind === "session-folder") await updateSessionFolder(item.id, { name });
-    else if (item.kind === "session") return;
-    else if (item.kind === "page") await updatePage(item.id, { name });
-    else if (item.kind === "table") await updateTable(item.id, { name });
-    else await updateFile(item.id, { name });
+    try {
+      if (item.kind === "folder" || item.kind === "skill") await updateFolder(item.id, { name });
+      else if (item.kind === "session-folder") await updateSessionFolder(item.id, { name });
+      else if (item.kind === "session") return;
+      else if (item.kind === "page") await updatePage(item.id, { name });
+      else if (item.kind === "table") await updateTable(item.id, { name });
+      else await updateFile(item.id, { name });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Rename failed");
+    }
     await load();
   }
 
@@ -278,10 +286,14 @@ export default function FilesExplorer({
     // The shared node is an index, not a thing — Delete is hidden on readOnly
     // rows, so reaching here at all is a bug rather than a user action.
     if (item.kind === "shared-root") throw new Error("The shared index cannot be deleted");
-    if (item.kind === "folder" || item.kind === "skill") await deleteFolder(item.id);
-    else if (item.kind === "session-folder") await deleteSessionFolder(item.id);
-    else if (item.kind === "table") await deleteTable(item.id);
-    else await trashItem(item.kind, item.id); // page | file | session
+    try {
+      if (item.kind === "folder" || item.kind === "skill") await deleteFolder(item.id);
+      else if (item.kind === "session-folder") await deleteSessionFolder(item.id);
+      else if (item.kind === "table") await deleteTable(item.id);
+      else await trashItem(item.kind, item.id); // page | file | session
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Delete failed");
+    }
     await load();
   }
 

--- a/frontend/src/lib/frontmatter.ts
+++ b/frontend/src/lib/frontmatter.ts
@@ -16,8 +16,15 @@ export function splitFrontmatter(markdown: string): SplitMarkdown {
   const rest = markdown.slice(afterFence);
   // The closing fence must be a whole line: "---\n" or "---" at EOF.
   if (rest !== "" && !rest.startsWith("\n")) return { frontmatter: null, body: markdown };
+  const block = markdown.slice(4, end);
+  // A document that opens with a horizontal rule also matches the fences.
+  // Frontmatter is key/value lines, so require the first non-empty line to
+  // look like one — otherwise the author's opening paragraph would be hidden
+  // in the read-only metadata strip and become uneditable.
+  const firstLine = block.split("\n").find((line) => line.trim() !== "") ?? "";
+  if (!/^[A-Za-z_][\w-]*\s*:/.test(firstLine)) return { frontmatter: null, body: markdown };
   return {
-    frontmatter: markdown.slice(4, end),
+    frontmatter: block,
     body: rest.replace(/^\n+/, ""),
   };
 }


### PR DESCRIPTION
What happens in this PR:
1. If we refuse to rename a skill, we alert about it in the UI
2. We discovered a large bug with our editor where it tends to silently edit markdown files; we will fix in #992. The second fix is a small mitigation against this happening but a larger solution is required
3. If an agent tries to read an empty skill, don't return "successfully read skill"
4. Eliminate a place where SKILL.md could be moved out of the skill
5. Demoting a publishable skill is refused until you unpublish it





# Slop

Third consumer sweep — this one over the rules tonight's PRs **added**, rather than the one they removed. All three are ours.

## 1. The sidebar silently swallows refusals (the incident's own disease, reintroduced)

`rename` was invoked as an un-awaited promise (`onBlur={(e) => rename(...)}`) and `del` had no try/catch. Before #985 those calls rarely failed, so it didn't show. #985 made them *able* to refuse — a skill's SKILL.md can't be renamed or deleted — so as of that deploy, **right-clicking SKILL.md → Delete does nothing at all, with no message**. That is precisely the failure that opened this incident, recreated by my own guard. Both paths now surface the server's explanation as a toast.

The main file browser already handled this correctly; only the workspace sidebar didn't.

## 2. Frontmatter splitter eats a leading horizontal rule

A document that opens with `---` as a divider matched the fence check, so its first paragraph was moved into the read-only metadata strip and became uneditable. Content round-tripped safely (no data loss) but the author couldn't edit their own intro. The splitter now requires the block to begin with a `key: value` line.

Verified against four shapes: standard frontmatter, the blank-line-separated style the customer actually writes (still parses), leading horizontal rule (correctly ignored), prose-between-rules (correctly ignored).

## 3. Agent `read_skill` hands back an empty draft

A skill with no SKILL.md is a draft. `read_skill` returned its empty document, letting a model proceed as though it had instructions. It now refuses with `no_instructions` plus the folder id — the boundary gate the flag design called for and I never wired up.

## Not ours, found while sweeping

Files search never filtered skill-subtree pages — a pre-existing violation of the Files/Skills MECE rule, unchanged by tonight's work. Flagged, not fixed here.

## Tests

New: the draft-refusal path. Backend **1,303 passed**, frontend **276 passed**, ruff + tsc + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Two more, found by continuing the sweep

**4. SKILL.md could be *moved* out of its skill.** The guard blocked rename and delete but not moves — so dragging the instructions into another folder still demoted the skill silently. The same hole, through a different door. Moves out (and to the scope root) now refuse; editing the file's content is untouched.

**5. Demoting a published skill left it publicly served.** The publish record survived demotion, so the folder stopped being a skill while its public URL kept working — and the confirm dialog told the user *"Its share link will stop working."* A user could take an action they believe makes something private and be wrong. Demotion is now refused while published (naming the slug, telling them to unpublish first), and the dialog says what actually happens. Non-destructive: no slug, view count, or install count is silently thrown away.

Both pinned by new tests. Backend **1,305 passed**, CLI **210 passed**, frontend **276 passed**.

---

## Re-sized after review

Checked prevalence in production rather than assuming, at the reviewer's prompting. The honest split:

**Live and user-visible (2):**
- The sidebar swallowing rename/delete refusals — reproducible today, and it is the incident's own failure mode.
- Demoting a published skill leaving it publicly served while the dialog says otherwise.

**Hardening against states that do not currently occur (3):**
- Moving SKILL.md out of a skill — a bypass of the delete refusal, not a defect; the skill stays a skill and becomes a draft.
- Frontmatter vs. a leading horizontal rule — **317 pages start with `---`; all 317 still parse; zero are horizontal-rule documents.**
- Agent `read_skill` on a draft — **282 skills in production; zero without instructions**, and no code path can produce one.

All five are worth keeping. Only two of them were breaking anything.