### PR TITLE
Home's canvases stop drawing when nothing is moving

### DIFF
--- a/frontend/src/components/memory/WikiGraph.tsx
+++ b/frontend/src/components/memory/WikiGraph.tsx
@@ -118,6 +118,10 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
   // (the settling layout grows past the canvas otherwise). Double-click
   // hands control back to the auto-fit.
   const userAdjustedRef = useRef(false);
+  // The render loop parks itself whenever nothing is moving; every handler
+  // that changes what the canvas should show wakes it for a frame.
+  const wakeRef = useRef<() => void>(() => {});
+  const refitRef = useRef(false);
   const [cursor, setCursor] = useState("grab");
 
   const toWorld = useCallback((mx: number, my: number) => {
@@ -255,8 +259,14 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
 
     let raf = 0;
     const step = () => {
-      if (sim.alpha > 0.02) tick(sim, w, HEIGHT);
-      if (!userAdjustedRef.current) fitView();
+      raf = 0;
+      const settling = sim.alpha > 0.02;
+      if (settling) tick(sim, w, HEIGHT);
+      // Auto-fit follows the layout while it moves, plus one frame on demand
+      // when a double-click hands control back to it. Refitting on a settled
+      // graph re-sorts every coordinate for a view that cannot change.
+      if (!userAdjustedRef.current && (settling || refitRef.current)) fitView();
+      refitRef.current = false;
       // A held node stays glued to the cursor — the tick above would
       // otherwise spring it back toward its neighbors every frame.
       const drag = dragRef.current;
@@ -267,10 +277,21 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
         sim.vy[drag.index] = 0;
       }
       draw();
-      raf = requestAnimationFrame(step);
+      // Park once the physics has settled and nothing is being dragged: the
+      // canvas keeps its last frame until something wakes it. This loop used
+      // to redraw every node, edge, and label at 60fps for as long as the tab
+      // stayed open, which starved the rest of the page on a large wiki.
+      if (settling || dragRef.current) wake();
     };
-    raf = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(raf);
+    const wake = () => {
+      if (!raf) raf = requestAnimationFrame(step);
+    };
+    wakeRef.current = wake;
+    wake();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      wakeRef.current = () => {};
+    };
   }, [data, draw]);
 
   // React registers onWheel passively, so preventDefault (needed to stop the
@@ -294,6 +315,7 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
       v.tx = mx - ((mx - v.tx) / v.scale) * next;
       v.ty = my - ((my - v.ty) / v.scale) * next;
       v.scale = next;
+      wakeRef.current();
     };
     canvas.addEventListener("wheel", onWheel, { passive: false });
     return () => canvas.removeEventListener("wheel", onWheel);
@@ -316,6 +338,7 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
               ? { mode: "node", index: i, moved: false, wx, wy }
               : { mode: "pan", lastX: mx, lastY: my, moved: false };
           if (i < 0) setCursor("grabbing");
+          wakeRef.current();
         }}
         onMouseMove={(e) => {
           const rect = e.currentTarget.getBoundingClientRect();
@@ -331,6 +354,7 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
             if (Math.abs(mx - drag.lastX) + Math.abs(my - drag.lastY) > 2) drag.moved = true;
             drag.lastX = mx;
             drag.lastY = my;
+            wakeRef.current();
             return;
           }
           if (drag?.mode === "node" && sim) {
@@ -343,17 +367,22 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
             // Re-warm so neighbors re-settle around the dragged node.
             sim.alpha = Math.max(sim.alpha, 0.25);
             drag.moved = true;
+            wakeRef.current();
             return;
           }
 
           const { wx, wy } = toWorld(mx, my);
           const i = findNode(wx, wy);
-          hoverRef.current = i;
+          if (hoverRef.current !== i) {
+            hoverRef.current = i;
+            wakeRef.current();
+          }
           setCursor(i >= 0 ? "pointer" : "grab");
         }}
         onMouseUp={() => {
           const drag = dragRef.current;
           if (drag?.mode === "pan") setCursor("grab");
+          wakeRef.current();
           // The click handler (which fires synchronously after mouseup) still
           // needs `moved` to suppress navigation — clear on the next task.
           setTimeout(() => {
@@ -364,6 +393,7 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
           dragRef.current = null;
           hoverRef.current = -1;
           setCursor("grab");
+          wakeRef.current();
         }}
         onClick={(e) => {
           const drag = dragRef.current;
@@ -377,6 +407,8 @@ export default function WikiGraph({ data }: { data: WikiGraphData }) {
         }}
         onDoubleClick={() => {
           userAdjustedRef.current = false;
+          refitRef.current = true;
+          wakeRef.current();
         }}
       />
       <div className="absolute bottom-2 left-2 rounded-md border border-border bg-base/85 px-2.5 py-1.5 font-mono text-[10.5px] text-muted-foreground backdrop-blur">

--- a/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
+++ b/frontend/src/components/viz/EmbeddingSpaceExplorer.tsx
@@ -137,6 +137,8 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
   const movedRef = useRef(false);
   const lastMouseRef = useRef({ x: 0, y: 0 });
   const autoRotateRef = useRef(true);
+  // Wakes the render loop after an interaction changes what should be shown.
+  const wakeRef = useRef<() => void>(() => {});
   const animRef = useRef<number>(0);
 
   const prep = useMemo(() => prepare(data.points), [data]);
@@ -225,17 +227,44 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
     }
   }, [data, prep, project]);
 
