### PR TITLE
Files page: drag a file from the OS to upload it

### DIFF
--- a/frontend/src/components/content/file-browser/FileBrowser.test.tsx
+++ b/frontend/src/components/content/file-browser/FileBrowser.test.tsx
@@ -217,3 +217,50 @@ describe("FileBrowser table creation", () => {
   });
 });
 
+
+describe("FileBrowser OS-file drop upload", () => {
+  function dropEvent(types: string[], files: File[] = []) {
+    return {
+      dataTransfer: { types, files, dropEffect: "none" },
+    };
+  }
+
+  it("uploads files dropped from the OS into the current view", async () => {
+    const { uploadFileOrPage } = await import("../../../lib/api");
+    vi.mocked(uploadFileOrPage).mockResolvedValue({
+      kind: "file",
+      file: { id: "file-1" },
+    } as never);
+
+    const { container } = render(<FileBrowser folderId={null} />);
+    await screen.findByText("+ Upload");
+    const root = container.firstElementChild as HTMLElement;
+
+    const pdf = new File(["%PDF-1.7"], "catalog.pdf", { type: "application/pdf" });
+    fireEvent.dragEnter(root, dropEvent(["Files"], [pdf]));
+    expect(screen.getByText(/Drop to upload/)).toBeTruthy();
+    fireEvent.drop(root, dropEvent(["Files"], [pdf]));
+
+    await waitFor(() =>
+      expect(uploadFileOrPage).toHaveBeenCalledWith(pdf, undefined)
+    );
+    expect(screen.queryByText(/Drop to upload/)).toBeNull();
+  });
+
+  it("ignores intra-app reparent drags", async () => {
+    const { uploadFileOrPage } = await import("../../../lib/api");
+
+    const { container } = render(<FileBrowser folderId={null} />);
+    await screen.findByText("+ Upload");
+    const root = container.firstElementChild as HTMLElement;
+
+    // Browsers set "Files" alongside custom types on some drags; our marker
+    // mime must win so a reparent never triggers an upload.
+    const drag = dropEvent(["application/x-skill-fb-item", "Files"]);
+    fireEvent.dragEnter(root, drag);
+    expect(screen.queryByText(/Drop to upload/)).toBeNull();
+    fireEvent.drop(root, drag);
+
+    expect(uploadFileOrPage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/content/file-browser/FileBrowser.tsx
+++ b/frontend/src/components/content/file-browser/FileBrowser.tsx
@@ -120,6 +120,10 @@ export default function FileBrowser({ folderId, folderHrefBase }: Props) {
     }
   }
   const [error, setError] = useState("");
+  // Drag-enter/leave fire for every child crossed, so a depth counter keeps
+  // the drop overlay steady until the pointer truly leaves the browser.
+  const dropDepth = useRef(0);
+  const [dropActive, setDropActive] = useState(false);
   const [undo, setUndo] = useState<{ kind: "page" | "file"; id: string; name: string } | null>(
     null,
   );
@@ -400,24 +404,44 @@ export default function FileBrowser({ folderId, folderHrefBase }: Props) {
     router.push(href);
   }
 
+  async function uploadFiles(files: File[]) {
+    let uploadedPageId: string | null = null;
+    try {
+      for (const file of files) {
+        const result = await uploadFileOrPage(file, folderId ?? undefined);
+        if (files.length === 1 && result.kind === "page") {
+          uploadedPageId = result.page.id;
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Upload failed");
+    }
+    if (uploadedPageId) {
+      router.push(`/p/${uploadedPageId}`);
+      return;
+    }
+    await refreshAll();
+  }
+
   async function handleUploadFile() {
     const input = document.createElement("input");
     input.type = "file";
-    input.onchange = async () => {
-      const file = input.files?.[0];
-      if (!file) return;
-      try {
-        const result = await uploadFileOrPage(file, folderId ?? undefined);
-        if (result.kind === "page") {
-          router.push(`/p/${result.page.id}`);
-          return;
-        }
-        await refreshAll();
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "Upload failed");
-      }
+    input.multiple = true;
+    input.onchange = () => {
+      if (input.files?.length) void uploadFiles(Array.from(input.files));
     };
     input.click();
+  }
+
+  // An OS file drag sets "Files" on the data transfer; our intra-app reparent
+  // drags set FB_DRAG_MIME instead, so the two never collide.
+  function isOsFileDrag(e: React.DragEvent) {
+    const types = Array.from(e.dataTransfer.types);
+    return (
+      types.includes("Files") &&
+      !types.includes(FB_DRAG_MIME) &&
+      !types.includes(FB_DRAG_MULTI_MIME)
+    );
   }
 
   async function handleNewPage() {
@@ -585,7 +609,40 @@ export default function FileBrowser({ folderId, folderHrefBase }: Props) {
   const showShared = !folderId && scope === "shared";
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto">
+    <div
+      className="scroll-thin relative flex-1 overflow-y-auto"
+      onDragEnter={(e) => {
+        if (showShared || !isOsFileDrag(e)) return;
+        dropDepth.current += 1;
+        setDropActive(true);
+      }}
+      onDragOver={(e) => {
+        if (showShared || !isOsFileDrag(e)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+      }}
+      onDragLeave={(e) => {
+        if (showShared || !isOsFileDrag(e)) return;
+        dropDepth.current = Math.max(0, dropDepth.current - 1);
+        if (dropDepth.current === 0) setDropActive(false);
+      }}
+      onDrop={(e) => {
+        if (showShared || !isOsFileDrag(e)) return;
+        e.preventDefault();
+        dropDepth.current = 0;
+        setDropActive(false);
+        const files = Array.from(e.dataTransfer.files);
+        if (files.length) void uploadFiles(files);
+      }}
+    >
+      {dropActive && (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-lg border-2 border-dashed border-foreground/40 bg-base/80">
+          <div className="rounded-lg border border-border bg-raised px-4 py-2 text-[13px] font-medium text-foreground shadow-lg">
+            Drop to upload
+            {contents?.folder ? ` into “${contents.folder.name}”` : ""}
+          </div>
+        </div>
+      )}
       <div className="mx-auto max-w-5xl px-8 py-7">
         {!folderId && <ScopeTabs scope={scope} onChange={setScope} />}
         {/* Header: the page path lives in AppShell's top-bar breadcrumb, so we


### PR DESCRIPTION
## What

Dragging a file from Finder onto the Files page did nothing. The file browser had drag-and-drop for *moving items between folders*, and `FB_DRAG_MIME`'s comment even acknowledged that OS file drags set `"Files"` on the data transfer — but no handler ever consumed them. Upload existed only behind the `+ Upload` button.

Now:
- **Drop to upload**: the browser root accepts OS file drops. A dashed "Drop to upload" overlay appears while dragging over (depth-counted so enter/leave events crossing children don't flicker it); dropped files upload into the folder being viewed.
- **Parity with the button**: a single dropped markdown file navigates to its new page, same as the button path; anything else refreshes the listing.
- **No collision with reparent drags**: intra-app drags carry our marker mime and are ignored by the dropzone (covered by a test, since some browsers set `"Files"` alongside custom types).
- **`+ Upload` accepts multiple files** now, sharing the same upload path as the dropzone.
- Drops are ignored on the Shared-with-me tab, where "upload here" has no meaning.

## Why now

Henry hit this live today while trying to upload an annotated PDF to test #1007 — dragged it in, nothing happened, ended up fighting the file picker. Mike will hit the same wall when he starts bulk-loading Sanjay's PDF backlog.

## Verified

- `npx vitest run` — 287 pass (62 files), including 2 new tests: OS drop uploads into the current view + overlay clears, and intra-app reparent drags never trigger an upload.
- `npm run lint` — 0 errors; the 5 pre-existing warnings are untouched files.
- No live-app screenshot: both stack ports on this machine are held by a sibling worktree session's dev stack, which per our worktree rules I don't touch. The change is overlay + drop wiring on the existing upload path; happy to attach a prod screenshot after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only upload path reusing existing `uploadFileOrPage`; drag discrimination is covered by tests and Shared tab is excluded.
> 
> **Overview**
> **OS drag-and-drop upload** is wired on the Files browser: dropping files from the desktop uploads into the folder you’re viewing, with a dashed **“Drop to upload”** overlay while dragging (depth counting avoids flicker when crossing child elements).
> 
> Upload logic is centralized in **`uploadFiles`**, which **`+ Upload`** now shares—**multiple files** in one pick or drop. A **single markdown** upload still navigates to the new page; other cases refresh the listing. **Intra-app reparent drags** (marker mime types) are ignored so they don’t trigger uploads, including when browsers also set `"Files"`. Drops are **disabled on Shared with me**.
> 
> Tests cover OS drop → `uploadFileOrPage` and reparent drags not calling upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fb1e3af26df9b88aae60c8d0bd50254ae0acab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->