### PR TITLE
Fix: five places sent a folder id to the published-skill route ("Skill not found")

### DIFF
--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.test.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FolderClient from "./FolderClient";
+import { getFolderContents } from "@/lib/api";
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ folderId: "folder-root" }),
+  useRouter: () => router,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status = 500;
+  },
+  convertFolderToSkill: vi.fn(),
+  getFolderContents: vi.fn(),
+  getPublicSkill: vi.fn(),
+}));
+
+vi.mock("@/lib/skillNavigationCache", () => ({
+  refreshSidebar: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/localSkill", () => ({
+  findInSkillContents: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/memory-folder", () => ({
+  sectionCrumbs: () => [],
+  useMemoryFolderId: () => null,
+}));
+
+vi.mock("@/components/BreadcrumbContext", () => ({
+  useBreadcrumbs: vi.fn(),
+}));
+
+vi.mock("@/components/ShellChromeContext", () => ({
+  useShareAction: vi.fn(),
+}));
+
+vi.mock("@/components/share/ResourceShareButton", () => ({
+  default: () => <button>Share resource</button>,
+}));
+
+vi.mock("@/components/content/file-browser/FileBrowser", () => ({
+  default: () => <div data-testid="file-browser" />,
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1", name: "henry" }, loading: false }),
+}));
+
+function contents(folderIsSkill: boolean, breadcrumbIsSkill = false) {
+  return {
+    folder: {
+      id: "folder-root",
+      name: "Brake Shoes",
+      parent_folder_id: null,
+      is_skill: folderIsSkill,
+    },
+    breadcrumbs: [{ id: "folder-root", name: "Brake Shoes", is_skill: breadcrumbIsSkill }],
+    subfolders: [],
+    pages: [],
+    files: [],
+    tables: [],
+  };
+}
+
+describe("FolderClient skill redirect", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  // /skills/<x> is the *published slug* route. Sending a folder id there
+  // renders "Skill not found" — which is what a user saw right after
+  // creating a skill. The skill's own browse page is /skills/folder/<id>.
+  it("sends a skill folder to the skill browse route, not the published-slug route", async () => {
+    vi.mocked(getFolderContents).mockResolvedValue(contents(true));
+
+    render(<FolderClient folderId="folder-root" />);
+
+    await waitFor(() => expect(router.replace).toHaveBeenCalled());
+    expect(router.replace).toHaveBeenCalledWith("/skills/folder/folder-root");
+  });
+
+  it("redirects a plain subfolder that lives inside a skill", async () => {
+    vi.mocked(getFolderContents).mockResolvedValue(contents(false, true));
+
+    render(<FolderClient folderId="folder-root" />);
+
+    await waitFor(() => expect(router.replace).toHaveBeenCalled());
+    expect(router.replace).toHaveBeenCalledWith("/skills/folder/folder-root");
+  });
+
+  it("leaves an ordinary folder where it is", async () => {
+    vi.mocked(getFolderContents).mockResolvedValue(contents(false));
+
+    render(<FolderClient folderId="folder-root" />);
+
+    await waitFor(() => expect(getFolderContents).toHaveBeenCalled());
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -98,8 +98,10 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
       .then((c) => {
         if (cancelled) return;
         // Skill folders live on the skill browse route — deep links self-heal.
+        // /skills/<x> is the published-slug route; a folder id there renders
+        // "Skill not found". The skill's own page is /skills/folder/<id>.
         if (c.folder.is_skill || c.breadcrumbs.some((b) => b.is_skill)) {
-          router.replace(`/skills/${folderId}`);
+          router.replace(`/skills/folder/${folderId}`);
           return;
         }
         setChain({ breadcrumbs: c.breadcrumbs, name: c.folder.name, id: c.folder.id });

--- a/frontend/src/app/(app)/skills/[slug]/AddToStashButton.test.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/AddToStashButton.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AddToStashButton from "./AddToStashButton";
+import { forkSkill } from "@/lib/api";
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+vi.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status = 500;
+  },
+  forkSkill: vi.fn(),
+}));
+
+describe("AddToStashButton", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  // Forking gives back a folder id. /skills/<x> is the published-slug route,
+  // so sending the folder id there renders "Skill not found" — the user
+  // installs a skill and Open takes them to a 404.
+  it("opens the forked skill on the folder route", async () => {
+    vi.mocked(forkSkill).mockResolvedValue({
+      folder_id: "folder-9",
+      name: "Brake Shoes",
+    });
+
+    render(<AddToStashButton slug="brake-shoes" />);
+    fireEvent.click(screen.getByText("Add to my files"));
+
+    const open = await screen.findByText(/Open Brake Shoes/);
+    fireEvent.click(open);
+
+    expect(router.push).toHaveBeenCalledWith("/skills/folder/folder-9");
+  });
+});

