### PR TITLE
Folder views default to rows; tables visible by default in the list

### DIFF
--- a/frontend/src/components/content/file-browser/FileBrowser.tsx
+++ b/frontend/src/components/content/file-browser/FileBrowser.tsx
@@ -79,7 +79,7 @@ export default function FileBrowser({ folderId, folderHrefBase }: Props) {
   const [rootFiles, setRootFiles] = useState<GridItem[]>([]);
   const [rootTables, setRootTables] = useState<GridItem[]>([]);
   const [allFiles, setAllFiles] = useState<GridItem[]>([]);
-  const [view, setView] = useState<View>("grid");
+  const [view, setView] = useState<View>("list");
   const [scope, setScope] = useState<Scope>("mine");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const pins = useFilePins();

--- a/frontend/src/components/content/file-browser/ItemsList.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.tsx
@@ -98,7 +98,9 @@ const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
 // author (HTML, Markdown). Other file types (PDFs, images, tables) stay hidden
 // until chosen from the Type menu, so uploads don't clutter the default view.
 // `typeFilter === null` means this doc set; ALL_TYPES means show everything.
-const DEFAULT_TYPES = new Set(["Folder", "HTML", "Markdown"]);
+// Tables are first-class residents of the folder tree, so they show by
+// default like documents do.
+const DEFAULT_TYPES = new Set(["Folder", "HTML", "Markdown", "Table"]);
 const ALL_TYPES = "__all__";
 
 function readSort(): Sort {


### PR DESCRIPTION
Folders open in the **List (rows) view** by default instead of Grid. A previously saved view preference still wins — the default only governs first sight.

Making List the default exposed a real bug: the list view's default type filter ("Documents only" — Folder/HTML/Markdown) was silently **hiding tables**. Tables are first-class residents of the folder tree since #1001, so `Table` joins the default-visible types; two existing tests that assert tables show at the root caught this and pass unchanged.

Browser-verified with a cleared preference (folder opens in rows view, tables included); 294 vitest tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI defaults in the file browser with no auth, API, or data-model changes; persisted view preferences are unchanged.
> 
> **Overview**
> **Folders open in List (rows) view by default** instead of Grid. A saved `stash_files_view` preference still applies on load; only users without a stored choice see the new default.
> 
> Because List is now the primary entry point, the list view’s default **“Documents only”** type filter is updated to include **`Table`** alongside Folder, HTML, and Markdown. Standalone tables in the folder tree were previously hidden until “All types” or a specific type was chosen; they now appear in the default list like other first-class folder items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184910c4c0bac78c9e100c662afc3e798bfc313d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->