### PR TITLE
Say what authorizing the CLI actually grants, at the moment of consent

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -5036,7 +5036,9 @@ def _run_setup_wizard() -> None:
     console.print(
         "\nStash records your coding agent sessions to your private Stash so you\n"
         "and your agents can search them later. Transcripts are visible only to\n"
-        "you unless you share them, and you can pause anytime with `stash stop`."
+        "you unless you share them, and you can pause anytime with `stash stop`.\n"
+        "[dim]Stash reads only the transcript files your agents already write\n"
+        "(like ~/.claude/projects) — never your code or documents.[/dim]"
     )
     cwd = Path.cwd()
     everywhere = "Everywhere on this machine"
@@ -5102,8 +5104,9 @@ def _run_setup_wizard() -> None:
     repo_root = _git_toplevel() or Path.cwd()
     _reserve_bottom_padding(4)
     connect = questionary.confirm(
-        f"Add Stash instructions to CLAUDE.md in {repo_root.name}, so agents "
-        "working there know how to use Stash?",
+        f"Write a note into {repo_root.name}/CLAUDE.md so agents working there "
+        "know how to use Stash? (This writes one file — it doesn't give Stash "
+        "access to the repo.)",
         default=True,
     ).ask()
     if connect is None:

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Check, X } from "lucide-react";
 import Header from "../../components/Header";
 import { AuthPageSkeleton, SkeletonBlock } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
@@ -202,10 +203,7 @@ function LoginPageInner() {
     return (
       <CliShell user={user} logout={logout} cliSession={cliSession}>
         <FormCard>{formBody}</FormCard>
-        <p className="text-center text-[11px] text-muted-foreground leading-relaxed max-w-[340px] mx-auto">
-          By authorizing, you grant this terminal session a personal API key on your behalf.
-          You can revoke it any time from your account settings.
-        </p>
+        <CliConsentCard />
       </CliShell>
     );
   }
@@ -230,6 +228,39 @@ function signInTitle(): string {
 }
 
 // --- Authorize CLI (already signed-in) ---------------------------------------
+
+/** What authorizing actually grants — shown wherever a terminal asks to
+ *  connect. The ✗ line matters most: the CLI reads agent transcript files,
+ *  never your code, and consent is staged — scope choices (which agents,
+ *  which folders) happen visibly in the terminal after this click. */
+function CliConsentCard() {
+  const row = "flex items-start gap-2.5 text-left text-[12.5px] leading-5";
+  return (
+    <div className="space-y-2.5 rounded-xl border border-border bg-surface px-4 py-3.5">
+      <div className={row}>
+        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--color-success)]" />
+        <span className="text-foreground">
+          Upload agent session transcripts — only from the agents and folders you pick in
+          the next step
+        </span>
+      </div>
+      <div className={row}>
+        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--color-success)]" />
+        <span className="text-foreground">
+          Read and write your Stash as you (files, pages, memory)
+        </span>
+      </div>
+      <div className={row}>
+        <X className="mt-0.5 h-3.5 w-3.5 shrink-0 text-error" />
+        <span className="text-dim">
+          It does <span className="font-semibold text-foreground">not</span> read your code
+          or documents — transcripts only, and nothing uploads until you finish setup in
+          the terminal
+        </span>
+      </div>
+    </div>
+  );
+}
 
 function AuthorizeCliPanel({
   username,
@@ -274,10 +305,13 @@ function AuthorizeCliPanel({
     <FormCard>
       <div className="space-y-3 text-center">
         <p className="text-sm text-foreground">
-          Authorize CLI as <span className="font-semibold">{username}</span>?
+          This terminal wants to connect to your Stash as{" "}
+          <span className="font-semibold">{username}</span>
         </p>
+        <CliConsentCard />
         <p className="text-[11px] text-muted-foreground">
-          A new API key scoped to this terminal will be created. You can revoke it anytime from account settings.
+          A new API key scoped to this terminal will be created. You can revoke it anytime
+          from account settings.
         </p>
         {error && <ErrorLine message={error} />}
         <button


### PR DESCRIPTION
Reopens the work from #1015, which GitHub auto-closed when `stash-revamp` was deleted after the revamp merge (#1021). Rebased onto `main`; one small conflict resolved by keeping both the "pause anytime with `stash stop`" sentence from #1020 and this branch's privacy line.

Fixes gripe #3 from Charlie's Aug 7 onboarding walkthrough: at the authorize click he asked *"is it going to look at all the data on my desktop?"* — and nothing on screen answered. The mechanics were already privacy-correct (the CLI reads agent transcript files, never your code); this makes the copy say so at both moments where the fear fires.

## Browser half (`/login?cli=…`)

The abstract "you grant this terminal a personal API key" line becomes a consent card, shown both when signing in for a terminal and when approving one while already signed in:

- ✓ Upload agent session transcripts — only from the agents and folders you pick in the next step
- ✓ Read and write your Stash as you (files, pages, memory)
- ✗ It does **not** read your code or documents — transcripts only, and nothing uploads until you finish setup in the terminal

The "next step" framing stages consent honestly: this click is identity; scope choices happen visibly in the terminal right after — which is now literally true, since setup asks *where* to record (#1020) with a Finder picker (#1023).

## CLI half (`stash signin` wizard)

- The recording intro adds: "Stash reads only the transcript files your agents already write (like ~/.claude/projects) — never your code or documents."
- The CLAUDE.md question no longer reads like an access grant: *"Write a note into {repo}/CLAUDE.md… (This writes one file — it doesn't give Stash access to the repo.)"*

## Deliberately not done

No granular-scopes UI — the minted key really is full Stash access, and scope checkboxes would imply enforcement that doesn't exist.

Verified: consent card screenshotted live in the authorize flow; 394 CLI+plugin tests, 297 frontend tests, tsc + ruff clean. The CLI half ships on the PyPI release train, the web half on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)