### PR TITLE
Transcribe uploaded images with vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Uploaded images are transcribed by vision, so agents can read them.
+  `file_extraction.extract_text` has no branch for images, so every uploaded
+  screenshot, photo, and diagram stored an empty knowledge-base entry and was
+  invisible to search, ask-the-stash, and the VFS. Images now take the same
+  path scanned PDFs take: text transcribed character-for-character, and
+  everything non-textual described in place. Formats Gemini cannot read
+  inline (SVG, TIFF) still store no text rather than pretending.
+
 - CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
   that can be re-run anytime with the new `stash setup` — no answer is final.
   Session recording is framed as private-by-default and on by default

--- a/backend/services/image_ocr.py
+++ b/backend/services/image_ocr.py
@@ -1,0 +1,81 @@
+"""Image transcription via Gemini vision.
+
+A screenshot is the most common thing a person drops into their stash and the
+one thing an agent could never read: `file_extraction.extract_text` has no
+branch for images, so every PNG landed with an empty knowledge-base entry.
+This module gives an image the same treatment `pdf_ocr` gives a scan — text
+transcribed character-for-character, and everything non-textual described in
+place so a reader who cannot see it still gets the information.
+
+Only the formats Gemini accepts inline are transcribable; anything else (SVG,
+TIFF, …) returns "" and stores no text, the same declared-support stance
+`extract_text` takes. Like `pdf_ocr`, it raises on failure so the extraction
+pipeline's retry machinery records the error rather than silently storing an
+empty entry.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import httpx
+
+from ..config import settings
+
+TRANSCRIBABLE_TYPES = ("image/png", "image/jpeg", "image/webp", "image/heic", "image/heif")
+MAX_OUTPUT_TOKENS = 8000
+REQUEST_TIMEOUT_SECONDS = 120.0
+
+_GENERATE_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+_PROMPT = (
+    "Describe this image so that someone who cannot see it gets everything it conveys. "
+    "Output only the description - no commentary, no surrounding code fence. "
+    "Transcribe every piece of visible text exactly as printed, in reading order, "
+    "character-for-character - names, numbers, codes, labels, UI text, handwriting. "
+    "Render any table as a markdown table. "
+    "Then state what the image shows: its subject, the setting, and every identifying "
+    "detail (people and what they are doing, objects, shapes, colors, charts and their "
+    "values, diagram structure and callouts). "
+    "If it is a screenshot, say what application or page it shows and what state it is in."
+)
+
+
+async def transcribe_image(content: bytes, content_type: str) -> str:
+    if content_type not in TRANSCRIBABLE_TYPES:
+        return ""
+    if not settings.GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY is required to transcribe images")
+
+    async with httpx.AsyncClient(
+        headers={"x-goog-api-key": settings.GEMINI_API_KEY},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    ) as client:
+        response = await client.post(
+            _GENERATE_URL.format(model=settings.GEMINI_EXTRACTION_MODEL),
+            json={
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": content_type,
+                                    "data": base64.standard_b64encode(content).decode("ascii"),
+                                }
+                            },
+                            {"text": _PROMPT},
+                        ]
+                    }
+                ],
+                "generationConfig": {"maxOutputTokens": MAX_OUTPUT_TOKENS, "temperature": 0},
+            },
+        )
+    response.raise_for_status()
+    candidates = response.json().get("candidates")
+    if not candidates:
+        raise RuntimeError("Gemini returned no candidates")
+    parts = candidates[0].get("content", {}).get("parts", [])
+    text = "".join(p.get("text", "") for p in parts if not p.get("thought")).strip()
+    if candidates[0].get("finishReason") == "MAX_TOKENS":
+        text += "\n\n[transcription truncated]"
+    return text

--- a/backend/tests/test_image_ocr.py
+++ b/backend/tests/test_image_ocr.py
@@ -1,0 +1,31 @@
+"""Images reach the knowledge base via vision, or not at all.
+
+No parser reads pixels, so a stored image with no transcription is a hole in
+the stash the user can see but the agent cannot. These tests pin the two edges
+of that: a format Gemini cannot take inline stores nothing rather than
+pretending, and a missing key fails loud so the retry machinery records it
+instead of persisting an empty entry.
+"""
+
+import pytest
+
+from backend.config import settings
+from backend.services import image_ocr
+
+
+@pytest.mark.asyncio
+async def test_format_gemini_cannot_read_stores_nothing(monkeypatch) -> None:
+    async def fail(*args, **kwargs):
+        raise AssertionError("no API call for an untranscribable format")
+
+    monkeypatch.setattr(image_ocr.httpx.AsyncClient, "post", fail)
+
+    assert await image_ocr.transcribe_image(b"<svg/>", "image/svg+xml") == ""
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_fails_loud(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "")
+
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+        await image_ocr.transcribe_image(b"\x89PNG....", "image/png")

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -23,7 +23,7 @@ import pypdf
 import pytest
 
 from backend.config import settings
-from backend.services import pdf_ocr, storage_service
+from backend.services import image_ocr, pdf_ocr, storage_service
 from backend.workers import extract_one
 
 PAGE_SIZE = (612, 792)
@@ -432,32 +432,40 @@ async def test_every_uploaded_pdf_is_transcribed_and_stored(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_pdf_upload_never_transcribes(monkeypatch):
-    """Vision costs an API call per chunk — only PDFs take that path."""
+async def test_parsable_upload_never_transcribes(monkeypatch):
+    """Vision costs an API call — a format a parser can read never takes it."""
     conn = _FakeConnection(uuid.uuid4(), "text/plain")
     _wire_extract_one(monkeypatch, conn, b"plain text body")
 
     async def fail_transcribe(content):
         raise AssertionError("transcribe_pdf must not be called")
 
+    async def fail_image(content, content_type):
+        raise AssertionError("transcribe_image must not be called")
+
     monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
+    monkeypatch.setattr(image_ocr, "transcribe_image", fail_image)
 
     assert await extract_one._run(conn.file_id) == 0
     assert conn.persisted_text == "plain text body"
 
 
 @pytest.mark.asyncio
-async def test_non_pdf_without_text_never_transcribes(monkeypatch):
+async def test_image_upload_is_transcribed_by_vision(monkeypatch):
+    """An image carries its meaning in pixels: no parser can read it, so
+    without vision a dropped screenshot stores nothing and every agent
+    surface is blind to it."""
     conn = _FakeConnection(uuid.uuid4(), "image/png")
     _wire_extract_one(monkeypatch, conn, b"\x89PNG....")
 
-    async def fail_transcribe(content):
-        raise AssertionError("transcribe_pdf must not be called")
+    async def fake_image(content, content_type):
+        assert content_type == "image/png"
+        return "a screenshot of the pricing page"
 
-    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
+    monkeypatch.setattr(image_ocr, "transcribe_image", fake_image)
 
     assert await extract_one._run(conn.file_id) == 0
-    assert conn.persisted_text is None
+    assert conn.persisted_text == "a screenshot of the pricing page"
 
 
 @pytest.mark.asyncio

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -58,6 +58,7 @@ async def _run(file_id: UUID) -> int:
     from ..config import settings
     from ..services import storage_service
     from ..services.file_extraction import extract_text, is_pdf
+    from ..services.image_ocr import transcribe_image
     from ..services.pdf_ocr import transcribe_pdf
 
     # A document that extracts to more than this is stored truncated rather
@@ -85,6 +86,11 @@ async def _run(file_id: UUID) -> int:
             # propagate to the except below so the row records the failure and
             # the retry machinery re-runs it.
             text = await transcribe_pdf(content) or None
+        elif row["content_type"].startswith("image/"):
+            # An image carries its meaning in pixels, so vision is the only
+            # reader it has. Without this a dropped screenshot stores nothing
+            # and every agent surface is blind to it.
+            text = await transcribe_image(content, row["content_type"]) or None
         else:
             text = extract_text(content, row["content_type"])
         if text and len(text) > MAX_EXTRACTED_TEXT:


### PR DESCRIPTION
## Why

`file_extraction.extract_text` has no branch for images. Every screenshot, photo, and diagram ever uploaded stored an empty knowledge-base entry — invisible to search, to ask-the-stash, and to any agent reading the VFS. The file is there, the pixels are there, and the agent is blind to all of it.

A screenshot is one of the most common things a person puts into their stash, and the one thing no parser can read.

## What

Images take the path scanned PDFs already take: vision. The prompt transcribes visible text character-for-character in reading order, renders tables as markdown, and then describes what the image shows — subject, setting, chart values, diagram structure, callouts — so a reader who cannot see it still gets the information.

Only formats Gemini accepts inline are transcribable. Anything else (SVG, TIFF) returns `""` and stores no text, the same declared-support stance `extract_text` takes. Like `pdf_ocr`, failures raise so the extraction pipeline's retry machinery records the error instead of silently persisting an empty entry.

Example, on a screenshot of the app's own nav rail:

> Home VFS Sessions Skills Tools Chat
>
> This image is a screenshot of a vertical navigation sidebar from a software application or website. The sidebar has a light beige background and contains six menu items, each with an icon and a text label…

## Two things the reviewer should weigh

**This changes the global upload path.** Every image uploaded anywhere — including avatars, page covers, and editor images — now costs one Gemini Flash call on ingest. I think that is the right trade (a Flash call is a fraction of a cent, and the alternative is a permanent blind spot), but it is a real cost change and it is why this is its own PR rather than folded into a feature.

**It reverses an assertion that was deliberately made.** `test_non_pdf_without_text_never_transcribes` pinned "vision costs an API call per chunk — only PDFs take that path". That rationale still holds for formats a parser *can* read, which is what the renamed `test_parsable_upload_never_transcribes` now asserts; the image case becomes `test_image_upload_is_transcribed_by_vision`.

## Verification

- New tests cover the two edges: an untranscribable format makes no API call, and a missing key fails loud.
- The extraction-worker test asserts an image reaches `transcribe_image` and a parsable format still does not.
- Exercised end to end against a live stack: a dropped PNG went `pending → done` with a real transcription stored in `extracted_text`.
- `test_image_ocr.py` + `test_pdf_ocr.py`: 24 passed. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the global file-extraction path so every image upload triggers an external Gemini API call, affecting cost and knowledge-base content quality. Failures are surfaced for retry rather than silently storing empty entries.
> 
> **Overview**
> Uploaded images are now transcribed via Gemini vision on ingest, so screenshots, photos, and diagrams become searchable and readable by agents instead of storing empty knowledge-base entries.
> 
> The extraction worker routes `image/*` uploads through a new `transcribe_image` path (mirroring scanned PDFs). Supported formats (`png`, `jpeg`, `webp`, `heic`, `heif`) get character-accurate text plus a scene description; unsupported formats like SVG/TIFF still store no text. API failures raise so retries record the error rather than silently persisting blanks.
> 
> **Note for reviewers:** this hits the global upload path — every image ingest (including avatars/covers) now costs one Gemini Flash call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daca8eef8ed2690a39014c197066cffa28209d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->