### PR TITLE
chore: bump stash release to 0.1.364 and plugin to 0.1.435

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash \u2014 stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.434",
+      "version": "0.1.435",
       "category": "productivity",
       "homepage": "https://joinstash.ai",
       "author": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.363
+    image: ghcr.io/fergana-labs/stash-backend:0.1.364
     restart: always
     expose:
       - "3456"
@@ -83,7 +83,7 @@ services:
       start_period: 30s
 
   worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.363
+    image: ghcr.io/fergana-labs/stash-backend:0.1.364
     restart: always
     depends_on:
       postgres:
@@ -123,7 +123,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heavy"]
 
   beat:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.363
+    image: ghcr.io/fergana-labs/stash-backend:0.1.364
     restart: always
     depends_on:
       redis:
@@ -139,7 +139,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    image: ghcr.io/fergana-labs/stash-frontend:0.1.363
+    image: ghcr.io/fergana-labs/stash-frontend:0.1.364
     restart: always
     expose:
       - "3457"

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "description": "Connect Claude Code to Stash \u2014 stream activity to your Stash and collaborate with your other agents.",
   "author": {
     "name": "Fergana Labs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.363"
+version = "0.1.364"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What

Version bump only — no code changes. Publishes the CLI work sitting unreleased on `main` since the 0.1.363 cut.

## Why

The published **0.1.363 wheel predates #963** — I verified by downloading it from PyPI: its bundled `stashvfs` has no sidecar path. So every released-CLI agent doing `stash vfs "cat '<some>.pdf'"` floods its context with raw PDF bytes, and none of the extracted-text improvements (including today's #1007 annotation extraction) are visible through the CLI's VFS.

Note this does NOT gate Heavi: their `search_stash` researcher calls the server-side `/api/v1/me/vfs` endpoint directly, which deploys from `main` and already serves extracted text with annotations (verified live against prod today). This release is for actual CLI users.

Merging triggers `publish.yml` → PyPI release + GHCR images.

## Verified

- `git diff` is exactly the four files the previous bump (#994) touched, same shape.
- PyPI wheel check for 0.1.363 documented above; the repo's `stashvfs/model.py` sidecar path confirmed working against prod via the dev CLI (annotated PDF cat shows `[Annotation: ...]` inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and image tag updates only; no runtime logic changes in the diff.
> 
> **Overview**
> Release-only version bump with **no application code changes**. It cuts **0.1.364** for the `stashai` CLI / PyPI package and pins self-host **GHCR** images (`stash-backend`, `stash-frontend`) to that tag in `docker-compose.prod.yml` for `backend`, `worker`, `beat`, and `frontend`.
> 
> The Claude plugin marketplace metadata moves to **0.1.435** in `plugin.json` and `.claude-plugin/marketplace.json`. Merging is expected to trigger **`publish.yml`** (PyPI wheel + tagged container images) so CLI users get VFS/sidecar PDF text improvements that have been on `main` since the prior **0.1.363** release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a228a352bbb497b4dbe8224a34409c2e6a5b2013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->