### PR TITLE
Home watches for the first transcript instead of repeating itself

### DIFF
--- a/frontend/src/components/memory/BrainDashboard.test.tsx
+++ b/frontend/src/components/memory/BrainDashboard.test.tsx
@@ -1,0 +1,85 @@
+// The first-run screen and the moment it stops being true.
+//
+// A brand-new stash is usually a stash mid-arrival: the user has just run the
+// installer and their history is uploading in the background. On a customer
+// call this exact gap read as "I don't know what changed or what happened" —
+// the page kept telling him to run a command he had already run. So the empty
+// state has to watch for the first transcript and get out of the way by
+// itself, without a reload.
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BrainDashboard from "./BrainDashboard";
+import { getMe, getMeOverview } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getMe: vi.fn(),
+  getMeOverview: vi.fn(),
+  getEmbeddingProjection: vi.fn(),
+  getMemoryGraph: vi.fn(),
+  listFileActivity: vi.fn(),
+}));
+
+vi.mock("@/components/viz/EmbeddingSpaceExplorer", () => ({ default: () => null }));
+vi.mock("@/components/memory/CuratorLog", () => ({ default: () => null }));
+vi.mock("@/components/memory/WikiGraph", () => ({ default: () => null }));
+vi.mock("@/components/CopyableCommandBlock", () => ({
+  default: ({ commands }: { commands: string }) => <pre>{commands}</pre>,
+}));
+
+const EMPTY = { pages: 0, files: 0, sessions: 0 };
+
+beforeEach(async () => {
+  const api = await import("@/lib/api");
+  vi.mocked(getMe).mockResolvedValue({ display_name: "Henry Dowling" } as never);
+  vi.mocked(api.listFileActivity).mockResolvedValue({ events: [], has_more: false } as never);
+  vi.mocked(api.getEmbeddingProjection).mockResolvedValue({ points: [] } as never);
+  vi.mocked(api.getMemoryGraph).mockResolvedValue({ nodes: [], edges: [] } as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("first-run state", () => {
+  it("asks for transcripts while the stash is empty", async () => {
+    vi.mocked(getMeOverview).mockResolvedValue(EMPTY);
+
+    render(<BrainDashboard />);
+
+    expect(await screen.findByText("Let's get you started")).toBeInTheDocument();
+    // It must not read as a dead end to someone who already ran the installer.
+    expect(screen.getByText(/Already ran it\?/)).toBeInTheDocument();
+  });
+
+  it("gets out of the way once the first transcript lands, with no reload", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(getMeOverview)
+      .mockResolvedValueOnce(EMPTY)
+      .mockResolvedValue({ pages: 0, files: 0, sessions: 1 });
+
+    render(<BrainDashboard />);
+    await screen.findByText("Let's get you started");
+
+    await vi.advanceTimersByTimeAsync(6000);
+
+    await waitFor(() =>
+      expect(screen.queryByText("Let's get you started")).not.toBeInTheDocument(),
+    );
+    expect(await screen.findByText(/Welcome back/)).toBeInTheDocument();
+  });
+
+  it("does not poll once there is something to show", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(getMeOverview).mockResolvedValue({ pages: 3, files: 0, sessions: 0 });
+
+    render(<BrainDashboard />);
+    await screen.findByText(/Welcome back/);
+
+    const callsAfterLoad = vi.mocked(getMeOverview).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(vi.mocked(getMeOverview).mock.calls.length).toBe(callsAfterLoad);
+  });
+});

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -28,6 +28,8 @@ import {
 import type { EmbeddingProjection } from "@/lib/types";
 
 const PAGE_SIZE = 50;
+// How often the first-run screen checks whether anything has landed yet.
+const EMPTY_POLL_MS = 5000;
 
 // The feed pages back indefinitely, so a bare "Mar 3" would read as this
 // year's March once the reader scrolls past the year boundary.
@@ -62,6 +64,9 @@ export default function BrainDashboard() {
   const [vitalsError, setVitalsError] = useState<string | null>(null);
   const [vitalsLoaded, setVitalsLoaded] = useState(false);
 
+  const stashIsEmpty =
+    vitals !== null && vitals.pages === 0 && vitals.files === 0 && vitals.sessions === 0;
+
   // The vitals decide whether this stash is brand new, so losing them isn't
   // cosmetic: without them Home would drop a first-run user into a grid of
   // empty panels instead of the setup instruction.
@@ -74,6 +79,22 @@ export default function BrainDashboard() {
       .catch((e) => setVitalsError(e instanceof Error ? e.message : "Failed to load your stash"))
       .finally(() => setVitalsLoaded(true));
   }, []);
+
+  // An empty stash is usually a stash mid-arrival: the user just ran the
+  // installer and their history is uploading in the background. Watch for the
+  // first transcript so this page turns into the dashboard on its own, instead
+  // of sitting there telling them to run the command they already ran.
+  //
+  // A failed poll is left alone rather than surfaced: the load that decides
+  // what this page *is* already reports its failure above, and a blip here
+  // changes nothing we know — still nothing in the stash, retry in 5s.
+  useEffect(() => {
+    if (!stashIsEmpty) return;
+    const timer = setInterval(() => {
+      getMeOverview().then(setVitals).catch(() => {});
+    }, EMPTY_POLL_MS);
+    return () => clearInterval(timer);
+  }, [stashIsEmpty]);
 
   useEffect(() => {
     let cancelled = false;
@@ -167,7 +188,7 @@ export default function BrainDashboard() {
 
   // A brand-new stash has nothing to dashboard. Until the first transcripts
   // arrive, Home is a single instruction: upload your agent transcripts.
-  if (vitalsLoaded && vitals && vitals.pages === 0 && vitals.files === 0 && vitals.sessions === 0) {
+  if (vitalsLoaded && stashIsEmpty) {
     return <EmptyStashSetup />;
   }
 
@@ -374,6 +395,11 @@ function EmptyStashSetup() {
           The installer signs you in and sets up session recording. Then use your coding
           agent like you always do — this page becomes your agents&apos; shared memory as
           transcripts arrive.
+        </p>
+        <p className="mt-3 flex items-center justify-center gap-2 text-[12.5px] text-dim">
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-brand" />
+          Already ran it? Your sessions import in the background — this page opens as soon
+          as the first one lands.
         </p>
       </div>
     </div>


### PR DESCRIPTION
I wanna test this one locally before making a call on it


# Slop
The last live piece of Charlie's *"Now I have no way to go back. I don't know what's going on here… I don't know what changed or what happened."*

## The problem

An empty stash is usually a stash **mid-arrival**: the user has just run the installer and their history is uploading in the background. But Home read vitals exactly once on mount, so it sat there showing *"Let's get you started — upload your session transcripts"* with the very command they had just run, until they thought to reload. The screen contradicted the action.

## The fix

- **The first-run screen re-checks vitals every 5s while the stash is empty** and turns into the dashboard the moment anything lands — no reload, no navigation. Polling stops as soon as there's something to show.
- **The copy no longer reads as a dead end**: "Already ran it? Your sessions import in the background — this page opens as soon as the first one lands," with a live pulse dot.

## What I couldn't do, and why

Real progress ("Importing 412 of 1,615…") isn't possible today: the import's status lives **only** in `~/.stash/import-history.json` on the user's machine, and the backend has no notion of an import in flight — there's nothing server-side for the web app to read. Reporting it would need a CLI→server channel (new endpoint + CLI posts + storage), and would only reach users after a PyPI CLI release. This fixes the contradiction without that dependency; happy to build the real progress feed as a follow-up if you want it.

## Verified

Live on the dev stack with a genuinely empty account: the first-run screen rendered, then a page was created through the API **without touching the browser**, and Home flipped to "Welcome back, onboarding-test" on its own within the poll window. Three new tests cover the empty state, the automatic flip, and that polling stops once there's content (fake timers, so the suite stays fast). 303 frontend tests pass, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)