-  // Animation loop for auto-rotation
+  // Animation loop for auto-rotation. It runs only while there is something
+  // to animate: the cloud is actually spinning and on screen, or the user is
+  // dragging it. Left unconditional, this redrew thousands of projected
+  // points at 60fps for the life of the tab — including after the user
+  // stopped the rotation, while scrolled out of view, and in a background
+  // tab — which is enough to starve the rest of the page.
   useEffect(() => {
-    const tick = () => {
-      if (autoRotateRef.current) {
-        rotYRef.current += 0.003;
-      }
+    const canvas = canvasRef.current;
+    let raf = 0;
+    let onScreen = true;
+
+    const spinning = () => autoRotateRef.current && onScreen && !document.hidden;
+    const step = () => {
+      raf = 0;
+      if (spinning()) rotYRef.current += 0.003;
       draw();
-      animRef.current = requestAnimationFrame(tick);
+      if (spinning() || draggingRef.current) wake();
     };
-    animRef.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(animRef.current);
+    const wake = () => {
+      if (!raf) raf = requestAnimationFrame(step);
+    };
+    wakeRef.current = wake;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      onScreen = entry.isIntersecting;
+      if (onScreen) wake();
+    });
+    if (canvas) observer.observe(canvas);
+    const onVisibilityChange = () => wake();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    wake();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      observer.disconnect();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      wakeRef.current = () => {};
+    };
   }, [draw]);
 
   const findPoint = useCallback(
@@ -287,6 +316,7 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
         rotXRef.current = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, rotXRef.current));
         lastMouseRef.current = { x: mx, y: my };
         setTooltip(null);
+        wakeRef.current();
         return;
       }
 
@@ -309,10 +339,12 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
     lastMouseRef.current = pos;
     downPosRef.current = pos;
     movedRef.current = false;
+    wakeRef.current();
   }, []);
 
   const handleMouseUp = useCallback(() => {
     draggingRef.current = false;
+    wakeRef.current();
   }, []);
 
   const handleClick = useCallback(
@@ -337,6 +369,7 @@ export default function EmbeddingSpaceExplorer({ data, onPointClick }: Props) {
         onMouseLeave={() => {
           setTooltip(null);
           draggingRef.current = false;
+          wakeRef.current();
         }}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}


### PR DESCRIPTION
Fixes the reported homepage hang. It isn't a hanging request — it's two render loops that never stop.

## Diagnosis

Prod request logs from the reported session:

| endpoint | result |
|---|---|
| `/me/curator-log` | **200 in 51–134ms** |
| `/me/vitals` | 200 in 0.7–1.5s |
| `/me/embedding-projection?max_points=2000` | 200 in **6.6–7.8s**, 125KB |

The Curator Log panel was a grey skeleton while its data had arrived in **51 milliseconds**. Data that fast can only stay invisible if the main thread never gets a frame to paint it.

Both canvases on Home rescheduled themselves unconditionally:

```js
// WikiGraph.tsx
const step = () => {
  if (sim.alpha > 0.02) tick(...);   // physics stops…
  if (!userAdjustedRef.current) fitView();
  draw();
  raf = requestAnimationFrame(step); // …drawing never does
};
```

`EmbeddingSpaceExplorer.tsx` had the same shape. So the tab redrew every node, edge, and label at 60fps for as long as it stayed open — after the layout settled, while scrolled out of view, and in a background tab. The wiki graph compounds it: its physics is all-pairs **O(n²) per frame**, and every frame also reallocated the canvas buffer (`canvas.width = …`) and re-sorted every coordinate for the auto-fit. Nothing caps the graph — `memory_wiki_graph` returns every Memory page and link — so it degrades as a stash matures, which is why a long-lived account feels it and a new one doesn't.

## Fix

Both loops park when there's nothing to animate and wake for a frame when something changes: zoom, pan, node drag, hover (only when the hovered node actually changes), mouse-leave, and the double-click refit. The auto-fit now runs while the layout is moving plus once on demand, instead of re-sorting every coordinate for a view that can't change. The knowledge map keeps auto-rotating as designed — but only while on screen (IntersectionObserver) and with the tab visible.

## Measured on the dashboard

- Before: 60fps sustained forever (~240 frames per 4s, indefinitely).
- After: **0 frames in 4s** once settled.
- Interactions still repaint: a pan wakes exactly one frame, a double-click refit one frame, then it parks again.
- Screenshot-verified the graph still renders identically (settled layout, labels, hover highlighting).

312 frontend tests pass, tsc and lint clean.

## Not done here

The knowledge map still spins at 60fps while visible, because auto-rotation is intentional — I didn't want to silently kill a deliberate animation. If you'd rather it stop after the first revolution and resume on hover, that's a one-line follow-up. Capping `memory_wiki_graph` server-side is also worth doing so the graph can't grow unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only render-loop and interaction timing changes on dashboard canvases; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes the reported **homepage hang** caused by two canvas components on Home (`WikiGraph`, `EmbeddingSpaceExplorer`) that **never stopped** their `requestAnimationFrame` loops, keeping the main thread busy even after layouts settled, while scrolled away, or in background tabs.
> 
> **`WikiGraph`** now **parks** the loop when force simulation has settled and nothing is being dragged, and **wakes** it for zoom, pan, node drag, hover (only when the hovered node changes), mouse leave, and double-click refit. **Auto-fit** runs while the layout is still moving or once on demand via `refitRef`, instead of every frame on a static graph.
> 
> **`EmbeddingSpaceExplorer`** keeps auto-rotation but only schedules frames while the canvas is **on screen** (`IntersectionObserver`), the **tab is visible**, and auto-rotate is on—or while the user is **dragging**; pointer handlers call the same wake hook.
> 
> After settling, the wiki graph draws **0 sustained frames** until interaction; the knowledge map no longer spins when off-screen or hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a84efcfe775d725f9d0873f20ae3b0cc45e8eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->