### PR TITLE
chore: bump stash release to 0.1.363 and plugin to 0.1.434

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash \u2014 stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.433",
+      "version": "0.1.434",
       "category": "productivity",
       "homepage": "https://joinstash.ai",
       "author": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.362
+    image: ghcr.io/fergana-labs/stash-backend:0.1.363
     restart: always
     expose:
       - "3456"
@@ -83,7 +83,7 @@ services:
       start_period: 30s
 
   worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.362
+    image: ghcr.io/fergana-labs/stash-backend:0.1.363
     restart: always
     depends_on:
       postgres:
@@ -101,7 +101,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
 
   beat:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.362
+    image: ghcr.io/fergana-labs/stash-backend:0.1.363
     restart: always
     depends_on:
       redis:
@@ -117,7 +117,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    image: ghcr.io/fergana-labs/stash-frontend:0.1.362
+    image: ghcr.io/fergana-labs/stash-frontend:0.1.363
     restart: always
     expose:
       - "3457"

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "description": "Connect Claude Code to Stash \u2014 stream activity to your Stash and collaborate with your other agents.",
   "author": {
     "name": "Fergana Labs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.362"
+version = "0.1.363"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
First CLI release since 0.1.362 (Aug 3). Merging this triggers `publish.yml`: tag `v0.1.363`, PyPI publish, GHCR release images — installed CLIs then self-update.

What reaches users with this release:

- The agent-side conflict guard from #982: `stash_edit_page` (MCP) and `stash files edit-page --content` require the `content_hash` from the read the edit is based on; a stale edit is refused with "read it again and apply your edit on top".
- New `stash files read-page` command — exposes the `content_hash` on the CLI.
- Empty piped stdin no longer counts as page content in `edit-page` (a scripted rename used to wipe the page).
- Everything else merged to `cli/` since Aug 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)