### PR TITLE
Record scheduled-agent run outcomes

### DIFF
--- a/backend/migrations/versions/0184_agent_last_run_outcome.py
+++ b/backend/migrations/versions/0184_agent_last_run_outcome.py
@@ -1,0 +1,29 @@
+"""Record how each scheduled-agent tick resolved.
+
+Revision ID: 0184
+Revises: 0183
+"""
+
+from alembic import op
+
+revision = "0184"
+down_revision = "0183"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE agents ADD COLUMN last_run_outcome text
+        CHECK (last_run_outcome IN (
+            'started', 'ran', 'failed',
+            'skipped_credits', 'skipped_no_credential', 'skipped_no_changes'
+        ))
+        """
+    )
+    op.execute("UPDATE agents SET last_run_outcome = 'failed' WHERE last_run_error IS NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN last_run_outcome")

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -18,7 +18,7 @@ from ..database import get_pool
 _COLUMNS = (
     "id, user_id, name, model_provider, system_prompt, run_mode, "
     "schedule_cron, schedule_prompt, is_default, is_curator, slack_bound, "
-    "telegram_bound, last_run_at, last_run_error, curated_through, "
+    "telegram_bound, last_run_at, last_run_error, last_run_outcome, curated_through, "
     "month_run_count, month_run_anchor, created_at"
 )
 
@@ -262,13 +262,14 @@ async def mark_run(agent_id: UUID) -> int:
     Returns the run count within the current month (including this one) —
     the free-tier curator credit gate reads it.
 
-    Also clears last_run_error, so after last_run_at advances the error state
-    is unambiguous: non-null means THIS run failed (clients poll on that)."""
+    Also clears last_run_error and stamps the outcome as started. Every path
+    after this call must resolve the outcome as ran, failed, or skipped."""
     return await get_pool().fetchval(
         """
         UPDATE agents SET
             last_run_at = now(),
             last_run_error = NULL,
+            last_run_outcome = 'started',
             month_run_count = CASE
                 WHEN month_run_anchor = date_trunc('month', now())::date
                 THEN month_run_count + 1 ELSE 1 END,
@@ -288,11 +289,29 @@ async def mark_run_failed(agent_id: UUID, error: str) -> None:
         """
         UPDATE agents SET
             last_run_error = left($2, 500),
+            last_run_outcome = 'failed',
             month_run_count = greatest(month_run_count - 1, 0)
         WHERE id = $1
         """,
         agent_id,
         error,
+    )
+
+
+async def mark_run_skipped(agent_id: UUID, reason: str) -> None:
+    """Resolve a consumed tick that stopped at a designed scheduler gate."""
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = $2 WHERE id = $1",
+        agent_id,
+        f"skipped_{reason}",
+    )
+
+
+async def mark_run_succeeded(agent_id: UUID) -> None:
+    """Resolve a run after execution and all post-run bookkeeping complete."""
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'ran' WHERE id = $1",
+        agent_id,
     )
 
 

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -62,13 +62,14 @@ async def _run_curator_now(agent_id: UUID) -> None:
         # Seconds-resolution stamp so a manual run never shares a session with
         # the beat's minute-stamped run.
         await sprite_agent_service.run_scheduled(agent, now.strftime("%Y%m%d%H%M%S"))
+        through = await curation_service.complete_through(
+            UUID(str(agent["user_id"])), agent["curated_through"], now
+        )
+        await agent_service.mark_curated(agent_id, through)
+        await agent_service.mark_run_succeeded(agent_id)
     except Exception as e:
         await agent_service.mark_run_failed(agent_id, str(e))
         raise
-    through = await curation_service.complete_through(
-        UUID(str(agent["user_id"])), agent["curated_through"], now
-    )
-    await agent_service.mark_curated(agent_id, through)
 
 
 async def _run_due() -> int:
@@ -96,18 +97,21 @@ async def _run_due() -> int:
                 logger.info(
                     "agent schedule: curator credits exhausted for user %s — skipping", user_id
                 )
