### PR TITLE
Connect goes straight to the OAuth consent screen

### DIFF
--- a/frontend/src/app/(app)/tools/page.tsx
+++ b/frontend/src/app/(app)/tools/page.tsx
@@ -23,6 +23,7 @@ import {
 import {
   INTEGRATIONS_CHANGED_EVENT,
   listIntegrations,
+  startConnect,
   type IntegrationStatus,
 } from "@/lib/integrations";
 import {
@@ -31,11 +32,24 @@ import {
   providerForSourceType,
   type Connector,
 } from "@/components/integrations/connectors";
+import PaywallModal from "@/components/PaywallModal";
 
-// One row per connector — the standard integrations list. The row is a
-// link: connecting, picking sources, and disconnecting all live on the
-// provider's own page.
-function IntegrationRow({ connector, connected }: { connector: Connector; connected: boolean }) {
+// One row per connector — the standard integrations list. The row is a link
+// to the provider's page (manage, pick sources, disconnect). For OAuth
+// providers the Connect button skips the page and goes straight to the
+// consent screen, returning here; api-key and extension providers still
+// route through their page (credential form / extension install).
+function IntegrationRow({
+  connector,
+  connected,
+  busy,
+  onOauthConnect,
+}: {
+  connector: Connector;
+  connected: boolean;
+  busy: boolean;
+  onOauthConnect: (() => void) | null;
+}) {
   return (
     <Link
       href={`/integrations/${connector.provider}`}
@@ -53,6 +67,19 @@ function IntegrationRow({ connector, connected }: { connector: Connector; connec
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
           Connected
         </span>
+      ) : onOauthConnect ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOauthConnect();
+          }}
+          disabled={busy}
+          className="shrink-0 cursor-pointer text-[12px] font-medium text-muted-foreground transition-colors hover:text-brand-700 disabled:cursor-not-allowed"
+        >
+          {busy ? "Connecting…" : "Connect"}
+        </button>
       ) : (
         <span className="shrink-0 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-brand-700">
           Connect
@@ -68,6 +95,22 @@ function IntegrationsGrid() {
   // was disconnected with its data kept reads "Connect", not "Connected".
   const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [paywalled, setPaywalled] = useState(false);
+
+  // Straight to the consent screen; the OAuth flow returns to /tools, where
+  // the row reads Connected. No successful-return path resets `busy` — the
+  // whole page navigates away.
+  async function connectNow(connector: Connector) {
+    setBusy(connector.provider);
+    try {
+      await startConnect(connector.provider, "/tools");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
+      else toast.error(e instanceof Error ? e.message : "Could not start connection");
+      setBusy(null);
+    }
+  }
 
   useEffect(() => {
     const load = () => {
@@ -102,13 +145,21 @@ function IntegrationsGrid() {
   const rows = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
   return (
     <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-      {rows.map((c) => (
-        <IntegrationRow
-          key={c.provider}
-          connector={c}
-          connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!statuses[c.provider]?.connected}
-        />
-      ))}
+      {rows.map((c) => {
+        const status = statuses[c.provider];
+        const oauth =
+          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
+        return (
+          <IntegrationRow
+            key={c.provider}
+            connector={c}
+            connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!status?.connected}
+            busy={busy === c.provider}
+            onOauthConnect={oauth ? () => void connectNow(c) : null}
+          />
+        );
+      })}
+      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
Stacked on #1009. The Connect affordance on the Tools integrations rows stops being a link to the provider page and becomes the real thing: for OAuth providers it calls `startConnect` directly, lands on the consent screen, and the flow returns to `/tools` with the row reading Connected.

- **Same quiet design** — the plain "Connect" text (brand on hover), no loud button; it just acts one click sooner. Shows "Connecting…" while the redirect is in flight.
- **Only where a straight jump is honest**: API-key providers (need a credential form) and extension providers (need the browser extension) keep routing to their page, as do server-disabled providers. Row click still opens the provider page for managing/picking sources either way.
- **Failure paths**: a 402 opens the paywall modal; other errors toast and re-enable the button.

Verified live: the direct flow was exercised end-to-end in the dev browser (GitHub row flipped to Connected on return). 294 vitest tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX on the Tools integrations list; reuses existing `startConnect` and paywall handling with no auth or data-model changes.
> 
> **Overview**
> On **Tools → Integrations**, disconnected **OAuth** providers no longer require a detour through the provider page to connect. The row still links to `/integrations/{provider}` for manage/pick sources, but the **Connect** affordance is now a button that calls `startConnect(provider, "/tools")` and sends the user straight to the OAuth consent screen; after return, the row should show **Connected**.
> 
> **API-key**, **browser extension**, and **server-disabled** connectors are unchanged: **Connect** stays a visual hint on the link (credential form / extension install / disabled still live on the provider page). While redirect is pending, the button shows **Connecting…** and is disabled.
> 
> Errors mirror the provider page pattern: **402** opens `PaywallModal`; other failures toast and clear busy state so the user can retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4121bad927d032e01c91da1c451f9afe9996d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->