### PR TITLE
Skill composer: explain a rejected submit instead of silently disabling

### DIFF
--- a/frontend/src/app/(app)/skills/page.test.tsx
+++ b/frontend/src/app/(app)/skills/page.test.tsx
@@ -159,16 +159,22 @@ describe("SkillsPage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /New Skill/ }));
 
-    // Both fields are required: Create stays disabled until each is filled,
-    // so a skill can never be created without the agent-trigger description.
+    // Both fields are required: a skill can never be created without the
+    // agent-trigger description. Submitting incomplete shows why instead of
+    // silently ignoring the click (a disabled button reads as broken).
     const create = await screen.findByRole("button", { name: "Create skill" });
-    expect(create).toBeDisabled();
+    fireEvent.click(create);
+    expect(createSkill).not.toHaveBeenCalled();
+    expect(screen.getByText("Give the skill a name.")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "My Skill" } });
-    expect(create).toBeDisabled();
+    fireEvent.click(create);
+    expect(createSkill).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Describe when an agent should use it — this is required."),
+    ).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("When should an agent use it?"), {
       target: { value: "Use for release planning." },
     });
-    expect(create).toBeEnabled();
     fireEvent.click(create);
 
     await waitFor(() =>

--- a/frontend/src/app/(app)/skills/page.tsx
+++ b/frontend/src/app/(app)/skills/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConfirm } from "@/components/ConfirmDialog";
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
 import {
@@ -118,12 +118,26 @@ export default function SkillsPage() {
   }, [load]);
 
   const [composerOpen, setComposerOpen] = useState(false);
+  const composerRef = useRef<HTMLDivElement | null>(null);
   // The sidebar's "New skill" action lands here with ?new=1 — creation lives
   // in this page's inline composer, not a modal.
   const searchParams = useSearchParams();
   useEffect(() => {
     if (searchParams.get("new") === "1") setComposerOpen(true);
   }, [searchParams]);
