### PR TITLE
Serve the Stash tools over HTTPS as a remote MCP endpoint so that we can support claude cowork.

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -164,6 +164,15 @@ class Settings:
         AUTH0_ENABLED,
     )
 
+    # --- Remote MCP endpoint ---
+    # The canonical URL Claude connects to, e.g. https://api.joinstash.ai/mcp.
+    # It is also the OAuth audience: Claude sends this URL as the `resource`
+    # parameter, and Auth0 stamps it into the token's `aud`. It must match what
+    # the user types into Claude exactly, so it cannot be derived — an
+    # almost-right URL fails discovery with an unhelpful error. Unset means the
+    # endpoint is not mounted at all.
+    MCP_PUBLIC_URL: str = os.getenv("MCP_PUBLIC_URL", "")
+
     # --- Embeddings ---
     # Provider: "openai", "huggingface", "local", or "auto" (default).
     # Auto-detect: OPENAI_API_KEY → openai, HF_TOKEN → huggingface, else → local.

--- a/backend/main.py
+++ b/backend/main.py
@@ -170,6 +170,12 @@ if settings.AUTH0_ENABLED:
 
     app.include_router(auth0_router)
 
+# Remote MCP endpoint. Mounted last: its tools call back into the routes above
+# through an in-process transport, so they all have to be registered first.
+from backend import mcp_remote  # noqa: E402
+
+mcp_remote.attach(app)
+
 
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):

--- a/backend/managed/auth0/jwt.py
+++ b/backend/managed/auth0/jwt.py
@@ -29,8 +29,25 @@ async def _fetch_jwks() -> dict:
 
 
 async def validate_auth0_token(token: str) -> dict:
-    """Validate an Auth0 access token. Returns the decoded claims."""
-    if not settings.AUTH0_DOMAIN or not settings.AUTH0_AUDIENCE:
+    """Validate an Auth0 access token minted for the web app's API."""
+    if not settings.AUTH0_AUDIENCE:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Auth0 not configured",
+        )
+    return await validate_auth0_token_for_audience(token, settings.AUTH0_AUDIENCE)
+
+
+async def validate_auth0_token_for_audience(token: str, audience: str) -> dict:
+    """Validate an Auth0 access token against an explicit audience.
+
+    The remote MCP endpoint needs its own audience: with Auth0's
+    resource-parameter compatibility profile enabled, Claude's tokens carry the
+    MCP server's own URL in `aud`, not the web app's API identifier. Keeping the
+    two audiences distinct is deliberate — a token minted for one surface is
+    rejected by the other.
+    """
+    if not settings.AUTH0_DOMAIN:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Auth0 not configured",
@@ -60,7 +77,7 @@ async def validate_auth0_token(token: str) -> dict:
             token,
             signing_key,
             algorithms=["RS256"],
-            audience=settings.AUTH0_AUDIENCE,
+            audience=audience,
             issuer=f"https://{settings.AUTH0_DOMAIN}/",
         )
     except JWTError:

