### PR TITLE
The CLI can authorize a provider, not just index one

### DIFF
--- a/backend/integrations/storage.py
+++ b/backend/integrations/storage.py
@@ -57,6 +57,11 @@ def _account_row(row) -> dict:
         "scopes": list(row["scopes"] or []),
         "expires_at": row["expires_at"].isoformat() if row["expires_at"] else None,
         "connected_at": row["created_at"].isoformat() if row["created_at"] else None,
+        # Every store_token rewrites this, so a re-authorization of an account
+        # that already exists moves it. `stash sources connect` polls on it to
+        # tell "the browser consent finished" from "nothing happened yet" —
+        # account_key alone can't, since a repair reuses the same key.
+        "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
     }
 
 
@@ -311,7 +316,7 @@ async def status(user_id: UUID, provider: str) -> dict:
     rows = await pool.fetch(
         """
         SELECT account_key, scopes, expires_at, account_email, account_display_name,
-               created_at, access_token_encrypted IS NULL AS disconnected
+               created_at, updated_at, access_token_encrypted IS NULL AS disconnected
         FROM user_integrations WHERE user_id = $1 AND provider = $2
         ORDER BY account_email NULLS LAST, account_display_name NULLS LAST, account_key
         """,
@@ -377,7 +382,7 @@ async def list_connections(user_id: UUID) -> list[dict]:
     rows = await pool.fetch(
         """
         SELECT provider, account_key, scopes, expires_at,
-               account_email, account_display_name, created_at,
+               account_email, account_display_name, created_at, updated_at,
                access_token_encrypted IS NULL AS disconnected
         FROM user_integrations WHERE user_id = $1
         ORDER BY provider, account_email NULLS LAST, account_display_name NULLS LAST, account_key

--- a/backend/routers/sources.py
+++ b/backend/routers/sources.py
@@ -83,9 +83,16 @@ async def _resolve_gmail_source(user_id, account_key: str | None) -> tuple[str, 
     if not accounts:
         raise HTTPException(status_code=401, detail="not connected to gmail")
 
+    # Both misses below name the authorized mailboxes: the caller's next move
+    # differs entirely depending on whether the one they asked for is merely
+    # unindexed (add it) or unauthorized (authorize it first), and a bare
+    # "not connected" leaves them unable to tell which.
+    connected = ", ".join(a.get("account_email") or a["account_key"] for a in accounts)
     if not account_key:
         if len(accounts) != 1:
-            raise HTTPException(status_code=400, detail="Choose a Gmail account to add.")
+            raise HTTPException(
+                status_code=400, detail=f"Choose a Gmail account to add: {connected}."
+            )
         account = accounts[0]
     else:
         key = account_key.strip().lower()
@@ -98,7 +105,13 @@ async def _resolve_gmail_source(user_id, account_key: str | None) -> tuple[str, 
             None,
         )
         if account is None:
-            raise HTTPException(status_code=400, detail="Gmail account is not connected.")
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"No authorized Gmail account for {account_key}. "
+                    f"Authorized: {connected}. Authorize that mailbox first, then add it."
+                ),
+            )
 
     email = account.get("account_email") or account["account_key"]
     await integration_storage.get_valid_token(user_id, "gmail", account["account_key"])

--- a/backend/tests/test_gmail_multi_account.py
+++ b/backend/tests/test_gmail_multi_account.py
@@ -133,7 +133,12 @@ async def test_gmail_sources_target_specific_mailboxes(client: AsyncClient):
         headers=_auth(api_key),
     )
     assert ambiguous.status_code == 400
-    assert ambiguous.json()["detail"] == "Choose a Gmail account to add."
+    # The caller has to pick, so the error has to say what there is to pick
+    # from — an unqualified "choose an account" leaves them guessing at the
+    # exact ref this endpoint will accept.
+    detail = ambiguous.json()["detail"]
+    assert "htdowling@gmail.com" in detail
+    assert "henry@joinstash.ai" in detail
 
     for email in ("htdowling@gmail.com", "henry@joinstash.ai"):
         added = await client.post(
@@ -152,6 +157,30 @@ async def test_gmail_sources_target_specific_mailboxes(client: AsyncClient):
         "htdowling@gmail.com",
         "henry@joinstash.ai",
     }
+
+
+@pytest.mark.asyncio
+async def test_adding_an_unauthorized_mailbox_says_which_ones_are_authorized(
+    client: AsyncClient,
+):
+    """Indexing a mailbox needs a prior OAuth grant, and the two failures look
+    identical from the caller's side: the mailbox exists but was never
+    authorized, versus a typo in the address. Listing the authorized accounts
+    is what separates "go authorize that one" from "you misspelled it" —
+    without it the caller retries the same doomed command."""
+    api_key, user_id = await _register(client)
+    await _store_gmail(user_id, "henry@joinstash.ai", "token-work")
+
+    resp = await client.post(
+        "/api/v1/me/sources",
+        json={"source_type": "gmail", "external_ref": "htdowling@gmail.com"},
+        headers=_auth(api_key),
+    )
+
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "htdowling@gmail.com" in detail
+    assert "henry@joinstash.ai" in detail
 
 
 class _StubResponse:

--- a/backend/tests/test_integration_connect_signal.py
+++ b/backend/tests/test_integration_connect_signal.py
@@ -1,0 +1,101 @@
+"""The account status a client polls to see an OAuth consent complete.
+
+`stash sources connect` opens the provider's consent screen and then watches
+this endpoint to know the grant landed. A brand-new account is easy to spot —
+a key appears. Repairing an expired grant is not: the row keeps its
+account_key, so the only evidence the consent succeeded is that store_token
+rewrote updated_at. If that field stops being exposed, the CLI cannot tell a
+finished reconnect from an abandoned one and waits out its whole timeout on a
+consent the user actually completed.
+"""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.integrations import crypto as integration_crypto
+from backend.integrations import storage
+from backend.integrations.base import AccountInfo, TokenSet
+
+from .conftest import unique_name
+
+TEST_FERNET_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+@pytest.fixture(autouse=True)
+def _integration_encryption(monkeypatch):
+    monkeypatch.setattr(integration_crypto.settings, "INTEGRATIONS_ENCRYPTION_KEY", TEST_FERNET_KEY)
+
+
+async def _register(client: AsyncClient) -> tuple[str, UUID]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("gmail"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return body["api_key"], UUID(body["id"])
+
+
+async def _authorize(user_id: UUID, email: str) -> None:
+    """A completed consent for one mailbox. The token is deliberately unexpired
+    so reading status never attempts a refresh over the network."""
+    await storage.store_token(
+        user_id,
+        "gmail",
+        TokenSet(
+            access_token=f"token-{email}",
+            refresh_token=f"refresh-{email}",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        ),
+        AccountInfo(email=email, display_name="Henry"),
+    )
+
+
+async def _accounts(client: AsyncClient, api_key: str) -> list[dict]:
+    resp = await client.get(
+        "/api/v1/integrations/gmail/status", headers={"Authorization": f"Bearer {api_key}"}
+    )
+    assert resp.status_code == 200
+    return resp.json()["accounts"]
+
+
+@pytest.mark.asyncio
+async def test_status_moves_updated_at_when_an_account_is_reauthorized(client: AsyncClient):
+    api_key, user_id = await _register(client)
+    await _authorize(user_id, "henry@ferganalabs.com")
+
+    before = await _accounts(client, api_key)
+    assert [a["account_key"] for a in before] == ["henry@ferganalabs.com"]
+    assert before[0]["updated_at"] is not None
+
+    await asyncio.sleep(0.01)
+    await _authorize(user_id, "henry@ferganalabs.com")
+    after = await _accounts(client, api_key)
+
+    # Same mailbox, same key — only the timestamp separates the repaired grant
+    # from the dead one it replaced.
+    assert [a["account_key"] for a in after] == ["henry@ferganalabs.com"]
+    assert after[0]["updated_at"] > before[0]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_status_lists_a_second_mailbox_separately(client: AsyncClient):
+    """Gmail holds several accounts, so authorizing a personal mailbox must add
+    a row rather than overwrite the work one — otherwise connecting the second
+    account would silently cost the user the first."""
+    api_key, user_id = await _register(client)
+    await _authorize(user_id, "henry@ferganalabs.com")
+    await _authorize(user_id, "htdowling@gmail.com")
+
+    accounts = await _accounts(client, api_key)
+
+    assert sorted(a["account_key"] for a in accounts) == [
+        "henry@ferganalabs.com",
+        "htdowling@gmail.com",
+    ]
+    assert all(a["disconnected"] is False for a in accounts)

--- a/cli/client.py
+++ b/cli/client.py
@@ -699,6 +699,16 @@ class StashClient:
             return data["text"].encode()
         return base64.b64decode(data["content_base64"])
 
+    # --- Integrations (the OAuth grant a connected source is built on) ---
+
+    def integration_status(self, provider: str) -> dict:
+        return self._get(f"/api/v1/integrations/{provider}/status")
+
+    def integration_authorize_url(self, provider: str) -> str:
+        """The provider's OAuth consent URL. Bearer-authed, so only the caller
+        who requested it can complete the grant it encodes."""
+        return self._get(f"/api/v1/integrations/{provider}/connect")["authorize_url"]
+
     # --- Sources (unified VFS: native files/sessions + connected sources) ---
 
     def list_sources(self) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -141,6 +141,14 @@ def _default_signin_page(api: str) -> str:
     return api + "/connect-token"
 
 
+def _is_ssh() -> bool:
+    """Over SSH the browser would open on the wrong machine, so callers print
+    the URL for the user to open locally instead."""
+    import os
+
+    return any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"))
+
+
 def _refocus_terminal() -> None:
     """Bring the user's terminal app back to the foreground after browser auth.
 
@@ -174,7 +182,6 @@ def _browser_auth_flow(
     API key back. Raises typer.Exit on failure or timeout. Caller is
     responsible for persisting the returned credentials.
     """
-    import os
     import socket
     import time
     import webbrowser
@@ -196,8 +203,7 @@ def _browser_auth_flow(
     sep = "&" if "?" in page else "?"
     url = f"{page}{sep}session={session_id}"
 
-    ssh = any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"))
-    opened = False if ssh else webbrowser.open(url)
+    opened = False if _is_ssh() else webbrowser.open(url)
 
     if opened:
         console.print(f"  [green]✓[/green] Opened [bold]{page}[/bold] in your browser.")
@@ -3497,6 +3503,95 @@ def changes(
     )
 
 
+def _live_account_fingerprints(status: dict) -> set[tuple[str, str | None]]:
+    """One entry per usable grant on a provider. Fingerprinted on updated_at as
+    well as account_key because re-authorizing an account reuses its key — on
+    key alone, `connect` could not tell a finished repair from a no-op."""
+    return {
+        (a["account_key"], a.get("updated_at"))
+        for a in status.get("accounts", [])
+        if not a.get("disconnected")
+    }
+
+
+@sources_app.command("connect")
+def sources_connect(
+    provider: str = typer.Argument(
+        ..., help="gmail | google | github | notion | slack | linear | jira | asana | gong | x"
+    ),
+    timeout: int = typer.Option(180, "--timeout", help="Seconds to wait for the browser consent."),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Authorize a provider account in the browser — the step before `add`.
+
+    `sources add` indexes a mailbox or repo you have already authorized; this
+    mints the grant it needs. Providers that hold several accounts (Gmail)
+    authorize one more per run, so re-running adds a second mailbox rather
+    than replacing the first.
+    """
+    import time
+    import webbrowser
+
+    json_out = _use_json(as_json)
+    with _client() as c:
+        try:
+            before = _live_account_fingerprints(c.integration_status(provider))
+            url = c.integration_authorize_url(provider)
+        except StashError as e:
+            _err(e)
+
+        # The consent screen wants a password and 2FA, so this half belongs to
+        # the user alone — all we can do is hand off the URL and watch for the
+        # grant to land. On stderr under --json so it can't corrupt stdout.
+        opened = False if _is_ssh() else webbrowser.open(url)
+        if json_out:
+            print(f"Authorize at: {url}", file=sys.stderr)
+        elif opened:
+            console.print(
+                f"  [green]✓[/green] Opened the {provider} consent screen in your browser."
+            )
+        else:
+            console.print(f"  Open this URL to authorize:\n    [bold]{url}[/bold]")
+        if not json_out:
+            console.print(f"  Waiting for you to finish (timeout {timeout}s)…")
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(2)
+            try:
+                status = c.integration_status(provider)
+            except StashError as e:
+                _err(e)
+            granted = _live_account_fingerprints(status) - before
+            if granted:
+                break
+        else:
+            console.print(
+                f"[red]Timed out waiting for the {provider} authorization.[/red] "
+                "Nothing was connected — re-run once you can finish the browser step."
+            )
+            raise typer.Exit(1)
+
+    _refocus_terminal()
+    keys = {key for key, _ in granted}
+    accounts = [a for a in status["accounts"] if a["account_key"] in keys]
+    if json_out:
+        output_json({"provider": provider, "accounts": accounts})
+        return
+    for account in accounts:
+        label = (
+            account.get("account_email")
+            or account.get("account_display_name")
+            or account["account_key"]
+        )
+        console.print(f"[green]Authorized[/green] {provider}  [dim]→ {label}[/dim]")
+    refs = " ".join(a["account_key"] for a in accounts)
+    console.print(
+        f"\nNow index it:  [cyan]stash sources add <type> --ref {refs}[/cyan]"
+        "  [dim](types: stash sources add --help)[/dim]"
+    )
+
+
 @sources_app.command("add")
 def sources_add(
     source_type: str = typer.Argument(
@@ -3508,7 +3603,10 @@ def sources_add(
     name: str = typer.Option("", "--name", help="Display name."),
     as_json: bool = typer.Option(False, "--json"),
 ):
-    """Connect a source. Slack/Granola resolve their ref from your token."""
+    """Index a source on an account you have already authorized.
+
+    Authorize first with `stash sources connect <provider>`. Slack/Granola
+    resolve their ref from your token."""
     with _client() as c:
         try:
             data = c.add_source(source_type, external_ref=ref or None, display_name=name or None)

--- a/cli/tests/test_sources_connect.py
+++ b/cli/tests/test_sources_connect.py
@@ -1,0 +1,177 @@
+"""`stash sources connect` is the OAuth-grant step that `sources add` depends
+on. The consent itself is the user's (password + 2FA), so the command's whole
+job is the handoff: surface the URL, then watch the provider's account list
+until the grant lands. These lock in what "landed" means — including the
+reconnect case, where the account key is unchanged and only the timestamp
+moves — and that a consent that never completes fails loudly instead of
+reporting a connection that does not exist.
+"""
+
+import json
+import time
+import webbrowser
+
+import pytest
+import typer
+
+from cli import main
+
+
+class _FakeClient:
+    """Serves a scripted status per call: the first is the baseline read the
+    command takes before opening the browser, the rest are polls. The last
+    entry repeats, which is what an abandoned consent looks like."""
+
+    def __init__(self, statuses: list[dict], calls: list):
+        self._statuses = statuses
+        self._reads = 0
+        self._calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def integration_status(self, provider):
+        self._calls.append(("status", provider))
+        status = self._statuses[min(self._reads, len(self._statuses) - 1)]
+        self._reads += 1
+        return status
+
+    def integration_authorize_url(self, provider):
+        self._calls.append(("authorize_url", provider))
+        return f"https://accounts.example.com/o/oauth2/auth?provider={provider}"
+
+
+def _account(key: str, updated_at: str, **overrides) -> dict:
+    account = {
+        "account_key": key,
+        "account_email": key,
+        "account_display_name": None,
+        "disconnected": False,
+        "updated_at": updated_at,
+    }
+    account.update(overrides)
+    return account
+
+
+def _wire(monkeypatch, statuses: list[dict], opened: bool = True) -> list:
+    """The command imports time/webbrowser inside its body, so the patches go
+    on the real modules. sleep drives a fake clock so a timeout costs no wall
+    time and lands on an exact number of polls."""
+    calls: list = []
+    now = {"t": 0.0}
+    monkeypatch.setattr(main, "_require_auth", lambda: None)
+    monkeypatch.setattr(main, "_client", lambda: _FakeClient(statuses, calls))
+    monkeypatch.setattr(main, "_refocus_terminal", lambda: None)
+    monkeypatch.setattr(main, "_is_ssh", lambda: False)
+    monkeypatch.setattr(webbrowser, "open", lambda _url: opened)
+    monkeypatch.setattr(time, "monotonic", lambda: now["t"])
+    monkeypatch.setattr(time, "sleep", lambda s: now.__setitem__("t", now["t"] + s))
+    return calls
+
+
+def test_connect_waits_for_a_new_account_then_reports_it(monkeypatch, capsys) -> None:
+    """The grant appears only after the user finishes in the browser, so the
+    command must keep polling past an unchanged status rather than declaring
+    victory on the first read."""
+    existing = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    arrived = _account("htdowling@gmail.com", "2026-08-11T12:00:00+00:00")
+    calls = _wire(
+        monkeypatch,
+        [
+            {"accounts": [existing]},  # baseline, before the browser opens
+            {"accounts": [existing]},  # still mid-consent
+            {"accounts": [existing, arrived]},
+        ],
+    )
+
+    main.sources_connect("gmail", timeout=60, as_json=False)
+
+    out = capsys.readouterr().out
+    assert "htdowling@gmail.com" in out
+    assert "stash sources add" in out  # the next step is spelled out
+    assert calls.count(("status", "gmail")) == 3
+
+
+def test_connect_reports_only_the_account_that_just_arrived(monkeypatch, capsys) -> None:
+    """Mailboxes authorized on earlier runs are not news. Reporting them again
+    would tell the user they just connected an account they already had."""
+    existing = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    arrived = _account("htdowling@gmail.com", "2026-08-11T12:00:00+00:00")
+    _wire(monkeypatch, [{"accounts": [existing]}, {"accounts": [existing, arrived]}])
+
+    main.sources_connect("gmail", timeout=60, as_json=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [a["account_key"] for a in payload["accounts"]] == ["htdowling@gmail.com"]
+
+
+def test_connect_detects_a_reconnect_of_an_existing_account(monkeypatch, capsys) -> None:
+    """Repairing an expired grant reuses the same account_key, so a key-only
+    comparison would poll forever through a consent that actually succeeded.
+    The moved updated_at is what makes the repair visible."""
+    stale = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    repaired = _account("henry@ferganalabs.com", "2026-08-11T12:00:00+00:00")
+    _wire(monkeypatch, [{"accounts": [stale]}, {"accounts": [repaired]}])
+
+    main.sources_connect("gmail", timeout=60, as_json=False)
+
+    assert "henry@ferganalabs.com" in capsys.readouterr().out
+
+
+def test_connect_ignores_a_disconnected_account(monkeypatch) -> None:
+    """A disconnected row keeps its key and timestamp but holds no token, so
+    counting it as a grant would report success for an unusable account."""
+    revoked = _account("henry@ferganalabs.com", "2026-08-11T12:00:00+00:00", disconnected=True)
+    _wire(monkeypatch, [{"accounts": []}, {"accounts": [revoked]}])
+
+    with pytest.raises(typer.Exit) as exc:
+        main.sources_connect("gmail", timeout=4, as_json=False)
+
+    assert exc.value.exit_code == 1
+
+
+def test_connect_fails_loudly_when_consent_never_completes(monkeypatch, capsys) -> None:
+    """An abandoned consent must exit non-zero: a caller that took silence for
+    success would go on to `sources add` against a grant that isn't there."""
+    existing = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    _wire(monkeypatch, [{"accounts": [existing]}])
+
+    with pytest.raises(typer.Exit) as exc:
+        main.sources_connect("gmail", timeout=4, as_json=False)
+
+    assert exc.value.exit_code == 1
+    assert "Timed out" in capsys.readouterr().out
+
+
+def test_connect_prints_the_url_when_the_browser_cannot_open(monkeypatch, capsys) -> None:
+    """Headless and SSH sessions have no local browser; the URL is the only
+    way the user can complete the step, so it has to be visible."""
+    existing = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    arrived = _account("htdowling@gmail.com", "2026-08-11T12:00:00+00:00")
+    _wire(
+        monkeypatch,
+        [{"accounts": [existing]}, {"accounts": [existing, arrived]}],
+        opened=False,
+    )
+
+    main.sources_connect("gmail", timeout=60, as_json=False)
+
+    assert "accounts.example.com" in capsys.readouterr().out
+
+
+def test_connect_json_keeps_stdout_parseable(monkeypatch, capsys) -> None:
+    """Agents consume --json on stdout. The authorize URL still has to reach a
+    human, so it goes to stderr where it cannot corrupt the payload."""
+    existing = _account("henry@ferganalabs.com", "2026-08-01T00:00:00+00:00")
+    arrived = _account("htdowling@gmail.com", "2026-08-11T12:00:00+00:00")
+    _wire(monkeypatch, [{"accounts": [existing]}, {"accounts": [existing, arrived]}])
+
+    main.sources_connect("gmail", timeout=60, as_json=True)
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["provider"] == "gmail"
+    assert "accounts.example.com" in captured.err


### PR DESCRIPTION
`stash sources add` indexes a mailbox or repo on an OAuth grant that already exists. Nothing in the CLI could *create* that grant, so the first half of connecting a source had no agent path at all — the user had to be told to go find the integrations page and click through it. Trying to add a personal Gmail account failed at `sources add` with a 400 that never mentioned the step it was missing.

## What this adds

`stash sources connect <provider>` — fetch the provider's authorize URL, open it, watch the account list until the grant lands, fail loud if it never does.

The consent itself stays the user's: it wants a password and 2FA, and an agent holding those is the thing OAuth exists to prevent. What was missing is the handoff around it. Both halves already existed — the backend returns an authorize URL for the frontend (it can't 302 with a Bearer header), and the CLI already had the open-a-URL-then-poll shape in its own sign-in flow. This joins them.

## Detecting that the grant landed

A new `account_key` is not enough. Repairing an expired grant reuses the key, so on key alone a finished reconnect is indistinguishable from an abandoned one, and the command would wait out its whole timeout on a consent that actually succeeded. Account status now exposes `updated_at`, which every `store_token` rewrites, and the poll fingerprints on `(account_key, updated_at)` over non-disconnected accounts.

## Error messages

Both Gmail 400s now name the authorized mailboxes. "Gmail account is not connected" is equally true whether the mailbox was never authorized or the address was misspelled, and those want opposite fixes.

## Notes for review

- `_is_ssh()` is extracted from `_browser_auth_flow` so sign-in and this flow agree on when a browser can be opened; behavior there is unchanged.
- Under `--json` the authorize URL goes to **stderr** so it can still reach a human without corrupting the payload on stdout.
- `updated_at` is additive on the integrations API; the frontend ignores unknown fields and its tests pass unchanged.
- One existing assertion in `test_gmail_multi_account.py` pinned the old error string and now asserts the mailboxes are named.

## Testing

- 7 new CLI tests, 2 new backend tests, 1 added to `test_gmail_multi_account.py`.
- Mutation-checked the fingerprint: keying on `account_key` alone fails exactly the reconnect test, with the real symptom ("Timed out… Nothing was connected").
- Full CLI suite (241) plus `test_sources`, `test_integration_sources`, `test_gmail_multi_account`, `test_integration_connect_signal`, `test_disconnect_retention`, `test_integration_reconnect` (168) green; ruff check + format clean.
- Exercised end-to-end against prod: authorized a second Gmail account, indexed it, synced, and searched it successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth connect handoff and integrations status API, but reuses existing authorize/status endpoints and only adds an additive `updated_at` field. No changes to token exchange or storage security.
> 
> **Overview**
> Adds **`stash sources connect <provider>`**, which opens the provider consent URL and polls until the OAuth grant lands — the missing step before `sources add`.
> 
> Account status now exposes **`updated_at`**, so the CLI can detect a reconnect that reuses the same `account_key`. Polling fingerprints on `(account_key, updated_at)` over live accounts and fails loudly on timeout.
> 
> Gmail add errors now **name the authorized mailboxes**, so callers can tell “authorize first” from “pick which one” or a typo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca789759bcd906a8368d4564942945d2bfa9acc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->