### PR TITLE
Clicking a provider or folder row in the /files lens navigates

### DIFF
--- a/frontend/src/components/content/files-overview/FilesOverview.test.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.test.tsx
@@ -126,6 +126,28 @@ describe("FilesOverview", () => {
     expect(screen.queryByText("Page 00")).toBeNull();
   });
 
+  it("dir rows with an href navigate; their chevron still toggles", async () => {
+    render(<FilesOverview />);
+    await waitFor(() => expect(screen.getByText("/sources")).toBeTruthy());
+
+    // A provider is a real Stash object — its row is a link to the
+    // integration page, not a click-swallowing toggle button.
+    hover("/sources");
+    const github = screen.getByRole("link", { name: /github/ });
+    expect(github.getAttribute("href")).toBe("/integrations/github");
+
+    // Folders under /files link to their explorer page the same way.
+    hover("/files");
+    const research = screen.getByRole("link", { name: /Research/ });
+    expect(research.getAttribute("href")).toBe("/folders/root-1");
+
+    // The chevron keeps expand/collapse duty without following the link.
+    hover("Research");
+    expect(screen.getByText("Page 00")).toBeTruthy();
+    fireEvent.click(research.querySelector('[aria-label="collapse"]')!);
+    expect(screen.queryByText("Page 00")).toBeNull();
+  });
+
   it("depth gauge peeks every mount open, and springs back flat on leave", async () => {
     render(<FilesOverview />);
     await waitFor(() => expect(screen.getByText("/files")).toBeTruthy());

--- a/frontend/src/components/content/files-overview/FilesOverview.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.tsx
@@ -474,7 +474,27 @@ function TreeRows({
             <span className="whitespace-pre font-mono text-[12px] leading-none text-muted-foreground/40">
               {glyph}
             </span>
-            {isDir ? (
+            {isDir && node.href ? (
+              // Inside a navigating row the chevron keeps toggle duty: label
+              // clicks follow the href, chevron clicks expand/collapse.
+              <span
+                role="button"
+                aria-label={open ? "collapse" : "expand"}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggle(node.key);
+                }}
+                className="flex shrink-0 items-center"
+              >
+                <ChevronRight
+                  className={cn(
+                    "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+                    open && "rotate-90",
+                  )}
+                />
+              </span>
+            ) : isDir ? (
               <ChevronRight
                 className={cn(
                   "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
@@ -504,15 +524,29 @@ function TreeRows({
         return (
           <div key={node.key}>
             {isDir ? (
-              <button
-                type="button"
-                onMouseEnter={() => onHoverDir(node.key)}
-                onClick={() => onToggle(node.key)}
-                aria-expanded={open}
-                className={rowClass}
-              >
-                {inner}
-              </button>
+              node.href ? (
+                // A dir that is also a Stash object (provider → its
+                // integration page, folder → its explorer page): the row
+                // navigates, hover still opens it in place.
+                <Link
+                  href={node.href}
+                  onMouseEnter={() => onHoverDir(node.key)}
+                  aria-expanded={open}
+                  className={rowClass}
+                >
+                  {inner}
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onMouseEnter={() => onHoverDir(node.key)}
+                  onClick={() => onToggle(node.key)}
+                  aria-expanded={open}
+                  className={rowClass}
+                >
+                  {inner}
+                </button>
+              )
             ) : node.href ? (
               <Link href={node.href} className={rowClass}>{inner}</Link>
             ) : (


### PR DESCRIPTION
## What

Clicking `google` (or any provider/folder row) in the `/files` VFS lens did nothing. Cause: any tree row with children rendered as a toggle-only `<button>` — its `href` was silently discarded, and since hovering the row had already expanded it, the click's toggle was imperceptible.

Now rows that are real Stash objects navigate, and the chevron keeps toggle duty:
- provider rows → `/integrations/<provider>`
- folder rows → `/folders/<id>`
- dirs without an href (source subdirectories) keep the existing button behavior

## Testing

- New test: provider and folder rows are links with the right hrefs; the chevron still collapses without navigating. Frontend suite 293/293, lint clean.
- Verified live: clicking `Hiring` under `/files` lands on `/folders/<id>`; chevron toggles in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the files overview tree with a focused regression test; no auth, API, or data-layer changes.
> 
> **Overview**
> **Provider and folder rows in the `/files` VFS lens now navigate** instead of acting as expand-only buttons that ignored `node.href`.
> 
> Directory rows that represent Stash objects render as **Next.js `Link`s** (providers → `/integrations/<provider>`, folders → `/folders/<id>`). **Hover-to-expand** on those rows is unchanged. Rows without an `href` (e.g. source subdirectories) still use a toggle **`<button>`**.
> 
> For linked directory rows, the **chevron is a separate control** (`preventDefault` / `stopPropagation`) so clicking it expands or collapses **without** following the link; clicking the row label still navigates.
> 
> A new test asserts correct link `href`s for github and Research and that the chevron collapses the tree without navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022ea9fd3768df099e000acc108c0266878bd3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->