### PR TITLE
Detect Claude Code by its folder, not by PATH

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -290,10 +290,40 @@ def _codex_present() -> bool:
     return False
 
 
+def _claude_binary() -> str | None:
+    """Resolve the `claude` executable, PATH first then the known install
+    locations.
+
+    PATH alone misses real installs: the local/migrate install parks the
+    binary at ~/.claude/local/claude behind a *shell alias* (never on PATH,
+    so `which` can never see it), and ~/.local/bin is on PATH only if a shell
+    rc put it there — which a non-interactive process may not inherit.
+    """
+    import os
+
+    found = shutil.which(_AGENT_BINARY["claude"])
+    if found:
+        return found
+    home = Path.home()
+    for candidate in (
+        home / ".local" / "bin" / "claude",
+        home / ".claude" / "local" / "claude",
+    ):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
 def _agent_present(agent: str) -> bool:
     """True if the agent is usable on this machine (binary on PATH or config dir exists)."""
     import shutil
 
+    if agent == "claude":
+        # ~/.claude is where Claude Code keeps the transcripts we record, so
+        # it — not PATH — is the honest signal that this machine runs Claude
+        # Code. Requiring the binary hid the flagship agent from users whose
+        # install isn't on PATH, and took their history import down with it.
+        return _claude_binary() is not None or (Path.home() / ".claude").is_dir()
     if shutil.which(_AGENT_BINARY[agent]):
         return True
     if agent == "codex":
@@ -394,6 +424,8 @@ def _install_claude(force: bool) -> tuple[str, str]:
     ok = _install_claude_plugin()
     if ok:
         return ("installed", "claude plugin installed via marketplace")
+    if _claude_binary() is None:
+        return ("failed", "no `claude` executable found — see above")
     return ("failed", "claude plugin install; see inline output")
 
 
