### PR TITLE
docs: skill membership is a stored flag, not derived

### DIFF
--- a/backend/services/github_skill_import.py
+++ b/backend/services/github_skill_import.py
@@ -2,8 +2,8 @@
 
 Two flavors:
 - User-facing (`import_repo_for_user`): straight copy of a whole repo into
-  the caller's scope as one root folder. Folders containing SKILL.md derive
-  as skills automatically. Uses the caller's GitHub connection when present,
+  the caller's scope as one root folder. Folders receiving a SKILL.md are
+  promoted to skills. Uses the caller's GitHub connection when present,
   so private repos work too.
 - Curator (`import_repo`, via scripts/import_github_skills.py): every
   directory whose immediate children include a SKILL.md becomes one
@@ -304,9 +304,9 @@ async def user_github_token(user_id: UUID) -> str | None:
 async def import_repo_for_user(owner_user_id: UUID, user_id: UUID, repo_url: str) -> dict:
     """Copy a whole repo into the active scope (the user's own, or a workspace
     they belong to) as one new root folder — a straight copy preserving
-    structure. Any folder containing a SKILL.md derives as a skill
-    automatically (skill-ness is never stored). Private repos work when the
-    user's GitHub connection can read them."""
+    structure. Any folder receiving a SKILL.md is promoted to a skill by
+    `write_folder_files`. Private repos work when the user's GitHub
+    connection can read them."""
     token = await user_github_token(user_id)
     repo_name, files = await fetch_repo_files(repo_url, token)
     if not files:


### PR DESCRIPTION
## What

Two docstrings in `backend/services/github_skill_import.py` still described the pre-#985 model of skills, including the flatly false parenthetical **"skill-ness is never stored"**.

Since [#985](https://github.com/Fergana-Labs/stash/pull/985) / migration `0181_is_skill_flag.py` (2026-08-07), membership is `folders.is_skill`, flipped only by deliberate verbs — precisely so that deleting a `SKILL.md` can no longer silently demote a skill out of every agent's catalog.

## Why it matters

The code is correct; only the prose is stale. But it's stale in the direction that misleads: it describes a model we deliberately removed after a customer lost skills three times in two weeks. It came up while designing Google Drive → Skills sync, where "does a vanishing file remove the skill?" is the central question — and this docstring answers it wrongly.

Replaced with what actually happens: folders **receiving** a `SKILL.md` are **promoted** by `write_folder_files`.

## Not in scope

Four other spots still use the "derive" verb without asserting anything false, left alone deliberately:

- `backend/routers/skills.py:173`
- `backend/tests/test_github_skill_import.py:216`
- `frontend/src/components/workspace/files-explorer.tsx:115`
- `frontend/src/lib/api.ts:1471`

## Test plan

Comments only — no behavior change. `ruff check` and `ruff format --check` pass on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Updates two stale docstrings in `github_skill_import.py` that still described the old derived-skill model (including the incorrect claim that "skill-ness is never stored").
> 
> They now match the post-#985 behavior: folders **receiving** a `SKILL.md` are **promoted** to skills by `write_folder_files` via the stored `folders.is_skill` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b173c5f996d6ff8d99182e9ed2218187883c3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->