### PR TITLE
Pick-a-folder pops the native Finder chooser on macOS

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4912,6 +4912,26 @@ def _pretty_path(path: Path) -> str:
     return "~" + raw[len(home) :] if raw.startswith(home) else raw
 
 
+def _choose_folder_finder(start: Path) -> Path | None:
+    """Pop the native macOS Finder folder chooser. None means the user hit
+    Cancel; any other failure (e.g. an SSH session with no GUI) raises so the
+    user re-runs and picks "Type a path" instead of silently losing the answer."""
+    import subprocess
+
+    script = (
+        "POSIX path of (choose folder with prompt "
+        '"Where should Stash record agent sessions?" '
+        f'default location POSIX file "{start}")'
+    )
+    result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    if result.returncode != 0:
+        if "-128" in result.stderr:  # AppleScript's "User canceled."
+            return None
+        raise RuntimeError(f"Finder dialog failed: {result.stderr.strip()}")
+    raw = result.stdout.strip()
+    return Path(raw) if raw else None
+
+
 def _browse_folders(start: Path) -> Path | None:
     """Arrow-key folder browser: 'record this folder' pinned on top, '..' to
     go up, subfolders to drill into. No typing required."""
@@ -4946,7 +4966,8 @@ def _pick_record_folder(start: Path) -> Path | None:
     """The ergonomic folder choice: your agents' actual working folders first,
     a browser second, a typed path as the escape hatch."""
     candidates = _agent_folder_candidates()
-    browse = "Browse folders…"
+    native = sys.platform == "darwin"
+    browse = "Choose in Finder…" if native else "Browse folders…"
     type_it = "Type a path"
     choices: list[questionary.Choice] = [
         questionary.Choice(f"{_pretty_path(p)}  ({n} session{'s' if n != 1 else ''})", value=str(p))
@@ -4964,7 +4985,7 @@ def _pick_record_folder(start: Path) -> Path | None:
     if picked is None:
         return None
     if picked == browse:
-        return _browse_folders(start)
+        return _choose_folder_finder(start) if native else _browse_folders(start)
     if picked == type_it:
         typed = questionary.path("Folder path:", only_directories=True).ask()
         if typed is None:


### PR DESCRIPTION
Follow-up to #1022: on macOS, the "pick a folder" option now opens the **native Finder folder chooser** (AppleScript `choose folder` via `osascript`) instead of the terminal browser — with the wizard's question as the dialog prompt and the suggested folder preselected.

- **Cancel is a first-class answer**: AppleScript's `User canceled (-128)` maps to a graceful return, verified live (the dialog was popped on a real Mac and canceled).
- **No-GUI environments fail loud**: an SSH session where `osascript` can't open a dialog raises with the real error, pointing the user at "Type a path" — no silent substitution.
- Linux/others keep the arrow-key terminal browser from #1022; "Type a path" survives everywhere as the last resort.

390 CLI+plugin tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to first-run/setup folder selection UX on Darwin; no changes to auth, recording logic, or server APIs.
> 
> **Overview**
> On **macOS**, the setup wizard’s custom-folder flow now opens the **native Finder** folder chooser (`osascript` + AppleScript `choose folder`) instead of the in-terminal arrow-key browser. The menu label becomes **“Choose in Finder…”**; non-Darwin platforms still use **“Browse folders…”** and `_browse_folders`.
> 
> The new `_choose_folder_finder` helper uses the wizard prompt as the dialog title and preselects the suggested start path. **Cancel** maps to AppleScript error **-128** and returns `None`; other failures (e.g. no GUI over SSH) **raise** with stderr so users can fall back to **“Type a path”** instead of a silent failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c44f66737435d4ed00c5a34aaa269490afe6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->