### PR TITLE
Onboarding role is multi-select

### DIFF
--- a/frontend/src/app/onboarding/page.test.tsx
+++ b/frontend/src/app/onboarding/page.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import OnboardingPage from "./page";
+import { updateMe } from "../../lib/api";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -24,7 +25,6 @@ vi.mock("../../components/Header", () => ({ default: () => null }));
 vi.mock("../../components/integrations/SourceConnectorList", () => ({
   default: () => null,
 }));
-vi.mock("./paths/memory/MemoryAskStep", () => ({ default: () => null }));
 vi.mock("../../lib/analytics", () => ({ track: vi.fn() }));
 vi.mock("../../lib/api", () => ({
   createMyKey: vi.fn(),
@@ -65,5 +65,56 @@ describe("about step pills", () => {
   it("there is no plan question — role and referral are the only requirements", () => {
     render(<OnboardingPage />);
     expect(screen.queryByText("Which plan fits you?")).toBeNull();
+  });
+});
+
+// Roles are multi-answer. A pre-seed founder who also writes the code is both,
+// and forcing one pill made the very first question in the product feel wrong
+// to the first investor who tried it.
+describe("role is multi-select", () => {
+  it("takes more than one answer and sends them all", async () => {
+    render(<OnboardingPage />);
+    const engineer = screen.getByRole("button", { name: "Engineer" });
+    const founder = screen.getByRole("button", { name: "Founder / Exec" });
+
+    fireEvent.click(engineer);
+    fireEvent.click(founder);
+    expect(engineer).toHaveAttribute("aria-pressed", "true");
+    expect(founder).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(updateMe).toHaveBeenCalledWith(
+        expect.objectContaining({ role: "Engineer, Founder / Exec" }),
+      ),
+    );
+  });
+
+  it("keeps referral single-select — you heard about us one way", () => {
+    render(<OnboardingPage />);
+    const search = screen.getByRole("button", { name: "Search" });
+    const github = screen.getByRole("button", { name: "GitHub" });
+
+    fireEvent.click(search);
+    fireEvent.click(github);
+
+    expect(search).toHaveAttribute("aria-pressed", "false");
+    expect(github).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("will not send a bare \"Other\" — it has to be spelled out", () => {
+    render(<OnboardingPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Other" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("What's your role?"), {
+      target: { value: "Founding engineer" },
+    });
+    expect(continueButton).toBeEnabled();
   });
 });

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -50,7 +50,8 @@ function OnboardingInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, loading, logout } = useAuth();
-  const [role, setRole] = useState("");
+  // Roles are multi-answer: plenty of people are a founder *and* an engineer.
+  const [roles, setRoles] = useState<string[]>([]);
   const [roleOther, setRoleOther] = useState("");
   const [referralSource, setReferralSource] = useState("");
   const [referralOther, setReferralOther] = useState("");
@@ -109,7 +110,13 @@ function OnboardingInner() {
   const isAbout = stepIdx <= 0;
 
   const continueLabel = isAbout ? "Continue" : "Finish";
-  const roleAnswer = role === "Other" ? roleOther.trim() && `Other: ${roleOther.trim()}` : role;
+  // "Other" only counts once it's spelled out, so picking it without typing
+  // leaves the question unanswered rather than sending a bare "Other".
+  const otherSpelledOut = !roles.includes("Other") || Boolean(roleOther.trim());
+  const roleAnswer =
+    roles.length > 0 && otherSpelledOut
+      ? roles.map((r) => (r === "Other" ? `Other: ${roleOther.trim()}` : r)).join(", ")
+      : "";
   const referralAnswer =
     referralSource === "Other"
       ? referralOther.trim() && `Other: ${referralOther.trim()}`
@@ -145,12 +152,14 @@ function OnboardingInner() {
           <ProgressBar stepIdx={stepIdx} />
           {isAbout && (
             <AboutStep
-              role={role}
+              roles={roles}
               roleOther={roleOther}
               referralSource={referralSource}
               referralOther={referralOther}
               useCase={useCase}
-              onRole={setRole}
+              onToggleRole={(r) =>
+                setRoles((prev) => (prev.includes(r) ? prev.filter((x) => x !== r) : [...prev, r]))
+              }
               onRoleOther={setRoleOther}
               onReferral={setReferralSource}
               onReferralOther={setReferralOther}
@@ -171,23 +180,23 @@ function OnboardingInner() {
 }
 
 function AboutStep({
-  role,
+  roles,
   roleOther,
   referralSource,
   referralOther,
   useCase,
-  onRole,
+  onToggleRole,
   onRoleOther,
   onReferral,
   onReferralOther,
   onUseCase,
 }: {
-  role: string;
+  roles: string[];
   roleOther: string;
   referralSource: string;
   referralOther: string;
   useCase: string;
-  onRole: (v: string) => void;
+  onToggleRole: (v: string) => void;
   onRoleOther: (v: string) => void;
   onReferral: (v: string) => void;
   onReferralOther: (v: string) => void;
@@ -203,14 +212,18 @@ function AboutStep({
           A few quick questions so we can tailor Stash to how you&rsquo;ll use it.
         </p>
       </div>
-      <Field label="What's your role?">
-        <PillGroup options={ROLE_OPTIONS} value={role} onChange={onRole} />
-        {role === "Other" && (
+      <Field label="What's your role? Pick as many as fit.">
+        <PillGroup options={ROLE_OPTIONS} selected={roles} onToggle={onToggleRole} />
+        {roles.includes("Other") && (
           <OtherInput value={roleOther} onChange={onRoleOther} placeholder="What's your role?" />
         )}
       </Field>
       <Field label="How did you hear about us?">
-        <PillGroup options={REFERRAL_OPTIONS} value={referralSource} onChange={onReferral} />
+        <PillGroup
+          options={REFERRAL_OPTIONS}
+          selected={referralSource ? [referralSource] : []}
+          onToggle={(v) => onReferral(referralSource === v ? "" : v)}
+        />
         {referralSource === "Other" && (
           <OtherInput
             value={referralOther}
@@ -253,27 +266,30 @@ function Field({
   );
 }
 
+/** Pills for one question. `selected` carries every chosen answer, so the same
+ *  component serves the multi-answer role question and the single-answer
+ *  referral one — the caller's onToggle decides which. */
 function PillGroup({
   options,
-  value,
-  onChange,
+  selected,
+  onToggle,
 }: {
   options: string[];
-  value: string;
-  onChange: (v: string) => void;
+  selected: string[];
+  onToggle: (v: string) => void;
 }) {
   return (
     <div className="flex flex-wrap gap-2">
       {options.map((option) => {
-        const selected = value === option;
+        const isSelected = selected.includes(option);
         return (
           <button
             key={option}
             type="button"
-            aria-pressed={selected}
-            onClick={() => onChange(selected ? "" : option)}
+            aria-pressed={isSelected}
+            onClick={() => onToggle(option)}
             className={`cursor-pointer rounded-full border px-3 py-1.5 text-[12.5px] transition-colors ${
-              selected
+              isSelected
                 ? "border-brand bg-brand text-white"
                 : "border-border bg-surface text-dim hover:border-foreground/40 hover:text-foreground"
             }`}


### PR DESCRIPTION
Gripe #2 from Charlie's Aug 7 walkthrough, hit within the first ten seconds of the product: *"I'm an engineer, founder exec. I guess founder. I don't know which one I am nowadays. Just maybe allow for more, because I'm a founder-engineer now."*

The very first question we ask forced a single pill.

## What changed

- **Roles are multi-answer.** Pick Engineer *and* Founder / Exec; they join into the same `role` string the backend already stores (`"Engineer, Founder / Exec"` — no schema change).
- **"Other" still has to be spelled out.** Selecting it without typing leaves the question unanswered, so we never store a bare `"Other"` — same rule as before, now applied per-selection.
- **Referral stays single-answer** — you heard about us one way. Both questions share one `PillGroup`; the caller's `onToggle` decides the rule, so there's one component rather than two near-copies.
- Drops a stale `vi.mock` for the memory ask-step that #1019 deleted.

## Verified

Browser-tested on the live wizard: Engineer and Founder / Exec both selected at once, referral still exclusive (clicking GitHub after Search moves the selection). Three new tests cover multi-select + the joined payload, referral exclusivity, and the bare-"Other" guard. 300 frontend tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and profile string formatting only; no auth, backend, or schema changes.
> 
> **Overview**
> Onboarding’s **role** question is now **multi-select** (“Pick as many as fit”), so users can choose combinations like Engineer and Founder / Exec. Selections are still sent as one comma-joined `role` string on `updateMe` (no API/schema change).
> 
> **Referral** stays single-select; both questions share a refactored `PillGroup` that takes `selected[]` and `onToggle`, with referral wired to replace/clear the one choice. **Other** for role still blocks Continue until custom text is entered.
> 
> Tests add coverage for multi-role payload, referral exclusivity, and the bare-**Other** guard; a stale `MemoryAskStep` mock is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930eb4d23076e999eb0857f007a3ffa0ab07e278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->