### PR TITLE
First-run cleanup: empty Home is one instruction, login drops its slogan

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -213,11 +213,7 @@ function LoginPageInner() {
   return (
     <AuthShell
       title={mode === "login" ? signInTitle() : "Create your stash"}
-      subtitle={
-        mode === "login"
-          ? "Sign in to the stash you share with your agents."
-          : "One account for you and your agents."
-      }
+      subtitle={mode === "login" ? undefined : "One account for you and your agents."}
     >
       <FormCard>{formBody}</FormCard>
       <p className="text-center text-[11px] text-muted-foreground">
@@ -361,10 +357,7 @@ function Auth0LoginPanel({ user, logout, cliSession, onCliApproved }: Auth0Panel
   }
 
   return (
-    <AuthShell
-      title={signInTitle()}
-      subtitle="Sign in to the stash you share with your agents."
-    >
+    <AuthShell title={signInTitle()}>
       <FormCard>{body}</FormCard>
     </AuthShell>
   );
@@ -402,7 +395,7 @@ function AuthShell({
   children,
 }: {
   title: string;
-  subtitle: string;
+  subtitle?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -415,7 +408,7 @@ function AuthShell({
             <h1 className="font-display text-[32px] leading-[1.05] font-bold tracking-tight text-foreground">
               {title}
             </h1>
-            <p className="text-sm text-dim">{subtitle}</p>
+            {subtitle && <p className="text-sm text-dim">{subtitle}</p>}
           </div>
           {children}
         </div>

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -13,12 +13,16 @@ import { FileIcon, PageIcon } from "@/components/SkillIcons";
 import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
 import CuratorLog from "@/components/memory/CuratorLog";
 import WikiGraph from "@/components/memory/WikiGraph";
+import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+import { StashIcon } from "@/components/SkillIcons";
 import {
   getEmbeddingProjection,
   getMe,
+  getMeOverview,
   getMemoryGraph,
   listFileActivity,
   type ActivityEvent,
+  type MeOverview,
   type WikiGraph as WikiGraphData,
 } from "@/lib/api";
 import type { EmbeddingProjection } from "@/lib/types";
@@ -49,9 +53,15 @@ export default function BrainDashboard() {
   const [projectionLoaded, setProjectionLoaded] = useState(false);
   const [graphLoaded, setGraphLoaded] = useState(false);
   const [firstName, setFirstName] = useState<string | null>(null);
+  const [vitals, setVitals] = useState<MeOverview | null>(null);
+  const [vitalsLoaded, setVitalsLoaded] = useState(false);
 
   useEffect(() => {
     getMe().then((me) => setFirstName(me.display_name.split(" ")[0])).catch(() => {});
+    getMeOverview()
+      .then(setVitals)
+      .catch(() => {})
+      .finally(() => setVitalsLoaded(true));
   }, []);
 
   useEffect(() => {
@@ -126,7 +136,13 @@ export default function BrainDashboard() {
     };
   }, []);
 
-  if (fetching) {
+  // A brand-new stash has nothing to dashboard. Until the first transcripts
+  // arrive, Home is a single instruction: upload your agent transcripts.
+  if (vitalsLoaded && vitals && vitals.pages === 0 && vitals.files === 0 && vitals.sessions === 0) {
+    return <EmptyStashSetup />;
+  }
+
+  if (fetching || !vitalsLoaded) {
     return (
       <div className="h-full min-h-0 overflow-y-auto">
         <ActivitySkeleton />
@@ -304,4 +320,33 @@ function EventGlyph({ kind }: { kind: string }) {
       </span>
     );
   return null;
+}
+
+/** Full-screen first-run state: one instruction, upload your agent
+ *  transcripts. Everything else Home shows grows out of those. */
+function EmptyStashSetup() {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto">
+      <div className="w-full max-w-xl px-8 py-10 text-center">
+        <StashIcon className="mx-auto text-[44px]" />
+        <h1 className="mt-5 font-display text-[26px] font-semibold tracking-tight text-foreground">
+          Upload your agent transcripts
+        </h1>
+        <p className="mx-auto mt-2 max-w-md text-[14px] leading-6 text-dim">
+          Stash is memory for you and your agents, and it starts with your coding sessions.
+          Install the CLI and sign in — after that, sessions from Claude Code, Codex, and
+          friends stream in on their own.
+        </p>
+        <div className="mx-auto mt-6 max-w-md text-left">
+          <CopyableCommandBlock
+            commands={`bash -c "$(curl -fsSL https://joinstash.ai/install)"\nstash signin`}
+          />
+        </div>
+        <p className="mt-4 text-[12.5px] text-muted-foreground">
+          Then use your coding agent like you always do. This page becomes your agents&apos;
+          shared memory as transcripts arrive.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -337,13 +337,14 @@ function EmptyStashSetup() {
           and you can choose which folders transcripts are uploaded from.
         </p>
         <div className="mx-auto mt-6 max-w-md text-left">
-          <CopyableCommandBlock
-            commands={`bash -c "$(curl -fsSL https://joinstash.ai/install)"\nstash signin`}
-          />
+          {/* One command on purpose: the installer ends by exec'ing
+              `stash signin`, which runs the whole setup wizard. */}
+          <CopyableCommandBlock commands={`bash -c "$(curl -fsSL https://joinstash.ai/install)"`} />
         </div>
         <p className="mt-4 text-[12.5px] text-muted-foreground">
-          Then use your coding agent like you always do. This page becomes your agents&apos;
-          shared memory as transcripts arrive.
+          The installer signs you in and sets up session recording. Then use your coding
+          agent like you always do — this page becomes your agents&apos; shared memory as
+          transcripts arrive.
         </p>
       </div>
     </div>

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -330,12 +330,11 @@ function EmptyStashSetup() {
       <div className="w-full max-w-xl px-8 py-10 text-center">
         <StashIcon className="mx-auto text-[44px]" />
         <h1 className="mt-5 font-display text-[26px] font-semibold tracking-tight text-foreground">
-          Upload your agent transcripts
+          Let&apos;s get you started
         </h1>
         <p className="mx-auto mt-2 max-w-md text-[14px] leading-6 text-dim">
-          Stash is memory for you and your agents, and it starts with your coding sessions.
-          Install the CLI and sign in — after that, sessions from Claude Code, Codex, and
-          friends stream in on their own.
+          Upload your session transcripts to get started. Transcripts are private to you,
+          and you can choose which folders transcripts are uploaded from.
         </p>
         <div className="mx-auto mt-6 max-w-md text-left">
           <CopyableCommandBlock


### PR DESCRIPTION
Two first-run fixes from today's onboarding pass:

- **Empty stash ⇒ Home is a full-screen setup state.** When vitals report zero pages, files, and sessions, the memory dashboard gives way to a single instruction: **Upload your agent transcripts** — octopus mark, one sentence, a copyable block with the CLI install + `stash signin`, and a note that the page becomes the agents' shared memory as transcripts arrive. First upload flips Home back to the dashboard (with the Welcome-back greeting).
- **The sign-in page loses its slogan.** "Sign in to the stash you share with your agents." is gone from both the dev-auth and Auth0 variants — it explained nothing to new users. Register mode keeps "One account for you and your agents."

Verified with a genuinely fresh account on the local stack: register → onboarding wizard fires → skip → Home shows the setup screen; the seeded demo user (non-empty stash) still gets the dashboard. 294 vitest tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding and copy changes with no auth or data-path changes; empty-state gating depends on vitals API accuracy.
> 
> **Overview**
> **Home** now loads stash vitals via `getMeOverview` and, when pages, files, and sessions are all zero, replaces the memory dashboard with a centered **EmptyStashSetup** screen: short copy, a copyable install command, and a note that the page fills in as transcripts arrive. Once anything exists in the stash, Home behaves as before (including the welcome-back dashboard).
> 
> **Login** removes *"Sign in to the stash you share with your agents."* from dev-auth and Auth0 sign-in flows. `AuthShell` treats `subtitle` as optional and only renders it when set; **register** still shows *"One account for you and your agents."*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c24a4bcc7b2ae288a6105de7174c0abab80064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->