### PR TITLE
The curator maintains three skills alongside the wiki

### DIFF
--- a/backend/migrations/versions/0185_curated_skills.py
+++ b/backend/migrations/versions/0185_curated_skills.py
@@ -1,0 +1,39 @@
+"""AI-curated skills: three reserved slots the nightly curator owns.
+
+The curator already compiles the user's activity into the Memory wiki. The
+wiki is pull — it helps only when an agent thinks to search it. Skills are
+push: every SKILL.md description is loaded at session start, so a curated
+skill fires without the agent knowing to look.
+
+Curated skills are ordinary skill folders (same ``is_skill`` flag, same
+sync, same Skills surface) marked ``is_curated`` so two things are
+expressible: the three-slot cap, and adoption — a human edit clears the flag
+and the curator may never touch that skill again.
+
+Revision ID: 0185
+Revises: 0184
+"""
+
+from alembic import op
+
+revision = "0185"
+down_revision = "0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE folders ADD COLUMN is_curated boolean NOT NULL DEFAULT false")
+    # A curated folder is always a skill, so the existing
+    # folders_protected_is_never_a_skill check keeps Memory and Clips out too.
+    op.execute(
+        "ALTER TABLE folders ADD CONSTRAINT folders_curated_is_a_skill "
+        "CHECK (NOT is_curated OR is_skill)"
+    )
+    op.execute("CREATE INDEX idx_folders_is_curated ON folders(owner_user_id) WHERE is_curated")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_folders_is_curated")
+    op.execute("ALTER TABLE folders DROP CONSTRAINT IF EXISTS folders_curated_is_a_skill")
+    op.execute("ALTER TABLE folders DROP COLUMN IF EXISTS is_curated")

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -31,6 +31,7 @@ from ..models import (
 )
 from ..services import (
     comment_service,
+    curated_skill_service,
     files_tree_service,
     page_events,
     permission_service,
@@ -815,6 +816,11 @@ async def update_page(
         )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    if page["folder_id"]:
+        # Editing inside a curated skill adopts it: the curator wrote a first
+        # draft, the human made it theirs, and the slot frees for a new
+        # candidate. No-op for every other folder.
+        await curated_skill_service.adopt(owner_user_id, page["folder_id"])
     # Write access was checked above; a save response must not flip the
     # editor read-only by omitting the flag.
     return PageResponse(**{**page, "can_write": True})

--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -17,6 +17,7 @@ from ..models import (
     SkillUpdateRequest,
 )
 from ..services import (
+    curated_skill_service,
     files_tree_service,
     github_skill_import,
     permission_service,
@@ -124,6 +125,65 @@ async def _set_is_skill(
     return {"folder_id": str(folder["id"]), "name": folder["name"], "is_skill": folder["is_skill"]}
 
 
+class CuratedSkillWriteRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=skill_service.MAX_SKILL_NAME_LENGTH)
+    description: str = Field(
+        ..., min_length=1, max_length=skill_service.MAX_SKILL_DESCRIPTION_LENGTH
+    )
+    body: str = Field(..., min_length=1)
+    replaces: str | None = Field(
+        None, description="Name or folder id of the curated skill this one evicts."
+    )
+
+
+@me_router.get("/curated-skills")
+async def list_curated_skills(owner_user_id: UUID = Depends(get_scope)):
+    """The curator's occupied slots. Read by the curator before it decides
+    whether tonight's candidate beats an incumbent, and by Home to show them."""
+    return {
+        "max_slots": curated_skill_service.MAX_CURATED_SKILLS,
+        "skills": await curated_skill_service.list_curated(owner_user_id),
+    }
+
+
+@me_router.post("/curated-skills", status_code=200)
+async def write_curated_skill(
+    req: CuratedSkillWriteRequest,
+    current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
+):
+    """Create or update one of the curated slots. 400s rather than evicting
+    anything by itself when the slots are full and `replaces` is missing."""
+    try:
+        return await curated_skill_service.write(
+            owner_user_id,
+            current_user["id"],
+            req.name,
+            req.description,
+            req.body,
+            req.replaces,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@me_router.post("/folders/{folder_id}/adopt-curated-skill", status_code=200)
+async def adopt_curated_skill(
+    folder_id: UUID,
+    current_user: dict = Depends(get_current_user),
+    owner_user_id: UUID = Depends(get_scope),
+):
+    """Take a curated skill out of the curator's hands. Called by
+    `stash skills sync` the moment it sees a local edit, and by the UI when
+    someone edits or publishes one."""
+    if not await permission_service.check_access(
+        "folder", folder_id, current_user["id"], owner_user_id=owner_user_id, require="write"
+    ):
+        raise HTTPException(status_code=403, detail="Not allowed to write this folder")
+    adopted = await curated_skill_service.adopt(owner_user_id, folder_id)
+    return {"adopted": adopted is not None}
+
+
 @me_router.post("/skills", response_model=SkillResponse, status_code=201)
 async def publish_skill(
     req: SkillPublishRequest,
@@ -146,6 +206,8 @@ async def publish_skill(
         raise HTTPException(status_code=403, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    # Publishing is standing behind it, so it stops being the curator's.
+    await curated_skill_service.adopt(owner_user_id, req.folder_id)
     return SkillResponse(**skill)
 
 
@@ -288,6 +350,9 @@ async def replace_skill_contents(
     written = await files_tree_service.write_folder_files(
         owner_user_id, current_user["id"], folder_id, payload
     )
+    # Only a human pushes contents — the curator writes through
+    # /curated-skills — so a push to a curated skill is the edit that adopts it.
+    await curated_skill_service.adopt(owner_user_id, folder_id)
     return {"folder_id": str(folder_id), "items": written}
 
 

--- a/backend/services/curated_skill_service.py
+++ b/backend/services/curated_skill_service.py
@@ -1,0 +1,192 @@
+"""AI-curated skills — the three slots the nightly curator owns.
+
+The curator's other output, the Memory wiki, is pull: it helps only when an
+agent thinks to search it. Skills are push — the harness loads every
+SKILL.md description at session start — so a curated skill fires without the
+agent knowing to look. This is the write surface for that second target.
+
+Every invariant lives here rather than in the curator's prompt, so a prompt
+regression degrades the skills' quality instead of reintroducing the sprawl
+the cap exists to prevent:
+
+- **Three slots.** Writing a fourth fails loud and must name the slot it
+  replaces; the replaced skill goes to the trash.
+- **A human edit adopts.** ``adopt`` clears the flag, the slot frees, and
+  the skill becomes an ordinary hand-authored one.
+- **The curator only writes what it owns.** ``write`` matches names against
+  curated skills only, so an adopted skill can never be overwritten by the
+  next night's run.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from ..database import get_pool
+from . import files_tree_service, skill_service
+
+MAX_CURATED_SKILLS = 3
+
+
+def _skill_md(name: str, description: str, body: str) -> str:
+    """The curated SKILL.md. `description` is the only text the harness
+    matches on, so it carries the whole trigger; the body is read after."""
+    md = (
+        f"---\nname: {json.dumps(name)}\ndescription: {json.dumps(description)}\n"
+        f"curated: true\n---\n\n{body.strip()}\n"
+    )
+    skill_service.validate_skill_md(md)
+    return md
+
+
+async def list_curated(owner_user_id: UUID) -> list[dict]:
+    """The occupied slots, oldest first — what the curator reads before
+    deciding whether tonight's candidate beats an incumbent."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT f.id, f.name, f.created_at, p.content_markdown, p.updated_at "
+        "FROM folders f "
+        "LEFT JOIN pages p ON p.folder_id = f.id AND p.name = $2 AND p.deleted_at IS NULL "
+        "WHERE f.owner_user_id = $1 AND f.is_curated "
+        "ORDER BY f.created_at",
+        owner_user_id,
+        skill_service.SKILL_MD_NAME,
+    )
+    out = []
+    for r in rows:
+        meta, body = skill_service.parse_frontmatter(r["content_markdown"] or "")
+        out.append(
+            {
+                "folder_id": str(r["id"]),
+                "name": meta.get("name") or r["name"],
+                "description": meta.get("description", ""),
+                "body": body,
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"] or r["created_at"],
+            }
+        )
+    return out
+
+
+async def write(
+    owner_user_id: UUID,
+    user_id: UUID,
+    name: str,
+    description: str,
+    body: str,
+    replaces: str | None = None,
+) -> dict:
+    """Create or update a curated skill. Raises ValueError with a sentence the
+    curator can act on when the write would break an invariant."""
+    name = name.strip()
+    description = description.strip()
+    if not name:
+        raise ValueError("name must not be blank")
+    if not description:
+        raise ValueError("description must not be blank — it is the skill's only trigger")
+    if not body.strip():
+        raise ValueError("body must not be blank")
+
+    skill_md = _skill_md(name, description, body)
+    curated = await list_curated(owner_user_id)
+
+    existing = next((c for c in curated if c["name"].lower() == name.lower()), None)
+    if existing:
+        await _write_skill_md(owner_user_id, user_id, UUID(existing["folder_id"]), skill_md)
+        return {"folder_id": existing["folder_id"], "name": name, "action": "updated"}
+
+    await _refuse_if_adopted(owner_user_id, name)
+    if len(curated) >= MAX_CURATED_SKILLS:
+        await _evict(owner_user_id, user_id, curated, replaces)
+
+    folder = await files_tree_service.create_skill(owner_user_id, user_id, name, description)
+    await _set_is_curated(folder["id"], owner_user_id, True)
+    await _write_skill_md(owner_user_id, user_id, folder["id"], skill_md)
+    return {"folder_id": str(folder["id"]), "name": folder["name"], "action": "created"}
+
+
+async def adopt(owner_user_id: UUID, folder_id: UUID) -> dict | None:
+    """A human touched it, so it's theirs: the skill stops being curated and
+    the slot frees. Returns None when the folder wasn't a curated skill —
+    adopting twice is not an error, it's already adopted."""
+    pool = get_pool()
+    row = await pool.fetchrow(
+        "UPDATE folders SET is_curated = false, updated_at = now() "
+        "WHERE id = $1 AND owner_user_id = $2 AND is_curated "
+        "RETURNING id, name",
+        folder_id,
+        owner_user_id,
+    )
+    if row is None:
+        return None
+    return {"folder_id": str(row["id"]), "name": row["name"]}
+
+
+async def _refuse_if_adopted(owner_user_id: UUID, name: str) -> None:
+    """A skill by this name that isn't curated was written or adopted by the
+    user. Writing it again would either overwrite their work or mint a
+    near-duplicate ('Name (2)') that competes with it for the same trigger."""
+    pool = get_pool()
+    taken = await pool.fetchval(
+        "SELECT name FROM folders "
+        "WHERE owner_user_id = $1 AND is_skill AND NOT is_curated AND lower(name) = lower($2)",
+        owner_user_id,
+        name,
+    )
+    if taken:
+        raise ValueError(
+            f"{taken!r} is the user's own skill, not a curated one — "
+            "they wrote it or adopted it. Leave it alone and pick another angle."
+        )
+
+
+async def _evict(
+    owner_user_id: UUID, user_id: UUID, curated: list[dict], replaces: str | None
+) -> None:
+    slots = ", ".join(f"{c['name']!r}" for c in curated)
+    if not replaces:
+        raise ValueError(
+            f"all {MAX_CURATED_SKILLS} curated slots are full ({slots}) — "
+            "pass the name of the one this replaces, or leave the set alone"
+        )
+    target = next(
+        (c for c in curated if replaces == c["folder_id"] or replaces.lower() == c["name"].lower()),
+        None,
+    )
+    if target is None:
+        raise ValueError(f"{replaces!r} is not a curated skill — the slots are {slots}")
+    await files_tree_service.delete_folder(UUID(target["folder_id"]), owner_user_id, user_id)
+
+
+async def _set_is_curated(folder_id: UUID, owner_user_id: UUID, is_curated: bool) -> None:
+    pool = get_pool()
+    await pool.execute(
+        "UPDATE folders SET is_curated = $3, updated_at = now() "
+        "WHERE id = $1 AND owner_user_id = $2",
+        folder_id,
+        owner_user_id,
+        is_curated,
+    )
+
+
+async def _write_skill_md(
+    owner_user_id: UUID, user_id: UUID, folder_id: UUID, skill_md: str
+) -> None:
+    pool = get_pool()
+    page_id = await pool.fetchval(
+        "SELECT id FROM pages WHERE folder_id = $1 AND name = $2 AND deleted_at IS NULL",
+        folder_id,
+        skill_service.SKILL_MD_NAME,
+    )
+    if page_id is None:
+        await files_tree_service.create_page(
+            owner_user_id,
+            skill_service.SKILL_MD_NAME,
+            user_id,
+            folder_id=folder_id,
+            content=skill_md,
+            content_type="markdown",
+        )
+        return
+    await files_tree_service.update_page(page_id, owner_user_id, user_id, content=skill_md)

--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -11,7 +11,7 @@ without waking a sprite.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from ..database import get_pool
@@ -27,6 +27,24 @@ _MAX_FILES = 100
 _MAX_SAVES = 100
 _MAX_SOURCE_DOCS = 100
 _SNIPPET = 280
+
+# Corrections are a rolling window, not part of the delta. Two reasons they
+# can't ride the history feed: the feed drains oldest-first, so a backlogged
+# account spends weeks of runs on old tool traffic before reaching this
+# month's words; and tool events outnumber user messages by ~50:1, so user
+# messages lose nearly every cap they compete for. (Measured on a real
+# account, 2026-08: 500 feed events held 295 tool events and 6 user messages.)
+# A single night also can't show recurrence, which is the whole test for a
+# skill — so this window deliberately overlaps run to run.
+_CORRECTION_WINDOW_DAYS = 30
+# Sampled per session, not newest-first overall: a skill earns its slot on how
+# many DISTINCT sessions show the pattern, so the input has to maximize
+# sessions rather than messages. Measured on a real account (2026-08): the
+# newest 200 messages covered 33 sessions over 1.4 days, while 4-per-session
+# across 120 sessions covered 8 days for 279 messages.
+_MAX_CORRECTION_SESSIONS = 120
+_MAX_PER_SESSION = 4
+_CORRECTION_SNIPPET = 600
 
 
 async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> bool:
@@ -213,8 +231,11 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         if not str(s.get("type", "")).startswith("native_")
     ]
 
+    corrections = await recent_user_messages(owner_user_id, datetime.now(UTC))
+
     return {
         "since": _iso(since),
+        "correction_window_days": _CORRECTION_WINDOW_DAYS,
         "counts": {
             "history": len(history),
             "pages": len(pages),
@@ -222,9 +243,11 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "source_docs": len(source_docs),
             "saves": len(saves),
             "sources": len(sources),
+            "corrections": len(corrections),
         },
         "history": history,
         "history_has_more": history_has_more,
+        "corrections": corrections,
         "pages": pages,
         "files": files,
         "source_docs": source_docs,
@@ -271,6 +294,62 @@ async def _feed_events(
     )
     has_more = len(rows) > limit
     return [dict(r) for r in rows[:limit]], has_more
+
+
+async def recent_user_messages(owner_user_id: UUID, now: datetime) -> list[dict]:
+    """The user's own words from the last `_CORRECTION_WINDOW_DAYS` — the
+    curator's evidence for what a skill should say. Up to `_MAX_PER_SESSION`
+    messages from each of the `_MAX_CORRECTION_SESSIONS` most recent sessions,
+    newest session first.
+
+    Deliberately outside the watermark: this is a window, not a delta, so it
+    never advances `complete_through` and re-presents the same messages night
+    after night. That repetition is the point — a skill earns its slot on
+    recurrence across sessions, which one night's delta cannot show."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        WITH ranked AS (
+          SELECT he.session_id, he.agent_name, he.created_at,
+                 left(coalesce(he.content, ''), $4) AS content,
+                 row_number() OVER (PARTITION BY he.session_id
+                                    ORDER BY he.created_at DESC) AS rn,
+                 max(he.created_at) OVER (PARTITION BY he.session_id) AS session_last
+          FROM history_events he
+          WHERE he.owner_user_id = $1
+            AND he.event_type = 'user_message'
+            AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')
+            AND he.created_at > $2
+            AND coalesce(he.content, '') <> ''
+        ),
+        top_sessions AS (
+          SELECT DISTINCT session_id, session_last FROM ranked
+          ORDER BY session_last DESC LIMIT $3
+        )
+        SELECT r.session_id, r.agent_name, r.created_at, r.content, sf.name AS folder
+        FROM ranked r
+        JOIN top_sessions t ON t.session_id IS NOT DISTINCT FROM r.session_id
+        LEFT JOIN sessions s ON s.owner_user_id = $1 AND s.session_id = r.session_id
+        LEFT JOIN session_folders sf ON sf.id = s.session_folder_id
+        WHERE r.rn <= $5
+        ORDER BY t.session_last DESC, r.created_at
+        """,
+        owner_user_id,
+        now - timedelta(days=_CORRECTION_WINDOW_DAYS),
+        _MAX_CORRECTION_SESSIONS,
+        _CORRECTION_SNIPPET,
+        _MAX_PER_SESSION,
+    )
+    return [
+        {
+            "session_id": r["session_id"],
+            "agent_name": r["agent_name"],
+            "folder": r["folder"],
+            "created_at": _iso(r["created_at"]),
+            "content": r["content"],
+        }
+        for r in rows
+    ]
 
 
 async def complete_through(

--- a/backend/services/files_tree_service.py
+++ b/backend/services/files_tree_service.py
@@ -1329,7 +1329,10 @@ async def set_folder_is_skill(folder_id: UUID, owner_user_id: UUID, is_skill: bo
                 "then convert it back to a folder."
             )
     updated = await pool.fetchrow(
-        "UPDATE folders SET is_skill = $3, updated_at = now() "
+        # Demoting a curated skill un-curates it: a plain folder can't hold a
+        # curator slot (the folders_curated_is_a_skill check says so), and
+        # turning one back into a folder is a human deciding it isn't a skill.
+        "UPDATE folders SET is_skill = $3, is_curated = (is_curated AND $3), updated_at = now() "
         "WHERE id = $1 AND owner_user_id = $2 "
         "RETURNING id, owner_user_id, parent_folder_id, name, is_skill, created_by, "
         "  created_at, updated_at",

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -193,6 +193,13 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
   edited in a connected Drive folder), new saves (clips and X/Instagram
   saves), and connected sources. This IS your work set; do not re-scan the
   whole corpus.
+- `corrections` — the user's own messages from the last
+  `correction_window_days`, sampled a few per session across their most recent
+  sessions and grouped newest session first. This is NOT part of the delta: it
+  is a rolling window that re-presents the same messages every run, because a
+  skill earns its slot on recurrence across sessions and one night can't show
+  that. Use it for the curated skills below; the wiki still works from the
+  delta.
 - `history_has_more: true` means the history overflowed this run's cap. The
   remainder is already queued for your next run (the watermark only advances
   through what you were shown) — curate what's present, don't try to page.
@@ -273,6 +280,59 @@ pages themselves.
 - Every page: a one-sentence summary; a markdown link up to its category;
   sideways links to related pages; confidence tags; date new content
   `<!-- added YYYY-MM-DD -->`.
+
+## Curated skills (at most three)
+
+The wiki is pull: it helps only when an agent thinks to search it. A skill is
+push — every agent session loads each skill's description at startup, so a
+curated skill fires without the agent knowing to look. You maintain at most
+three of them. The cap is enforced by the server, not by your restraint.
+
+Start by reading the slots: `stash skills curated ls --json`.
+
+Work from `corrections` — the user's own messages. That is where a human told
+an agent it was wrong, which is the exact gap between what a model assumes and
+what is true here. Write only that gap, never what a competent agent already
+does. The delta's history is tool traffic and is nearly useless for this.
+
+A candidate earns a slot only when BOTH are true:
+- **It recurs** — the same situation shows up in >=3 DISTINCT sessions of the
+  corrections window. Count the distinct `session_id`s before you write; one
+  session complaining four times is one session, not four.
+- **Getting it wrong is expensive** — the user corrected the agent, the agent
+  backtracked, or work was lost. Anything an agent discovers in one command
+  ("tests run with pytest") costs nothing and never earns a slot.
+
+A candidate that clears one bar and not the other does not get a slot. If
+merging two near-identical candidates is what gets them over the recurrence
+bar, merge them — but count the sessions again after merging, don't assume.
+
+**Incumbents hold their slots.** Replace one only for a clearly stronger
+candidate — and never because an incumbent stopped generating evidence. A
+skill that works stops producing the mistakes that justified it; evicting it
+for going quiet brings the mistake back.
+
+Write a slot with:
+```
+stash skills curated write "<Name>" --description "<when this fires>" \\
+  --replaces "<incumbent name>" --body "<markdown>"
+```
+- Writing a name that already holds a slot updates it in place.
+- `--description` is the ONLY text an agent matches on. Write the trigger,
+  not a summary: name the situation, the tools, and the words that signal it.
+  An over-broad description is worse than no skill at all — it fires in
+  unrelated sessions and wastes the context it takes.
+- The body is imperative and short: at most ten rules, each a thing to do or
+  not do, each traceable to material you actually read this run. Link the
+  wiki pages holding the detail (`[<Title>](/p/<page_id>)`) instead of
+  restating them — the skill is the index, the wiki is the knowledge.
+- `--replaces` is required once all three slots are full. The command fails
+  rather than guessing, and leaving the set untouched is a correct outcome —
+  most nights it is the right one.
+- A write refused because the name belongs to the user's own skill means they
+  adopted it. It is theirs now: don't recreate it under another name.
+
+Record every slot change as a `curated` line in `Log`.
 
 ## Lint (end of every run)
 Check the pages you touched plus the index for: contradictions between pages,

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -108,6 +108,7 @@ async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     readable = permission_service.readable_content_condition("folder", "f", 2)
     rows = await pool.fetch(
         "SELECT f.id AS folder_id, f.name AS folder_name, f.updated_at AS folder_updated_at, "
+        "  f.is_curated, "
         "  p.id AS skill_md_id, p.content_markdown AS skill_md, p.updated_at, "
         "  (SELECT COUNT(*) FROM pages p2 WHERE p2.folder_id = f.id "
         "   AND p2.deleted_at IS NULL) AS file_count, "
@@ -142,6 +143,9 @@ async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
                 "when_to_use": meta.get("when_to_use", ""),
                 "version": meta.get("version", ""),
                 "mcp_exposed": bool(meta.get("mcp_exposed", False)),
+                # True while the nightly curator owns this skill: it holds one
+                # of the reserved slots and a human edit adopts it out of them.
+                "curated": bool(r["is_curated"]),
                 "file_count": int(r["file_count"]),
                 "updated_at": r["updated_at"] or r["folder_updated_at"],
                 # False = a draft skill: it exists and is named, but has no

--- a/backend/tests/test_curated_skills.py
+++ b/backend/tests/test_curated_skills.py
@@ -1,0 +1,204 @@
+"""The three curated slots the nightly curator owns.
+
+Every rule here exists because a curated skill is *push*: its description
+loads into every agent session whether or not anyone asked for it. That makes
+the failure modes structural rather than cosmetic — an unbounded set crowds
+out the context it was meant to improve, and a curator that overwrites a
+human's skill changes behavior the human thought they controlled. So the cap
+and the adoption boundary are enforced by the server, not by the prompt.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _write(client: AsyncClient, api_key: str, name: str, **extra):
+    body = {
+        "name": name,
+        "description": f"When the user is doing {name}.",
+        "body": f"- Always {name}.",
+        **extra,
+    }
+    return await client.post("/api/v1/me/curated-skills", json=body, headers=_auth(api_key))
+
+
+async def _fill_slots(client: AsyncClient, api_key: str) -> None:
+    for name in ("alpha", "beta", "gamma"):
+        assert (await _write(client, api_key, name)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_curated_skill_is_a_real_skill_carrying_its_trigger(client: AsyncClient):
+    """A curated skill has to be an ordinary skill or it never reaches an
+    agent — sync only materializes what /me/skills lists. The description is
+    the only text the harness matches on, so it must survive into SKILL.md."""
+    api_key = await _register(client)
+    resp = await _write(client, api_key, "port-discipline")
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "created"
+
+    listed = (await client.get("/api/v1/me/skills", headers=_auth(api_key))).json()["skills"]
+    entry = next(s for s in listed if s["name"] == "port-discipline")
+    assert entry["curated"] is True
+    assert entry["description"] == "When the user is doing port-discipline."
+
+    contents = await client.get(
+        f"/api/v1/me/skills/{entry['folder_id']}/contents", headers=_auth(api_key)
+    )
+    skill_md = next(p for p in contents.json()["contents"]["pages"] if p["name"] == "SKILL.md")
+    assert "curated: true" in skill_md["content_markdown"]
+    assert "- Always port-discipline." in skill_md["content_markdown"]
+
+
+@pytest.mark.asyncio
+async def test_writing_the_same_name_updates_in_place(client: AsyncClient):
+    """Nightly runs refine what they already wrote. If re-writing a slot minted
+    a second skill instead, the set would grow past the cap one night at a
+    time and two skills would compete for the same trigger."""
+    api_key = await _register(client)
+    first = await _write(client, api_key, "alpha")
+    second = await _write(client, api_key, "alpha", body="- Sharper rule.")
+
+    assert second.json()["action"] == "updated"
+    assert second.json()["folder_id"] == first.json()["folder_id"]
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert len(curated["skills"]) == 1
+    assert "- Sharper rule." in curated["skills"][0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_fourth_slot_fails_loud_and_changes_nothing(client: AsyncClient):
+    """The cap is the whole design: three skills the user can read in a minute.
+    A curator that could quietly add a fourth would eventually rebuild the
+    hundred-skill catalog this feature exists to avoid, so an unnamed
+    replacement is an error rather than an eviction of the server's choosing."""
+    api_key = await _register(client)
+    await _fill_slots(client, api_key)
+
+    resp = await _write(client, api_key, "delta")
+    assert resp.status_code == 400
+    assert "replaces" in resp.json()["detail"]
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert [s["name"] for s in curated["skills"]] == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.asyncio
+async def test_replaces_evicts_exactly_the_named_slot(client: AsyncClient):
+    """Eviction has to remove the old skill, not merely stop advertising it:
+    a retired skill still sitting in the agent's skills dir keeps firing."""
+    api_key = await _register(client)
+    await _fill_slots(client, api_key)
+
+    resp = await _write(client, api_key, "delta", replaces="beta")
+    assert resp.status_code == 200
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert sorted(s["name"] for s in curated["skills"]) == ["alpha", "delta", "gamma"]
+    listed = (await client.get("/api/v1/me/skills", headers=_auth(api_key))).json()["skills"]
+    assert "beta" not in [s["name"] for s in listed]
+
+
+@pytest.mark.asyncio
+async def test_replaces_an_unknown_name_evicts_nothing(client: AsyncClient):
+    """A curator that misremembers a slot name must not get a free eviction of
+    whichever skill the server would have picked."""
+    api_key = await _register(client)
+    await _fill_slots(client, api_key)
+
+    resp = await _write(client, api_key, "delta", replaces="nonexistent")
+    assert resp.status_code == 400
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert [s["name"] for s in curated["skills"]] == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.asyncio
+async def test_editing_a_curated_skill_adopts_it(client: AsyncClient):
+    """The adoption rule: a human edit takes the skill out of the curator's
+    hands for good. Without it, the two authors overwrite each other nightly
+    and the user's edit silently disappears."""
+    api_key = await _register(client)
+    resp = await _write(client, api_key, "alpha")
+    folder_id = resp.json()["folder_id"]
+
+    contents = await client.get(f"/api/v1/me/skills/{folder_id}/contents", headers=_auth(api_key))
+    page = next(p for p in contents.json()["contents"]["pages"] if p["name"] == "SKILL.md")
+    edited = await client.patch(
+        f"/api/v1/me/pages/{page['id']}",
+        json={"content": '---\nname: "alpha"\ndescription: "mine now"\n---\n\n- My rule.'},
+        headers=_auth(api_key),
+    )
+    assert edited.status_code == 200
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert curated["skills"] == []
+    listed = (await client.get("/api/v1/me/skills", headers=_auth(api_key))).json()["skills"]
+    assert next(s for s in listed if s["name"] == "alpha")["curated"] is False
+
+
+@pytest.mark.asyncio
+async def test_curator_refuses_to_rewrite_an_adopted_skill(client: AsyncClient):
+    """Adoption is permanent. The next night's run must not resurrect its own
+    version of a skill the user took over — under that name or a uniquified
+    copy of it competing for the same trigger."""
+    api_key = await _register(client)
+    folder_id = (await _write(client, api_key, "alpha")).json()["folder_id"]
+    await client.post(f"/api/v1/me/folders/{folder_id}/adopt-curated-skill", headers=_auth(api_key))
+
+    resp = await _write(client, api_key, "alpha", body="- The curator's version.")
+    assert resp.status_code == 400
+    assert "own skill" in resp.json()["detail"]
+
+    listed = (await client.get("/api/v1/me/skills", headers=_auth(api_key))).json()["skills"]
+    assert [s["name"] for s in listed] == ["alpha"]
+
+
+@pytest.mark.asyncio
+async def test_publishing_a_curated_skill_adopts_it(client: AsyncClient):
+    """Publishing is standing behind it in public. The curator must not keep
+    rewriting a skill that now carries the user's name on a public URL."""
+    api_key = await _register(client)
+    folder_id = (await _write(client, api_key, "alpha")).json()["folder_id"]
+
+    published = await client.post(
+        "/api/v1/me/skills",
+        json={"folder_id": folder_id, "description": "mine", "discoverable": False},
+        headers=_auth(api_key),
+    )
+    assert published.status_code == 201
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert curated["skills"] == []
+
+
+@pytest.mark.asyncio
+async def test_demoting_a_curated_skill_to_a_folder_frees_the_slot(client: AsyncClient):
+    """ "Not a skill" is the strongest possible rejection, so it has to release
+    the slot too. It also has to be representable at all: a curated flag on a
+    plain folder violates the folders_curated_is_a_skill check."""
+    api_key = await _register(client)
+    folder_id = (await _write(client, api_key, "alpha")).json()["folder_id"]
+
+    demoted = await client.post(
+        f"/api/v1/me/folders/{folder_id}/convert-to-folder", headers=_auth(api_key)
+    )
+    assert demoted.status_code == 200
+
+    curated = (await client.get("/api/v1/me/curated-skills", headers=_auth(api_key))).json()
+    assert curated["skills"] == []

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -761,3 +761,166 @@ async def test_memory_tree_nests_folders_and_scopes_to_memory(client: AsyncClien
     files_tree = (await client.get("/api/v1/me/tree", headers=_auth(key))).json()
     assert [p["name"] for p in files_tree["pages"]] == ["Outside"]
     assert all(f["id"] != mem["id"] for f in files_tree["folders"])
+
+
+@pytest.mark.asyncio
+async def test_corrections_survive_a_delta_flooded_with_tool_traffic(
+    client: AsyncClient, _db_pool, monkeypatch
+):
+    """The reason this input exists. Measured on a real account: 500 feed
+    events held 295 tool events and 6 user messages, because tool traffic
+    outnumbers user messages ~50:1 and the feed drains oldest-first. Skills
+    are mined from the user's words, so those words cannot be left to compete
+    for delta slots they will always lose."""
+    monkeypatch.setattr(curation_service, "_MAX_EVENTS", 3)
+    key, uid = await _register(client)
+    now = datetime.now(UTC)
+
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "claude",
+                "event_type": "tool_use",
+                "content": f"ran a command {i}",
+                "session_id": "s-noise",
+                "created_at": (now - timedelta(days=3, minutes=i)).isoformat(),
+            }
+            for i in range(10)
+        ]
+        + [
+            {
+                "agent_name": "claude",
+                "event_type": "user_message",
+                "content": "no, never pkill by pattern",
+                "session_id": "s-real",
+                "created_at": (now - timedelta(days=1)).isoformat(),
+            }
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, now - timedelta(days=10))
+    assert feed["history_has_more"] is True
+    assert all(h["event_type"] == "tool_use" for h in feed["history"])
+    assert [c["content"] for c in feed["corrections"]] == ["no, never pkill by pattern"]
+    assert feed["counts"]["corrections"] == 1
+
+
+@pytest.mark.asyncio
+async def test_corrections_ignore_the_watermark_so_recurrence_is_visible(
+    client: AsyncClient, _db_pool
+):
+    """A skill earns its slot on recurrence across sessions, which one night's
+    delta can never show. The window re-presents the same messages every run
+    on purpose — if it respected the watermark, every message would be seen
+    exactly once and no candidate could ever reach three sessions."""
+    key, uid = await _register(client)
+    now = datetime.now(UTC)
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "claude",
+                "event_type": "user_message",
+                "content": f"correction in session {i}",
+                "session_id": f"s-{i}",
+                "created_at": (now - timedelta(days=i + 1)).isoformat(),
+            }
+            for i in range(3)
+        ],
+    )
+
+    # A watermark past every one of those events: the delta is empty, and the
+    # corrections window still shows all three.
+    feed = await curation_service.changes_since(uid, uid, now)
+    assert feed["history"] == []
+    assert len(feed["corrections"]) == 3
+    assert len({c["session_id"] for c in feed["corrections"]}) == 3
+
+
+@pytest.mark.asyncio
+async def test_corrections_exclude_stale_messages_and_the_curators_own(
+    client: AsyncClient, _db_pool
+):
+    """The window is recent-and-real: material older than the window is not
+    evidence about how the user works now, and the curator's own transcripts
+    would let it learn from behavior it caused."""
+    key, uid = await _register(client)
+    now = datetime.now(UTC)
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "claude",
+                "event_type": "user_message",
+                "content": "ancient history",
+                "session_id": "s-old",
+                "created_at": (now - timedelta(days=400)).isoformat(),
+            },
+            {
+                "agent_name": "Memory curator",
+                "event_type": "user_message",
+                "content": "the curator talking to itself",
+                "session_id": "agent-curate-123",
+                "created_at": (now - timedelta(hours=2)).isoformat(),
+            },
+            {
+                "agent_name": "claude",
+                "event_type": "user_message",
+                "content": "this one counts",
+                "session_id": "s-live",
+                "created_at": (now - timedelta(hours=1)).isoformat(),
+            },
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, now - timedelta(days=500))
+    assert [c["content"] for c in feed["corrections"]] == ["this one counts"]
+
+
+@pytest.mark.asyncio
+async def test_one_chatty_session_cannot_crowd_out_the_others(
+    client: AsyncClient, _db_pool, monkeypatch
+):
+    """Recurrence is counted in distinct sessions, so the sample maximizes
+    sessions rather than messages. Newest-first-overall would have handed a
+    single talkative session the whole window — measured on a real account,
+    the newest 200 messages covered just 33 sessions over 1.4 days."""
+    monkeypatch.setattr(curation_service, "_MAX_PER_SESSION", 2)
+    key, uid = await _register(client)
+    now = datetime.now(UTC)
+
+    chatty = [
+        {
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": f"chatty {i}",
+            "session_id": "s-chatty",
+            "created_at": (now - timedelta(minutes=i)).isoformat(),
+        }
+        for i in range(20)
+    ]
+    others = [
+        {
+            "agent_name": "claude",
+            "event_type": "user_message",
+            "content": f"quiet session {i}",
+            "session_id": f"s-quiet-{i}",
+            "created_at": (now - timedelta(days=i + 1)).isoformat(),
+        }
+        for i in range(3)
+    ]
+    await _push_events(client, key, chatty + others)
+
+    corrections = await curation_service.recent_user_messages(uid, now)
+
+    per_session: dict[str, int] = {}
+    for c in corrections:
+        per_session[c["session_id"]] = per_session.get(c["session_id"], 0) + 1
+    assert per_session["s-chatty"] == 2
+    assert {f"s-quiet-{i}" for i in range(3)} <= set(per_session)
+    # Newest session first, so the curator reads current context before older.
+    assert corrections[0]["session_id"] == "s-chatty"

--- a/cli/client.py
+++ b/cli/client.py
@@ -228,6 +228,19 @@ class StashClient:
     def get_skill_contents(self, folder_id: str) -> dict:
         return self._get(f"/api/v1/me/skills/{folder_id}/contents")
 
+    # --- Curated skills (the nightly curator's reserved slots) ---
+
+    def list_curated_skills(self) -> dict:
+        return self._get("/api/v1/me/curated-skills")
+
+    def write_curated_skill(
+        self, name: str, description: str, body: str, replaces: str | None = None
+    ) -> dict:
+        payload = {"name": name, "description": description, "body": body}
+        if replaces:
+            payload["replaces"] = replaces
+        return self._post("/api/v1/me/curated-skills", json=payload)
+
     def list_shared_skills(self) -> list:
         return self._list("/api/v1/me/shared-skills", "skills")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1635,6 +1635,65 @@ skills_app = typer.Typer(
 )
 app.add_typer(skills_app, name="skills")
 
+curated_app = typer.Typer(
+    help=(
+        "The three slots the nightly curator owns. Curated skills sync into "
+        "your agents' skills dir like any other; editing one adopts it out of "
+        "the curator's hands and frees the slot."
+    )
+)
+skills_app.add_typer(curated_app, name="curated")
+
+
+@curated_app.command("ls")
+def curated_ls(as_json: bool = typer.Option(False, "--json")):
+    """The occupied slots — read this before writing, to see what a new
+    candidate would have to beat."""
+    with _client() as c:
+        try:
+            data = c.list_curated_skills()
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+        return
+    console.print(f"[dim]{len(data['skills'])}/{data['max_slots']} slots used[/dim]")
+    for s in data["skills"]:
+        console.print(f"[cyan]{s['name']}[/cyan]  [dim]{s['folder_id']}[/dim]")
+        console.print(f"  {s['description']}")
+
+
+@curated_app.command("write")
+def curated_write(
+    name: str = typer.Argument(..., help="Skill name. Writing an existing one updates it."),
+    description: str = typer.Option(
+        ...,
+        "--description",
+        help="When this skill should fire. The only text an agent matches on.",
+    ),
+    body: str = typer.Option(None, "--body", help="SKILL.md body. Reads stdin if omitted."),
+    replaces: str = typer.Option(
+        None, "--replaces", help="Name of the curated skill this evicts, when the slots are full."
+    ),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Create or update a curated skill. Fails when the slots are full and
+    --replaces names nothing: the cap is the design, not a suggestion."""
+    if body is None and not sys.stdin.isatty():
+        body = sys.stdin.read()
+    if body is None:
+        console.print("[red]No body: pass --body or pipe it on stdin.[/red]")
+        raise typer.Exit(1)
+    with _client() as c:
+        try:
+            data = c.write_curated_skill(name, description, body, replaces)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(data)
+    else:
+        console.print(f"[green]Curated skill '{data['name']}' {data['action']}.[/green]")
+
 
 @skills_app.command("add")
 def skills_add(
@@ -2106,6 +2165,17 @@ def _local_skill_dirs(root: Path) -> dict[str, Path]:
     return {p.name: p for p in sorted(root.iterdir()) if p.is_dir() and (p / "SKILL.md").exists()}
 
 
+def _local_skill_is_curated(skill_dir: Path) -> bool:
+    """Curated skills carry `curated: true` in their frontmatter, so a local
+    copy says what it is without asking the cloud — which is exactly what sync
+    can't do in the case that needs this: the skill is gone from the cloud."""
+    md = (skill_dir / "SKILL.md").read_text()
+    if not md.startswith("---\n"):
+        return False
+    end = md.find("\n---", 4)
+    return end != -1 and "curated: true" in md[4:end]
+
+
 def _collect_local_files(skill_dir: Path) -> list[tuple[str, bytes]]:
     out = []
     for path in sorted(skill_dir.rglob("*")):
@@ -2162,10 +2232,17 @@ def _sync_skills(
     remote: dict[str, dict] = {}
     for s in c.list_skills():
         detail = c.get_skill_contents(s["folder_id"])
-        remote[detail["folder_name"]] = detail
+        remote[detail["folder_name"]] = {**detail, "curated": s["curated"]}
 
     local = _local_skill_dirs(root)
-    summary: dict = {"pulled": [], "pushed": [], "conflicts": [], "ignored": [], "unchanged": []}
+    summary: dict = {
+        "pulled": [],
+        "pushed": [],
+        "conflicts": [],
+        "ignored": [],
+        "unchanged": [],
+        "retired": [],
+    }
     new_state: dict = {}
 
     for name in sorted(set(remote) & set(skip)):
@@ -2209,7 +2286,15 @@ def _sync_skills(
                 # local deletion gets re-pulled; remove skills in Stash.
                 pull(name, detail)
             elif name in local and not detail:
-                if rec:
+                if rec and _local_skill_is_curated(local[name]):
+                    # The curator gave this slot to a better candidate. Its
+                    # cloud copy is the whole truth, so the local dir goes too
+                    # — a retired skill that keeps loading is worse than none.
+                    # Only ever a dir sync itself pulled (rec): frontmatter is
+                    # copyable, so it can't be the sole license to delete.
+                    shutil.rmtree(local[name])
+                    summary["retired"].append(name)
+                elif rec:
                     summary["ignored"].append(f"{name} (deleted in Stash; kept local copy)")
                 elif push_new:
                     folder = c.create_folder(name)
@@ -2224,7 +2309,10 @@ def _sync_skills(
             else:
                 local_changed = _hash_local_skill(local[name]) != rec["local_hash"]
                 remote_changed = _hash_remote_contents(detail["contents"]) != rec["remote_hash"]
-                if local_changed and remote_changed:
+                # A curated skill can't conflict: the human's edit always wins,
+                # and pushing it adopts the skill away from the curator, so
+                # there's no second author left to disagree with.
+                if local_changed and remote_changed and not detail["curated"]:
                     new_state[name] = rec
                     summary["conflicts"].append(f"{name} (changed locally AND in Stash)")
                 elif local_changed:
@@ -2364,6 +2452,8 @@ def skills_sync(
         console.print(f"[green]pushed[/green]  {name}")
     for name in summary["updated"]:
         console.print(f"[green]updated[/green] {name}")
+    for name in summary["retired"]:
+        console.print(f"[green]retired[/green] {name} (curated slot reassigned)")
     for note in summary["ignored"]:
         console.print(f"[dim]ignored[/dim]  {note}")
     for note in summary["conflicts"]:

--- a/cli/tests/test_skills_sync.py
+++ b/cli/tests/test_skills_sync.py
@@ -18,13 +18,17 @@ class _FakeSyncClient:
         self.skills: dict[str, dict] = {}
         self._next = 0
 
-    def add_remote_skill(self, name: str, files: dict[str, bytes]) -> str:
+    def add_remote_skill(self, name: str, files: dict[str, bytes], curated: bool = False) -> str:
         folder_id = self.create_folder(name)["id"]
         self.skills[folder_id]["files"] = dict(files)
+        self.skills[folder_id]["curated"] = curated
         return folder_id
 
     def list_skills(self):
-        return [{"folder_id": fid, "name": s["folder_name"]} for fid, s in self.skills.items()]
+        return [
+            {"folder_id": fid, "name": s["folder_name"], "curated": s["curated"]}
+            for fid, s in self.skills.items()
+        ]
 
     def get_skill_contents(self, folder_id):
         s = self.skills[folder_id]
@@ -64,7 +68,7 @@ class _FakeSyncClient:
     def create_folder(self, name):
         folder_id = f"folder-{self._next}"
         self._next += 1
-        self.skills[folder_id] = {"folder_name": name, "files": {}}
+        self.skills[folder_id] = {"folder_name": name, "files": {}, "curated": False}
         return {"id": folder_id}
 
     def fetch_bytes(self, url: str) -> bytes:
@@ -131,6 +135,77 @@ def test_both_sides_changed_conflicts_without_clobbering(tmp_path):
     # The conflict stays pending — the next run reports it again.
     summary, _state = _sync(c, tmp_path, state)
     assert len(summary["conflicts"]) == 1
+
+
+def _curated_skill_md(body: str) -> bytes:
+    return (
+        f'---\nname: "deploy"\ndescription: "Deploy the service."\ncurated: true\n---\n{body}'
+    ).encode()
+
+
+def test_curated_skill_never_conflicts_because_the_human_wins(tmp_path):
+    """The curator rewrites its slots nightly, so a user who edits one would
+    hit a conflict on almost every run and their edit would sit unsynced. For
+    curated skills the local edit pushes instead — which adopts the skill
+    server-side, leaving one author and nothing left to conflict over."""
+    c = _FakeSyncClient()
+    fid = c.add_remote_skill("deploy", {"SKILL.md": _curated_skill_md("# v1")}, curated=True)
+    _summary, state = _sync(c, tmp_path, {})
+
+    (tmp_path / "deploy" / "SKILL.md").write_bytes(_curated_skill_md("# local edit"))
+    c.skills[fid]["files"]["SKILL.md"] = _curated_skill_md("# tonight's rewrite")
+
+    summary, _state = _sync(c, tmp_path, state)
+
+    assert summary["conflicts"] == []
+    assert summary["pushed"] == ["deploy"]
+    assert c.skills[fid]["files"]["SKILL.md"] == _curated_skill_md("# local edit")
+
+
+def test_retired_curated_skill_is_deleted_locally(tmp_path):
+    """When the curator gives a slot to a better candidate it deletes the old
+    skill. An ordinary skill missing from the cloud keeps its local copy, but
+    a retired curated skill must not: the whole point of the three-slot cap is
+    that exactly three curated skills load into an agent session, and a stale
+    dir would keep firing forever with nothing left to retire it."""
+    c = _FakeSyncClient()
+    fid = c.add_remote_skill("deploy", {"SKILL.md": _curated_skill_md("# v1")}, curated=True)
+    _summary, state = _sync(c, tmp_path, {})
+    assert (tmp_path / "deploy" / "SKILL.md").exists()
+
+    del c.skills[fid]
+    summary, _state = _sync(c, tmp_path, state)
+
+    assert summary["retired"] == ["deploy"]
+    assert not (tmp_path / "deploy").exists()
+
+
+def test_local_only_skill_is_never_deleted_for_claiming_to_be_curated(tmp_path):
+    """Frontmatter is copyable — a user can paste a curated skill's SKILL.md
+    into a directory of their own. Sync deletes only what sync itself pulled,
+    so an untracked local dir survives no matter what it claims to be."""
+    c = _FakeSyncClient()
+    (tmp_path / "mine").mkdir()
+    (tmp_path / "mine" / "SKILL.md").write_bytes(_curated_skill_md("# my own copy"))
+
+    summary, _state = _sync(c, tmp_path, {})
+
+    assert summary["retired"] == []
+    assert (tmp_path / "mine" / "SKILL.md").exists()
+
+
+def test_hand_authored_skill_missing_from_the_cloud_is_kept(tmp_path):
+    """The retire path keys off the curated frontmatter, not off absence from
+    the cloud — a user's own skill deleted in Stash still keeps its local copy."""
+    c = _FakeSyncClient()
+    fid = c.add_remote_skill("deploy", {"SKILL.md": _skill_md("# v1")})
+    _summary, state = _sync(c, tmp_path, {})
+
+    del c.skills[fid]
+    summary, _state = _sync(c, tmp_path, state)
+
+    assert summary["retired"] == []
+    assert (tmp_path / "deploy" / "SKILL.md").exists()
 
 
 def test_new_local_skill_pushes_only_in_project_mode(tmp_path):

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -11,6 +11,7 @@ import {
 import { ActivitySkeleton, SkeletonBlock } from "@/components/SkeletonStates";
 import { FileIcon, PageIcon } from "@/components/SkillIcons";
 import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
+import CuratedSkills from "@/components/memory/CuratedSkills";
 import CuratorLog from "@/components/memory/CuratorLog";
 import WikiGraph from "@/components/memory/WikiGraph";
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
@@ -211,6 +212,11 @@ export default function BrainDashboard() {
           </div>
 
           <div className="flex min-h-0 min-w-0 flex-col gap-4">
+            {/* The curator's other output. It sits above the decorative panels
+                because it's the one thing here the user is asked to judge:
+                these three load into every agent session. */}
+            <CuratedSkills />
+
             {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
             <VizCard label="Knowledge map">
               {!projectionLoaded ? (

--- a/frontend/src/components/memory/CuratedSkills.tsx
+++ b/frontend/src/components/memory/CuratedSkills.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { SkeletonBlock } from "@/components/SkeletonStates";
+import { getCuratorSkills, type CuratorSkill } from "@/lib/api";
+
+/** The curator's reserved slots. Three skills is few enough to read in a
+ *  minute, which is the whole review mechanism: these load into every agent
+ *  session, so the user has to be able to see what they say at a glance. */
+export default function CuratedSkills() {
+  const [skills, setSkills] = useState<CuratorSkill[] | null>(null);
+  const [maxSlots, setMaxSlots] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getCuratorSkills()
+      .then((data) => {
+        if (cancelled) return;
+        setSkills(data.skills);
+        setMaxSlots(data.max_slots);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load curated skills");
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!loaded) {
+    return (
+      <section>
+        <div className="sys-label mb-1.5">Curated skills</div>
+        <SkeletonBlock className="h-[120px] w-full" />
+      </section>
+    );
+  }
+
+  // "No skills yet" is a claim about the curator — never make it on a failure.
+  if (error) {
+    return (
+      <section>
+        <div className="sys-label mb-1.5">Curated skills</div>
+        <div className="card-soft px-4 py-6 text-center text-[12.5px] text-destructive">
+          Couldn&apos;t load your curated skills: {error}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <div className="sys-label">Curated skills</div>
+        {skills && skills.length > 0 && (
+          <span className="text-[11.5px] text-dim">
+            {skills.length}/{maxSlots} slots
+          </span>
+        )}
+      </div>
+      {!skills || skills.length === 0 ? (
+        <div className="card-soft px-4 py-6 text-center text-[12.5px] text-muted-foreground">
+          None yet. When the curator finds a procedure you repeat — and
+          correct — it writes one here, and your agents load it everywhere.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {skills.map((skill) => (
+            <SkillCard key={skill.folder_id} skill={skill} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SkillCard({ skill }: { skill: CuratorSkill }) {
+  return (
+    <article className="card px-4 py-3.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-[13.5px] font-medium text-foreground">{skill.name}</span>
+        <Link
+          href={`/skills/folder/${skill.folder_id}`}
+          className="shrink-0 text-[11.5px] text-dim hover:text-foreground"
+        >
+          Open →
+        </Link>
+      </div>
+      {/* The description, not the body: it's the only text an agent matches
+          on, so it's the only text that decides when this fires. */}
+      <p className="mt-1.5 text-[13px] leading-[1.6] text-muted-foreground">
+        {skill.description}
+      </p>
+    </article>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -574,6 +574,25 @@ export async function getCuratorLog(): Promise<{ entries: CuratorLogEntry[] }> {
   return apiFetch(`${ME}/curator-log`);
 }
 
+// One of the reserved slots the nightly curator maintains. `description` is
+// the only text an agent matches on, so it's what the user reads to judge it.
+// Not `CuratedSkill` — that name already means a skill recommended for an app.
+export interface CuratorSkill {
+  folder_id: string;
+  name: string;
+  description: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getCuratorSkills(): Promise<{
+  max_slots: number;
+  skills: CuratorSkill[];
+}> {
+  return apiFetch(`${ME}/curated-skills`);
+}
+
 export async function createFolder(
   name: string,
   parentFolderId?: string | null


### PR DESCRIPTION
The Memory wiki is **pull**: it helps only when an agent thinks to search it. Skills are **push** — the harness loads every SKILL.md description at session start — so a curated skill fires without the agent knowing to look. This teaches the nightly curator to compile both from the same run.

## Three slots, enforced in the service

Every invariant lives in `curated_skill_service`, not in the prompt, so a prompt regression degrades the skills' quality instead of reintroducing the skill sprawl the cap exists to prevent.

- **Three slots.** A fourth write 400s and must name the slot it replaces; the replaced skill is deleted.
- **A human edit adopts.** Editing a page inside the folder, pushing contents through sync, publishing, or demoting to a plain folder each clear the curated flag. The slot frees, and the curator never touches that skill again.
- **Adoption is permanent.** Writing a name that belongs to a non-curated skill is refused, so the curator can't resurrect its version under that name or a uniquified `Name (2)` competing for the same trigger.

`folders.is_curated` carries a CHECK that a curated folder is always a skill, which inherits the existing `folders_protected_is_never_a_skill` constraint — Memory and Clips can't be captured.

## Sync: two branches, not a new codepath

Curated skills ride the normal three-way sync. Only two things differ:

- A curated skill whose local copy changed **pushes instead of conflicting**. The push adopts it server-side, so there's no second author left to disagree with.
- A dir **sync itself pulled** is deleted when its cloud copy is gone, so a skill the curator retired stops loading. Keyed on `rec` as well as frontmatter — frontmatter is copyable, so it can't be the sole license to delete a directory.

## Corrections become their own feed input

The change feed drains oldest-first through the watermark, and tool events outnumber user messages by ~50:1. Measured on a real account: **500 feed events held 295 tool events and 6 user messages.** The words a skill is mined from lose every cap they compete for.

`corrections` is a rolling 30-day window sampled per session, deliberately outside the watermark — it re-presents the same messages every night, because recurrence across sessions is the test for a skill and one night's delta can't show it. The wiki's delta semantics are untouched.

## Tests

1378 backend, 237 CLI, 309 frontend vitest; ruff and eslint clean. New coverage locks the cap, all four adoption paths, eviction, the sync branches, and the corrections window (including that one chatty session can't crowd out the others).

## What is NOT proven

**The full pipeline has never run.** Feed → prompt → three slots has not been exercised by a real curator run; the mechanism is tested, the output is not.

An offline experiment gave the rendered prompt and a real corrections window to a fresh agent. The prompt's discipline held — it counted distinct sessions per candidate, rejected four for failing recurrence, and left the third slot empty rather than filling it. But its two picks came from short lookup sessions, because **of the 120 sessions the sampler selects, 67 have only one or two user messages.** A 191-turn working session contributes the same four messages as "what time is my flight."

So session weighting is an open problem: the sampler maximizes session count, which is what the recurrence rule counts, but that gives a throwaway ask the same standing as a day of engineering. Worth resolving before this is trusted to write skills unattended.

**Suggested rollout:** merging deploys to prod, and the nightly curator would then write skills into every user's Stash, which sync pushes into their agents' skills dirs. Consider gating to one account until a few real runs have been watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds curator-owned skills that load into every agent session and changes skills sync (local retire/delete, conflict bypass). Cap and adoption are server-enforced, but a bad curator run would still write into users' skills dirs.
> 
> **Overview**
> Enables the nightly curator to maintain **at most three push skills** alongside the Memory wiki. Skills load into every agent session; the three-slot cap, eviction, and adoption rules live in `curated_skill_service` so a prompt regression can't sprawl.
> 
> **Adoption is permanent:** editing a page in the folder, sync push, publishing, or demoting to a folder clears `is_curated` and frees the slot. The curator cannot rewrite an adopted name.
> 
> Adds a **`corrections` feed** — a rolling 30-day window of user messages sampled per session, outside the watermark — so skills are mined from recurrence across sessions rather than competing with tool traffic in the delta. The curator prompt and `stash skills curated` CLI teach/write against that input.
> 
> Skills sync treats curated skills specially: a local edit **pushes instead of conflicting** (and adopts), and a retired curated skill sync itself pulled is **deleted locally** so it stops loading. The Brain dashboard surfaces the three slots for review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe588f9bbe6ec01edf219bda79d9c08804e7618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->