### PR TITLE
Agents is just Ask the Stash: a ChatGPT-shaped chat page

### DIFF
--- a/frontend/src/app/(app)/agents/page.tsx
+++ b/frontend/src/app/(app)/agents/page.tsx
@@ -1,9 +1,14 @@
-"use client";
+import type { Metadata } from "next";
+import { Suspense } from "react";
 
-// /agents is a workbench route: the workspace shell renders the Agents explorer
-// and the tab workbench instead of this page (see rendersRouteContent). The
-// route only exists so the path resolves; `?resume=` is consumed by the
-// Workbench's URL → tab sync.
+import AgentsChat from "@/components/agents/AgentsChat";
+
+export const metadata: Metadata = { title: "Chat - Stash" };
+
 export default function AgentsPage() {
-  return null;
+  return (
+    <Suspense>
+      <AgentsChat />
+    </Suspense>
+  );
 }

--- a/frontend/src/components/agents/AgentChatView.tsx
+++ b/frontend/src/components/agents/AgentChatView.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ChatPanel from "@/components/agents/ChatPanel";
+import AgentRunsView from "@/components/agents/AgentRunsView";
+import { takeSkillRun } from "@/lib/skill-launch";
+import { getAgent, type Agent } from "@/lib/api";
+
+/** The agentId a conversation ref points at. Only a per-agent ref
+ *  (`agent-<uuid>`) encodes one — stored session ids also start with `agent-`
+ *  (chats mint `agent-<hex>`, runs `agent-curate|sched-…`), so match the full
+ *  uuid shape instead of the prefix. Everything else is a chat-only ref. */
+function agentIdFromRef(refId: string): string | null {
+  const m = refId.match(
+    /^agent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/,
+  );
+  return m ? m[1] : null;
+}
+
+/** One live agent conversation. The refId is `agent-<uuid>` (a named agent),
+ *  a stored sessionId from a deep link, or `new-<nonce>` (the server mints the
+ *  session on turn 1). A chat agent's conversation is its persistent session;
+ *  a scheduled agent's is the runs feed. No config surface — this view is for
+ *  talking to the Stash, nothing else. */
+export default function AgentChatView({
+  refId,
+  onSessionMinted,
+}: {
+  refId: string;
+  /** Fires when the server mints a session for a fresh chat, so the host can
+   *  sync its URL / history list to the now-real conversation. */
+  onSessionMinted?: (id: string) => void;
+}) {
+  const isNew = refId.startsWith("new");
+  const agentId = agentIdFromRef(refId);
+  const [sessionId, setSessionId] = useState<string | null>(isNew ? null : refId);
+  // A skill launched into this view: taken once, so reopening it shows the
+  // conversation rather than running the skill again.
+  const [openingMessage] = useState(() => takeSkillRun(refId));
+  const [agent, setAgent] = useState<Agent | null>(null);
+  useEffect(() => {
+    if (agentId) getAgent(agentId).then(setAgent).catch(() => {});
+  }, [agentId]);
+
+  // A named agent's body waits for the agent row — rendering the chat first
+  // would flash an empty conversation before a scheduled agent's runs load.
+  if (agentId && agent === null) return null;
+  const scheduled = agent !== null && (agent.run_mode === "scheduled" || agent.is_curator);
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col">
+      {scheduled && agentId ? (
+        <AgentRunsView agentId={agentId} />
+      ) : (
+        <ChatPanel
+          sessionId={sessionId}
+          onSessionId={(id) => {
+            setSessionId(id);
+            onSessionMinted?.(id);
+          }}
+          agentId={agentId}
+          openingMessage={openingMessage}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/agents/AgentsChat.tsx
+++ b/frontend/src/components/agents/AgentsChat.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// /agents, ChatGPT-shaped: a sidebar of past chats and one conversation.
+// No tabs, no explorer, no agent roster — this tab exists to ask the Stash,
+// and every chat talks to the default agent. The conversation pane is
+// AgentChatView, the same component stale workbench tabs render.
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { nanoid } from "nanoid";
+import { SquarePen } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { listMySessions, type SessionSummary } from "@/lib/api";
+import { timeAgo } from "@/components/content/files-overview/build";
+import AgentChatView from "./AgentChatView";
+
+// Web chats mint `agent-<32 hex>` session ids; scheduled and curator runs use
+// `agent-sched-…` / `agent-curate-…`, and coding-agent sessions have their own
+// shapes. The id shape is the discriminator the whole agent surface uses.
+const CHAT_SESSION_ID = /^agent-[0-9a-f]{32}$/;
+
+function SideRow({
+  label,
+  annotation,
+  active,
+  onClick,
+}: {
+  label: string;
+  annotation?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px]",
+        active ? "bg-raised font-medium text-foreground" : "text-foreground hover:bg-raised/60",
+      )}
+    >
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {annotation && (
+        <span className="shrink-0 text-[11px] text-muted-foreground">{annotation}</span>
+      )}
+    </button>
+  );
+}
+
+export default function AgentsChat() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // ?chat= selects a conversation (a stored session, a named agent, or a
+  // staged `new-…` skill run); ?resume= is the deep link from a stored
+  // session's "Resume in chat". A bare /agents is a fresh chat.
+  const urlRef = searchParams.get("chat") ?? searchParams.get("resume");
+  const [newRef, setNewRef] = useState(() => `new-${nanoid(5)}`);
+  const selected = urlRef ?? newRef;
+  // When a fresh chat's session is minted mid-stream, the URL flips to the
+  // real id but the mounted view keeps its `new-…` ref — remounting on the
+  // key change would drop the live stream. Cleared on any user selection.
+  const [mintedFrom, setMintedFrom] = useState<{ sessionId: string; ref: string } | null>(null);
+  const viewRef = mintedFrom?.sessionId === selected ? mintedFrom.ref : selected;
+
+  const [chats, setChats] = useState<SessionSummary[] | null>(null);
+
+  const loadChats = useCallback(async () => {
+    const all = await listMySessions(100);
+    setChats(all.filter((s) => CHAT_SESSION_ID.test(s.session_id)));
+  }, []);
+  useEffect(() => {
+    loadChats().catch(() => setChats([]));
+  }, [loadChats]);
+
+  function select(ref: string) {
+    setMintedFrom(null);
+    router.replace(`/agents?chat=${encodeURIComponent(ref)}`);
+  }
+
+  function newChat() {
+    setMintedFrom(null);
+    setNewRef(`new-${nanoid(5)}`);
+    router.replace("/agents");
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      <aside className="flex w-[260px] shrink-0 flex-col border-r border-border bg-surface">
+        <div className="p-2">
+          <button
+            type="button"
+            onClick={newChat}
+            className="flex w-full cursor-pointer items-center gap-2 rounded-lg border border-border bg-base px-3 py-2 text-[13px] font-medium text-foreground hover:bg-raised"
+          >
+            <SquarePen className="h-4 w-4" /> New chat
+          </button>
+        </div>
+        <div className="scroll-thin min-h-0 flex-1 overflow-y-auto px-2 pb-3">
+          <div className="px-2.5 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Chats
+          </div>
+          {chats?.map((s) => (
+            <SideRow
+              key={s.session_id}
+              label={s.title || "Untitled chat"}
+              annotation={timeAgo(s.last_event_at)}
+              active={selected === s.session_id}
+              onClick={() => select(s.session_id)}
+            />
+          ))}
+          {chats !== null && chats.length === 0 && (
+            <div className="px-2.5 py-1.5 text-[12px] text-muted-foreground">No chats yet</div>
+          )}
+        </div>
+      </aside>
+      <main className="min-w-0 flex-1 bg-base">
+        {/* Keyed so switching conversations remounts a clean view. */}
+        <AgentChatView
+          key={viewRef}
+          refId={viewRef}
+          onSessionMinted={(id) => {
+            setMintedFrom({ sessionId: id, ref: viewRef });
+            router.replace(`/agents?chat=${encodeURIComponent(id)}`);
+            void loadChats();
+          }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/agents/ChatPanel.test.tsx
+++ b/frontend/src/components/agents/ChatPanel.test.tsx
@@ -24,15 +24,17 @@ describe("ChatPanel", () => {
     vi.clearAllMocks();
   });
 
-  it("shows setup guidance inside the empty chat state", () => {
+  // The empty state is chat-only: setup/onboarding for local agents lives in
+  // Settings, not in the conversation (it made the chat read as a docs page).
+  it("shows a plain ask-your-agent empty state with no setup guidance", () => {
     render(<ChatPanel sessionId={null} onSessionId={vi.fn()} />);
 
-    expect(screen.getByText("Chat with your agent")).toBeInTheDocument();
-    expect(screen.getByText("Connect your local agent")).toBeInTheDocument();
+    expect(screen.getByText("Ask your agent")).toBeInTheDocument();
+    expect(screen.queryByText("Connect your local agent")).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText("Ask your agent anything...")).toBeInTheDocument();
   });
 
-  it("hides setup guidance after the first message starts a chat", async () => {
+  it("replaces the empty state once the first message starts a chat", async () => {
     const onSessionId = vi.fn();
     render(<ChatPanel sessionId={null} onSessionId={onSessionId} />);
 
@@ -49,7 +51,7 @@ describe("ChatPanel", () => {
       );
     });
     expect(await screen.findByText("Here is what I found.")).toBeInTheDocument();
-    expect(screen.queryByText("Connect your local agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ask your agent")).not.toBeInTheDocument();
     expect(onSessionId).toHaveBeenCalledWith("agent-session-1");
   });
 

--- a/frontend/src/components/agents/ChatPanel.tsx
+++ b/frontend/src/components/agents/ChatPanel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowUp } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -163,10 +164,10 @@ export default function ChatPanel({
   }, [openingMessage, send]);
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col rounded-xl border border-border bg-base">
+    <div className="flex h-full min-h-0 flex-col bg-base">
       <div ref={scrollRef} className="scroll-thin flex-1 space-y-4 overflow-y-auto p-4">
         {messages.length === 0 && !streaming ? (
-          <EmptyChatState onPrompt={(prompt) => void send(prompt)} />
+          <EmptyChatState />
         ) : (
           messages.map((m, i) => <MessageBubble key={i} message={m} />)
         )}
@@ -193,108 +194,27 @@ export default function ChatPanel({
   );
 }
 
-const suggestedPrompts = [
-  "Catch me up on my stash",
-  "What changed recently?",
-  "Find the planning docs",
-];
-
-function EmptyChatState({ onPrompt }: { onPrompt: (prompt: string) => void }) {
+// ChatGPT-plain: a centered title and one line pointing at the primary way to
+// use Stash. The composer below is the whole interface.
+function EmptyChatState() {
   return (
     <div className="flex min-h-full items-center justify-center px-2 py-8">
-      <div className="w-full max-w-3xl">
-        <div className="text-center">
-          <div className="text-[20px] font-semibold text-foreground">
-            Chat with your agent
-          </div>
-          <p className="mx-auto mt-2 max-w-xl text-[13px] leading-5 text-dim">
-            Ask about files, sessions, pages, tables, and connected sources in your stash.
-          </p>
-        </div>
-
-        <div className="mt-5 grid gap-2 sm:grid-cols-3">
-          {suggestedPrompts.map((prompt) => (
-            <button
-              key={prompt}
-              type="button"
-              onClick={() => onPrompt(prompt)}
-              className="min-h-12 cursor-pointer rounded-md border border-border bg-surface px-3 py-2 text-left text-[12.5px] leading-4 text-foreground hover:border-[var(--color-brand-300)] hover:bg-raised"
-            >
-              {prompt}
-            </button>
-          ))}
-        </div>
-
-        <div className="mt-7 border-t border-border pt-5 text-left">
-          <div className="text-[13.5px] font-semibold text-foreground">
-            Connect your local agent
-          </div>
-          <p className="mt-1.5 text-[13px] leading-5 text-dim">
-            Install the CLI when you want Codex, Claude Code, or another coding agent to push
-            sessions into Skill and search your stash directly.
-          </p>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <SetupStep n={1} title="Install the Skill CLI">
-              <Code>{`bash -c "$(curl -fsSL https://joinstash.ai/install)"`}</Code>
-            </SetupStep>
-            <SetupStep n={2} title="Sign in">
-              <Code>stash signin</Code>
-            </SetupStep>
-            <SetupStep n={3} title="Point your agent at Skill">
-              <a
-                className="text-[var(--color-brand-700)] underline"
-                href="https://joinstash.ai/docs/mcp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                MCP setup docs
-              </a>
-            </SetupStep>
-            <SetupStep n={4} title="Use the API directly">
-              <a className="text-[var(--color-brand-700)] underline" href="/settings">
-                Settings
-              </a>
-              <span className="text-dim"> and </span>
-              <a
-                className="text-[var(--color-brand-700)] underline"
-                href="https://joinstash.ai/docs/api"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                API docs
-              </a>
-            </SetupStep>
-          </div>
-        </div>
+      <div className="w-full max-w-2xl text-center">
+        <div className="text-[22px] font-semibold text-foreground">Ask your agent</div>
+        <p className="mx-auto mt-2 max-w-xl text-[13px] leading-5 text-dim">
+          <a
+            href="https://joinstash.ai/docs/mcp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--color-brand-700)] underline"
+          >
+            Click here
+          </a>{" "}
+          to learn how to use Stash directly from your coding agent, like Codex or Claude
+          Code.
+        </p>
       </div>
     </div>
-  );
-}
-
-function SetupStep({
-  n,
-  title,
-  children,
-}: {
-  n: number;
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <div className="text-[12.5px] font-semibold text-foreground">
-        {n}. {title}
-      </div>
-      <div className="mt-1.5 text-[12.5px] text-dim">{children}</div>
-    </div>
-  );
-}
-
-function Code({ children }: { children: string }) {
-  return (
-    <pre className="overflow-x-auto rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[11.5px] text-foreground">
-      {children}
-    </pre>
   );
 }
 
@@ -394,9 +314,10 @@ function Composer({
   onSend: () => void;
   disabled: boolean;
 }) {
+  // ChatGPT-style: one rounded box with the send button living inside it.
   return (
-    <div className="border-t border-border p-3">
-      <div className="flex items-end gap-2">
+    <div className="px-4 pb-4 pt-2">
+      <div className="flex items-end gap-2 rounded-2xl border border-border bg-base px-3 py-2 shadow-sm focus-within:border-brand">
         <textarea
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -409,15 +330,16 @@ function Composer({
           }}
           rows={2}
           placeholder="Ask your agent anything..."
-          className="flex-1 resize-none rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-brand focus:outline-none"
+          className="flex-1 resize-none bg-transparent px-1 py-1 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none"
         />
         <button
           type="button"
+          aria-label="Send"
           onClick={onSend}
           disabled={disabled || !value.trim()}
-          className="cursor-pointer rounded-md bg-brand px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
+          className="mb-0.5 flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full bg-brand text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-40"
         >
-          Send
+          <ArrowUp className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/skill/SkillLauncher.test.tsx
+++ b/frontend/src/components/skill/SkillLauncher.test.tsx
@@ -6,17 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import SkillLauncher from "./SkillLauncher";
 import { takeSkillRun } from "@/lib/skill-launch";
-import { useWorkspace, type WorkspaceState } from "@/lib/workspace-store";
 
 const router = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
-
-const openTab = vi.fn();
-
-vi.mock("@/lib/workspace-store", () => ({
-  useWorkspace: vi.fn(),
-}));
 
 const skill = {
   name: "resurface",
@@ -24,22 +17,15 @@ const skill = {
   when_to_use: "When the user asks what they have forgotten.",
 };
 
-beforeEach(() => {
-  // The launcher reads exactly one slice of the store, so a stub with just
-  // that member is enough to drive it.
-  vi.mocked(useWorkspace).mockImplementation((selector) =>
-    selector({ openTab } as unknown as WorkspaceState),
-  );
-});
-
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-/** The refId the launcher opened its chat tab with. */
-function openedTabRef(): string {
-  return openTab.mock.calls[0][1];
+/** The chat ref the launcher navigated to (/agents?chat=<ref>). */
+function launchedRef(): string {
+  const url = router.push.mock.calls[0][0] as string;
+  return new URLSearchParams(url.split("?")[1]).get("chat")!;
 }
 
 describe("SkillLauncher", () => {
@@ -66,23 +52,19 @@ describe("SkillLauncher", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /Run/ }));
 
-    await waitFor(() => expect(openTab).toHaveBeenCalled());
-    expect(takeSkillRun(openedTabRef())).toBe(
+    await waitFor(() => expect(router.push).toHaveBeenCalled());
+    expect(takeSkillRun(launchedRef())).toBe(
       "Use the resurface skill.\n\nWhat should I revisit?",
     );
-    expect(router.push).toHaveBeenCalledWith("/agents");
   });
 
-  it("opens its own chat per run", async () => {
+  it("opens its own chat per run on the chat page", async () => {
     render(<SkillLauncher skill={skill} onClose={vi.fn()} />);
 
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Go" } });
     fireEvent.click(screen.getByRole("button", { name: /Run/ }));
 
-    await waitFor(() => expect(openTab).toHaveBeenCalled());
-    const [kind, refId, title] = openTab.mock.calls[0];
-    expect(kind).toBe("agent");
-    expect(refId).toMatch(/^new-run-/);
-    expect(title).toBe("Run: resurface");
+    await waitFor(() => expect(router.push).toHaveBeenCalled());
+    expect(router.push.mock.calls[0][0]).toMatch(/^\/agents\?chat=new-run-/);
   });
 });

--- a/frontend/src/components/skill/SkillLauncher.tsx
+++ b/frontend/src/components/skill/SkillLauncher.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Play, X } from "lucide-react";
-import { useWorkspace } from "@/lib/workspace-store";
 import { newRunTabRef, runPrompt, stageSkillRun } from "@/lib/skill-launch";
 import type { LaunchableSkill } from "@/lib/types";
 
@@ -21,7 +20,6 @@ export default function SkillLauncher({
   onClose: () => void;
 }) {
   const router = useRouter();
-  const openTab = useWorkspace((s) => s.openTab);
   const [request, setRequest] = useState("");
 
   useEffect(() => {
@@ -36,8 +34,8 @@ export default function SkillLauncher({
     if (!request.trim()) return;
     const ref = newRunTabRef();
     stageSkillRun(ref, runPrompt(skill.name, request));
-    openTab("agent", ref, `Run: ${skill.name}`);
-    router.push("/agents");
+    // The chat page picks the staged run up off the ?chat= ref and sends it.
+    router.push(`/agents?chat=${encodeURIComponent(ref)}`);
   }
 
   return (

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -115,25 +115,16 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
       router.replace(alreadyInVfs ? "/files" : useWorkspace.getState().lastVfsUrl ?? "/files");
       return;
     }
-    // Every other section with a landing page navigates there. Only Agents
-    // swaps its explorer panel beside whatever's open — Sessions/Skills/Tools
-    // have no panel anymore, so a param swap would do nothing visible.
-    const LANDING: Partial<Record<RailSection, string>> = {
+    // Every other section is a page; the rail is pure navigation.
+    const LANDING: Record<Exclude<RailSection, "files" | "computer">, string> = {
       home: "/",
+      agents: "/agents",
       sessions: "/sessions",
       skills: "/skills",
       tools: "/tools",
     };
-    const landing = LANDING[section];
-    if (landing) {
-      setRailSection(section);
-      router.replace(landing);
-      return;
-    }
-    const params = new URLSearchParams(searchParams);
-    params.set("section", section);
     setRailSection(section);
-    router.replace(`${pathname}?${params.toString()}`);
+    router.replace(LANDING[section as keyof typeof LANDING]);
   }
 
   return (

--- a/frontend/src/components/workspace/tab-body.tsx
+++ b/frontend/src/components/workspace/tab-body.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import PageClient from "@/app/(app)/p/[pageId]/PageClient";
 import FileClient from "@/app/(app)/f/[fileId]/FileClient";
 import TableClient from "@/app/(app)/tables/[tableId]/TableClient";
@@ -8,115 +7,14 @@ import SessionsPage from "@/app/(app)/sessions/page";
 import SessionClient from "@/app/(app)/sessions/[sessionId]/SessionClient";
 import SkillFolderClient from "@/app/(app)/skills/folder/[folderId]/SkillFolderClient";
 import FolderClient from "@/app/(app)/folders/[folderId]/FolderClient";
-import ChatPanel from "@/components/agents/ChatPanel";
-import AgentRunsView from "@/components/agents/AgentRunsView";
+import AgentChatView from "@/components/agents/AgentChatView";
 import IntegrationsSettings from "@/components/integrations/IntegrationsSettings";
 import { IntegrationDetail } from "@/app/(app)/integrations/[provider]/page";
 import { connectorForProvider } from "@/components/integrations/connectors";
 import MachineFileView from "@/components/workspace/machine-file-view";
 import TerminalPanel from "@/components/agents/TerminalPanel";
 import AgentConfigPanel from "@/components/agents/AgentConfigPanel";
-import { takeAgentConfigView } from "@/lib/agent-tab-view";
-import { takeSkillRun } from "@/lib/skill-launch";
-import { getAgent, type Agent } from "@/lib/api";
 import type { WorkbenchTab } from "@/lib/workspace-store";
-
-/** The agentId an agent tab's refId points at. Only a per-agent tab
- *  (`agent-<uuid>`) encodes one — stored session ids also start with `agent-`
- *  (chats mint `agent-<hex>`, runs `agent-curate|sched-…`), so match the full
- *  uuid shape instead of the prefix. Everything else is a chat-only tab. */
-function agentIdFromRef(refId: string): string | null {
-  const m = refId.match(
-    /^agent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/,
-  );
-  return m ? m[1] : null;
-}
-
-function AgentViewSelector({
-  view,
-  chatLabel,
-  onChange,
-}: {
-  view: "chat" | "config";
-  chatLabel: string;
-  onChange: (v: "chat" | "config") => void;
-}) {
-  return (
-    <div className="flex shrink-0 justify-center border-b border-border px-4 py-2">
-      <div className="inline-flex gap-1 rounded-full border border-border bg-surface/60 p-1 shadow-sm">
-        {(["chat", "config"] as const).map((key) => {
-          const active = view === key;
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => onChange(key)}
-              className={
-                "cursor-pointer rounded-full px-3 py-1 text-[12px] leading-none transition-colors " +
-                (active
-                  ? "bg-base font-semibold text-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-raised/70 hover:text-foreground")
-              }
-            >
-              {key === "config" ? "Config" : chatLabel}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/** A live agent tab: the agent's single conversation plus config, switched by
- *  a selector. The refId is `agent-<uuid>` (a named agent), a stored sessionId
- *  from a deep link, or `new-<nonce>` from the tab strip (the server mints the
- *  session on turn 1). A chat agent's conversation is its persistent session;
- *  a scheduled agent's is the runs feed. Panels stay mounted so switching
- *  never drops an in-flight stream. */
-function AgentChatTab({ refId }: { refId: string }) {
-  const isNew = refId.startsWith("new");
-  const agentId = agentIdFromRef(refId);
-  const [sessionId, setSessionId] = useState<string | null>(isNew ? null : refId);
-  // A skill launched into this tab: taken once, so reopening the tab shows the
-  // conversation rather than running the skill again.
-  const [openingMessage] = useState(() => takeSkillRun(refId));
-  const [agent, setAgent] = useState<Agent | null>(null);
-  const [view, setView] = useState<"chat" | "config">(() =>
-    agentId && takeAgentConfigView(agentId) ? "config" : "chat",
-  );
-  useEffect(() => {
-    if (agentId) getAgent(agentId).then(setAgent).catch(() => {});
-  }, [agentId]);
-
-  // A named agent's body waits for the agent row — rendering the chat first
-  // would flash an empty conversation before a scheduled agent's runs load.
-  if (agentId && agent === null) return null;
-  const scheduled = agent !== null && (agent.run_mode === "scheduled" || agent.is_curator);
-  return (
-    <div className="mx-auto flex h-full w-full max-w-3xl flex-col">
-      {agentId && (
-        <AgentViewSelector view={view} chatLabel={scheduled ? "Runs" : "Chat"} onChange={setView} />
-      )}
-      <div className={view === "chat" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-        {scheduled && agentId ? (
-          <AgentRunsView agentId={agentId} />
-        ) : (
-          <ChatPanel
-            sessionId={sessionId}
-            onSessionId={setSessionId}
-            agentId={agentId}
-            openingMessage={openingMessage}
-          />
-        )}
-      </div>
-      {agentId && (
-        <div className={view === "config" ? "min-h-0 flex-1 overflow-y-auto" : "hidden"}>
-          <AgentConfigPanel agentId={agentId} />
-        </div>
-      )}
-    </div>
-  );
-}
 
 /** Renders a tab's content by (kind, refId). Each kind reuses the same client
  *  its permanent route renders, so a tab and a deep link show identical content.
@@ -130,7 +28,7 @@ export default function TabBody({ tab }: { tab: WorkbenchTab }) {
   if (tab.kind === "session") return <SessionClient sessionId={tab.refId} />;
   if (tab.kind === "skill") return <SkillFolderClient folderId={tab.refId} />;
   if (tab.kind === "folder") return <FolderClient folderId={tab.refId} />;
-  if (tab.kind === "agent") return <AgentChatTab refId={tab.refId} />;
+  if (tab.kind === "agent") return <AgentChatView refId={tab.refId} />;
   // Tool + agent-config bodies are plain document flows with no height or
   // scroller of their own, so the tab gives them one (same as AgentChatTab
   // does for the config side of a chat tab).

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -38,10 +38,9 @@ function NewTabMenu() {
     openTab("page", page.id, page.name || "Untitled");
     router.replace(urlForTab({ kind: "page", refId: page.id }));
   }
+  // Chat is not a tab — it lives on the ChatGPT-style /agents page.
   function newChat() {
-    const id = `new-${nanoid(5)}`;
-    openTab("agent", id, "New Chat");
-    router.replace(urlForTab({ kind: "agent", refId: id }));
+    router.push("/agents");
   }
 
   return (
@@ -211,16 +210,12 @@ export default function Workbench() {
   // URL → tab: opening/focusing happens off the pathname only (never off `tabs`),
   // so this can't loop with the imperative router.replace on tab clicks.
   useEffect(() => {
-    // `/agents?resume=<sessionId>` is the "Resume in chat" deep link from a
-    // stored web-chat session.
-    const resume = pathname === "/agents" ? searchParams.get("resume") : null;
-    const match = resume
-      ? { kind: "agent" as const, refId: resume }
-      : pathname === "/sessions" && searchParams.get("workspace") === "1"
+    const match =
+      pathname === "/sessions" && searchParams.get("workspace") === "1"
         ? { kind: "sessions-home" as const, refId: "sessions" }
         : tabFromPath(pathname);
     if (!match) return;
-    const title = match.kind === "agent" ? "Chat" : match.kind === "sessions-home" ? "Sessions" : match.refId;
+    const title = match.kind === "sessions-home" ? "Sessions" : match.refId;
     const existing = useWorkspace.getState().tabs.find((t) => t.kind === match.kind && t.refId === match.refId);
     if (existing) setActiveTab(existing.id);
     // Deep links navigate the current tab — only cmd/ctrl-click and the

--- a/frontend/src/components/workspace/workspace-shell.test.tsx
+++ b/frontend/src/components/workspace/workspace-shell.test.tsx
@@ -19,9 +19,12 @@ describe("rendersRouteContent", () => {
   });
 
   it("workbench sections do not render route content", () => {
-    expect(rendersRouteContent("/agents", null, null)).toBe(false);
     // An opened skill is a tab, not the launcher.
     expect(rendersRouteContent("/skills/folder/abc", null, null)).toBe(false);
+  });
+
+  it("the chat page owns /agents — no workbench there", () => {
+    expect(rendersRouteContent("/agents", null, null)).toBe(true);
   });
 
   it("an explicit explorer section always wins", () => {

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -17,10 +17,11 @@ const MAX_W = 600;
 const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "sessions", "skills", "agents", "tools", "computer"];
 
 // Experiment (2026-08-10): only the VFS keeps the tree sidebar. Sessions,
-// Skills, and Tools render full-width — their explorer was a second nav axis
-// over the same content as the rail, and the two looked independent. Agents
-// (chat list) and the VM (browser) keep panels: that content lives nowhere else.
-const PANELLED_SECTIONS: ExplorerSection[] = ["files", "agents", "computer"];
+// Skills, Tools, and Agents render full-width — the explorers were a second
+// nav axis over the same content as the rail, and the two looked independent.
+// Agents brings its own ChatGPT-style chat list; the VM (browser) keeps its
+// panel because that content lives nowhere else.
+const PANELLED_SECTIONS: ExplorerSection[] = ["files", "computer"];
 
 /** Resizable explorer panel — drag the right edge to set width (persisted). */
 function ExplorerPanel({ section }: { section: ExplorerSection }) {
@@ -95,7 +96,9 @@ export function rendersRouteContent(
   // path: /skills/folder/<id> is a skill you opened, which belongs in a tab.
   if (pathname === "/skills") return true;
   // The MCP-server registry is a management page like /sessions.
-  return pathname === "/tools";
+  if (pathname === "/tools") return true;
+  // /agents is the ChatGPT-style chat page — its own sidebar, no workbench.
+  return pathname === "/agents";
 }
 
 


### PR DESCRIPTION
## What this is

The Agents section rebuilt as the Aug 8 design audit prescribed: *"kill the agents tab, make it a very simple talk-to-stash… like ChatGPT, don't overthink it."* Chat stops being a workbench tab; `/agents` is now a self-contained ChatGPT-shaped page whose only purpose is asking the Stash. Builds on the one-tree navigation work merged in #1004.

## What changed

- **One page, ChatGPT layout.** Sidebar: a New chat button and the history of past web chats (identified by their `agent-<32hex>` session-id shape, so coding-agent sessions and scheduled runs stay out). Main pane: the conversation, deep-linkable via `?chat=`. The URL flips to the real session id when the server mints one, without remounting the streaming view.
- **The surface got emptier on purpose:**
  - No agents explorer panel, no roster — every chat talks to the default agent. The curator is gone from the sidebar (it's infrastructure, not someone to talk to; its runs still surface on Home).
  - No Chat/Config selector. Agent config currently has **no UI entry point** — `AgentConfigPanel` survives in the tree for a future home in Settings.
  - No CLI-setup wall in the empty chat, no suggested-prompt boxes. The empty state is a title and one line linking the coding-agent (MCP) docs.
- **Flows rerouted, not broken.** The conversation body moved out of tab-body into a reusable `AgentChatView` (stale persisted agent tabs still render). The workbench "+ → New chat" and the skill launcher navigate to the chat page — a staged skill run rides the `?chat=` ref and fires exactly once. `/agents?resume=` deep links from stored sessions keep working.

## Verified

Browser-tested: empty state, chat history sidebar, curator deep link (runs feed, no config), skill-run navigation, and the mid-stream URL flip. 294 vitest tests pass (SkillLauncher/shell/ChatPanel tests updated to encode the new intent), tsc and lint clean. No live message sent (the streaming path is untouched; only presentation moved).

## Known consequences (deliberate, but decisions to revisit before shipping)

- Agent creation, agent config, and curator config are UI-unreachable — API/CLI only until they get a home (likely Settings).
- The rail still says "Agents"; the section's actual purpose is now just "Ask the Stash", so a rename ("Chat"/"Ask") is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large navigation and shell routing change for a primary section; streaming path is unchanged but users lose in-app agent config until Settings (or similar) exists. Stale persisted agent tabs may behave differently without config UI.
> 
> **Overview**
> **`/agents` is now a dedicated ChatGPT-style chat page** instead of a workbench tab with an agents explorer. The route renders `AgentsChat`: a sidebar (New chat + web chat history filtered to `agent-<32hex>` ids) and a main pane driven by `?chat=` or `?resume=`, with a **mintedFrom** trick so the URL can update to the real session id mid-stream without remounting the live view.
> 
> Conversation UI is centralized in **`AgentChatView`** (chat vs scheduled/curator runs feed, skill opening messages, `onSessionMinted`). Workbench agent tabs still use it but **without** the old Chat/Config toggle or `AgentConfigPanel` in that flow.
> 
> **`ChatPanel`** is simplified: borderless layout, ChatGPT-style composer (round send), empty state is “Ask your agent” plus an MCP doc link—no suggested prompts or CLI setup wall.
> 
> **Navigation reroutes:** rail **Agents** goes to `/agents`; skill launcher and workbench “New chat” push `/agents` (skills via `?chat=new-run-…`); workbench no longer auto-opens tabs from `/agents?resume=`. Shell treats `/agents` as **full-page route content**, not the tab workbench, and drops agents from **panelled** explorer sections.
> 
> **Deliberate product gap:** agent config/creation have **no UI entry** from this surface anymore (only stale `agent-config` tabs / `AgentConfigPanel` in tree).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efbf2e7078f9574ac8cfc71f1e5583e3ef1c55bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->