+
+  // The button must visibly respond even when the composer is already open —
+  // an inert press reads as a broken button, not an already-open form.
+  function showComposer() {
+    if (!composerOpen) {
+      setComposerOpen(true);
+      return;
+    }
+    const box = composerRef.current;
+    if (!box) return;
+    box.scrollIntoView({ behavior: "smooth", block: "center" });
+    box.querySelector<HTMLElement>("input, textarea")?.focus();
+  }
 
   async function newSkill({ name, description }: { name: string; description: string }) {
     const created = await createSkill(name, description);
@@ -188,7 +202,7 @@ export default function SkillsPage() {
           </h1>
           <button
             type="button"
-            onClick={() => setComposerOpen(true)}
+            onClick={showComposer}
             className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-[var(--color-brand-600)] px-2.5 py-1.5 text-[12.5px] font-medium text-white hover:bg-[var(--color-brand-700)]"
           >
             <PlusGlyph /> New Skill
@@ -196,7 +210,7 @@ export default function SkillsPage() {
         </div>
 
         {composerOpen && (
-          <div className="mt-4">
+          <div ref={composerRef} className="mt-4">
             <SkillComposer onSubmit={newSkill} onCancel={() => setComposerOpen(false)} />
           </div>
         )}

--- a/frontend/src/components/skill/SkillComposer.tsx
+++ b/frontend/src/components/skill/SkillComposer.tsx
@@ -25,14 +25,24 @@ export function SkillComposer({
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Per-field messages shown on a failed submit. The button stays clickable —
+  // a disabled submit gives no clue why the form is ignoring you.
+  const [fieldErrors, setFieldErrors] = useState<{ name?: string; description?: string }>({});
 
   const converting = convertFolderName !== undefined;
-  const canSubmit =
-    (converting || name.trim().length > 0) && description.trim().length > 0 && !submitting;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    if (!canSubmit) return;
+    if (submitting) return;
+    const errors: { name?: string; description?: string } = {};
+    if (!converting && name.trim().length === 0) errors.name = "Give the skill a name.";
+    if (description.trim().length === 0)
+      errors.description = "Describe when an agent should use it — this is required.";
+    if (errors.name || errors.description) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
     setSubmitting(true);
     setError(null);
     try {
@@ -65,11 +75,17 @@ export function SkillComposer({
             <Input
               autoFocus
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                setFieldErrors((f) => ({ ...f, name: undefined }));
+              }}
               maxLength={MAX_NAME_LENGTH}
-              placeholder="Release notes drafting"
+              placeholder="e.g. Release notes drafting"
             />
           </label>
+        )}
+        {fieldErrors.name && (
+          <p className="text-[12.5px] text-destructive">{fieldErrors.name}</p>
         )}
         <label className="block space-y-1.5">
           <span className="text-[12.5px] font-medium text-foreground">
@@ -78,12 +94,18 @@ export function SkillComposer({
           <Textarea
             autoFocus={converting}
             value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            onChange={(e) => {
+              setDescription(e.target.value);
+              setFieldErrors((f) => ({ ...f, description: undefined }));
+            }}
             maxLength={MAX_DESCRIPTION_LENGTH}
             rows={2}
-            placeholder="Use when drafting release notes from merged PRs and changelog entries."
+            placeholder="e.g. Use when drafting release notes from merged PRs and changelog entries."
           />
         </label>
+        {fieldErrors.description && (
+          <p className="text-[12.5px] text-destructive">{fieldErrors.description}</p>
+        )}
         <p className="text-[12px] text-muted-foreground">
           Agents read this to decide when to load the skill — name the tasks it covers.
         </p>
@@ -93,7 +115,7 @@ export function SkillComposer({
         <Button type="button" variant="outline" size="sm" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" size="sm" disabled={!canSubmit}>
+        <Button type="submit" size="sm" disabled={submitting}>
           {submitting ? "Creating…" : converting ? "Convert to skill" : "Create skill"}
         </Button>
       </div>


### PR DESCRIPTION
## The failure

Pressing "+ New Skill" on prod appeared to do nothing. Three compounding UX problems, no functional bug:

1. The composer's placeholders ("Release notes drafting" / "Use when drafting release notes…") are specific enough to read as pre-filled values — so the form looks complete when it's empty.
2. With empty fields the Create button was `disabled` — clicking it gave zero feedback. No message, nothing.
3. Pressing "+ New Skill" when the composer was already open was a no-op (`setComposerOpen(true)` on an open composer) — an inert press on a primary button reads as "broken", not "already open".

## The fix

- **Create is always clickable.** A submit with missing fields shows which field is missing, directly under that field ("Give the skill a name." / "Describe when an agent should use it — this is required."), clearing as you type. The business rule is unchanged: a skill still cannot be created without a name and an agent-trigger description — the page test now encodes that via rejected submits instead of a disabled button.
- **Placeholders are prefixed with "e.g."** so they can't be mistaken for values.
- **"+ New Skill" always responds:** if the composer is already open, the press scrolls it into view and focuses its first field.

Applies to both composer uses (Skills page creation and folder → skill conversion).

## Testing

- Updated the skills-page creation test: empty submit → no `createSkill` call + name message; name-only submit → no call + description message; complete submit → creates and navigates.
- Full suite: 291 tests / 62 files pass; lint unchanged (same 5 pre-existing warnings).
- ⚠️ No screenshots yet — ports 3456/3457 are held by another worktree's stack on this machine. Will attach once free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only form validation and navigation UX; no API or auth changes.
> 
> **Overview**
> Improves **skill creation UX** so empty or incomplete forms give clear feedback instead of feeling broken.
> 
> **`SkillComposer`** keeps **Create** enabled (only disabled while submitting). Submitting with missing fields shows per-field errors under name and description; errors clear as the user types. Placeholders are prefixed with **"e.g."** so they are not mistaken for filled values. Required name + agent-trigger description rules are unchanged.
> 
> On the **Skills page**, **+ New Skill** uses **`showComposer`**: opens the inline composer when closed, or scrolls it into view and focuses the first input when already open. The skills page test now asserts rejected submits and error copy instead of a disabled submit button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5de7f6f2f2c0420be1696e5dce7f9904c19c4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->