### PR TITLE
UI polish: welcome greeting, real octopus logo, Chat last in the rail

### DIFF
--- a/frontend/src/components/SkillIcons.tsx
+++ b/frontend/src/components/SkillIcons.tsx
@@ -66,8 +66,30 @@ export function SkillIcon(props: IconProps) {
   return <LowResOctopusIcon {...props} />;
 }
 
-export function StashIcon(props: IconProps) {
-  return <LowResOctopusIcon {...props} />;
+/** The brand mark — the same octopus as the favicon and the landing page
+ *  (public/octopus.svg), inlined so it sizes with text like every icon here.
+ *  Full-color on purpose: this is the logo, not a themed glyph. */
+export function StashIcon({ className }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={iconClass(className)}
+      width="1em"
+      height="1em"
+      viewBox="0 0 64 72"
+    >
+      <ellipse cx="32" cy="24" rx="22" ry="18" fill="#F97316" />
+      <circle cx="25" cy="22" r="4" fill="#fff" />
+      <circle cx="39" cy="22" r="4" fill="#fff" />
+      <circle cx="26" cy="22" r="2" fill="#0F172A" />
+      <circle cx="40" cy="22" r="2" fill="#0F172A" />
+      <path d="M12 38 Q8 52 4 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M20 40 Q18 54 14 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M32 42 Q32 56 32 64" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M44 40 Q46 54 50 62" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+      <path d="M52 38 Q56 52 60 60" stroke="#F97316" strokeWidth="4" strokeLinecap="round" fill="none" />
+    </svg>
+  );
 }
 
 export function SessionsIcon(props: IconProps) {

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -15,6 +15,7 @@ import CuratorLog from "@/components/memory/CuratorLog";
 import WikiGraph from "@/components/memory/WikiGraph";
 import {
   getEmbeddingProjection,
+  getMe,
   getMemoryGraph,
   listFileActivity,
   type ActivityEvent,
@@ -47,6 +48,11 @@ export default function BrainDashboard() {
   const [graph, setGraph] = useState<WikiGraphData | null>(null);
   const [projectionLoaded, setProjectionLoaded] = useState(false);
   const [graphLoaded, setGraphLoaded] = useState(false);
+  const [firstName, setFirstName] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMe().then((me) => setFirstName(me.display_name.split(" ")[0])).catch(() => {});
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,7 +138,7 @@ export default function BrainDashboard() {
     <div className="h-full min-h-0 overflow-y-auto">
       <div className="mx-auto max-w-[1360px] px-8 pb-10 pt-7">
         <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
-          Home
+          Welcome back{firstName ? `, ${firstName}` : ""}
         </h1>
 
         {/* Dashboard grid: wiki graph with the curator log beneath it on

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -14,18 +14,18 @@ type RailItem = { key: RailSection; label: string; icon: typeof Bot; match: (p: 
 // Primary sections — each opens its own explorer panel (see workspace-shell).
 const PRIMARY: RailItem[] = [
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
-  { key: "agents", label: "Agents", icon: Bot, match: (p) => p.startsWith("/agents") },
   { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
   { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
   { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
   { key: "tools", label: "Tools", icon: Wrench, match: (p) => p.startsWith("/tools") || p.startsWith("/integrations") },
+  { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
 ];
 
-// Home is the memory dashboard, and Agents is a lens over the stash rather
-// than a place in it — the divider falls after them, above the VFS sections.
+// Home is the memory dashboard — the divider separates it from the VFS
+// sections. Chat sits last: it's a lens over the stash, not a place in it.
 // Apps and the VM aren't rail-worthy: Apps lives at /apps, the VM under the
 // explorer's Home root.
-const DIVIDER_AFTER_INDEX = 1;
+const DIVIDER_AFTER_INDEX = 0;
 
 function RailButton({
   item,


### PR DESCRIPTION
Three small follow-ups to the navigation and chat rework (#1004, #1005):

- **Home greets by name.** "Welcome back, Henry" (first word of `display_name`) instead of the bare "Home" heading. Shows just "Welcome back" until the user record loads — no placeholder flash.
- **The topbar wears the real logo.** The brand mark is now the same octopus as the favicon and the landing page (`public/octopus.svg`), inlined into `StashIcon` so it sizes with text. The pixel-art variant stays behind `SkillIcon` on purpose — at 13px on skill rows the detailed mark smears into a blob.
- **The chat section is called Chat and sits last in the rail,** below Tools. It's a lens over the stash, not a place in it, so it moves out of the prime slot; the rail divider now separates Home alone from the stash sections.

Browser-verified (greeting, logo, rail order/label); 294 vitest tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic UI and nav ordering only; optional `getMe()` on the dashboard with silent failure on error.
> 
> **Overview**
> Polishes home, branding, and primary navigation without changing backend behavior.
> 
> The **home dashboard** heading switches from "Home" to **"Welcome back"** with the user's first name once `getMe()` returns; until then it shows only "Welcome back" (no placeholder).
> 
> **`StashIcon`** is no longer the low-res pixel octopus—it inlines the full-color favicon/landing octopus so the **topbar** shows the real brand mark at text size. **`SkillIcon`** still uses the pixel variant for small skill rows.
> 
> In the **workspace rail**, the agents section is labeled **Chat**, moved **below Tools**, and the divider now sits **only under Home** (stash sections grouped together; Chat treated as a lens, not a stash place).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223811cc6f94fa5dc16ad35c0d2450ca4388dec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->