### PR TITLE
Tab titles are derived from content, not stored on the tab

### DIFF
--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -30,6 +30,7 @@ import FileContentRenderer, {
 } from "@/components/content/FileContentRenderer";
 import FileViewerHeader from "@/components/content/FileViewerHeader";
 import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
+import { useTabTitle } from "@/lib/workspace-store";
 import ResourceShareButton from "@/components/share/ResourceShareButton";
 
 function isCsv(ct: string) {
@@ -67,6 +68,7 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
   void _logout;
 
   const [file, setFile] = useState<FileInfo | null>(null);
+  useTabTitle("file", fileId, file?.name);
   const [folderChain, setFolderChain] = useState<FolderBreadcrumb[]>([]);
   const [error, setError] = useState("");
   const [skillTitle, setSkillTitle] = useState<string | null>(null);

--- a/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
+++ b/frontend/src/app/(app)/folders/[folderId]/FolderClient.tsx
@@ -23,6 +23,7 @@ import { findInSkillContents } from "@/lib/localSkill";
 import { loginPathWithNext } from "@/lib/loginRedirect";
 import { sectionCrumbs, useMemoryFolderId } from "@/lib/memory-folder";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
+import { useTabTitle } from "@/lib/workspace-store";
 
 export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?: string }) {
   const params = useParams();
@@ -51,6 +52,7 @@ export default function FolderDetailPage({ folderId: folderIdProp }: { folderId?
     ];
   }, [chain, memoryFolderId]);
   const [folderName, setFolderName] = useState<string | null>(null);
