### PR TITLE
Sources sync as a side effect of being looked at

### DIFF
--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -143,9 +143,19 @@ async def list_sources(
     scope_user_id: UUID = Depends(get_scope),
 ):
     """Sources in the active scope's view: native files + sessions, plus the
-    scope's connected sources."""
+    scope's connected sources.
+
+    Listing doubles as the freshness trigger: any stale source in the scope is
+    claimed and enqueued for sync before the listing is built, so the response
+    already shows it as syncing. Both the integration pages and the VFS read
+    through here — accessing your sources is what keeps them fresh."""
     owner_user_id = scope_user_id
     await _require_member(owner_user_id, current_user["id"])
+    for source_id in await source_service.kick_stale_sources(owner_user_id):
+        celery.send_task(
+            "backend.tasks.sources.sync_source",
+            kwargs={"source_id": source_id},
+        )
     return {"sources": await source_service.list_sources(owner_user_id, current_user["id"])}
 
 

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -577,6 +577,39 @@ async def mark_sync_started(source_id: UUID) -> None:
     )
 
 
+# How stale a source may get before merely looking at it triggers a sync.
+# Listing sources IS the access path — integration pages and every VFS read go
+# through GET /me/sources — so freshness rides on usage instead of only the
+# 30-minute schedule.
+ACCESS_KICK_STALE_S = 300
+
+
+async def kick_stale_sources(owner_user_id: UUID) -> list[str]:
+    """Claim the scope's stale, sync-enabled sources for an access-triggered
+    sync; the caller enqueues one sync task per returned id.
+
+    The claim applies mark_sync_started's mutation atomically, so concurrent
+    listings enqueue each source at most once. The updated_at guard is the
+    debounce: every sync start/finish/failure touches updated_at, so a source
+    is kicked at most once per window even when it fails every time.
+    'needs_setup' is excluded — it means the user must act, and re-syncing on
+    read cannot fix it."""
+    rows = await get_pool().fetch(
+        "UPDATE user_sources SET sync_status = 'syncing', sync_error = NULL, "
+        "next_sync_at = now() + (sync_interval_s || ' seconds')::interval, updated_at = now() "
+        "WHERE id IN ("
+        "  SELECT id FROM user_sources "
+        "  WHERE owner_user_id = $1 AND sync_enabled "
+        "  AND sync_status NOT IN ('syncing', 'needs_setup') "
+        "  AND updated_at < now() - ($2 || ' seconds')::interval "
+        "  FOR UPDATE SKIP LOCKED"
+        ") RETURNING id",
+        owner_user_id,
+        str(ACCESS_KICK_STALE_S),
+    )
+    return [str(r["id"]) for r in rows]
+
+
 async def mark_sync_done(source_id: UUID, cursor: str | None) -> None:
     await get_pool().execute(
         "UPDATE user_sources SET sync_status = 'idle', sync_cursor = COALESCE($2, sync_cursor), "

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -4235,3 +4235,80 @@ async def test_source_recipient_cannot_reshare_or_share_write(client: AsyncClien
             permission="write",
             owner_id=owner_id,
         )
+
+
+@pytest.mark.asyncio
+async def test_listing_sources_kicks_stale_syncs(client: AsyncClient, monkeypatch):
+    """GET /me/sources is the freshness trigger: a stale source gets claimed
+    and enqueued as a side effect of looking, exactly once per window — the
+    integration pages and the VFS both read through this endpoint."""
+    from backend.database import get_pool
+
+    key, owner_id = await _register(client, "kick")
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref="acme/kick-repo",
+        display_name="Kick Repo",
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        "backend.routers.sources.celery.send_task",
+        lambda *args, **kwargs: sent.append(kwargs.get("kwargs", {})),
+    )
+
+    # Freshly created: inside the window, listing must not re-kick.
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+    assert resp.status_code == 200
+    assert sent == []
+
+    # Age the row past the access-kick window.
+    await get_pool().execute(
+        "UPDATE user_sources SET updated_at = now() - interval '1 hour', "
+        "last_synced_at = now() - interval '1 hour', sync_status = 'idle' WHERE id = $1",
+        UUID(src["id"]),
+    )
+
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+    assert resp.status_code == 200
+    assert [t["source_id"] for t in sent] == [src["id"]]
+    # The claim happened before the listing was built: the response already
+    # shows the sync in flight.
+    listed = next(s for s in resp.json()["sources"] if s.get("source") == src["id"])
+    assert listed["sync_status"] == "syncing"
+
+    # Immediately listing again must not double-enqueue.
+    sent.clear()
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+    assert resp.status_code == 200
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_needs_setup_sources_are_not_kicked_by_access(client: AsyncClient, monkeypatch):
+    """needs_setup means the user must act; re-syncing on read cannot fix it,
+    so access must not churn those sources."""
+    from backend.database import get_pool
+
+    key, owner_id = await _register(client, "kick2")
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref="acme/setup-repo",
+        display_name="Setup Repo",
+    )
+    await get_pool().execute(
+        "UPDATE user_sources SET updated_at = now() - interval '1 hour', "
+        "sync_status = 'needs_setup' WHERE id = $1",
+        UUID(src["id"]),
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        "backend.routers.sources.celery.send_task",
+        lambda *args, **kwargs: sent.append(kwargs),
+    )
+
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+
+    assert resp.status_code == 200
+    assert sent == []

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -801,18 +801,9 @@ function SourceRow({
         )}
       </button>
       <div className="flex shrink-0 items-center gap-1.5">
-        <div className="flex items-center gap-1.5 opacity-55 transition-opacity group-hover:opacity-100">
-          <button type="button" onClick={onOpen} className={rowButton()}>
-            {open ? "Close" : "Browse"}
-          </button>
-          {syncs && (
-            <button type="button" disabled={busySync} onClick={onSync} className={rowButton()}>
-              {busySync ? "Syncing..." : "Sync"}
-            </button>
-          )}
-        </div>
-        {/* The menu and share dialog live outside the hover-dim group: an open
-            dialog must not inherit the row's hover-dimming. */}
+        {/* Browsing is the row itself (and the VFS); syncing is automatic —
+            scheduled, plus kicked by access when stale. The old Browse/Sync
+            buttons duplicated those, so the escape hatches live in ⋯ now. */}
         <div ref={menuBoundaryRef} className="relative">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -825,6 +816,11 @@ function SourceRow({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-max min-w-28">
+              {syncs && (
+                <DropdownMenuItem disabled={busySync} onClick={onSync}>
+                  {busySync ? "Syncing..." : "Sync now"}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem onClick={() => setShareOpen(true)}>Share</DropdownMenuItem>
               <DropdownMenuItem
                 variant="destructive"
@@ -850,11 +846,6 @@ function SourceRow({
       </div>
     </div>
   );
-}
-
-// The quiet bordered row action (Browse/Sync).
-function rowButton(): string {
-  return "cursor-pointer rounded-lg border border-[var(--color-border)] bg-base px-3 py-1.5 text-[12px] font-semibold text-foreground hover:bg-raised disabled:opacity-60";
 }
 
 function BrowsePanel({


### PR DESCRIPTION
## What

"Why do we have a manual sync button in 2026?" — now we mostly don't.

**Sync-on-access.** `GET /me/sources` is the read behind both the integration pages and every VFS access (`stash vfs`, the /files lens, server-side shell). It now claims any stale, sync-enabled source in the scope and enqueues its sync *before* building the listing — so the response already shows `syncing`. Debounce: one kick per source per 5-minute window (`ACCESS_KICK_STALE_S`), enforced by an atomic claim (`FOR UPDATE SKIP LOCKED` + the same mutation as `mark_sync_started`), so concurrent listings enqueue exactly once and a permanently failing source retries at most every 5 minutes. `needs_setup` sources are excluded — the user must act; re-reading can't fix them. The 30-minute beat schedule stays as the floor for sources nobody looks at.

**Button cleanup.** The per-row **Browse** button duplicated clicking the row name (same handler) and the VFS; it's gone. The per-row **Sync** button is demoted to "Sync now" in the row's ⋯ menu as an escape hatch. Connect stays — OAuth consent can't be automated away. The BrowsePanel itself is untouched (X/Instagram pages use it as their primary content view).

## Notes

- Heavy VFS users effectively pin their sources to ~5-minute freshness; if provider quota ever becomes a concern the window is one constant.
- Screenshot (seeded demo data): https://app.joinstash.ai/f/c6704e99-525e-4a3d-88de-ec318e214f50

## Testing

- New: listing kicks a stale source exactly once per window and the response already shows it syncing; fresh sources and `needs_setup` sources are not kicked.
- Source/VFS backend suites 153/153, frontend 293/293, ruff + eslint clean.
- Verified live: aged the seeded sources, listed them, both flipped to `syncing`; row UI shows name + status + ⋯ (Sync now / Share / Remove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every list/VFS path that hits `GET /me/sources` can enqueue Celery sync work and touch provider quotas; claim logic limits duplicate enqueues but increases background load for active users.
> 
> **Overview**
> **Sync-on-access.** `GET /me/sources` now calls `kick_stale_sources` before building the list: stale, sync-enabled rows in the scope are claimed with the same mutation as `mark_sync_started` (`FOR UPDATE SKIP LOCKED`, 300s `updated_at` debounce), each id is enqueued to `sync_source`, and the response already shows `syncing`. `needs_setup` sources are skipped.
> 
> **UI.** Integration source rows no longer show per-row **Browse** / **Sync**; manual sync moves to **Sync now** under ⋯, reflecting that browsing the row/VFS and listing already drive freshness.
> 
> **Tests.** Coverage for kick-on-stale (once per window, response reflects syncing) and no kick for fresh or `needs_setup` sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b613c46506b24b39a48ec2ee0d534d18aa223d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->