+                await agent_service.mark_run_skipped(agent["id"], "credits")
                 continue
         # No runnable credential (unconnected free user) → nothing can run.
         try:
             await agent_auth.resolve(user_id, agent["model_provider"])
         except (agent_auth.NeedsAuth, agent_auth.ProviderNotConfigured):
             logger.info("agent schedule: no credential for agent %s — skipping", agent["id"])
+            await agent_service.mark_run_skipped(agent["id"], "no_credential")
             continue
         # Cost gate: skip the curator (and the sprite wake) when nothing changed
         # since its watermark. Idle users cost one EXISTS per day.
         if agent["is_curator"] and not await curation_service.has_changes_since(
             user_id, user_id, agent["curated_through"]
         ):
+            await agent_service.mark_run_skipped(agent["id"], "no_changes")
             continue
         run_scheduled_agent.delay(str(agent["id"]), stamp)
         dispatched += 1
@@ -140,6 +144,7 @@ async def _run_scheduled_agent(agent_id: UUID, stamp: str) -> None:
                 user_id, agent["curated_through"], now
             )
             await agent_service.mark_curated(agent_id, through)
+        await agent_service.mark_run_succeeded(agent_id)
     except Exception as e:
         logger.exception("agent schedule: run failed for agent %s", agent_id)
         await agent_service.mark_run_failed(agent_id, str(e))
@@ -163,9 +168,8 @@ async def _alert_stale_curators() -> int:
     """Alert on curators whose watermark stopped advancing despite pending
     changes. Alerting on the stale *outcome* catches every cause — dead
     provider keys, harness bugs, a wedged beat — where per-run failure alerts
-    only catch runs that started. `last_run_error IS NOT NULL` scopes this to
-    curators whose last attempted run actually failed; curators skipped by
-    design (credit allowance, no credential) keep a NULL error and stay quiet.
+    only catch runs that started. A failed outcome or an unresolved started
+    outcome qualifies. Designed skips resolve explicitly and stay quiet.
     """
     from ..database import get_pool
     from ..services import alert_service, curation_service
@@ -173,11 +177,11 @@ async def _alert_stale_curators() -> int:
     cutoff = datetime.now(UTC) - timedelta(hours=STALE_CURATOR_HOURS)
     rows = await get_pool().fetch(
         """
-        SELECT a.user_id, a.curated_through, a.last_run_error, u.email
+        SELECT a.user_id, a.curated_through, a.last_run_error, a.last_run_outcome, u.email
         FROM agents a JOIN users u ON u.id = a.user_id
         WHERE a.is_curator AND a.run_mode = 'scheduled'
           AND a.curated_through IS NOT NULL AND a.curated_through < $1
-          AND a.last_run_error IS NOT NULL
+          AND a.last_run_outcome IN ('started', 'failed')
         """,
         cutoff,
     )