@@ -5305,9 +5337,19 @@ def _install_claude_plugin() -> bool:
     """
     import subprocess as _sp
 
+    binary = _claude_binary()
+    if binary is None:
+        console.print(
+            "  [yellow]Found your Claude Code folder, but no `claude` executable to "
+            "install the live-recording plugin with. Past sessions still import; new "
+            "ones won't stream until you re-run [bold]stash setup[/bold] from a shell "
+            "where `claude --version` works.[/yellow]"
+        )
+        return False
+
     for cmd in (
-        ["claude", "plugin", "marketplace", "add", "Fergana-Labs/stash"],
-        ["claude", "plugin", "install", "stash@stash-plugins"],
+        [binary, "plugin", "marketplace", "add", "Fergana-Labs/stash"],
+        [binary, "plugin", "install", "stash@stash-plugins"],
     ):
         try:
             result = _sp.run(cmd, check=True, capture_output=True, text=True, timeout=60)

--- a/cli/tests/test_agent_detection.py
+++ b/cli/tests/test_agent_detection.py
@@ -35,3 +35,71 @@ def test_codex_detects_macos_desktop_app_without_binary_or_session_history(
     (tmp_path / "Library" / "Application Support" / "Codex").mkdir(parents=True)
 
     assert _agent_present("codex")
+
+
+# --- Claude Code: detection must not hinge on PATH ---
+#
+# Claude Code is the flagship agent, and `shutil.which("claude")` misses real
+# installs — the local/migrate install hides the binary behind a shell alias,
+# and ~/.local/bin reaches PATH only via a shell rc. When detection missed it
+# the user lost *both* live recording and their history import (the import is
+# scoped to the detected agents), which is exactly what happened on a customer
+# call: the picker offered Cursor — detected from a stray ~/.cursor — while the
+# agent they actually used went unseen.
+
+
+def test_claude_detected_from_its_folder_without_binary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    (tmp_path / ".claude" / "projects").mkdir(parents=True)
+
+    assert _agent_present("claude")
+
+
+def test_claude_detected_from_alias_style_local_install(monkeypatch, tmp_path: Path) -> None:
+    # ~/.claude/local/claude + a shell alias: never on PATH, still a real install.
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    local = tmp_path / ".claude" / "local"
+    local.mkdir(parents=True)
+    binary = local / "claude"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    assert main._claude_binary() == str(binary)
+    assert _agent_present("claude")
+
+
+def test_claude_absent_when_nothing_on_the_machine(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert not _agent_present("claude")
+
+
+def test_undetected_claude_would_strand_its_history_import(monkeypatch, tmp_path: Path) -> None:
+    """The import is scoped to detected agents, so missing Claude silently
+    strands every transcript on disk — the failure that cost a customer their
+    whole first impression."""
+    from cli import import_history
+
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    # The discoverer freezes this path at import time, so patching home alone
+    # would read the developer's own transcripts.
+    monkeypatch.setattr(import_history, "CLAUDE_PROJECTS_DIR", tmp_path / ".claude" / "projects")
+
+    proj = tmp_path / ".claude" / "projects" / "-Users-someone-repo"
+    proj.mkdir(parents=True)
+    proj.joinpath("s1.jsonl").write_text(
+        '{"type":"summary","summary":"work"}\n'
+        '{"type":"user","timestamp":"2026-08-07T12:00:00Z","cwd":"/Users/someone/repo",'
+        '"sessionId":"s1","message":{"role":"user","content":"hi"}}\n'
+    )
+
+    detected = main._detected_agents()
+    assert detected == ["claude"]
+    found = import_history.discover_conversations(detected)
+    assert [(c.agent, c.session_id) for c in found] == [("claude", "s1")]


### PR DESCRIPTION
Root-causes the moment on Charlie's Aug 7 call where the agent picker offered **Cursor but not Claude Code** — *"I don't use cursor really, I just brute force with Claude Code"* / *"it's not working, that's weird — normally it auto-detects Claude."*

## The bug

`_agent_present()` gives every agent a config-directory fallback when the binary isn't on PATH — codex, cursor, gemini, hermes — **except claude**, which returns `False` outright. So Cursor is detected by a stray `~/.cursor` (a trial-install leftover is enough) while Claude Code, with `~/.claude/projects` full of transcripts, is invisible unless `shutil.which("claude")` succeeds.

`which` misses real installs routinely: the local/migrate install parks the binary at `~/.claude/local/claude` behind a **shell alias** (never on PATH, so `which` can never find it), and `~/.local/bin` is on PATH only because a shell rc put it there — on this repo's own dev machine, `~/.zshrc:74`. Nothing in the codebase handled either case.

## Why it was expensive

`_onboarding_import_history()` scopes `discover_conversations()` to the detected agents. Undetected Claude therefore cost the user **both** live recording and the history import — a machine full of transcripts imported nothing. That is the explanation for the next beat of the call, when the customer opened memory and the reply was *"I guess you haven't uploaded anything."*

## The fix

- `_agent_present("claude")` trusts `~/.claude` — the folder holding the transcripts we record, and already the authority everywhere else in the CLI (`import_history.py`, session/plugin state in `main.py`).
- New `_claude_binary()` resolves the executable past PATH (`~/.local/bin/claude`, `~/.claude/local/claude`); `_install_claude_plugin()` shells out to that instead of a bare `claude`.
- Folder present but no executable → setup says so plainly ("past sessions still import; new ones stream once `claude --version` works") instead of silently dropping the agent.

## Verified

Simulated the customer's machine (transcripts on disk, empty `~/.cursor`, no `claude` on PATH): before → `['cursor']` detected, **zero** conversations discovered; after → `['claude', 'cursor']`, the Claude transcript discovered. Real-machine sanity check still resolves `~/.local/bin/claude` and detects all six agents. Four new tests cover folder detection, alias-style local install, true absence, and the history-import consequence. 394 CLI+plugin tests pass, ruff clean.

Ships on the PyPI CLI release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI detection and install behavior; aligns Claude with other agents’ folder fallbacks and only broadens who sees Claude in setup/import.
> 
> **Overview**
> **Fixes Claude Code being invisible in onboarding** when the `claude` binary is not on `PATH` (alias/local install at `~/.claude/local/claude`, or `~/.local/bin` without inherited shell rc), while other agents already fell back to config folders.
> 
> Adds **`_claude_binary()`** to resolve the executable from PATH then `~/.local/bin/claude` and `~/.claude/local/claude`. **`_agent_present("claude")`** now treats a found binary **or** an existing **`~/.claude`** directory as present, so **`_detected_agents()`** and history import scoped to detected agents include Claude again.
> 
> **Setup/install paths** invoke the resolved binary for marketplace/plugin commands; if the folder exists but no executable is found, setup prints a yellow warning (past import still works; live streaming needs a working `claude`). **`_install_claude`** fails explicitly when no binary is found.
> 
> Four tests cover folder-only detection, alias-style local binary, true absence, and that undetected Claude would skip history discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b69680d671ae31d89ffada5ae33ea6db047a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->