### PR TITLE
Tools is the integrations page

### DIFF
--- a/frontend/src/app/(app)/tools/page.test.tsx
+++ b/frontend/src/app/(app)/tools/page.test.tsx
@@ -36,6 +36,13 @@ vi.mock("@/lib/api", () => ({
   listMcpServers: vi.fn(),
   createMcpServer: vi.fn(),
   deleteMcpServer: vi.fn(),
+  // The integrations grid above the MCP registry loads these on mount.
+  listSources: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  INTEGRATIONS_CHANGED_EVENT: "integrations-changed",
+  listIntegrations: vi.fn().mockResolvedValue({ providers: [] }),
 }));
 
 const SERVERS: McpServer[] = [

--- a/frontend/src/app/(app)/tools/page.tsx
+++ b/frontend/src/app/(app)/tools/page.tsx
@@ -1,21 +1,117 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Globe, Plus, Terminal, Wrench } from "lucide-react";
+import { Globe, Plus, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   ApiError,
   createMcpServer,
   deleteMcpServer,
   listMcpServers,
+  listSources,
   type McpServer,
+  type Source,
 } from "@/lib/api";
+import {
+  INTEGRATIONS_CHANGED_EVENT,
+  listIntegrations,
+  type IntegrationStatus,
+} from "@/lib/integrations";
+import {
+  CONNECTORS,
+  connectorIcon,
+  providerForSourceType,
+  type Connector,
+} from "@/components/integrations/connectors";
+
+// One row per connector — the standard integrations list. The row is a
+// link: connecting, picking sources, and disconnecting all live on the
+// provider's own page.
+function IntegrationRow({ connector, connected }: { connector: Connector; connected: boolean }) {
+  return (
+    <Link
+      href={`/integrations/${connector.provider}`}
+      className="group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-raised"
+    >
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
+        {connectorIcon(connector.provider)}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-[13.5px] font-semibold text-foreground">{connector.label}</div>
+        <p className="truncate text-[12.5px] text-dim">{connector.blurb}</p>
+      </div>
+      {connected ? (
+        <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-medium text-[var(--color-success)]">
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
+          Connected
+        </span>
+      ) : (
+        <span className="shrink-0 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-brand-700">
+          Connect
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function IntegrationsGrid() {
+  // Extension connectors have no token — source presence is their "connected".
+  // OAuth/api-key connectors use the integration status, so a provider that
+  // was disconnected with its data kept reads "Connect", not "Connected".
+  const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
+  const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
+
+  useEffect(() => {
+    const load = () => {
+      listSources()
+        .then((all) => setSourceProviders(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type))))
+        .catch(() => {});
+      listIntegrations()
+        .then((r) => {
+          const byProvider: Record<string, IntegrationStatus> = {};
+          for (const p of r.providers) byProvider[p.provider] = p;
+          setStatuses(byProvider);
+        })
+        .catch(() => {});
+    };
+    load();
+    window.addEventListener(INTEGRATIONS_CHANGED_EVENT, load);
+    return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
+  }, []);
+
+  if (statuses === null) {
+    return (
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} className="h-[54px] rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  // The server omits providers this user may not use (customer-specific
+  // integrations like Heavi) — extension connectors are always available.
+  const rows = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
+  return (
+    <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
+      {rows.map((c) => (
+        <IntegrationRow
+          key={c.provider}
+          connector={c}
+          connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!statuses[c.provider]?.connected}
+        />
+      ))}
+    </div>
+  );
+}
 
 // One "KEY=VALUE" line per header, parsed at submit time.
 function parseHeaderLines(raw: string): Record<string, string> {
@@ -191,30 +287,47 @@ export default function ToolsPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto flex max-w-2xl flex-col gap-6 p-6">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 py-7">
         <div>
-          <h1 className="flex items-center gap-2 text-base font-semibold">
-            <Wrench className="h-4 w-4" />
+          <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
             Tools
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            MCP servers registered here are available to your cloud agent, and installable locally
-            with <code className="text-xs">stash tools install</code>.
+            Everything your agent can reach — connected sources and MCP servers.
           </p>
         </div>
 
-        {servers !== null && servers.length === 0 && (
-          <p className="text-sm text-muted-foreground">No MCP servers yet — add one below.</p>
-        )}
-        {servers !== null && servers.length > 0 && (
-          <ul className="flex flex-col gap-2">
-            {servers.map((s) => (
-              <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
-            ))}
-          </ul>
-        )}
+        <section>
+          <h2 className="text-[15px] font-semibold text-foreground">Integrations</h2>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">
+            Connect accounts and choose what your agent can read. Click one to connect or manage
+            it.
+          </p>
+          <div className="mt-4">
+            <IntegrationsGrid />
+          </div>
+        </section>
 
-        <AddServerForm onAdded={() => void refresh()} />
+        <section>
+          <h2 className="text-[15px] font-semibold text-foreground">MCP servers</h2>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">
+            Available to your cloud agent, and installable locally with{" "}
+            <code className="text-xs">stash tools install</code>.
+          </p>
+          <div className="mt-4 flex flex-col gap-3">
+            {servers !== null && servers.length === 0 && (
+              <p className="text-sm text-muted-foreground">No MCP servers yet — add one below.</p>
+            )}
+            {servers !== null && servers.length > 0 && (
+              <ul className="flex flex-col gap-2">
+                {servers.map((s) => (
+                  <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
+                ))}
+              </ul>
+            )}
+            <AddServerForm onAdded={() => void refresh()} />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/tools/page.tsx
+++ b/frontend/src/app/(app)/tools/page.tsx
@@ -23,6 +23,7 @@ import {
 import {
   INTEGRATIONS_CHANGED_EVENT,
   listIntegrations,
+  startConnect,
   type IntegrationStatus,
 } from "@/lib/integrations";
 import {
@@ -31,11 +32,24 @@ import {
   providerForSourceType,
   type Connector,
 } from "@/components/integrations/connectors";
+import PaywallModal from "@/components/PaywallModal";
 
-// One row per connector — the standard integrations list. The row is a
-// link: connecting, picking sources, and disconnecting all live on the
-// provider's own page.
-function IntegrationRow({ connector, connected }: { connector: Connector; connected: boolean }) {
+// One row per connector — the standard integrations list. The row is a link
+// to the provider's page (manage, pick sources, disconnect). For OAuth
+// providers the Connect button skips the page and goes straight to the
+// consent screen, returning here; api-key and extension providers still
+// route through their page (credential form / extension install).
+function IntegrationRow({
+  connector,
+  connected,
+  busy,
+  onOauthConnect,
+}: {
+  connector: Connector;
+  connected: boolean;
+  busy: boolean;
+  onOauthConnect: (() => void) | null;
+}) {
   return (
     <Link
       href={`/integrations/${connector.provider}`}
@@ -53,6 +67,19 @@ function IntegrationRow({ connector, connected }: { connector: Connector; connec
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
           Connected
         </span>
+      ) : onOauthConnect ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOauthConnect();
+          }}
+          disabled={busy}
+          className="shrink-0 cursor-pointer text-[12px] font-medium text-muted-foreground transition-colors hover:text-brand-700 disabled:cursor-not-allowed"
+        >
+          {busy ? "Connecting…" : "Connect"}
+        </button>
       ) : (
         <span className="shrink-0 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-brand-700">
           Connect
@@ -68,6 +95,22 @@ function IntegrationsGrid() {
   // was disconnected with its data kept reads "Connect", not "Connected".
   const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [paywalled, setPaywalled] = useState(false);
+
+  // Straight to the consent screen; the OAuth flow returns to /tools, where
+  // the row reads Connected. No successful-return path resets `busy` — the
+  // whole page navigates away.
+  async function connectNow(connector: Connector) {
+    setBusy(connector.provider);
+    try {
+      await startConnect(connector.provider, "/tools");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
+      else toast.error(e instanceof Error ? e.message : "Could not start connection");
+      setBusy(null);
+    }
+  }
 
   useEffect(() => {
     const load = () => {
@@ -102,13 +145,21 @@ function IntegrationsGrid() {
   const rows = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
   return (
     <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-      {rows.map((c) => (
-        <IntegrationRow
-          key={c.provider}
-          connector={c}
-          connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!statuses[c.provider]?.connected}
-        />
-      ))}
+      {rows.map((c) => {
+        const status = statuses[c.provider];
+        const oauth =
+          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
+        return (
+          <IntegrationRow
+            key={c.provider}
+            connector={c}
+            connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!status?.connected}
+            busy={busy === c.provider}
+            onOauthConnect={oauth ? () => void connectNow(c) : null}
+          />
+        );
+      })}
+      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
     </div>
   );
 }

--- a/frontend/src/components/skill/SkillLauncher.test.tsx
+++ b/frontend/src/components/skill/SkillLauncher.test.tsx
@@ -2,7 +2,7 @@
 // agent, and what does not: a skill only reaches the launcher once it is in
 // your Skills, so a run must never install anything.
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import SkillLauncher from "./SkillLauncher";
 import { takeSkillRun } from "@/lib/skill-launch";

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { nanoid } from "nanoid";
 import { X, SplitSquareHorizontal, PanelRightClose, Plus, Bot, Plug, FileText } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";


### PR DESCRIPTION
The Tools section becomes what every SaaS has: **the integrations page**. Previously /tools was only the MCP-server registry, and with the tools explorer gone (#1005) there was no surface listing connectable providers at all.

## What changed

- **/tools is a full-width page with an Integrations row list** — one row per connector (brand icon, name, blurb) with a Connect / green-dot Connected state on the right. Rows link to the provider's existing page, where connect, source-picking, and disconnect already live — no duplicated OAuth logic.
- **Connected-state semantics match the old tools explorer**: extension providers (X, Instagram) count as connected when a pushed source exists; OAuth/api-key providers use integration status, so a provider disconnected with its data kept honestly reads "Connect". Providers the server hides for this user (customer-specific ones) don't render.
- **The MCP-server registry is unchanged functionally** and moves into a section below the list.
- Drive-by: removes two unused imports left behind by #1005 (caught by lint).

## Verified

Browser-tested as the demo user: 12-connector row list with status states, MCP section with add-server form intact below. 294 vitest tests pass (the tools page tests now mock the integrations APIs the grid loads), tsc clean, lint back to its 6 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UI that reuses existing integration/OAuth helpers and provider pages; no auth or API contract changes beyond mounting list calls on /tools.
> 
> **Overview**
> **Tools** becomes the main place to see what the agent can reach: a new **Integrations** section lists connectors (icon, name, blurb, Connect / Connected) above the unchanged **MCP servers** block.
> 
> The list loads `listIntegrations` and `listSources`, refreshes on `integrations-changed`, and filters to server-visible providers plus extension connectors. **Connected** follows prior explorer rules: extension providers when a pushed source exists; OAuth/api-key from integration status (disconnected-but-data-kept stays Connect). Rows link to `/integrations/{provider}`; OAuth rows can call **`startConnect`** inline (return to `/tools`) with **402 → PaywallModal**; api-key/extension still go through their provider pages. Layout widens (`max-w-5xl`) and copy is updated accordingly.
> 
> Tests mock the new APIs on mount. Minor cleanup: unused imports in `SkillLauncher.test.tsx` and `workbench.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb71945224bdd05b7663b2ef958b5c7a479213b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->