### PR TITLE
Local embeddings run on the CPU, not Apple's Metal device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Local embeddings run on the CPU (fixes a crash on Apple Silicon).
+  sentence-transformers 5.x selects Apple's Metal (`mps`) device when it can,
+  and a Metal context cannot survive `fork()` — so every Celery prefork child
+  that embedded died on SIGABRT, crashlooping the embed-reconcile task and
+  taking down any process that had touched the model. Affects local dev and
+  self-hosters using `EMBEDDING_PROVIDER=local`; hosted prod embeds with
+  OpenAI and was never affected.
+
 - CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
   that can be re-run anytime with the new `stash setup` — no answer is final.
   Session recording is framed as private-by-default and on by default

--- a/backend/services/embeddings/local.py
+++ b/backend/services/embeddings/local.py
@@ -46,7 +46,13 @@ class LocalEmbedder(BaseEmbedder):
                 "Install it with: pip install sentence-transformers"
             )
         logger.info("Loading local embedding model: %s", self.model_name)
-        self._model = SentenceTransformer(self.model_name)
+        # CPU, explicitly: sentence-transformers picks Apple's Metal backend
+        # (mps) when it can, and a Metal context cannot survive fork(). Celery
+        # runs a prefork pool, so every child that embedded died on SIGABRT
+        # ("Unable to get MPS kernel ... XPC_ERROR_CONNECTION_INVALID"), taking
+        # the reconcile task — and any process that had touched the model —
+        # down with it. This model is 22M params; CPU is fast enough.
+        self._model = SentenceTransformer(self.model_name, device="cpu")
 
     async def embed_batch(self, texts: list[str]) -> list[np.ndarray] | None:
         if not texts:

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,3 +1,4 @@
+import sys
 from uuid import uuid4
 
 import numpy as np
@@ -110,3 +111,28 @@ async def test_openai_embedder_clips_inputs_before_http_request():
 
     assert vectors is not None
     assert len(client.payload["input"][0]) == embedding_service.MAX_TEXT_CHARS
+
+
+def test_local_embedder_loads_on_cpu(monkeypatch):
+    """The local model must never land on Apple's Metal (mps) device.
+
+    A Metal context cannot survive fork(), and Celery runs a prefork pool, so
+    an mps-backed model aborts (SIGABRT) in every worker child that embeds —
+    crashlooping the reconcile task. CI runs on Linux where mps does not
+    exist, so no behavioural test can catch a regression here; pinning the
+    device at construction is the only guard.
+    """
+    from backend.services.embeddings.local import LocalEmbedder
+
+    captured = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, device=None):
+            captured["device"] = device
+
+    fake_module = type("m", (), {"SentenceTransformer": FakeSentenceTransformer})
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
+
+    LocalEmbedder()._load()
+
+    assert captured["device"] == "cpu"


### PR DESCRIPTION
## The bug

On Apple Silicon, the local embedding provider crashlooped every Celery worker that touched it, and killed the API server on any request that reached the embedding path. The visible symptoms were a `WorkerLostError: signal 6 (SIGABRT)` every 60 seconds from `embedding-reconcile`, a backend that died whenever Home loaded its embedding projection, and a `pytest` run that aborted partway through with a segfault in `modeling_bert.py`.

## Root cause

`sentence-transformers` 5.x selects Apple's Metal (`mps`) device when it is available — older versions defaulted to CPU. A Metal context cannot survive `fork()`: the child inherits a fully-initialized Metal object in copied memory, pointing at an XPC connection to the shader-compiler service that does not exist in the child. Celery runs a **prefork** pool, so the child aborted on its first GPU kernel:

```
MPSLibrary::MPSKey_Create internal error: Unable to get MPS kernel
mmul_kernel_a16_float_float_float. Error: Compiler encountered
XPC_ERROR_CONNECTION_INVALID
```

`mmul_kernel_a16_float_float_float` is a matrix multiply, which is why the crash trace pointed into the BERT forward pass.

Minimal reproduction — load the model, encode in the parent, then encode in a forked child:

| device | child exit |
|---|---|
| `mps` | signal 11 |
| `cpu` | 0 |

## The fix

Construct the model with `device="cpu"`. all-MiniLM-L6-v2 is 22M params, so CPU is fast enough — the reconcile cleared its backlog in 5.2s.

## Verification

With the fix, on this machine:

- `embedding-reconcile` succeeds instead of crashlooping (`succeeded in 5.2s: 4`), and no `SIGABRT` / `MPSLibrary` lines appear in the stack log.
- Home loads and the backend stays up.
- `/api/v1/me/embedding-projection` returns 200 (`total_embeddings: 9, projected: 9`).
- Semantic search returns sensible ranked results over freshly embedded pages.
- The two test files that used to segfault (`test_activity.py`, `test_embeddings.py`) pass, and the full backend suite runs to completion for the first time on this machine.

## Test

CI runs on Linux, where `mps` does not exist and no behavioural test can reproduce this, so the added test pins the device at construction — the only thing that can catch a regression on a machine that cannot trigger the bug.

## Scope

Local dev and self-hosters running `EMBEDDING_PROVIDER=local`. Hosted prod embeds with OpenAI (`OPENAI_API_KEY` is set on Render), so it was never affected.

## Note for the reviewer

The full suite currently reports 1366 passed / 8 failed. Those 8 (in `test_url_imports`, `test_vfs`, `test_workspaces`) all pass when run on their own — they are pre-existing order-dependent flakes, newly visible because the suite can now run to completion instead of aborting early. `test_embeddings.py::test_reconcile_pages_clears_empty_pages_without_embedding_call` is flaky the same way and fails roughly 1 run in 3 under random ordering **without** this change. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0760eeca0c7ed2bc3c6331d6729a991e2a9fc59a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->