### PR TITLE
Hotfix the defects the stash-revamp review found

### DIFF
--- a/backend/routers/aggregate.py
+++ b/backend/routers/aggregate.py
@@ -80,13 +80,14 @@ async def list_file_activity(
     current_user: dict = Depends(get_current_user),
 ):
     """New and edited files and pages across accessible scopes, cursor-paginated
-    by ts. The Memory subtree is excluded: curation output is the curator log's
-    story, not file activity."""
+    by ts. Memory subtrees are excluded: curation output is the curator log's
+    story, not file activity. Every scope's Memory is excluded, not just the
+    caller's — a workspace scope's nightly curation churn would otherwise flood
+    the feed of every member who can read it."""
     pool = get_pool()
-    memory_ids = list(await files_tree_service.memory_subtree_folder_ids(current_user["id"]))
     events = await pool.fetch(
         """
-        WITH accessible_scopes AS (
+        WITH RECURSIVE accessible_scopes AS (
           -- The user's own scope plus any scope that has shared content with
           -- the user. Page/file rows still pass readable_content_condition, so
           -- a share only surfaces the specific shared rows — never the whole
@@ -97,6 +98,14 @@ async def list_file_activity(
         + permission_service.accessible_scope_ids_sql(1)
         + """
           AND ($3::uuid IS NULL OR u.id = $3)
+        ),
+        memory_folders AS (
+          SELECT mf.id FROM folders mf
+          JOIN accessible_scopes aw ON aw.id = mf.owner_user_id
+          WHERE mf.is_memory
+          UNION
+          SELECT mf.id FROM folders mf
+          JOIN memory_folders m ON m.id = mf.parent_folder_id
         )
         SELECT * FROM (
         (
@@ -111,7 +120,7 @@ async def list_file_activity(
           FROM pages p
           JOIN accessible_scopes aw ON aw.id = p.owner_user_id
           WHERE p.deleted_at IS NULL
-            AND ($5::uuid[] = '{}' OR p.folder_id IS NULL OR p.folder_id <> ALL($5))
+            AND NOT EXISTS (SELECT 1 FROM memory_folders m WHERE m.id = p.folder_id)
             AND """
         + permission_service.readable_content_condition("page", "p", 1)
         + """
@@ -129,6 +138,7 @@ async def list_file_activity(
           FROM files f
           JOIN accessible_scopes aw ON aw.id = f.owner_user_id
           WHERE f.deleted_at IS NULL
+            AND NOT EXISTS (SELECT 1 FROM memory_folders m WHERE m.id = f.folder_id)
             AND """
         + permission_service.readable_content_condition("file", "f", 1)
         + """
@@ -141,7 +151,6 @@ async def list_file_activity(
         limit + 1,
         owner_user_id,
         before,
-        memory_ids,
     )
     has_more = len(events) > limit
     if has_more:

--- a/backend/routers/curator_log.py
+++ b/backend/routers/curator_log.py
@@ -14,6 +14,7 @@ from ..services.sprite_agent_service import (
     RUN_FAILED_PREFIX,
     STOPPED_NOTE,
     scheduled_session_prefix,
+    turn_running,
 )
 
 router = APIRouter(prefix="/api/v1/me", tags=["curator-log"])
@@ -43,13 +44,16 @@ async def curator_log(
         f"{prefix}%",
         limit,
     )
-    return {"entries": [_entry(dict(run)) for run in runs]}
+    return {"entries": [await _entry(dict(run)) for run in runs]}
 
 
-def _entry(run: dict) -> dict:
+async def _entry(run: dict) -> dict:
     final_text = run["final_text"]
     if final_text is None:
-        status, summary, error = "interrupted", None, None
+        # Tonight's pass is still writing: no final message yet. The turn lock
+        # is what separates it from a run that died before writing one.
+        status = "running" if await turn_running(run["session_id"]) else "interrupted"
+        summary, error = None, None
     elif final_text.startswith(RUN_FAILED_PREFIX):
         status, summary = "failed", None
         error = final_text.removeprefix(RUN_FAILED_PREFIX).strip()

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -91,6 +91,7 @@ async def _session_artifacts(session_row_id: UUID) -> list[dict]:
 async def list_my_sessions(
     owner_user_id: UUID | None = Query(None),
     session_folder_id: UUID | None = Query(None),
+    session_id_prefix: str | None = Query(None, max_length=64),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     current_user: dict = Depends(get_current_user),
@@ -102,6 +103,10 @@ async def list_my_sessions(
 
     Pass `session_folder_id` to scope to one folder — without it the list is a
     global recent window, so a folder's older sessions would never appear.
+    `session_id_prefix` narrows to one family of sessions by id — the chat
+    sidebar asks for `agent-` so a user whose recent window is full of recorded
+    CLI transcripts still sees their web chats; filtering client-side loses
+    every chat that falls outside the window.
     `offset` pages through the (last_event_at DESC) order for infinite scroll."""
     # The personal view spans every accessible scope (own + shared + workspace);
     # switching into a workspace narrows the window to that scope's sessions.
@@ -130,6 +135,12 @@ async def list_my_sessions(
     if session_folder_id is not None:
         args.append(session_folder_id)
         where.append(f"s.session_folder_id = ${len(args)}")
+    if session_id_prefix is not None:
+        args.append(session_id_prefix)
+        # starts_with, not LIKE: the prefix is caller-supplied and LIKE would
+        # read '%' and '_' in it as wildcards.
+        where.append(f"starts_with(he.session_id, ${len(args)})")
+        title_where.append(f"starts_with(he_title.session_id, ${len(args)})")
 
     rows = await pool.fetch(
         f"""

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -11,6 +11,7 @@ endpoints just manage the registry.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from datetime import UTC, datetime
@@ -137,6 +138,16 @@ async def _resolve_posthog_source(user_id) -> tuple[str, str]:
     return "project", f"PostHog ({display_name})"
 
 
+def _enqueue_source_syncs(source_ids: list[str]) -> None:
+    """Publishing to the broker is blocking socket work, so a batch of them
+    runs off the event loop."""
+    for source_id in source_ids:
+        celery.send_task(
+            "backend.tasks.sources.sync_source",
+            kwargs={"source_id": source_id},
+        )
+
+
 @router.get("")
 async def list_sources(
     current_user: dict = Depends(get_current_user),
@@ -145,17 +156,17 @@ async def list_sources(
     """Sources in the active scope's view: native files + sessions, plus the
     scope's connected sources.
 
-    Listing doubles as the freshness trigger: any stale source in the scope is
-    claimed and enqueued for sync before the listing is built, so the response
-    already shows it as syncing. Both the integration pages and the VFS read
-    through here — accessing your sources is what keeps them fresh."""
+    Listing doubles as the freshness trigger: any source in the scope that is
+    already due is claimed and enqueued before the listing is built, so the
+    response shows it as syncing. The integration pages and the workspace
+    explorer read through here, so looking at your sources pulls their next
+    sync forward instead of waiting for the Beat tick. Entry trees (/tree) do
+    not kick — they read what the last sync indexed."""
     owner_user_id = scope_user_id
     await _require_member(owner_user_id, current_user["id"])
-    for source_id in await source_service.kick_stale_sources(owner_user_id):
-        celery.send_task(
-            "backend.tasks.sources.sync_source",
-            kwargs={"source_id": source_id},
-        )
+    source_ids = await source_service.kick_stale_sources(owner_user_id)
+    if source_ids:
+        await asyncio.to_thread(_enqueue_source_syncs, source_ids)
     return {"sources": await source_service.list_sources(owner_user_id, current_user["id"])}
 
 

--- a/backend/routers/sql.py
+++ b/backend/routers/sql.py
@@ -2,17 +2,25 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..auth import get_current_user, get_scope
+from ..middleware import limiter
 from ..models import SqlQueryRequest, SqlQueryResponse
 from ..services import security_audit_service, sql_service, user_scope_service
 
 router = APIRouter(prefix="/api/v1/me", tags=["sql"])
 
+# Every call materializes the scope's whole table set into a fresh DuckDB, so
+# this is the most expensive endpoint in the app — capped like the other heavy
+# ones (marketing chat) rather than left open.
+_SQL_LIMIT = "30/minute"
+
 
 @router.post("/sql", response_model=SqlQueryResponse)
+@limiter.limit(_SQL_LIMIT)
 async def run_sql(
+    request: Request,
     req: SqlQueryRequest,
     current_user: dict = Depends(get_current_user),
     scope_user_id: UUID = Depends(get_scope),

--- a/backend/services/source_service.py
+++ b/backend/services/source_service.py
@@ -577,23 +577,33 @@ async def mark_sync_started(source_id: UUID) -> None:
     )
 
 
-# How stale a source may get before merely looking at it triggers a sync.
-# Listing sources IS the access path — integration pages and every VFS read go
-# through GET /me/sources — so freshness rides on usage instead of only the
-# 30-minute schedule.
+# How quiet a source must be before merely looking at it triggers a sync.
+# Listing sources is the access path, so this is the debounce that keeps a
+# burst of page views (or a source that fails every run) from churning.
 ACCESS_KICK_STALE_S = 300
+
+# One listing claims at most this many sources, matching the Beat reconciler's
+# batch: a single page view must not fan out into an unbounded number of
+# Celery publishes.
+ACCESS_KICK_LIMIT = 50
 
 
 async def kick_stale_sources(owner_user_id: UUID) -> list[str]:
-    """Claim the scope's stale, sync-enabled sources for an access-triggered
+    """Claim the scope's due, sync-enabled sources for an access-triggered
     sync; the caller enqueues one sync task per returned id.
 
+    Access pulls a sync forward, it does not invent a new cadence: a source is
+    only claimed once next_sync_at has passed, the same bar the Beat reconciler
+    uses, so a source configured to sync every 6 hours still syncs every 6
+    hours no matter how often its owner opens the page. The updated_at guard is
+    the debounce on top of that — every sync start/finish/failure touches
+    updated_at, so a source is kicked at most once per window even when it
+    fails every time, and a just-created source (next_sync_at defaults to now)
+    is not re-kicked by the listing that follows its own connect.
+
     The claim applies mark_sync_started's mutation atomically, so concurrent
-    listings enqueue each source at most once. The updated_at guard is the
-    debounce: every sync start/finish/failure touches updated_at, so a source
-    is kicked at most once per window even when it fails every time.
-    'needs_setup' is excluded — it means the user must act, and re-syncing on
-    read cannot fix it."""
+    listings enqueue each source at most once. 'needs_setup' is excluded — it
+    means the user must act, and re-syncing on read cannot fix it."""
     rows = await get_pool().fetch(
         "UPDATE user_sources SET sync_status = 'syncing', sync_error = NULL, "
         "next_sync_at = now() + (sync_interval_s || ' seconds')::interval, updated_at = now() "
@@ -601,11 +611,15 @@ async def kick_stale_sources(owner_user_id: UUID) -> list[str]:
         "  SELECT id FROM user_sources "
         "  WHERE owner_user_id = $1 AND sync_enabled "
         "  AND sync_status NOT IN ('syncing', 'needs_setup') "
+        "  AND next_sync_at <= now() "
         "  AND updated_at < now() - ($2 || ' seconds')::interval "
+        "  ORDER BY next_sync_at "
+        "  LIMIT $3 "
         "  FOR UPDATE SKIP LOCKED"
         ") RETURNING id",
         owner_user_id,
         str(ACCESS_KICK_STALE_S),
+        ACCESS_KICK_LIMIT,
     )
     return [str(r["id"]) for r in rows]
 

--- a/backend/services/sql_service.py
+++ b/backend/services/sql_service.py
@@ -120,12 +120,20 @@ def _run_in_duckdb(
     schema_by_folder: dict[UUID, str],
     query: str,
 ) -> dict:
-    statements = duckdb.extract_statements(query)
+    # Parsing is where a syntax error lands, and it is the user's mistake.
+    try:
+        statements = duckdb.extract_statements(query)
+    except duckdb.Error as exc:
+        raise SqlError(str(exc)) from None
     if len(statements) != 1:
         raise SqlError("stash sql runs exactly one statement per call")
-    if statements[0].type not in (duckdb.StatementType.SELECT, duckdb.StatementType.EXPLAIN):
+    # EXPLAIN is not allowed: `EXPLAIN ANALYZE <write>` reports the EXPLAIN
+    # statement type while actually running the write it wraps, and DuckDB
+    # exposes no way to inspect the wrapped statement. DESCRIBE, SHOW and
+    # SUMMARIZE all parse as SELECT, so introspection is unaffected.
+    if statements[0].type != duckdb.StatementType.SELECT:
         raise SqlError(
-            "stash sql is read-only: only SELECT (and EXPLAIN) are supported. "
+            "stash sql is read-only: only SELECT is supported. "
             "Write through the tables API or `stash tables` commands."
         )
 
@@ -133,21 +141,24 @@ def _run_in_duckdb(
         ":memory:",
         config={"enable_external_access": False, "memory_limit": "512MB", "threads": 2},
     )
+    # The timer covers materialization too: a scope near the row cap can spend
+    # the whole budget on INSERTs before the user's query ever starts.
+    timer = threading.Timer(QUERY_TIMEOUT_SECONDS, con.interrupt)
+    timer.start()
     try:
         _materialize(con, tables, rows_by_table, schema_by_folder)
-        timer = threading.Timer(QUERY_TIMEOUT_SECONDS, con.interrupt)
-        timer.start()
-        try:
-            cursor = con.execute(query)
-            columns = [{"name": d[0], "type": str(d[1])} for d in (cursor.description or [])]
-            fetched = cursor.fetchmany(MAX_RESULT_ROWS + 1)
-        except duckdb.InterruptException:
-            raise SqlError(f"query timed out after {QUERY_TIMEOUT_SECONDS}s") from None
-        except duckdb.Error as exc:
-            raise SqlError(str(exc)) from None
-        finally:
-            timer.cancel()
+        cursor = con.execute(query)
+        columns = [{"name": d[0], "type": str(d[1])} for d in (cursor.description or [])]
+        fetched = cursor.fetchmany(MAX_RESULT_ROWS + 1)
+    except duckdb.InterruptException:
+        raise SqlError(f"query timed out after {QUERY_TIMEOUT_SECONDS}s") from None
+    except duckdb.Error as exc:
+        raise SqlError(str(exc)) from None
     finally:
+        # cancel() does not wait out a timer that already fired, and
+        # interrupting a closed connection is a use-after-free.
+        timer.cancel()
+        timer.join()
         con.close()
 
     truncated = len(fetched) > MAX_RESULT_ROWS
@@ -168,12 +179,12 @@ def _materialize(
 ) -> None:
     name_counts: dict[str, int] = {}
     for table in tables:
-        key = (table["name"] or "table").lower()
+        key = table["name"].lower()
         name_counts[key] = name_counts.get(key, 0) + 1
 
     seen_qualified: set[tuple[str, str]] = set()
     for table in tables:
-        table_name = table["name"] or "table"
+        table_name = table["name"]
         folder_id = table.get("folder_id")
         schema = schema_by_folder[folder_id] if folder_id else "files"
         # DuckDB resolves identifiers case-insensitively, so "Jobs" and "jobs"
@@ -183,23 +194,31 @@ def _materialize(
         seen_qualified.add((schema, table_name.lower()))
 
         columns = _column_defs(table["columns"])
-        con.execute(f"CREATE SCHEMA IF NOT EXISTS {_ident(schema)}")
         qualified = f"{_ident(schema)}.{_ident(table_name)}"
         column_sql = ", ".join(
             f"{_ident(name)} {_DUCKDB_TYPES[ctype]}" for name, ctype, _ in columns
         )
-        con.execute(f"CREATE TABLE {qualified} ({column_sql})")
-
         records = rows_by_table.get(table["id"], [])
-        if records:
-            placeholders = ", ".join("?" for _ in columns)
-            con.executemany(
-                f"INSERT INTO {qualified} VALUES ({placeholders})",
-                [_row_values(record, columns) for record in records],
-            )
-
-        if name_counts[(table["name"] or "table").lower()] == 1:
-            con.execute(f"CREATE VIEW main.{_ident(table_name)} AS SELECT * FROM {qualified}")
+        try:
+            con.execute(f"CREATE SCHEMA IF NOT EXISTS {_ident(schema)}")
+            con.execute(f"CREATE TABLE {qualified} ({column_sql})")
+            if records:
+                placeholders = ", ".join("?" for _ in columns)
+                con.executemany(
+                    f"INSERT INTO {qualified} VALUES ({placeholders})",
+                    [_row_values(record, columns) for record in records],
+                )
+            if name_counts[table["name"].lower()] == 1:
+                con.execute(f"CREATE VIEW main.{_ident(table_name)} AS SELECT * FROM {qualified}")
+        except duckdb.InterruptException:
+            # A timeout stays a timeout; it is not this table's fault.
+            raise
+        except duckdb.Error as exc:
+            # Every query materializes every table, so a table whose rows no
+            # longer match its column types (the column type was changed after
+            # the rows were written) would otherwise break `stash sql` for the
+            # entire scope with an opaque 500.
+            raise SqlError(f"table {table['name']!r} could not be loaded: {exc}") from None
 
 
 def _column_defs(columns: list[dict]) -> list[tuple[str, str, str | None]]:

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -394,6 +394,93 @@ async def test_file_activity_is_scoped_and_excludes_memory(client: AsyncClient):
     assert "Wiki page" not in labels
 
 
+async def _file_row(pool, owner_user_id: UUID, name: str, folder_id: UUID | None) -> None:
+    await pool.execute(
+        "INSERT INTO files (owner_user_id, name, content_type, size_bytes, storage_key, "
+        "uploaded_by, folder_id) VALUES ($1, $2, 'image/png', 9, $2, $1, $3)",
+        owner_user_id,
+        name,
+        folder_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_activity_excludes_files_inside_the_memory_subtree(client: AsyncClient, pool):
+    """The Memory exclusion is about what the curator churns through, and the
+    curator writes files as well as pages — a filter that only covers pages
+    leaks half of that churn into Home. Nested folders count too: Memory's
+    descendants are Memory."""
+    api_key = await _register(client, "activity_mem_files")
+    scope = UUID((await _scope(client, api_key))["id"])
+    memory_id = UUID(
+        (await client.get("/api/v1/me/memory-folder", headers=_auth(api_key))).json()["id"]
+    )
+    nested_id = await pool.fetchval(
+        "INSERT INTO folders (owner_user_id, parent_folder_id, name, created_by) "
+        "VALUES ($1, $2, 'Wiki', $1) RETURNING id",
+        scope,
+        memory_id,
+    )
+
+    await _file_row(pool, scope, "Loose file", None)
+    await _file_row(pool, scope, "Memory file", memory_id)
+    await _file_row(pool, scope, "Nested memory file", nested_id)
+
+    resp = await client.get(
+        "/api/v1/me/file-activity", params={"limit": 200}, headers=_auth(api_key)
+    )
+    assert resp.status_code == 200
+    labels = [e["target_label"] for e in resp.json()["events"]]
+    assert "Loose file" in labels
+    assert "Memory file" not in labels
+    assert "Nested memory file" not in labels
+
+
+@pytest.mark.asyncio
+async def test_file_activity_excludes_memory_shared_from_another_scope(client: AsyncClient, pool):
+    """Memory belongs to the curator log whoever's Memory it is. The feed spans
+    every scope the caller can read, so excluding only the caller's Memory lets
+    a teammate's nightly curation churn land in the caller's Home."""
+    owner_key = await _register(client, "activity_mem_owner")
+    friend_key = await _register(client, "activity_mem_friend")
+    owner = UUID((await _scope(client, owner_key))["id"])
+    friend = UUID((await _scope(client, friend_key))["id"])
+
+    memory_id = (await client.get("/api/v1/me/memory-folder", headers=_auth(owner_key))).json()[
+        "id"
+    ]
+    wiki = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Their wiki page", "content": "curated", "folder_id": memory_id},
+        headers=_auth(owner_key),
+    )
+    assert wiki.status_code == 201
+    plain = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Their shared page", "content": "hello"},
+        headers=_auth(owner_key),
+    )
+    assert plain.status_code == 201
+    for page_id in (wiki.json()["id"], plain.json()["id"]):
+        await pool.execute(
+            "INSERT INTO shares (owner_user_id, object_type, object_id, principal_type, "
+            "principal_id, permission, created_by) VALUES ($1,'page',$2,'user',$3,'read',$1)",
+            owner,
+            UUID(page_id),
+            friend,
+        )
+
+    resp = await client.get(
+        "/api/v1/me/file-activity", params={"limit": 200}, headers=_auth(friend_key)
+    )
+    assert resp.status_code == 200
+    labels = [e["target_label"] for e in resp.json()["events"]]
+    # The plain share proves the feed does surface another scope's content —
+    # so the wiki page's absence is the Memory rule, not a missing share.
+    assert "Their shared page" in labels
+    assert "Their wiki page" not in labels
+
+
 @pytest.mark.asyncio
 async def test_file_activity_paginates_with_before_cursor(client: AsyncClient):
     api_key = await _register(client, "activity_paged")

--- a/backend/tests/test_curator_log.py
+++ b/backend/tests/test_curator_log.py
@@ -44,6 +44,20 @@ async def _seed_run(pool, uid: UUID, curator_id: str, stamp: str, at: datetime, 
     return session
 
 
+async def _seed_started_run(pool, uid: UUID, curator_id: str, stamp: str, at: datetime) -> str:
+    """A run that has begun but written no final message yet."""
+    session = f"agent-curate-{curator_id}-{stamp}"
+    await pool.execute(
+        "INSERT INTO history_events (owner_user_id, created_by, agent_name, event_type, "
+        "content, session_id, created_at) VALUES "
+        "($1, $1, 'Memory curator', 'user_message', '(prompt)', $2, $3)",
+        uid,
+        session,
+        at,
+    )
+    return session
+
+
 @pytest.mark.asyncio
 async def test_log_lists_runs_newest_first(client: AsyncClient, pool):
     key, uid = await _register(client)
@@ -78,6 +92,29 @@ async def test_failed_runs_carry_their_error_not_a_summary(client: AsyncClient, 
     assert entries[0]["status"] == "failed"
     assert entries[0]["summary"] is None
     assert entries[0]["error"] == "credential expired"
+
+
+@pytest.mark.asyncio
+async def test_a_pass_still_in_flight_reads_as_running_not_interrupted(
+    client: AsyncClient, pool, sprite_exec
+):
+    """No final message means either "still writing" or "died mid-pass", and the
+    turn lock is the only thing that tells them apart. Calling a live run
+    interrupted tells the user tonight's curation failed while it is running."""
+    key, uid = await _register(client)
+    curator = await agent_service.get_or_create_curator(uid)
+    session = await _seed_started_run(
+        pool, uid, curator["id"], "n1", datetime(2026, 8, 8, 9, 0, tzinfo=UTC)
+    )
+
+    await sprite_exec.redis.set(f"agent-turn:{session}", "1")
+    entries = (await client.get("/api/v1/me/curator-log", headers=_auth(key))).json()["entries"]
+    assert entries[0]["status"] == "running"
+    assert entries[0]["summary"] is None
+
+    await sprite_exec.redis.delete(f"agent-turn:{session}")
+    entries = (await client.get("/api/v1/me/curator-log", headers=_auth(key))).json()["entries"]
+    assert entries[0]["status"] == "interrupted"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -4312,3 +4312,48 @@ async def test_needs_setup_sources_are_not_kicked_by_access(client: AsyncClient,
 
     assert resp.status_code == 200
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_access_kick_respects_the_configured_sync_interval(client: AsyncClient, monkeypatch):
+    """Looking at a source pulls its next sync forward; it must not replace the
+    source's own cadence. A source on a 6-hour interval that synced an hour ago
+    is not due, so no amount of page-viewing may re-crawl it — otherwise every
+    long-interval source silently collapses to the access window and we hammer
+    the provider (a 6-hour source would crawl 72x more often)."""
+    from backend.database import get_pool
+
+    key, owner_id = await _register(client, "kick3")
+    src = await source_service.create_source(
+        owner_user_id=owner_id,
+        source_type="github_repo",
+        external_ref="acme/slow-repo",
+        display_name="Slow Repo",
+    )
+    # Quiet long enough to clear the access debounce, but synced an hour ago on
+    # a six-hour schedule: five hours short of due.
+    await get_pool().execute(
+        "UPDATE user_sources SET sync_interval_s = 21600, "
+        "updated_at = now() - interval '1 hour', "
+        "last_synced_at = now() - interval '1 hour', sync_status = 'idle', "
+        "next_sync_at = now() + interval '5 hours' WHERE id = $1",
+        UUID(src["id"]),
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        "backend.routers.sources.celery.send_task",
+        lambda *args, **kwargs: sent.append(kwargs.get("kwargs", {})),
+    )
+
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+    assert resp.status_code == 200
+    assert sent == []
+
+    # Once the schedule actually comes due, access enqueues it.
+    await get_pool().execute(
+        "UPDATE user_sources SET next_sync_at = now() - interval '1 minute' WHERE id = $1",
+        UUID(src["id"]),
+    )
+    resp = await client.get("/api/v1/me/sources", headers=_auth(key))
+    assert resp.status_code == 200
+    assert [t["source_id"] for t in sent] == [src["id"]]

--- a/backend/tests/test_sql.py
+++ b/backend/tests/test_sql.py
@@ -192,15 +192,64 @@ async def test_writes_are_rejected(client: AsyncClient):
         "DELETE FROM jobs",
         "DROP TABLE jobs",
         "SELECT 1; SELECT 2",
+        # EXPLAIN ANALYZE runs the statement it wraps while still parsing as an
+        # EXPLAIN, so allowing EXPLAIN would let any write through the gate.
+        "EXPLAIN ANALYZE DELETE FROM jobs",
+        "EXPLAIN ANALYZE INSERT INTO jobs VALUES ('x', 'Evil', 1, DATE '2026-01-01')",
     ]:
         resp = await _sql(client, headers, query)
         assert resp.status_code == 400, query
 
 
+async def test_read_only_introspection_still_works(client: AsyncClient):
+    """Rejecting EXPLAIN must not cost the caller schema discovery: DESCRIBE,
+    SHOW and SUMMARIZE all parse as SELECT and stay available."""
+    headers, _ = await _register(client)
+    await _make_table(client, headers, "Jobs", JOBS_COLUMNS, JOBS_ROWS)
+
+    for query in ["DESCRIBE jobs", "SHOW TABLES", "SUMMARIZE jobs"]:
+        resp = await _sql(client, headers, query)
+        assert resp.status_code == 200, query
+
+
 async def test_sql_errors_surface_as_400(client: AsyncClient):
+    """A binder error and a syntax error are both the caller's mistake. They
+    take different paths — the binder error comes from executing the query, the
+    syntax error from parsing it before anything is materialized — and both
+    have to reach the caller as a 400 they can act on."""
     headers, _ = await _register(client)
 
     resp = await _sql(client, headers, "SELECT * FROM nonexistent")
-
     assert resp.status_code == 400
     assert "nonexistent" in resp.json()["detail"]
+
+    malformed = await _sql(client, headers, "SELEC * FROM jobs")
+    assert malformed.status_code == 400
+    assert "SELEC" in malformed.json()["detail"]
+
+
+async def test_stale_column_type_names_the_offending_table(client: AsyncClient):
+    """Changing a column's type does not rewrite rows already stored, so a text
+    value can end up under a number column. Every query materializes every table
+    in the scope, so this one table decides whether `stash sql` works at all —
+    it must come back as a 400 naming the table, not an opaque 500."""
+    headers, _ = await _register(client)
+    table = await _make_table(
+        client,
+        headers,
+        "Payroll",
+        [{"name": "Salary", "type": "text"}],
+        [{"Salary": "not a number"}],
+    )
+    column_id = table["columns"][0]["id"]
+    patched = await client.patch(
+        f"/api/v1/me/tables/{table['id']}/columns/{column_id}",
+        json={"type": "number"},
+        headers=headers,
+    )
+    assert patched.status_code == 200
+
+    resp = await _sql(client, headers, "SELECT 1")
+
+    assert resp.status_code == 400
+    assert "Payroll" in resp.json()["detail"]

--- a/cli/main.py
+++ b/cli/main.py
@@ -4925,7 +4925,11 @@ def _agent_folder_candidates(limit: int = 6) -> list[tuple[Path, int]]:
 
     counts: dict[str, int] = {}
     for conv in discover_conversations():
-        if conv.cwd:
+        # Cursor reports an encoded project slug rather than a path
+        # (import_history._encode_cursor_dir), and a relative entry in
+        # recorded_paths resolves against each session's own cwd — matching
+        # nothing, which the scope gate reads as "record nothing at all".
+        if conv.cwd and conv.cwd.startswith("/"):
             counts[conv.cwd] = counts.get(conv.cwd, 0) + 1
     ranked = sorted(counts.items(), key=lambda kv: -kv[1])
     result: list[tuple[Path, int]] = []
@@ -4939,9 +4943,18 @@ def _agent_folder_candidates(limit: int = 6) -> list[tuple[Path, int]]:
 
 
 def _pretty_path(path: Path) -> str:
-    home = str(Path.home())
+    home = Path.home()
     raw = str(path)
-    return "~" + raw[len(home) :] if raw.startswith(home) else raw
+    if path != home and home not in path.parents:
+        return raw
+    return "~" + raw[len(str(home)) :]
+
+
+# AppleScript's "User canceled." Matched as the trailing error code, never as a
+# substring of the message: osascript echoes the offending path into stderr, so
+# a plain `"-128" in stderr` reads a real failure under ~/work/PROJ-128 as a
+# cancel and drops the user's answer on the floor.
+_APPLESCRIPT_CANCELED = re.compile(r"\(-128\)\s*$")
 
 
 def _choose_folder_finder(start: Path) -> Path | None:
@@ -4950,18 +4963,23 @@ def _choose_folder_finder(start: Path) -> Path | None:
     user re-runs and picks "Type a path" instead of silently losing the answer."""
     import subprocess
 
+    # A quoted AppleScript string: backslashes first, then the quotes that end it.
+    literal = str(start).replace("\\", "\\\\").replace('"', '\\"')
     script = (
         "POSIX path of (choose folder with prompt "
         '"Where should Stash record agent sessions?" '
-        f'default location POSIX file "{start}")'
+        f'default location POSIX file "{literal}")'
     )
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    stderr = result.stderr.strip()
     if result.returncode != 0:
-        if "-128" in result.stderr:  # AppleScript's "User canceled."
+        if _APPLESCRIPT_CANCELED.search(stderr):
             return None
-        raise RuntimeError(f"Finder dialog failed: {result.stderr.strip()}")
+        raise RuntimeError(f"Finder dialog failed: {stderr}")
     raw = result.stdout.strip()
-    return Path(raw) if raw else None
+    if not raw:
+        raise RuntimeError("Finder dialog returned no folder")
+    return Path(raw)
 
 
 def _browse_folders(start: Path) -> Path | None:
@@ -4969,13 +4987,12 @@ def _browse_folders(start: Path) -> Path | None:
     go up, subfolders to drill into. No typing required."""
     cur = start.resolve()
     while True:
-        try:
-            subdirs = sorted(
-                (d for d in cur.iterdir() if d.is_dir() and not d.name.startswith(".")),
-                key=lambda d: d.name.lower(),
-            )
-        except PermissionError:
-            subdirs = []
+        # An unreadable directory is not an empty one: rendering it as empty
+        # would let the user record a folder believing they saw its contents.
+        subdirs = sorted(
+            (d for d in cur.iterdir() if d.is_dir() and not d.name.startswith(".")),
+            key=lambda d: d.name.lower(),
+        )
         use = f"✓ Record {_pretty_path(cur)}"
         up = ".. (up one level)"
         choices: list[str] = [use]
@@ -5022,7 +5039,17 @@ def _pick_record_folder(start: Path) -> Path | None:
         typed = questionary.path("Folder path:", only_directories=True).ask()
         if typed is None:
             return None
-        return Path(typed).expanduser().resolve()
+        folder = Path(typed).expanduser().resolve()
+        # An empty answer resolves to the current folder and a typo resolves to
+        # a folder no session will ever run in — one records the wrong place,
+        # the other records nothing at all, both without saying so.
+        if not typed.strip() or not folder.is_dir():
+            console.print(
+                f"[red]Not a folder: {typed!r}. Nothing was changed — "
+                "re-run [bold]stash setup[/bold] to pick again.[/red]"
+            )
+            raise typer.Exit(1)
+        return folder
     return Path(picked)
 
 
@@ -5203,9 +5230,17 @@ def _run_setup_headless(
             )
             raise typer.Exit(1)
         start_streaming()
+        # Headless has no folder-scope flag, so `--record` means this machine.
+        # Writing that explicitly is what makes the run deterministic: without
+        # it a folder scope left by an earlier `stash setup` would silently
+        # survive, and the ✓ below would be describing recording that isn't
+        # happening outside that folder.
+        save_recorded_paths([])
         save_enabled_agents(selected)
         _install_all_hooks(selected)
-        console.print(f"  [green]✓[/green] Recording on for: {', '.join(selected)}")
+        console.print(
+            f"  [green]✓[/green] Recording on everywhere on this machine for: {', '.join(selected)}"
+        )
     else:
         stop_streaming()
         console.print("  [green]✓[/green] Recording off")
@@ -5216,9 +5251,7 @@ def _run_setup_headless(
         console.print("  [green]✓[/green] Folder context skipped")
 
     if import_history:
-        from .import_history import discover_conversations
-
-        conversations = discover_conversations(selected)
+        conversations = _conversations_to_import(selected)
         if conversations:
             _spawn_history_import(len(conversations))
         else:
@@ -5383,8 +5416,8 @@ def _install_claude_plugin() -> bool:
     # a working install, and the plugin's session-start drift warning names any
     # remaining staleness.
     for cmd in (
-        ["claude", "plugin", "marketplace", "update", "stash-plugins"],
-        ["claude", "plugin", "update", "stash@stash-plugins"],
+        [binary, "plugin", "marketplace", "update", "stash-plugins"],
+        [binary, "plugin", "update", "stash@stash-plugins"],
     ):
         try:
             _sp.run(cmd, check=True, capture_output=True, text=True, timeout=120)
@@ -5476,12 +5509,36 @@ def _spawn_history_import(count: int) -> None:
     )
 
 
+def _conversations_to_import(agents: list[str] | None) -> list:
+    """Past conversations the recording scope covers.
+
+    Importing is recording, backwards: a user who answered "only this folder"
+    must not have every other folder's history uploaded behind that answer.
+    `recorded_paths` is the same list the plugin's live gate reads, so past and
+    future sessions obey one setting."""
+    from .import_history import discover_conversations
+
+    recorded = [p for p in (load_config().get("recorded_paths") or []) if p]
+    if not recorded:
+        return discover_conversations(agents)
+
+    seen: set[tuple[str, str]] = set()
+    scoped = []
+    for folder in recorded:
+        for conv in discover_conversations(agents, repo_dir=folder):
+            if (conv.agent, conv.session_id) in seen:
+                continue
+            seen.add((conv.agent, conv.session_id))
+            scoped.append(conv)
+    return scoped
+
+
 def _onboarding_import_history(detected_agents: list[str]) -> None:
     """Offer to import historical conversations during onboarding."""
-    from .import_history import discover_conversations, summarize_discovery
+    from .import_history import summarize_discovery
 
     agents = detected_agents or None
-    conversations = discover_conversations(agents)
+    conversations = _conversations_to_import(agents)
     if not conversations:
         return
 
@@ -5541,9 +5598,10 @@ def import_history_cmd(
 ):
     """Import all historical agent conversations into your Stash.
 
-    Safe to re-run: the server skips sessions that already exist. The setup
-    wizard launches this as a background process; run it directly to import
-    in the foreground with a progress bar."""
+    Scoped to the folders you chose to record (`recorded_paths`), so the import
+    covers exactly what live recording covers. Safe to re-run: the server skips
+    sessions that already exist. The setup wizard launches this as a background
+    process; run it directly to import in the foreground with a progress bar."""
     if status:
         _show_import_status()
         return
@@ -5555,9 +5613,9 @@ def import_history_cmd(
 
     from rich.progress import Progress
 
-    from .import_history import discover_conversations, upload_conversation
+    from .import_history import upload_conversation
 
-    conversations = discover_conversations(load_enabled_agents() or None)
+    conversations = _conversations_to_import(load_enabled_agents() or None)
     if not conversations:
         console.print("No historical conversations found.")
         return
@@ -5605,13 +5663,23 @@ def _active_import() -> dict | None:
 
 
 def _setup_complete_intro(
-    frontend_url: str, connected: bool, recording: bool, importing: dict | None
+    frontend_url: str,
+    connected: bool,
+    recording: bool,
+    importing: dict | None,
+    recorded_paths: list[str] | None = None,
 ) -> str:
     memory_url = f"{frontend_url}/memory"
+    # Empty = everywhere, the contract `recorded_paths` carries everywhere else
+    # (cli/config.py, the plugin's gate). The splash has to say which one the
+    # user just chose — promising machine-wide capture to someone who scoped
+    # recording to one folder is the setup lying about what it did.
+    scope = ", ".join(_pretty_path(Path(p)) for p in recorded_paths or [])
+    where = f"in {scope}" if scope else "on this machine"
     recording_section = (
         "[bold]You're recording[/bold]\n"
-        "This machine's agent sessions upload to your private Stash.\n"
-        "[dim]Pause with stash stop, exclude folders in stash settings[/dim]"
+        f"Agent sessions {where} upload to your private Stash.\n"
+        "[dim]Pause with stash stop, change folders with stash setup[/dim]"
         if recording
         else "[bold]Recording is off[/bold]\n"
         "Turn it on anytime with [cyan]stash start[/cyan] or [cyan]stash setup[/cyan]."
@@ -5633,7 +5701,7 @@ def _setup_complete_intro(
     )
     return (
         "[bold]Your agents just got a memory[/bold]\n"
-        "Every coding session on this machine now lands in your private Stash.\n"
+        f"Every coding session {where} now lands in your private Stash.\n"
         "Your agents can draw on everything you've worked on before — past fixes,\n"
         "decisions, dead ends — instead of starting every session from zero.\n"
         "\n"
@@ -5664,7 +5732,13 @@ def _show_setup_complete_splash() -> None:
     console.print(
         Panel(
             Text.from_markup(
-                _setup_complete_intro(_frontend_base_url(), connected, recording, _active_import())
+                _setup_complete_intro(
+                    _frontend_base_url(),
+                    connected,
+                    recording,
+                    _active_import(),
+                    load_config().get("recorded_paths"),
+                )
             ),
             title="[bold #1e3a8a]Your agent memory[/bold #1e3a8a]",
             border_style="#1e3a8a",

--- a/cli/tests/test_agent_detection.py
+++ b/cli/tests/test_agent_detection.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from cli import main
 from cli.main import _agent_present
 
@@ -103,3 +105,82 @@ def test_undetected_claude_would_strand_its_history_import(monkeypatch, tmp_path
     assert detected == ["claude"]
     found = import_history.discover_conversations(detected)
     assert [(c.agent, c.session_id) for c in found] == [("claude", "s1")]
+
+
+def test_finder_cancel_is_told_apart_from_a_real_failure(monkeypatch, tmp_path: Path) -> None:
+    """osascript echoes the offending path into stderr, so matching "-128"
+    anywhere in the message turns a genuine failure under a folder like
+    ~/work/PROJ-128 into a fake Cancel — and a fake Cancel aborts setup with no
+    message and no recorded_paths written. Only the trailing code means Cancel."""
+    import subprocess
+
+    def run_with(returncode: int, stderr: str):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], returncode, "", stderr),
+        )
+        return main._choose_folder_finder(tmp_path)
+
+    assert run_with(1, "execution error: User canceled. (-128)") is None
+
+    with pytest.raises(RuntimeError):
+        run_with(1, 'execution error: Can\'t make file "HD:work:PROJ-128" into type file. (-1700)')
+
+    # Exit 0 with no folder is an anomaly, not a silent "never mind".
+    with pytest.raises(RuntimeError):
+        run_with(0, "")
+
+
+def test_claude_plugin_freshen_uses_the_resolved_binary(monkeypatch, tmp_path: Path) -> None:
+    """The whole point of resolving the binary is the install that parks claude
+    outside PATH; a bare "claude" in any one call fails for exactly that user."""
+    import subprocess
+
+    binary = str(tmp_path / ".claude" / "local" / "claude")
+    monkeypatch.setattr(main, "_claude_binary", lambda: binary)
+    monkeypatch.setattr(main, "_enable_marketplace_autoupdate", lambda _p: True)
+
+    argv0: list[str] = []
+
+    def fake_run(cmd, *a, **k):
+        argv0.append(cmd[0])
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    main._install_claude_plugin()
+
+    assert argv0, "expected the installer to shell out"
+    assert set(argv0) == {binary}, f"a call still used a bare binary name: {argv0}"
+
+
+def test_agent_folder_candidates_never_offer_a_relative_path(monkeypatch, tmp_path: Path) -> None:
+    """Cursor reports an encoded slug, not a path. A relative entry written into
+    recorded_paths resolves against each session's own cwd, matches nothing, and
+    the scope gate then reads that as "record nothing" — recording silently off."""
+    from cli import import_history
+
+    real = tmp_path / "repo"
+    real.mkdir()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Users-someone-projects-stash").mkdir()
+
+    class Conv:
+        def __init__(self, cwd):
+            self.cwd = cwd
+
+    monkeypatch.setattr(
+        main,
+        "_agent_folder_candidates",
+        main._agent_folder_candidates,
+    )
+    monkeypatch.setattr(
+        import_history,
+        "discover_conversations",
+        lambda *a, **k: [Conv("Users-someone-projects-stash")] * 5 + [Conv(str(real))],
+    )
+
+    candidates = main._agent_folder_candidates()
+
+    assert [str(p) for p, _ in candidates] == [str(real)]
+    assert all(p.is_absolute() for p, _ in candidates)

--- a/cli/tests/test_mount_vfs.py
+++ b/cli/tests/test_mount_vfs.py
@@ -448,6 +448,32 @@ def test_vfs_suffixes_only_colliding_names():
     assert "Untitled table" not in entries
 
 
+class SkillFolderTableClient(FakeClient):
+    """A table filed inside a skill folder, alongside a normal one. Tables come
+    from their own listing, which does not hide skill subtrees the way the
+    overview's file tree does — so this table names a folder the files tree
+    never mentions."""
+
+    def list_tables(self):
+        return [
+            {"id": "skilltable-99999999", "name": "Rubrics", "folder_id": "skillfolder-12345678"},
+            *super().list_tables(),
+        ]
+
+
+def test_a_table_inside_a_skill_folder_does_not_break_the_mount():
+    """A skill's folder subtree is deliberately absent from /files, so a table
+    filed there has no path to mount at. It has to be left out rather than take
+    the whole tree down: every VFS command rebuilds this model, so one such
+    table turned every `stash vfs` call into a crash."""
+    model = StashVfsModel(SkillFolderTableClient(), include_computer=True)
+    model.refresh()
+
+    assert "Rubrics" not in model.list_dir("/files")
+    # The tables that do have a home are unaffected — the skip is surgical.
+    assert b'"Name": "Mount"' in model.read_file("/files/Notes/Ideas/rows.json")
+
+
 class CountingLoaderClient(FakeClient):
     """Records every document body fetched, and whether two fetches ever overlapped.
 

--- a/frontend/src/app/(app)/tools/page.test.tsx
+++ b/frontend/src/app/(app)/tools/page.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ToolsPage from "./page";
 import { createMcpServer, deleteMcpServer, listMcpServers, type McpServer } from "@/lib/api";
+import { listIntegrations } from "@/lib/integrations";
 
 const router = vi.hoisted(() => ({ push: vi.fn() }));
 
@@ -134,6 +135,15 @@ describe("ToolsPage", () => {
         command: "npx -y fs-mcp",
       })
     );
+  });
+
+  // A failed integrations load used to leave the grid on skeletons forever,
+  // so the user could never tell that "not connected" was really "unknown".
+  it("surfaces a failed integrations load instead of skeletons", async () => {
+    vi.mocked(listIntegrations).mockRejectedValueOnce(new Error("integrations are down"));
+    render(<ToolsPage />);
+
+    expect(await screen.findByText(/integrations are down/)).toBeTruthy();
   });
 
   it("removes a server", async () => {

--- a/frontend/src/app/(app)/tools/page.tsx
+++ b/frontend/src/app/(app)/tools/page.tsx
@@ -95,6 +95,7 @@ function IntegrationsGrid() {
   // was disconnected with its data kept reads "Connect", not "Connected".
   const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [paywalled, setPaywalled] = useState(false);
 
@@ -112,23 +113,36 @@ function IntegrationsGrid() {
     }
   }
 
+  // Both calls decide what a row says — statuses which rows exist, sources
+  // whether an extension row reads Connected — so either one failing makes
+  // the whole list wrong. Fail together, loudly, instead of showing a list
+  // that lies or skeletons that never resolve.
   useEffect(() => {
     const load = () => {
-      listSources()
-        .then((all) => setSourceProviders(new Set(all.map((s: Source) => providerForSourceType[s.type] ?? s.type))))
-        .catch(() => {});
-      listIntegrations()
-        .then((r) => {
+      setLoadError(null);
+      Promise.all([listSources(), listIntegrations()])
+        .then(([sources, integrations]) => {
+          setSourceProviders(new Set(sources.map((s: Source) => providerForSourceType[s.type])));
           const byProvider: Record<string, IntegrationStatus> = {};
-          for (const p of r.providers) byProvider[p.provider] = p;
+          for (const p of integrations.providers) byProvider[p.provider] = p;
           setStatuses(byProvider);
         })
-        .catch(() => {});
+        .catch((e) =>
+          setLoadError(e instanceof Error ? e.message : "Failed to load integrations")
+        );
     };
     load();
     window.addEventListener(INTEGRATIONS_CHANGED_EVENT, load);
     return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
   }, []);
+
+  if (loadError) {
+    return (
+      <div className="rounded-xl border border-border bg-surface px-4 py-6 text-center text-[13px] text-destructive">
+        Couldn&apos;t load integrations: {loadError}
+      </div>
+    );
+  }
 
   if (statuses === null) {
     return (

--- a/frontend/src/components/agents/AgentsChat.tsx
+++ b/frontend/src/components/agents/AgentsChat.tsx
@@ -11,6 +11,7 @@ import { nanoid } from "nanoid";
 import { SquarePen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { listMySessions, type SessionSummary } from "@/lib/api";
+import { useAuth } from "@/hooks/useAuth";
 import { timeAgo } from "@/components/content/files-overview/build";
 import AgentChatView from "./AgentChatView";
 
@@ -18,6 +19,19 @@ import AgentChatView from "./AgentChatView";
 // `agent-sched-…` / `agent-curate-…`, and coding-agent sessions have their own
 // shapes. The id shape is the discriminator the whole agent surface uses.
 const CHAT_SESSION_ID = /^agent-[0-9a-f]{32}$/;
+// The server-side narrowing for the same family. Scheduled and curator runs
+// share it, so the regex above still does the exact match.
+const CHAT_SESSION_PREFIX = "agent-";
+// A named agent's ref — the other thing ?chat= is allowed to point at.
+const AGENT_REF = /^agent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** ?chat= only ever carries a ref this app minted: a fresh chat (`new-…`), a
+ *  stored chat session, or a named agent. An unrecognized ref cannot be opened
+ *  as a chat — the first message would mint a real session under whatever id
+ *  the URL happened to carry. */
+function isChatRef(ref: string): boolean {
+  return ref.startsWith("new-") || CHAT_SESSION_ID.test(ref) || AGENT_REF.test(ref);
+}
 
 function SideRow({
   label,
@@ -50,10 +64,12 @@ function SideRow({
 export default function AgentsChat() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useAuth();
   // ?chat= selects a conversation (a stored session, a named agent, or a
   // staged `new-…` skill run); ?resume= is the deep link from a stored
   // session's "Resume in chat". A bare /agents is a fresh chat.
-  const urlRef = searchParams.get("chat") ?? searchParams.get("resume");
+  const chatRef = searchParams.get("chat");
+  const urlRef = chatRef ?? searchParams.get("resume");
   const [newRef, setNewRef] = useState(() => `new-${nanoid(5)}`);
   const selected = urlRef ?? newRef;
   // When a fresh chat's session is minted mid-stream, the URL flips to the
@@ -63,24 +79,43 @@ export default function AgentsChat() {
   const viewRef = mintedFrom?.sessionId === selected ? mintedFrom.ref : selected;
 
   const [chats, setChats] = useState<SessionSummary[] | null>(null);
+  const [chatsError, setChatsError] = useState<string | null>(null);
 
   const loadChats = useCallback(async () => {
-    const all = await listMySessions(100);
-    setChats(all.filter((s) => CHAT_SESSION_ID.test(s.session_id)));
-  }, []);
+    // The list needs the caller's id to filter, and useAuth resolves it a tick
+    // after mount; the effect re-runs once it lands.
+    if (!user) return;
+    setChatsError(null);
+    try {
+      // Narrowed server-side: a recent window of every session kind is mostly
+      // recorded CLI transcripts, so filtering to chats here would hide every
+      // chat that fell outside it — "No chats yet" for someone with chats.
+      const all = await listMySessions(100, undefined, 0, CHAT_SESSION_PREFIX);
+      // The chat API reads a session in the caller's own scope only, so a chat
+      // shared in from another scope would open blank — it doesn't belong in a
+      // list whose only action is opening it.
+      setChats(
+        all.filter((s) => CHAT_SESSION_ID.test(s.session_id) && s.owner_user_id === user.id),
+      );
+    } catch (e) {
+      setChatsError(e instanceof Error ? e.message : String(e));
+    }
+  }, [user]);
   useEffect(() => {
-    loadChats().catch(() => setChats([]));
+    void loadChats();
   }, [loadChats]);
 
+  // push, not replace: a conversation is a place, so Back walks the chats you
+  // visited. (Minting below stays a replace — it renames the chat you're in.)
   function select(ref: string) {
     setMintedFrom(null);
-    router.replace(`/agents?chat=${encodeURIComponent(ref)}`);
+    router.push(`/agents?chat=${encodeURIComponent(ref)}`);
   }
 
   function newChat() {
     setMintedFrom(null);
     setNewRef(`new-${nanoid(5)}`);
-    router.replace("/agents");
+    router.push("/agents");
   }
 
   return (
@@ -99,31 +134,47 @@ export default function AgentsChat() {
           <div className="px-2.5 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             Chats
           </div>
-          {chats?.map((s) => (
-            <SideRow
-              key={s.session_id}
-              label={s.title || "Untitled chat"}
-              annotation={timeAgo(s.last_event_at)}
-              active={selected === s.session_id}
-              onClick={() => select(s.session_id)}
-            />
-          ))}
-          {chats !== null && chats.length === 0 && (
-            <div className="px-2.5 py-1.5 text-[12px] text-muted-foreground">No chats yet</div>
+          {chatsError ? (
+            // An unreadable list is not an empty one: "No chats yet" here would
+            // read as lost history.
+            <div className="px-2.5 py-1.5 text-[12px] text-error">
+              {`Couldn't load your chats: ${chatsError}`}
+            </div>
+          ) : (
+            <>
+              {chats?.map((s) => (
+                <SideRow
+                  key={s.session_id}
+                  label={s.title || "Untitled chat"}
+                  annotation={timeAgo(s.last_event_at)}
+                  active={selected === s.session_id}
+                  onClick={() => select(s.session_id)}
+                />
+              ))}
+              {chats !== null && chats.length === 0 && (
+                <div className="px-2.5 py-1.5 text-[12px] text-muted-foreground">No chats yet</div>
+              )}
+            </>
           )}
         </div>
       </aside>
       <main className="min-w-0 flex-1 bg-base">
-        {/* Keyed so switching conversations remounts a clean view. */}
-        <AgentChatView
-          key={viewRef}
-          refId={viewRef}
-          onSessionMinted={(id) => {
-            setMintedFrom({ sessionId: id, ref: viewRef });
-            router.replace(`/agents?chat=${encodeURIComponent(id)}`);
-            void loadChats();
-          }}
-        />
+        {chatRef !== null && !isChatRef(chatRef) ? (
+          <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-error">
+            {`This link doesn't point at a chat: ${chatRef}`}
+          </div>
+        ) : (
+          /* Keyed so switching conversations remounts a clean view. */
+          <AgentChatView
+            key={viewRef}
+            refId={viewRef}
+            onSessionMinted={(id) => {
+              setMintedFrom({ sessionId: id, ref: viewRef });
+              router.replace(`/agents?chat=${encodeURIComponent(id)}`);
+              void loadChats();
+            }}
+          />
+        )}
       </main>
     </div>
   );

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -29,8 +29,13 @@ import type { EmbeddingProjection } from "@/lib/types";
 
 const PAGE_SIZE = 50;
 
+// The feed pages back indefinitely, so a bare "Mar 3" would read as this
+// year's March once the reader scrolls past the year boundary.
 function editTimestamp(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+  const at = new Date(iso);
+  const year = at.getFullYear() === new Date().getFullYear() ? undefined : "numeric";
+  return at.toLocaleString(undefined, {
+    year,
     month: "short",
     day: "numeric",
     hour: "numeric",
@@ -54,13 +59,19 @@ export default function BrainDashboard() {
   const [graphLoaded, setGraphLoaded] = useState(false);
   const [firstName, setFirstName] = useState<string | null>(null);
   const [vitals, setVitals] = useState<MeOverview | null>(null);
+  const [vitalsError, setVitalsError] = useState<string | null>(null);
   const [vitalsLoaded, setVitalsLoaded] = useState(false);
 
+  // The vitals decide whether this stash is brand new, so losing them isn't
+  // cosmetic: without them Home would drop a first-run user into a grid of
+  // empty panels instead of the setup instruction.
   useEffect(() => {
-    getMe().then((me) => setFirstName(me.display_name.split(" ")[0])).catch(() => {});
-    getMeOverview()
-      .then(setVitals)
-      .catch(() => {})
+    Promise.all([getMe(), getMeOverview()])
+      .then(([me, overview]) => {
+        setFirstName(me.display_name.split(" ")[0]);
+        setVitals(overview);
+      })
+      .catch((e) => setVitalsError(e instanceof Error ? e.message : "Failed to load your stash"))
       .finally(() => setVitalsLoaded(true));
   }, []);
 
@@ -96,8 +107,16 @@ export default function BrainDashboard() {
     }
   }, [events, hasMore, loadingMore]);
 
+  // The dashboard renders only once both the feed and the vitals have
+  // settled, in whichever order they arrive.
+  const ready = !fetching && vitalsLoaded;
+
+  // The sentinel exists only while the dashboard is rendered, so this has to
+  // re-run when the skeleton clears: if the vitals settle last, `loadMore`
+  // keeps its identity across that render and the observer would never
+  // attach — infinite scroll dead, feed silently capped at one page.
   useEffect(() => {
-    if (!sentinelRef.current) return;
+    if (!ready || !sentinelRef.current) return;
     const obs = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) loadMore();
@@ -106,7 +125,7 @@ export default function BrainDashboard() {
     );
     obs.observe(sentinelRef.current);
     return () => obs.disconnect();
-  }, [loadMore]);
+  }, [loadMore, ready]);
 
   // The brain's vitals + visualizations. All span the user's own content plus
   // everything shared with them (the /me/* aggregates, called without a
@@ -136,13 +155,23 @@ export default function BrainDashboard() {
     };
   }, []);
 
+  if (vitalsError) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center px-8">
+        <p className="max-w-md text-center text-[13px] text-destructive">
+          Couldn&apos;t load your stash: {vitalsError}
+        </p>
+      </div>
+    );
+  }
+
   // A brand-new stash has nothing to dashboard. Until the first transcripts
   // arrive, Home is a single instruction: upload your agent transcripts.
   if (vitalsLoaded && vitals && vitals.pages === 0 && vitals.files === 0 && vitals.sessions === 0) {
     return <EmptyStashSetup />;
   }
 
-  if (fetching || !vitalsLoaded) {
+  if (!ready) {
     return (
       <div className="h-full min-h-0 overflow-y-auto">
         <ActivitySkeleton />

--- a/frontend/src/components/memory/CuratorLog.test.tsx
+++ b/frontend/src/components/memory/CuratorLog.test.tsx
@@ -70,4 +70,13 @@ describe("CuratorLog", () => {
     render(<CuratorLog />);
     expect(await screen.findByText(/No entries yet/)).toBeTruthy();
   });
+
+  // "No entries yet" is a statement about the curator, not about the network:
+  // claiming it after a failed load tells the user their curator never ran.
+  it("reports a failed load instead of claiming the curator never ran", async () => {
+    vi.mocked(getCuratorLog).mockRejectedValue(new Error("curator log unavailable"));
+    render(<CuratorLog />);
+    expect(await screen.findByText(/curator log unavailable/)).toBeTruthy();
+    expect(screen.queryByText(/No entries yet/)).toBeNull();
+  });
 });

--- a/frontend/src/components/memory/CuratorLog.tsx
+++ b/frontend/src/components/memory/CuratorLog.tsx
@@ -21,6 +21,7 @@ const ENTRY_ROWS = 5;
  *  A failed run shows as failed. */
 export default function CuratorLog() {
   const [entries, setEntries] = useState<CuratorLogEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [showOlder, setShowOlder] = useState(false);
 
@@ -30,7 +31,9 @@ export default function CuratorLog() {
       .then((log) => {
         if (!cancelled) setEntries(log.entries);
       })
-      .catch(() => {})
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load the curator log");
+      })
       .finally(() => {
         if (!cancelled) setLoaded(true);
       });
@@ -44,6 +47,19 @@ export default function CuratorLog() {
       <section>
         <div className="sys-label mb-1.5">Curator log</div>
         <SkeletonBlock className="h-[120px] w-full" />
+      </section>
+    );
+  }
+
+  // An empty log and an unreachable log look identical from here, and "no
+  // entries yet" is a claim about the curator — never make it on a failure.
+  if (error) {
+    return (
+      <section>
+        <div className="sys-label mb-1.5">Curator log</div>
+        <div className="card-soft px-4 py-6 text-center text-[12.5px] text-destructive">
+          Couldn&apos;t load the curator log: {error}
+        </div>
       </section>
     );
   }

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -7,7 +7,7 @@ import { ApiError, listMySessions, listSessionFolders, listSharedWithMe, listSki
 import { requestAgentConfigView } from "@/lib/agent-tab-view";
 import { cn } from "@/lib/utils";
 import { useWorkspace, type TabKind } from "@/lib/workspace-store";
-import { urlForTab } from "@/lib/workspace-routes";
+import { urlForTab, hasPermanentUrl } from "@/lib/workspace-routes";
 import { CONNECTORS, connectorIcon, providerForSourceType } from "@/components/integrations/connectors";
 import { INTEGRATIONS_CHANGED_EVENT, listIntegrations } from "@/lib/integrations";
 import { opensNewTab } from "@/lib/tab-nav";
@@ -32,7 +32,7 @@ function useOpenTab() {
   const openTab = useWorkspace((s) => s.openTab);
   return (kind: TabKind, refId: string, title: string, opts?: { newTab?: boolean }) => {
     openTab(kind, refId, { title, newTab: opts?.newTab ?? opensNewTab() });
-    router.replace(urlForTab({ kind, refId }));
+    if (hasPermanentUrl(kind)) router.replace(urlForTab({ kind, refId }));
   };
 }
 

--- a/frontend/src/components/workspace/files-explorer.tsx
+++ b/frontend/src/components/workspace/files-explorer.tsx
@@ -118,12 +118,6 @@ export default function FilesExplorer({
   /** This section can create VFS items (new file/folder/upload). Default true;
    *  Sessions is a read-through view, so false. */
   vfsWritable?: boolean;
-  /** A labeled section-specific action on its own row under the toolbar (e.g.
-   *  Memory's "Curate wiki"). The toolbar row itself can't fit a labeled
-   *  button — its action cluster doesn't shrink, so it would overflow the
-   *  sidebar. */
-  /** Memory is the curator agent's knowledge base, so a manual write there is
-   *  unusual: confirm it first and offer to send the item to Files instead. */
 }) {
   const router = useRouter();
   const { user } = useAuth();
@@ -152,8 +146,6 @@ export default function FilesExplorer({
   // but empty; stays null when GitHub isn't connected → URL paste only).
   const [githubRepos, setGithubRepos] = useState<GithubImportRepo[] | null>(null);
   const [repoFilter, setRepoFilter] = useState("");
-  // A write action waiting on the "Add to Memory?" confirmation. `run` receives
-  // the destination folder: the browsed Memory folder, or null for Files root.
   const fileRef = useRef<HTMLInputElement>(null);
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -23,8 +23,9 @@ const PRIMARY: RailItem[] = [
 
 // Home is the memory dashboard — the divider separates it from the VFS
 // sections. Chat sits last: it's a lens over the stash, not a place in it.
-// Apps and the VM aren't rail-worthy: Apps lives at /apps, the VM under the
-// explorer's Home root.
+// Apps lives at /apps. The VM has NO entry point since it left this rail: the
+// explorer's Home root is the only thing that lists it, and that root only
+// renders once you are already inside the VM section (?section=computer).
 const DIVIDER_AFTER_INDEX = 0;
 
 function RailButton({

--- a/frontend/src/components/workspace/tab-body.tsx
+++ b/frontend/src/components/workspace/tab-body.tsx
@@ -30,8 +30,7 @@ export default function TabBody({ tab }: { tab: WorkbenchTab }) {
   if (tab.kind === "folder") return <FolderClient folderId={tab.refId} />;
   if (tab.kind === "agent") return <AgentChatView refId={tab.refId} />;
   // Tool + agent-config bodies are plain document flows with no height or
-  // scroller of their own, so the tab gives them one (same as AgentChatTab
-  // does for the config side of a chat tab).
+  // scroller of their own, so the tab gives them one.
   if (tab.kind === "tool")
     return (
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import { createPage } from "@/lib/api";
 import { useWorkspace, titleKey, type WorkbenchTab } from "@/lib/workspace-store";
 import { ShellChromeScope, useShellChromeValue } from "@/components/ShellChromeContext";
-import { urlForTab, tabFromPath } from "@/lib/workspace-routes";
+import { urlForTab, tabFromPath, hasPermanentUrl } from "@/lib/workspace-routes";
 import { PageIcon, FileIcon, TableIcon, SessionsIcon, SkillIcon, FolderIcon } from "@/components/SkillIcons";
 import TabBody from "./tab-body";
 
@@ -86,6 +86,9 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
   // derived from the URL, and switching tabs must never move the sidebar.
   function focus(tab: WorkbenchTab) {
     setActiveTab(tab.id);
+    // A workbench-only tab (the box's terminal and its files) has no address;
+    // refocusing one leaves the URL pointing at whatever it was.
+    if (!hasPermanentUrl(tab.kind)) return;
     const section = searchParams.get("section");
     router.replace(urlForTab(tab) + (section ? `?section=${section}` : ""));
   }

--- a/frontend/src/components/workspace/workspace-shell.test.tsx
+++ b/frontend/src/components/workspace/workspace-shell.test.tsx
@@ -3,8 +3,10 @@
 // (tests rendered the component directly, the shell never did). This locks the
 // route → content mapping so a new management page failing to register fails a
 // test instead of failing in prod.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { rendersRouteContent } from "./workspace-shell";
+import { WORKBENCH_TAB_KINDS, urlForTab, hasPermanentUrl } from "@/lib/workspace-routes";
+import { useWorkspace } from "@/lib/workspace-store";
 
 describe("rendersRouteContent", () => {
   it("renders management pages beside the explorer", () => {
@@ -34,5 +36,103 @@ describe("rendersRouteContent", () => {
 
   it("sessions workspace view keeps the workbench", () => {
     expect(rendersRouteContent("/sessions", null, "1")).toBe(false);
+  });
+});
+
+// The workbench pushes urlForTab on every tab click, and the shell decides off
+// that URL whether to draw the workbench at all. A tab kind whose URL is a
+// full page is therefore a tab you can never click back into — clicking it
+// replaces the strip with that page. Chat tabs became exactly that when
+// /agents turned into its own page, and pre-revamp localStorage is full of
+// them, so the two rules below have to agree.
+describe("tabs the workbench can host", () => {
+  it("every hostable kind's URL still lands on the workbench", () => {
+    for (const kind of WORKBENCH_TAB_KINDS) {
+      // `tool` with the legacy "integrations" refId routes to the /tools
+      // management page, so give every kind a content-shaped refId.
+      const [path, query] = urlForTab({ kind, refId: "abc" }).split("?");
+      const workspaceParam = new URLSearchParams(query).get("workspace");
+      expect([kind, rendersRouteContent(path, null, workspaceParam)]).toEqual([kind, false]);
+    }
+  });
+
+  it("chat is not a hostable kind — its URL is the chat page", () => {
+    expect(WORKBENCH_TAB_KINDS).not.toContain("agent");
+    expect(rendersRouteContent("/agents", null, null)).toBe(true);
+  });
+
+  it("kinds with no route at all refuse to invent one", () => {
+    expect(() => urlForTab({ kind: "terminal", refId: "terminal" })).toThrow();
+    expect(() => urlForTab({ kind: "machine-file", refId: "notes.md" })).toThrow();
+  });
+
+  // The explorer's VM section still opens these, and the workbench refocuses
+  // them. Both ask hasPermanentUrl first, so the throw above stays a
+  // programmer-error guard instead of a crash on a real click.
+  it("marks the kinds that throw as having no permanent URL", () => {
+    for (const kind of ["terminal", "machine-file", "agent-config"] as const) {
+      expect(hasPermanentUrl(kind)).toBe(false);
+      expect(() => urlForTab({ kind, refId: "x" })).toThrow();
+    }
+    for (const kind of WORKBENCH_TAB_KINDS) {
+      expect(hasPermanentUrl(kind)).toBe(true);
+    }
+  });
+});
+
+// Users who had tabs open before the revamp deploy hydrate that state on their
+// next visit. A chat tab among them is unclickable and takes the workbench down
+// with it, so hydrate carries the layout forward without those tabs rather than
+// leaving the user to find the wreck.
+describe("hydrate migrates pre-revamp tabs", () => {
+  beforeEach(() => {
+    useWorkspace.setState({ tabs: [], activeTabId: null, activeTab1: null, split: false, paneOf: {}, focusedPane: 0 });
+  });
+
+  it("drops chat tabs and keeps the content tabs beside them", () => {
+    useWorkspace.getState().hydrate({
+      tabs: [
+        { id: "t1", kind: "agent", refId: "agent-abc" },
+        { id: "t2", kind: "page", refId: "p1" },
+      ],
+      paneOf: { t1: 0, t2: 0 },
+      activeTabId: "t1",
+    });
+
+    const s = useWorkspace.getState();
+    expect(s.tabs).toEqual([{ id: "t2", kind: "page", refId: "p1" }]);
+    expect(s.paneOf).toEqual({ t2: 0 });
+    // The dropped tab was the active one — the strip must not point at a ghost.
+    expect(s.activeTabId).toBe("t2");
+  });
+
+  it("closes the split when its only tab was a chat tab", () => {
+    useWorkspace.getState().hydrate({
+      tabs: [
+        { id: "t1", kind: "page", refId: "p1" },
+        { id: "t2", kind: "terminal", refId: "terminal" },
+      ],
+      paneOf: { t1: 0, t2: 1 },
+      activeTabId: "t1",
+      activeTab1: "t2",
+      split: true,
+      focusedPane: 1,
+    });
+
+    const s = useWorkspace.getState();
+    expect(s.split).toBe(false);
+    expect(s.activeTab1).toBeNull();
+    expect(s.focusedPane).toBe(0);
+  });
+
+  it("leaves state that needs no migration untouched", () => {
+    useWorkspace.getState().hydrate({
+      tabs: [{ id: "t1", kind: "page", refId: "p1" }],
+      paneOf: { t1: 0 },
+      activeTabId: "t1",
+    });
+
+    expect(useWorkspace.getState().tabs).toHaveLength(1);
+    expect(useWorkspace.getState().activeTabId).toBe("t1");
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -565,7 +565,7 @@ export async function getMemoryGraph(): Promise<WikiGraph> {
 export interface CuratorLogEntry {
   session_id: string;
   started_at: string;
-  status: "completed" | "failed" | "stopped" | "interrupted";
+  status: "completed" | "failed" | "stopped" | "interrupted" | "running";
   summary: string | null;
   error: string | null;
 }
@@ -1321,12 +1321,14 @@ export interface LinearTicketLabel {
 export async function listMySessions(
   limit = 50,
   sessionFolderId?: string,
-  offset = 0
+  offset = 0,
+  sessionIdPrefix?: string
 ): Promise<SessionSummary[]> {
   const qs = new URLSearchParams();
   qs.set("limit", String(limit));
   if (offset) qs.set("offset", String(offset));
   if (sessionFolderId) qs.set("session_folder_id", sessionFolderId);
+  if (sessionIdPrefix) qs.set("session_id_prefix", sessionIdPrefix);
   const data = await apiFetch<{ sessions: SessionSummary[] }>(
     `${ME}/sessions?${qs.toString()}`
   );

--- a/frontend/src/lib/workspace-routes.ts
+++ b/frontend/src/lib/workspace-routes.ts
@@ -5,6 +5,30 @@ export const routes = {
   extension: "/extension",
 };
 
+/** Tab kinds whose permanent URL renders the workbench. The workbench pushes
+ *  urlForTab on every focus, so a kind missing from this list is a tab you can
+ *  open but never click back into — focusing it navigates the strip away.
+ *  workspace-store migrates persisted tabs against this list. */
+export const WORKBENCH_TAB_KINDS: TabKind[] = [
+  "page",
+  "file",
+  "table",
+  "session",
+  "sessions-home",
+  "skill",
+  "folder",
+  "tool",
+];
+
+/** Tabs that live only inside the workbench: the cloud box's terminal and its
+ *  files exist on the box, not at an address. Opening or refocusing one must
+ *  leave the URL alone — ask urlForTab for one and it throws, by design. */
+const WORKBENCH_ONLY_KINDS: TabKind[] = ["machine-file", "terminal", "agent-config"];
+
+export function hasPermanentUrl(kind: TabKind): boolean {
+  return !WORKBENCH_ONLY_KINDS.includes(kind);
+}
+
 /** Canonical permanent URL for a tab — the same route that deep-links/sharing use. */
 export function urlForTab(tab: Pick<WorkbenchTab, "kind" | "refId">): string {
   switch (tab.kind) {
@@ -23,17 +47,20 @@ export function urlForTab(tab: Pick<WorkbenchTab, "kind" | "refId">): string {
     case "folder":
       return `/folders/${tab.refId}`;
     case "agent":
-      return `/agents`;
+      // Chat left the workbench: a conversation's address is now the chat
+      // page's ?chat= ref, the same one the skill launcher pushes.
+      return `/agents?chat=${encodeURIComponent(tab.refId)}`;
     case "tool":
       // A provider slug deep-links to its manager; the legacy list stays /tools.
       return tab.refId === "integrations" ? `/tools` : `/integrations/${tab.refId}`;
     case "machine-file":
-      // Machine files have no permanent route — they live on the box.
-      return `/agents`;
     case "terminal":
-      return `/agents`;
     case "agent-config":
-      return `/agents`;
+      // These exist only inside the workbench — nothing routes to them. They
+      // used to borrow /agents, which worked only while /agents rendered the
+      // workbench; it is the chat page now, so borrowing it evicts the user
+      // from the strip. There is no honest URL to hand back.
+      throw new Error(`${tab.kind} tabs have no permanent URL`);
   }
 }
 

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { create } from "zustand";
 import { nanoid } from "nanoid";
+import { WORKBENCH_TAB_KINDS } from "@/lib/workspace-routes";
 
 /**
  * Workspace shell state — the tab strip, split view, rail section, and explorer
@@ -76,6 +77,32 @@ function placeTab(s: WorkspaceState, tab: WorkbenchTab): Partial<WorkspaceState>
     paneOf: { ...s.paneOf, [tab.id]: pane },
     ...(pane === 0 ? { activeTabId: tab.id } : { activeTab1: tab.id, split: true }),
   };
+}
+
+/** Pre-revamp state holds tabs the workbench can no longer host: chat became a
+ *  page of its own, so focusing one of its tabs navigates out of the strip
+ *  instead of into it, and the whole workbench disappears. Carry the layout
+ *  forward once, on hydrate, minus those tabs — the conversations themselves
+ *  are not lost, they are listed on /agents. */
+function dropUnhostableTabs(data: Partial<WorkspaceState>): Partial<WorkspaceState> {
+  if (!data.tabs) return data;
+  const tabs = data.tabs.filter((t) => WORKBENCH_TAB_KINDS.includes(t.kind));
+  if (tabs.length === data.tabs.length) return data;
+
+  const live = new Set(tabs.map((t) => t.id));
+  const paneOf = Object.fromEntries(
+    Object.entries(data.paneOf ?? {}).filter(([id]) => live.has(id)),
+  );
+  const lastInPane = (pane: 0 | 1) => {
+    const inPane = tabs.filter((t) => (paneOf[t.id] ?? 0) === pane);
+    return inPane[inPane.length - 1]?.id ?? null;
+  };
+  const activeTabId = data.activeTabId && live.has(data.activeTabId) ? data.activeTabId : lastInPane(0);
+  const activeTab1 = data.activeTab1 && live.has(data.activeTab1) ? data.activeTab1 : lastInPane(1);
+  const split = activeTab1 !== null;
+  const migrated = { ...data, tabs, paneOf, activeTabId, activeTab1, split };
+  // The right pane can't stay focused once the drop emptied it.
+  return split ? migrated : { ...migrated, focusedPane: 0 as const };
 }
 
 /** Focus an existing tab in whichever pane holds it. */
@@ -183,7 +210,7 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
 
   setLastVfsUrl: (url) => set({ lastVfsUrl: url }),
 
-  hydrate: (data) => set({ ...data }),
+  hydrate: (data) => set(dropUnhostableTabs(data)),
 }));
 
 /** Declare the hosting tab's title from inside a content body. Call with the

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -369,6 +369,13 @@ class StashVfsModel:
         for table in tables:
             table_id = str(table["id"])
             parent_id = table.get("folder_id")
+            # The table listing is its own endpoint and does not hide skill
+            # subtrees the way the overview's file tree does, so a table filed
+            # inside a skill names a folder that has no path here. Its whole
+            # subtree is projected under /skills, not /files — skip it rather
+            # than crash the mount on the missing folder.
+            if parent_id and str(parent_id) not in folders and str(parent_id) != memory_folder_id:
+                continue
             parent_path = folder_path(str(parent_id)) if parent_id else root_path
             created_at = table.get("created_at")
             updated_at = table.get("updated_at")


### PR DESCRIPTION
Post-merge fixes for the defects a full review of #1021 found. That PR merged and deployed before the review finished, so these land as a follow-up rather than as review comments.

Production is healthy — zero 5xx and zero error-level logs since the deploy — but several things are quietly wrong, and the common thread is that this release swallows load failures and renders them as calm empty states, so the app looks fine while being wrong.

## Highest impact

**Access-triggered source syncs ignored each source's configured cadence.** The kick claimed any source untouched for 5 minutes regardless of `sync_interval_s`, so Slack/Granola/Gong (6h) were crawled up to 72x more often, the 30-minute sources ~6x, GitHub ~12x. It now requires `next_sync_at` to have passed — the same bar the Beat reconciler uses — and keeps the `updated_at` window as a debounce. Also claims at most 50 sources per listing (it was unbounded, so one page view could fan out into hundreds of blocking broker publishes) and publishes off the event loop.

**The chat sidebar showed "No chats yet" to users who have chats.** It pulled 100 recent sessions of every kind and filtered for chats client-side, so anyone whose recent window is full of recorded CLI transcripts saw an empty list. `GET /me/sessions` now takes `session_id_prefix` and the narrowing happens in SQL.

**Pre-revamp workspace tabs could take the workbench down.** Chat stopped being a hostable tab kind, but persisted state still holds those tabs; clicking one navigated away from the strip. `hydrate` now runs a one-shot forward migration that drops unhostable tabs and repairs the active/split state, rather than carrying a fallback.

**`stash sql` returned 500s.** A syntax error escaped as an uncaught `ParserException` (parse-time errors took a different path than the bind-time errors the tests covered), and any table whose stored rows no longer match its declared column types — reachable via the public column-type PATCH — broke the endpoint for the entire scope. Both are now 400s that name the cause. `EXPLAIN ANALYZE` no longer slips writes past the read-only gate, the timeout now covers materialization, and the endpoint is rate limited using the existing slowapi limiter.

**Memory exclusion in file activity was half-applied.** The `page.updated` branch excluded the Memory subtree; `file.uploaded` had no folder filter at all. Now a recursive CTE covers both, across every accessible scope rather than only the caller's own.

**A table inside a skill folder crashed the whole VFS build** with a KeyError.

## Setup wizard (PRs #1022–#1024, which shipped in the merge without review)

These were never in the branch the review ran against, so nobody had looked at them.

- The plugin "freshen now" loop still shelled out to a bare `claude`, which fails deterministically for exactly the alias/`~/.claude/local` installs #1024 was written to rescue — a scary error on an otherwise successful install, plus a stale plugin.
- The Finder chooser matched `-128` anywhere in stderr as "user cancelled", but osascript echoes the offending path into stderr. Running setup from a folder like `~/work/PROJ-128` turned any genuine failure into a fake cancel, which aborted setup silently with nothing written.
- A Cursor project slug could be written into `recorded_paths` as a relative path, which the scope gate resolves per-session — matching nothing, which reads as "record nothing at all".

## Swallowed errors, now surfaced

Home, the curator log, the chat sidebar, and the integrations grid all had `.catch(() => {})` on their loads. A failed fetch rendered "No entries yet", "Nothing here yet", or six skeletons forever. Each now shows the failure.

## Verification

- Backend: 1364 passed, coverage 81%
- Frontend: 305 tests across 62 files, eslint 0 errors, `next build` clean
- CLI + plugin: 398 passed
- `ruff check` + `ruff format --check` on `backend/ cli/` clean, exactly as CI runs it

New regression tests cover the behaviors that shipped broken, and the sync-cadence test was confirmed to fail against the merged code before the fix. One defect was caught by reviewing the diff rather than the report: making `urlForTab` throw for address-less tabs would have turned a navigation bug into an uncaught crash, because the explorer still opens those tabs — both call sites now check `hasPermanentUrl` first, and a test pins the two lists in agreement.

Several reported findings were rejected rather than "fixed" after checking them against the real code — the dead `ActivityFeed` component, the blank-page-on-failed-`getAgent`, and an event-loop stall claim that turned out to already run in a worker thread. All were pre-existing or factually wrong.

## Not addressed — these are product decisions

The revamp removed four capabilities. Restoring them means deciding where they live in the new design, so I've left them alone:

1. Uploading a file or creating a folder/table at the root of the VFS — no entry point remains.
2. Files shared with you — nothing renders the root file browser any more.
3. The VM (cloud browser + terminal) — unreachable.
4. Agent configuration — `AgentConfigPanel` still exists but nothing can open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-adjacent SQL execution, permission-aware activity queries, and persisted workspace state migration; changes are targeted with regression tests but span critical user-facing paths.
> 
> **Overview**
> Follow-up hotfixes for defects found after the revamp shipped. The theme is **failures that looked like empty or healthy UI** plus a few backend correctness bugs.
> 
> **Backend:** Access-triggered source syncs now honor `next_sync_at` (same as Beat), cap at 50 claims per listing, and enqueue Celery off the event loop. File activity excludes **Memory** subtrees for pages and files across **all** accessible scopes via a recursive CTE. Curator log entries without a final message report **`running`** when the turn lock is held. `GET /me/sessions` adds **`session_id_prefix`** for server-side chat filtering. **`stash sql`** is rate-limited, blocks `EXPLAIN` (including analyze-wrapped writes), times out during materialization, and returns named 400s for parse/load errors.
> 
> **Frontend:** Home, curator log, chat sidebar, and tools integrations **surface load errors** instead of empty/skeleton states. Chat list uses prefix filtering and ownership; invalid `?chat=` refs are rejected. Workbench **`hasPermanentUrl`** / **`WORKBENCH_TAB_KINDS`** keep terminal and chat tabs from navigating away; hydrate drops legacy chat tabs. Brain dashboard fixes infinite-scroll observer timing and year-aware timestamps.
> 
> **CLI / VFS:** Setup/import respect **`recorded_paths`**; headless `stash start` clears folder scope; Finder cancel uses trailing `(-128)`; plugin freshen uses resolved `claude` binary. VFS skips tables under skill folders that have no `/files` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ddc7d1ab5a1816114705edb4656e36d7311203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->