### PR TITLE
/files: the Stash VFS as a cursor-driven lens

### DIFF
--- a/frontend/src/app/(app)/files/page.tsx
+++ b/frontend/src/app/(app)/files/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { FileBrowserSkeleton } from "@/components/SkeletonStates";
-import FileBrowser from "@/components/content/file-browser/FileBrowser";
+import FilesOverview from "@/components/content/files-overview/FilesOverview";
 import { useAuth } from "@/hooks/useAuth";
 
 export default function FilesPage() {
@@ -20,5 +20,5 @@ export default function FilesPage() {
   if (loading) return <FileBrowserSkeleton />;
   if (!user) return null;
 
-  return <FileBrowser folderId={null} />;
+  return <FilesOverview />;
 }

--- a/frontend/src/components/content/files-overview/FilesOverview.test.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.test.tsx
@@ -1,0 +1,189 @@
+// The /files lens must rest as bare `ls` output, bloom the hovered mount one
+// level, open folders as the cursor touches them, keep big directories behind
+// "+N more", and disclose rows the API withheld — the behaviors that make it
+// a whole-stash view that never overwhelms.
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FilesOverview from "./FilesOverview";
+import {
+  getMemoryFolder,
+  getMeOverview,
+  getSidebar,
+  getSourcesTree,
+  listSkills,
+  listTables,
+} from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getSidebar: vi.fn(),
+  listTables: vi.fn(),
+  listSkills: vi.fn(),
+  getMeOverview: vi.fn(),
+  getMemoryFolder: vi.fn(),
+  getSourcesTree: vi.fn(),
+}));
+
+const MEMORY_ID = "memory-folder";
+
+function sidebar() {
+  return {
+    sessions: [
+      {
+        id: "s1", session_id: "sess-1", title: "Fix the onboarding wizard",
+        linear_tickets: [], user_name: "henry", agent_name: "claude",
+        size_bytes: 10, last_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+      },
+    ],
+    files: {
+      folders: [
+        { id: "root-1", name: "Research", parent_folder_id: null, page_count: 12, file_count: 0 },
+        { id: MEMORY_ID, name: "Memory", parent_folder_id: null, page_count: 0, file_count: 0 },
+      ],
+      // 12 pages inside Research: enough to trip the per-directory cap.
+      pages: Array.from({ length: 12 }, (_, i) => ({
+        id: `p${i}`, name: `Page ${String(i).padStart(2, "0")}`,
+        content_type: "markdown" as const, folder_id: "root-1",
+      })),
+      files: [],
+    },
+    skills: [],
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getSidebar).mockResolvedValue(sidebar());
+  vi.mocked(listTables).mockResolvedValue({ tables: [] });
+  vi.mocked(listSkills).mockResolvedValue([]);
+  vi.mocked(getMeOverview).mockResolvedValue({ pages: 14, files: 0, sessions: 5 });
+  vi.mocked(getMemoryFolder).mockResolvedValue({
+    id: MEMORY_ID, name: "Memory", owner_user_id: "u1", parent_folder_id: null,
+    created_by: "u1", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z",
+  });
+  vi.mocked(getSourcesTree).mockResolvedValue([
+    // Alphabetically first but empty — must sort AFTER github, which has content.
+    {
+      source: "asana", type: "provider", provider: "asana", display_name: "asana",
+      members: [{ handle: "src-2", display_name: "Roadmap" }],
+      sync_status: "idle", last_synced_at: null,
+      tree: [],
+    },
+    {
+      source: "github", type: "provider", provider: "github", display_name: "github",
+      members: [{ handle: "src-1", display_name: "stash" }],
+      sync_status: "idle", last_synced_at: null,
+      tree: [
+        {
+          name: "docs", kind: "folder",
+          children: [
+            { name: "api.md", kind: "file", path: "docs/api.md" },
+            { name: "", kind: "truncated", hidden: 40 },
+          ],
+        },
+      ],
+    },
+  ]);
+});
+
+afterEach(cleanup);
+
+// React derives onMouseEnter from mouseover, so mouseOver is the reliable
+// way to hover a row in jsdom.
+function hover(text: string) {
+  fireEvent.mouseOver(screen.getByText(text));
+}
+
+describe("FilesOverview", () => {
+  it("rests as bare ls output: every mount name, no tree", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/sources")).toBeTruthy());
+    for (const path of ["/files", "/sessions", "/memory", "/skills", "/tables", "/sources"]) {
+      expect(screen.getByText(path)).toBeTruthy();
+    }
+    expect(screen.queryByText("Research")).toBeNull();
+    // Providers live INSIDE /sources, exactly like the real VFS.
+    expect(screen.queryByText("github")).toBeNull();
+    // Memory renders as its own mount, not a folder row under /files.
+    expect(screen.queryByText("Memory")).toBeNull();
+  });
+
+  it("blooms the hovered mount one level, and opens folders on hover", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/files")).toBeTruthy());
+
+    hover("/files");
+    expect(screen.getByText("Research")).toBeTruthy();
+    // The mount blooms one level: Research itself shows, its contents don't.
+    expect(screen.queryByText("Page 00")).toBeNull();
+
+    hover("Research");
+    expect(screen.getByText("Page 00")).toBeTruthy();
+
+    // Moving the lens to another mount swaps the bloom and forgets open dirs.
+    hover("/sessions");
+    expect(screen.queryByText("Research")).toBeNull();
+    expect(screen.getByText("Fix the onboarding wizard")).toBeTruthy();
+    hover("/files");
+    expect(screen.queryByText("Page 00")).toBeNull();
+  });
+
+  it("depth gauge peeks every mount open, and springs back flat on leave", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/files")).toBeTruthy());
+
+    const gauge = screen.getByRole("slider", { name: "tree depth" });
+    // jsdom has no layout, so pin the gauge's rect for the sweep math.
+    Object.defineProperty(gauge, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, right: 200, bottom: 20, width: 200, height: 20, x: 0, y: 0, toJSON: () => ({}) }),
+    });
+
+    // 90% across = full depth: github's docs/ folder is three levels down.
+    fireEvent.mouseMove(gauge, { clientX: 180 });
+    expect(screen.getByText("Page 00")).toBeTruthy();
+    expect(screen.getByText("Fix the onboarding wizard")).toBeTruthy();
+    expect(screen.getByText("api.md")).toBeTruthy();
+
+    // Leaving the gauge is not a mode change — everything snaps back flat.
+    fireEvent.mouseLeave(gauge);
+    expect(screen.queryByText("Research")).toBeNull();
+    expect(screen.queryByText("api.md")).toBeNull();
+
+    // Clicking pins the depth: it survives leaving the gauge.
+    fireEvent.mouseMove(gauge, { clientX: 120 });
+    fireEvent.click(gauge, { clientX: 120 });
+    fireEvent.mouseLeave(gauge);
+    expect(screen.getByText("Page 00")).toBeTruthy();
+
+    // Clicking the same depth again unpins — back to a peek.
+    fireEvent.click(gauge, { clientX: 120 });
+    fireEvent.mouseLeave(gauge);
+    expect(screen.queryByText("Research")).toBeNull();
+  });
+
+  it("caps big directories behind a +N more toggle", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/files")).toBeTruthy());
+    hover("/files");
+    hover("Research");
+    expect(screen.getByText("Page 00")).toBeTruthy();
+    expect(screen.queryByText("Page 11")).toBeNull();
+    fireEvent.click(screen.getByText("… +2 more"));
+    expect(screen.getByText("Page 11")).toBeTruthy();
+  });
+
+  it("nests providers under /sources and discloses rows the API withheld", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/sources")).toBeTruthy());
+    hover("/sources");
+    expect(screen.getByText("github")).toBeTruthy();
+    expect(screen.queryByText("docs")).toBeNull();
+    // Synced providers sort ahead of empty ones, despite the alphabet.
+    const order = document.body.textContent!;
+    expect(order.indexOf("github")).toBeLessThan(order.indexOf("asana"));
+    hover("github");
+    expect(screen.getByText("docs")).toBeTruthy();
+    expect(screen.queryByText("api.md")).toBeNull();
+    hover("docs");
+    expect(screen.getByText("api.md")).toBeTruthy();
+    expect(screen.getByText(/40 more synced/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/content/files-overview/FilesOverview.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.tsx
@@ -1,0 +1,578 @@
+"use client";
+
+// The /files page: the VFS root as a cursor-driven lens. At rest it is bare
+// `ls -1` output — one mount path per line. The mount under the cursor blooms
+// open one level, and hovering any folder row expands it in place. Folders
+// stay open while the lens is on their mount — collapsing happens only when
+// focus moves to another mount — so rows are never yanked out from under a
+// traveling cursor. A spring-loaded depth gauge above the tree gives a
+// transient overview: sweeping across it opens every mount 1-4 levels in
+// real time, and leaving it snaps the tree back flat — a peek, not a mode.
+
+import Link from "next/link";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUpRight, Brain, Cable, ChevronRight, FolderTree, GraduationCap, MessagesSquare } from "lucide-react";
+import {
+  getMemoryFolder,
+  getMeOverview,
+  getSidebar,
+  getSourcesTree,
+  listSkills,
+  listTables,
+  type MeOverview,
+  type SourceTreeRoot,
+} from "@/lib/api";
+import { FileIcon, FolderIcon, PageIcon, TableIcon } from "@/components/SkillIcons";
+import { connectorIcon } from "@/components/integrations/connectors";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import {
+  buildFilesNodes,
+  buildSessionNodes,
+  buildSkillNodes,
+  buildSourceNodes,
+  buildTableNodes,
+  type VNode,
+} from "./build";
+
+const SHOW_PER_DIR = 10;
+const RECENT_SESSIONS = 8;
+const UNFOCUS_DELAY_MS = 250;
+
+/** Cursor position across the gauge bars → depth floor 0-3. */
+function gaugeDepth(e: React.MouseEvent<HTMLDivElement>): number {
+  const r = e.currentTarget.getBoundingClientRect();
+  if (r.width <= 0) return 0;
+  const frac = (e.clientX - r.left) / r.width;
+  return Math.max(0, Math.min(3, Math.floor(frac * 4)));
+}
+
+interface Mount {
+  path: string;
+  icon: ReactNode;
+  nodes: VNode[];
+  href?: string;
+  /** Rows the API cut off before we ever saw them (sources per-dir cap). */
+  apiHidden?: number;
+  /** Where "+N more" rows we can't expand locally should take the user. */
+  moreHref?: string;
+  footer?: { label: string; href: string };
+  emptyLabel: string;
+}
+
+interface CoreData {
+  filesNodes: VNode[];
+  memoryNodes: VNode[];
+  sessionNodes: VNode[];
+  skillNodes: VNode[];
+  tableNodes: VNode[];
+  vitals: MeOverview;
+}
+
+export default function FilesOverview() {
+  const [core, setCore] = useState<CoreData | null>(null);
+  const [coreError, setCoreError] = useState<string | null>(null);
+  const [sources, setSources] = useState<SourceTreeRoot[] | null>(null);
+  const [sourcesError, setSourcesError] = useState<string | null>(null);
+
+  // The lens: which mount is bloomed open, and which of its folders the
+  // cursor has opened. Hover opens; a chevron click closes; changing mounts
+  // resets everything.
+  const [focus, setFocus] = useState<string | null>(null);
+  const [open, setOpen] = useState<Set<string>>(new Set());
+  const [showAll, setShowAll] = useState<Set<string>>(new Set());
+  // The gauge's global floor while the cursor sweeps it: 0 = bare list,
+  // 1 = every mount bloomed one level, ... Springs back on leave — to 0, or
+  // to the depth the user pinned by clicking the gauge.
+  const [globalDepth, setGlobalDepth] = useState(0);
+  const [pinnedDepth, setPinnedDepth] = useState<number | null>(null);
+
+  const unfocusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getSidebar(), listTables(), listSkills(), getMeOverview(), getMemoryFolder()])
+      .then(([sidebar, tables, skills, vitals, memoryFolder]) => {
+        if (cancelled) return;
+        const { files, memory } = buildFilesNodes(sidebar.files, memoryFolder.id);
+        setCore({
+          filesNodes: files,
+          memoryNodes: memory,
+          sessionNodes: buildSessionNodes(sidebar.sessions.slice(0, RECENT_SESSIONS)),
+          skillNodes: buildSkillNodes(skills),
+          tableNodes: buildTableNodes(tables.tables),
+          vitals,
+        });
+      })
+      .catch((e) => { if (!cancelled) setCoreError(e instanceof Error ? e.message : String(e)); });
+    // The sources tree walks every connected source, so it loads on its own
+    // clock — the native mounts render without waiting for it.
+    getSourcesTree()
+      .then((s) => { if (!cancelled) setSources(s); })
+      .catch((e) => { if (!cancelled) setSourcesError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const mounts = useMemo<Mount[]>(() => {
+    if (!core) return [];
+    const native: Mount[] = [
+      {
+        path: "/files",
+        icon: <FolderTree className="h-4 w-4 text-chart-4" />,
+        nodes: core.filesNodes,
+        emptyLabel: "empty",
+      },
+      {
+        path: "/sessions",
+        icon: <MessagesSquare className="h-4 w-4 text-chart-1" />,
+        nodes: core.sessionNodes,
+        href: "/sessions",
+        footer:
+          core.vitals.sessions > core.sessionNodes.length
+            ? { label: `all ${core.vitals.sessions} sessions`, href: "/sessions" }
+            : undefined,
+        emptyLabel: "no sessions yet",
+      },
+      {
+        path: "/memory",
+        icon: <Brain className="h-4 w-4 text-chart-2" />,
+        nodes: core.memoryNodes,
+        href: "/memory",
+        emptyLabel: "nothing remembered yet",
+      },
+      {
+        path: "/skills",
+        icon: <GraduationCap className="h-4 w-4 text-chart-3" />,
+        nodes: core.skillNodes,
+        href: "/skills",
+        emptyLabel: "no skills yet",
+      },
+      {
+        path: "/tables",
+        icon: <span className="text-chart-5"><TableIcon /></span>,
+        nodes: core.tableNodes,
+        emptyLabel: "no tables yet",
+      },
+    ];
+    if (sources === null) return native;
+    // One faithful /sources mount, exactly like the VFS: providers are
+    // directories inside it, wearing their brand marks.
+    const providerNodes = sources
+      .map<VNode>((root) => {
+        const provider = root.provider ?? root.source;
+        const { nodes, hiddenCount } = buildSourceNodes(root.tree, `/sources/${provider}`);
+        return {
+          key: `/sources/${provider}`,
+          kind: "folder",
+          name: provider,
+          icon: connectorIcon(provider),
+          href: `/integrations/${provider}`,
+          children: nodes,
+          hiddenCount: hiddenCount || undefined,
+          moreHref: `/integrations/${provider}`,
+        };
+      })
+      // Providers with synced content are what the VFS really materializes,
+      // so they sort ahead of the empty (greyed) ones; alphabetical within
+      // each group.
+      .sort((a, b) => {
+        const aEmpty = a.children!.length === 0 && !a.hiddenCount ? 1 : 0;
+        const bEmpty = b.children!.length === 0 && !b.hiddenCount ? 1 : 0;
+        return aEmpty - bEmpty || a.name.localeCompare(b.name);
+      });
+    return [
+      ...native,
+      {
+        path: "/sources",
+        icon: <Cable className="h-4 w-4 text-chart-1" />,
+        nodes: providerNodes,
+        footer:
+          providerNodes.length === 0
+            ? { label: "connect a source", href: "/settings/integrations" }
+            : undefined,
+        emptyLabel: "no sources connected",
+      },
+    ];
+  }, [core, sources]);
+
+  function focusMount(path: string) {
+    if (unfocusTimer.current) clearTimeout(unfocusTimer.current);
+    unfocusTimer.current = null;
+    setFocus((current) => {
+      if (current !== path) setOpen(new Set());
+      return path;
+    });
+  }
+
+  function onLensLeave() {
+    unfocusTimer.current = setTimeout(() => {
+      setFocus(null);
+      setOpen(new Set());
+      setGlobalDepth(pinnedDepth ?? 0);
+    }, UNFOCUS_DELAY_MS);
+  }
+
+  function hoverDir(key: string) {
+    setOpen((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+  }
+
+  function toggle(key: string) {
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+  function revealAll(key: string) {
+    setShowAll((prev) => new Set(prev).add(key));
+  }
+
+  if (coreError) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="font-mono text-[13px] text-error">✗ couldn&apos;t read the stash: {coreError}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-base">
+      <div className="mx-auto max-w-[680px] px-8 pb-16 pt-10" onMouseLeave={onLensLeave}>
+        {core && (
+          <div className="mb-8 flex items-start justify-between gap-2.5">
+            <div>
+              <h1 className="text-[26px] font-semibold tracking-tight text-foreground">Virtual Filesystem</h1>
+              <p className="mt-1.5 text-[13.5px] text-dim">Browse everything your agents can see through the Stash VFS.</p>
+            </div>
+            {/* Spring-loaded: depth follows the cursor across the bars and
+                snaps back when it leaves — to flat, or to a depth pinned by
+                clicking. Peek by default, setting only on purpose. */}
+            <div className="ml-auto flex items-center gap-2 self-start pt-2">
+            <span className="select-none font-mono text-[11px] text-muted-foreground">depth</span>
+            <div
+              role="slider"
+              aria-label="tree depth"
+              aria-valuemin={1}
+              aria-valuemax={4}
+              aria-valuenow={globalDepth + 1}
+              tabIndex={-1}
+              onMouseMove={(e) => setGlobalDepth(gaugeDepth(e))}
+              onMouseLeave={() => setGlobalDepth(pinnedDepth ?? 0)}
+              onClick={(e) => {
+                const d = gaugeDepth(e);
+                setPinnedDepth((current) => (current === d ? null : d));
+                setGlobalDepth(d);
+              }}
+              className="flex cursor-ew-resize items-end gap-[3px] px-1 py-1"
+            >
+              {[0, 1, 2, 3].map((d) => (
+                <span
+                  key={d}
+                  style={{ height: 5 + d * 4 }}
+                  className={cn(
+                    "w-[14px] rounded-[2px] transition-colors duration-100",
+                    d <= globalDepth ? "bg-brand-500" : "bg-raised",
+                  )}
+                />
+              ))}
+            </div>
+            </div>
+          </div>
+        )}
+        {!core && (
+          <div className="space-y-3 py-1">
+            {Array.from({ length: 6 }, (_, i) => (
+              <Skeleton key={i} className="h-4" style={{ width: `${90 + (i % 3) * 30}px` }} />
+            ))}
+          </div>
+        )}
+        {mounts.map((mount) => (
+          <MountBlock
+            key={mount.path}
+            mount={mount}
+            bloomed={focus === mount.path || globalDepth >= 1}
+            globalDepth={globalDepth}
+            onFocus={() => focusMount(mount.path)}
+            openDirs={open}
+            onHoverDir={hoverDir}
+            onToggle={toggle}
+            showAll={showAll}
+            onRevealAll={revealAll}
+          />
+        ))}
+        {core && sources === null && !sourcesError && (
+          <div className="space-y-3 py-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        )}
+        {sourcesError && (
+          <div className="py-1 font-mono text-[13px] text-error">✗ /sources: {sourcesError}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** One mount: a bare `ls` row at rest; the tree blooms beneath it while the
+ *  lens is on it. The whole block keeps focus, so the cursor can travel into
+ *  the subtree without the view changing underneath it. */
+function MountBlock({
+  mount,
+  bloomed,
+  globalDepth,
+  onFocus,
+  openDirs,
+  onHoverDir,
+  onToggle,
+  showAll,
+  onRevealAll,
+}: {
+  mount: Mount;
+  bloomed: boolean;
+  globalDepth: number;
+  onFocus: () => void;
+  openDirs: Set<string>;
+  onHoverDir: (key: string) => void;
+  onToggle: (key: string) => void;
+  showAll: Set<string>;
+  onRevealAll: (key: string) => void;
+}) {
+  const name = (
+    <span className="flex items-center gap-2">
+      <span className="flex w-[15px] items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px]">
+        {mount.icon}
+      </span>
+      <span
+        className={cn(
+          "font-mono text-[13px]",
+          mount.nodes.length === 0 ? "text-muted-foreground" : "text-foreground",
+          bloomed && "font-semibold",
+        )}
+      >
+        {mount.path}
+      </span>
+    </span>
+  );
+
+  return (
+    <div onMouseEnter={onFocus}>
+      {mount.href ? (
+        <Link href={mount.href} className="inline-flex rounded-md px-1.5 py-[3px] hover:bg-raised">{name}</Link>
+      ) : (
+        <div className="inline-flex px-1.5 py-[3px]">{name}</div>
+      )}
+      {bloomed && (
+        <div className="pb-2 pl-1.5 animate-in fade-in-0 duration-150">
+          {mount.nodes.length === 0 && !mount.footer ? (
+            <div className="flex items-center gap-1 px-1.5 py-1 font-mono text-[12px] text-muted-foreground">
+              <span className="whitespace-pre text-muted-foreground/40">└─ </span>
+              <span className="italic">{mount.emptyLabel}</span>
+            </div>
+          ) : (
+            <TreeRows
+              nodes={mount.nodes}
+              nodeDepth={0}
+              ancestors={[]}
+              parentKey={mount.path}
+              mount={mount}
+              globalDepth={globalDepth}
+              apiHidden={mount.apiHidden}
+              moreHref={mount.moreHref}
+              hasTrailing={!!mount.footer}
+              openDirs={openDirs}
+              onHoverDir={onHoverDir}
+              onToggle={onToggle}
+              showAll={showAll}
+              onRevealAll={onRevealAll}
+            />
+          )}
+          {mount.footer && (
+            <Link
+              href={mount.footer.href}
+              className="group flex w-full items-center gap-1 rounded-md px-1.5 py-1 text-[12.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              <span className="whitespace-pre font-mono text-[12px] leading-none text-muted-foreground/40">└─ </span>
+              <span className="font-mono">{mount.footer.label}</span>
+              <ArrowUpRight className="h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100" />
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NodeIcon({ node, open }: { node: VNode; open: boolean }) {
+  if (node.icon) {
+    return (
+      <span className="flex w-[15px] shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px]">
+        {node.icon}
+      </span>
+    );
+  }
+  const cls = cn("shrink-0", open ? "text-brand-600" : "text-muted-foreground");
+  if (node.kind === "folder") return <span className={cls}><FolderIcon /></span>;
+  if (node.kind === "page") return <span className="shrink-0 text-muted-foreground"><PageIcon /></span>;
+  if (node.kind === "table") return <span className="shrink-0 text-muted-foreground"><TableIcon /></span>;
+  if (node.kind === "session") return <MessagesSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  if (node.kind === "skill") return <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  return <span className="shrink-0 text-muted-foreground"><FileIcon /></span>;
+}
+
+/** One directory level, tree(1)-style: `├─`/`└─` glyphs with `│` continuation
+ *  lines inherited from open ancestors. Hovering a directory row opens it in
+ *  place (a chevron click closes it again). Long listings stop at
+ *  SHOW_PER_DIR rows behind a "+N more" toggle; rows the API itself withheld
+ *  get an honest "not shown" row instead. */
+function TreeRows({
+  nodes,
+  nodeDepth,
+  ancestors,
+  parentKey,
+  mount,
+  globalDepth,
+  apiHidden,
+  moreHref,
+  hasTrailing,
+  openDirs,
+  onHoverDir,
+  onToggle,
+  showAll,
+  onRevealAll,
+}: {
+  nodes: VNode[];
+  nodeDepth: number;
+  ancestors: boolean[]; // isLast flag per ancestor level, for continuation glyphs
+  parentKey: string;
+  mount: Mount;
+  globalDepth: number;
+  apiHidden?: number;
+  moreHref?: string;
+  hasTrailing?: boolean;
+  openDirs: Set<string>;
+  onHoverDir: (key: string) => void;
+  onToggle: (key: string) => void;
+  showAll: Set<string>;
+  onRevealAll: (key: string) => void;
+}) {
+  const visible = showAll.has(parentKey) ? nodes : nodes.slice(0, SHOW_PER_DIR);
+  const localHidden = nodes.length - visible.length;
+  const syntheticRows = (localHidden > 0 ? 1 : 0) + (apiHidden ? 1 : 0);
+  const continuation = ancestors.map((last) => (last ? "   " : "│  ")).join("");
+
+  return (
+    <div className={nodeDepth > 0 ? "animate-in fade-in-0 duration-150" : undefined}>
+      {visible.map((node, i) => {
+        const isLast = i === visible.length - 1 && syntheticRows === 0 && !hasTrailing;
+        const glyph = continuation + (isLast ? "└─ " : "├─ ");
+        // A dir with nothing in it (and nothing hidden) has nothing to expand
+        // — it renders greyed out, the way an empty dir has no weight in a
+        // real filesystem. Open when the cursor has touched it, or the
+        // scrubber's global floor reaches past its children.
+        const isDir = !!node.children && (node.children.length > 0 || !!node.hiddenCount);
+        const isEmptyDir = !!node.children && !isDir;
+        const open = isDir && (openDirs.has(node.key) || nodeDepth + 1 < globalDepth);
+        const rowClass =
+          "group flex w-full items-center gap-1.5 rounded-md px-1.5 py-[3px] text-left text-[13px] hover:bg-raised";
+        const inner = (
+          <>
+            <span className="whitespace-pre font-mono text-[12px] leading-none text-muted-foreground/40">
+              {glyph}
+            </span>
+            {isDir ? (
+              <ChevronRight
+                className={cn(
+                  "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+                  open && "rotate-90",
+                )}
+              />
+            ) : (
+              <span className="w-3 shrink-0" />
+            )}
+            <NodeIcon node={node} open={open} />
+            <span
+              className={cn(
+                "truncate",
+                isEmptyDir ? "text-muted-foreground" : "text-foreground group-hover:text-brand-700",
+              )}
+            >
+              {node.name}
+              {(isDir || isEmptyDir) && <span className="text-muted-foreground">/</span>}
+            </span>
+            {node.annotation && (
+              <span className="shrink-0 pl-1.5 font-mono text-[11px] text-muted-foreground">
+                {node.annotation}
+              </span>
+            )}
+          </>
+        );
+        return (
+          <div key={node.key}>
+            {isDir ? (
+              <button
+                type="button"
+                onMouseEnter={() => onHoverDir(node.key)}
+                onClick={() => onToggle(node.key)}
+                aria-expanded={open}
+                className={rowClass}
+              >
+                {inner}
+              </button>
+            ) : node.href ? (
+              <Link href={node.href} className={rowClass}>{inner}</Link>
+            ) : (
+              <div className={cn(rowClass, "hover:bg-transparent")}>{inner}</div>
+            )}
+            {isDir && open && (
+              <TreeRows
+                nodes={node.children!}
+                nodeDepth={nodeDepth + 1}
+                ancestors={[...ancestors, isLast]}
+                parentKey={node.key}
+                mount={mount}
+                globalDepth={globalDepth}
+                apiHidden={node.hiddenCount}
+                moreHref={node.moreHref ?? moreHref}
+                openDirs={openDirs}
+                onHoverDir={onHoverDir}
+                onToggle={onToggle}
+                showAll={showAll}
+                onRevealAll={onRevealAll}
+              />
+            )}
+          </div>
+        );
+      })}
+      {localHidden > 0 && (
+        <button
+          type="button"
+          onClick={() => onRevealAll(parentKey)}
+          className="flex w-full items-center gap-1 rounded-md px-1.5 py-1 text-left font-mono text-[12px] text-dim hover:bg-raised hover:text-brand-700"
+        >
+          <span className="whitespace-pre leading-none text-muted-foreground/40">
+            {continuation + (apiHidden ? "├─ " : "└─ ")}
+          </span>
+          … +{localHidden} more
+        </button>
+      )}
+      {apiHidden ? (
+        moreHref ? (
+          <Link
+            href={moreHref}
+            className="flex w-full items-center gap-1 rounded-md px-1.5 py-1 font-mono text-[12px] text-dim hover:bg-raised hover:text-brand-700"
+          >
+            <span className="whitespace-pre leading-none text-muted-foreground/40">{continuation + "└─ "}</span>
+            … {apiHidden} more synced <ArrowUpRight className="h-3 w-3" />
+          </Link>
+        ) : (
+          <div className="flex w-full items-center gap-1 px-1.5 py-1 font-mono text-[12px] text-muted-foreground">
+            <span className="whitespace-pre leading-none text-muted-foreground/40">{continuation + "└─ "}</span>
+            … {apiHidden} more synced
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/content/files-overview/build.test.ts
+++ b/frontend/src/components/content/files-overview/build.test.ts
@@ -1,0 +1,70 @@
+// The bird's-eye view promises two things: Memory renders as its own mount
+// (never duplicated inside /files), and anything the API withheld surfaces as
+// an explicit hidden count instead of silently vanishing.
+import { describe, expect, it } from "vitest";
+import { buildFilesNodes, buildSourceNodes } from "./build";
+import type { FilesTree, SourceTreeEntry } from "@/lib/api";
+
+const MEMORY_ID = "mem-folder";
+
+const tree: FilesTree = {
+  folders: [
+    { id: "a", name: "Research", parent_folder_id: null, page_count: 1, file_count: 0 },
+    { id: "b", name: "Papers", parent_folder_id: "a", page_count: 0, file_count: 1 },
+    { id: MEMORY_ID, name: "Memory", parent_folder_id: null, page_count: 0, file_count: 0 },
+    { id: "m1", name: "People", parent_folder_id: MEMORY_ID, page_count: 2, file_count: 0 },
+  ],
+  pages: [
+    { id: "p1", name: "Notes", content_type: "markdown", folder_id: "a" },
+    { id: "p2", name: "Root page", content_type: "markdown", folder_id: null },
+  ],
+  files: [
+    {
+      id: "f1", name: "spec.pdf", folder_id: "b", size_bytes: 2048,
+      content_type: "application/pdf", url: null, created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+describe("buildFilesNodes", () => {
+  it("nests by parent id and splits Memory into its own mount", () => {
+    const { files, memory } = buildFilesNodes(tree, MEMORY_ID);
+
+    expect(files.map((n) => n.name)).toEqual(["Research", "Root page"]);
+    const research = files[0];
+    expect(research.children!.map((n) => n.name)).toEqual(["Papers", "Notes"]);
+    expect(research.children![0].children![0]).toMatchObject({
+      name: "spec.pdf",
+      href: "/f/f1",
+      annotation: "2 KB",
+    });
+
+    // Memory is a separate mount — not a folder row under /files.
+    expect(files.some((n) => n.key === MEMORY_ID)).toBe(false);
+    expect(memory.map((n) => n.name)).toEqual(["People"]);
+  });
+});
+
+describe("buildSourceNodes", () => {
+  it("turns truncation markers into hidden counts instead of rows", () => {
+    const entries: SourceTreeEntry[] = [
+      {
+        name: "docs",
+        kind: "folder",
+        children: [
+          { name: "api.md", kind: "file", path: "docs/api.md" },
+          { name: "", kind: "truncated", hidden: 7 },
+        ],
+      },
+      { name: "", kind: "truncated", hidden: 3 },
+    ];
+
+    const { nodes, hiddenCount } = buildSourceNodes(entries, "/sources/github");
+    expect(hiddenCount).toBe(3);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({ name: "docs", kind: "folder", hiddenCount: 7 });
+    // The annotation counts what's really there: 1 shown + 7 hidden.
+    expect(nodes[0].annotation).toBe("8 items");
+    expect(nodes[0].children![0]).toMatchObject({ name: "api.md", kind: "source-doc" });
+  });
+});

--- a/frontend/src/components/content/files-overview/build.ts
+++ b/frontend/src/components/content/files-overview/build.ts
@@ -1,0 +1,187 @@
+// Pure data shaping for the /files bird's-eye view: every mount (files,
+// memory, sessions, skills, tables, connected sources) is normalized into one
+// VNode tree so a single renderer can draw the whole stash.
+
+import type { ReactNode } from "react";
+import type {
+  FilesTree,
+  SidebarSession,
+  Skill,
+  SourceTreeEntry,
+  TreeFolder,
+} from "@/lib/api";
+import type { Table } from "@/lib/types";
+
+export type VNodeKind =
+  | "folder"
+  | "page"
+  | "file"
+  | "table"
+  | "session"
+  | "skill"
+  | "source-doc";
+
+export interface VNode {
+  key: string;
+  kind: VNodeKind;
+  name: string;
+  /** Deep link into the product; absent for rows with no in-app view (source docs). */
+  href?: string;
+  /** Dim note after the name — "4 pages", "12 rows", "2h ago". */
+  annotation?: string;
+  children?: VNode[];
+  /** Rows the API itself cut off (sources tree per-dir cap). */
+  hiddenCount?: number;
+  /** Custom row icon (provider brand marks); falls back to the kind icon. */
+  icon?: ReactNode;
+  /** Where this subtree's "+N more" rows should take the user. */
+  moreHref?: string;
+}
+
+function byName<T extends { name: string }>(a: T, b: T): number {
+  return a.name.localeCompare(b.name);
+}
+
+export function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function timeAgo(iso: string): string {
+  const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 86400 * 30) return `${Math.floor(seconds / 86400)}d ago`;
+  return `${Math.floor(seconds / (86400 * 30))}mo ago`;
+}
+
+function folderAnnotation(folder: TreeFolder): string | undefined {
+  const parts = [];
+  if (folder.page_count > 0) parts.push(`${folder.page_count} page${folder.page_count === 1 ? "" : "s"}`);
+  if (folder.file_count > 0) parts.push(`${folder.file_count} file${folder.file_count === 1 ? "" : "s"}`);
+  return parts.length ? parts.join(", ") : undefined;
+}
+
+/** Nest the flat sidebar tree into VNodes, splitting the Memory subtree out
+ *  into its own mount (Memory is a reserved folder presented as its own root,
+ *  exactly like the VFS does). */
+export function buildFilesNodes(
+  tree: FilesTree,
+  memoryFolderId: string,
+): { files: VNode[]; memory: VNode[] } {
+  const childFolders = new Map<string | null, TreeFolder[]>();
+  for (const folder of tree.folders) {
+    const list = childFolders.get(folder.parent_folder_id) ?? [];
+    list.push(folder);
+    childFolders.set(folder.parent_folder_id, list);
+  }
+
+  function folderNode(folder: TreeFolder): VNode {
+    return {
+      key: folder.id,
+      kind: "folder",
+      name: folder.name,
+      href: `/folders/${folder.id}`,
+      annotation: folderAnnotation(folder),
+      children: childrenOf(folder.id),
+    };
+  }
+
+  function childrenOf(folderId: string | null): VNode[] {
+    const folders = (childFolders.get(folderId) ?? [])
+      .filter((f) => f.id !== memoryFolderId)
+      .sort(byName)
+      .map(folderNode);
+    const pages = tree.pages
+      .filter((p) => p.folder_id === folderId)
+      .sort(byName)
+      .map<VNode>((p) => ({ key: p.id, kind: "page", name: p.name, href: `/p/${p.id}` }));
+    const files = tree.files
+      .filter((f) => f.folder_id === folderId)
+      .sort(byName)
+      .map<VNode>((f) => ({
+        key: f.id,
+        kind: "file",
+        name: f.name,
+        href: `/f/${f.id}`,
+        annotation: humanSize(f.size_bytes),
+      }));
+    return [...folders, ...pages, ...files];
+  }
+
+  return { files: childrenOf(null), memory: childrenOf(memoryFolderId) };
+}
+
+export function buildSessionNodes(sessions: SidebarSession[]): VNode[] {
+  return sessions.map((s) => ({
+    key: s.session_id,
+    kind: "session",
+    name: s.title || s.agent_name || "session",
+    href: `/sessions/${s.session_id}`,
+    annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
+  }));
+}
+
+export function buildSkillNodes(skills: Skill[]): VNode[] {
+  return [...skills].sort(byName).map((s) => ({
+    key: s.folder_id,
+    kind: "skill",
+    name: s.name,
+    href: `/skills/folder/${s.folder_id}`,
+    annotation: [
+      `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
+      s.published ? "published" : null,
+    ]
+      .filter(Boolean)
+      .join(", "),
+  }));
+}
+
+export function buildTableNodes(tables: Table[]): VNode[] {
+  return [...tables].sort(byName).map((t) => ({
+    key: t.id,
+    kind: "table",
+    name: t.name,
+    href: `/tables/${t.id}`,
+    annotation: `${t.row_count ?? 0} row${t.row_count === 1 ? "" : "s"}`,
+  }));
+}
+
+/** Convert one source's entry tree. Truncation markers become the parent's
+ *  hiddenCount instead of a child row, so the renderer owns the "+N more" UI. */
+export function buildSourceNodes(entries: SourceTreeEntry[], keyPrefix: string): {
+  nodes: VNode[];
+  hiddenCount: number;
+} {
+  let hiddenCount = 0;
+  const nodes: VNode[] = [];
+  entries.forEach((entry, index) => {
+    if (entry.kind === "truncated") {
+      hiddenCount += entry.hidden ?? 0;
+      return;
+    }
+    const key = `${keyPrefix}/${entry.path ?? entry.name}#${index}`;
+    if (entry.children) {
+      const child = buildSourceNodes(entry.children, key);
+      nodes.push({
+        key,
+        kind: "folder",
+        name: entry.name,
+        annotation: annotateDir(child),
+        children: child.nodes,
+        hiddenCount: child.hiddenCount || undefined,
+      });
+      return;
+    }
+    nodes.push({ key, kind: "source-doc", name: entry.name });
+  });
+  return { nodes, hiddenCount };
+}
+
+function annotateDir(child: { nodes: VNode[]; hiddenCount: number }): string {
+  const total = child.nodes.length + child.hiddenCount;
+  return `${total} item${total === 1 ? "" : "s"}`;
+}
+

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -106,11 +106,13 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
   const requestedSection = searchParams.get("section");
 
   function selectSection(section: RailSection) {
-    // Memory and Apps have their own landing pages, so they navigate; other
-    // sections just swap the explorer beside whatever's open.
-    if (section === "memory" || section === "apps") {
+    // Memory, Apps, and Files have their own landing pages, so they navigate;
+    // other sections just swap the explorer beside whatever's open.
+    const LANDING: Partial<Record<RailSection, string>> = { memory: "/memory", apps: "/apps", files: "/files" };
+    const landing = LANDING[section];
+    if (landing) {
       setRailSection(section);
-      router.replace(section === "memory" ? "/memory" : "/apps");
+      router.replace(landing);
       return;
     }
     const params = new URLSearchParams(searchParams);

--- a/frontend/src/components/workspace/workspace-shell.test.tsx
+++ b/frontend/src/components/workspace/workspace-shell.test.tsx
@@ -13,10 +13,10 @@ describe("rendersRouteContent", () => {
     expect(rendersRouteContent("/memory", null, null)).toBe(true);
     expect(rendersRouteContent("/memory/wiki", null, null)).toBe(true);
     expect(rendersRouteContent("/skills", null, null)).toBe(true);
+    expect(rendersRouteContent("/files", null, null)).toBe(true);
   });
 
   it("workbench sections do not render route content", () => {
-    expect(rendersRouteContent("/files", null, null)).toBe(false);
     expect(rendersRouteContent("/agents", null, null)).toBe(false);
     // An opened skill is a tab, not the launcher.
     expect(rendersRouteContent("/skills/folder/abc", null, null)).toBe(false);

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -81,6 +81,9 @@ export function rendersRouteContent(
   workspaceParam: string | null,
 ): boolean {
   if (selectedSection) return false;
+  // The Files home is the bird's-eye view of the whole stash; opening any
+  // item navigates to its own route, which returns to the workbench.
+  if (pathname === "/files") return true;
   if (pathname === "/sessions") return workspaceParam !== "1";
   // Memory routes (brain dashboard, wiki file system) render as pages
   // beside the explorer; opening an item switches to the workbench.
@@ -119,6 +122,9 @@ export default function WorkspaceShell({
     selectedSection,
     searchParams.get("workspace"),
   );
+  // /files IS a file tree — showing the explorer's tree beside it would be
+  // the same thing twice. An explicit ?section= still summons the panel.
+  const showExplorer = section !== null && !(pathname === "/files" && !selectedSection);
 
   return (
     // Chrome surface — the content panel floats on top of it.
@@ -128,7 +134,7 @@ export default function WorkspaceShell({
       <div className="flex min-h-0 flex-1">
         <Rail user={user} onLogout={onLogout} />
         <div className="min-w-0 flex-1 pb-0">
-          {section ? (
+          {section && showExplorer ? (
             <div className="flex h-full">
               <ExplorerPanel section={section} />
               {/* Floating content panel: clean white paper, subtly elevated. */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -333,6 +333,38 @@ export async function listSources(): Promise<Source[]> {
   return data.sources.filter((s) => !NATIVE_SOURCE_TYPES.has(s.type));
 }
 
+// One node in a source's entry tree (GET /me/sources/tree). Directories carry
+// `children`; a capped directory ends with a {kind: "truncated", hidden: N}
+// marker so renderers can say "+N more" honestly.
+export interface SourceTreeEntry {
+  name: string;
+  kind: string; // 'folder' | 'file' | 'page' | 'session' | 'truncated' | ...
+  path?: string;
+  ref?: string;
+  hidden?: number;
+  source?: string; // connection handle, on multi-connection member folders
+  sync_status?: string | null;
+  children?: SourceTreeEntry[];
+}
+
+export interface SourceTreeRoot {
+  source: string; // provider key ("github") or native handle
+  type: string; // 'provider' | 'native_files' | 'native_sessions'
+  provider?: string;
+  display_name: string;
+  members?: { handle: string; display_name: string }[];
+  sync_status?: string | null;
+  last_synced_at?: string | null;
+  tree: SourceTreeEntry[];
+}
+
+export async function getSourcesTree(depth = 4): Promise<SourceTreeRoot[]> {
+  const data = await apiFetch<{ sources: SourceTreeRoot[] }>(`${ME}/sources/tree?depth=${depth}`);
+  // Files and sessions render from their own richer endpoints; this call is
+  // for the connected-source trees.
+  return data.sources.filter((s) => s.type === "provider");
+}
+
 export async function addSource(body: {
   source_type: string;
   external_ref?: string;


### PR DESCRIPTION
we do a little cooking


## What

`/files` existed but rendered nothing (the route was missing from `rendersRouteContent`, so the shell always swallowed it). It's now the bird's-eye view of the whole Stash virtual filesystem — the tree an agent sees, rendered the way a person wants to skim it.

**The interaction model** (each layer composes with the others):
- **At rest**: a bare `ls` of the six VFS mounts — `/files /sessions /memory /skills /tables /sources`. Nothing else.
- **Hover a mount**: it blooms open one level in place.
- **Hover any folder**: it opens; folders stay open while you explore that mount, so rows are never yanked out from under a traveling cursor.
- **Depth gauge** (top right): sweep across it to peek the entire tree 1–4 levels deep, spring-loaded — it snaps back flat when you leave. Click to pin a depth; click again to release.
- **Click any row**: deep-links to the real product route (`/p/…`, `/f/…`, `/folders/…`, `/sessions/…`, `/tables/…`, `/skills/folder/…`).

**Faithfulness rules:**
- Providers nest *inside* `/sources`, exactly like the real VFS — no flattened `/sources/github` mounts at root.
- Empty directories (unsynced providers, empty folders) render greyed with no expand affordance.
- Providers with synced content sort ahead of empty ones, alphabetical within each group.
- Directories cap at 10 children behind a "… +N more" toggle, and rows the backend itself withheld render an explicit "… N more synced" link — nothing silently vanishes.
- Memory renders as its own mount, split out of the files tree, like the VFS presents it.

## How

- New `frontend/src/components/content/files-overview/` — `build.ts` (pure tree shaping: nesting, memory split, truncation accounting) + `FilesOverview.tsx` (the lens UI).
- New `getSourcesTree()` client for `GET /me/sources/tree` — the endpoint existed but was CLI-only. It loads on its own clock (it walks every connected source), so native mounts render without waiting for it.
- `/files` registered in `rendersRouteContent` (+ lock-in test updated).
- Rail's **Files** item now navigates to `/files`, like Memory and Apps (previously it only swapped the explorer, leaving users on whatever stale tab the workbench had).
- The explorer panel hides on `/files` — the page *is* a file tree; showing another one beside it was the same thing twice. An explicit `?section=` still summons it.

## Testing

- `build.test.ts`: nesting by parent id, memory-mount split, truncation markers → honest hidden counts.
- `FilesOverview.test.tsx`: rest = bare ls, hover-bloom + hover-expand, gauge sweep/spring-back/pin/unpin, per-dir caps, providers-under-`/sources` disclosure chain, synced-before-empty ordering.
- Full suite: 292 passing. Lint and `tsc` clean, production build verified.
- Manually QA'd in the browser end to end (light + dark, all interactions).

Screenshots incoming in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only navigation and a new read-heavy overview; no auth or data-mutation paths changed beyond new GET usage for sources tree.
> 
> **Overview**
> Replaces the `/files` folder browser with a **Virtual Filesystem** overview that lists the six VFS mounts (`/files`, `/sessions`, `/memory`, `/skills`, `/tables`, `/sources`) and expands them on hover, with a spring-loaded **depth** gauge to peek or pin tree depth, per-directory **+N more** caps, and honest **… N more synced** rows for API truncation.
> 
> Adds `files-overview/` (`build.ts` shapes sidebar/memory/sources into `VNode` trees; `FilesOverview.tsx` is the lens UI) and wires **`getSourcesTree()`** in `api.ts` for connected providers under `/sources`. Shell fixes that previously swallowed `/files`: **`rendersRouteContent`** treats `/files` as a full-page management view, the rail **Files** item navigates to `/files` (like Memory/Apps), and the side **explorer is hidden** on `/files` unless `?section=` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bedfc10695ffc09b443b4ab78e69997ff0dbf17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->