### PR TITLE
The folder question offers answers: agent history candidates + a browser

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4884,6 +4884,95 @@ def signin(
     _run_setup_wizard()
 
 
+def _agent_folder_candidates(limit: int = 6) -> list[tuple[Path, int]]:
+    """Folders the user actually runs agents in, ranked by session count —
+    mined from the same transcript history the importer reads, so the folder
+    question can offer real answers instead of a blank path prompt. Only
+    folders that still exist qualify."""
+    from .import_history import discover_conversations
+
+    counts: dict[str, int] = {}
+    for conv in discover_conversations():
+        if conv.cwd:
+            counts[conv.cwd] = counts.get(conv.cwd, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: -kv[1])
+    result: list[tuple[Path, int]] = []
+    for raw, count in ranked:
+        path = Path(raw)
+        if path.is_dir():
+            result.append((path, count))
+        if len(result) == limit:
+            break
+    return result
+
+
+def _pretty_path(path: Path) -> str:
+    home = str(Path.home())
+    raw = str(path)
+    return "~" + raw[len(home) :] if raw.startswith(home) else raw
+
+
+def _browse_folders(start: Path) -> Path | None:
+    """Arrow-key folder browser: 'record this folder' pinned on top, '..' to
+    go up, subfolders to drill into. No typing required."""
+    cur = start.resolve()
+    while True:
+        try:
+            subdirs = sorted(
+                (d for d in cur.iterdir() if d.is_dir() and not d.name.startswith(".")),
+                key=lambda d: d.name.lower(),
+            )
+        except PermissionError:
+            subdirs = []
+        use = f"✓ Record {_pretty_path(cur)}"
+        up = ".. (up one level)"
+        choices: list[str] = [use]
+        if cur.parent != cur:
+            choices.append(up)
+        choices.extend(f"{d.name}/" for d in subdirs)
+        _reserve_bottom_padding(min(len(choices), 15) + 2)
+        picked = questionary.select(f"Browsing {_pretty_path(cur)}", choices=choices).ask()
+        if picked is None:
+            return None
+        if picked == use:
+            return cur
+        if picked == up:
+            cur = cur.parent
+            continue
+        cur = cur / picked.rstrip("/")
+
+
+def _pick_record_folder(start: Path) -> Path | None:
+    """The ergonomic folder choice: your agents' actual working folders first,
+    a browser second, a typed path as the escape hatch."""
+    candidates = _agent_folder_candidates()
+    browse = "Browse folders…"
+    type_it = "Type a path"
+    choices: list[questionary.Choice] = [
+        questionary.Choice(f"{_pretty_path(p)}  ({n} session{'s' if n != 1 else ''})", value=str(p))
+        for p, n in candidates
+    ]
+    choices.append(questionary.Choice(browse, value=browse))
+    choices.append(questionary.Choice(type_it, value=type_it))
+    _reserve_bottom_padding(len(choices) + 3)
+    picked = questionary.select(
+        "Which folder? (these are where your agents already run)"
+        if candidates
+        else "Which folder?",
+        choices=choices,
+    ).ask()
+    if picked is None:
+        return None
+    if picked == browse:
+        return _browse_folders(start)
+    if picked == type_it:
+        typed = questionary.path("Folder path:", only_directories=True).ask()
+        if typed is None:
+            return None
+        return Path(typed).expanduser().resolve()
+    return Path(picked)
+
+
 def _run_setup_wizard() -> None:
     """First-run setup: session recording, agent hooks, folder context, history
     import. Re-runnable anytime via `stash setup` — no answer here is final."""
@@ -4900,23 +4989,38 @@ def _run_setup_wizard() -> None:
     everywhere = "Everywhere on this machine"
     here = f"Only this folder ({cwd.name})"
     custom = "Only a folder I pick…"
-    _reserve_bottom_padding(6)
+    # The folders this user's agents already run in go straight into the
+    # question — most people should recognize their answer, not produce it.
+    inline = [(p, n) for p, n in _agent_folder_candidates(limit=3) if p.resolve() != cwd.resolve()]
+    choices: list[questionary.Choice] = [
+        questionary.Choice(everywhere, value=everywhere),
+        questionary.Choice(here, value=str(cwd)),
+        *(
+            questionary.Choice(
+                f"Only {_pretty_path(p)}  ({n} session{'s' if n != 1 else ''})",
+                value=str(p),
+            )
+            for p, n in inline
+        ),
+        questionary.Choice(custom, value=custom),
+    ]
+    _reserve_bottom_padding(len(choices) + 3)
     where = questionary.select(
         "Where should Stash record agent sessions?",
-        choices=[everywhere, here, custom],
+        choices=choices,
         default=everywhere,
     ).ask()
     if where is None:
         raise typer.Exit(1)
-    if where == here:
-        save_recorded_paths([str(cwd)])
+    if where == everywhere:
+        save_recorded_paths([])
     elif where == custom:
-        picked = questionary.path("Which folder?", only_directories=True).ask()
+        picked = _pick_record_folder(cwd)
         if picked is None:
             raise typer.Exit(1)
-        save_recorded_paths([str(Path(picked).expanduser().resolve())])
+        save_recorded_paths([str(picked)])
     else:
-        save_recorded_paths([])
+        save_recorded_paths([where])
     start_streaming()
 
     detected = _detected_agents()


### PR DESCRIPTION
Follow-up to #1020, which shipped the "Where should Stash record agent sessions?" question with a blank `Which folder?` path prompt behind the pick-a-folder option — a UI that asks the user to *produce* an answer. Stash already knows the answer: the transcript history the importer reads carries every past session's working directory.

## What changed

- **The user's real agent folders appear inline in the where-to-record question itself**, ranked by session count (existing directories only, current folder deduped): e.g. `Only ~/projects/stash (419 sessions)`. Most users recognize their answer in the first list and never type anything.
- **"Only a folder I pick…" opens the full ranked candidate list**, then an **arrow-key folder browser** — "✓ Record this folder" pinned on top, `..` to go up, subfolders to drill into, permission-denied dirs render as empty rather than crashing.
- **Typing a path still exists** — as the explicitly last-resort option.

Mining reuses `discover_conversations()` from the history importer (no new scanning code) and runs on the same data the import step reads seconds later.

## Verified

Smoke-tested the candidate mining against a real machine: it surfaced the actual top agent folders with correct counts (882/419/360-session folders, correctly ranked, `~`-abbreviated). 389 CLI+plugin tests pass, ruff clean. The interactive select/browser paths need a TTY — reviewed by reading; worth one manual `stash setup` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-first-run UX only; reuses existing history discovery and local path config with no auth or streaming pipeline changes.
> 
> **Overview**
> Improves **`stash setup`** so users rarely need to type a recording folder path.
> 
> The **“Where should Stash record agent sessions?”** step now lists up to three **real working directories** from past agent transcripts (via `discover_conversations()`), ranked by session count and shown with `~`-short paths. **“Only a folder I pick…”** routes through **`_pick_record_folder`**: ranked candidates, an arrow-key **folder browser** (`_browse_folders`), with **type a path** as last resort.
> 
> Recording scope saving is aligned with the new choice values: **everywhere** → empty `recorded_paths`, **custom** → picked path, **inline/here** → the selected folder path string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dfc317ebe919bf135f2f99f1acef05f77c1ae0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->