### PR TITLE
Browse the VFS as a filesystem; open Sessions on your sessions

### DIFF
--- a/frontend/src/app/(app)/sessions/page.tsx
+++ b/frontend/src/app/(app)/sessions/page.tsx
@@ -317,12 +317,11 @@ export default function SkillSessionsPage() {
           </section>
         )}
 
-        {/* Folder-first: the landing is the set of folders (Default catches
-            chat + un-targeted sessions); the chronological/filter views live
-            inside a folder once you drill in. */}
-        {openFolder ? (
-          <FolderDrill
-            folder={openFolder}
+        {/* Sessions-first: the landing is every session, flat, because the tab
+            exists to let you look at your sessions. Folders organise them and
+            sit below; the VFS view is where sessions nest into directories. */}
+        <FolderDrill
+            folder={openFolder ?? ALL_SESSIONS}
             refreshKey={drillRefresh}
             folders={folders}
             view={view}
@@ -340,15 +339,17 @@ export default function SkillSessionsPage() {
             dragActive={dragActive}
             onDropSessions={moveRowsToFolder}
           />
-        ) : (
-          <FoldersSection
-            ownFolders={folders}
-            sharedFolders={sharedFolders}
-            onOpen={setOpenFolder}
-            onNewFolder={newFolder}
-            onShare={(f) => setShareFolder(f)}
-            onDropSessions={moveRowsToFolder}
-          />
+        {!openFolder && (
+          <div className="mt-8 border-t border-border pt-5">
+            <FoldersSection
+              ownFolders={folders}
+              sharedFolders={sharedFolders}
+              onOpen={setOpenFolder}
+              onNewFolder={newFolder}
+              onShare={(f) => setShareFolder(f)}
+              onDropSessions={moveRowsToFolder}
+            />
+          </div>
         )}
       </div>
 
@@ -923,11 +924,16 @@ function formatDate(iso: string | null): string {
 // `folder` is the full record for own folders (enables Share/Delete + access
 // badge); shared-with-me folders only carry the id/name.
 type OpenFolder = {
-  id: string;
+  /** null = every session in the scope: the tab's flat landing view. Folders
+   *  are a way to organise sessions, not a wall you must click through to see
+   *  them. */
+  id: string | null;
   name: string;
   shared: boolean;
   folder?: SessionFolder;
 };
+
+const ALL_SESSIONS: OpenFolder = { id: null, name: "All sessions", shared: false };
 
 const VIS_DOT: Record<DisplayVisibility, string> = {
   public: "#22C55E",
@@ -1152,9 +1158,10 @@ function FolderDrill({
   useEffect(() => {
     setFolderSessions(null);
     setHasMore(false);
-    const request = folder.shared
-      ? listSharedSessionFolderSessions(folder.id)
-      : listMySessions(SESSIONS_PAGE_SIZE, folder.id, 0);
+    const request =
+      folder.shared && folder.id
+        ? listSharedSessionFolderSessions(folder.id)
+        : listMySessions(SESSIONS_PAGE_SIZE, folder.id ?? undefined, 0);
     request
       .then((rows) => {
         setFolderSessions(rows);
@@ -1169,7 +1176,7 @@ function FolderDrill({
     try {
       const rows = await listMySessions(
         SESSIONS_PAGE_SIZE,
-        folder.id,
+        folder.id ?? undefined,
         folderSessions.length
       );
       setFolderSessions((prev) => [...(prev ?? []), ...rows]);
@@ -1206,18 +1213,24 @@ function FolderDrill({
   // without selection (no move/delete on sessions you don't own).
   const drillSessions = sortSessions(folderSessions ?? [], sort);
 
+  const isAll = folder.id === null;
+
   return (
     <div>
-      <button
-        type="button"
-        onClick={onBack}
-        className="mb-3 inline-flex cursor-pointer items-center gap-1 text-[12.5px] text-muted-foreground hover:text-foreground"
-      >
-        ← All folders
-      </button>
+      {!isAll && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-3 inline-flex cursor-pointer items-center gap-1 text-[12.5px] text-muted-foreground hover:text-foreground"
+        >
+          ← All folders
+        </button>
+      )}
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <h2 className="m-0 flex items-center gap-2 font-display text-[18px] font-semibold text-foreground">
-          <span aria-hidden>{folder.shared ? "🗂️" : ownFolder?.is_default ? "🗃️" : "📁"}</span>
+          {!isAll && (
+            <span aria-hidden>{folder.shared ? "🗂️" : ownFolder?.is_default ? "🗃️" : "📁"}</span>
+          )}
           {folder.name}
           {ownFolder && <FolderAccessBadge folder={ownFolder} />}
         </h2>

--- a/frontend/src/app/(app)/vfs/[[...path]]/page.tsx
+++ b/frontend/src/app/(app)/vfs/[[...path]]/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useBreadcrumbs } from "@/components/BreadcrumbContext";
+import { FileBrowserSkeleton } from "@/components/SkeletonStates";
+import VfsBrowser from "@/components/content/vfs-browser/VfsBrowser";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function VfsPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+
+  useBreadcrumbs([{ label: "VFS", href: "/files" }], "files");
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  if (loading) return <FileBrowserSkeleton />;
+  if (!user) return null;
+
+  return <VfsBrowser />;
+}

--- a/frontend/src/components/content/file-browser/ItemsList.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.tsx
@@ -73,21 +73,32 @@ export function isFbDrag(e: DragEvent<HTMLElement>): boolean {
 // inline style. Keeps the four-column Drive-style layout: name takes 2fr,
 // modified + type each take 1fr, action button is fixed 36px.
 const LIST_GRID_COLS = "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) 64px";
+// With a detail column ("Agent" on /sessions), Name yields the width for it.
+const LIST_GRID_COLS_DETAIL =
+  "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) minmax(0,1fr) 64px";
 
 interface Props {
   items: GridItem[];
   onNavigate: (item: GridItem, options?: NavigateOptions) => void;
-  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
-  onDelete: (item: GridItem) => Promise<void>;
-  isPinned: (item: GridItem) => boolean;
-  onTogglePin: (item: GridItem) => void;
-  selectedIds: Set<string>;
-  onToggleSelect: (item: GridItem) => void;
-  selectedDragPayloads: FBDragPayload[];
+  /** Header for the optional secondary column. A listing where every row has
+   *  the same Type ("Session") wastes that column; the mount says what the
+   *  useful fact is instead — the agent that ran it, the skill's contents. */
+  detailColumn?: string;
+  // Everything below is a capability, not a callback the caller may stub: the
+  // VFS mounts that are not files (sessions, skills, source documents) have no
+  // reparent, pin, or delete, so they pass nothing and the row renders without
+  // those controls rather than offering one that does nothing.
+  onReparent?: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
+  isPinned?: (item: GridItem) => boolean;
+  onTogglePin?: (item: GridItem) => void;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (item: GridItem) => void;
+  selectedDragPayloads?: FBDragPayload[];
 }
 
-type SortKey = "name" | "modified" | "type";
+type SortKey = "name" | "modified" | "type" | "detail";
 type Sort = { key: SortKey; dir: "asc" | "desc" } | null;
 
 const SORT_STORAGE_KEY = "stash_files_sort";
@@ -127,6 +138,9 @@ function timeOf(item: GridItem): number {
 function compareItems(a: GridItem, b: GridItem, key: SortKey): number {
   if (key === "modified") return timeOf(a) - timeOf(b) || a.name.localeCompare(b.name);
   if (key === "type") return typeFor(a).localeCompare(typeFor(b)) || a.name.localeCompare(b.name);
+  if (key === "detail") {
+    return (a.detail ?? "").localeCompare(b.detail ?? "") || a.name.localeCompare(b.name);
+  }
   return a.name.localeCompare(b.name);
 }
 
@@ -137,6 +151,7 @@ function compareItems(a: GridItem, b: GridItem, key: SortKey): number {
 export default function ItemsList({
   items,
   onNavigate,
+  detailColumn,
   onReparent,
   onReparentMany,
   onDelete,
@@ -150,10 +165,15 @@ export default function ItemsList({
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
 
   function applySort(next: NonNullable<Sort>) {
-    try {
-      window.localStorage.setItem(SORT_STORAGE_KEY, `${next.key}:${next.dir}`);
-    } catch {
-      /* ignore */
+    // The detail column belongs to one listing, but the sort preference is
+    // shared across every file browser — persisting "detail" would silently
+    // reset the user's Files sort to the default on the next load.
+    if (next.key !== "detail") {
+      try {
+        window.localStorage.setItem(SORT_STORAGE_KEY, `${next.key}:${next.dir}`);
+      } catch {
+        /* ignore */
+      }
     }
     setSort(next);
   }
@@ -191,9 +211,12 @@ export default function ItemsList({
     <div className="rounded-xl border border-border bg-surface">
       <div
         className="grid items-center gap-3 rounded-t-xl border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
-        style={{ gridTemplateColumns: LIST_GRID_COLS }}
+        style={{ gridTemplateColumns: detailColumn ? LIST_GRID_COLS_DETAIL : LIST_GRID_COLS }}
       >
         <SortHeader label="Name" sortKey="name" sort={sort} onSort={toggleSort} />
+        {detailColumn && (
+          <SortHeader label={detailColumn} sortKey="detail" sort={sort} onSort={toggleSort} />
+        )}
         <SortHeader label="Modified" sortKey="modified" sort={sort} onSort={toggleSort} />
         <TypeHeader
           sort={sort}
@@ -210,12 +233,13 @@ export default function ItemsList({
             key={`${item.kind}-${item.id}`}
             item={item}
             onNavigate={onNavigate}
+            hasDetail={detailColumn !== undefined}
             onReparent={onReparent}
             onReparentMany={onReparentMany}
             onDelete={onDelete}
-            pinned={isPinned(item)}
+            pinned={isPinned ? isPinned(item) : false}
             onTogglePin={onTogglePin}
-            selected={selectedIds.has(item.id)}
+            selected={selectedIds ? selectedIds.has(item.id) : false}
             onToggleSelect={onToggleSelect}
             selectedDragPayloads={selectedDragPayloads}
           />
@@ -364,6 +388,7 @@ function MenuItem({
 function Row({
   item,
   onNavigate,
+  hasDetail,
   onReparent,
   onReparentMany,
   onDelete,
@@ -375,14 +400,15 @@ function Row({
 }: {
   item: GridItem;
   onNavigate: (item: GridItem, options?: NavigateOptions) => void;
-  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
-  onDelete: (item: GridItem) => Promise<void>;
+  hasDetail: boolean;
+  onReparent?: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
   pinned: boolean;
-  onTogglePin: (item: GridItem) => void;
+  onTogglePin?: (item: GridItem) => void;
   selected: boolean;
-  onToggleSelect: (item: GridItem) => void;
-  selectedDragPayloads: FBDragPayload[];
+  onToggleSelect?: (item: GridItem) => void;
+  selectedDragPayloads?: FBDragPayload[];
 }) {
   const [over, setOver] = useState(false);
   const isFolder = item.kind === "folder";
@@ -398,12 +424,12 @@ function Row({
       onKeyDown={(e) => {
         if (e.key === "Enter") onNavigate(item);
       }}
-      draggable={item.movable !== false}
+      draggable={onReparent !== undefined && item.movable !== false}
       onDragStart={(e: DragEvent<HTMLDivElement>) =>
-        startItemDrag(e, item, selected, selectedDragPayloads)
+        startItemDrag(e, item, selected, selectedDragPayloads ?? [])
       }
       onDragOver={(e) => {
-        if (!isFolder) return;
+        if (!isFolder || !onReparent) return;
         if (!isFbDrag(e)) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
@@ -411,7 +437,7 @@ function Row({
       }}
       onDragLeave={() => setOver(false)}
       onDrop={(e) => {
-        if (!isFolder) return;
+        if (!isFolder || !onReparent || !onReparentMany) return;
         setOver(false);
         e.preventDefault();
         handleFolderDrop(e, item.id, onReparent, onReparentMany);
@@ -423,21 +449,32 @@ function Row({
           : "hover:bg-[var(--color-brand-50)]/50 ") +
         (over ? "ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
-      style={{ gridTemplateColumns: LIST_GRID_COLS }}
+      style={{ gridTemplateColumns: hasDetail ? LIST_GRID_COLS_DETAIL : LIST_GRID_COLS }}
     >
       <div className="flex min-w-0 items-center gap-2.5">
-        <SelectBox
-          selected={selected}
-          onToggle={() => onToggleSelect(item)}
-        />
-        <span className={"flex h-4 w-4 flex-shrink-0 items-center justify-center " + tintFor(item)}>
-          <KindIcon kind={item.kind} />
+        {onToggleSelect && (
+          <SelectBox
+            selected={selected}
+            onToggle={() => onToggleSelect(item)}
+          />
+        )}
+        <span
+          className={
+            "flex h-4 w-4 flex-shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px] " +
+            tintFor(item)
+          }
+        >
+          {item.icon ?? <KindIcon kind={item.kind} />}
         </span>
         <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
       </div>
+      {hasDetail && (
+        <span className="truncate text-[12px] text-muted-foreground">{item.detail ?? "—"}</span>
+      )}
       <span className="truncate text-[12px] text-muted-foreground">{formatRelative(item.updatedAt)}</span>
       <span className="truncate text-[12px] text-muted-foreground">{typeFor(item)}</span>
       <div className="flex items-center justify-end gap-0.5">
+        {onTogglePin && (
         <button
           type="button"
           onClick={(e) => {
@@ -456,6 +493,8 @@ function Row({
         >
           <PinIcon className="text-[15px]" />
         </button>
+        )}
+        {onDelete && (
         <button
           type="button"
           onClick={(e) => {
@@ -474,6 +513,7 @@ function Row({
             <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
           </svg>
         </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/content/file-browser/kind.tsx
+++ b/frontend/src/components/content/file-browser/kind.tsx
@@ -1,9 +1,24 @@
+import type { ReactNode } from "react";
+import { GraduationCap, MessagesSquare } from "lucide-react";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../SkillIcons";
 
 // "table" = a CSV/spreadsheet *file* linked to a table; "datatable" = a
 // standalone structured-data table (the `tables` entity). Both render with the
 // table icon, but they have different backing rows so move/delete/nav differ.
-export type ItemKind = "folder" | "page" | "html" | "table" | "datatable" | "file";
+// The last three are VFS mounts that are not files: /sessions, /skills, and
+// the documents inside /sources. They list in the same browser as files
+// because that is what the VFS shows an agent, but they are not stored as
+// files and carry none of the file operations.
+export type ItemKind =
+  | "folder"
+  | "page"
+  | "html"
+  | "table"
+  | "datatable"
+  | "file"
+  | "session"
+  | "skill"
+  | "source-doc";
 
 export interface GridItem {
   kind: ItemKind;
@@ -19,17 +34,29 @@ export interface GridItem {
   /** ISO timestamp. Renders as "Modified" in the Drive-style List view.
    *  Not all rows have one — FolderContents.pages currently omits it. */
   updatedAt?: string;
+  /** The one secondary fact worth a column in this listing — the agent that
+   *  ran a session, what a skill contains. Rendered only when the caller asks
+   *  for a detail column. */
+  detail?: string;
+  /** Row icon that overrides the kind icon — connected sources wear their
+   *  own brand mark, which is how you tell gmail from slack at a glance. */
+  icon?: ReactNode;
 }
 
 export function KindIcon({ kind }: { kind: ItemKind }) {
   if (kind === "folder") return <FolderIcon />;
   if (kind === "page" || kind === "html") return <PageIcon />;
   if (kind === "table" || kind === "datatable") return <TableIcon />;
+  if (kind === "session") return <MessagesSquare className="h-[15px] w-[15px]" />;
+  if (kind === "skill") return <GraduationCap className="h-[15px] w-[15px]" />;
   return <FileIcon />;
 }
 
 export function tintFor(item: GridItem): string {
   if (item.kind === "folder") return "text-muted-foreground";
+  if (item.kind === "session") return "text-chart-1";
+  if (item.kind === "skill") return "text-chart-3";
+  if (item.kind === "source-doc") return "text-muted-foreground";
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table" || item.kind === "datatable") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
@@ -40,6 +67,9 @@ export function tintFor(item: GridItem): string {
 
 export function typeFor(item: GridItem): string {
   if (item.kind === "folder") return "Folder";
+  if (item.kind === "session") return "Session";
+  if (item.kind === "skill") return "Skill";
+  if (item.kind === "source-doc") return "Document";
   if (item.kind === "table" || item.kind === "datatable") return "Table";
   if (item.kind === "html") return "HTML";
   if (item.kind === "page") return "Markdown";

--- a/frontend/src/components/content/files-overview/build.ts
+++ b/frontend/src/components/content/files-overview/build.ts
@@ -36,6 +36,10 @@ export interface VNode {
   icon?: ReactNode;
   /** Where this subtree's "+N more" rows should take the user. */
   moreHref?: string;
+  /** ISO timestamp, when the entry has one — the browse view sorts on it. */
+  updatedAt?: string;
+  /** The one secondary fact the browse view gives a column to. */
+  detail?: string;
 }
 
 function byName<T extends { name: string }>(a: T, b: T): number {
@@ -129,14 +133,36 @@ export function buildFilesNodes(
 // Session and skill hrefs carry ?section=files: these nodes are only rendered
 // by VFS surfaces (the /files lens and the docked tree), and the stamp keeps
 // the VFS docked when one opens instead of teleporting to another section.
+// The four files stashvfs materializes inside every session directory
+// (stashvfs/model.py::_add_sessions). They all open the session itself: the
+// point of the drill-down is seeing what an agent can read, not four
+// destinations.
+const SESSION_FILES = ["metadata.json", "events.json", "transcript.jsonl", "transcript.md"];
+
 export function buildSessionNodes(sessions: SidebarSession[]): VNode[] {
-  return sessions.map((s) => ({
-    key: s.session_id,
-    kind: "session",
-    name: s.title || s.agent_name || "session",
-    href: `/sessions/${s.session_id}?section=files`,
-    annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
-  }));
+  return sessions.map((s) => {
+    const href = `/sessions/${s.session_id}?section=files`;
+    return {
+      key: s.session_id,
+      kind: "session",
+      name: s.title || s.agent_name || "session",
+      href,
+      annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
+      updatedAt: s.last_at,
+      // "Henry's codex", not "codex": in a shared scope the same agent runs for
+      // several people, and whose run it was is the thing you scan for.
+      detail: s.user_name ? `${s.user_name}’s ${s.agent_name}` : s.agent_name,
+      // A session is a directory in the VFS, so it is one here too — that
+      // nesting is what the browse view has that a flat list does not.
+      children: SESSION_FILES.map((name) => ({
+        key: `${s.session_id}/${name}`,
+        kind: "file" as const,
+        name,
+        href,
+        updatedAt: s.last_at,
+      })),
+    };
+  });
 }
 
 export function buildSkillNodes(skills: Skill[]): VNode[] {
@@ -145,6 +171,13 @@ export function buildSkillNodes(skills: Skill[]): VNode[] {
     kind: "skill",
     name: s.name,
     href: `/skills/folder/${s.folder_id}?section=files`,
+    updatedAt: s.updated_at,
+    detail: [
+      `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
+      s.published ? "published" : null,
+    ]
+      .filter(Boolean)
+      .join(", "),
     annotation: [
       `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
       s.published ? "published" : null,

--- a/frontend/src/components/content/files-overview/useVfsMounts.tsx
+++ b/frontend/src/components/content/files-overview/useVfsMounts.tsx
@@ -34,6 +34,10 @@ export interface Mount {
   icon: ReactNode;
   nodes: VNode[];
   href?: string;
+  /** Header for the browse view's secondary column, when this mount has one
+   *  fact worth scanning down. Type earns nothing there — every row in
+   *  /sessions is a Session. */
+  detailLabel?: string;
   /** Rows the API cut off before we ever saw them (sources per-dir cap). */
   apiHidden?: number;
   /** Where "+N more" rows we can't expand locally should take the user. */
@@ -115,13 +119,15 @@ export function useVfsMounts(): {
         path: "/files",
         icon: <FolderTree className="h-4 w-4 text-chart-4" />,
         nodes: core.filesNodes,
+        href: "/vfs/files",
         emptyLabel: "empty",
       },
       {
         path: "/sessions",
         icon: <MessagesSquare className="h-4 w-4 text-chart-1" />,
         nodes: core.sessionNodes,
-        href: "/sessions",
+        href: "/vfs/sessions",
+        detailLabel: "Agent",
         footer:
           core.vitals.sessions > core.sessionNodes.length
             ? { label: `all ${core.vitals.sessions} sessions`, href: "/sessions" }
@@ -139,7 +145,8 @@ export function useVfsMounts(): {
         path: "/skills",
         icon: <GraduationCap className="h-4 w-4 text-chart-3" />,
         nodes: core.skillNodes,
-        href: "/skills",
+        href: "/vfs/skills",
+        detailLabel: "Contents",
         emptyLabel: "no skills yet",
       },
     ];
@@ -177,6 +184,7 @@ export function useVfsMounts(): {
         path: "/sources",
         icon: <Cable className="h-4 w-4 text-chart-1" />,
         nodes: providerNodes,
+        href: "/vfs/sources",
         footer:
           providerNodes.length === 0
             ? { label: "connect a source", href: "/settings/integrations" }

--- a/frontend/src/components/content/vfs-browser/VfsBrowser.tsx
+++ b/frontend/src/components/content/vfs-browser/VfsBrowser.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+// The third VFS surface: one mount, full-page, in the same browser every
+// folder uses. The lens (/files) answers "what is in my stash"; this answers
+// "what does /sessions actually look like as a filesystem".
+//
+// /files renders the real FileBrowser, because it is a real filesystem and
+// gets the whole toolkit — views, sort, upload, preview. The other mounts are
+// not files (sessions, skills, source documents), so they render the same
+// rows through ItemsList but pass no reparent/pin/delete capability: the list
+// looks identical and offers only what actually exists for them.
+
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Skeleton } from "@/components/ui/skeleton";
+import FileBrowser from "@/components/content/file-browser/FileBrowser";
+import ItemsList from "@/components/content/file-browser/ItemsList";
+import type { GridItem, ItemKind } from "@/components/content/file-browser/kind";
+import type { VNode, VNodeKind } from "@/components/content/files-overview/build";
+import { useVfsMounts, type Mount } from "@/components/content/files-overview/useVfsMounts";
+
+const KIND: Record<VNodeKind, ItemKind> = {
+  folder: "folder",
+  page: "page",
+  file: "file",
+  table: "datatable",
+  session: "session",
+  skill: "skill",
+  "source-doc": "source-doc",
+};
+
+function vfsHref(segments: string[]): string {
+  return `/vfs/${segments.map(encodeURIComponent).join("/")}`;
+}
+
+type Resolved =
+  | { ok: true; nodes: VNode[]; emptyLabel: string; mount: Mount }
+  | { ok: false; missing: string };
+
+/** Walk `segments` from the mount roots. Names are the path, which is what
+ *  makes the URL read like the filesystem it is describing. */
+function resolve(mounts: Mount[], segments: string[]): Resolved {
+  const mount = mounts.find((m) => m.path === `/${segments[0]}`);
+  if (!mount) return { ok: false, missing: `/${segments[0]}` };
+
+  let nodes = mount.nodes;
+  for (const segment of segments.slice(1)) {
+    const next = nodes.find((n) => n.name === segment);
+    if (!next || !next.children) return { ok: false, missing: segment };
+    nodes = next.children;
+  }
+  // The mount's empty label speaks for the mount ("no sources connected"); a
+  // directory inside it is just empty, and saying otherwise misreports why.
+  const emptyLabel = segments.length === 1 ? mount.emptyLabel : "empty";
+  return { ok: true, nodes, emptyLabel, mount };
+}
+
+function Breadcrumbs({ segments }: { segments: string[] }) {
+  return (
+    <div className="flex flex-wrap items-center font-mono text-[15px]">
+      {segments.map((segment, i) => {
+        const last = i === segments.length - 1;
+        return (
+          <span key={segment} className="flex items-center">
+            <span className="text-muted-foreground/40">/</span>
+            {last ? (
+              <span className="font-semibold text-foreground">{segment}</span>
+            ) : (
+              <Link
+                href={vfsHref(segments.slice(0, i + 1))}
+                className="rounded px-0.5 text-dim hover:bg-raised hover:text-brand-700"
+              >
+                {segment}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function VfsBrowser() {
+  const params = useParams();
+  const router = useRouter();
+  const raw = params.path;
+  const segments = (Array.isArray(raw) ? raw : raw ? [raw] : []).map((s) => decodeURIComponent(s));
+
+  const { mounts, coreLoaded, coreError, sourcesPending } = useVfsMounts();
+
+  if (segments.length === 1 && segments[0] === "files") {
+    return (
+      <div className="h-full overflow-y-auto px-8 py-6">
+        <Breadcrumbs segments={segments} />
+        <FileBrowser folderId={null} />
+      </div>
+    );
+  }
+
+  if (coreError) {
+    return <div className="px-8 py-6 font-mono text-[13px] text-error">✗ {coreError}</div>;
+  }
+  // /sources arrives on its own clock, so a bare /vfs/sources is still loading
+  // while the native mounts are ready.
+  if (!coreLoaded || (segments[0] === "sources" && sourcesPending)) {
+    return (
+      <div className="space-y-2 px-8 py-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-6 w-64" />
+        ))}
+      </div>
+    );
+  }
+
+  const resolved = resolve(mounts, segments);
+
+  // A directory drills deeper into this view; a leaf opens its own page. That
+  // split is what keeps /sources/gmail browsing the filesystem instead of
+  // jumping to the Gmail integration screen.
+  const destinations = new Map<string, string>();
+  const items: GridItem[] = !resolved.ok
+    ? []
+    : resolved.nodes.map((node) => {
+        const dir = node.children !== undefined;
+        const destination = dir ? vfsHref([...segments, node.name]) : node.href;
+        if (destination) destinations.set(node.key, destination);
+        return {
+          kind: dir ? "folder" : KIND[node.kind],
+          id: node.key,
+          name: node.name,
+          subtitle: node.annotation ?? "",
+          updatedAt: node.updatedAt,
+          detail: node.detail,
+          icon: node.icon,
+          movable: false,
+        };
+      });
+
+  function navigate(item: GridItem, options?: { newTab?: boolean }) {
+    // Source documents live in the provider, not in Stash: they are real VFS
+    // entries with no page of ours to open, so their rows do not navigate.
+    const destination = destinations.get(item.id);
+    if (!destination) return;
+    if (options?.newTab) window.open(destination, "_blank");
+    else router.push(destination);
+  }
+
+  return (
+    <div className="h-full overflow-y-auto px-8 py-6">
+      <Breadcrumbs segments={segments} />
+      <div className="mt-5">
+        {!resolved.ok ? (
+          <div className="font-mono text-[13px] text-muted-foreground">
+            no such path: {resolved.missing}
+          </div>
+        ) : resolved.nodes.length === 0 ? (
+          <div className="font-mono text-[13px] italic text-muted-foreground">
+            {resolved.emptyLabel}
+          </div>
+        ) : (
+          <ItemsList
+            items={items}
+            onNavigate={navigate}
+            detailColumn={resolved.mount.detailLabel}
+          />
+        )}
+      </div>
+      {resolved.ok && resolved.mount.footer && (
+        <Link
+          href={resolved.mount.footer.href}
+          className="mt-4 inline-flex items-center gap-1 font-mono text-[12.5px] text-dim hover:text-brand-700"
+        >
+          {resolved.mount.footer.label} →
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -21,7 +21,7 @@ type RailItem = {
 const PRIMARY: RailItem[] = [
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
   { key: "hopper", label: "Hopper", icon: HopperIcon, match: (p) => p.startsWith("/hopper") },
-  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
+  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/vfs") || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
   { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
   { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
   { key: "tools", label: "Tools", icon: Wrench, match: (p) => p.startsWith("/tools") || p.startsWith("/integrations") },

--- a/frontend/src/components/workspace/vfs-tree.tsx
+++ b/frontend/src/components/workspace/vfs-tree.tsx
@@ -388,9 +388,10 @@ function MountBlock({
   const collapsedMounts = useVfsTreeStore((s) => s.collapsedMounts);
   const toggleMount = useVfsTreeStore((s) => s.toggleMount);
   const open = !collapsedMounts.has(mount.path);
-  // In the lens /files is where you already are; docked, its row is the way
-  // back to the full-screen view.
-  const href = mount.path === "/files" ? "/files" : mount.href;
+  // Every mount row opens its own browse view, /files included. Zooming back
+  // out to the lens is the rail's VFS button, not a row that behaves unlike
+  // its neighbours.
+  const href = mount.href;
   const foldable = mount.path === "/files";
   const pad = { paddingLeft: 6 + INDENT_PX };
 

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -71,7 +71,10 @@ function ExplorerPanel({ section }: { section: ExplorerSection }) {
  *  render the tab workbench; `/sessions` keeps its full management page
  *  beside the Sessions explorer. */
 function sectionForPath(pathname: string): ExplorerSection | null {
-  if (pathname === "/files" || /^\/(p|f|folders|tables)\//.test(pathname)) return "files";
+  // /vfs/<mount>/... browses a mount as a filesystem, so it belongs to the
+  // Files section however deep it goes — including into /sessions or /skills,
+  // whose management pages are a different section entirely.
+  if (pathname === "/files" || pathname.startsWith("/vfs") || /^\/(p|f|folders|tables)\//.test(pathname)) return "files";
   if (pathname === "/sessions" || pathname.startsWith("/sessions/") || pathname.startsWith("/session-folders")) return "sessions";
   if (pathname === "/skills" || pathname.startsWith("/skills/folder")) return "skills";
   if (pathname === "/agents") return "agents";
@@ -91,6 +94,9 @@ export function rendersRouteContent(
   // The Files home is the bird's-eye view of the whole stash; opening any
   // item navigates to its own route, which returns to the workbench.
   if (pathname === "/files") return true;
+  // The VFS browse view is a page in its own right, beside the docked tree —
+  // it is what the tree is a miniature of, not something to open in a tab.
+  if (pathname.startsWith("/vfs")) return true;
   if (pathname === "/sessions") return workspaceParam !== "1";
   // The Skills home is the launcher — pick a skill, run it. Only the bare
   // path: /skills/folder/<id> is a skill you opened, which belongs in a tab.


### PR DESCRIPTION
The VFS lens could describe the stash but had nowhere to send you that was still the VFS. Clicking `/sessions` teleported to the Sessions management page — a different section doing a different job — and `/files` was not a link at all, because it would have pointed at the page you were already on.

This adds the missing destination and settles the split we kept circling:

**`/vfs/<mount>/...` — how a thing is materialized.** A row with children drills deeper; only leaves follow their own href, which is what keeps `/sources/gmail` browsing Gmail's documents instead of jumping to its integration screen. Mounts come from `useVfsMounts`, so this is a third surface over the existing model, not a fourth model.

**The management pages — where you control a thing.** The rail still goes to Sessions, Skills, and Tools; the sessions mount's "all N sessions" footer becomes the explicit bridge between the halves.

### Notable pieces

- **`/files` renders the real `FileBrowser`**, rooted at the VFS root — views, sort, upload, preview. `FileBrowser` already accepted a `null` folderId for exactly this; no route had ever asked for it.
- **Sessions nest as `stashvfs` materializes them** — each session a directory of `metadata.json`, `events.json`, `transcript.jsonl`, `transcript.md`, so the browse view shows what an agent sees when it walks the stash.
- **`ItemsList`'s mutation handlers are now capabilities.** They were required, so listing anything that is not a file forced the caller to stub them, and a delete button that does nothing is worse than no button. Pass a handler and the control appears; pass nothing and the row does not offer it.
- **Sessions and skills declare the one fact worth a column** (whose agent run it was, what a skill contains). Type is dead weight in a list where every row says "Session". That column's sort is deliberately unpersisted — the sort key is shared across every browser, so writing to it would silently reset the Files sort.
- **`/sessions` opens on every session, flat**, with the columns and lenses a tree cannot give you. Folders still organise sessions and sit below the list. The drill view grew an all-sessions mode rather than a parallel component, so paging and infinite scroll came along unchanged.

### Verification

- `npx tsc --noEmit` clean, and clean on each of the three commits independently
- `npm run lint` — 0 errors (7 pre-existing warnings in untouched files)
- `npx vitest run` — 319 tests across 64 files pass
- Clicked through `/files`, `/vfs/files`, `/vfs/files/Images`, `/vfs/sessions`, a session directory, `/vfs/skills`, `/vfs/sources`, `/vfs/sources/github`, and the new `/sessions` landing

### Known, deliberately not fixed here

- **Column view ignores which folder you opened.** `ItemsColumns` receives only `rootItems`, never `items` or `folderId`, so every folder renders the root under its own heading. Pre-existing and untouched by this branch, but it undercuts the browse experience and is probably the next thing worth fixing.
- Inside a session directory the Agent column shows `—`; that fact belongs to the session, not its files.
- `/memory` still points at `/folders/<id>` rather than `/vfs/memory` — defensible, since that is already a browse view, but it is the one mount that does not follow the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary navigation (Sessions landing, VFS tree links, workspace section routing) and shared `ItemsList` behavior; changes are mostly UI/routing with no auth or data-layer changes, but wrong routing could confuse users or hide management pages.
> 
> **Overview**
> Introduces **`/vfs/<mount>/...`** as a full-page browse surface beside the docked tree: mount data still comes from `useVfsMounts`, directories drill in-URL, leaves follow their product links, and **`/vfs/files`** uses the real `FileBrowser` at the VFS root (`folderId={null}`). Workspace routing treats `/vfs` as the Files section; tree mount rows now link to `/vfs/...` instead of jumping to Sessions/Skills management pages.
> 
> **`ItemsList`** gains an optional **detail** column (e.g. Agent, Contents), new grid item kinds (`session`, `skill`, `source-doc`), and **optional** pin/delete/reparent/select/drag — controls only render when handlers are passed. Session nodes in the VFS model nest **stashvfs-style** child files; mounts expose `detailLabel` and browse hrefs like `/vfs/sessions`.
> 
> **`/sessions`** landing is **sessions-first**: `FolderDrill` always runs with an **All sessions** mode (`folder.id === null`), folders sit in a section below when not drilled in, and list APIs use `folder.id ?? undefined` for paging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df999a78c486d77415579e89c270f0c7cb1b61e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->