### PR TITLE
Drop Apps and VM from the rail

### DIFF
--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bot, FolderTree, MessagesSquare, GraduationCap, Home, LayoutGrid, Monitor, Wrench, Settings } from "lucide-react";
+import { Bot, FolderTree, MessagesSquare, GraduationCap, Home, Wrench, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -15,18 +15,17 @@ type RailItem = { key: RailSection; label: string; icon: typeof Bot; match: (p: 
 const PRIMARY: RailItem[] = [
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
   { key: "agents", label: "Agents", icon: Bot, match: (p) => p.startsWith("/agents") },
-  { key: "apps", label: "Apps", icon: LayoutGrid, match: (p) => p.startsWith("/apps") },
   { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
   { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
   { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
   { key: "tools", label: "Tools", icon: Wrench, match: (p) => p.startsWith("/tools") || p.startsWith("/integrations") },
-  { key: "computer", label: "VM", icon: Monitor, match: () => false },
 ];
 
-// Home is the memory dashboard, and Agents and Apps are lenses over the stash
-// rather than places in it — the divider falls after them, above the VFS
-// sections.
-const DIVIDER_AFTER_INDEX = 2;
+// Home is the memory dashboard, and Agents is a lens over the stash rather
+// than a place in it — the divider falls after them, above the VFS sections.
+// Apps and the VM aren't rail-worthy: Apps lives at /apps, the VM under the
+// explorer's Home root.
+const DIVIDER_AFTER_INDEX = 1;
 
 function RailButton({
   item,
@@ -107,10 +106,10 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
   const requestedSection = searchParams.get("section");
 
   function selectSection(section: RailSection) {
-    // Home (the memory dashboard), Apps, and Files have their own landing
-    // pages, so they navigate; other sections just swap the explorer beside
-    // whatever's open.
-    const LANDING: Partial<Record<RailSection, string>> = { home: "/", apps: "/apps", files: "/files" };
+    // Home (the memory dashboard) and Files have their own landing pages, so
+    // they navigate; other sections just swap the explorer beside whatever's
+    // open.
+    const LANDING: Partial<Record<RailSection, string>> = { home: "/", files: "/files" };
     const landing = LANDING[section];
     if (landing) {
       setRailSection(section);

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid";
  * components/workspace/persistence.tsx (localStorage).
  */
 
-export type RailSection = "home" | "files" | "agents" | "sessions" | "skills" | "apps" | "tools" | "computer";
+export type RailSection = "home" | "files" | "agents" | "sessions" | "skills" | "tools" | "computer";
 
 export type TabKind = "page" | "file" | "table" | "session" | "sessions-home" | "skill" | "folder" | "agent" | "agent-config" | "tool" | "machine-file" | "terminal";
 


### PR DESCRIPTION
## What

Removes the **Apps** and **VM** items from the icon rail. Neither is deleted as a feature:

- **Apps** stays reachable at `/apps` (the route and pages are untouched) — it just no longer has a rail slot.
- **VM** stays a row under the explorer's **Home** root (Home → VM), which was already its second entry point.

The rail is now: Home, Agents │ VFS, Sessions, Skills, Tools. The divider moved to fall after Agents, and the now-unset `apps` rail-section value was dropped from `RailSection`.

## Screenshot

https://app.joinstash.ai/f/473c4c60-bd6b-4fcb-833f-174edf50511d

## Testing

- `npm test` — 292/292 pass
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (5 pre-existing warnings)
- Verified live at `localhost:3457` (screenshot above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only UI changes with no auth, API, or data-layer edits; minor risk that persisted `section=apps` URLs no longer map to a rail slot.
> 
> **Overview**
> **Simplifies primary workspace navigation** by removing **Apps** and **VM** from the icon rail. The rail is now **Home, Agents │ VFS, Sessions, Skills, Tools**; the visual divider runs after **Agents** (`DIVIDER_AFTER_INDEX` **2 → 1**).
> 
> **Apps** is no longer a rail item or landing shortcut in `selectSection` (removed from the `LANDING` map). **`apps`** is dropped from the **`RailSection`** union in `workspace-store.ts`. **`computer`** stays on the type for explorer/Home-root VM access even though the rail button is gone.
> 
> Comments in `rail.tsx` note that Apps remains at **`/apps`** and the VM under the explorer **Home** root—routes and features are not deleted, only rail entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe3c2b0d2e9acb0aa769b0535dcbaf743bfa637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->