@@ -192,7 +196,7 @@ async def _alert_stale_curators() -> int:
         return 0
     lines = [
         f"- {r['email']}: last curated {r['curated_through']:%Y-%m-%d %H:%M} UTC "
-        f"({r['last_run_error'][:200]})"
+        f"({(r['last_run_error'] or 'run started but never resolved')[:200]})"
         for r in stale
     ]
     await alert_service.send_alert(

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -43,11 +43,14 @@ async def _make_curator(
     user_id: uuid.UUID, *, curated_hours_ago: int, last_run_error: str | None
 ) -> dict:
     agent = await agent_service.get_or_create_curator(user_id)
+    last_run_outcome = "failed" if last_run_error is not None else None
     await get_pool().execute(
-        "UPDATE agents SET curated_through = $2, last_run_error = $3 WHERE id = $1",
+        "UPDATE agents SET curated_through = $2, last_run_error = $3, "
+        "last_run_outcome = $4 WHERE id = $1",
         agent["id"],
         datetime.now(UTC) - timedelta(hours=curated_hours_ago),
         last_run_error,
+        last_run_outcome,
     )
     return agent
 
@@ -69,10 +72,11 @@ async def test_stale_failing_curator_alerts(client: AsyncClient, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_skipped_by_design_curator_stays_quiet(client: AsyncClient, monkeypatch):
-    # Curators skipped on purpose (credit allowance, no credential) never run,
-    # so their error stays NULL — a stalled watermark there is not a failure.
     user_id = await _register(client)
-    await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'skipped_no_changes' WHERE id = $1", agent["id"]
+    )
     await memory_service.push_event(
         user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
     )
@@ -80,6 +84,22 @@ async def test_skipped_by_design_curator_stays_quiet(client: AsyncClient, monkey
 
     assert await agent_schedules._alert_stale_curators() == 0
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_stale_curator_with_unresolved_run_alerts(client: AsyncClient, monkeypatch):
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=72, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET last_run_outcome = 'started' WHERE id = $1", agent["id"]
+    )
+    await memory_service.push_event(
+        user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
+    )
+    sent = _capture_alerts(monkeypatch)
+
+    assert await agent_schedules._alert_stale_curators() == 1
+    assert len(sent) == 1 and "never resolved" in sent[0]
 
 
 @pytest.mark.asyncio
@@ -143,10 +163,11 @@ async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
     assert "Scheduled agent run failed" in sent[0] and "opencode error" in sent[0]
     # The failure is also stored on the agent, which is what the stale-curator
     # watchdog keys off — the two alert paths must stay connected.
-    error = await get_pool().fetchval(
-        "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
+    row = await get_pool().fetchrow(
+        "SELECT last_run_error, last_run_outcome FROM agents WHERE id = $1", agent["id"]
     )
-    assert error is not None and "opencode error" in error
+    assert row["last_run_error"] is not None and "opencode error" in row["last_run_error"]
+    assert row["last_run_outcome"] == "failed"
 
 
 @pytest.mark.asyncio
@@ -172,10 +193,63 @@ async def test_run_bookkeeping_failure_sends_alert(client: AsyncClient, monkeypa
     await agent_schedules._run_scheduled_agent(uuid.UUID(agent["id"]), "202608091200")
 
     assert len(sent) == 1 and "watermark write failed" in sent[0]
-    error = await get_pool().fetchval(
-        "SELECT last_run_error FROM agents WHERE id = $1", agent["id"]
+    row = await get_pool().fetchrow(
+        "SELECT last_run_error, last_run_outcome FROM agents WHERE id = $1", agent["id"]
     )
-    assert error is not None and "watermark write failed" in error
+    assert row["last_run_error"] is not None and "watermark write failed" in row["last_run_error"]
+    assert row["last_run_outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_run_due_records_no_changes_skip(client: AsyncClient, monkeypatch):
+    from backend.services import agent_auth, curation_service
+
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=1, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET schedule_cron = '* * * * *', last_run_at = $2 WHERE id = $1",
+        agent["id"],
+        datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+    async def fake_resolve(user_id, prefer_provider=None):
+        return None
+
+    async def no_changes(owner_user_id, user_id, since):
+        return False
+
+    monkeypatch.setattr(agent_auth, "resolve", fake_resolve)
+    monkeypatch.setattr(curation_service, "has_changes_since", no_changes)
+
+    assert await agent_schedules._run_due() == 0
+    outcome = await get_pool().fetchval(
+        "SELECT last_run_outcome FROM agents WHERE id = $1", agent["id"]
+    )
+    assert outcome == "skipped_no_changes"
+
+
+@pytest.mark.asyncio
+async def test_run_due_records_missing_credential_skip(client: AsyncClient, monkeypatch):
+    from backend.services import agent_auth
+
+    user_id = await _register(client)
+    agent = await _make_curator(user_id, curated_hours_ago=1, last_run_error=None)
+    await get_pool().execute(
+        "UPDATE agents SET schedule_cron = '* * * * *', last_run_at = $2 WHERE id = $1",
+        agent["id"],
+        datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+    async def no_credential(user_id, prefer_provider=None):
+        raise agent_auth.NeedsAuth
+
+    monkeypatch.setattr(agent_auth, "resolve", no_credential)
+
+    assert await agent_schedules._run_due() == 0
+    outcome = await get_pool().fetchval(
+        "SELECT last_run_outcome FROM agents WHERE id = $1", agent["id"]
+    )
+    assert outcome == "skipped_no_credential"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -386,12 +386,14 @@ async def test_idle_curator_skipped_by_beat(client: AsyncClient, sprite_exec, _d
     await _run_due()
 
     row = await _db_pool.fetchrow(
-        "SELECT last_run_at, curated_through FROM agents WHERE id = $1", UUID(curator["id"])
+        "SELECT last_run_at, curated_through, last_run_outcome FROM agents WHERE id = $1",
+        UUID(curator["id"]),
     )
     assert sprite_exec.calls == []  # no sprite wake
     assert row["curated_through"] == future  # watermark preserved
     # Tick consumed — the next beat won't re-check until the next cron tick.
     assert row["last_run_at"] > datetime.now(UTC) - timedelta(minutes=1)
+    assert row["last_run_outcome"] == "skipped_no_changes"
 
 
 @pytest.mark.asyncio
@@ -415,13 +417,14 @@ async def test_curator_run_does_not_echo_loop(
     assert await _run_due() == 1
     await _run_scheduled_agent(UUID(dispatched[0][0]), dispatched[0][1])
 
-    after = await _db_pool.fetchval(
-        "SELECT curated_through FROM agents WHERE id = $1", UUID(curator["id"])
+    row = await _db_pool.fetchrow(
+        "SELECT curated_through, last_run_outcome FROM agents WHERE id = $1", UUID(curator["id"])
     )
     # Watermark advanced past the page change, and the run's own transcript
     # doesn't re-trigger the gate or appear in the feed.
-    assert await curation_service.has_changes_since(uid, uid, after) is False
-    feed = await curation_service.changes_since(uid, uid, after)
+    assert row["last_run_outcome"] == "ran"
+    assert await curation_service.has_changes_since(uid, uid, row["curated_through"]) is False
+    feed = await curation_service.changes_since(uid, uid, row["curated_through"])
     assert all(not str(e["session_id"] or "").startswith("agent-curate-") for e in feed["history"])
 
 
@@ -562,10 +565,12 @@ async def test_recompute_runs_curator_now(client: AsyncClient, sprite_exec, _db_
     before = datetime.now(UTC)
     await _run_curator_now(UUID(curator["id"]))
     row = await _db_pool.fetchrow(
-        "SELECT curated_through, last_run_at FROM agents WHERE id = $1", UUID(curator["id"])
+        "SELECT curated_through, last_run_at, last_run_outcome FROM agents WHERE id = $1",
+        UUID(curator["id"]),
     )
     assert sprite_exec.calls  # the run actually woke the sprite
     assert row["curated_through"] >= before - timedelta(seconds=5)
+    assert row["last_run_outcome"] == "ran"
 
     # The run's events carry the curator's own name, so its sessions are
     # attributable in the Agents/Sessions lists (not generic "Stash Agent").
@@ -605,6 +610,33 @@ async def test_failed_manual_recompute_records_error(
     r = await client.get("/api/v1/me/agents", headers=_auth(key))
     fetched = next(a for a in r.json()["agents"] if a["is_curator"])
     assert fetched["last_run_error"] == "harness missing"
+
+
+@pytest.mark.asyncio
+async def test_manual_recompute_bookkeeping_failure_records_failed_outcome(
+    client: AsyncClient, sprite_exec, _db_pool, monkeypatch
+):
+    """A successful turn is not a successful curator run until its watermark
+    advances. The outcome must cover that post-turn work too."""
+    from backend.services import curation_service
+    from backend.tasks.agent_schedules import _run_curator_now
+
+    _key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+
+    async def boom(user_id, curated_through, now):
+        raise RuntimeError("watermark write failed")
+
+    monkeypatch.setattr(curation_service, "complete_through", boom)
+    with pytest.raises(RuntimeError):
+        await _run_curator_now(UUID(curator["id"]))
+
+    row = await _db_pool.fetchrow(
+        "SELECT last_run_error, last_run_outcome FROM agents WHERE id = $1",
+        UUID(curator["id"]),
+    )
+    assert "watermark write failed" in row["last_run_error"]
+    assert row["last_run_outcome"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_plan_gate.py
+++ b/backend/tests/test_plan_gate.py
@@ -122,10 +122,11 @@ async def test_free_curator_credits_exhausted_skips_run(
 
     assert ran == 0
     assert sprite_exec.calls == []  # no sprite wake
-    after = await _db_pool.fetchval(
-        "SELECT curated_through FROM agents WHERE id = $1", UUID(curator["id"])
+    after = await _db_pool.fetchrow(
+        "SELECT curated_through, last_run_outcome FROM agents WHERE id = $1", UUID(curator["id"])
     )
-    assert after == watermark  # skipped run never discards un-curated changes
+    assert after["curated_through"] == watermark  # skipped run never discards un-curated changes
+    assert after["last_run_outcome"] == "skipped_credits"
 
     # Enterprise grant → the same overdue curator runs on the next beat.
     await _db_pool.execute("UPDATE users SET plan = 'enterprise' WHERE id = $1", uid)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2199,6 +2199,14 @@ export type Agent = {
   telegram_bound: boolean;
   last_run_at: string | null;
   last_run_error: string | null;
+  last_run_outcome:
+    | "started"
+    | "ran"
+    | "failed"
+    | "skipped_credits"
+    | "skipped_no_credential"
+    | "skipped_no_changes"
+    | null;
   curated_through: string | null;
 };
 


### PR DESCRIPTION
## Why

A consumed curator tick previously left the same database shape when it was deliberately skipped and when execution died before recording an error. That ambiguity caused repeated false alarms during Heavi investigations, while the stale-curator watchdog could still miss the real silent-death shape.

## What changed

- Add constrained `agents.last_run_outcome` state: `started`, `ran`, `failed`, or one of three designed skip reasons.
- Backfill existing rows with `last_run_error` as `failed`.
- Resolve every beat gate before it returns: credits, missing credential, and no changes.
- Resolve heavy-queue and manual runs only after curator watermark bookkeeping completes.
- Alert on stale curators with pending changes when the latest outcome is `started` or `failed`; designed skips remain quiet.
- Expose the outcome through the typed frontend Agent contract.

Credit metering and scheduler eligibility do not change.

## Verification

- Full backend suite: 1,341 passed, 81.21% coverage.
- Backend Ruff lint and format checks pass.
- Migration graph has one head: 0184.
- Frontend lint has zero errors (five pre-existing warnings).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduler state machine and stale-curator alerting; migration is additive but wrong outcome resolution could mis-page or hide real failures.
> 
> **Overview**
> Adds **`agents.last_run_outcome`** with a DB check constraint (`started`, `ran`, `failed`, and three `skipped_*` reasons), backfills rows that already had **`last_run_error`** as `failed`, and threads the field through agent reads and the frontend **`Agent`** type.
> 
> **Scheduler behavior:** **`mark_run`** now sets `started` and every path must resolve it—beat gates call **`mark_run_skipped`** (credits, no credential, no changes); successful scheduled and manual curator runs call **`mark_run_succeeded`** only after sprite execution **and** curator watermark bookkeeping. **`mark_run_failed`** also sets `failed`.
> 
> **Alerting:** The stale-curator watchdog alerts on pending changes when the outcome is **`started`** or **`failed`** (including “never resolved” runs), not on designed skips.
> 
> Tests cover skip outcomes, unresolved `started`, and bookkeeping failures on manual recompute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a5abeb5048f31922e1535184e2f09b304bae6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->