### PR TITLE
Setup splash links Home, and stops asking about Codex's sandbox

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -485,22 +485,6 @@ def _upsert_agents_md(path: Path, body: str) -> None:
     path.write_text(new)
 
 
-def _ask_codex_network_access() -> bool:
-    """Prompt the user to enable top-level `network_access` for codex's
-    workspace-write sandbox."""
-    console.print(
-        "For stash to work on codex specifically, we need to let bash "
-        "commands make network requests so that we can upload session "
-        "transcripts to the remote server."
-    )
-    answer = questionary.confirm(
-        "Allow codex bash commands to make outbound network requests?",
-        default=True,
-    ).ask()
-    # Dismissing the prompt (Esc/Ctrl-C) must not grant network access.
-    return bool(answer)
-
-
 def _merge_snippet_into_toml(existing: str, snippet: str) -> tuple[str, str]:
     """Merge snippet sections into existing TOML without creating duplicates.
 
@@ -592,23 +576,6 @@ def _merge_snippet_into_toml(existing: str, snippet: str) -> tuple[str, str]:
     return merged_existing, cleaned_snippet
 
 
-def _strip_top_level_sandbox(snippet: str) -> str:
-    """Call this when the user opts not to grant outbound network
-    request access. It removes the toml that grants codex outbound
-    network request access."""
-    start = snippet.find("[sandbox_workspace_write]")
-    if start == -1:
-        return snippet
-    prev_blank = snippet.rfind("\n\n", 0, start)
-    block_start = prev_blank + 2 if prev_blank != -1 else start
-    end = snippet.find("[profiles.stash]", start)
-    if end == -1:
-        return snippet[:block_start].rstrip() + "\n"
-    prev_blank_end = snippet.rfind("\n\n", start, end)
-    block_end = prev_blank_end + 2 if prev_blank_end != -1 else end
-    return snippet[:block_start] + snippet[block_end:]
-
-
 def _install_codex(force: bool) -> tuple[str, str]:
     root = _assets_dir("codex")
     hooks_dest = Path.home() / ".codex" / "hooks.json"
@@ -640,15 +607,22 @@ def _install_codex(force: bool) -> tuple[str, str]:
         PLUGIN_ROOT=str(root)
     )
 
-    if _CODEX_MARKER not in existing:
-        if not _ask_codex_network_access():
-            snippet = _strip_top_level_sandbox(snippet)
-
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     if _CODEX_MARKER not in existing:
         existing, snippet = _merge_snippet_into_toml(existing, snippet)
         sep = "\n" if existing and not existing.endswith("\n") else ""
         cfg_path.write_text(f"{existing}{sep}\n{_CODEX_MARKER}\n{snippet}\n")
+        # Codex's workspace-write sandbox blocks outbound network, which
+        # silently kills our hook uploads — recording Codex is impossible
+        # without lifting it. The user chose to record Codex a question ago,
+        # so state the consequence rather than asking a second, scarier
+        # version of the same question.
+        console.print(
+            f"  [dim]Lifted the outbound-network block in Codex's workspace-write "
+            f"sandbox ({cfg_path}) — its hooks can't upload without it. Delete that "
+            f"block to keep the sandbox tight and launch `codex --profile stash` "
+            f"instead.[/dim]"
+        )
 
     agents_src = root / "AGENTS.md"
     agents_dest = Path.home() / ".codex" / "AGENTS.md"
@@ -5607,7 +5581,8 @@ def _active_import() -> dict | None:
 def _setup_complete_intro(
     frontend_url: str, connected: bool, recording: bool, importing: dict | None
 ) -> str:
-    memory_url = f"{frontend_url}/memory"
+    # Home *is* the memory dashboard — there is no /memory route.
+    memory_url = frontend_url
     recording_section = (
         "[bold]You're recording[/bold]\n"
         "This machine's agent sessions upload to your private Stash.\n"

--- a/cli/tests/test_install_codex.py
+++ b/cli/tests/test_install_codex.py
@@ -7,15 +7,16 @@ import json
 import tomllib
 from pathlib import Path
 
+import pytest
+
 from cli.main import _install_codex
 
 _CODEX_EVENTS = ("on_session_start", "on_prompt", "on_tool_use", "on_stop")
 
 
-def _run_install(monkeypatch, tmp_path: Path, allow_network: bool = True) -> Path:
+def _run_install(monkeypatch, tmp_path: Path) -> Path:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
-    monkeypatch.setattr("cli.main._ask_codex_network_access", lambda: allow_network)
     _install_codex(False)
     return tmp_path / ".codex" / "config.toml"
 
@@ -190,3 +191,20 @@ def test_preexisting_unmarked_skill_sections_do_not_duplicate(monkeypatch, tmp_p
         parsed = tomllib.load(f)
     assert parsed["features"]["hooks"] is True
     assert parsed["features"]["suppress_unstable_features_warning"] is True
+
+
+def test_install_grants_network_without_prompting(monkeypatch, tmp_path: Path) -> None:
+    """Recording Codex is impossible while its sandbox blocks outbound network,
+    and the user already chose to record Codex when they picked their agents.
+    Asking again — in scarier words, about *their* sandbox — belongs nowhere in
+    onboarding, so the install states the change instead of gating on it."""
+    monkeypatch.setattr(
+        "questionary.confirm",
+        lambda *a, **k: pytest.fail("codex install must not prompt"),
+    )
+
+    cfg = _run_install(monkeypatch, tmp_path)
+
+    with cfg.open("rb") as f:
+        parsed = tomllib.load(f)
+    assert parsed["sandbox_workspace_write"]["network_access"] is True

--- a/cli/tests/test_setup_complete_splash.py
+++ b/cli/tests/test_setup_complete_splash.py
@@ -24,7 +24,9 @@ def test_setup_complete_intro_always_links_memory() -> None:
     for connected in (False, True):
         intro = _intro(connected=connected)
         assert "Your knowledge base" in intro
-        assert f"{FRONTEND_URL}/memory" in intro
+        # Home is the memory dashboard; /memory is not a route.
+        assert FRONTEND_URL in intro
+        assert f"{FRONTEND_URL}/memory" not in intro
 
 
 def test_setup_complete_intro_states_recording_on() -> None:


### PR DESCRIPTION
Two things a fresh run through onboarding turned up. Both in the CLI's first-run path.

## The one link we hand a new user was broken

The setup splash's "Your knowledge base" line pointed at `{frontend}/memory` — **not a route**. Home *is* the memory dashboard now, so a brand-new user finishing setup got a 404 at the exact moment they go looking for what just happened. It now points at the app root.

## The Codex sandbox prompt is gone

Setup asked: *"Allow codex bash commands to make outbound network requests?"* — a per-agent sandbox implementation detail, phrased as us asking to weaken the user's own sandbox, at the most trust-sensitive moment in the product.

It was also the same question twice. Codex's `workspace-write` sandbox blocks outbound network, which silently kills our hook POSTs, so **recording Codex is impossible without lifting it** — and the user chose to record Codex one question earlier, in the agent picker. The install now makes the change and states it in one line, naming the file it touched and how to undo it:

> Lifted the outbound-network block in Codex's workspace-write sandbox (~/.codex/config.toml) — its hooks can't upload without it. Delete that block to keep the sandbox tight and launch `codex --profile stash` instead.

Same principle as the where-to-record question (#1020): say what's happening at the moment it happens, rather than gating on a scarier restatement of a decision already made.

**Bonus fix:** in headless setup the prompt hit `questionary` on a non-TTY, which returned `None` -> `False` -> silently stripped the network grant. Scripted installs therefore never streamed from plain `codex`. That path is now consistent with the interactive one.

## Trade-off, stated plainly

This grants network to *all* Codex bash commands, not only ours — the same thing the prompt granted whenever it was accepted, which it was by default. If you'd rather preserve the sandbox by default, the alternative is profile-only (`codex --profile stash`), at the cost of silent non-recording for anyone launching plain `codex`. Happy to switch if you prefer that trade.

New test asserts the install grants top-level network access **and** never prompts; the dead `_strip_top_level_sandbox` helper goes with the prompt. 395 CLI+plugin tests pass, ruff clean. Ships on the PyPI CLI release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI onboarding and Codex config merge only; behavior matches the previous default when users accepted the prompt, with clearer messaging and a fix for non-interactive installs.
> 
> **Overview**
> **Setup splash** now links “Your knowledge base” to the app root instead of `{frontend}/memory`, which was not a route and 404’d for new users.
> 
> **Codex install** no longer asks to allow outbound network for bash commands. The full `config.toml` snippet (including top-level `[sandbox_workspace_write]` `network_access`) is always merged when needed, and a dim one-line message explains the sandbox change and how to undo it (`codex --profile stash`). Removes `_ask_codex_network_access` and `_strip_top_level_sandbox`, fixing headless installs where a non-TTY prompt returned `None` and silently dropped the network grant.
> 
> Tests cover no-prompt install with top-level network access and the corrected memory URL in the setup intro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106c8559f983b27ec06da2da96f34a9846d0a0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->