### PR TITLE
Hopper: open the folder from the confirmation, and stop hiding files

### DIFF
--- a/backend/routers/hopper.py
+++ b/backend/routers/hopper.py
@@ -211,7 +211,7 @@ async def classify_drop(
     # Only ever files something loose: a folder drop, or filing that already
     # happened, is not for a classifier to revisit.
     if row["folder_id"] is not None:
-        return {"filed_in": None}
+        return {"filed_in": None, "folder_id": None}
 
     folder_id, path = await file_classifier.suggest_folder(
         owner_user_id, row["name"], row["content_type"]
@@ -222,7 +222,7 @@ async def classify_drop(
         folder_id = await _folder_for_path(owner_user_id, current_user["id"], IMAGES_FOLDER)
         path = IMAGES_FOLDER
     if folder_id is None:
-        return {"filed_in": None}
+        return {"filed_in": None, "folder_id": None}
     await pool.execute(
         f"UPDATE {table} SET folder_id = $1 WHERE id = $2 AND owner_user_id = $3 "  # noqa: S608
         "AND folder_id IS NULL",
@@ -230,7 +230,9 @@ async def classify_drop(
         body.id,
         owner_user_id,
     )
-    return {"filed_in": path}
+    # The id as well as the path: a person told where something went will
+    # want to go there, and only the id can open the folder.
+    return {"filed_in": path, "folder_id": str(folder_id)}
 
 
 @router.post("/link", status_code=201)

--- a/backend/routers/hopper.py
+++ b/backend/routers/hopper.py
@@ -24,11 +24,29 @@ from .files import MAX_FILE_SIZE, _strip_ext, ingest_bytes
 
 router = APIRouter(prefix="/api/v1/me/hopper", tags=["hopper"])
 
-# An image with a meaningless name (IMG_0917, CleanShot 2026-08-12) has no
-# semantic home, but it does have an obvious kind. Without this they pile up at
-# the top level, which is exactly the junk drawer a filesystem is meant to
-# prevent.
-IMAGES_FOLDER = "Images"
+# A photo, clip or recording with a meaningless name (IMG_0917, IMG_3503.MOV)
+# has no semantic home, but it does have an obvious kind. Without this they
+# pile up at the top level, which is exactly the junk drawer a filesystem is
+# meant to prevent.
+#
+# Keyed by extension as well as content type because browsers routinely hand
+# over application/octet-stream for anything they do not recognise — a .MOV
+# from an iPhone arrives untyped.
+_MEDIA_FOLDERS = (
+    ("Images", "image/", (".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic", ".heif", ".bmp")),
+    ("Videos", "video/", (".mov", ".mp4", ".m4v", ".avi", ".mkv", ".webm")),
+    ("Audio", "audio/", (".mp3", ".m4a", ".wav", ".aac", ".flac", ".ogg")),
+)
+
+
+def _media_folder(filename: str, content_type: str) -> str | None:
+    """The kind-based home for a file, or None for anything that is not media."""
+    name = filename.lower()
+    for folder, prefix, extensions in _MEDIA_FOLDERS:
+        if content_type.startswith(prefix) or name.endswith(extensions):
+            return folder
+    return None
+
 
 # Dropping a directory mirrors its structure, so the depth cap is the only
 # guard against someone dragging in their home folder.
@@ -216,11 +234,13 @@ async def classify_drop(
     folder_id, path = await file_classifier.suggest_folder(
         owner_user_id, row["name"], row["content_type"]
     )
-    if folder_id is None and row["content_type"].startswith("image/"):
-        # No folder fits, but an image still has somewhere to be. This is a
-        # rule, not a guess: the kind is known, only the meaning is not.
-        folder_id = await _folder_for_path(owner_user_id, current_user["id"], IMAGES_FOLDER)
-        path = IMAGES_FOLDER
+    if folder_id is None:
+        # No folder fits, but a photo or clip still has somewhere to be. This
+        # is a rule, not a guess: the kind is known, only the meaning is not.
+        media = _media_folder(row["name"], row["content_type"])
+        if media:
+            folder_id = await _folder_for_path(owner_user_id, current_user["id"], media)
+            path = media
     if folder_id is None:
         return {"filed_in": None, "folder_id": None}
     await pool.execute(

--- a/backend/tests/test_hopper.py
+++ b/backend/tests/test_hopper.py
@@ -409,6 +409,34 @@ async def test_a_named_image_still_goes_where_it_belongs(
 
 
 @pytest.mark.asyncio
+async def test_an_untyped_video_still_finds_its_kind(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """Browsers hand over application/octet-stream for anything they do not
+    recognise, so an iPhone clip arrives untyped — the extension is the only
+    thing that says what it is."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    landed = await _drop(client, headers, "IMG_3503.MOV", b"\x00\x00", "application/octet-stream")
+
+    async def declines(**kwargs):
+        return {"folder": None}
+
+    monkeypatch.setattr(llm, "complete_json", declines)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] == "Videos"
+    folder = await pool.fetchval(
+        "SELECT f.name FROM files fi JOIN folders f ON f.id = fi.folder_id WHERE fi.id = $1",
+        UUID(landed["id"]),
+    )
+    assert folder == "Videos"
+
+
+@pytest.mark.asyncio
 async def test_an_unfilable_document_is_left_alone(client: AsyncClient, pool, monkeypatch) -> None:
     """Only images get a kind-based home; a document with no obvious folder
     stays where the person can see it."""

--- a/frontend/src/app/(app)/hopper/page.tsx
+++ b/frontend/src/app/(app)/hopper/page.tsx
@@ -43,6 +43,9 @@ function hrefFor(event: ActivityEvent): string {
   return event.kind.startsWith("page") ? `/p/${event.target_id}` : `/f/${event.target_id}`;
 }
 
+/** Where a drop was filed, when it was. */
+type Filing = { path: string; folderId: string } | null;
+
 type Batch = {
   total: number;
   done: number;
@@ -95,11 +98,11 @@ export default function HopperRoute() {
   // Filing runs after the uploads are confirmed, at the same concurrency.
   // Nothing here can fail the drop: an item that cannot be filed stays where
   // it already is, which is a fine place for it.
-  const fileAway = useCallback(async (landed: HopperDrop[]): Promise<Array<string | null>> => {
+  const fileAway = useCallback(async (landed: HopperDrop[]): Promise<Filing[]> => {
     const results = await runPool(landed, UPLOAD_CONCURRENCY, async (drop) => {
       if (!drop.classifiable || drop.kind === "link") return null;
-      const { filed_in } = await classifyDrop(drop.kind, drop.id);
-      return filed_in;
+      const { filed_in, folder_id } = await classifyDrop(drop.kind, drop.id);
+      return filed_in && folder_id ? { path: filed_in, folderId: folder_id } : null;
     });
     return results.map((r) => (r.ok === true ? r.value : null));
   }, []);
@@ -181,7 +184,18 @@ export default function HopperRoute() {
           toast.success(`${only.name} uploaded successfully`, {
             id,
             // Say so either way: no second line reads as "filing never ran".
-            description: filed ? `Filed in ${filed}` : "Kept at the top level",
+            // Naming a folder without a way to open it is a tease.
+            description: filed ? (
+              <button
+                type="button"
+                onClick={() => router.push(`/folders/${filed.folderId}`)}
+                className="underline-offset-2 hover:underline"
+              >
+                Filed in {filed.path}
+              </button>
+            ) : (
+              "Kept at the top level"
+            ),
             action: goTo,
           });
         });

--- a/frontend/src/app/(app)/hopper/page.tsx
+++ b/frontend/src/app/(app)/hopper/page.tsx
@@ -183,8 +183,9 @@ export default function HopperRoute() {
         void fileAway(landed).then(([filed]) => {
           toast.success(`${only.name} uploaded successfully`, {
             id,
-            // Say so either way: no second line reads as "filing never ran".
-            // Naming a folder without a way to open it is a tease.
+            // Only when there is something to say: "kept at the top level"
+            // announces a non-event. Naming a folder without a way to open it
+            // would be a tease, so the line is a link.
             description: filed ? (
               <button
                 type="button"
@@ -193,9 +194,7 @@ export default function HopperRoute() {
               >
                 Filed in {filed.path}
               </button>
-            ) : (
-              "Kept at the top level"
-            ),
+            ) : undefined,
             action: goTo,
           });
         });
@@ -220,8 +219,7 @@ export default function HopperRoute() {
         live.filed = filed.filter(Boolean).length;
         toast.success(summarise(live), {
           id,
-          description:
-            failedNames || (live.filed ? undefined : "All kept at the top level"),
+          description: failedNames || undefined,
           action: goToVfs,
         });
       });

--- a/frontend/src/components/content/file-browser/ItemsList.test.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.test.tsx
@@ -68,35 +68,36 @@ describe("ItemsList type filter", () => {
     );
   }
 
-  it("hides non-document types by default so uploads don't clutter the view", () => {
+  it("shows every type by default, uploads included", () => {
     renderMixedList();
 
-    // HTML/Markdown/folders are the default doc set; the PNG stays hidden until
-    // it's explicitly chosen from the Type menu.
-    expect(screen.getByText(item.name)).toBeDefined();
-    expect(screen.queryByText(png.name)).toBeNull();
-  });
-
-  it("reveals every type via All types", () => {
-    renderMixedList();
-
-    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
-    fireEvent.click(screen.getByRole("button", { name: "All types" }));
-
+    // This used to open on documents only, which meant a folder of
+    // screenshots read as "Empty folder" while the tree beside it counted
+    // six. A file browser that hides files is the wrong kind of tidy.
     expect(screen.getByText(item.name)).toBeDefined();
     expect(screen.getByText(png.name)).toBeDefined();
   });
 
-  it("returns to the document set via Documents only", () => {
+  it("narrows to the document set via Documents only", () => {
     renderMixedList();
 
     fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
-    fireEvent.click(screen.getByRole("button", { name: "All types" }));
-    fireEvent.click(screen.getByRole("button", { name: /^Type: All$/i }));
     fireEvent.click(screen.getByRole("button", { name: "Documents only" }));
 
     expect(screen.getByText(item.name)).toBeDefined();
     expect(screen.queryByText(png.name)).toBeNull();
+  });
+
+  it("returns to everything via All types", () => {
+    renderMixedList();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Documents only" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Type: Documents$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "All types" }));
+
+    expect(screen.getByText(item.name)).toBeDefined();
+    expect(screen.getByText(png.name)).toBeDefined();
   });
 
   it("narrows the list to the chosen type", () => {

--- a/frontend/src/components/content/file-browser/ItemsList.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.tsx
@@ -94,14 +94,16 @@ const SORT_STORAGE_KEY = "stash_files_sort";
 
 const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
 
-// The List view opens on documents only — folders plus the page types people
-// author (HTML, Markdown). Other file types (PDFs, images, tables) stay hidden
-// until chosen from the Type menu, so uploads don't clutter the default view.
-// `typeFilter === null` means this doc set; ALL_TYPES means show everything.
-// Tables are first-class residents of the folder tree, so they show by
-// default like documents do.
-const DEFAULT_TYPES = new Set(["Folder", "HTML", "Markdown", "Table"]);
-const ALL_TYPES = "__all__";
+// The List view shows everything a folder holds. It used to open on documents
+// only — folders, HTML, Markdown, Table — so uploads would not "clutter" it,
+// but that predates a product whose front door is uploads: a folder of
+// screenshots read as "Empty folder" while the tree beside it counted six.
+// A file browser that hides files is the wrong kind of tidy.
+//
+// `typeFilter === null` now means everything; DOC_TYPES stays as the explicit
+// "Documents only" choice in the Type menu.
+const DOC_TYPES = new Set(["Folder", "HTML", "Markdown", "Table"]);
+const DOCS_ONLY = "__docs__";
 
 function readSort(): Sort {
   if (typeof window === "undefined") return null;
@@ -165,20 +167,16 @@ export default function ItemsList({
     applySort(next);
   }
 
-  // Only the non-default types are pickable here; folders/HTML/Markdown already
-  // show by default, so the menu is purely for revealing the other types.
+  // Every type present, so the menu can narrow to any one of them.
   const typeOptions = useMemo(
-    () =>
-      Array.from(new Set(items.map(typeFor)))
-        .filter((type) => !DEFAULT_TYPES.has(type))
-        .sort(),
+    () => Array.from(new Set(items.map(typeFor))).sort(),
     [items],
   );
 
   const sortedItems = useMemo(() => {
     const visible = items.filter((item) => {
-      if (typeFilter === null) return DEFAULT_TYPES.has(typeFor(item));
-      if (typeFilter === ALL_TYPES) return true;
+      if (typeFilter === null) return true;
+      if (typeFilter === DOCS_ONLY) return DOC_TYPES.has(typeFor(item));
       return typeFor(item) === typeFilter;
     });
     if (!sort) return visible;
@@ -224,7 +222,7 @@ export default function ItemsList({
         ))}
         {sortedItems.length === 0 && (
           <div className="px-4 py-10 text-center text-[12.5px] text-muted-foreground">
-            {typeFilter && typeFilter !== ALL_TYPES
+            {typeFilter && typeFilter !== DOCS_ONLY
               ? `No ${typeFilter} items here.`
               : "Empty folder."}
           </div>
@@ -314,8 +312,8 @@ function TypeHeader({
       >
         {filter === null
           ? "Type"
-          : filter === ALL_TYPES
-            ? "Type: All"
+          : filter === DOCS_ONLY
+            ? "Type: Documents"
             : `Type: ${filter}`}
         {sortActive && <span className="text-[9px]">{sort?.dir === "desc" ? "▼" : "▲"}</span>}
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -327,8 +325,8 @@ function TypeHeader({
           <MenuItem label="Sort A → Z" checked={sortActive && sort?.dir === "asc"} onSelect={() => choose(() => onSort("asc"))} />
           <MenuItem label="Sort Z → A" checked={sortActive && sort?.dir === "desc"} onSelect={() => choose(() => onSort("desc"))} />
           <div className="my-1 border-t border-border" />
-          <MenuItem label="Documents only" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
-          <MenuItem label="All types" checked={filter === ALL_TYPES} onSelect={() => choose(() => onFilter(ALL_TYPES))} />
+          <MenuItem label="All types" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
+          <MenuItem label="Documents only" checked={filter === DOCS_ONLY} onSelect={() => choose(() => onFilter(DOCS_ONLY))} />
           {options.map((type) => (
             <MenuItem key={type} label={type} checked={filter === type} onSelect={() => choose(() => onFilter(type))} />
           ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2490,7 +2490,7 @@ export async function dropHopperFile(
 export async function classifyDrop(
   kind: "file" | "page",
   id: string,
-): Promise<{ filed_in: string | null }> {
+): Promise<{ filed_in: string | null; folder_id: string | null }> {
   return apiFetch(`${ME}/hopper/classify`, {
     method: "POST",
     body: JSON.stringify({ kind, id }),


### PR DESCRIPTION
Three small things, all found by using the merged Hopper.

## The folder named in the confirmation opens it

"Filed in Images" told you where a drop went and then made you find it. Classification returns the folder's id alongside its path now, and the line is a link. Verified by clicking it: lands on `/folders/<id>`, which the database confirms is `Images`.

## Video and audio get a home too

`IMG_3503.MOV` was "kept at the top level" — the kind-based home only covered images, and worse, browsers hand over `application/octet-stream` for a `.MOV`, so even a `video/` check would have missed it. The rule keys off the extension as well now, and covers video and audio. Folders are created on demand, so a stash with no recordings never grows an `Audio/`.

## Silence when nothing was filed

"Kept at the top level" was over-correction — I added it when silence looked like filing had not run. Announcing a non-event is chatter. The second line appears only when there is a destination, and then it is a link.

## And the bug that made the first one embarrassing

Clicking "Filed in Images" landed on a folder reading **"Empty folder"** while the tree beside it counted six files. `ItemsList` opened on documents only — folders, HTML, Markdown, Table — so PDFs and images were hidden until chosen from the Type menu. The comment said it was so uploads would not "clutter the default view", which predates a product whose front door is uploads.

The default is everything now; "Documents only" remains an explicit choice in the Type menu. This is a product-wide change to every folder's List view, which is why it is called out here rather than buried.

Two tests pinned the old behaviour and now pin the new one.

## Verification

The `Images` folder now lists all six screenshots (screenshot-verified, `saysEmpty: false`). 319 frontend tests, 17 hopper backend tests, tsc / ruff / eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Product-wide change to the file browser’s default visibility, plus broader auto-filing of media into kind folders. Low security risk, but UX and filing behavior shift for all folders.
> 
> **Overview**
> Improves Hopper filing feedback and media placement, and fixes the file browser default that made uploaded media look missing.
> 
> **Hopper filing** now returns `folder_id` with `filed_in`, so the upload toast’s “Filed in …” line links straight to that folder. Unfiled drops stay silent instead of saying “kept at the top level.”
> 
> **Kind-based homes** expand beyond images to **Videos** and **Audio**, matching on extension as well as content type so untyped browser uploads (e.g. iPhone `.MOV` as `application/octet-stream`) still land correctly.
> 
> **List view** defaults to showing every type. “Documents only” remains available in the Type menu, so folders of screenshots no longer read as empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb27332e6dcb0be55f5ee91add00b66f7ccac35b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->