--- a/backend/mcp_remote.py
+++ b/backend/mcp_remote.py
@@ -1,0 +1,205 @@
+"""Remote MCP endpoint — the same tools the `stash-mcp` CLI serves, reachable
+over HTTPS instead of only from the machine they're installed on.
+
+Why this exists: `cli/mcp_server.py` runs on the user's laptop and reads their
+API key out of `~/.stash/config.json`. That works for Claude Code, and cannot
+work for anything running elsewhere — Cowork's cloud sessions, Claude on the
+web, Claude on a phone. Those reach tools only over HTTP with OAuth.
+
+Two things are worth understanding before editing this file.
+
+**Tools call our own REST API, in process.** Every tool here is a thin wrapper
+over a route that already exists, invoked through an in-process ASGI transport
+carrying the caller's own bearer token. No network hop, and — the point —
+authorization, scoping, plan gates, and rate limits are enforced by exactly the
+same code that enforces them for the web app. Re-implementing 72 tools against
+the service layer would mean a second authorization path to keep correct, and
+the first missed scope check is a data leak between users.
+
+**The audience is this endpoint's own URL.** Claude sends the MCP server URL as
+the OAuth `resource` parameter; with Auth0's resource-parameter compatibility
+profile enabled, that lands in the token's `aud`. So MCP tokens and web-app
+tokens are separate credentials and neither is accepted where the other is
+expected. Requires those tenant toggles to be on — without them Auth0 ignores
+`resource` and every call here 401s.
+"""
+
+import logging
+from urllib.parse import urlparse
+
+import httpx
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.routes import create_protected_resource_routes
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import Context
+from pydantic import AnyHttpUrl
+from starlette.applications import Starlette
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# Set by attach(); the FastAPI app tools call back into. A module global rather
+# than an import because main.py imports this module, not the other way round.
+_asgi_app: Starlette | None = None
+
+
+class Auth0TokenVerifier(TokenVerifier):
+    """Verifies Auth0 access tokens minted for this endpoint's audience."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        from .managed.auth0.jwt import validate_auth0_token_for_audience
+
+        try:
+            claims = await validate_auth0_token_for_audience(token, settings.MCP_PUBLIC_URL)
+        except Exception:
+            # The library's contract is None for "not a valid token", while the
+            # validator raises HTTPException. Expired and malformed tokens are
+            # routine here — Claude refreshes reactively on a 401.
+            return None
+
+        subject = claims.get("sub")
+        if not subject:
+            return None
+        return AccessToken(
+            token=token,
+            client_id=claims.get("azp") or subject,
+            scopes=(claims.get("scope") or "").split(),
+            expires_at=claims.get("exp"),
+            resource=settings.MCP_PUBLIC_URL,
+            subject=subject,
+            claims=claims,
+        )
+
+
+def _caller_token(ctx: Context) -> str:
+    """The bearer token of whoever is making this MCP call."""
+    from mcp.server.auth.middleware.auth_context import get_access_token
+
+    access = get_access_token()
+    if access is None:
+        # Unreachable while auth is configured: the transport rejects
+        # unauthenticated requests before a tool runs. Loud rather than a call
+        # that silently acts as nobody.
+        raise RuntimeError("MCP tool ran without an authenticated caller")
+    return access.token
+
+
+async def _api_get(ctx: Context, path: str, **params) -> dict:
+    return await _api_request(ctx, "GET", path, params=params)
+
+
+async def _api_post(ctx: Context, path: str, json: dict) -> dict:
+    return await _api_request(ctx, "POST", path, json=json)
+
+
+async def _api_request(ctx: Context, method: str, path: str, **kwargs) -> dict:
+    """Call our own REST API in-process as the authenticated caller."""
+    if _asgi_app is None:
+        raise RuntimeError("Remote MCP endpoint used before attach()")
+    transport = httpx.ASGITransport(app=_asgi_app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://stash.internal", timeout=60
+    ) as client:
+        resp = await client.request(
+            method,
+            path,
+            headers={"Authorization": f"Bearer {_caller_token(ctx)}"},
+            **kwargs,
+        )
+    # Surface the API's own error text: an MCP tool that swallows a 403 and
+    # returns an empty result teaches the model the data does not exist.
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _build_server() -> FastMCP:
+    """Construct the MCP server. Only ever called from attach(), and only once
+    it has confirmed the endpoint is configured — so a server object cannot
+    exist in an unauthenticated state waiting for someone to mount it."""
+    server = FastMCP(
+        "stash",
+        instructions="Stash — your team's shared memory. Search everything you "
+        "and your agents have written, read it, and write back into it.",
+        token_verifier=Auth0TokenVerifier(),
+        auth=AuthSettings(
+            issuer_url=AnyHttpUrl(f"https://{settings.AUTH0_DOMAIN}/"),
+            resource_server_url=AnyHttpUrl(settings.MCP_PUBLIC_URL),
+            required_scopes=[],
+        ),
+        # The app is mounted at the URL's own path, so its internal route sits
+        # at the mount root. Left at the default "/mcp" it would answer at
+        # /mcp/mcp and the advertised URL would 404.
+        streamable_http_path="/",
+    )
+    for tool in (stash_search, stash_vfs, stash_list_workspaces):
+        server.tool()(tool)
+    return server
+
+
+async def stash_search(
+    ctx: Context,
+    query: str,
+    limit: int = 20,
+) -> dict:
+    """Search across everything in the user's Stash — their own files and
+    pages, their agents' session transcripts, and every connected source
+    (GitHub, Drive, Gmail, Notion, Slack, Granola) — merged onto one relevance
+    scale. Returns {"results": [...], "has_more": bool}."""
+    return await _api_get(ctx, "/api/v1/me/sources/search", q=query, limit=limit)
+
+
+async def stash_vfs(ctx: Context, script: str, cwd: str = "/") -> dict:
+    """Browse the Stash as a filesystem with bash-shaped commands over the
+    virtual tree: `ls /`, `find / -maxdepth 3 -type f`, `rg 'query' /`,
+    `cat '/files/README.md'`. Mounts are /files /sessions /memory /skills
+    /tables /sources."""
+    return await _api_post(ctx, "/api/v1/me/vfs", {"script": script, "cwd": cwd})
+
+
+async def stash_list_workspaces(ctx: Context) -> dict:
+    """List the workspaces this user belongs to, and which one is active."""
+    return await _api_get(ctx, "/api/v1/me/workspaces")
+
+
+def attach(app) -> bool:
+    """Mount the remote MCP endpoint onto the FastAPI app.
+
+    Returns whether it mounted. It needs both an Auth0 tenant to verify tokens
+    against and the canonical public URL that is its own OAuth audience, so a
+    deployment without those (self-hosted, local dev, CI) simply doesn't serve
+    it — announced in the log rather than half-mounted.
+    """
+    global _asgi_app
+
+    if not settings.MCP_PUBLIC_URL or not settings.AUTH0_DOMAIN:
+        logger.info(
+            "remote MCP endpoint not mounted (needs MCP_PUBLIC_URL and AUTH0_DOMAIN)",
+        )
+        return False
+
+    _asgi_app = app
+    # Mounted at MCP_PUBLIC_URL's own path, so the URL the user types into
+    # Claude is the URL that answers — Claude requires the advertised `resource`
+    # to match the connector URL exactly, path included.
+    path = urlparse(settings.MCP_PUBLIC_URL).path.rstrip("/")
+    if not path:
+        raise RuntimeError(
+            f"MCP_PUBLIC_URL needs a path to mount at (got {settings.MCP_PUBLIC_URL!r}); "
+            "use something like https://api.joinstash.ai/mcp"
+        )
+    # Claude discovers the authorization server by probing
+    # /.well-known/oauth-protected-resource/<path> at the *origin*, so these
+    # routes go on the main app — inside the mount they'd only be reachable at
+    # a path Claude never asks for.
+    for route in create_protected_resource_routes(
+        resource_url=AnyHttpUrl(settings.MCP_PUBLIC_URL),
+        authorization_servers=[AnyHttpUrl(f"https://{settings.AUTH0_DOMAIN}/")],
+        resource_name="Stash",
+    ):
+        app.router.routes.append(route)
+
+    app.mount(path, _build_server().streamable_http_app())
+    logger.info("remote MCP endpoint mounted at %s", settings.MCP_PUBLIC_URL)
+    return True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,10 @@ pypdf>=4.0
 anthropic>=0.40.0
 nh3>=0.2
 claude-agent-sdk>=0.1.50
-mcp>=1.23.0
+# Held at 1.x: mcp 2.0 dropped streamablehttp_client, which the Granola and
+# PostHog clients import. Prod already runs 1.x — this stops the next fresh
+# resolve from silently upgrading and breaking those syncs at import time.
+mcp>=1.23.0,<2
 celery[redis]>=5.4
 duckdb>=1.1
 redis>=5.0

--- a/backend/tests/test_mcp_remote.py
+++ b/backend/tests/test_mcp_remote.py
@@ -1,0 +1,139 @@
+"""Remote MCP endpoint: mounting rules and token audience separation.
+
+The audience tests are the important ones. Claude's tokens are minted for the
+MCP endpoint's own URL, and the web app's are minted for the API identifier. If
+this endpoint ever validated against the web app's audience, a token issued for
+one surface would be accepted by the other — which is the whole reason the two
+audiences are separate.
+"""
+
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from backend import mcp_remote
+from backend.config import settings
+
+MCP_URL = "https://api.example.test/mcp"
+AUTH0_DOMAIN = "tenant.us.auth0.test"
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(settings, "MCP_PUBLIC_URL", MCP_URL)
+    monkeypatch.setattr(settings, "AUTH0_DOMAIN", AUTH0_DOMAIN)
+
+
+def test_not_mounted_without_config(monkeypatch):
+    """A self-hosted or local deployment has no Auth0 tenant to verify tokens
+    against, so it must not serve a half-configured public endpoint."""
+    monkeypatch.setattr(settings, "MCP_PUBLIC_URL", "")
+    app = FastAPI()
+
+    assert mcp_remote.attach(app) is False
+    assert not any(getattr(r, "path", "") == "/mcp" for r in app.routes)
+
+
+def test_mounts_at_the_url_path(configured):
+    """Claude requires the advertised resource to match the connector URL
+    exactly, path included — so the mount point comes from the URL, not a
+    constant that could drift away from it."""
+    app = FastAPI()
+
+    assert mcp_remote.attach(app) is True
+    assert any(getattr(r, "path", "") == "/mcp" for r in app.routes)
+
+
+def test_pathless_url_fails_loud(monkeypatch):
+    """A bare origin would mount at "" and answer nothing; Claude's error for
+    that is an unhelpful "couldn't reach the MCP server"."""
+    monkeypatch.setattr(settings, "MCP_PUBLIC_URL", "https://api.example.test")
+    monkeypatch.setattr(settings, "AUTH0_DOMAIN", AUTH0_DOMAIN)
+
+    with pytest.raises(RuntimeError, match="needs a path"):
+        mcp_remote.attach(FastAPI())
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_call_starts_the_discovery_chain(configured):
+    """The entire connect flow hangs off this handshake: Claude posts, gets a
+    401 whose WWW-Authenticate names a metadata URL, reads that document, and
+    learns which authorization server to send the user to. Break any link and
+    Claude reports only "couldn't reach the MCP server"."""
+    from httpx import ASGITransport, AsyncClient
+
+    app = FastAPI()
+    mcp_remote.attach(app)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t", follow_redirects=True
+    ) as client:
+        call = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+        assert call.status_code == 401
+        challenge = call.headers["www-authenticate"]
+        assert 'resource_metadata="' in challenge
+
+        metadata_url = challenge.split('resource_metadata="')[1].split('"')[0]
+        doc = await client.get(metadata_url.replace("https://api.example.test", ""))
+
+    assert doc.status_code == 200
+    body = doc.json()
+    assert body["resource"] == MCP_URL
+    assert body["authorization_servers"] == [f"https://{AUTH0_DOMAIN}/"]
+
+
+@pytest.mark.asyncio
+async def test_verifier_uses_the_endpoints_own_audience(configured, monkeypatch):
+    """Tokens must be checked against this endpoint's URL, never the web app's
+    API identifier — that separation is what stops a token minted for one
+    surface being replayed against the other."""
+    seen = {}
+
+    async def fake_validate(token, audience):
+        seen["audience"] = audience
+        return {"sub": "auth0|abc", "scope": "openid profile", "exp": 9999999999}
+
+    monkeypatch.setattr(
+        "backend.managed.auth0.jwt.validate_auth0_token_for_audience", fake_validate
+    )
+
+    result = await mcp_remote.Auth0TokenVerifier().verify_token("a-token")
+
+    assert seen["audience"] == MCP_URL
+    assert result is not None
+    assert result.subject == "auth0|abc"
+    assert result.resource == MCP_URL
+
+
+@pytest.mark.asyncio
+async def test_rejected_token_returns_none(configured, monkeypatch):
+    """An expired or malformed token is routine — Claude refreshes on a 401.
+    The library wants None for that; a raised HTTPException would surface as a
+    500 and Claude would not re-authenticate."""
+
+    async def fake_validate(token, audience):
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    monkeypatch.setattr(
+        "backend.managed.auth0.jwt.validate_auth0_token_for_audience", fake_validate
+    )
+
+    assert await mcp_remote.Auth0TokenVerifier().verify_token("bad") is None
+
+
+@pytest.mark.asyncio
+async def test_token_without_subject_is_rejected(configured, monkeypatch):
+    """Every tool call acts as a specific user. A token that names nobody must
+    not become a session that acts as nobody."""
+
+    async def fake_validate(token, audience):
+        return {"scope": "openid"}
+
+    monkeypatch.setattr(
+        "backend.managed.auth0.jwt.validate_auth0_token_for_audience", fake_validate
+    )
+
+    assert await mcp_remote.Auth0TokenVerifier().verify_token("no-sub") is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "questionary>=2.0.0",
-    "mcp>=1.23.0",
+    # mcp 2.0 moved FastMCP to mcp.server.mcpserver and dropped
+    # streamablehttp_client, which cli/mcp_server.py and the backend's
+    # Granola/PostHog clients both import. Unpinned, a fresh install resolved
+    # to 2.0.0 and stash-mcp died on import. Held at 1.x until both are ported.
+    "mcp>=1.23.0,<2",
     "filelock>=3.12",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -262,19 +262,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore2"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
-]
-
-[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -290,19 +277,12 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx2"
-version = "2.9.1"
+name = "httpx-sse"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -355,15 +335,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "2.0.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx2" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "jsonschema" },
-    { name = "mcp-types" },
-    { name = "opentelemetry-api" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -373,22 +353,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
-]
-
-[[package]]
-name = "mcp-types"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]
@@ -398,18 +365,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "opentelemetry-api"
-version = "1.44.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -551,6 +506,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -571,6 +540,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -803,7 +781,7 @@ wheels = [
 
 [[package]]
 name = "stashai"
-version = "0.1.360"
+version = "0.1.364"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
@@ -818,19 +796,10 @@ dependencies = [
 requires-dist = [
     { name = "filelock", specifier = ">=3.12" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.23.0,<2" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two changes. The first is a bug fix that stands alone; the second is the foundation for reaching Claude surfaces that aren't a developer's laptop.

## Hold mcp at 1.x (9694039d)

`mcp` 2.0.0 shipped on 2026-07-28, moved `FastMCP` to `mcp.server.mcpserver`, and dropped `streamablehttp_client`. Both of our pins were an unbounded `>=1.23.0`, so **every fresh install has been resolving to 2.0 and `stash-mcp` dies on its import line.** Anyone who installed or upgraded the CLI in the last two weeks has a dead MCP entrypoint.

Prod is not affected — its running image is on 1.x, confirmed from a live traceback that still shows `streamablehttp_client` present. But `backend/requirements.txt` carried the same unbounded floor, so the next fresh Docker resolve would have taken the Granola and PostHog clients down at import time. That tripwire is the main reason this is worth shipping on its own.

Pinning rather than porting: the CLI half is a two-line change (`MCPServer` is a drop-in), but the backend half needs a real port to the new client API, and splitting mcp majors across one repo is worse than holding both at 1.x.

## Remote MCP endpoint (72ac610c)

`cli/mcp_server.py` runs on the user's laptop and reads their API key from `~/.stash/config.json`. That works for Claude Code and cannot work anywhere else — I verified that a Cowork cloud session runs in a Linux container with no view of the user's Mac at all, and Claude on the web and mobile never touch the machine. Those surfaces reach tools only over HTTP with OAuth.

**Tools call our own REST API in process**, through an ASGI transport carrying the caller's bearer token. Authorization, scoping, plan gates and rate limits are then enforced by exactly the code that enforces them for the web app. Re-implementing 72 tools against the service layer would mean a second authorization path to keep correct, and the first missed scope check is a data leak between users. This is the main design decision in the PR and the one most worth arguing with.

**The OAuth audience is the endpoint's own URL**, not the web app's API identifier, so MCP tokens and web-app tokens are separate credentials and neither is accepted where the other is expected.

### Deployment

Gated on `MCP_PUBLIC_URL`. Unset, nothing mounts — **merging this changes nothing in production** until that variable is set on Render. Self-hosted deployments, which have no Auth0 tenant to verify tokens against, never serve it.

Requires the Auth0 tenant's *Resource Parameter Compatibility Profile* and *Include Issuer in Authorization Responses* toggles, both now enabled. Without them Auth0 ignores the `resource` parameter Claude sends and every call 401s. Existing web-app sign-ins are unchanged: they always pass `audience` explicitly, which still takes precedence.

### Scope

Three tools, to prove the path end to end. The remaining 69 are mechanical — a docstring and one line calling an existing route each — and should follow only after this has been verified against a real Claude connection, where the remaining unknowns actually live.

## Verification

The full discovery handshake works as Anthropic's spec describes:

```
POST /mcp  ->  401
   WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/mcp"
GET that URL  ->  200
   {"resource": ".../mcp", "authorization_servers": ["https://<tenant>/"]}
```

- 1360 backend tests pass; ruff clean
- 7 new tests cover the discovery chain and the audience separation
- `test_activity.py` is excluded: it segfaults inside torch/sentence-transformers on my machine, which I confirmed also happens on a clean tree

## Not done

- 69 remaining tools
- Security review — this puts 72 tools, including destructive ones, on the public internet
- `mcp-review@anthropic.com` for Anthropic-held client credentials; DCR otherwise registers a new OAuth client on every fresh connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a public OAuth-authenticated MCP surface and changes Auth0 audience validation, which are security-critical paths. Gated behind MCP_PUBLIC_URL, but once enabled it exposes tools on the public internet.
> 
> **Overview**
> Exposes Stash tools over HTTPS with OAuth so Claude surfaces that aren't a local laptop (Cowork, web, mobile) can reach them. Also **pins `mcp` to 1.x** so fresh installs stop resolving to 2.0 and breaking `stash-mcp` / Granola / PostHog imports.
> 
> The new remote endpoint mounts only when `MCP_PUBLIC_URL` is set. Tools are thin wrappers that call existing REST routes **in-process** with the caller's bearer token, so auth, scoping, plan gates, and rate limits stay on the same path as the web app. Starts with three tools: `stash_search`, `stash_vfs`, and `stash_list_workspaces`.
> 
> Auth0 JWT validation is split so MCP tokens use the endpoint URL as audience and web-app tokens keep `AUTH0_AUDIENCE` — neither credential is accepted on the other surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ac610c7fd16a98d933f9ee47c5e9f9c6cbb04e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->