### PR TITLE
Setup asks WHERE to record, not whether

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -203,6 +203,18 @@ def start_streaming() -> None:
     _write_to(USER_CONFIG_FILE, {"stopped_streaming": False})
 
 
+# --- Recording folder scope ---
+#
+# Empty = record everywhere (the default). Non-empty = only sessions whose
+# working directory is under one of these folders stream; the plugin's scope
+# gate (stashai/plugin/scope.py) enforces it. `excluded_paths` still carves
+# folders out either way.
+
+
+def save_recorded_paths(paths: list[str]) -> None:
+    _write_to(USER_CONFIG_FILE, {"recorded_paths": paths})
+
+
 def stop_streaming() -> None:
     _write_to(USER_CONFIG_FILE, {"stopped_streaming": True})
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -35,6 +35,7 @@ from .config import (
     load_manifest,
     save_config,
     save_enabled_agents,
+    save_recorded_paths,
     save_scope,
     session_link_enabled,
     set_codex_auto_update,
@@ -4888,48 +4889,56 @@ def _run_setup_wizard() -> None:
     import. Re-runnable anytime via `stash setup` — no answer here is final."""
     cfg = load_config()
 
-    # --- Session recording ---
+    # --- Session recording: always on — the question is WHERE, not whether.
+    # (`stash stop` remains the pause switch.) ---
     console.print(
         "\nStash records your coding agent sessions to your private Stash so you\n"
         "and your agents can search them later. Transcripts are visible only to\n"
-        "you unless you share them."
+        "you unless you share them, and you can pause anytime with `stash stop`."
     )
-    _reserve_bottom_padding(4)
-    record = questionary.confirm(
-        "Record your agent sessions? (pause anytime with `stash stop`)",
-        default=True,
+    cwd = Path.cwd()
+    everywhere = "Everywhere on this machine"
+    here = f"Only this folder ({cwd.name})"
+    custom = "Only a folder I pick…"
+    _reserve_bottom_padding(6)
+    where = questionary.select(
+        "Where should Stash record agent sessions?",
+        choices=[everywhere, here, custom],
+        default=everywhere,
     ).ask()
-    if record is None:
+    if where is None:
         raise typer.Exit(1)
+    if where == here:
+        save_recorded_paths([str(cwd)])
+    elif where == custom:
+        picked = questionary.path("Which folder?", only_directories=True).ask()
+        if picked is None:
+            raise typer.Exit(1)
+        save_recorded_paths([str(Path(picked).expanduser().resolve())])
+    else:
+        save_recorded_paths([])
+    start_streaming()
 
     detected = _detected_agents()
-    if record:
-        start_streaming()
-        if detected:
-            enabled = load_enabled_agents()
-            default_enabled = enabled if enabled is not None else detected
+    if detected:
+        enabled = load_enabled_agents()
+        default_enabled = enabled if enabled is not None else detected
 
-            _reserve_bottom_padding(len(detected) + 6)
-            selected = _pick_agents(
-                "Which coding agents should Stash record?", detected, default_enabled
-            )
-            if selected is None:
-                raise typer.Exit(1)
+        _reserve_bottom_padding(len(detected) + 6)
+        selected = _pick_agents(
+            "Which coding agents should Stash record?", detected, default_enabled
+        )
+        if selected is None:
+            raise typer.Exit(1)
 
-            save_enabled_agents(selected)
-            _install_all_hooks(selected)
-        else:
-            save_enabled_agents([])
-            console.print(
-                "  [yellow]No coding agents found on this machine, so nothing will be\n"
-                "  recorded yet. Re-run [bold]stash setup[/bold] after installing one\n"
-                "  (Claude Code, Codex, Cursor, opencode, Gemini CLI…).[/yellow]"
-            )
+        save_enabled_agents(selected)
+        _install_all_hooks(selected)
     else:
-        stop_streaming()
+        save_enabled_agents([])
         console.print(
-            "  Recording is off. Turn it on later with [cyan]stash setup[/cyan] "
-            "or [cyan]stash start[/cyan]."
+            "  [yellow]No coding agents found on this machine, so nothing will be\n"
+            "  recorded yet. Re-run [bold]stash setup[/bold] after installing one\n"
+            "  (Claude Code, Codex, Cursor, opencode, Gemini CLI…).[/yellow]"
         )
 
     # --- Folder context (any folder works — git repo not required) ---
@@ -4948,8 +4957,7 @@ def _run_setup_wizard() -> None:
         console.print("  [dim]Run stash connect from any project folder later.[/dim]")
 
     # --- Import historical conversations ---
-    if record:
-        _onboarding_import_history(detected)
+    _onboarding_import_history(detected)
 
     _show_setup_complete_splash()
 

--- a/plugins/tests/test_scope.py
+++ b/plugins/tests/test_scope.py
@@ -124,3 +124,51 @@ def test_gate_on_allows_live_events(monkeypatch):
         HookEvent(kind="prompt", cwd="/anywhere"),
     )
     assert len(c.calls) == 1
+
+
+# --- Folder-scoped recording: `recorded_paths` is the include side of the
+# gate. Empty/absent = record everywhere; non-empty = only sessions whose cwd
+# is under an entry stream. Boundary-safe like exclusions (/repo must not
+# capture /repo2), and an unprovable location (no cwd) fails closed rather
+# than leaking a session the user chose not to record. ---
+
+
+def test_recorded_paths_absent_streams_everywhere(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k"})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert scope_mod.cwd_in_scope("/some/deep/path")
+
+
+def test_recorded_paths_scopes_recording_to_the_folder(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "recorded_paths": ["/work/repo"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert scope_mod.cwd_in_scope("/work/repo")
+    assert scope_mod.cwd_in_scope("/work/repo/sub/dir")
+    assert not scope_mod.cwd_in_scope("/elsewhere")
+
+
+def test_recorded_paths_is_path_boundary_safe(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "recorded_paths": ["/work/repo"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert not scope_mod.cwd_in_scope("/work/repo2")
+
+
+def test_recorded_paths_with_no_cwd_fails_closed(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, {"api_key": "k", "recorded_paths": ["/work/repo"]})
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert not scope_mod.cwd_in_scope("")
+    assert not scope_mod.cwd_in_scope(None)
+
+
+def test_exclusions_still_carve_out_of_recorded_paths(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path,
+        {
+            "api_key": "k",
+            "recorded_paths": ["/work"],
+            "excluded_paths": ["/work/secret"],
+        },
+    )
+    monkeypatch.setattr(scope_mod, "_CONFIG_FILE", cfg)
+    assert scope_mod.cwd_in_scope("/work/repo")
+    assert not scope_mod.cwd_in_scope("/work/secret/project")

--- a/stashai/plugin/scope.py
+++ b/stashai/plugin/scope.py
@@ -2,9 +2,10 @@
 
 A session streams iff the plugin is configured (an api_key is present in the
 user CLI config), streaming has not been globally stopped (`stopped_streaming`
-in the user config), and the session's working directory is not under any
-entry in `excluded_paths` — the per-folder opt-out that Stash Desktop's
-"Session uploads" card manages.
+in the user config), the working directory is inside `recorded_paths` when the
+user scoped recording to specific folders (empty/absent = everywhere), and it
+is not under any entry in `excluded_paths` — the per-folder opt-out that Stash
+Desktop's "Session uploads" card manages.
 """
 
 from __future__ import annotations
@@ -39,14 +40,24 @@ def _under(cwd: Path, excluded: Path) -> bool:
 def cwd_in_scope(cwd: str | None = None) -> bool:
     """True if a session in `cwd` should stream.
 
-    Globally enabled AND cwd is not inside an excluded folder. An empty cwd
-    (some per-turn events carry none) can't match an exclusion and streams.
+    Globally enabled, inside the recorded folders when recording is
+    folder-scoped, and not inside an excluded folder. An empty cwd (some
+    per-turn events carry none) can't match an exclusion and streams —
+    except under folder-scoped recording, where an unprovable location
+    fails closed rather than leaking a session the user chose not to record.
     """
     if not streaming_enabled():
         return False
+    cfg = _read_user_config()
+    recorded = [e for e in (cfg.get("recorded_paths") or []) if isinstance(e, str) and e]
+    if recorded:
+        if not cwd:
+            return False
+        cwd_path = Path(cwd).resolve()
+        if not any(_under(cwd_path, Path(e).resolve()) for e in recorded):
+            return False
     if not cwd:
         return True
-    cfg = _read_user_config()
     cwd_path = Path(cwd).resolve()
     for entry in cfg.get("excluded_paths") or []:
         if isinstance(entry, str) and entry and _under(cwd_path, Path(entry).resolve()):


### PR DESCRIPTION
From today's onboarding pass: the wizard's first question — **"Record your agent sessions? (Y/n)"** — is scary at exactly the moment we want trust, and it's a remnant of an old product vision where recording was optional. The actual first thought a new user has is about *scope*: "I only want them from a certain folder."

## What changed

- **The Y/n is gone. Recording is always on** (`stash stop` remains the pause switch, and the intro line says so). The wizard instead asks: **"Where should Stash record agent sessions?"** — *Everywhere on this machine* (default) / *Only this folder ({cwd})* / *Only a folder I pick…*
- **Folder-scoped recording is a new capability**, not copy: `recorded_paths` in `~/.stash/config.json` is the include side of the plugin's scope gate (`stashai/plugin/scope.py`). Empty = everywhere; non-empty = only sessions whose working directory is under an entry stream. It composes with the existing `excluded_paths` opt-out, which still carves folders out either way.
- **Privacy edge fails closed**: a rare cwd-less event streams under the old rules, but under folder-scoped recording it is dropped — an unprovable location must not leak a session the user chose not to record.
- Headless setup (`--record/--no-record` flags) is untouched — that's the automation surface.

This also answers the moment in Charlie's Aug 7 walkthrough where the folder-vs-global scope question confused him mid-consent: scope is now a first-class, named choice.

## Verified

New scope-gate tests cover: absent list streams everywhere, include scoping with subdirectories, path-boundary safety (`/work/repo` doesn't capture `/work/repo2`), fail-closed on missing cwd, and exclusions carving out of included folders. 389 CLI+plugin tests pass, ruff clean. The interactive wizard path needs a TTY, so the new questions were reviewed by reading, not by an automated run — worth one manual `stash setup` before shipping.

Ships via the PyPI CLI release train (plus the plugin), separate from the web deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default onboarding consent model and adds a new include gate in the streaming path; mis-scoped `recorded_paths` could drop sessions users expect to upload, though behavior is covered by new scope tests.
> 
> **Overview**
> **Onboarding no longer asks whether to record** — `stash setup` treats recording as on by default (`stash stop` pauses) and asks **where** sessions should be captured: everywhere, the current folder, or a user-picked directory. Choices persist as **`recorded_paths`** in `~/.stash/config.json` via new **`save_recorded_paths`**.
> 
> **Folder-scoped recording is enforced in the plugin** — `cwd_in_scope` in `stashai/plugin/scope.py` now requires the session cwd to sit under a `recorded_paths` entry when that list is non-empty (empty/absent still means everywhere). **`excluded_paths`** continues to opt folders out on top of includes. Events with **no cwd fail closed** when recording is folder-scoped so scope cannot be bypassed.
> 
> Agent selection, hooks, and history import always run after the location step (no longer gated on a record opt-in). Headless **`--record/--no-record`** setup flags are unchanged.
> 
> New tests in `plugins/tests/test_scope.py` cover default-everywhere behavior, subdirectory matching, path-boundary safety, missing-cwd fail-closed, and exclusions within included trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bef6dc6c54cf8e51b62642ea4364dbe3495fbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->