--- a/frontend/src/app/(app)/skills/[slug]/AddToStashButton.tsx
+++ b/frontend/src/app/(app)/skills/[slug]/AddToStashButton.tsx
@@ -52,7 +52,7 @@ export default function AddToStashButton({ slug }: Props) {
       {attached ? (
         <button
           type="button"
-          onClick={() => router.push(`/skills/${attached.folderId}`)}
+          onClick={() => router.push(`/skills/folder/${attached.folderId}`)}
           className="cursor-pointer rounded-lg border border-border-subtle px-4 py-2 text-[14px] font-medium text-foreground transition hover:border-brand hover:text-brand"
         >
           Open {attached.name}

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.test.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SkillFolderClient from "./SkillFolderClient";
 import { getFolderContents, listSkills } from "@/lib/api";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
+import { useShareAction } from "@/components/ShellChromeContext";
 import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
 
 function render(ui: ReactNode) {
@@ -43,7 +44,9 @@ vi.mock("@/components/ShellChromeContext", () => ({
 }));
 
 vi.mock("@/components/share/ResourceShareButton", () => ({
-  default: () => <button>Share resource</button>,
+  default: ({ resourceUrlPath }: { resourceUrlPath?: string }) => (
+    <button data-share-url={resourceUrlPath}>Share resource</button>
+  ),
 }));
 
 vi.mock("@/components/skill/SkillShareButton", () => ({
@@ -100,9 +103,11 @@ describe("SkillFolderClient", () => {
     await screen.findByTestId("file-browser");
 
     const crumbs = vi.mocked(useBreadcrumbs).mock.calls.at(-1)?.[0];
+    // Crumbs point at /skills/folder/<id>, not /skills/<id> — the latter is
+    // the published-slug route and renders "Skill not found" for a folder id.
     expect(crumbs).toEqual([
       { label: "Skills", href: "/skills" },
-      { label: "Launch Plan", href: "/skills/folder-root" },
+      { label: "Launch Plan", href: "/skills/folder/folder-root" },
       { label: "research" },
     ]);
     // Ancestors above the skill root (plain folders) stay out of the trail.
@@ -113,7 +118,9 @@ describe("SkillFolderClient", () => {
     render(<SkillFolderClient folderId="folder-sub" />);
 
     const browser = await screen.findByTestId("file-browser");
-    expect(browser).toHaveAttribute("data-href-base", "/skills");
+    // FileBrowser builds `${folderHrefBase}/${id}`, so a subfolder inside a
+    // skill must resolve to /skills/folder/<id>.
+    expect(browser).toHaveAttribute("data-href-base", "/skills/folder");
   });
 
   it("bounces non-skill folders back to the Files route", async () => {
@@ -135,6 +142,35 @@ describe("SkillFolderClient", () => {
 
     await waitFor(() =>
       expect(router.replace).toHaveBeenCalledWith("/folders/folder-sub"),
+    );
+  });
+
+  // The Share dialog turns this path into the link the user copies. Pointing
+  // it at /skills/<folderId> hands the recipient a "Skill not found" page.
+  it("shares the skill with a link the recipient can open", async () => {
+    vi.mocked(getFolderContents).mockResolvedValue({
+      folder: {
+        id: "folder-root",
+        name: "Launch Plan",
+        parent_folder_id: null,
+        is_skill: true,
+      },
+      breadcrumbs: [{ id: "folder-root", name: "Launch Plan", is_skill: true }],
+      subfolders: [],
+      pages: [],
+      files: [],
+      tables: [],
+    });
+
+    render(<SkillFolderClient folderId="folder-root" />);
+    await screen.findByTestId("file-browser");
+
+    const action = vi.mocked(useShareAction).mock.calls.at(-1)?.[0];
+    render(<>{action}</>);
+
+    expect(screen.getByText("Share resource")).toHaveAttribute(
+      "data-share-url",
+      "/skills/folder/folder-root",
     );
   });
 });

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
@@ -85,7 +85,7 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
       .slice(firstSkillIndex === -1 ? 0 : firstSkillIndex, -1)
       .map((cr) => ({
         label: cr.name,
-        href: `/skills/${cr.id}`,
+        href: `/skills/folder/${cr.id}`,
       }));
     return [
       { label: "Skills", href: `/skills` },
@@ -141,7 +141,7 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
           objectType="folder"
           objectId={folderId}
           resourceName={folderName}
-          resourceUrlPath={`/skills/${folderId}`}
+          resourceUrlPath={`/skills/folder/${folderId}`}
           currentUser={user}
         />
         <SkillShareButton
@@ -169,7 +169,7 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
   return (
     <FileBrowser
       folderId={folderId}
-      folderHrefBase={`/skills`}
+      folderHrefBase={`/skills/folder`}
     />
   );
 }


### PR DESCRIPTION
`/skills/<x>` resolves a **published skill slug**. Five places handed it a folder id instead, and every one of them rendered "Skill not found".

### The five

| Where | What the user does | |
|---|---|---|
| `FolderClient.tsx:102` | Opens a skill from the **Files** tree — it lands on `/folders/<id>`, which self-heals onto the skill route, into the 404 | fixed |
| `AddToStashButton.tsx:55` | Adds someone's public skill, then clicks **Open \<name\>** — the whole Discover install path | fixed |
| `SkillFolderClient.tsx:88` | Clicks a **breadcrumb** to go back up from a subfolder | fixed |
| `SkillFolderClient.tsx:172` | Opens a **subfolder inside a skill** — so any skill with a subfolder can't be browsed past its top level | fixed |
| `SkillFolderClient.tsx:144` | **Shares a skill.** This is the path the Share dialog turns into the copied link, so the recipient got a 404 | fixed |

All five now use `/skills/folder/<id>`, matching `urlForTab`, the convert-to-skill flow, and `SkillPageClient`.

### Why it took two passes

The first pass grepped for the literal text ``/skills/${...}`` and caught two. It missed the other three because `SkillFolderClient` passes a *prefix* to `FileBrowser`, which builds the URL as `` `${folderHrefBase}/${item.id}` `` — so the broken pattern never appears at the call site. Every `/skills` URL construction in the frontend has now been enumerated and classified by hand; the remaining ~40 all pass a real slug or already use the folder route.

Two existing tests in `SkillFolderClient.test.tsx` asserted the broken URLs (`href: "/skills/folder-root"`, `data-href-base="/skills"`). They encoded the bug, so they are corrected here.

### Testing

Every assertion was confirmed to fail against the old code before the fix. The share link had no coverage at all and now does.

- **Verified live in a browser:** opening a skill from Files, and opening a subfolder inside a skill.
- **Verified by unit test:** breadcrumbs, the share link, the Discover install path.

Frontend **292 passed** (from 279), ESLint 0 errors. Two pre-existing `tsc` errors reproduce identically with these changes stashed and are untouched; CI's `next build + type-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)