### PR TITLE
Wizard's Capture option shows one command too

### DIFF
--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -474,9 +474,11 @@ function TryItOutStep({
         lead="Stream every Claude Code / Codex session into Stash automatically."
       >
         <div className="space-y-2">
-          <p className="text-[12px] text-dim">Run this in your terminal:</p>
+          <p className="text-[12px] text-dim">
+            Run this in your terminal — the installer signs you in and sets up recording:
+          </p>
+          {/* One command on purpose: install.sh ends by exec'ing `stash signin`. */}
           <CommandBlock command={CLI_INSTALL_COMMAND} />
-          <CommandBlock command="stash signin" />
         </div>
       </TryOption>
       <TryOption badge="Clip" lead="Save anything you read, straight from your browser.">


### PR DESCRIPTION
Follow-up to #1011: the onboarding wizard's Capture accordion had the same redundant `stash signin` second line that #1011 removed from the empty Home. install.sh ends by exec'ing `stash signin`, so it's one copyable command everywhere now, with the lead-in explaining the installer signs you in and sets up recording.

Browser-verified on the wizard's Try-it-out step; 294 vitest tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only onboarding UI change with no auth, API, or data-path impact.
> 
> **Overview**
> Aligns the onboarding **Capture** accordion with the empty Home flow (#1011): users see **one** copyable install command instead of install plus a separate `stash signin` line.
> 
> The lead-in now states that the installer signs you in and sets up recording, and an inline comment documents that `install.sh` execs `stash signin` so the second command is intentionally omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d16f9972e8c991abdc537986d508fca5e6e75ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->