### PR TITLE
Uploads, transcript posts, and sidebar send the scope header

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1037,9 +1037,16 @@ async function uploadAny(
   const formData = new FormData();
   formData.append("file", file);
   if (folderId) formData.append("folder_id", folderId);
+  // Hand-rolled fetch (FormData must set its own Content-Type), so the scope
+  // header has to be attached here too — without it the server resolves the
+  // upload to the personal scope and rejects any workspace-scoped folder_id.
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const scopeUserId = getScopeUserId();
+  if (scopeUserId) headers[SCOPE_HEADER] = scopeUserId;
   const resp = await fetch(`${API_BASE}${ME}/files`, {
     method: "POST",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    headers,
     body: formData,
   });
   if (!resp.ok) {
@@ -1819,9 +1826,15 @@ export async function uploadTranscript(
   formData.append("agent_name", agentName);
   if (cwd) formData.append("cwd", cwd);
 
+  // Hand-rolled fetch (FormData); the scope header must ride along or the
+  // server files the transcript under the personal scope.
+  const transcriptHeaders: Record<string, string> = {};
+  if (token) transcriptHeaders["Authorization"] = `Bearer ${token}`;
+  const transcriptScope = getScopeUserId();
+  if (transcriptScope) transcriptHeaders[SCOPE_HEADER] = transcriptScope;
   const resp = await fetch(`${API_BASE}${ME}/transcripts`, {
     method: "POST",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    headers: transcriptHeaders,
     body: formData,
   });
   if (!resp.ok) {
@@ -1906,6 +1919,8 @@ export async function getSidebar(): Promise<Sidebar> {
   const token = await getAuthToken();
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (token) headers["Authorization"] = `Bearer ${token}`;
+  const sidebarScope = getScopeUserId();
+  if (sidebarScope) headers[SCOPE_HEADER] = sidebarScope;
   if (_sidebarEtag) headers["If-None-Match"] = _sidebarEtag;
 
   const res = await fetch(`${API_BASE}${ME}/sidebar`, {


### PR DESCRIPTION
## The bug

Uploading anything into a skill folder (or any folder) while in a workspace failed with **"folder_id does not belong to scope"** — drag-and-drop and the "+ Upload" button alike. Personal scope was unaffected, which is why this survived the Heavi testing (they upload in their own account).

Root cause: three call sites in `frontend/src/lib/api.ts` hand-roll their `fetch` instead of going through `apiFetch` (FormData must set its own Content-Type; the sidebar fetch manages an ETag) and only attached `Authorization` — never `X-Stash-Scope`. The server (`get_scope`, backend/auth.py) treats a missing header as personal scope, so the folder-ownership check `folders WHERE id=$1 AND owner_user_id=$2` correctly rejected workspace-owned folders.

Affected call sites, all scope-dependent server-side:

- `uploadAny` (`POST /me/files`) — the reported failure
- `uploadTranscript` (`POST /me/transcripts`) — transcripts silently filed under the personal scope
- `getSidebar` (`GET /me/sidebar`) — sidebar content read from the wrong scope in a workspace

## The fix

Each attaches `X-Stash-Scope` from the scope store, exactly as `apiFetch`/`fetchAuthed` already do. No server changes; the server behavior was correct.

`/api/v1/feed` and `/api/v1/pastes` also use raw fetches but their endpoints take no scope — left alone.

## Testing

Full frontend suite passes (291 tests / 62 files); tsc clean apart from the two pre-existing `main` errors. Not click-verified against a live stack (dev ports held by another worktree) — reviewer with a running stack: create a skill in a workspace scope, drag a CSV into it; before this change it 400s, after it lands in the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted client header parity with existing `apiFetch`/`fetchAuthed` behavior; no server changes.
> 
> **Overview**
> Fixes workspace-scoped operations that bypassed `apiFetch` and only sent `Authorization`, so the backend treated requests as **personal** scope.
> 
> **`uploadAny`** (`POST /me/files`) now sets `X-Stash-Scope` from `getScopeUserId()`, fixing uploads into workspace folders (e.g. skill folders) that failed with *folder_id does not belong to scope*.
> 
> **`uploadTranscript`** and **`getSidebar`** get the same header so transcripts land in the active scope and the sidebar reads the correct workspace tree instead of personal content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fba85c4a5457e256bf78a6eaab52093fd6bcd66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->