### PR TITLE
Address a source-backed skill by its upstream Drive file

### DIFF
--- a/backend/routers/skills.py
+++ b/backend/routers/skills.py
@@ -225,16 +225,17 @@ async def get_local_skill(
     return skill
 
 
-@me_router.get("/source-skills/{doc_id}")
+@me_router.get("/source-skills/{source_ref}")
 async def read_source_skill(
-    doc_id: UUID,
+    source_ref: str,
     current_user: dict = Depends(get_current_user),
     owner_user_id: UUID = Depends(get_scope),
 ):
-    """Read one source-backed skill by the document that backs it. Addressed by
-    document rather than name because a shelf can hold two docs with the same
-    title, and the page has to open the one that was clicked."""
-    skill = await skill_service.read_source_skill(owner_user_id, doc_id, current_user["id"])
+    """Read one source-backed skill by the upstream file that backs it.
+    Addressed by file rather than name because a shelf can hold two documents
+    with the same title, and by the upstream id rather than ours because a
+    rename in Drive replaces our row."""
+    skill = await skill_service.read_source_skill(owner_user_id, source_ref, current_user["id"])
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
     return skill

--- a/backend/services/agent_runtime.py
+++ b/backend/services/agent_runtime.py
@@ -338,11 +338,12 @@ def _skill_app_url(folder_id: object) -> str:
     return f"{settings.PUBLIC_URL.rstrip('/')}/skills/folder/{folder_id}"
 
 
-def _source_skill_app_url(doc_id: object) -> str:
-    """A source-backed skill has no folder, so it has its own read-only page.
+def _source_skill_app_url(source_ref: object) -> str:
+    """A source-backed skill has no folder, so it has its own read-only page,
+    addressed by the upstream file id so the link survives a rename in Drive.
     Without this the model hands out /skills/folder/None — the exact wrong-URL
     failure `_skill_app_url` exists to prevent."""
-    return f"{settings.PUBLIC_URL.rstrip('/')}/skills/source/{doc_id}"
+    return f"{settings.PUBLIC_URL.rstrip('/')}/skills/source/{source_ref}"
 
 
 @tool(
@@ -371,7 +372,7 @@ async def _list_skills(args: dict) -> dict:
             "app_url": (
                 _skill_app_url(s["folder_id"])
                 if s["backing"] == "folder"
-                else _source_skill_app_url(s["source_doc_id"])
+                else _source_skill_app_url(s["source_ref"])
             ),
         }
         for s in skills
@@ -413,7 +414,7 @@ async def _read_skill(args: dict) -> dict:
                             "url": (
                                 _skill_app_url(m["folder_id"])
                                 if m["backing"] == "folder"
-                                else _source_skill_app_url(m["source_doc_id"])
+                                else _source_skill_app_url(m["source_ref"])
                             ),
                         }
                         for m in matches

--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -189,12 +189,15 @@ async def list_source_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
         # Only the frontmatter is needed to list a skill, and only a document
         # that starts with a delimiter can carry any — so the shelf's bodies
         # stay in the database instead of crossing the wire to be discarded.
-        f"SELECT d.id, d.name, left(d.content, {FRONTMATTER_SCAN_BYTES}) AS head, d.updated_at, "
-        "  src.display_name AS source_name "
+        f"SELECT d.external_ref, d.name, left(d.content, {FRONTMATTER_SCAN_BYTES}) AS head, "
+        "  d.updated_at, src.display_name AS source_name "
         "FROM drive_documents d "
         "JOIN user_sources src ON src.id = d.source_id "
         "WHERE d.owner_user_id = $1 AND d.deleted_at IS NULL AND src.binds_skills "
         f"  AND position('/' in d.path) = 0 AND d.content LIKE '---%' AND {readable} "
+        # A document with no upstream id has no stable address, so it cannot be
+        # offered as a skill. The Drive walk always records one.
+        "  AND d.external_ref IS NOT NULL "
         "ORDER BY d.name",
         owner_user_id,
         user_id,
@@ -203,7 +206,7 @@ async def list_source_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     return [
         {
             "folder_id": None,
-            "source_doc_id": str(r["id"]),
+            "source_ref": r["external_ref"],
             "backing": "source",
             "source_name": r["source_name"],
             "name": meta["name"],
@@ -266,7 +269,7 @@ async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
         out.append(
             {
                 "folder_id": str(r["folder_id"]),
-                "source_doc_id": None,
+                "source_ref": None,
                 "backing": "folder",
                 "source_name": None,
                 "name": meta.get("name") or r["folder_name"],
@@ -287,8 +290,13 @@ async def list_skills(owner_user_id: UUID, user_id: UUID) -> list[dict]:
     return out
 
 
-async def read_source_skill(owner_user_id: UUID, doc_id: UUID, user_id: UUID) -> dict | None:
+async def read_source_skill(owner_user_id: UUID, source_ref: str, user_id: UUID) -> dict | None:
     """Read a source-backed skill: the upstream document is the instructions.
+
+    Addressed by `source_ref` — the upstream file's own id — because our row is
+    keyed on the document's path and is therefore destroyed and recreated when
+    its author renames it in Drive. The file id survives that; a row id does
+    not, and a skill's address must outlive a rename.
 
     A document that does not declare itself a skill reads as None — it is not
     a broken skill, it is a file that happens to live on the shelf, and the
@@ -296,13 +304,19 @@ async def read_source_skill(owner_user_id: UUID, doc_id: UUID, user_id: UUID) ->
     """
     readable = permission_service.readable_content_condition("source", "src", 3)
     row = await get_pool().fetchrow(
-        "SELECT d.id, d.name, d.content, d.updated_at, src.display_name AS source_name "
+        "SELECT d.external_ref, d.name, d.content, d.updated_at, "
+        "  src.display_name AS source_name "
         "FROM drive_documents d "
         "JOIN user_sources src ON src.id = d.source_id "
-        "WHERE d.owner_user_id = $1 AND d.id = $2 AND d.deleted_at IS NULL "
-        f"  AND src.binds_skills AND position('/' in d.path) = 0 AND {readable}",
+        "WHERE d.owner_user_id = $1 AND d.external_ref = $2 AND d.deleted_at IS NULL "
+        f"  AND src.binds_skills AND position('/' in d.path) = 0 AND {readable} "
+        # A Drive shortcut resolves to its target's file id, so a shortcut
+        # sitting beside its target puts that id on two rows. They are the same
+        # upstream document, so either answers the read — ordered so the answer
+        # is at least the same one every time.
+        "ORDER BY d.path LIMIT 1",
         owner_user_id,
-        doc_id,
+        source_ref,
         user_id,
     )
     if row is None:
@@ -315,7 +329,7 @@ async def read_source_skill(owner_user_id: UUID, doc_id: UUID, user_id: UUID) ->
     _meta, body = parse_frontmatter(row["content"] or "")
     return {
         "folder_id": None,
-        "source_doc_id": str(row["id"]),
+        "source_ref": row["external_ref"],
         "backing": "source",
         "source_name": row["source_name"],
         "name": meta["name"],
@@ -325,7 +339,7 @@ async def read_source_skill(owner_user_id: UUID, doc_id: UUID, user_id: UUID) ->
         "body": body,
         "files": [
             {
-                "id": str(row["id"]),
+                "id": row["external_ref"],
                 "name": row["name"],
                 "updated_at": row["updated_at"],
                 "content": body,
@@ -355,7 +369,7 @@ async def read_skill(owner_user_id: UUID, name: str, user_id: UUID) -> dict | No
         return None
 
     if match["backing"] == "source":
-        return await read_source_skill(owner_user_id, UUID(match["source_doc_id"]), user_id)
+        return await read_source_skill(owner_user_id, match["source_ref"], user_id)
 
     folder_id = match["folder_id"]
     pages = await pool.fetch(
@@ -388,7 +402,7 @@ async def read_skill(owner_user_id: UUID, name: str, user_id: UUID) -> dict | No
 
     return {
         "folder_id": folder_id,
-        "source_doc_id": None,
+        "source_ref": None,
         "backing": "folder",
         "name": match["name"],
         "description": match["description"],

--- a/backend/tests/test_source_backed_skills.py
+++ b/backend/tests/test_source_backed_skills.py
@@ -60,6 +60,7 @@ async def _doc(
     path: str,
     content: str | None,
     status: str = "done",
+    external_ref: str | None = None,
 ) -> UUID:
     return await pool.fetchval(
         "INSERT INTO drive_documents "
@@ -69,7 +70,7 @@ async def _doc(
         source_id,
         path,
         path.rpartition("/")[2],
-        f"drive-{path}",
+        external_ref or f"drive-{path}",
         content,
         status,
     )
@@ -235,7 +236,7 @@ async def test_reading_a_skill_returns_the_document_without_its_frontmatter(
     instructions alone — the same split a folder skill gets."""
     _key, owner_id = await _register(client)
     source_id = await _skill_shelf(pool, owner_id)
-    doc_id = await _doc(
+    await _doc(
         pool,
         owner_id,
         source_id,
@@ -243,7 +244,7 @@ async def test_reading_a_skill_returns_the_document_without_its_frontmatter(
         content=_declared("Turbochargers", "Boost loss.", "Check the wastegate first."),
     )
 
-    skill = await skill_service.read_source_skill(owner_id, doc_id, owner_id)
+    skill = await skill_service.read_source_skill(owner_id, "drive-Turbochargers.md", owner_id)
 
     assert skill is not None
     assert skill["name"] == "Turbochargers"
@@ -257,9 +258,9 @@ async def test_reading_an_undeclared_document_is_not_found(client: AsyncClient, 
     so there is no skill page for it to open."""
     _key, owner_id = await _register(client)
     source_id = await _skill_shelf(pool, owner_id)
-    doc_id = await _doc(pool, owner_id, source_id, path="Scratch.md", content="weeeeee\n")
+    await _doc(pool, owner_id, source_id, path="Scratch.md", content="weeeeee\n")
 
-    assert await skill_service.read_source_skill(owner_id, doc_id, owner_id) is None
+    assert await skill_service.read_source_skill(owner_id, "drive-Scratch.md", owner_id) is None
 
 
 @pytest.mark.asyncio
@@ -270,7 +271,7 @@ async def test_a_declaration_with_nothing_under_it_is_a_draft(client: AsyncClien
     trigger. Declaring yourself a skill is not the same as being one."""
     _key, owner_id = await _register(client)
     source_id = await _skill_shelf(pool, owner_id)
-    doc_id = await _doc(
+    await _doc(
         pool,
         owner_id,
         source_id,
@@ -282,7 +283,7 @@ async def test_a_declaration_with_nothing_under_it_is_a_draft(client: AsyncClien
     assert [s["name"] for s in listed] == ["Turbochargers"]
     assert listed[0]["has_instructions"] is False
 
-    skill = await skill_service.read_source_skill(owner_id, doc_id, owner_id)
+    skill = await skill_service.read_source_skill(owner_id, "drive-Turbochargers.md", owner_id)
     assert skill is not None
     assert skill["has_instructions"] is False
     assert skill["combined"] == ""
@@ -296,7 +297,7 @@ async def test_listing_and_reading_agree_on_a_long_frontmatter_block(client: Asy
     catalogue — visible on its own page, invisible to every agent."""
     _key, owner_id = await _register(client)
     source_id = await _skill_shelf(pool, owner_id)
-    doc_id = await _doc(
+    await _doc(
         pool,
         owner_id,
         source_id,
@@ -308,7 +309,7 @@ async def test_listing_and_reading_agree_on_a_long_frontmatter_block(client: Asy
     )
 
     listed = await skill_service.list_skills(owner_id, owner_id)
-    read = await skill_service.read_source_skill(owner_id, doc_id, owner_id)
+    read = await skill_service.read_source_skill(owner_id, "drive-Turbochargers.md", owner_id)
 
     assert [s["name"] for s in listed] == ["Turbochargers"]
     assert read is not None
@@ -349,3 +350,38 @@ async def test_an_owned_shelf_with_nothing_in_it_still_reports_itself(client: As
     counts = await skill_service.count_shelf_skills(owner_id, [str(source_id)])
 
     assert counts == {str(source_id): {"skills": 0, "documents": 0, "not_skills": []}}
+
+
+@pytest.mark.asyncio
+async def test_a_rename_in_drive_does_not_change_a_skill_s_address(client: AsyncClient, pool):
+    """Our row is keyed on the document's path, so renaming it upstream deletes
+    one row and inserts another. A skill addressed by that row would lose its
+    url, its pin, and any link an agent had been handed — for a rename. The
+    upstream file id survives, so that is what a skill is addressed by."""
+    _key, owner_id = await _register(client)
+    source_id = await _skill_shelf(pool, owner_id)
+    await _doc(
+        pool,
+        owner_id,
+        source_id,
+        path="Turbos.md",
+        content=_declared("Turbochargers", "Boost loss."),
+        external_ref="drive-file-stable",
+    )
+    before = (await skill_service.list_skills(owner_id, owner_id))[0]["source_ref"]
+
+    # The walk after the author renames the file: same Drive id, new path, and
+    # the row at the old path swept away.
+    await pool.execute("DELETE FROM drive_documents WHERE source_id = $1", source_id)
+    await _doc(
+        pool,
+        owner_id,
+        source_id,
+        path="Turbochargers.md",
+        content=_declared("Turbochargers", "Boost loss."),
+        external_ref="drive-file-stable",
+    )
+
+    after = (await skill_service.list_skills(owner_id, owner_id))[0]["source_ref"]
+    assert after == before
+    assert await skill_service.read_source_skill(owner_id, before, owner_id) is not None

--- a/frontend/src/app/(app)/skills/page.test.tsx
+++ b/frontend/src/app/(app)/skills/page.test.tsx
@@ -54,7 +54,7 @@ vi.mock("@/lib/api", () => ({
   listSkills: vi.fn(),
   // Real behaviour, not a stub: the page keys pins, selection, and React
   // children off this, so a mock returning undefined collapses the render.
-  skillKey: (s: Skill) => (s.backing === "folder" ? s.folder_id : s.source_doc_id),
+  skillKey: (s: Skill) => (s.backing === "folder" ? s.folder_id : s.source_ref),
   // useAuth (mounted by the page) short-circuits to a signed-out state when
   // there's no token, so these never hit the network.
   getToken: vi.fn(() => null),
@@ -78,7 +78,7 @@ vi.mock("@/lib/skillNavigationCache", () => ({
 function skill(overrides: Partial<FolderBackedSkill> = {}): Skill {
   return {
     backing: "folder",
-    source_doc_id: null,
+    source_ref: null,
     source_name: null,
     folder_id: "folder-1",
     name: "Launch Plan",
@@ -97,7 +97,7 @@ function sourceSkill(overrides: Partial<Skill> = {}): Skill {
   return {
     backing: "source",
     folder_id: null,
-    source_doc_id: "doc-1",
+    source_ref: "drive-file-1",
     source_name: "skillz",
     name: "Turbochargers",
     description: "Use when a customer reports boost loss.",
@@ -215,8 +215,8 @@ describe("SkillsPage", () => {
     // This is why the page keys off skillKey and not the folder.
     const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(listSkills).mockResolvedValue([
-      sourceSkill({ source_doc_id: "doc-1", name: "Turbochargers" }),
-      sourceSkill({ source_doc_id: "doc-2", name: "Brake Shoes" }),
+      sourceSkill({ source_ref: "drive-file-1", name: "Turbochargers" }),
+      sourceSkill({ source_ref: "drive-file-2", name: "Brake Shoes" }),
     ]);
 
     render(<SkillsPage />);
@@ -234,14 +234,14 @@ describe("SkillsPage", () => {
     // Read-only is about editing, not about visibility: you must always be
     // able to open a skill and read exactly what an agent will be handed.
     // It goes to the document view, not a folder page it hasn't got.
-    vi.mocked(listSkills).mockResolvedValue([sourceSkill({ source_doc_id: "doc-1" })]);
+    vi.mocked(listSkills).mockResolvedValue([sourceSkill({ source_ref: "drive-file-1" })]);
 
     render(<SkillsPage />);
 
     const links = (await screen.findAllByText("Turbochargers")).map((el) => el.closest("a"));
     expect(links.length).toBeGreaterThan(0);
     for (const link of links) {
-      expect(link).toHaveAttribute("href", "/skills/source/doc-1");
+      expect(link).toHaveAttribute("href", "/skills/source/drive-file-1");
     }
     // The badge names the shelf, not the provider: two shelves can hold
     // skills with the same name and the card is where you tell them apart.

--- a/frontend/src/app/(app)/skills/page.tsx
+++ b/frontend/src/app/(app)/skills/page.tsx
@@ -593,7 +593,7 @@ function SearchGlyph() {
 function skillHref(skill: Skill): string {
   return skill.backing === "folder"
     ? `/skills/folder/${skill.folder_id}`
-    : `/skills/source/${skill.source_doc_id}`;
+    : `/skills/source/${encodeURIComponent(skill.source_ref)}`;
 }
 
 // Names the shelf a skill was read from. Two shelves can hold skills with the

--- a/frontend/src/app/(app)/skills/source/[sourceRef]/SourceSkillClient.tsx
+++ b/frontend/src/app/(app)/skills/source/[sourceRef]/SourceSkillClient.tsx
@@ -9,19 +9,19 @@ import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { FileBrowserSkeleton } from "@/components/SkeletonStates";
 import { readSourceSkill, type SourceSkillRead } from "@/lib/api";
 
-export default function SourceSkillClient({ docId }: { docId: string }) {
+export default function SourceSkillClient({ sourceRef }: { sourceRef: string }) {
   const [skill, setSkill] = useState<SourceSkillRead | null>(null);
   const [error, setError] = useState("");
 
   useEffect(() => {
-    readSourceSkill(docId)
+    readSourceSkill(sourceRef)
       .then(setSkill)
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load this skill"));
-  }, [docId]);
+  }, [sourceRef]);
 
   useBreadcrumbs(
     [{ label: "Skills" }, { label: skill?.name ?? "Skill" }],
-    `source-skill/${docId}`
+    `source-skill/${sourceRef}`
   );
 
   if (error) {

--- a/frontend/src/app/(app)/skills/source/[sourceRef]/page.tsx
+++ b/frontend/src/app/(app)/skills/source/[sourceRef]/page.tsx
@@ -9,12 +9,12 @@ export const metadata: Metadata = { title: "Skill - Stash" };
 export default async function SourceSkillRoute({
   params,
 }: {
-  params: Promise<{ docId: string }>;
+  params: Promise<{ sourceRef: string }>;
 }) {
-  const { docId } = await params;
+  const { sourceRef } = await params;
   return (
     <Suspense fallback={<FileBrowserSkeleton />}>
-      <SourceSkillClient docId={docId} />
+      <SourceSkillClient sourceRef={decodeURIComponent(sourceRef)} />
     </Suspense>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1490,13 +1490,13 @@ export type Skill =
   | (SkillCommon & {
       backing: "folder";
       folder_id: string;
-      source_doc_id: null;
+      source_ref: null;
       source_name: null;
     })
   | (SkillCommon & {
       backing: "source";
       folder_id: null;
-      source_doc_id: string;
+      source_ref: string;
       // The shelf it was read from — two shelves can hold skills with the
       // same name, and the card is where you tell them apart.
       source_name: string;
@@ -1507,7 +1507,7 @@ export type FolderBackedSkill = Extract<Skill, { backing: "folder" }>;
 
 // One source-backed skill, read: its document IS the instructions.
 export interface SourceSkillRead {
-  source_doc_id: string;
+  source_ref: string;
   name: string;
   description: string;
   source_name: string;
@@ -1516,14 +1516,15 @@ export interface SourceSkillRead {
   files: { id: string; name: string; updated_at: string; content: string }[];
 }
 
-export async function readSourceSkill(docId: string): Promise<SourceSkillRead> {
-  return apiFetch(`${ME}/source-skills/${docId}`);
+// Addressed by the upstream file id, so the link survives a rename in Drive.
+export async function readSourceSkill(sourceRef: string): Promise<SourceSkillRead> {
+  return apiFetch(`${ME}/source-skills/${encodeURIComponent(sourceRef)}`);
 }
 
 // A skill's identity across surfaces that only need to tell skills apart —
 // pins, selection, React keys.
 export function skillKey(skill: Skill): string {
-  return skill.backing === "folder" ? skill.folder_id : skill.source_doc_id;
+  return skill.backing === "folder" ? skill.folder_id : skill.source_ref;
 }
 
 export async function listSkills(): Promise<Skill[]> {

--- a/stashvfs/model.py
+++ b/stashvfs/model.py
@@ -419,22 +419,22 @@ class StashVfsModel:
         # filter on folder_id alone silently dropped every source-backed skill
         # out of the tree agents browse.
         addressable = [
-            skill for skill in skills if skill.get("folder_id") or skill.get("source_doc_id")
+            skill for skill in skills if skill.get("folder_id") or skill.get("source_ref")
         ]
         ambiguous = _ambiguous_basenames(
             [_safe_name(skill.get("name") or "skill") for skill in addressable]
         )
         for skill in addressable:
-            key = str(skill.get("folder_id") or skill["source_doc_id"])
+            key = str(skill.get("folder_id") or skill["source_ref"])
             basename = _dir_display_name(skill.get("name") or "skill", key, ambiguous)
             self._add_json_file(f"{skills_path}/{basename}.json", skill)
-            if skill.get("source_doc_id"):
+            if skill.get("source_ref"):
                 # Only when there is something to read. A document that
                 # declares itself a skill and says nothing gets no .md, the way
                 # a folder skill with no instructions gets none — an empty file
                 # reads as an empty skill rather than an unwritten one.
                 if skill.get("has_instructions"):
-                    doc_id = str(skill["source_doc_id"])
+                    doc_id = str(skill["source_ref"])
                     self._add_file(
                         f"{skills_path}/{basename}.md",
                         loader=lambda d=doc_id: _text_bytes(self.client.get_source_skill_text(d)),


### PR DESCRIPTION
**Draft. Stacked on #1040** — base is `feat/source-backed-skills`, so review that first.

## The bug

`drive_documents` is keyed `UNIQUE (source_id, path)` and upserted by path. Renaming a document in Drive therefore looks like *"old file gone, new file arrived"*: the row is deleted and a new one inserted, even though Drive's own file id never changed.

Reproduced before fixing:

```
same Drive file, renamed by its author:
  skill id before: fabcfa6f-…
  skill id after:  79178608-…
  identity survived: False
```

For ordinary source documents that was invisible. #1040 makes it user-visible: a skill's page, its pin, its VFS path, and **any link an agent was handed** all point at the row. So renaming a Doc silently 404s every reference to that skill.

## The fix

Skills are addressed by `source_ref` — the upstream file's own id — instead of our row id. That survives the rename. It's also the id in the document's own Drive URL, so a skill's address and the Doc's address agree:

```
/skills/source/1saZbRU77h4CNqt4Cc7vCbwphhKP4qtZg5iwBZJLHvw8
docs.google.com/document/d/1saZbRU77h4CNqt4Cc7vCbwphhKP4qtZg5iwBZJLHvw8/edit
```

`source_doc_id` is renamed to `source_ref` across the service, router, agent tools, VFS projection, and frontend, and the route segment becomes `/skills/source/[sourceRef]`. The rename is mechanical — the discriminated union on `Skill` meant the compiler found every frontend site.

## The one collision, accepted deliberately

`_resolve_shortcut` gives a Drive shortcut its **target's** file id. A shortcut sitting beside its target in the same folder therefore puts one id on two rows. They are the same upstream document, so either answers the read; the query orders by path so it is at least the same one every time. Documented at the call site.

## Why not re-key the table

Making `drive_documents` itself key on `external_ref` would fix the churn at the source — no delete-and-reinsert, no re-extraction (an OCR pass) for a rename. It's also a migration on a live content table that changes behaviour for **every** Drive folder source, not just skills, so it wants its own PR and its own review.

## Test plan

- New test: a rename upstream leaves the skill's address unchanged and still readable.
- Existing source-backed tests moved onto the new address.
- 190 backend tests pass across the affected suites; `tsc`, vitest (311), ruff and eslint clean.
- Verified end to end against the live Drive folder — app page and `stash vfs ls /skills` both serve the skill at the Doc's own id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skill identity, API URLs, pins, and agent links end-to-end; shortcut duplicate `external_ref` is handled but not eliminated. Existing bookmarks using old internal doc ids will 404 until users follow new links.
> 
> **Overview**
> **Fixes broken skill URLs after a Drive rename** by keying source-backed skills on the upstream file id (`external_ref` / `source_ref`) instead of the internal `drive_documents` row id, which is recreated when path-based sync treats a rename as delete+insert.
> 
> The API route becomes `GET /api/v1/me/source-skills/{source_ref}`; listings and reads filter on `external_ref`, skip docs without one, and use `ORDER BY d.path LIMIT 1` when shortcut rows share the same id. **`source_doc_id` is renamed to `source_ref`** across `skill_service`, agent `list_skills` / `read_skill` URLs, VFS `/skills`, and the frontend (`/skills/source/[sourceRef]` with `encodeURIComponent`).
> 
> A new backend test asserts the skill address stays readable across a simulated rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50dc72710fe638fc6b87ac0038f7039b770a3e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->