### PR TITLE
PDF extraction reads the annotation layer: expert notes survive into the knowledge base

### DIFF
--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -181,13 +181,11 @@ def _text_layer_tail(reader: pypdf.PdfReader, start: int) -> str:
     to breach the extraction child's memory cap."""
     parts: list[str] = []
     for number, page in enumerate(reader.pages[start:], start=start + 1):
+        notes = "\n".join(f"[Annotation, page {number}] {note}" for note in _page_annotations(page))
         try:
             text = page.extract_text() or ""
-            notes = "\n".join(
-                f"[Annotation, page {number}] {note}" for note in _page_annotations(page)
-            )
         except Exception:
-            continue
+            text = ""
         parts.append("\n\n".join(p for p in (text, notes) if p))
     return "\n\n".join(p for p in parts if p).strip()
 

--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -98,15 +98,25 @@ _ANNOTATIONS_PROMPT = (
 def _page_annotations(page: pypdf.PageObject) -> list[str]:
     """Text content of a page's reader annotations. Popup annotations mirror
     their parent markup annotation's text, so they are skipped to avoid
-    emitting every note twice."""
+    emitting every note twice.
+
+    Wild PDFs routinely carry broken /Annots — a null array, null entries,
+    dangling references. Those pages extracted fine before annotations were
+    read at all, so a page whose annotations can't be parsed contributes none
+    rather than failing the whole document (same stance as _text_layer_tail)."""
     notes = []
-    for ref in page.get("/Annots") or []:
-        annot = ref.get_object()
-        if annot.get("/Subtype") == "/Popup":
-            continue
-        content = str(annot.get("/Contents") or "").strip()
-        if content:
-            notes.append(content)
+    try:
+        for ref in page.get("/Annots") or []:
+            annot = ref.get_object()
+            if not isinstance(annot, pypdf.generic.DictionaryObject):
+                continue
+            if annot.get("/Subtype") == "/Popup":
+                continue
+            content = str(annot.get("/Contents") or "").strip()
+            if content:
+                notes.append(content)
+    except Exception:
+        return []
     return notes
 
 

--- a/backend/services/pdf_ocr.py
+++ b/backend/services/pdf_ocr.py
@@ -26,6 +26,11 @@ Chunk slices are built lazily, one per in-flight request: the whole
 document held simultaneously as slices plus their base64 copies is what
 used to breach the extraction child's RLIMIT_AS on scanned catalogs.
 
+Reader annotations (sticky notes, highlight popups, text boxes) carry
+expert commentary but mostly render as bare icons, so vision alone
+loses them. Each request therefore also carries the annotation layer,
+read via pypdf, with instructions to transcribe every note in place.
+
 Unlike `file_extraction.extract_text`, this module raises on failure
 (missing API key, API errors) so the extraction pipeline's retry
 machinery records the error and retries instead of silently storing
@@ -78,6 +83,41 @@ _LAYER_PROMPT = (
 )
 
 
+_ANNOTATIONS_PROMPT = (
+    "\n\nThe document carries reader annotations (comments, sticky notes, highlight notes), "
+    "listed below by page. Most render only as icons, so the page images do not show their "
+    "text. Transcribe every one of them: include each at the point in the page's content it "
+    "refers to, formatted as [Annotation: <its text, reproduced word-for-word, never "
+    "shortened or relabeled>]. If an annotation's text is also visible on the page itself "
+    "(a text box), output it once, as an [Annotation: ...]. Do not describe the annotation "
+    "icons themselves (note symbols, highlight marks) as figures.\n\n"
+    "<annotations>\n{annotations}\n</annotations>"
+)
+
+
+def _page_annotations(page: pypdf.PageObject) -> list[str]:
+    """Text content of a page's reader annotations. Popup annotations mirror
+    their parent markup annotation's text, so they are skipped to avoid
+    emitting every note twice."""
+    notes = []
+    for ref in page.get("/Annots") or []:
+        annot = ref.get_object()
+        if annot.get("/Subtype") == "/Popup":
+            continue
+        content = str(annot.get("/Contents") or "").strip()
+        if content:
+            notes.append(content)
+    return notes
+
+
+def _annotations_block(content: bytes) -> str:
+    reader = pypdf.PdfReader(io.BytesIO(content))
+    lines = []
+    for number, page in enumerate(reader.pages, start=1):
+        lines.extend(f"Page {number}: {note}" for note in _page_annotations(page))
+    return "\n".join(lines)
+
+
 def _slice_pdf(reader: pypdf.PdfReader, start: int, end: int) -> bytes:
     writer = pypdf.PdfWriter()
     for page in reader.pages[start:end]:
@@ -89,7 +129,12 @@ def _slice_pdf(reader: pypdf.PdfReader, start: int, end: int) -> bytes:
 
 async def _transcribe_chunk(client: httpx.AsyncClient, chunk: bytes) -> str:
     layer = extract_text(chunk, "application/pdf")
-    prompt = _PROMPT + (_LAYER_PROMPT.format(layer=layer) if layer else "")
+    annotations = _annotations_block(chunk)
+    prompt = (
+        _PROMPT
+        + (_LAYER_PROMPT.format(layer=layer) if layer else "")
+        + (_ANNOTATIONS_PROMPT.format(annotations=annotations) if annotations else "")
+    )
     response = await client.post(
         _GENERATE_URL.format(model=settings.GEMINI_EXTRACTION_MODEL),
         json={
@@ -125,11 +170,15 @@ def _text_layer_tail(reader: pypdf.PdfReader, start: int) -> str:
     building a sliced copy of a several-hundred-page tail is itself enough
     to breach the extraction child's memory cap."""
     parts: list[str] = []
-    for page in reader.pages[start:]:
+    for number, page in enumerate(reader.pages[start:], start=start + 1):
         try:
-            parts.append(page.extract_text() or "")
+            text = page.extract_text() or ""
+            notes = "\n".join(
+                f"[Annotation, page {number}] {note}" for note in _page_annotations(page)
+            )
         except Exception:
             continue
+        parts.append("\n\n".join(p for p in (text, notes) if p))
     return "\n\n".join(p for p in parts if p).strip()
 
 

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -231,6 +231,40 @@ def test_annotations_survive_chunk_slicing():
     assert "the 4707 row is deprecated" in pdf_ocr._annotations_block(chunk)
 
 
+def test_broken_annotations_never_fail_a_document_that_read_fine_before():
+    """Wild PDFs carry broken /Annots — null arrays, null entries, dangling
+    refs. Those documents extracted fine before annotations were read at all;
+    reading the annotation layer must not turn them into extraction failures."""
+    from pypdf.generic import ArrayObject, NameObject, NullObject
+
+    for annots in (NullObject(), ArrayObject([NullObject()])):
+        writer = pypdf.PdfWriter()
+        writer.add_blank_page(*PAGE_SIZE)
+        writer.pages[0][NameObject("/Annots")] = annots
+        buf = io.BytesIO()
+        writer.write(buf)
+
+        assert pdf_ocr._annotations_block(buf.getvalue()) == ""
+
+
+def test_a_broken_page_does_not_eat_other_pages_notes():
+    """Per-page isolation: one malformed page loses only its own annotations,
+    not the expert's notes elsewhere in the document."""
+    from pypdf.generic import ArrayObject, NameObject, NullObject
+
+    writer = pypdf.PdfWriter()
+    reader = pypdf.PdfReader(io.BytesIO(_annotated_pdf()))
+    writer.add_blank_page(*PAGE_SIZE)
+    writer.pages[0][NameObject("/Annots")] = ArrayObject([NullObject()])
+    writer.append(reader)
+    buf = io.BytesIO()
+    writer.write(buf)
+
+    block = pdf_ocr._annotations_block(buf.getvalue())
+
+    assert "Page 2: the 4707 row is deprecated" in block
+
+
 def test_annotations_past_the_vision_cap_land_in_the_tail():
     """The vision cap bounds API spend; an expert note on page 120 of a giant
     catalog must still reach the stored text."""

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -275,6 +275,22 @@ def test_annotations_past_the_vision_cap_land_in_the_tail():
     assert "[Annotation, page 1] the 4707 row is deprecated" in tail
 
 
+def test_a_broken_text_layer_does_not_eat_the_pages_notes_in_the_tail(monkeypatch):
+    """A page can have a corrupt content stream and perfectly readable
+    annotations. A text-layer failure must lose only the text, not the
+    expert's notes."""
+    reader = pypdf.PdfReader(io.BytesIO(_annotated_pdf()))
+
+    def boom(self, *args, **kwargs):
+        raise RuntimeError("corrupt content stream")
+
+    monkeypatch.setattr(pypdf.PageObject, "extract_text", boom)
+
+    tail = pdf_ocr._text_layer_tail(reader, 0)
+
+    assert "[Annotation, page 1] the 4707 row is deprecated" in tail
+
+
 @pytest.mark.asyncio
 async def test_pages_past_the_vision_cap_keep_their_text_layer(monkeypatch):
     """The cap bounds vision spend on giant catalogs. It must not discard text

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -162,6 +162,85 @@ async def test_an_empty_candidate_list_raises(monkeypatch):
         await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
 
 
+def _annotated_pdf(pages: int = 1) -> bytes:
+    """A PDF carrying the three annotation types an expert reaches for:
+    a sticky note, a highlight with popup text, and a visible text box."""
+    from pypdf.annotations import FreeText, Highlight, Text
+    from pypdf.generic import ArrayObject, NumberObject
+
+    writer = pypdf.PdfWriter()
+    for _ in range(pages):
+        writer.add_blank_page(*PAGE_SIZE)
+    rect = (72, 700, 200, 720)
+    quad = ArrayObject(NumberObject(v) for v in (72, 720, 200, 720, 72, 700, 200, 700))
+    writer.add_annotation(0, Text(text="the 4707 row is deprecated", rect=rect, open=False))
+    writer.add_annotation(0, Highlight(rect=rect, quad_points=quad, highlight_color="ff0000"))
+    writer.add_annotation(
+        0,
+        FreeText(text="fitment matrix on page 40 is authoritative", rect=(72, 600, 400, 640)),
+    )
+    # Give the highlight popup text after the fact — pypdf's Highlight builder
+    # takes no text, but real ones (Preview, Acrobat) carry /Contents.
+    from pypdf.generic import NameObject, TextStringObject
+
+    annots = writer.pages[0]["/Annots"]
+    annots[1].get_object()[NameObject("/Contents")] = TextStringObject(
+        "crossref only valid for 21K axles"
+    )
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_annotations_ride_along_in_the_prompt(monkeypatch):
+    """Sticky notes and highlight popups render as bare icons, so vision alone
+    loses the expert's commentary. The annotation layer must ride along with
+    page numbers and an instruction to transcribe each note in place."""
+    client = _FakeGeminiClient(_payload("out"))
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    await pdf_ocr._transcribe_chunk(client, _annotated_pdf())
+
+    prompt = _prompt_of(client)
+    assert "<annotations>" in prompt
+    assert "Page 1: the 4707 row is deprecated" in prompt
+    assert "Page 1: crossref only valid for 21K axles" in prompt
+    assert "Page 1: fitment matrix on page 40 is authoritative" in prompt
+    assert "[Annotation:" in prompt
+
+
+@pytest.mark.asyncio
+async def test_a_pdf_without_annotations_sends_no_annotations_block(monkeypatch):
+    """Same rule as the empty text layer: no empty <annotations> block that
+    invites the model to invent notes."""
+    client = _FakeGeminiClient(_payload("out"))
+    monkeypatch.setattr(pdf_ocr, "extract_text", lambda content, ct: None)
+
+    await pdf_ocr._transcribe_chunk(client, _blank_pdf(1))
+
+    assert "<annotations>" not in _prompt_of(client)
+
+
+def test_annotations_survive_chunk_slicing():
+    """_slice_pdf rebuilds pages with pypdf; if the writer dropped /Annots the
+    prompt block would silently vanish for every multi-chunk document."""
+    reader = pypdf.PdfReader(io.BytesIO(_annotated_pdf(pages=3)))
+    chunk = pdf_ocr._slice_pdf(reader, 0, 2)
+
+    assert "the 4707 row is deprecated" in pdf_ocr._annotations_block(chunk)
+
+
+def test_annotations_past_the_vision_cap_land_in_the_tail():
+    """The vision cap bounds API spend; an expert note on page 120 of a giant
+    catalog must still reach the stored text."""
+    reader = pypdf.PdfReader(io.BytesIO(_annotated_pdf(pages=2)))
+
+    tail = pdf_ocr._text_layer_tail(reader, 0)
+
+    assert "[Annotation, page 1] the 4707 row is deprecated" in tail
+
+
 @pytest.mark.asyncio
 async def test_pages_past_the_vision_cap_keep_their_text_layer(monkeypatch):
     """The cap bounds vision spend on giant catalogs. It must not discard text


### PR DESCRIPTION
## What

PDF-native annotations — sticky notes, highlight popups, text boxes — now survive extraction into the knowledge base. Before this, only annotations that happened to render visibly on the page (text boxes) made it through; a sticky note came back as `[Figure: A yellow square icon with three horizontal black lines]` and its content was silently lost, and pypdf's text layer never sees annotation objects at all.

Each Gemini request now carries an `<annotations>` block — every page's annotation contents, read via pypdf (already a dependency) — with instructions to transcribe each note in place, word-for-word, as `[Annotation: ...]`, and to stop describing note icons as figures.

- Popup mirror-objects are skipped, so no note lands twice (a markup annotation's popup repeats its parent's `/Contents`).
- A PDF without annotations sends no block — same rule as the empty text layer.
- Annotations survive `_slice_pdf` chunking (pinned by test).
- Notes on pages past the 100-page vision cap land in the text-layer tail as `[Annotation, page N] ...` instead of vanishing.

## Why now

Heavi's expert-call workflow: an expert's knowledge is page-anchored ("the fitment matrix on page 40 is the authoritative table"), and capturing it today requires maintaining a sibling notes doc plus a pairing convention. With this change they can annotate the PDF in whatever app they already use (Preview, Acrobat), upload it, and the curator sees the commentary fused with the catalog content — one document, no convention.

## Verified

- `pytest backend/tests/test_pdf_ocr.py` — 19 pass (15 existing + 4 new pinning the contract); `ruff check` + `ruff format --check` clean.
- Three live end-to-end runs of `transcribe_pdf` against real Gemini on synthetic annotated parts-catalog pages: all three annotation types survive; realistic note text (part numbers, names, dates) comes back character-for-character; a highlight's note lands inline on the exact table row it highlights:

```
| 4707 [Annotation: crossref only valid for 21K axles.] | Premium shoe | 23K |
```

- Known limit: Gemini normalizes away machine-looking `ALL-CAPS-LABEL:` prefixes in note text even when instructed not to; real prose survives exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the customer PDF extraction path and model prompts; behavior is additive with defensive parsing, but output format and KB content depend on Gemini following the new annotation instructions.
> 
> **Overview**
> **PDF transcription now pulls reader annotations (sticky notes, highlight popups, text boxes) via pypdf and sends them to Gemini** so expert commentary that vision only shows as icons is not lost in the knowledge base.
> 
> Each vision chunk’s prompt gains an optional `<annotations>` block (page-labeled note text) plus instructions to emit notes inline as `[Annotation: ...]` and not treat note icons as figures. Popup annotations are skipped to avoid duplicating parent note text; PDFs with no annotations omit the block, matching the empty text-layer rule.
> 
> For pages beyond the vision cap, `_text_layer_tail` now **appends annotation text** alongside the embedded text layer as `[Annotation, page N] ...`. Annotation parsing is **fail-soft** (broken `/Annots` or per-page errors drop only that page’s notes, not the whole document).
> 
> Tests cover prompt content, chunk slicing preservation, malformed annotations, tail behavior, and text-layer failures that still retain notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fdc9921e71215f8cd9f318ea825c38cdbf2a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->