+  useTabTitle("folder", folderId, folderName);
   const [skillFallback, setSkillFallback] = useState<{
     skillSlug: string;
     skillTitle: string;

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { User } from "@/lib/types";
 import { routes } from "@/lib/workspace-routes";
+import { useTabTitle } from "@/lib/workspace-store";
 
 // How often a row re-checks a source that is mid-sync, and how many times before
 // it gives up. A sync that hasn't settled in ~5 minutes is wedged; polling it for
@@ -82,6 +83,7 @@ export function IntegrationDetail({ provider }: { provider: string }) {
   const confirm = useConfirm();
 
   const connector = connectorForProvider(provider);
+  useTabTitle("tool", provider, connector?.label);
 
   const [status, setStatus] = useState<IntegrationStatus | null>(null);
   // null until the server list loads; false when the server omitted this

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -53,6 +53,7 @@ import { findInSkillContents } from "@/lib/localSkill";
 import { getScope, getScopeUserId, setScope } from "@/lib/scope-store";
 import type { CommentThread, Page, Scope, Workspace } from "@/lib/types";
 import { subscribePageEvents } from "@/lib/pageEvents";
+import { useTabTitle } from "@/lib/workspace-store";
 
 function wrapHtml(title: string, body: string): string {
   // HTML pages can be stored as a full document (when imported from .html
@@ -105,6 +106,7 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
   const skillSlug = searchParams.get("skill");
 
   const [page, setPage] = useState<Page | null>(null);
+  useTabTitle("page", pageId, page?.name.replace(/\.md$/, ""));
   // The scope is the current user. Empty until auth resolves — every
   // consumer below renders or fires only after that.
   const scopeId = user?.id ?? "";

--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -26,6 +26,7 @@ import {
   type Skill,
 } from "@/lib/api";
 import EditableTitle from "@/components/content/EditableTitle";
+import { useTabTitle } from "@/lib/workspace-store";
 
 // One transcript page. The viewer loads this many turns at a time and fetches
 // more on scroll, so long sessions don't load every event up front.
@@ -126,6 +127,7 @@ export default function SessionViewerPage({ sessionId }: { sessionId: string }) 
 
   const [agentName, setAgentName] = useState("");
   const [sessionDetail, setSessionDetail] = useState<SessionDetail | null>(null);
+  useTabTitle("session", sessionId, sessionDetail && sessionHeading(sessionDetail, sessionId));
   const [turns, setTurns] = useState<MessageTurn[]>([]);
   const [totalTurns, setTotalTurns] = useState(0);
   const [hasMore, setHasMore] = useState(false);

--- a/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
+++ b/frontend/src/app/(app)/skills/folder/[folderId]/SkillFolderClient.tsx
@@ -18,6 +18,7 @@ import {
   type SkillPublishInfo,
 } from "@/lib/api";
 import { refreshSidebar } from "@/lib/skillNavigationCache";
+import { useTabTitle } from "@/lib/workspace-store";
 
 // Browse a skill folder (or a subfolder inside one). Same file browser as
 // the Files routes, but folder links stay on the skill browse route and the
@@ -30,6 +31,7 @@ export default function SkillFolderClient({ folderId }: { folderId: string }) {
   const [contents, setContents] = useState<FolderContents | null>(null);
   const [publish, setPublish] = useState<SkillPublishInfo | null>(null);
   const [error, setError] = useState("");
+  useTabTitle("skill", folderId, contents?.folder.name);
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");

--- a/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
+++ b/frontend/src/app/(app)/tables/[tableId]/TableClient.tsx
@@ -41,6 +41,7 @@ import { findInSkillContents } from "../../../../lib/localSkill";
 import type { Table, TableColumn, TableRow, TableView } from "../../../../lib/types";
 import FileViewerHeader from "../../../../components/content/FileViewerHeader";
 import { parseCsv, inferColumnType, detectDelimiter } from "../../../../lib/csv";
+import { useTabTitle } from "../../../../lib/workspace-store";
 
 const TYPE_ICONS: Record<string, string> = {
   text: "Aa", number: "#", boolean: "\u2713", date: "\uD83D\uDCC5", datetime: "\uD83D\uDD53",
@@ -281,6 +282,7 @@ function TableEditorPageInner({
 
   // Core state.
   const [table, setTable] = useState<Table | null>(null);
+  useTabTitle("table", tableId, table?.name);
   const [rows, setRows] = useState<TableRow[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [error, setError] = useState("");

--- a/frontend/src/components/skill/SkillLauncher.test.tsx
+++ b/frontend/src/components/skill/SkillLauncher.test.tsx
@@ -80,9 +80,9 @@ describe("SkillLauncher", () => {
     fireEvent.click(screen.getByRole("button", { name: /Run/ }));
 
     await waitFor(() => expect(openTab).toHaveBeenCalled());
-    const [kind, refId, title] = openTab.mock.calls[0];
+    const [kind, refId, opts] = openTab.mock.calls[0];
     expect(kind).toBe("agent");
     expect(refId).toMatch(/^new-run-/);
-    expect(title).toBe("Run: resurface");
+    expect(opts).toMatchObject({ title: "Run: resurface" });
   });
 });

--- a/frontend/src/components/skill/SkillLauncher.tsx
+++ b/frontend/src/components/skill/SkillLauncher.tsx
@@ -36,7 +36,7 @@ export default function SkillLauncher({
     if (!request.trim()) return;
     const ref = newRunTabRef();
     stageSkillRun(ref, runPrompt(skill.name, request));
-    openTab("agent", ref, `Run: ${skill.name}`);
+    openTab("agent", ref, { title: `Run: ${skill.name}` });
     router.push("/agents");
   }
 

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -43,7 +43,7 @@ function useOpenTab() {
   const router = useRouter();
   const openTab = useWorkspace((s) => s.openTab);
   return (kind: TabKind, refId: string, title: string, opts?: { newTab?: boolean }) => {
-    openTab(kind, refId, title, { newTab: opts?.newTab ?? opensNewTab() });
+    openTab(kind, refId, { title, newTab: opts?.newTab ?? opensNewTab() });
     router.replace(urlForTab({ kind, refId }));
   };
 }

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -228,7 +228,7 @@ export default function FilesExplorer({
     const kind = item.kind === "folder" ? "folder" : item.kind === "skill" ? "skill" : item.kind === "session" ? "session" : item.kind === "table" ? "table" : item.kind === "page" ? "page" : "file";
     // Plain click navigates the current tab; cmd/ctrl-click (or the explicit
     // "Open in new tab" menu item) opens a new one.
-    openTab(kind, item.id, item.name, { newTab: opts?.forceNewTab || opensNewTab() });
+    openTab(kind, item.id, { title: item.name, newTab: opts?.forceNewTab || opensNewTab() });
     const suffix = tabSection ? `?section=${tabSection}` : "";
     router.replace(urlForTab({ kind, refId: item.id }) + suffix);
   }

--- a/frontend/src/components/workspace/persistence.tsx
+++ b/frontend/src/components/workspace/persistence.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useWorkspace, type WorkspaceState } from "@/lib/workspace-store";
+import { useWorkspace, titleKey, type WorkspaceState } from "@/lib/workspace-store";
 
 const KEY = "moltchat_workspace";
 
-/** The layout slice we persist — references + pane arrangement only, no content. */
+/** The layout slice we persist — references + pane arrangement only, no content.
+ *  `titles` rides along because only the active tab's body mounts: without the
+ *  cache, background tabs would have no name after a reload until visited. */
 type Persisted = Pick<
   WorkspaceState,
-  "tabs" | "paneOf" | "activeTabId" | "activeTab1" | "split" | "focusedPane" | "railSection" | "explorerFolderId"
+  "tabs" | "paneOf" | "activeTabId" | "activeTab1" | "split" | "focusedPane" | "railSection" | "explorerFolderId" | "titles"
 >;
 
 function readPersisted(): Partial<Persisted> | null {
@@ -33,6 +35,9 @@ export default function Persistence() {
     const write = () => {
       timer = null;
       const s = useWorkspace.getState();
+      // Titles for closed tabs are dropped here, so the cache can't grow
+      // without bound across sessions.
+      const openKeys = new Set(s.tabs.map((t) => titleKey(t.kind, t.refId)));
       const slice: Persisted = {
         tabs: s.tabs,
         paneOf: s.paneOf,
@@ -42,6 +47,7 @@ export default function Persistence() {
         focusedPane: s.focusedPane,
         railSection: s.railSection,
         explorerFolderId: s.explorerFolderId,
+        titles: Object.fromEntries(Object.entries(s.titles).filter(([k]) => openKeys.has(k))),
       };
       localStorage.setItem(KEY, JSON.stringify(slice));
     };

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -8,7 +8,7 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/componen
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { createPage } from "@/lib/api";
-import { useWorkspace, type WorkbenchTab } from "@/lib/workspace-store";
+import { useWorkspace, titleKey, type WorkbenchTab } from "@/lib/workspace-store";
 import { ShellChromeScope, useShellChromeValue } from "@/components/ShellChromeContext";
 import { urlForTab, tabFromPath } from "@/lib/workspace-routes";
 import { PageIcon, FileIcon, TableIcon, SessionsIcon, SkillIcon, FolderIcon } from "@/components/SkillIcons";
@@ -35,12 +35,12 @@ function NewTabMenu() {
 
   async function newPage() {
     const page = await createPage("Untitled", null, "");
-    openTab("page", page.id, page.name || "Untitled");
+    openTab("page", page.id, { title: page.name || "Untitled" });
     router.replace(urlForTab({ kind: "page", refId: page.id }));
   }
   function newChat() {
     const id = `new-${nanoid(5)}`;
-    openTab("agent", id, "New Chat");
+    openTab("agent", id, { title: "New Chat" });
     router.replace(urlForTab({ kind: "agent", refId: id }));
   }
 
@@ -69,6 +69,7 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tabs = useWorkspace((s) => s.tabs);
+  const titles = useWorkspace((s) => s.titles);
   const paneOf = useWorkspace((s) => s.paneOf);
   const activeTabId = useWorkspace((s) => s.activeTabId);
   const activeTab1 = useWorkspace((s) => s.activeTab1);
@@ -107,6 +108,9 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
         <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
           {paneTabs.map((tab) => {
             const active = tab.id === activeId;
+            // The content body publishes the title once loaded; until then the
+            // tab shows a quiet placeholder rather than a raw content id.
+            const title = titles[titleKey(tab.kind, tab.refId)] ?? "…";
             return (
               <div
                 key={tab.id}
@@ -117,10 +121,10 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
                   "group flex max-w-[200px] shrink-0 cursor-pointer items-center gap-1.5 border-r border-border px-3 text-[13px]",
                   active ? "bg-base text-foreground" : "text-muted-foreground hover:bg-base/60",
                 )}
-                title={tab.title}
+                title={title}
               >
                 <TabIcon kind={tab.kind} />
-                <span className="min-w-0 flex-1 truncate">{tab.title}</span>
+                <span className="min-w-0 flex-1 truncate">{title}</span>
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -220,12 +224,14 @@ export default function Workbench() {
         ? { kind: "sessions-home" as const, refId: "sessions" }
         : tabFromPath(pathname);
     if (!match) return;
-    const title = match.kind === "agent" ? "Chat" : match.kind === "sessions-home" ? "Sessions" : match.refId;
+    // Content tabs get no title here — their body publishes the real name via
+    // useTabTitle. Only the two app surfaces without a content body are named.
+    const title = match.kind === "agent" ? "Chat" : match.kind === "sessions-home" ? "Sessions" : undefined;
     const existing = useWorkspace.getState().tabs.find((t) => t.kind === match.kind && t.refId === match.refId);
     if (existing) setActiveTab(existing.id);
     // Deep links navigate the current tab — only cmd/ctrl-click and the
     // explicit new-tab affordances ever add tabs.
-    else openTab(match.kind, match.refId, title, { newTab: false });
+    else openTab(match.kind, match.refId, { newTab: false, title });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname, searchParams]);
 

--- a/frontend/src/lib/workspace-store.test.ts
+++ b/frontend/src/lib/workspace-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useWorkspace } from "./workspace-store";
+import { titleKey, useWorkspace } from "./workspace-store";
 
 function reset() {
   useWorkspace.setState({
@@ -10,6 +10,7 @@ function reset() {
     split: false,
     paneOf: {},
     focusedPane: 0,
+    titles: {},
   });
 }
 
@@ -17,45 +18,79 @@ describe("openTab: navigate current tab vs open new tab", () => {
   beforeEach(reset);
 
   it("opens a first tab when nothing is active", () => {
-    useWorkspace.getState().openTab("page", "a", "A", { newTab: false });
+    useWorkspace.getState().openTab("page", "a", { newTab: false, title: "A" });
     const s = useWorkspace.getState();
     expect(s.tabs).toHaveLength(1);
-    expect(s.tabs[0]).toMatchObject({ kind: "page", refId: "a", title: "A" });
+    expect(s.tabs[0]).toMatchObject({ kind: "page", refId: "a" });
     expect(s.activeTabId).toBe(s.tabs[0].id);
   });
 
   it("a plain navigation click REPLACES the active tab in place", () => {
     const st = useWorkspace.getState();
-    st.openTab("page", "a", "A", { newTab: false });
+    st.openTab("page", "a", { newTab: false, title: "A" });
     const firstId = useWorkspace.getState().tabs[0].id;
-    useWorkspace.getState().openTab("file", "b", "B", { newTab: false });
+    useWorkspace.getState().openTab("file", "b", { newTab: false, title: "B" });
     const s = useWorkspace.getState();
     expect(s.tabs).toHaveLength(1); // no new tab
     expect(s.tabs[0].id).toBe(firstId); // same tab id…
-    expect(s.tabs[0]).toMatchObject({ kind: "file", refId: "b", title: "B" }); // …new content
+    expect(s.tabs[0]).toMatchObject({ kind: "file", refId: "b" }); // …new content
   });
 
   it("cmd/ctrl-click (newTab:true) opens a second tab", () => {
-    useWorkspace.getState().openTab("page", "a", "A", { newTab: false });
-    useWorkspace.getState().openTab("file", "b", "B", { newTab: true });
+    useWorkspace.getState().openTab("page", "a", { newTab: false, title: "A" });
+    useWorkspace.getState().openTab("file", "b", { newTab: true, title: "B" });
     const s = useWorkspace.getState();
     expect(s.tabs).toHaveLength(2);
     expect(s.activeTabId).toBe(s.tabs[1].id);
   });
 
   it("default (no opts) keeps opening new tabs — deep-links / new chat", () => {
-    useWorkspace.getState().openTab("page", "a", "A");
-    useWorkspace.getState().openTab("file", "b", "B");
+    useWorkspace.getState().openTab("page", "a");
+    useWorkspace.getState().openTab("file", "b");
     expect(useWorkspace.getState().tabs).toHaveLength(2);
   });
 
   it("reopening an already-open target focuses it instead of duplicating", () => {
-    useWorkspace.getState().openTab("page", "a", "A", { newTab: true });
-    useWorkspace.getState().openTab("file", "b", "B", { newTab: true });
+    useWorkspace.getState().openTab("page", "a", { newTab: true, title: "A" });
+    useWorkspace.getState().openTab("file", "b", { newTab: true, title: "B" });
     const firstId = useWorkspace.getState().tabs[0].id;
-    useWorkspace.getState().openTab("page", "a", "A", { newTab: false });
+    useWorkspace.getState().openTab("page", "a", { newTab: false });
     const s = useWorkspace.getState();
     expect(s.tabs).toHaveLength(2); // no dup, no replace
     expect(s.activeTabId).toBe(firstId);
+  });
+});
+
+describe("tab titles: content-keyed, body-published", () => {
+  beforeEach(reset);
+
+  it("openTab without a title leaves the cache empty — no id-as-title", () => {
+    // The deep-link path: only the content id is known at open time. The tab
+    // must NOT be named after it; the body publishes the real name later.
+    useWorkspace.getState().openTab("skill", "11346cd2", { newTab: false });
+    const s = useWorkspace.getState();
+    expect(s.titles[titleKey("skill", "11346cd2")]).toBeUndefined();
+  });
+
+  it("setTitle publishes the content's name for its tab", () => {
+    useWorkspace.getState().openTab("skill", "11346cd2", { newTab: false });
+    useWorkspace.getState().setTitle("skill", "11346cd2", "Brake Shoes");
+    expect(useWorkspace.getState().titles[titleKey("skill", "11346cd2")]).toBe("Brake Shoes");
+  });
+
+  it("a body-published title overwrites the opener's seed (content wins)", () => {
+    useWorkspace.getState().openTab("page", "a", { newTab: false, title: "stale name" });
+    useWorkspace.getState().setTitle("page", "a", "fresh name");
+    expect(useWorkspace.getState().titles[titleKey("page", "a")]).toBe("fresh name");
+  });
+
+  it("in-place navigation shows the new target's title, not the old tab's", () => {
+    // Titles are keyed by content, not by tab id — replacing a tab's target
+    // must never leave the old content's name on the strip.
+    useWorkspace.getState().openTab("page", "a", { newTab: false, title: "A" });
+    useWorkspace.getState().openTab("file", "b", { newTab: false, title: "B" });
+    const s = useWorkspace.getState();
+    expect(s.titles[titleKey("file", "b")]).toBe("B");
+    expect(s.titles[titleKey("page", "a")]).toBe("A"); // still cached for its own content
   });
 });

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { create } from "zustand";
 import { nanoid } from "nanoid";
 
@@ -20,7 +21,13 @@ export interface WorkbenchTab {
   kind: TabKind;
   /** The content id this tab shows: pageId / fileId / tableId / sessionId / skill slug. */
   refId: string;
-  title: string;
+}
+
+/** Cache key for a tab title. Titles belong to the content, not the tab, so two
+ *  tabs on the same content share one entry and in-place navigation picks up
+ *  the new target's title automatically. */
+export function titleKey(kind: TabKind, refId: string): string {
+  return `${kind}:${refId}`;
 }
 
 export interface WorkspaceState {
@@ -39,13 +46,19 @@ export interface WorkspaceState {
   /** VFS folder the Files explorer is showing (null = root). */
   explorerFolderId: string | null;
 
-  openTab: (kind: TabKind, refId: string, title: string, opts?: { newTab?: boolean }) => void;
+  /** Display titles keyed by titleKey(kind, refId). The content body is the
+   *  source of truth — it publishes its loaded name via useTabTitle. openTab
+   *  callers that already know the name seed the cache so the strip doesn't
+   *  flash a placeholder while the body loads. */
+  titles: Record<string, string>;
+
+  openTab: (kind: TabKind, refId: string, opts?: { newTab?: boolean; title?: string }) => void;
   closeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
   splitTab: (id: string) => void;
   moveTabToPane: (id: string, pane: 0 | 1) => void;
   setFocusedPane: (pane: 0 | 1) => void;
-  renameTab: (id: string, title: string) => void;
+  setTitle: (kind: TabKind, refId: string, title: string) => void;
   setRailSection: (s: RailSection) => void;
   setExplorerFolderId: (id: string | null) => void;
   hydrate: (data: Partial<WorkspaceState>) => void;
@@ -76,12 +89,14 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
   focusedPane: 0,
   railSection: "files",
   explorerFolderId: null,
+  titles: {},
 
-  openTab: (kind, refId, title, opts) => {
+  openTab: (kind, refId, opts) => {
     const s = get();
+    const titles = opts?.title ? { ...s.titles, [titleKey(kind, refId)]: opts.title } : s.titles;
     const existing = s.tabs.find((t) => t.kind === kind && t.refId === refId);
     if (existing) {
-      set(focusTab(s, existing.id));
+      set({ ...focusTab(s, existing.id), titles });
       return;
     }
     // Default is a new tab (deep-links, "new chat", etc. rely on it). Navigation
@@ -91,10 +106,10 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
     const activeId = s.focusedPane === 0 ? s.activeTabId : s.activeTab1;
     if (newTab || !activeId) {
       const id = `${kind}-${nanoid(5)}`;
-      set(placeTab(s, { id, kind, refId, title }));
+      set({ ...placeTab(s, { id, kind, refId }), titles });
       return;
     }
-    set({ tabs: s.tabs.map((t) => (t.id === activeId ? { ...t, kind, refId, title } : t)) });
+    set({ tabs: s.tabs.map((t) => (t.id === activeId ? { ...t, kind, refId } : t)), titles });
   },
 
   closeTab: (id) => {
@@ -151,7 +166,11 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
 
   setFocusedPane: (pane) => set({ focusedPane: pane }),
 
-  renameTab: (id, title) => set({ tabs: get().tabs.map((t) => (t.id === id ? { ...t, title } : t)) }),
+  setTitle: (kind, refId, title) => {
+    const key = titleKey(kind, refId);
+    if (get().titles[key] === title) return;
+    set({ titles: { ...get().titles, [key]: title } });
+  },
 
   setRailSection: (s) => set({ railSection: s }),
 
@@ -159,3 +178,14 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
 
   hydrate: (data) => set({ ...data }),
 }));
+
+/** Declare the hosting tab's title from inside a content body. Call with the
+ *  content's current display name (null/undefined while loading): the strip
+ *  shows the live name, so deep-linked tabs get real titles once loaded and
+ *  renames propagate to every tab showing that content. */
+export function useTabTitle(kind: TabKind, refId: string, title: string | null | undefined) {
+  const setTitle = useWorkspace((s) => s.setTitle);
+  useEffect(() => {
+    if (title) setTitle(kind, refId, title);
+  }, [kind, refId, title, setTitle]);
+}


### PR DESCRIPTION
## The bug

Creating a new skill opened a tab titled with the raw folder UUID (`11346cd2-f1e3-46e...`). Root cause: tabs stored a snapshot of their title from whoever opened them. Explorer clicks knew the name; URL navigations (skill creation's `router.push`, any pasted deep link) only knew the refId, so `workbench.tsx` used the refId as the title — and nothing ever renamed a tab after open (`renameTab` had zero callers).

## The fix

A tab title is derived data — "what is this tab's content called right now" — so it no longer lives on the tab:

- `WorkbenchTab` drops `title`. Titles live in a store cache keyed by `(kind, refId)`.
- The content body is the source of truth: each client (`SkillFolderClient`, `PageClient`, `FileClient`, `TableClient`, `SessionClient`, `FolderClient`, `IntegrationDetail`) declares its loaded name via a new one-line `useTabTitle` hook.
- `openTab` callers that already know the name (explorer clicks) seed the same cache, so the strip never flashes; a never-seen deep link shows `…` until the body loads.
- The cache persists with the layout (pruned to open tabs) because only the active tab's body mounts after a reload.

Free consequences: pasted deep links get real tab names, renaming content updates every tab showing it, and the dead `renameTab` action is deleted.

## Testing

- New store tests cover the regression directly: opening by refId alone never uses the id as a title; the body's published name fills it in; in-place navigation shows the new target's title.
- Full suite: 289 tests / 62 files pass; lint clean; tsc clean (the two remaining errors exist on `main` too).
- ⚠️ No product screenshots yet: ports 3456/3457 are held by another worktree's live stack on this machine, so I couldn't click through the changed UI. Will attach screenshots once the stack frees up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only workspace UI refactor with targeted store tests; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes workbench tabs showing raw UUIDs on deep links (e.g. new skills) by **removing `title` from `WorkbenchTab`** and keeping display names in a **`titles` cache** keyed by `kind:refId`.
> 
> **`openTab`** now takes an optional `{ title?, newTab? }` instead of a separate title argument; known names seed the cache, unknown deep links show **`…`** until the mounted body publishes a name. The tab strip reads from **`titles`**, not the tab record.
> 
> Content clients call **`useTabTitle(kind, refId, name)`** once loaded (files, folders, pages, tables, sessions, skills, integrations). **`setTitle`** replaces unused **`renameTab`**, so renames and multiple tabs on the same content stay in sync.
> 
> **Persistence** saves **`titles`** with the layout (pruned to open tabs on write) so background tabs still have labels after reload when only the active body mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ea0eb46d6cc3ababcb89a6a04589ef786ef7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->