### PR TITLE
The VFS is one tree: the lens docks to a persistent sidebar

### DIFF
--- a/frontend/src/components/content/files-overview/FilesOverview.test.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.test.tsx
@@ -131,10 +131,11 @@ describe("FilesOverview", () => {
     await waitFor(() => expect(screen.getByText("/sources")).toBeTruthy());
 
     // A provider is a real Stash object — its row is a link to the
-    // integration page, not a click-swallowing toggle button.
+    // integration page, not a click-swallowing toggle button. The section
+    // stamp keeps the VFS docked instead of teleporting to Tools.
     hover("/sources");
     const github = screen.getByRole("link", { name: /github/ });
-    expect(github.getAttribute("href")).toBe("/integrations/github");
+    expect(github.getAttribute("href")).toBe("/integrations/github?section=files");
 
     // Folders under /files link to their explorer page the same way.
     hover("/files");

--- a/frontend/src/components/content/files-overview/FilesOverview.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.tsx
@@ -10,32 +10,14 @@
 // real time, and leaving it snaps the tree back flat — a peek, not a mode.
 
 import Link from "next/link";
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowUpRight, Brain, Cable, ChevronRight, FolderTree, GraduationCap, MessagesSquare } from "lucide-react";
-import {
-  getMemoryFolder,
-  getMeOverview,
-  getSidebar,
-  getSourcesTree,
-  listSkills,
-  listTables,
-  type MeOverview,
-  type SourceTreeRoot,
-} from "@/lib/api";
-import { FileIcon, FolderIcon, PageIcon, TableIcon } from "@/components/SkillIcons";
-import { connectorIcon } from "@/components/integrations/connectors";
+import { useRef, useState } from "react";
+import { ArrowUpRight, ChevronRight } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import {
-  buildFilesNodes,
-  buildSessionNodes,
-  buildSkillNodes,
-  buildSourceNodes,
-  type VNode,
-} from "./build";
+import type { VNode } from "./build";
+import { NodeIcon, useVfsMounts, type Mount } from "./useVfsMounts";
 
 const SHOW_PER_DIR = 10;
-const RECENT_SESSIONS = 8;
 const UNFOCUS_DELAY_MS = 250;
 
 /** Cursor position across the gauge bars → depth floor 0-3. */
@@ -46,33 +28,8 @@ function gaugeDepth(e: React.MouseEvent<HTMLDivElement>): number {
   return Math.max(0, Math.min(3, Math.floor(frac * 4)));
 }
 
-interface Mount {
-  path: string;
-  icon: ReactNode;
-  nodes: VNode[];
-  href?: string;
-  /** Rows the API cut off before we ever saw them (sources per-dir cap). */
-  apiHidden?: number;
-  /** Where "+N more" rows we can't expand locally should take the user. */
-  moreHref?: string;
-  footer?: { label: string; href: string };
-  emptyLabel: string;
-}
-
-interface CoreData {
-  filesNodes: VNode[];
-  memoryFolderId: string;
-  memoryNodes: VNode[];
-  sessionNodes: VNode[];
-  skillNodes: VNode[];
-  vitals: MeOverview;
-}
-
 export default function FilesOverview() {
-  const [core, setCore] = useState<CoreData | null>(null);
-  const [coreError, setCoreError] = useState<string | null>(null);
-  const [sources, setSources] = useState<SourceTreeRoot[] | null>(null);
-  const [sourcesError, setSourcesError] = useState<string | null>(null);
+  const { mounts, coreLoaded, coreError, sourcesPending, sourcesError } = useVfsMounts();
 
   // The lens: which mount is bloomed open, and which of its folders the
   // cursor has opened. Hover opens; a chevron click closes; changing mounts
@@ -87,106 +44,6 @@ export default function FilesOverview() {
   const [pinnedDepth, setPinnedDepth] = useState<number | null>(null);
 
   const unfocusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    Promise.all([getSidebar(), listTables(), listSkills(), getMeOverview(), getMemoryFolder()])
-      .then(([sidebar, tables, skills, vitals, memoryFolder]) => {
-        if (cancelled) return;
-        const { files, memory } = buildFilesNodes(sidebar.files, memoryFolder.id, tables.tables);
-        setCore({
-          filesNodes: files,
-          memoryFolderId: memoryFolder.id,
-          memoryNodes: memory,
-          sessionNodes: buildSessionNodes(sidebar.sessions.slice(0, RECENT_SESSIONS)),
-          skillNodes: buildSkillNodes(skills),
-          vitals,
-        });
-      })
-      .catch((e) => { if (!cancelled) setCoreError(e instanceof Error ? e.message : String(e)); });
-    // The sources tree walks every connected source, so it loads on its own
-    // clock — the native mounts render without waiting for it.
-    getSourcesTree()
-      .then((s) => { if (!cancelled) setSources(s); })
-      .catch((e) => { if (!cancelled) setSourcesError(e instanceof Error ? e.message : String(e)); });
-    return () => { cancelled = true; };
-  }, []);
-
-  const mounts = useMemo<Mount[]>(() => {
-    if (!core) return [];
-    const native: Mount[] = [
-      {
-        path: "/files",
-        icon: <FolderTree className="h-4 w-4 text-chart-4" />,
-        nodes: core.filesNodes,
-        emptyLabel: "empty",
-      },
-      {
-        path: "/sessions",
-        icon: <MessagesSquare className="h-4 w-4 text-chart-1" />,
-        nodes: core.sessionNodes,
-        href: "/sessions",
-        footer:
-          core.vitals.sessions > core.sessionNodes.length
-            ? { label: `all ${core.vitals.sessions} sessions`, href: "/sessions" }
-            : undefined,
-        emptyLabel: "no sessions yet",
-      },
-      {
-        path: "/memory",
-        icon: <Brain className="h-4 w-4 text-chart-2" />,
-        nodes: core.memoryNodes,
-        href: `/folders/${core.memoryFolderId}`,
-        emptyLabel: "nothing remembered yet",
-      },
-      {
-        path: "/skills",
-        icon: <GraduationCap className="h-4 w-4 text-chart-3" />,
-        nodes: core.skillNodes,
-        href: "/skills",
-        emptyLabel: "no skills yet",
-      },
-    ];
-    if (sources === null) return native;
-    // One faithful /sources mount, exactly like the VFS: providers are
-    // directories inside it, wearing their brand marks.
-    const providerNodes = sources
-      .map<VNode>((root) => {
-        const provider = root.provider ?? root.source;
-        const { nodes, hiddenCount } = buildSourceNodes(root.tree, `/sources/${provider}`);
-        return {
-          key: `/sources/${provider}`,
-          kind: "folder",
-          name: provider,
-          icon: connectorIcon(provider),
-          href: `/integrations/${provider}`,
-          children: nodes,
-          hiddenCount: hiddenCount || undefined,
-          moreHref: `/integrations/${provider}`,
-        };
-      })
-      // Providers with synced content are what the VFS really materializes,
-      // so they sort ahead of the empty (greyed) ones; alphabetical within
-      // each group.
-      .sort((a, b) => {
-        const aEmpty = a.children!.length === 0 && !a.hiddenCount ? 1 : 0;
-        const bEmpty = b.children!.length === 0 && !b.hiddenCount ? 1 : 0;
-        return aEmpty - bEmpty || a.name.localeCompare(b.name);
-      });
-    return [
-      ...native,
-      {
-        path: "/sources",
-        icon: <Cable className="h-4 w-4 text-chart-1" />,
-        nodes: providerNodes,
-        footer:
-          providerNodes.length === 0
-            ? { label: "connect a source", href: "/settings/integrations" }
-            : undefined,
-        emptyLabel: "no sources connected",
-      },
-    ];
-  }, [core, sources]);
 
   function focusMount(path: string) {
     if (unfocusTimer.current) clearTimeout(unfocusTimer.current);
@@ -232,7 +89,7 @@ export default function FilesOverview() {
   return (
     <div className="h-full overflow-y-auto bg-base">
       <div className="mx-auto max-w-[680px] px-8 pb-16 pt-10" onMouseLeave={onLensLeave}>
-        {core && (
+        {coreLoaded && (
           <div className="mb-8 flex items-start justify-between gap-2.5">
             <div>
               <h1 className="text-[26px] font-semibold tracking-tight text-foreground">Virtual Filesystem</h1>
@@ -273,7 +130,7 @@ export default function FilesOverview() {
             </div>
           </div>
         )}
-        {!core && (
+        {!coreLoaded && (
           <div className="space-y-3 py-1">
             {Array.from({ length: 6 }, (_, i) => (
               <Skeleton key={i} className="h-4" style={{ width: `${90 + (i % 3) * 30}px` }} />
@@ -294,7 +151,7 @@ export default function FilesOverview() {
             onRevealAll={revealAll}
           />
         ))}
-        {core && sources === null && !sourcesError && (
+        {coreLoaded && sourcesPending && (
           <div className="space-y-3 py-2">
             <Skeleton className="h-4 w-32" />
             <Skeleton className="h-4 w-24" />
@@ -395,23 +252,6 @@ function MountBlock({
       )}
     </div>
   );
-}
-
-function NodeIcon({ node, open }: { node: VNode; open: boolean }) {
-  if (node.icon) {
-    return (
-      <span className="flex w-[15px] shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px]">
-        {node.icon}
-      </span>
-    );
-  }
-  const cls = cn("shrink-0", open ? "text-brand-600" : "text-muted-foreground");
-  if (node.kind === "folder") return <span className={cls}><FolderIcon /></span>;
-  if (node.kind === "page") return <span className="shrink-0 text-muted-foreground"><PageIcon /></span>;
-  if (node.kind === "table") return <span className="shrink-0 text-muted-foreground"><TableIcon /></span>;
-  if (node.kind === "session") return <MessagesSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
-  if (node.kind === "skill") return <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
-  return <span className="shrink-0 text-muted-foreground"><FileIcon /></span>;
 }
 
 /** One directory level, tree(1)-style: `├─`/`└─` glyphs with `│` continuation

--- a/frontend/src/components/content/files-overview/build.ts
+++ b/frontend/src/components/content/files-overview/build.ts
@@ -126,12 +126,15 @@ export function buildFilesNodes(
   return { files: childrenOf(null), memory: childrenOf(memoryFolderId) };
 }
 
+// Session and skill hrefs carry ?section=files: these nodes are only rendered
+// by VFS surfaces (the /files lens and the docked tree), and the stamp keeps
+// the VFS docked when one opens instead of teleporting to another section.
 export function buildSessionNodes(sessions: SidebarSession[]): VNode[] {
   return sessions.map((s) => ({
     key: s.session_id,
     kind: "session",
     name: s.title || s.agent_name || "session",
-    href: `/sessions/${s.session_id}`,
+    href: `/sessions/${s.session_id}?section=files`,
     annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
   }));
 }
@@ -141,7 +144,7 @@ export function buildSkillNodes(skills: Skill[]): VNode[] {
     key: s.folder_id,
     kind: "skill",
     name: s.name,
-    href: `/skills/folder/${s.folder_id}`,
+    href: `/skills/folder/${s.folder_id}?section=files`,
     annotation: [
       `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
       s.published ? "published" : null,

--- a/frontend/src/components/content/files-overview/useVfsMounts.tsx
+++ b/frontend/src/components/content/files-overview/useVfsMounts.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+// The one VFS, loaded and shaped once for two surfaces: the full-screen
+// /files lens and the docked sidebar tree render these same mounts, so what
+// you saw full-screen is exactly what appears on the left after you click.
+
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { Brain, Cable, FolderTree, GraduationCap, MessagesSquare } from "lucide-react";
+import {
+  getMemoryFolder,
+  getMeOverview,
+  getSidebar,
+  getSourcesTree,
+  listSkills,
+  listTables,
+  type MeOverview,
+  type SourceTreeRoot,
+} from "@/lib/api";
+import { FileIcon, FolderIcon, PageIcon, TableIcon } from "@/components/SkillIcons";
+import { connectorIcon } from "@/components/integrations/connectors";
+import { cn } from "@/lib/utils";
+import {
+  buildFilesNodes,
+  buildSessionNodes,
+  buildSkillNodes,
+  buildSourceNodes,
+  type VNode,
+} from "./build";
+
+const RECENT_SESSIONS = 8;
+
+export interface Mount {
+  path: string;
+  icon: ReactNode;
+  nodes: VNode[];
+  href?: string;
+  /** Rows the API cut off before we ever saw them (sources per-dir cap). */
+  apiHidden?: number;
+  /** Where "+N more" rows we can't expand locally should take the user. */
+  moreHref?: string;
+  footer?: { label: string; href: string };
+  emptyLabel: string;
+}
+
+interface CoreData {
+  filesNodes: VNode[];
+  memoryFolderId: string;
+  memoryNodes: VNode[];
+  sessionNodes: VNode[];
+  skillNodes: VNode[];
+  vitals: MeOverview;
+}
+
+export function NodeIcon({ node, open }: { node: VNode; open: boolean }) {
+  if (node.icon) {
+    return (
+      <span className="flex w-[15px] shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px]">
+        {node.icon}
+      </span>
+    );
+  }
+  const cls = cn("shrink-0", open ? "text-brand-600" : "text-muted-foreground");
+  if (node.kind === "folder") return <span className={cls}><FolderIcon /></span>;
+  if (node.kind === "page") return <span className="shrink-0 text-muted-foreground"><PageIcon /></span>;
+  if (node.kind === "table") return <span className="shrink-0 text-muted-foreground"><TableIcon /></span>;
+  if (node.kind === "session") return <MessagesSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  if (node.kind === "skill") return <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  return <span className="shrink-0 text-muted-foreground"><FileIcon /></span>;
+}
+
+export function useVfsMounts(): {
+  mounts: Mount[];
+  coreLoaded: boolean;
+  coreError: string | null;
+  sourcesPending: boolean;
+  sourcesError: string | null;
+} {
+  const [core, setCore] = useState<CoreData | null>(null);
+  const [coreError, setCoreError] = useState<string | null>(null);
+  const [sources, setSources] = useState<SourceTreeRoot[] | null>(null);
+  const [sourcesError, setSourcesError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getSidebar(), listTables(), listSkills(), getMeOverview(), getMemoryFolder()])
+      .then(([sidebar, tables, skills, vitals, memoryFolder]) => {
+        if (cancelled) return;
+        const { files, memory } = buildFilesNodes(sidebar.files, memoryFolder.id, tables.tables);
+        setCore({
+          filesNodes: files,
+          memoryFolderId: memoryFolder.id,
+          memoryNodes: memory,
+          sessionNodes: buildSessionNodes(sidebar.sessions.slice(0, RECENT_SESSIONS)),
+          skillNodes: buildSkillNodes(skills),
+          vitals,
+        });
+      })
+      .catch((e) => { if (!cancelled) setCoreError(e instanceof Error ? e.message : String(e)); });
+    // The sources tree walks every connected source, so it loads on its own
+    // clock — the native mounts render without waiting for it.
+    getSourcesTree()
+      .then((s) => { if (!cancelled) setSources(s); })
+      .catch((e) => { if (!cancelled) setSourcesError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const mounts = useMemo<Mount[]>(() => {
+    if (!core) return [];
+    const native: Mount[] = [
+      {
+        path: "/files",
+        icon: <FolderTree className="h-4 w-4 text-chart-4" />,
+        nodes: core.filesNodes,
+        emptyLabel: "empty",
+      },
+      {
+        path: "/sessions",
+        icon: <MessagesSquare className="h-4 w-4 text-chart-1" />,
+        nodes: core.sessionNodes,
+        href: "/sessions",
+        footer:
+          core.vitals.sessions > core.sessionNodes.length
+            ? { label: `all ${core.vitals.sessions} sessions`, href: "/sessions" }
+            : undefined,
+        emptyLabel: "no sessions yet",
+      },
+      {
+        path: "/memory",
+        icon: <Brain className="h-4 w-4 text-chart-2" />,
+        nodes: core.memoryNodes,
+        href: `/folders/${core.memoryFolderId}`,
+        emptyLabel: "nothing remembered yet",
+      },
+      {
+        path: "/skills",
+        icon: <GraduationCap className="h-4 w-4 text-chart-3" />,
+        nodes: core.skillNodes,
+        href: "/skills",
+        emptyLabel: "no skills yet",
+      },
+    ];
+    if (sources === null) return native;
+    // One faithful /sources mount, exactly like the VFS: providers are
+    // directories inside it, wearing their brand marks.
+    const providerNodes = sources
+      .map<VNode>((root) => {
+        const provider = root.provider ?? root.source;
+        const { nodes, hiddenCount } = buildSourceNodes(root.tree, `/sources/${provider}`);
+        return {
+          key: `/sources/${provider}`,
+          kind: "folder",
+          name: provider,
+          icon: connectorIcon(provider),
+          // ?section=files keeps the VFS docked when a provider opens from
+          // either VFS surface, instead of teleporting to the Tools section.
+          href: `/integrations/${provider}?section=files`,
+          children: nodes,
+          hiddenCount: hiddenCount || undefined,
+          moreHref: `/integrations/${provider}?section=files`,
+        };
+      })
+      // Providers with synced content are what the VFS really materializes,
+      // so they sort ahead of the empty (greyed) ones; alphabetical within
+      // each group.
+      .sort((a, b) => {
+        const aEmpty = a.children!.length === 0 && !a.hiddenCount ? 1 : 0;
+        const bEmpty = b.children!.length === 0 && !b.hiddenCount ? 1 : 0;
+        return aEmpty - bEmpty || a.name.localeCompare(b.name);
+      });
+    return [
+      ...native,
+      {
+        path: "/sources",
+        icon: <Cable className="h-4 w-4 text-chart-1" />,
+        nodes: providerNodes,
+        footer:
+          providerNodes.length === 0
+            ? { label: "connect a source", href: "/settings/integrations" }
+            : undefined,
+        emptyLabel: "no sources connected",
+      },
+    ];
+  }, [core, sources]);
+
+  return {
+    mounts,
+    coreLoaded: core !== null,
+    coreError,
+    sourcesPending: sources === null && !sourcesError,
+    sourcesError,
+  };
+}

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -12,6 +12,7 @@ import { CONNECTORS, connectorIcon, providerForSourceType } from "@/components/i
 import { INTEGRATIONS_CHANGED_EVENT, listIntegrations } from "@/lib/integrations";
 import { opensNewTab } from "@/lib/tab-nav";
 import FilesExplorer, { type Item } from "./files-explorer";
+import VfsTree from "./vfs-tree";
 
 export type ExplorerSection = "files" | "sessions" | "skills" | "agents" | "tools" | "computer";
 
@@ -23,16 +24,6 @@ const SECTIONS: { key: ExplorerSection; label: string; route: string; icon: Reac
   { key: "computer", label: "VM", route: "/agents", icon: <Monitor className="h-4 w-4 text-chart-4" /> },
 ];
 const LABEL: Record<ExplorerSection, string> = { files: "Files", skills: "Skills", sessions: "Sessions", tools: "Tools", agents: "Agents", computer: "VM" };
-
-// Shared kinds the Files explorer indexes. Session folders are excluded: the
-// Sessions tree already merges those into its own root.
-const SHARED_FILE_KINDS = new Set(["folder", "page", "file", "table"]);
-const SHARED_ITEM_KIND: Record<string, "folder" | "page" | "file" | "table"> = {
-  folder: "folder",
-  page: "page",
-  file: "file",
-  table: "table",
-};
 
 /** Open any item as a workbench tab and sync the URL. A plain click navigates
  *  the current tab; cmd/ctrl-click (or an explicit newTab) opens a new one. */
@@ -188,6 +179,11 @@ function RootSection() {
   const setRailSection = useWorkspace((s) => s.setRailSection);
 
   function selectSection(section: ExplorerSection) {
+    // Skills/Sessions/Tools have no explorer panel — go to their pages instead.
+    if (section === "skills" || section === "sessions" || section === "tools") {
+      router.push(SECTIONS.find((s) => s.key === section)!.route);
+      return;
+    }
     const params = new URLSearchParams(searchParams);
     params.set("section", section);
     setRailSection(section);
@@ -298,21 +294,6 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
     }));
   }, []);
 
-  // Everything else shared with you. Skill folders are filtered out because
-  // Files and Skills are MECE everywhere else in the app, and a shared skill
-  // belongs under Skills.
-  const sharedFiles = useCallback(async (): Promise<Item[]> => {
-    const [shared, skills] = await Promise.all([listSharedWithMe(), listSkillsSharedWithMe()]);
-    const skillFolderIds = new Set(skills.map((s) => s.folder_id));
-    return shared
-      .filter((s) => SHARED_FILE_KINDS.has(s.object_type) && !skillFolderIds.has(s.object_id))
-      .map((s) => ({
-        kind: SHARED_ITEM_KIND[s.object_type],
-        id: s.object_id,
-        name: `${s.name} (${s.owner_name})`,
-        readOnly: true,
-      }));
-  }, []);
   // A skill needs a name + agent-trigger description, so creation happens in
   // the Skills page's inline composer — this action just takes you there.
   const createSkill = useCallback(async (): Promise<Item | void> => {
@@ -364,8 +345,11 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
 
   if (section === "agents") return <AgentsExplorer />;
 
-  // Files, Skills & Sessions are all file managers (own breadcrumb/toolbar).
-  if ((section === "files" || section === "skills" || section === "sessions") && !atRoot) {
+  // The VFS section docks the same tree the /files lens shows full-screen.
+  if (section === "files") return <VfsTree />;
+
+  // Skills & Sessions are file managers (own breadcrumb/toolbar).
+  if ((section === "skills" || section === "sessions") && !atRoot) {
     const isSessions = section === "sessions";
     return (
       <div className="flex h-full flex-col bg-sidebar">
@@ -382,9 +366,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
           loadFolder={isSessions ? sessionsFolder : undefined}
           // Sessions already merges shared folders into its root — it doesn't
           // get a second shared surface.
-          loadShared={
-            section === "skills" ? sharedSkills : section === "files" ? sharedFiles : undefined
-          }
+          loadShared={section === "skills" ? sharedSkills : undefined}
           newRootItem={
             section === "skills" ? { label: "New skill", run: createSkill } :
             isSessions ? { label: "New folder", run: createSessionFolderItem } : undefined

--- a/frontend/src/components/workspace/persistence.tsx
+++ b/frontend/src/components/workspace/persistence.tsx
@@ -8,7 +8,7 @@ const KEY = "moltchat_workspace";
 /** The layout slice we persist — references + pane arrangement only, no content. */
 type Persisted = Pick<
   WorkspaceState,
-  "tabs" | "paneOf" | "activeTabId" | "activeTab1" | "split" | "focusedPane" | "railSection" | "explorerFolderId"
+  "tabs" | "paneOf" | "activeTabId" | "activeTab1" | "split" | "focusedPane" | "railSection" | "explorerFolderId" | "lastVfsUrl"
 >;
 
 function readPersisted(): Partial<Persisted> | null {
@@ -42,6 +42,7 @@ export default function Persistence() {
         focusedPane: s.focusedPane,
         railSection: s.railSection,
         explorerFolderId: s.explorerFolderId,
+        lastVfsUrl: s.lastVfsUrl,
       };
       localStorage.setItem(KEY, JSON.stringify(slice));
     };

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -106,10 +106,24 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
   const requestedSection = searchParams.get("section");
 
   function selectSection(section: RailSection) {
-    // Home (the memory dashboard) and Files have their own landing pages, so
-    // they navigate; other sections just swap the explorer beside whatever's
-    // open.
-    const LANDING: Partial<Record<RailSection, string>> = { home: "/", files: "/files" };
+    // VFS resumes where the user left off; clicking it while already in the
+    // VFS zooms out to the full-screen lens.
+    if (section === "files") {
+      const filesItem = PRIMARY.find((i) => i.key === "files")!;
+      const alreadyInVfs = requestedSection === "files" || (!requestedSection && filesItem.match(pathname));
+      setRailSection(section);
+      router.replace(alreadyInVfs ? "/files" : useWorkspace.getState().lastVfsUrl ?? "/files");
+      return;
+    }
+    // Every other section with a landing page navigates there. Only Agents
+    // swaps its explorer panel beside whatever's open — Sessions/Skills/Tools
+    // have no panel anymore, so a param swap would do nothing visible.
+    const LANDING: Partial<Record<RailSection, string>> = {
+      home: "/",
+      sessions: "/sessions",
+      skills: "/skills",
+      tools: "/tools",
+    };
     const landing = LANDING[section];
     if (landing) {
       setRailSection(section);

--- a/frontend/src/components/workspace/vfs-tree.tsx
+++ b/frontend/src/components/workspace/vfs-tree.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+// The docked VFS — the same mounts the full-screen /files lens shows, drawn
+// as a persistent VS Code-style tree: the whole filesystem stays visible,
+// folders pin open on click, and whatever the workbench has open is
+// highlighted with its ancestors revealed. It shares the lens's paper
+// background and icons on purpose: clicking an item in the lens should read
+// as that view snapping to the left, not as arriving somewhere new.
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { ArrowUpRight, ChevronRight } from "lucide-react";
+import { create } from "zustand";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { VNode } from "@/components/content/files-overview/build";
+import { NodeIcon, useVfsMounts, type Mount } from "@/components/content/files-overview/useVfsMounts";
+
+const SHOW_PER_DIR = 10;
+const INDENT_PX = 14;
+
+// Expansion lives in a store, not component state: the tree unmounts whenever
+// the user visits a full-screen surface and must come back looking the same.
+// Mounts are open unless collapsed; inner folders are closed unless expanded.
+interface VfsTreeState {
+  expanded: Set<string>;
+  collapsedMounts: Set<string>;
+  toggleNode: (key: string) => void;
+  toggleMount: (path: string) => void;
+  reveal: (mountPath: string, nodeKeys: string[]) => void;
+}
+
+const useVfsTreeStore = create<VfsTreeState>((set) => ({
+  expanded: new Set<string>(),
+  collapsedMounts: new Set<string>(),
+  toggleNode: (key) =>
+    set((s) => {
+      const expanded = new Set(s.expanded);
+      if (expanded.has(key)) expanded.delete(key);
+      else expanded.add(key);
+      return { expanded };
+    }),
+  toggleMount: (path) =>
+    set((s) => {
+      const collapsedMounts = new Set(s.collapsedMounts);
+      if (collapsedMounts.has(path)) collapsedMounts.delete(path);
+      else collapsedMounts.add(path);
+      return { collapsedMounts };
+    }),
+  reveal: (mountPath, nodeKeys) =>
+    set((s) => {
+      const expanded = new Set(s.expanded);
+      nodeKeys.forEach((k) => expanded.add(k));
+      const collapsedMounts = new Set(s.collapsedMounts);
+      collapsedMounts.delete(mountPath);
+      return { expanded, collapsedMounts };
+    }),
+}));
+
+function pathOf(href: string | undefined): string | undefined {
+  return href?.split("?")[0];
+}
+
+/** Keys of every folder above the node whose href matches `pathname`. */
+function ancestorsOf(nodes: VNode[], pathname: string, trail: string[]): string[] | null {
+  for (const node of nodes) {
+    if (pathOf(node.href) === pathname) return trail;
+    if (node.children) {
+      const found = ancestorsOf(node.children, pathname, [...trail, node.key]);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function Row({
+  depth,
+  icon,
+  label,
+  annotation,
+  isDir,
+  isEmptyDir,
+  open,
+  active,
+  href,
+  mono,
+  onToggle,
+}: {
+  depth: number;
+  icon: React.ReactNode;
+  label: string;
+  annotation?: string;
+  isDir: boolean;
+  isEmptyDir?: boolean;
+  open?: boolean;
+  active?: boolean;
+  href?: string;
+  mono?: boolean;
+  onToggle?: () => void;
+}) {
+  const pad = { paddingLeft: 6 + depth * INDENT_PX };
+  const inner = (
+    <>
+      {isDir ? (
+        // Inside a navigating row the chevron keeps toggle duty: label clicks
+        // follow the href, chevron clicks expand/collapse.
+        <span
+          role="button"
+          aria-label={open ? "collapse" : "expand"}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggle?.();
+          }}
+          className="flex h-4 w-4 shrink-0 items-center justify-center"
+        >
+          <ChevronRight
+            className={cn("h-3 w-3 text-muted-foreground transition-transform", open && "rotate-90")}
+          />
+        </span>
+      ) : (
+        <span className="w-4 shrink-0" />
+      )}
+      <span className="flex w-[15px] shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px]">
+        {icon}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-left text-[13px]",
+          mono && "font-mono",
+          isEmptyDir ? "text-muted-foreground" : active ? "text-brand-700" : "text-foreground",
+        )}
+      >
+        {label}
+        {(isDir || isEmptyDir) && !mono && <span className="text-muted-foreground">/</span>}
+      </span>
+      {annotation && (
+        <span className="shrink-0 pl-1.5 font-mono text-[10.5px] text-muted-foreground">{annotation}</span>
+      )}
+    </>
+  );
+  const cls = cn(
+    "group flex w-full items-center gap-1.5 rounded-md py-[3px] pr-1.5",
+    active ? "bg-brand-500/10" : "hover:bg-raised",
+  );
+  if (href) {
+    return (
+      // Navigating into a closed folder also opens it, like VS Code.
+      <Link href={href} style={pad} className={cls} onClick={() => { if (isDir && !open) onToggle?.(); }}>
+        {inner}
+      </Link>
+    );
+  }
+  if (isDir) {
+    return (
+      <button type="button" onClick={onToggle} style={pad} className={cls}>
+        {inner}
+      </button>
+    );
+  }
+  return <div style={pad} className={cn(cls, "hover:bg-transparent")}>{inner}</div>;
+}
+
+function Nodes({
+  nodes,
+  depth,
+  parentKey,
+  apiHidden,
+  moreHref,
+  pathname,
+  showAll,
+  onRevealAll,
+}: {
+  nodes: VNode[];
+  depth: number;
+  parentKey: string;
+  apiHidden?: number;
+  moreHref?: string;
+  pathname: string;
+  showAll: Set<string>;
+  onRevealAll: (key: string) => void;
+}) {
+  const expanded = useVfsTreeStore((s) => s.expanded);
+  const toggleNode = useVfsTreeStore((s) => s.toggleNode);
+  const visible = showAll.has(parentKey) ? nodes : nodes.slice(0, SHOW_PER_DIR);
+  const hidden = nodes.length - visible.length;
+  const pad = { paddingLeft: 6 + depth * INDENT_PX };
+
+  return (
+    <>
+      {visible.map((node) => {
+        const isDir = !!node.children && (node.children.length > 0 || !!node.hiddenCount);
+        const isEmptyDir = !!node.children && !isDir;
+        const open = isDir && expanded.has(node.key);
+        return (
+          <div key={node.key}>
+            <Row
+              depth={depth}
+              icon={<NodeIcon node={node} open={open} />}
+              label={node.name}
+              annotation={node.annotation}
+              isDir={isDir}
+              isEmptyDir={isEmptyDir}
+              open={open}
+              active={pathOf(node.href) === pathname}
+              href={node.href}
+              onToggle={() => toggleNode(node.key)}
+            />
+            {open && (
+              <Nodes
+                nodes={node.children!}
+                depth={depth + 1}
+                parentKey={node.key}
+                apiHidden={node.hiddenCount}
+                moreHref={node.moreHref ?? moreHref}
+                pathname={pathname}
+                showAll={showAll}
+                onRevealAll={onRevealAll}
+              />
+            )}
+          </div>
+        );
+      })}
+      {hidden > 0 && (
+        <button
+          type="button"
+          onClick={() => onRevealAll(parentKey)}
+          style={pad}
+          className="flex w-full items-center gap-1 rounded-md py-1 pl-5 text-left font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+        >
+          … +{hidden} more
+        </button>
+      )}
+      {apiHidden ? (
+        moreHref ? (
+          <Link
+            href={moreHref}
+            style={pad}
+            className="flex w-full items-center gap-1 rounded-md py-1 pl-5 font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+          >
+            … {apiHidden} more synced <ArrowUpRight className="h-3 w-3" />
+          </Link>
+        ) : (
+          <div style={pad} className="flex w-full items-center gap-1 py-1 pl-5 font-mono text-[11.5px] text-muted-foreground">
+            … {apiHidden} more synced
+          </div>
+        )
+      ) : null}
+    </>
+  );
+}
+
+function MountBlock({
+  mount,
+  pathname,
+  showAll,
+  onRevealAll,
+}: {
+  mount: Mount;
+  pathname: string;
+  showAll: Set<string>;
+  onRevealAll: (key: string) => void;
+}) {
+  const collapsedMounts = useVfsTreeStore((s) => s.collapsedMounts);
+  const toggleMount = useVfsTreeStore((s) => s.toggleMount);
+  const open = !collapsedMounts.has(mount.path);
+  // In the lens /files is where you already are; docked, its row is the way
+  // back to the full-screen view.
+  const href = mount.path === "/files" ? "/files" : mount.href;
+  const pad = { paddingLeft: 6 + INDENT_PX };
+
+  return (
+    <div className="pb-1">
+      <Row
+        depth={0}
+        icon={mount.icon}
+        label={mount.path}
+        isDir
+        open={open}
+        active={pathOf(href) === pathname}
+        href={href}
+        mono
+        onToggle={() => toggleMount(mount.path)}
+      />
+      {open && (
+        <>
+          {mount.nodes.length === 0 && !mount.footer ? (
+            <div style={pad} className="py-1 pl-5 font-mono text-[11.5px] italic text-muted-foreground">
+              {mount.emptyLabel}
+            </div>
+          ) : (
+            <Nodes
+              nodes={mount.nodes}
+              depth={1}
+              parentKey={mount.path}
+              apiHidden={mount.apiHidden}
+              moreHref={mount.moreHref}
+              pathname={pathname}
+              showAll={showAll}
+              onRevealAll={onRevealAll}
+            />
+          )}
+          {mount.footer && (
+            <Link
+              href={mount.footer.href}
+              style={pad}
+              className="group flex w-full items-center gap-1 rounded-md py-1 pl-5 font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              {mount.footer.label}
+              <ArrowUpRight className="h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100" />
+            </Link>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function VfsTree() {
+  const pathname = usePathname();
+  const { mounts, coreLoaded, coreError, sourcesPending, sourcesError } = useVfsMounts();
+  const reveal = useVfsTreeStore((s) => s.reveal);
+  const [showAll, setShowAll] = useState<Set<string>>(new Set());
+
+  // Whatever the workbench has open gets its ancestor chain expanded, so the
+  // highlight is always on screen — including right after the lens docks here.
+  useEffect(() => {
+    for (const mount of mounts) {
+      const trail = ancestorsOf(mount.nodes, pathname, []);
+      if (trail) {
+        reveal(mount.path, trail);
+        return;
+      }
+    }
+  }, [pathname, mounts, reveal]);
+
+  if (coreError) {
+    return <div className="p-3 font-mono text-[12px] text-error">✗ couldn&apos;t read the stash: {coreError}</div>;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-base px-1.5 py-2">
+      {!coreLoaded && (
+        <div className="space-y-3 p-2">
+          {Array.from({ length: 6 }, (_, i) => (
+            <Skeleton key={i} className="h-4" style={{ width: `${90 + (i % 3) * 30}px` }} />
+          ))}
+        </div>
+      )}
+      {mounts.map((mount) => (
+        <MountBlock
+          key={mount.path}
+          mount={mount}
+          pathname={pathname}
+          showAll={showAll}
+          onRevealAll={(key) => setShowAll((prev) => new Set(prev).add(key))}
+        />
+      ))}
+      {coreLoaded && sourcesPending && (
+        <div className="space-y-2 p-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      )}
+      {sourcesError && <div className="p-2 font-mono text-[12px] text-error">✗ /sources: {sourcesError}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useWorkspace } from "@/lib/workspace-store";
 import type { User } from "@/lib/types";
 import { Toaster } from "@/components/ui/sonner";
 import Persistence from "./persistence";
@@ -14,6 +15,12 @@ const WIDTH_KEY = "moltchat_explorer_width";
 const MIN_W = 220;
 const MAX_W = 600;
 const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "sessions", "skills", "agents", "tools", "computer"];
+
+// Experiment (2026-08-10): only the VFS keeps the tree sidebar. Sessions,
+// Skills, and Tools render full-width — their explorer was a second nav axis
+// over the same content as the rail, and the two looked independent. Agents
+// (chat list) and the VM (browser) keep panels: that content lives nowhere else.
+const PANELLED_SECTIONS: ExplorerSection[] = ["files", "agents", "computer"];
 
 /** Resizable explorer panel — drag the right edge to set width (persisted). */
 function ExplorerPanel({ section }: { section: ExplorerSection }) {
@@ -118,9 +125,19 @@ export default function WorkspaceShell({
     selectedSection,
     searchParams.get("workspace"),
   );
+  // Remember where the user is inside the VFS, so the rail's VFS button can
+  // bring them back instead of restarting at the bare lens.
+  const setLastVfsUrl = useWorkspace((s) => s.setLastVfsUrl);
+  useEffect(() => {
+    if (section !== "files") return;
+    const query = searchParams.toString();
+    setLastVfsUrl(query ? `${pathname}?${query}` : pathname);
+  }, [section, pathname, searchParams, setLastVfsUrl]);
+
   // /files IS a file tree — showing the explorer's tree beside it would be
   // the same thing twice. An explicit ?section= still summons the panel.
-  const showExplorer = section !== null && !(pathname === "/files" && !selectedSection);
+  const isFilesHome = pathname === "/files" && !selectedSection;
+  const showExplorer = section !== null && PANELLED_SECTIONS.includes(section) && !isFilesHome;
 
   return (
     // Chrome surface — the content panel floats on top of it.
@@ -130,9 +147,9 @@ export default function WorkspaceShell({
       <div className="flex min-h-0 flex-1">
         <Rail user={user} onLogout={onLogout} />
         <div className="min-w-0 flex-1 pb-0">
-          {section && showExplorer ? (
+          {section && !isFilesHome ? (
             <div className="flex h-full">
-              <ExplorerPanel section={section} />
+              {showExplorer && <ExplorerPanel section={section} />}
               {/* Floating content panel: clean white paper, subtly elevated. */}
               <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-tl-2xl border-l border-t border-border bg-base shadow-[-10px_-6px_28px_-16px_rgba(30,25,15,0.10)]">
                 {renderRouteContent ? (

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -38,6 +38,9 @@ export interface WorkspaceState {
   railSection: RailSection;
   /** VFS folder the Files explorer is showing (null = root). */
   explorerFolderId: string | null;
+  /** Last URL visited inside the VFS section — the rail's VFS button returns
+   *  here, so tabbing away and back doesn't restart you at the bare lens. */
+  lastVfsUrl: string | null;
 
   openTab: (kind: TabKind, refId: string, title: string, opts?: { newTab?: boolean }) => void;
   closeTab: (id: string) => void;
@@ -48,6 +51,7 @@ export interface WorkspaceState {
   renameTab: (id: string, title: string) => void;
   setRailSection: (s: RailSection) => void;
   setExplorerFolderId: (id: string | null) => void;
+  setLastVfsUrl: (url: string) => void;
   hydrate: (data: Partial<WorkspaceState>) => void;
 }
 
@@ -76,6 +80,7 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
   focusedPane: 0,
   railSection: "files",
   explorerFolderId: null,
+  lastVfsUrl: null,
 
   openTab: (kind, refId, title, opts) => {
     const s = get();
@@ -156,6 +161,8 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
   setRailSection: (s) => set({ railSection: s }),
 
   setExplorerFolderId: (id) => set({ explorerFolderId: id }),
+
+  setLastVfsUrl: (url) => set({ lastVfsUrl: url }),
 
   hydrate: (data) => set({ ...data }),
 }));


### PR DESCRIPTION
## What this is

A navigation experiment attacking the "two correlated axes" problem from the Aug 8 design audit: the rail sections and the VFS described the same content as two seemingly independent hierarchies, so any click in one teleported you into the other with no way back. This PR commits to one principle: **there is one tree, and every surface is a zoom level on it.**

Putting it up to sit on — draft on purpose.

## What changed

**Only the VFS keeps a tree sidebar.** Sessions, Skills, and Tools render full-width; their rail buttons navigate to their pages. Agents keeps its chat-list panel and the VM its browser (that content lives nowhere else).

**The full-screen `/files` lens docks.** Mount-building is extracted into a shared `useVfsMounts()` hook, and a new `VfsTree` sidebar renders the identical mounts — same data, icons, and paper background. Clicking an item in the lens reads as the view snapping to the left: the same tree appears docked with the item highlighted and its ancestors auto-expanded. It replaces the one-folder-at-a-time `FilesExplorer` for the files section with a persistent VS Code-style tree: whole filesystem visible, folders pin open on click, expansion state survives navigation.

**No more teleporting.** Session/skill/provider links in the VFS carry `?section=files`, so opening a session from the tree keeps the tree docked beside it instead of dumping you into the Sessions section.

**The VFS resumes where you left off.** The shell records your last VFS URL (persisted with the workspace layout, so it survives reloads); the rail's VFS button returns there. Clicking VFS while already in the VFS zooms out to the full-screen lens.

## Verified

Browser-tested as the seeded demo user: lens → click → docked tree with highlight; session opened from the tree stays docked; folder expand-in-place; `/files` mount row un-docks; Sessions → VFS round-trip restores the exact view. 293 vitest tests pass (one updated for the new provider href), tsc and lint clean.

## Known gaps (fine for an experiment, blockers for shipping)

- Sessions/Skills section pages still exist as second homes for the same items — the natural next step is folding them into the tree.
- The VM browser lost its last entry point (the old explorer's Home root). If this sticks it should become a `/computer` mount.
- "Shared with me" is only reachable via the Sessions/Skills sections now (the lens never surfaced it; the old files explorer did).
- The docked tree refetches on re-dock (brief skeleton; sources mount arrives last).
- The sidebar tree is read-only — no upload/new-folder/context-menu file management yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace layout, routing, and URL/query conventions across many entry points; behavior is UX-heavy with known gaps (shared-with-me, refetch on re-dock) but no auth or data-layer changes.
> 
> **Overview**
> Unifies navigation around **one VFS tree** shared by the full-screen `/files` lens and a new docked **`VfsTree`** sidebar. Mount data and icons move into **`useVfsMounts()`** so both surfaces render the same mounts; the lens keeps hover/bloom behavior while the sidebar is a persistent VS Code-style tree with zustand-backed expand/collapse and auto-reveal of the active route.
> 
> **Shell and rail:** Only **Files**, **Agents**, and **VM** keep explorer panels; Sessions, Skills, and Tools go full-width and their rail entries navigate to `/sessions`, `/skills`, `/tools`. The files section swaps **`FilesExplorer`** for **`VfsTree`**. **`?section=files`** is added on session, skill, and integration links from the tree so opening them keeps the VFS docked instead of jumping sections.
> 
> **Resume behavior:** **`lastVfsUrl`** is tracked in the workspace store, persisted in localStorage, updated while in the files section; the rail **VFS** button returns to that URL or opens `/files` when already in the VFS (zoom-out to the lens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949de2c99c86a4e98a9e2f723a250320ed38ae9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->